### PR TITLE
Fix the infinite loading state on Jetpack Backups list

### DIFF
--- a/client/my-sites/backup/status/hooks.js
+++ b/client/my-sites/backup/status/hooks.js
@@ -40,13 +40,13 @@ const useBackupDeltas = ( siteId, { before, after, number = 1000 } = {}, enabled
 
 	const isValidRequest = filter.before && filter.after;
 
-	const { data, isLoading } = useRewindableActivityLogQuery( siteId, filter, {
+	const { data, isInitialLoading } = useRewindableActivityLogQuery( siteId, filter, {
 		enabled: isValidRequest && enabled,
 		refetchOnWindowFocus: false,
 	} );
 
 	return {
-		isLoading,
+		isLoading: isInitialLoading,
 		deltas: getDeltaActivitiesByType( data ?? [] ),
 	};
 };

--- a/client/my-sites/backup/status/hooks.js
+++ b/client/my-sites/backup/status/hooks.js
@@ -46,7 +46,7 @@ const useBackupDeltas = ( siteId, { before, after, number = 1000 } = {}, enabled
 	} );
 
 	return {
-		isLoading: isInitialLoading,
+		isInitialLoading,
 		deltas: getDeltaActivitiesByType( data ?? [] ),
 	};
 };
@@ -142,7 +142,9 @@ export const useDailyBackupStatus = ( siteId, selectedDate ) => {
 
 	return {
 		isLoading:
-			lastBackupBeforeDate.isLoading || lastAttemptOnDate.isLoading || backupDeltas.isLoading,
+			lastBackupBeforeDate.isLoading ||
+			lastAttemptOnDate.isLoading ||
+			backupDeltas.isInitialLoading,
 		lastBackupBeforeDate: lastBackupBeforeDate.backupAttempt,
 		lastBackupAttemptOnDate: lastAttemptOnDate.backupAttempt,
 		deltas: backupDeltas.deltas,


### PR DESCRIPTION
After the migration to `@tanstack/react-query` (see #76077) we were incorrectly still using the `isLoading` flag (which was never changing to false) instead of `isInitialLoading`.

Before this change: https://github.com/Automattic/wp-calypso/blob/b17472abcf76eb36ae7960887d65f2d5ddede251/client/my-sites/backup/status/hooks.js#L43

_Under the hood `useRewindableActivityLogQuery()` uses `useQuery` from `@tanstack/react-query`._

## Testing Instructions

1. Start the local Calypso env and see whether your site's backups list loads fine.
2. Now, using [the "Switch to User" tool switch to the `userref` selecting `calypso.local` from the dropdown](https://mc.a8c.com/tools/support-user/). Navigate to Jetpack / Backups where you should see:

<img width="1513" alt="Screenshot 2023-05-04 at 15 20 18" src="https://user-images.githubusercontent.com/1929317/236235976-8248dc99-d41f-4d0f-abfa-5ed44ec8f44b.png">