### PR TITLE
Subscriptions Management: Create "Email me new comments" toggle for the Sites page (logged-in user)

### DIFF
--- a/client/landing/subscriptions/components/settings-popover/site-settings/email-me-new-comments-toggle.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/email-me-new-comments-toggle.tsx
@@ -1,0 +1,43 @@
+import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+
+// This is a fix to get around the fact that the original ToggleControl component doesn't support the disabled prop.
+// TODO: Remove this when the original ToggleControl component supports the disabled prop.
+const ToggleControl = OriginalToggleControl as React.ComponentType<
+	OriginalToggleControl.Props & {
+		disabled?: boolean;
+	}
+>;
+
+type EmailMeNewCommentsToggleProps = {
+	value: boolean;
+	isUpdating: boolean;
+	onChange: ( value: boolean ) => void;
+};
+
+const EmailMeNewCommentsToggle = ( {
+	value = false,
+	isUpdating = false,
+	onChange,
+}: EmailMeNewCommentsToggleProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<PopoverMenuItem
+			itemComponent="div"
+			focusOnHover={ false }
+			className="settings-popover__email-me-new-comments-item"
+		>
+			<ToggleControl
+				className="settings-popover__email-me-new-comments-toggle"
+				label={ translate( 'Email me new comments' ) }
+				onChange={ () => onChange( ! value ) }
+				checked={ value }
+				disabled={ isUpdating }
+			/>
+		</PopoverMenuItem>
+	);
+};
+
+export default EmailMeNewCommentsToggle;

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -18,6 +18,8 @@ type SiteSettingsProps = {
 	deliveryFrequency: SiteSubscriptionDeliveryFrequency;
 	onDeliveryFrequencyChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
 	emailMeNewComments: boolean;
+	onEmailMeNewCommentsChange: ( value: boolean ) => void;
+	updatingEmailMeNewComments: boolean;
 	onUnsubscribe: () => void;
 	unsubscribing: boolean;
 	updatingFrequency: boolean;
@@ -33,6 +35,8 @@ const SiteSettings = ( {
 	deliveryFrequency,
 	onDeliveryFrequencyChange,
 	emailMeNewComments,
+	onEmailMeNewCommentsChange,
+	updatingEmailMeNewComments,
 	onUnsubscribe,
 	unsubscribing,
 	updatingFrequency,
@@ -65,8 +69,8 @@ const SiteSettings = ( {
 			{ isLoggedIn && (
 				<EmailMeNewCommentsToggle
 					value={ emailMeNewComments }
-					onChange={ () => null }
-					isUpdating={ false }
+					onChange={ onEmailMeNewCommentsChange }
+					isUpdating={ updatingEmailMeNewComments }
 				/>
 			) }
 			<Separator />

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -17,6 +17,7 @@ type SiteSettingsProps = {
 	updatingEmailMeNewPosts: boolean;
 	deliveryFrequency: SiteSubscriptionDeliveryFrequency;
 	onDeliveryFrequencyChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
+	emailMeNewComments: boolean;
 	onUnsubscribe: () => void;
 	unsubscribing: boolean;
 	updatingFrequency: boolean;
@@ -31,6 +32,7 @@ const SiteSettings = ( {
 	updatingEmailMeNewPosts,
 	deliveryFrequency,
 	onDeliveryFrequencyChange,
+	emailMeNewComments,
 	onUnsubscribe,
 	unsubscribing,
 	updatingFrequency,
@@ -61,7 +63,11 @@ const SiteSettings = ( {
 				/>
 			) }
 			{ isLoggedIn && (
-				<EmailMeNewCommentsToggle value={ true } onChange={ () => null } isUpdating={ false } />
+				<EmailMeNewCommentsToggle
+					value={ emailMeNewComments }
+					onChange={ () => null }
+					isUpdating={ false }
+				/>
 			) }
 			<Separator />
 			<UnsubscribeSiteButton unsubscribing={ unsubscribing } onUnsubscribe={ onUnsubscribe } />

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -2,6 +2,7 @@ import { SubscriptionManager } from '@automattic/data-stores';
 import Separator from 'calypso/components/popover-menu/separator';
 import SettingsPopover from '../settings-popover';
 import DeliveryFrequencyInput from './delivery-frequency-input';
+import EmailMeNewCommentsToggle from './email-me-new-comments-toggle';
 import EmailMeNewPostsToggle from './email-me-new-posts-toggle';
 import NotifyMeOfNewPostsToggle from './notify-me-of-new-posts-toggle';
 import UnsubscribeSiteButton from './unsubscribe-site-button';
@@ -58,6 +59,9 @@ const SiteSettings = ( {
 					onChange={ onDeliveryFrequencyChange }
 					isUpdating={ updatingFrequency }
 				/>
+			) }
+			{ isLoggedIn && (
+				<EmailMeNewCommentsToggle value={ true } onChange={ () => null } isUpdating={ false } />
 			) }
 			<Separator />
 			<UnsubscribeSiteButton unsubscribing={ unsubscribing } onUnsubscribe={ onUnsubscribe } />

--- a/client/landing/subscriptions/components/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings-popover/styles.scss
@@ -1,5 +1,14 @@
 @import "@automattic/color-studio/dist/color-variables";
 
+%toggle-styles {
+	font-size: $font-body-small;
+
+	.components-form-toggle {
+		display: flex;
+		align-items: center;
+	}
+}
+
 .settings-popover {
 	outline: none;
 	min-width: 305px;
@@ -89,20 +98,20 @@
 		margin-bottom: 16px;
 	}
 
-	.settings-popover__email-me-new-posts-item {
+	.settings-popover__email-me-new-posts-item,
+	.settings-popover__email-me-new-comments-item {
 		padding-top: 0;
 		padding-bottom: 0;
 	}
 
 	.settings-popover__notify-me-of-new-posts-toggle,
 	.settings-popover__email-me-new-posts-toggle {
-		font-size: $font-body-small;
+		@extend %toggle-styles;
 		margin-bottom: 16px;
+	}
 
-		.components-form-toggle {
-			display: flex;
-			align-items: center;
-		}
+	.settings-popover__email-me-new-comments-toggle {
+		margin-bottom: 24px;
 	}
 
 	.settings-popover__popout-hint {

--- a/client/landing/subscriptions/components/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings-popover/styles.scss
@@ -111,6 +111,7 @@
 	}
 
 	.settings-popover__email-me-new-comments-toggle {
+		@extend %toggle-styles;
 		margin-bottom: 24px;
 	}
 

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -56,6 +56,12 @@ export default function SiteRow( {
 		() => delivery_methods?.email?.post_delivery_frequency as SiteSubscriptionDeliveryFrequency,
 		[ delivery_methods?.email?.post_delivery_frequency ]
 	);
+
+	const emailMeNewComments = useMemo(
+		() => delivery_methods?.email?.send_comments,
+		[ delivery_methods?.email?.send_comments ]
+	);
+
 	const newPostDelivery = useMemo( () => {
 		const emailDelivery = delivery_methods?.email?.send_posts ? translate( 'Email' ) : null;
 		const notificationDelivery = delivery_methods?.notification?.send_posts
@@ -126,6 +132,7 @@ export default function SiteRow( {
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )
 					}
 					updatingFrequency={ updatingFrequency }
+					emailMeNewComments={ emailMeNewComments }
 					onUnsubscribe={ () => unsubscribe( { blog_id: blog_ID } ) }
 					unsubscribing={ unsubscribing }
 				/>

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -81,6 +81,8 @@ export default function SiteRow( {
 		SubscriptionManager.useSiteEmailMeNewPostsMutation();
 	const { mutate: updateDeliveryFrequency, isLoading: updatingFrequency } =
 		SubscriptionManager.useSiteDeliveryFrequencyMutation();
+	const { mutate: updateEmailMeNewComments, isLoading: updatingEmailMeNewComments } =
+		SubscriptionManager.useSiteEmailMeNewCommentsMutation();
 	const { mutate: unsubscribe, isLoading: unsubscribing } =
 		SubscriptionManager.useSiteUnsubscribeMutation();
 
@@ -133,6 +135,10 @@ export default function SiteRow( {
 					}
 					updatingFrequency={ updatingFrequency }
 					emailMeNewComments={ emailMeNewComments }
+					onEmailMeNewCommentsChange={ ( send_comments ) =>
+						updateEmailMeNewComments( { blog_id: blog_ID, send_comments } )
+					}
+					updatingEmailMeNewComments={ updatingEmailMeNewComments }
 					onUnsubscribe={ () => unsubscribe( { blog_id: blog_ID } ) }
 					unsubscribing={ unsubscribing }
 				/>

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -10,6 +10,7 @@ import {
 	usePendingPostDeleteMutation,
 	useSiteNotifyMeOfNewPostsMutation,
 	useSiteEmailMeNewPostsMutation,
+	useSiteEmailMeNewCommentsMutation,
 } from './mutations';
 import {
 	PostSubscriptionsSortBy,
@@ -42,6 +43,7 @@ export const SubscriptionManager = {
 	usePendingPostDeleteMutation,
 	useSiteNotifyMeOfNewPostsMutation,
 	useSiteEmailMeNewPostsMutation,
+	useSiteEmailMeNewCommentsMutation,
 	useIsLoggedIn,
 };
 

--- a/packages/data-stores/src/reader/mutations/index.ts
+++ b/packages/data-stores/src/reader/mutations/index.ts
@@ -8,3 +8,4 @@ export { default as usePendingPostConfirmMutation } from './use-pending-post-con
 export { default as usePendingPostDeleteMutation } from './use-pending-post-delete-mutation';
 export { default as useSiteNotifyMeOfNewPostsMutation } from './use-site-notify-me-of-new-posts-mutation';
 export { default as useSiteEmailMeNewPostsMutation } from './use-site-email-me-new-posts-mutation';
+export { default as useSiteEmailMeNewCommentsMutation } from './use-site-email-me-new-comments-mutation';

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
@@ -1,0 +1,96 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { callApi } from '../helpers';
+import { useCacheKey, useIsLoggedIn } from '../hooks';
+import type { SiteSubscriptionsPages } from '../types';
+
+type SiteSubscriptionEmailMeNewCommentsParams = {
+	send_comments: boolean;
+	blog_id: number | string;
+};
+
+type SiteSubscriptionEmailMeNewCommentsResponse = {
+	success: boolean;
+	subscribed: boolean;
+};
+
+const useSiteEmailMeNewCommentsMutation = () => {
+	const { isLoggedIn } = useIsLoggedIn();
+	const queryClient = useQueryClient();
+
+	const siteSubscriptionsCacheKey = useCacheKey( [ 'read', 'site-subscriptions' ] );
+
+	return useMutation(
+		async ( params: SiteSubscriptionEmailMeNewCommentsParams ) => {
+			if ( ! params.blog_id || typeof params.send_comments !== 'boolean' ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while changing the "Email me new comments" setting.'
+				);
+			}
+
+			const action = params.send_comments ? 'new' : 'delete';
+
+			const response = await callApi< SiteSubscriptionEmailMeNewCommentsResponse >( {
+				path: `/read/site/${ params.blog_id }/comment_email_subscriptions/${ action }`,
+				method: 'POST',
+				body: {},
+				isLoggedIn,
+				apiVersion: '1.2',
+			} );
+			if ( ! response.success ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while changing the "Email me comments posts" setting.'
+				);
+			}
+
+			return response;
+		},
+		{
+			onMutate: async ( params ) => {
+				await queryClient.cancelQueries( siteSubscriptionsCacheKey );
+
+				const previousSiteSubscriptions =
+					queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
+
+				if ( previousSiteSubscriptions ) {
+					queryClient.setQueryData( siteSubscriptionsCacheKey, {
+						...previousSiteSubscriptions,
+						pages: previousSiteSubscriptions.pages.map( ( page ) => {
+							return {
+								...page,
+								subscriptions: page.subscriptions.map( ( siteSubscription ) => {
+									if ( siteSubscription.blog_ID === params.blog_id ) {
+										return {
+											...siteSubscription,
+											delivery_methods: {
+												...siteSubscription.delivery_methods,
+												email: {
+													...siteSubscription.delivery_methods?.email,
+													send_comments: params.send_comments,
+												},
+											},
+										};
+									}
+									return siteSubscription;
+								} ),
+							};
+						} ),
+					} );
+				}
+				return { previousSiteSubscriptions };
+			},
+
+			onError: ( err, params, context ) => {
+				if ( context?.previousSiteSubscriptions ) {
+					queryClient.setQueryData( siteSubscriptionsCacheKey, context.previousSiteSubscriptions );
+				}
+			},
+			onSettled: () => {
+				queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
+			},
+		}
+	);
+};
+
+export default useSiteEmailMeNewCommentsMutation;


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/76394.

## Proposed Changes

The proposed changes add the "Email me new posts" toggle with everything it needs to work properly. The toggle is displayed to logged-in users only:

![Markup on 2023-05-04 at 17:00:32](https://user-images.githubusercontent.com/25105483/236247733-bb2aa33d-3eba-4e70-8ac9-d4fbb137be77.png)

For the external user nothing changes:

![Markup on 2023-05-02 at 16:41:08](https://user-images.githubusercontent.com/25105483/235717648-d9d274ac-a972-4c5c-885d-d84ed08b349a.png)

Main changes in bulletpoints:

* create `EmailMeNewCommentsToggle` component
* create `useSiteEmailMeNewCommentsMutation` mutation
* create shared styles for toggles in Subscriptions Management

Design: inDLaEQV8jJ21O4WXawIsJ-fi-712_13475

ℹ️ The color of the toggle is blue (not black as in the design). The reason for this is that the toggle should respect user's color profile which our Subscriptions app doesn't support yet. I have created a separate task to address that issue: https://github.com/Automattic/wp-calypso/issues/76490.

## Testing Instructions

1. Check out the PR.
2. Navigate to `client/server/pages/index.js` and temporarily add `return next();` to the line `833`:

![Markup on 2023-04-28 at 17:50:44](https://user-images.githubusercontent.com/25105483/235195033-4902bb9d-db57-43a4-b295-2d90feb6731f.png)

3. Build the app.
4. Log in to a test WordPress.com account that has some Site subscriptions.
5. Navigate to http://calypso.localhost:3000/subscriptions/sites.
6. When you click on the "three dots" settings menu on any row, you should be able to switch the "Email me new comments" toggle.
7. The change should reflect to the same setting of the same site in the Reader at https://wordpress.com/following/manage.
8. Remove the temporary change that was introduced in the Step 2 and navigate to http://calypso.localhost:3000/subscriptions/sites as an **external** user (it is required to do the `subkey` dance 💃🏼🕺🏼 ).
9. The popup menu should work as expected - the "Email me new comments" toggle should not display.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
