### PR TITLE
Remove Autobots as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -147,12 +147,4 @@
 /packages/wpcom.js/src/lib/domains.js @Automattic/nomado
 
 #Plans
-/client/signup/steps/plans @Automattic/martech-autobots
-/client/lib/plans @Automattic/martech-autobots
-/client/my-sites/plan-features-comparison @Automattic/martech-autobots
-/client/my-sites/plan-features @Automattic/martech-autobots
-/client/my-sites/plans-comparison @Automattic/martech-autobots
-/client/my-sites/plans-features-main @Automattic/martech-autobots
-/client/my-sites/plan-price @Automattic/martech-autobots
-/packages/calypso-products/src/plans-list.tsx @Automattic/martech-autobots
 /client/my-sites/plan-features-2023-grid @Automattic/martech-decepticons


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The Autobots were added as code owners to plan pages paths back when we were actively working on these pages and running several experiments. It helped pre-empt conflicts that other teams might introduce to our experiments. It appears that right now, watching these paths is not very useful as we are not (yet) working on Calypso plan pages as our primary focus. Moreover, the Decepticons are already watching over (as code owners) any changes made to the 2023 pricing grid paths.

I'm removing Autobots as code owners for now, and we can later revisit to be more intentional about which paths we want to oversee. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify code, ensure that Autobots are removed as code owners from all paths.

