### PR TITLE
Hide plan upsell when having monthly product in cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -311,6 +311,7 @@ export default function WPCheckout( {
 	}
 
 	const isDIFMInCart = hasDIFMProduct( responseCart );
+	const showUpsellMonthly = responseCart?.products?.some( isMonthlyProduct );
 
 	return (
 		<CheckoutStepGroup
@@ -336,7 +337,9 @@ export default function WPCheckout( {
 								onChangePlanLength={ changePlanLength }
 								nextDomainIsFree={ responseCart?.next_domain_is_free }
 							/>
-							{ ! isWcMobile && ! isDIFMInCart && <CheckoutSidebarPlanUpsell /> }
+							{ ! isWcMobile && ! isDIFMInCart && showUpsellMonthly && (
+								<CheckoutSidebarPlanUpsell />
+							) }
 							<SecondaryCartPromotions
 								responseCart={ responseCart }
 								addItemToCart={ addItemToCart }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -337,7 +337,7 @@ export default function WPCheckout( {
 								onChangePlanLength={ changePlanLength }
 								nextDomainIsFree={ responseCart?.next_domain_is_free }
 							/>
-							{ ! isWcMobile && ! isDIFMInCart && showUpsellMonthly && (
+							{ ! isWcMobile && ! isDIFMInCart && ! showUpsellMonthly && (
 								<CheckoutSidebarPlanUpsell />
 							) }
 							<SecondaryCartPromotions

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -311,7 +311,7 @@ export default function WPCheckout( {
 	}
 
 	const isDIFMInCart = hasDIFMProduct( responseCart );
-	const showUpsellMonthly = responseCart?.products?.some( isMonthlyProduct );
+	const hasMonthlyProduct = responseCart?.products?.some( isMonthlyProduct );
 
 	return (
 		<CheckoutStepGroup
@@ -337,7 +337,7 @@ export default function WPCheckout( {
 								onChangePlanLength={ changePlanLength }
 								nextDomainIsFree={ responseCart?.next_domain_is_free }
 							/>
-							{ ! isWcMobile && ! isDIFMInCart && ! showUpsellMonthly && (
+							{ ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct && (
 								<CheckoutSidebarPlanUpsell />
 							) }
 							<SecondaryCartPromotions


### PR DESCRIPTION
Related to [#](https://github.com/Automattic/payments-shilling/issues/1552)

## Proposed Changes

* Remove the upsell that appears on the right sidebar for monthly carts

## Testing Instructions

1. Add a monthly plan to the cart from the plans page http://calypso.localhost:3000/plans/monthly/{sitename}
2. On the checkout page we should see the upsell like this ![Gp0KiI.png](https://user-images.githubusercontent.com/552016/236534000-5dc3454b-abc1-45a7-baf4-2a0e07bcf4ec.png)

3. Apply the patch
4. Refresh the cart and now the upsell component should not be shown any more like this: ![9rwBsd.png](https://user-images.githubusercontent.com/552016/236534775-684f35d0-b28f-4f6e-a665-9c5cbeecf859.png)
5. For yearly plans, nothing should change.