### PR TITLE
Payments: Replace fallback with "tax (VAT/GST/CT)" for "Add VAT details"

### DIFF
--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -43,7 +43,7 @@ function BillingHistory() {
 
 	const genericTaxName =
 		/* translators: This is a generic name for taxes to use when we do not know the user's country. */
-		i18n.hasTranslation( 'tax (VAT/GST/CT)' );
+		translate( 'tax (VAT/GST/CT)' );
 	const fallbackTaxName =
 		getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax (VAT/GST/CT)' )
 			? genericTaxName

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { CompactCard, Card } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -41,15 +41,22 @@ function BillingHistory() {
 		translate
 	);
 
+	const genericTaxName =
+		/* translators: This is a generic name for taxes to use when we do not know the user's country. */
+		i18n.hasTranslation( 'tax (VAT/GST/CT)' );
+	const fallbackTaxName =
+		getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax (VAT/GST/CT)' )
+			? genericTaxName
+			: translate( 'VAT', { textOnly: true } );
 	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
 	const editVatText = translate( 'Edit %s details', {
 		textOnly: true,
-		args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
+		args: [ vendorInfo?.taxName ?? fallbackTaxName ],
 	} );
 	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
 	const addVatText = translate( 'Add %s details', {
 		textOnly: true,
-		args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
+		args: [ vendorInfo?.taxName ?? fallbackTaxName ],
 	} );
 	const vatText = vatDetails.id ? editVatText : addVatText;
 

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -155,7 +155,7 @@ export function vatDetails( context, next ) {
 		);
 		const genericTaxName =
 			/* translators: This is a generic name for taxes to use when we do not know the user's country. */
-			i18n.hasTranslation( 'tax (VAT/GST/CT)' );
+			translate( 'tax (VAT/GST/CT)' );
 		const fallbackTaxName =
 			getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax (VAT/GST/CT)' )
 				? genericTaxName

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
-import { localize, useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { Fragment, useCallback } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -153,10 +153,17 @@ export function vatDetails( context, next ) {
 			'now',
 			translate
 		);
+		const genericTaxName =
+			/* translators: This is a generic name for taxes to use when we do not know the user's country. */
+			i18n.hasTranslation( 'tax (VAT/GST/CT)' );
+		const fallbackTaxName =
+			getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax (VAT/GST/CT)' )
+				? genericTaxName
+				: translate( 'VAT', { textOnly: true } );
 		/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
 		const title = translate( 'Add %s details', {
 			textOnly: true,
-			args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
+			args: [ vendorInfo?.taxName ?? fallbackTaxName ],
 		} );
 
 		return (

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -1,5 +1,5 @@
 import { CompactCard, Button, Card } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
@@ -53,6 +53,19 @@ export default function VatInfoPage() {
 		);
 	}
 
+	const genericTaxName =
+		/* translators: This is a generic name for taxes to use when we do not know the user's country. */
+		i18n.hasTranslation( 'tax (VAT/GST/CT)' );
+	const fallbackTaxName =
+		getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax (VAT/GST/CT)' )
+			? genericTaxName
+			: translate( 'VAT', { textOnly: true } );
+	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+	const title = translate( 'Add %s details', {
+		textOnly: true,
+		args: [ vendorInfo?.taxName ?? fallbackTaxName ],
+	} );
+
 	return (
 		<Layout className={ isLoading ? 'vat-info is-loading' : 'vat-info' }>
 			<Column type="main">
@@ -69,13 +82,7 @@ export default function VatInfoPage() {
 			<Column type="sidebar">
 				<Card className="vat-info__sidebar-card">
 					<CardHeading tagName="h1" size={ 16 } isBold={ true } className="vat-info__sidebar-title">
-						{
-							/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-							translate( 'Add %s details', {
-								textOnly: true,
-								args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
-							} )
-						}
+						{ title }
 					</CardHeading>
 					<p className="vat-info__sidebar-paragraph">
 						{ translate(

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -55,7 +55,7 @@ export default function VatInfoPage() {
 
 	const genericTaxName =
 		/* translators: This is a generic name for taxes to use when we do not know the user's country. */
-		i18n.hasTranslation( 'tax (VAT/GST/CT)' );
+		translate( 'tax (VAT/GST/CT)' );
 	const fallbackTaxName =
 		getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax (VAT/GST/CT)' )
 			? genericTaxName

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -160,7 +160,7 @@ export function VatForm( {
 
 	const genericTaxName =
 		/* translators: This is a generic name for taxes to use when we do not know the user's country. */
-		i18n.hasTranslation( 'tax (VAT/GST/CT)' );
+		translate( 'tax (VAT/GST/CT)' );
 	const fallbackTaxName =
 		getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax (VAT/GST/CT)' )
 			? genericTaxName

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -1,7 +1,7 @@
 import { Field } from '@automattic/wpcom-checkout';
 import { CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -158,6 +158,19 @@ export function VatForm( {
 		reduxDispatch( recordTracksEvent( 'calypso_vat_details_support_click' ) );
 	};
 
+	const genericTaxName =
+		/* translators: This is a generic name for taxes to use when we do not know the user's country. */
+		i18n.hasTranslation( 'tax (VAT/GST/CT)' );
+	const fallbackTaxName =
+		getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax (VAT/GST/CT)' )
+			? genericTaxName
+			: translate( 'VAT', { textOnly: true } );
+	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+	const addVatText = translate( 'Add %s details', {
+		textOnly: true,
+		args: [ vendorInfo?.taxName ?? fallbackTaxName ],
+	} );
+
 	if ( ! isFormActive ) {
 		return (
 			<div className="vat-form__row">
@@ -165,13 +178,7 @@ export function VatForm( {
 					className="vat-form__expand-button"
 					checked={ isFormActive }
 					onChange={ toggleVatForm }
-					label={
-						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-						translate( 'Add %s details', {
-							textOnly: true,
-							args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
-						} )
-					}
+					label={ addVatText }
 					disabled={ isDisabled }
 				/>
 			</div>
@@ -185,13 +192,7 @@ export function VatForm( {
 					className="vat-form__expand-button"
 					checked={ isFormActive }
 					onChange={ toggleVatForm }
-					label={
-						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-						translate( 'Add %s details', {
-							textOnly: true,
-							args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
-						} )
-					}
+					label={ addVatText }
 					disabled={ isDisabled || Boolean( vatDetailsFromServer.id ) }
 				/>
 				{ countryCode === 'GB' && (


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/75044 we modified each mention of "VAT" in calypso checkout and payment management to use the local term for taxes in the user's selected (tax) country (eg: "CT" for Japan). However, there are cases where we do not know what the country should be. In that case, https://github.com/Automattic/wp-calypso/pull/75044 relies on the user's geolocation to determine which string to display, but this is imperfect since, for example, it's possible for a user that pays taxes in Japan to be using an IP address in the US.

In this PR we change the fallback text to be "tax (VAT/GST/CT)". For example, when you see the button to reach the VAT info page or view the title of the VAT info page when no country has been set, these will now read "Add tax (VAT/GST/CT) details" instead of "Add VAT details" (if you are in the US).

Since this is the fallback text, **this will have no effect if the user has a selected tax location or if they are geolocated in a country that has a tax acronym**.

Before (geolocated in the US since there is no acronym for taxes there):

<img width="965" alt="Screenshot 2023-05-04 at 5 17 29 PM" src="https://user-images.githubusercontent.com/2036909/236332163-c991fb01-f734-47be-8038-1549267e28ea.png">


<img width="984" alt="Screenshot 2023-05-02 at 1 36 34 PM" src="https://user-images.githubusercontent.com/2036909/235742172-f765434d-f776-4810-9362-48902d794edf.png">

After (geolocated in the US):

<img width="964" alt="Screenshot 2023-05-04 at 5 09 14 PM" src="https://user-images.githubusercontent.com/2036909/236331246-1fd474aa-2cb7-4691-b792-a0b74e996c64.png">

<img width="980" alt="Screenshot 2023-05-04 at 5 09 27 PM" src="https://user-images.githubusercontent.com/2036909/236331260-0571d724-2ffd-4454-ac28-0b36607f80f2.png">

Fixes https://github.com/Automattic/wp-calypso/issues/75445

## Testing Instructions

- Use an account set to English and geolocated in a country without a tax acronym (eg: the US). Also make sure the user does not have VAT details saved.
- Visit `/me/purchases/billing` and verify the button at the bottom of the page reads "Add tax (VAT/GST/CT) details".
- Click the button.
- Verify that the title of the page reads "Add tax (VAT/GST/CT) details".