### PR TITLE
Newsletter: highlight personal plan instead of premium

### DIFF
--- a/client/my-sites/plan-features-2023-grid/hooks/use-highlight-adjacency-matrix.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-highlight-adjacency-matrix.ts
@@ -1,4 +1,4 @@
-import { isBusinessPlan, isPremiumPlan } from '@automattic/calypso-products';
+import { isBusinessPlan, isPersonalPlan, isPremiumPlan } from '@automattic/calypso-products';
 import { isNewsletterFlow } from '@automattic/onboarding';
 import { useSelector } from 'react-redux';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -21,7 +21,7 @@ const useHighlightIndices = ( visiblePlans: PlanProperties[], flowName: string )
 		let isHighlight = false;
 
 		if ( isNewsletterFlow( flowName ) ) {
-			isHighlight = isPremiumPlan( planName ) || currentPlan?.productSlug === planName;
+			isHighlight = isPersonalPlan( planName ) || currentPlan?.productSlug === planName;
 		} else {
 			isHighlight =
 				isBusinessPlan( planName ) ||

--- a/client/my-sites/plan-features-2023-grid/hooks/use-highlight-label.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-highlight-label.ts
@@ -1,4 +1,4 @@
-import { isBusinessPlan, isPremiumPlan } from '@automattic/calypso-products';
+import { isBusinessPlan, isPersonalPlan } from '@automattic/calypso-products';
 import { isNewsletterFlow } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
@@ -13,7 +13,7 @@ const useHighlightLabel = ( planName: string, flowName: string | null ) => {
 	const isCurrentPlan = currentPlan?.productSlug === planName;
 
 	if ( isNewsletterFlow( flowName ) ) {
-		if ( isPremiumPlan( planName ) ) {
+		if ( isPersonalPlan( planName ) ) {
 			return translate( 'Best for Newsletter' );
 		}
 	} else if ( isCurrentPlan ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to https://github.com/Automattic/wp-calypso/pull/75174 based on Slack convo p1683211735098789-slack-C052XEUUBL4 where we discussed to adjust some copy and recommended plan. Copy changes I'll do in another PR.

## Proposed Changes

* Switch to Personal plan as "recommended" for newsletters, instead of Premium plan

## Testing Instructions

* Go to `/setup/newsletter`
* At the plans step, note Personal plan getting recommended, and corners are neatly rounded everywhere.

Other on-boarding flows shouldn't get affected.

<img width="1559" alt="Screenshot 2023-05-05 at 12 50 48" src="https://user-images.githubusercontent.com/87168/236427752-22c7307c-5dca-4d41-bb6b-e82f6b38e3c9.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
