### PR TITLE
Hosting site creation flow ends on /sites page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -298,6 +298,7 @@ function triggerPostRedirectNotices( {
 
 	reduxDispatch(
 		successNotice( translate( 'Your purchase has been completed!' ), {
+			id: 'checkout-thank-you-success',
 			displayOnNextPage: true,
 		} )
 	);

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -16,13 +16,13 @@ export function generateFlows( {
 	getDestinationFromIntent = noop,
 	getDIFMSignupDestination = noop,
 	getDIFMSiteContentCollectionDestination = noop,
-	getHomeDestination = noop,
+	getSitesDestination = noop,
 } = {} ) {
 	const flows = [
 		{
 			name: HOSTING_LP_FLOW,
 			steps: [ 'plans-hosting', 'user-hosting', 'domains' ],
-			destination: getHomeDestination,
+			destination: getSitesDestination,
 			description:
 				'Create an account and a blog and give the user the option of adding a domain and plan to the cart.',
 			lastModified: '2023-02-09',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -169,8 +169,8 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 	return `/home/${ siteSlug }`;
 }
 
-function getHomeDestination( { siteSlug } ) {
-	return `/home/${ siteSlug }`;
+function getSitesDestination( { siteSlug } ) {
+	return addQueryArgs( { 'new-site': siteSlug }, '/sites' );
 }
 
 const flows = generateFlows( {
@@ -186,7 +186,7 @@ const flows = generateFlows( {
 	getDestinationFromIntent,
 	getDIFMSignupDestination,
 	getDIFMSiteContentCollectionDestination,
-	getHomeDestination,
+	getSitesDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -18,6 +18,7 @@ export interface SitesDashboardQueryParams {
 	search?: string;
 	showHidden?: boolean;
 	status?: GroupableSiteLaunchStatuses;
+	newSiteSlug?: string;
 }
 
 const FilterBar = styled.div( {

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -14,6 +14,7 @@ import Pagination from 'calypso/components/pagination';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
+import { withoutHttp } from 'calypso/lib/url';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
 import { MEDIA_QUERIES } from '../utils';
@@ -334,9 +335,9 @@ function useShowSiteCreationNotice( allSites: SiteExcerptData[], newSiteSlug: st
 		dispatch(
 			successNotice(
 				createInterpolateElement(
-					/* translators: siteName is the display name of a newly created site */
-					sprintf( __( 'New site <strong>%(siteName)s</strong> created.' ), {
-						siteName: site.name,
+					/* translators: siteURL is the URL name of a newly created site, excluding the "http://" */
+					sprintf( __( 'New site <strong>%(siteURL)s</strong> created.' ), {
+						siteURL: withoutHttp( site.URL ),
 					} ),
 					{ strong: <strong /> }
 				),

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -3,15 +3,18 @@ import { Button, Gridicon, useScrollToTop, JetpackLogo } from '@automattic/compo
 import { createSitesListComponent } from '@automattic/sites';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import Pagination from 'calypso/components/pagination';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
+import { successNotice } from 'calypso/state/notices/actions';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
 import { MEDIA_QUERIES } from '../utils';
 import { NoSitesMessage } from './no-sites-message';
@@ -24,6 +27,7 @@ import { SitesDashboardOptInBanner } from './sites-dashboard-opt-in-banner';
 import { useSitesDisplayMode } from './sites-display-mode-switcher';
 import { SitesGrid } from './sites-grid';
 import { SitesTable } from './sites-table';
+import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 interface SitesDashboardProps {
 	queryParams: SitesDashboardQueryParams;
@@ -138,7 +142,7 @@ const ScrollButton = styled( Button, { shouldForwardProp: ( prop ) => prop !== '
 const SitesDashboardSitesList = createSitesListComponent();
 
 export function SitesDashboard( {
-	queryParams: { page = 1, perPage = 96, search, status = 'all' },
+	queryParams: { page = 1, perPage = 96, search, status = 'all', newSiteSlug },
 }: SitesDashboardProps ) {
 	const { __, _n } = useI18n();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
@@ -158,6 +162,8 @@ export function SitesDashboard( {
 		isBelowThreshold,
 		smoothScrolling: true,
 	} );
+
+	useShowSiteCreationNotice( allSites, newSiteSlug );
 
 	return (
 		<main>
@@ -306,4 +312,36 @@ export function SitesDashboard( {
 			</ScrollButton>
 		</main>
 	);
+}
+
+function useShowSiteCreationNotice( allSites: SiteExcerptData[], newSiteSlug: string | undefined ) {
+	const { __ } = useI18n();
+	const dispatch = useDispatch();
+	const shownSiteCreationNotice = useRef( false );
+
+	useEffect( () => {
+		if ( shownSiteCreationNotice.current || ! newSiteSlug ) {
+			return;
+		}
+
+		const site = allSites.find( ( { slug } ) => slug === newSiteSlug );
+		if ( ! site ) {
+			return;
+		}
+
+		shownSiteCreationNotice.current = true;
+
+		dispatch(
+			successNotice(
+				createInterpolateElement(
+					/* translators: siteName is the display name of a newly created site */
+					sprintf( __( 'New site <strong>%(siteName)s</strong> created.' ), {
+						siteName: site.name,
+					} ),
+					{ strong: <strong /> }
+				),
+				{ duration: 8000 }
+			)
+		);
+	}, [ __, allSites, dispatch, newSiteSlug ] );
 }

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -344,5 +344,10 @@ function useShowSiteCreationNotice( allSites: SiteExcerptData[], newSiteSlug: st
 				{ duration: 8000 }
 			)
 		);
+
+		// Remove query param without triggering a re-render
+		const newUrl = new URL( window.location.href );
+		newUrl.searchParams.delete( 'new-site' );
+		window.history.replaceState( null, '', newUrl.toString() );
 	}, [ __, allSites, dispatch, newSiteSlug ] );
 }

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -74,6 +74,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 						: undefined,
 					search: context.query.search,
 					status: context.query.status,
+					newSiteSlug: context.query[ 'new-site' ] || undefined,
 				} }
 			/>
 		</>

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -5,6 +5,7 @@ import {
 import { Global, css } from '@emotion/react';
 import { removeQueryArgs } from '@wordpress/url';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { removeNotice } from 'calypso/state/notices/actions';
 import { SitesDashboard } from './components/sites-dashboard';
 import { MEDIA_QUERIES } from './utils';
 import type { Context as PageJSContext } from 'page';
@@ -79,5 +80,14 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 			/>
 		</>
 	);
+	next();
+}
+
+export function maybeRemoveCheckoutSuccessNotice( context: PageJSContext, next: () => void ) {
+	if ( context.query[ 'new-site' ] ) {
+		// `?new-site` shows a site creation notice and we don't want to show a double notice,
+		// so hide the checkout success notice if it's there.
+		context.store.dispatch( removeNotice( 'checkout-thank-you-success' ) );
+	}
 	next();
 }

--- a/client/sites-dashboard/index.ts
+++ b/client/sites-dashboard/index.ts
@@ -1,7 +1,11 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { getSiteBySlug, getSiteHomeUrl } from 'calypso/state/sites/selectors';
-import { sanitizeQueryParameters, sitesDashboard } from './controller';
+import {
+	maybeRemoveCheckoutSuccessNotice,
+	sanitizeQueryParameters,
+	sitesDashboard,
+} from './controller';
 
 export default function () {
 	// Maintain old `/sites/:id` URLs by redirecting them to My Home
@@ -13,5 +17,12 @@ export default function () {
 		page.redirect( getSiteHomeUrl( state, siteId ) );
 	} );
 
-	page( '/sites', sanitizeQueryParameters, sitesDashboard, makeLayout, clientRender );
+	page(
+		'/sites',
+		maybeRemoveCheckoutSuccessNotice,
+		sanitizeQueryParameters,
+		sitesDashboard,
+		makeLayout,
+		clientRender
+	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2174

Supersedes #76346

Design discussion p1682990296072929-slack-C041RHH38NQ

## Proposed Changes

As discussed in https://github.com/Automattic/dotcom-forge/issues/2174, users going through the hosting onboarding flow should land on `/sites` after their site has been created.

This PR also adds a new success notification to the sites page which is controlled by the `?new-site` query param.
The purpose of this new banner is to prevent "change blindness" after landing on `/sites`, like forgetting what they've just done after going through the checkout process.

![CleanShot 2023-05-05 at 10 59 28@2x](https://user-images.githubusercontent.com/1500769/236347830-82332d03-d6b6-4b80-bdbd-c7bfe5895374.png)

![CleanShot 2023-05-05 at 10 58 55@2x](https://user-images.githubusercontent.com/1500769/236347835-a3e37f57-7e5c-4c29-b375-42e6b67051de.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a new user using `/start/hosting`
   - The user should land on `/sites` after their first site is created
   - You should see the success banner (there's also one for a successful payment)
- Create a new user using `/start` to check nothing has changed
   -The user should land on `/home` after their first site is created

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?