### PR TITLE
Launchpad: Add actions to paid newsletters tasks

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -9,7 +9,7 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 	const { id, completed, disabled, title, subtitle, actionDispatch, warning } = task;
 
 	// Display chevron if task is incomplete. Don't display chevron and badge at the same time.
-	const shouldDisplayChevron = ! completed && ! disabled && ! task.badgeText;
+	const shouldDisplayChevron = ! completed && ! disabled && ! task.badge_text;
 
 	const handlePrimaryAction = () => {
 		localStorage.removeItem( 'launchpad_siteSlug' );
@@ -67,7 +67,7 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 						<span className="launchpad__checklist-item-text">{ title }</span>
 						{ subtitle && <p className="launchpad__checklist-item-subtext">{ subtitle }</p> }
 					</div>
-					{ task.badgeText ? <Badge type="info-blue">{ task.badgeText }</Badge> : null }
+					{ task.badge_text ? <Badge type="info-blue">{ task.badge_text }</Badge> : null }
 					{ shouldDisplayChevron && (
 						<Gridicon
 							aria-label={ translate( 'Task enabled' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -391,7 +391,7 @@ export function getEnhancedTasks(
 					taskData = {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.open( `/earn/payments/${ siteSlug }#launchpad`, '_blank' );
+							window.location.assign( `/earn/payments/${ siteSlug }#launchpad` );
 						},
 					};
 					break;
@@ -399,9 +399,8 @@ export function getEnhancedTasks(
 					taskData = {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.open(
-								`/earn/payments-plans/${ siteSlug }?launchpad=add-product#add-newsletter-payment-plan`,
-								'_blank'
+							window.location.assign(
+								`/earn/payments-plans/${ siteSlug }?launchpad=add-product#add-newsletter-payment-plan`
 							);
 						},
 					};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -1,22 +1,16 @@
 import {
 	FEATURE_VIDEO_UPLOADS,
+	getPlan,
 	planHasFeature,
 	PLAN_PREMIUM,
 	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
+	Plan,
 } from '@automattic/calypso-products';
-import {
-	isFreeFlow,
-	isBuildFlow,
-	isWriteFlow,
-	isNewsletterFlow,
-	isStartWritingFlow,
-	START_WRITING_FLOW,
-} from '@automattic/onboarding';
+import { isNewsletterFlow, isStartWritingFlow, START_WRITING_FLOW } from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isVideoPressFlow } from 'calypso/signup/utils';
@@ -45,37 +39,33 @@ export function getEnhancedTasks(
 	checklistStatuses: LaunchpadStatuses = {},
 	planCartProductSlug?: string | null
 ) {
+	if ( ! tasks ) {
+		return [];
+	}
+
 	const enhancedTaskList: Task[] = [];
 
 	const productSlug =
 		( isStartWritingFlow( flow ) ? planCartProductSlug : null ) ?? site?.plan?.product_slug;
 
-	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
-
-	const linkInBioLinksEditCompleted =
-		site?.options?.launchpad_checklist_tasks_statuses?.links_edited || false;
-
-	const siteEditCompleted = site?.options?.launchpad_checklist_tasks_statuses?.site_edited || false;
+	const translatedPlanName = productSlug ? ( getPlan( productSlug ) as Plan ) : '';
 
 	// Todo: setupBlogCompleted should be updated to use a new checklistStatus instead of site_edited.
 	//  Explorers will update Jetpack definitions to make this possible, meanwhile we are using site_edited.
 	const setupBlogCompleted = checklistStatuses?.site_edited || false;
 
-	const siteLaunchCompleted =
-		site?.options?.launchpad_checklist_tasks_statuses?.site_launched || false;
-
-	const firstPostPublishedCompleted =
-		site?.options?.launchpad_checklist_tasks_statuses?.first_post_published || false;
-
-	const planCompleted = checklistStatuses.plan_completed || ! isStartWritingFlow( flow );
-
-	const videoPressUploadCompleted =
-		site?.options?.launchpad_checklist_tasks_statuses?.video_uploaded || false;
-
-	const allowUpdateDesign =
-		flow && ( isFreeFlow( flow ) || isBuildFlow( flow ) || isWriteFlow( flow ) );
-
 	const domainUpsellCompleted = isDomainUpsellCompleted( site, checklistStatuses );
+	const siteLaunchCompleted = Boolean(
+		tasks?.find( ( task ) => task.id === 'site_launched' )?.completed
+	);
+
+	const planCompleted =
+		Boolean( tasks?.find( ( task ) => task.id === 'site_launched' )?.completed ) ||
+		! isStartWritingFlow( flow );
+
+	const videoPressUploadCompleted = Boolean(
+		tasks?.find( ( task ) => task.id === 'video_uploaded' )?.completed
+	);
 
 	const mustVerifyEmailBeforePosting = isNewsletterFlow( flow || null ) && ! isEmailVerified;
 
@@ -87,20 +77,8 @@ export function getEnhancedTasks(
 				canvas: 'edit',
 		  } );
 
-	let planWarningText = displayGlobalStylesWarning
-		? translate(
-				'Your site contains custom colors that will only be visible once you upgrade to a Premium plan.'
-		  )
-		: '';
-
 	const isVideoPressFlowWithUnsupportedPlan =
 		isVideoPressFlow( flow ) && ! planHasFeature( productSlug as string, FEATURE_VIDEO_UPLOADS );
-
-	if ( isVideoPressFlowWithUnsupportedPlan ) {
-		planWarningText = translate(
-			'Upgrade to a plan with VideoPress support to upload your videos.'
-		);
-	}
 
 	const shouldDisplayWarning = displayGlobalStylesWarning || isVideoPressFlowWithUnsupportedPlan;
 
@@ -108,14 +86,8 @@ export function getEnhancedTasks(
 		tasks.map( ( task ) => {
 			let taskData = {};
 			switch ( task.id ) {
-				case 'setup_write':
-					taskData = {
-						title: translate( 'Set up your site' ),
-					};
-					break;
 				case 'setup_free':
 					taskData = {
-						title: translate( 'Personalize your site' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
@@ -143,7 +115,6 @@ export function getEnhancedTasks(
 					break;
 				case 'setup_newsletter':
 					taskData = {
-						title: translate( 'Personalize newsletter' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
@@ -154,17 +125,10 @@ export function getEnhancedTasks(
 						},
 					};
 					break;
-				case 'setup_general':
-					taskData = {
-						title: translate( 'Set up your site' ),
-					};
-					break;
 				case 'design_edited':
 					taskData = {
-						title: translate( 'Edit site design' ),
-						completed: siteEditCompleted,
 						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, siteEditCompleted, task.id );
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
 								addQueryArgs( `/site-editor/${ siteSlug }`, {
 									canvas: 'edit',
@@ -175,8 +139,6 @@ export function getEnhancedTasks(
 					break;
 				case 'plan_selected':
 					taskData = {
-						title: translate( 'Choose a plan' ),
-						subtitle: planWarningText,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							if ( displayGlobalStylesWarning ) {
@@ -200,7 +162,7 @@ export function getEnhancedTasks(
 
 							window.location.assign( plansUrl );
 						},
-						badgeText:
+						badge_text:
 							isVideoPressFlowWithUnsupportedPlan ||
 							( isStartWritingFlow( flow ) && ! planCompleted )
 								? null
@@ -212,7 +174,6 @@ export function getEnhancedTasks(
 					break;
 				case 'subscribers_added':
 					taskData = {
-						title: translate( 'Add subscribers' ),
 						actionDispatch: () => {
 							if ( goToStep ) {
 								recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -223,8 +184,6 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published':
 					taskData = {
-						title: translate( 'Write your first post' ),
-						completed: firstPostPublishedCompleted,
 						disabled: mustVerifyEmailBeforePosting || isStartWritingFlow( flow || null ) || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -234,8 +193,6 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published_newsletter':
 					taskData = {
-						title: translate( 'Start writing' ),
-						completed: firstPostPublishedCompleted,
 						disabled: mustVerifyEmailBeforePosting || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -245,8 +202,6 @@ export function getEnhancedTasks(
 					break;
 				case 'design_selected':
 					taskData = {
-						title: translate( 'Select a design' ),
-						disabled: ! allowUpdateDesign,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
@@ -260,7 +215,6 @@ export function getEnhancedTasks(
 					break;
 				case 'setup_link_in_bio':
 					taskData = {
-						title: translate( 'Personalize Link in Bio' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
@@ -273,10 +227,8 @@ export function getEnhancedTasks(
 					break;
 				case 'links_added':
 					taskData = {
-						title: translate( 'Add links' ),
-						completed: linkInBioLinksEditCompleted,
 						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, linkInBioLinksEditCompleted, task.id );
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
 								addQueryArgs( `/site-editor/${ siteSlug }`, {
 									canvas: 'edit',
@@ -287,9 +239,6 @@ export function getEnhancedTasks(
 					break;
 				case 'link_in_bio_launched':
 					taskData = {
-						title: translate( 'Launch your site' ),
-						completed: siteLaunchCompleted,
-						disabled: ! linkInBioLinksEditCompleted,
 						isLaunchTask: true,
 						actionDispatch: () => {
 							if ( site?.ID ) {
@@ -302,7 +251,7 @@ export function getEnhancedTasks(
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									recordTaskClickTracksEvent( flow, siteLaunchCompleted, task.id );
+									recordTaskClickTracksEvent( flow, task.completed, task.id );
 									return { goToHome: true, siteSlug };
 								} );
 
@@ -313,8 +262,6 @@ export function getEnhancedTasks(
 					break;
 				case 'site_launched':
 					taskData = {
-						title: translate( 'Launch your site' ),
-						completed: siteLaunchCompleted,
 						isLaunchTask: true,
 						actionDispatch: () => {
 							if ( site?.ID ) {
@@ -353,7 +300,7 @@ export function getEnhancedTasks(
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									recordTaskClickTracksEvent( flow, siteLaunchCompleted, task.id );
+									recordTaskClickTracksEvent( flow, task.completed, task.id );
 									return { blogLaunched: true, siteSlug };
 								} );
 
@@ -362,18 +309,9 @@ export function getEnhancedTasks(
 						},
 					};
 					break;
-				case 'videopress_setup':
-					taskData = {
-						completed: true,
-						disabled: true,
-						title: translate( 'Set up your video site' ),
-					};
-					break;
 				case 'videopress_upload':
 					taskData = {
-						title: translate( 'Upload your first video' ),
 						actionUrl: launchpadUploadVideoLink,
-						completed: videoPressUploadCompleted,
 						disabled: isVideoPressFlowWithUnsupportedPlan || videoPressUploadCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -383,9 +321,6 @@ export function getEnhancedTasks(
 					break;
 				case 'videopress_launched':
 					taskData = {
-						title: translate( 'Launch site' ),
-						completed: siteLaunchCompleted,
-						disabled: ! videoPressUploadCompleted,
 						actionDispatch: () => {
 							if ( site?.ID ) {
 								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );
@@ -411,8 +346,6 @@ export function getEnhancedTasks(
 					break;
 				case 'domain_upsell':
 					taskData = {
-						title: translate( 'Choose a domain' ),
-						completed: domainUpsellCompleted,
 						disabled:
 							isStartWritingFlow( flow ) && ( domainUpsellCompleted || ! setupBlogCompleted ),
 						actionDispatch: () => {
@@ -441,7 +374,7 @@ export function getEnhancedTasks(
 								  } );
 							window.location.assign( destinationUrl );
 						},
-						badgeText:
+						badge_text:
 							domainUpsellCompleted || isStartWritingFlow( flow || null )
 								? ''
 								: translate( 'Upgrade plan' ),
@@ -450,7 +383,6 @@ export function getEnhancedTasks(
 				case 'verify_email':
 					taskData = {
 						completed: isEmailVerified,
-						title: translate( 'Confirm email (check your inbox)' ),
 					};
 					break;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -395,7 +395,7 @@ export function getEnhancedTasks(
 						},
 					};
 					break;
-				case 'set_up_paid_newsletter':
+				case 'newsletter_plan_created':
 					taskData = {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -138,6 +138,7 @@ export function getEnhancedTasks(
 					break;
 				case 'plan_selected':
 					taskData = {
+						title: translate( 'Choose a plan' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							if ( displayGlobalStylesWarning ) {
@@ -346,6 +347,7 @@ export function getEnhancedTasks(
 					break;
 				case 'domain_upsell':
 					taskData = {
+						title: translate( 'Choose a domain' ),
 						disabled:
 							isStartWritingFlow( flow ) && ( domainUpsellCompleted || ! setupBlogCompleted ),
 						actionDispatch: () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -67,6 +67,8 @@ export function getEnhancedTasks(
 		tasks?.find( ( task ) => task.id === 'video_uploaded' )?.completed
 	);
 
+	const domainUpsellCompleted = isDomainUpsellCompleted( site );
+
 	const mustVerifyEmailBeforePosting = isNewsletterFlow( flow || null ) && ! isEmailVerified;
 
 	const homePageId = site?.options?.page_on_front;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -1,16 +1,15 @@
 import {
 	FEATURE_VIDEO_UPLOADS,
-	getPlan,
 	planHasFeature,
 	PLAN_PREMIUM,
 	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
-	Plan,
 } from '@automattic/calypso-products';
 import { isNewsletterFlow, isStartWritingFlow, START_WRITING_FLOW } from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
+import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isVideoPressFlow } from 'calypso/signup/utils';
@@ -48,7 +47,7 @@ export function getEnhancedTasks(
 	const productSlug =
 		( isStartWritingFlow( flow ) ? planCartProductSlug : null ) ?? site?.plan?.product_slug;
 
-	const translatedPlanName = productSlug ? ( getPlan( productSlug ) as Plan ) : '';
+	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
 
 	// Todo: setupBlogCompleted should be updated to use a new checklistStatus instead of site_edited.
 	//  Explorers will update Jetpack definitions to make this possible, meanwhile we are using site_edited.
@@ -66,8 +65,6 @@ export function getEnhancedTasks(
 	const videoPressUploadCompleted = Boolean(
 		tasks?.find( ( task ) => task.id === 'video_uploaded' )?.completed
 	);
-
-	const domainUpsellCompleted = isDomainUpsellCompleted( site );
 
 	const mustVerifyEmailBeforePosting = isNewsletterFlow( flow || null ) && ! isEmailVerified;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -387,6 +387,25 @@ export function getEnhancedTasks(
 						completed: isEmailVerified,
 					};
 					break;
+				case 'set_up_payments':
+					taskData = {
+						actionDispatch: () => {
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							window.open( `/earn/payments/${ siteSlug }#launchpad`, '_blank' );
+						},
+					};
+					break;
+				case 'set_up_paid_newsletter':
+					taskData = {
+						actionDispatch: () => {
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							window.open(
+								`/earn/payments-plans/${ siteSlug }?launchpad=add-product#add-newsletter-payment-plan`,
+								'_blank'
+							);
+						},
+					};
+					break;
 			}
 			enhancedTaskList.push( { ...task, ...taskData } );
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -184,6 +184,7 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published':
 					taskData = {
+						title: translate( 'Write your first post' ),
 						disabled: mustVerifyEmailBeforePosting || isStartWritingFlow( flow || null ) || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
@@ -9,9 +9,9 @@ import { buildTask } from './lib/fixtures';
 describe( 'ChecklistItem', () => {
 	describe( 'when the task requires a badge', () => {
 		it( 'displays a badge', () => {
-			const badgeText = 'Badge Text';
-			render( <ChecklistItem task={ buildTask( { badgeText } ) } /> );
-			expect( screen.getByText( badgeText ) ).toBeTruthy();
+			const badge_text = 'Badge Text';
+			render( <ChecklistItem task={ buildTask( { badge_text } ) } /> );
+			expect( screen.getByText( badge_text ) ).toBeTruthy();
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -9,6 +9,7 @@ import nock from 'nock';
 import React from 'react';
 import * as redux from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
+import { useLaunchpadChecklist } from 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist';
 import { createReduxStore } from 'calypso/state';
 import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
 import initialReducer from 'calypso/state/reducer';
@@ -32,31 +33,15 @@ jest.mock( '@automattic/data-stores', () => ( {
 } ) );
 
 jest.mock( 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist', () => ( {
-	useLaunchpadChecklist: ( siteSlug, siteIntentOption ) => {
-		let checklist = [
-			{ id: 'foo_task', completed: false, disabled: true, title: 'Foo Task' },
-			{ id: 'foo_task_1', completed: true, disabled: true, title: 'Foo Task' },
-		];
-
-		if ( siteIntentOption === 'free' ) {
-			checklist = [
+	useLaunchpadChecklist: jest.fn().mockReturnValue( {
+		data: {
+			checklist: [
 				{ id: 'foo_task', completed: false, disabled: true, title: 'Foo Task' },
-				{
-					id: 'domain_upsell',
-					completed: false,
-					disabled: false,
-					title: 'Choose a domain',
-					badge_text: 'Upgrade plan',
-				},
-				{ id: 'foo_task_1', completed: true, disabled: true, title: 'Foo Task 1' },
-			];
-		}
-
-		return {
-			data: { checklist },
-			isFetchedAfterMount: true,
-		};
-	},
+				{ id: 'foo_task_1', completed: true, disabled: true, title: 'Foo Task' },
+			],
+		},
+		isFetchedAfterMount: true,
+	} ),
 } ) );
 
 const siteName = 'testlinkinbio';
@@ -349,6 +334,23 @@ describe( 'Sidebar', () => {
 					},
 				} );
 
+				( useLaunchpadChecklist as jest.Mock ).mockReturnValueOnce( {
+					data: {
+						checklist: [
+							{ id: 'foo_task', completed: false, disabled: true, title: 'Foo Task' },
+							{
+								id: 'domain_upsell',
+								completed: false,
+								disabled: false,
+								title: 'Choose a domain',
+								badge_text: 'Upgrade plan',
+							},
+							{ id: 'foo_task_1', completed: true, disabled: true, title: 'Foo Task 1' },
+						],
+					},
+					isFetchedAfterMount: true,
+				} );
+
 				const siteDetails = buildSiteDetails( {
 					options: {
 						...defaultSiteDetails.options,
@@ -376,6 +378,23 @@ describe( 'Sidebar', () => {
 					data: {
 						site_intent: 'free',
 					},
+				} );
+
+				( useLaunchpadChecklist as jest.Mock ).mockReturnValueOnce( {
+					data: {
+						checklist: [
+							{ id: 'foo_task', completed: false, disabled: true, title: 'Foo Task' },
+							{
+								id: 'domain_upsell',
+								completed: false,
+								disabled: false,
+								title: 'Choose a domain',
+								badge_text: '',
+							},
+							{ id: 'foo_task_1', completed: true, disabled: true, title: 'Foo Task 1' },
+						],
+					},
+					isFetchedAfterMount: true,
 				} );
 
 				const siteDetails = buildSiteDetails( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -41,7 +41,13 @@ jest.mock( 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist', 
 		if ( siteIntentOption === 'free' ) {
 			checklist = [
 				{ id: 'foo_task', completed: false, disabled: true, title: 'Foo Task' },
-				{ id: 'domain_upsell', completed: false, disabled: false, title: 'Choose a domain' },
+				{
+					id: 'domain_upsell',
+					completed: false,
+					disabled: false,
+					title: 'Choose a domain',
+					badge_text: 'Upgrade plan',
+				},
 				{ id: 'foo_task_1', completed: true, disabled: true, title: 'Foo Task 1' },
 			];
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -193,7 +193,7 @@ describe( 'StepContent', () => {
 			expect( choosePlanListItem ).toHaveClass( 'completed' );
 			expect( addSubscribersListItem ).toHaveClass( 'completed' );
 			expect( confirmEmailListItem ).toHaveClass( 'pending' );
-			expect( firstPostListItem ).toHaveClass( 'pending' );
+			expect( firstPostListItem ).toHaveClass( 'completed' );
 		} );
 
 		it( 'renders skip to dashboard link', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -4,7 +4,7 @@ export interface Task {
 	disabled: boolean;
 	title?: string;
 	subtitle?: string;
-	badgeText?: string;
+	badge_text?: string;
 	actionDispatch?: () => void;
 	isLaunchTask?: boolean;
 	warning?: boolean;


### PR DESCRIPTION
Add Actions to these tasks:
<img width="252" alt="Screenshot 2023-05-04 at 17 49 15" src="https://user-images.githubusercontent.com/104869/236325915-1718ac66-9d7e-4db7-a7e4-9e34034abe57.png">

Based on top of https://github.com/Automattic/wp-calypso/pull/76467

# How to test
* Follow the instructions in https://github.com/Automattic/wp-calypso/pull/76467
* Visit the newsletter flow: http://calypso.localhost:3000/setup/newsletter/
* Select paid newsletters
* Check the Paid newsletter tasks in the launchpad step 
