### PR TITLE
Hide domain preview if start-writing and domain task incomplete

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,5 +1,6 @@
 import { Gridicon, CircularProgressBar } from '@automattic/components';
 import { OnboardSelect, useLaunchpad } from '@automattic/data-stores';
+import { isStartWritingFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useRef, useState } from '@wordpress/element';
 import { Icon, copy } from '@wordpress/icons';
@@ -58,6 +59,9 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	const {
 		data: { site_intent: siteIntentOption, checklist_statuses: checklistStatuses },
 	} = useLaunchpad( siteSlug );
+
+	const showDomain =
+		! isStartWritingFlow( flow ) || checklistStatuses?.domain_upsell_deferred === true;
 
 	const { getDomainCartItem } = useSelect(
 		( select ) => ( {
@@ -154,42 +158,44 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 					{ showLaunchTitle && launchTitle ? launchTitle : title }
 				</h1>
 				<p className="launchpad__sidebar-description">{ subtitle }</p>
-				<div className="launchpad__url-box">
-					{ /* Google Chrome is adding an extra space after highlighted text. This extra wrapping div prevents that */ }
-					<div className="launchpad__url-box-domain">
-						<div className="launchpad__url-box-domain-text">{ getDomainName() }</div>
-						{ showClipboardButton && (
-							<>
-								<ClipboardButton
-									aria-label={ translate( 'Copy URL' ) }
-									text={ siteSlug }
-									className="launchpad__clipboard-button"
-									borderless
-									compact
-									onCopy={ () => setClipboardCopied( true ) }
-									onMouseLeave={ () => setClipboardCopied( false ) }
-									ref={ clipboardButtonEl }
-								>
-									<Icon icon={ copy } size={ 18 } />
-								</ClipboardButton>
-								<Tooltip
-									context={ clipboardButtonEl.current }
-									isVisible={ clipboardCopied }
-									position="top"
-								>
-									{ translate( 'Copied to clipboard!' ) }
-								</Tooltip>
-							</>
+				{ showDomain && (
+					<div className="launchpad__url-box">
+						{ /* Google Chrome is adding an extra space after highlighted text. This extra wrapping div prevents that */ }
+						<div className="launchpad__url-box-domain">
+							<div className="launchpad__url-box-domain-text">{ getDomainName() }</div>
+							{ showClipboardButton && (
+								<>
+									<ClipboardButton
+										aria-label={ translate( 'Copy URL' ) }
+										text={ siteSlug }
+										className="launchpad__clipboard-button"
+										borderless
+										compact
+										onCopy={ () => setClipboardCopied( true ) }
+										onMouseLeave={ () => setClipboardCopied( false ) }
+										ref={ clipboardButtonEl }
+									>
+										<Icon icon={ copy } size={ 18 } />
+									</ClipboardButton>
+									<Tooltip
+										context={ clipboardButtonEl.current }
+										isVisible={ clipboardCopied }
+										position="top"
+									>
+										{ translate( 'Copied to clipboard!' ) }
+									</Tooltip>
+								</>
+							) }
+						</div>
+						{ showDomainUpgradeBadge && (
+							<a href={ domainUpgradeBadgeUrl }>
+								<Badge className="launchpad__domain-upgrade-badge" type="info-blue">
+									{ translate( 'Customize' ) }
+								</Badge>
+							</a>
 						) }
 					</div>
-					{ showDomainUpgradeBadge && (
-						<a href={ domainUpgradeBadgeUrl }>
-							<Badge className="launchpad__domain-upgrade-badge" type="info-blue">
-								{ translate( 'Customize' ) }
-							</Badge>
-						</a>
-					) }
-				</div>
+				) }
 				{ isDomainSSLProcessing && (
 					<div className="launchpad__domain-notification">
 						<div className="launchpad__domain-notification-icon">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -60,15 +60,14 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 		data: { site_intent: siteIntentOption, checklist_statuses: checklistStatuses },
 	} = useLaunchpad( siteSlug );
 
-	const showDomain =
-		! isStartWritingFlow( flow ) || checklistStatuses?.domain_upsell_deferred === true;
-
-	const { getDomainCartItem } = useSelect(
-		( select ) => ( {
-			getDomainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem,
-		} ),
+	const selectedDomain = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
 		[]
 	);
+
+	const showDomain =
+		! isStartWritingFlow( flow ) ||
+		( checklistStatuses?.domain_upsell_deferred === true && selectedDomain );
 
 	const {
 		data: { checklist: launchpadChecklist },
@@ -128,9 +127,9 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	}
 
 	function getDomainName() {
-		if ( getDomainCartItem() ) {
+		if ( selectedDomain ) {
 			return (
-				<span className="launchpad__url-box-top-level-domain">{ getDomainCartItem()?.meta }</span>
+				<span className="launchpad__url-box-top-level-domain">{ selectedDomain.domain_name }</span>
 			);
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -157,6 +157,18 @@ describe( 'Sidebar', () => {
 		expect( renderedDomain ).toBeVisible();
 	} );
 
+	it( 'start-writing flow does not display the current site url', () => {
+		renderSidebar( {
+			...props,
+			flow: 'start-writing',
+		} );
+
+		const renderedDomain = screen.queryByText( ( content ) =>
+			content.includes( secondAndTopLevelDomain )
+		);
+		expect( renderedDomain ).toBeNull();
+	} );
+
 	it( 'displays customize badge for wpcom domains (free)', () => {
 		renderSidebar( props );
 		expect( screen.getByRole( 'link', { name: upgradeDomainBadgeText } ) ).toHaveAttribute(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2335

## Proposed Changes

* This PR hides the domain name preview in the Launchpad sidebar for the start-writing onboarding flow, if the the domain selection task is incomplete.


https://user-images.githubusercontent.com/140841/236248626-80d38081-d2f9-4db9-9cbc-b3afa85fb469.mp4



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* On an account with 1 or 0 sites go to the launchpad http://calypso.localhost:3000/setup/start-writing/launchpad?siteSlug={slug}&start-writing=true
* The domain name div should not be visible.
* Select a domain using the Launchpad.
* The domain name div should now be visible
* Ensure this only happens in the start-writing flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
