### PR TITLE
(WIP) chore: Upgrade to `webauthn-json` `0.4.1` to `2.1.1`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -70,7 +70,7 @@
 		"@emotion/jest": "^11.5.0",
 		"@emotion/react": "^11.4.1",
 		"@emotion/styled": "^11.3.0",
-		"@github/webauthn-json": "^0.4.1",
+		"@github/webauthn-json": "^2.1.1",
 		"@sentry/react": "^7.33.0",
 		"@stripe/react-stripe-js": "^1.4.1",
 		"@stripe/stripe-js": "1.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4033,12 +4033,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@github/webauthn-json@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@github/webauthn-json@npm:0.4.1"
+"@github/webauthn-json@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@github/webauthn-json@npm:2.1.1"
   bin:
-    webauthn-json: ./dist/bin/webauthn-json.js
-  checksum: e8834ae2082d38e5f8eba2cd4576060c53cdc2d0152e3635f87fecbc3ab4f142c709b7a1f8bb1c898e30eed5d7b3d5fb00dc1f815b48ae31a880c4b14d9ba757
+    webauthn-json: dist/bin/main.js
+  checksum: 4423ddd1e5b74d91ded02ea551923a73c45b1ee2ee4294943aaddfc12e1929405ea1e8b4380456db829fcdc3a4d8a89bf8ee29c6a35be3889dc00236b1c96968
   languageName: node
   linkType: hard
 
@@ -11922,7 +11922,7 @@ __metadata:
     "@emotion/jest": ^11.5.0
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
-    "@github/webauthn-json": ^0.4.1
+    "@github/webauthn-json": ^2.1.1
     "@sentry/react": ^7.33.0
     "@sentry/webpack-plugin": ^1.18.8
     "@stripe/react-stripe-js": ^1.4.1


### PR DESCRIPTION
This PR upgrades @github/webauthn-json to https://github.com/github/webauthn-json/releases/tag/v2.1.1

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
