### PR TITLE
Help Center: Update useLaunchpad hook

### DIFF
--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -43,7 +43,7 @@ type LaunchpadUpdateSettings = {
 
 export const fetchLaunchpad = (
 	siteSlug: string | null,
-	checklist_slug?: string | null
+	checklist_slug?: string | 0 | null | undefined
 ): Promise< LaunchpadResponse > => {
 	const slug = encodeURIComponent( siteSlug as string );
 	const requestUrl = checklist_slug
@@ -62,7 +62,10 @@ export const fetchLaunchpad = (
 		  } as APIFetchOptions );
 };
 
-export const useLaunchpad = ( siteSlug: string | null, checklist_slug?: string | null ) => {
+export const useLaunchpad = (
+	siteSlug: string | null,
+	checklist_slug?: string | 0 | null | undefined
+) => {
 	const key = [ 'launchpad', siteSlug, checklist_slug ];
 	return useQuery( key, () => fetchLaunchpad( siteSlug, checklist_slug ), {
 		retry: 3,

--- a/packages/help-center/src/components/help-center-launchpad.tsx
+++ b/packages/help-center/src/components/help-center-launchpad.tsx
@@ -2,13 +2,13 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { CircularProgressBar } from '@automattic/components';
+import { useLaunchpad } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useSelect } from '@wordpress/data';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { useLaunchpadChecklist } from '../hooks/use-launchpad-checklist';
 import { SITE_STORE } from '../stores';
 import type { SiteSelect } from '@automattic/data-stores';
 
@@ -44,7 +44,7 @@ export const HelpCenterLaunchpad = () => {
 		siteSlug = window?.location?.host;
 	}
 
-	const { data } = useLaunchpadChecklist( siteSlug, siteIntent || '' );
+	const { data } = useLaunchpad( siteSlug, siteIntent );
 	const totalLaunchpadSteps = data?.checklist?.length || 4;
 	const completeLaunchpadSteps =
 		data?.checklist?.filter( ( checklistItem ) => checklistItem.completed ).length || 1;


### PR DESCRIPTION
### Proposed Changes

This PR simply updates the Help Center > Launchpad icon component to use the new useLaunchpad hook from data stores. That hook, in turn, leverages our new Jetpack backend endpoint. Behavior should be the same as before, although given the improved backend code, the progress indicator on the Launchpad icons should now generally be correct. 

### Testing Instructions

You no longer need to sync a Jetpack branch to your sandbox.

1. Checkout this branch and run yarn and yarn start. This should build the help center package fresh for testing in addition to starting your local dev environment. Note that the relevant changes here are in a package. I sometimes needed to run `yarn build-packages` to force the help center package to rebuild with latest changes. 
3. You will need to create or test with a Launchpad enabled site. 
4. Go to http://calypso.localhost:3000/posts/YOURSITESLUG
4. TEST: Click on the help / question mark icon in the upper right icon. You should see the Launchpad icon. Historically, this has always rendered with the progress bar at 25% complete. It should now be dynamically based on the total and completed site steps. Once you've seen this once, consider navigating back to Launchpad, completing additional task(s), and then checking /posts/ again to see if the progress on the Help Center Launchpad icon has updated.