### PR TITLE
Launchpad: Remove unused task definitions

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -3,6 +3,15 @@ import { LaunchpadFlowTaskList, Task } from './types';
 
 export const DOMAIN_UPSELL = 'domain_upsell';
 
+/**
+ * Task definitions will soon be fetched through a WordPress REST API, making this file
+ * redundant. We're doing this because it will allow us to access checklist and task
+ * information outside of the Calypso client.
+ *
+ * Please DO NOT add any new tasks or checklists to this file. Instead, add it to the
+ * jetpack mu wpcom plugin.
+ */
+
 export const tasks: Task[] = [
 	{
 		id: 'plan_selected',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -1,21 +1,11 @@
-import { LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW, START_WRITING_FLOW } from '@automattic/onboarding';
+import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { LaunchpadFlowTaskList, Task } from './types';
 
 export const DOMAIN_UPSELL = 'domain_upsell';
 
 export const tasks: Task[] = [
 	{
-		id: 'setup_newsletter',
-		completed: true,
-		disabled: false,
-	},
-	{
 		id: 'plan_selected',
-		completed: true,
-		disabled: false,
-	},
-	{
-		id: 'subscribers_added',
 		completed: true,
 		disabled: false,
 	},
@@ -25,67 +15,7 @@ export const tasks: Task[] = [
 		disabled: false,
 	},
 	{
-		id: 'first_post_published_newsletter',
-		completed: false,
-		disabled: false,
-	},
-	{
-		id: 'design_selected',
-		completed: true,
-		disabled: true,
-	},
-	{
-		id: 'setup_link_in_bio',
-		completed: true,
-		disabled: false,
-	},
-	{
-		id: 'links_added',
-		completed: false,
-		disabled: false,
-	},
-	{
-		id: 'link_in_bio_launched',
-		completed: false,
-		disabled: true,
-	},
-	{
-		id: 'videopress_setup',
-		completed: true,
-		disabled: false,
-	},
-	{
-		id: 'videopress_upload',
-		completed: false,
-		disabled: false,
-	},
-	{
-		id: 'videopress_launched',
-		completed: false,
-		disabled: true,
-	},
-	{
-		id: 'setup_free',
-		completed: true,
-		disabled: false,
-	},
-	{
 		id: 'setup_blog',
-		completed: false,
-		disabled: false,
-	},
-	{
-		id: 'setup_general',
-		completed: true,
-		disabled: true,
-	},
-	{
-		id: 'design_edited',
-		completed: false,
-		disabled: false,
-	},
-	{
-		id: 'site_launched',
 		completed: false,
 		disabled: false,
 	},
@@ -95,57 +25,13 @@ export const tasks: Task[] = [
 		disabled: false,
 	},
 	{
-		id: 'setup_write',
-		completed: true,
-		disabled: true,
-	},
-	{
 		id: DOMAIN_UPSELL,
 		completed: false,
 		disabled: false,
 	},
-	{
-		id: 'verify_email',
-		completed: false,
-		disabled: true,
-	},
-];
-
-const linkInBioTaskList = [
-	'design_selected',
-	'setup_link_in_bio',
-	'plan_selected',
-	'links_added',
-	'link_in_bio_launched',
 ];
 
 export const launchpadFlowTasks: LaunchpadFlowTaskList = {
-	newsletter: [
-		'setup_newsletter',
-		'plan_selected',
-		'subscribers_added',
-		'verify_email',
-		'first_post_published_newsletter',
-	],
-	[ LINK_IN_BIO_FLOW ]: linkInBioTaskList,
-	[ LINK_IN_BIO_TLD_FLOW ]: linkInBioTaskList,
-	free: [
-		'setup_free',
-		'design_selected',
-		DOMAIN_UPSELL,
-		'first_post_published',
-		'design_edited',
-		'site_launched',
-	],
-	build: [
-		'setup_general',
-		'design_selected',
-		'first_post_published',
-		'design_edited',
-		'site_launched',
-	],
-	write: [ 'setup_write', 'design_selected', 'first_post_published', 'site_launched' ],
-	videopress: [ 'videopress_setup', 'plan_selected', 'videopress_upload', 'videopress_launched' ],
 	[ START_WRITING_FLOW ]: [
 		'first_post_published',
 		'setup_blog',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -1,8 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { getArrayOfFilteredTasks, getEnhancedTasks } from '../task-helper';
-import { tasks, launchpadFlowTasks } from '../tasks';
+import { getEnhancedTasks } from '../task-helper';
 import { buildTask } from './lib/fixtures';
 
 describe( 'Task Helpers', () => {
@@ -99,102 +98,6 @@ describe( 'Task Helpers', () => {
 					);
 					expect( enhancedTasks[ 0 ].disabled ).toEqual( true );
 				} );
-			} );
-		} );
-	} );
-
-	describe( 'getArrayOfFilteredTasks', () => {
-		describe( 'when the user has not verified their email address', () => {
-			const isEmailVerified = false;
-
-			describe( 'and no flow is provided', () => {
-				it( 'then no tasks are found', () => {
-					expect( getArrayOfFilteredTasks( tasks, null, isEmailVerified ) ).toBe( null );
-				} );
-			} );
-
-			describe( 'and a non-existing flow is provided', () => {
-				it( 'then no tasks are found', () => {
-					expect( getArrayOfFilteredTasks( tasks, 'custom-flow', isEmailVerified ) ).toBe(
-						undefined
-					);
-				} );
-			} );
-
-			describe( 'and an existing flow is provided', () => {
-				it( 'then it returns found tasks', () => {
-					expect(
-						getArrayOfFilteredTasks( tasks, 'newsletter', isEmailVerified )?.sort( ( a, b ) =>
-							a.id < b.id ? -1 : 1
-						)
-					).toEqual(
-						tasks
-							.sort( ( a, b ) => ( a.id < b.id ? -1 : 1 ) )
-							.filter( ( task ) => launchpadFlowTasks[ 'newsletter' ].includes( task.id ) )
-					);
-				} );
-			} );
-		} );
-
-		describe( 'when the user has verified their email address', () => {
-			const isEmailVerified = true;
-
-			describe( 'and an existing flow is provided', () => {
-				it( 'then it returns tasks without an email verified task', () => {
-					expect(
-						getArrayOfFilteredTasks( tasks, 'newsletter', isEmailVerified )?.sort( ( a, b ) =>
-							a.id < b.id ? -1 : 1
-						)
-					).toEqual(
-						tasks
-							.sort( ( a, b ) => ( a.id < b.id ? -1 : 1 ) )
-							.filter( ( task ) => {
-								if ( task.id === 'verify_email' ) {
-									return false;
-								}
-
-								return launchpadFlowTasks[ 'newsletter' ].includes( task.id );
-							} )
-					);
-				} );
-			} );
-		} );
-	} );
-
-	describe( 'domain upsell task', () => {
-		describe( 'when flow is newsletter', () => {
-			it( 'does not include upsell task', () => {
-				expect(
-					launchpadFlowTasks[ 'newsletter' ].filter( ( task ) => task === 'domain_upsell' ).length
-				).toBe( 0 );
-			} );
-		} );
-		describe( 'when flow is link-in-bio', () => {
-			it( 'does not include upsell task', () => {
-				expect(
-					launchpadFlowTasks[ 'link-in-bio' ].filter( ( task ) => task === 'domain_upsell' ).length
-				).toBe( 0 );
-			} );
-		} );
-		describe( 'when flow is write', () => {
-			it( 'does not include upsell task', () => {
-				expect(
-					launchpadFlowTasks[ 'write' ].filter( ( task ) => task === 'domain_upsell' ).length
-				).toBe( 0 );
-			} );
-		} );
-		describe( 'when flow is build', () => {
-			it( 'does not include upsell task', () => {
-				expect(
-					launchpadFlowTasks[ 'build' ].filter( ( task ) => task === 'domain_upsell' ).length
-				).toBe( 0 );
-			} );
-		} );
-		describe( 'when flow is free', () => {
-			it( 'does include upsell task', () => {
-				expect(
-					launchpadFlowTasks[ 'free' ].filter( ( task ) => task === 'domain_upsell' ).length
-				).toBe( 1 );
 			} );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/75504

## Proposed Changes

* Removes all unused launchpad task definitions

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this branch and run `yarn` and `yarn start` if needed. 
2. Start any new launchpad enabled site
   - Newsletter http://calypso.localhost:3000/setup/newsletter/intro 
   - Link-in-Bio http://calypso.localhost:3000/setup/link-in-bio/intro
   - VideoPress http://calypso.localhost:3000/setup/videopress/intro
   - Free http://calypso.localhost:3000/setup/free/intro
   - Build http://calypso.localhost:3000/start ( select `Other` as the site goal )
   - Write http://calypso.localhost:3000/start ( select `Write & Publish` as the site goal )
3. Navigate to the Launchpad by completing onboarding
4. Smoke test behavior of launchpad tasks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
