### PR TITLE
Cleanup retired price anchor test

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -171,7 +171,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					plansWithScroll={ isDesktop }
 					planTypes={ planTypes }
 					flowName={ flowName }
-					showTreatmentPlansReorderTest={ false }
 					isAllPaidPlansShown={ true }
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					shouldShowPlansFeatureComparison={ isDesktop } // Show feature comparison layout in signup flow and desktop resolutions

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -831,8 +831,6 @@ export function createAccount(
 
 		const marketing_price_group = response?.marketing_price_group ?? '';
 
-		const plans_reorder_abtest_variation = response?.plans_reorder_abtest_variation ?? '';
-
 		// Fire tracking events, but only after a _new_ user registers.
 		if ( newAccountCreated ) {
 			recordRegistration( {
@@ -845,7 +843,6 @@ export function createAccount(
 		const providedDependencies = {
 			username,
 			marketing_price_group,
-			plans_reorder_abtest_variation,
 			...bearerToken,
 		};
 

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -2,7 +2,6 @@ import { URL } from '../../types';
 
 export type UserMetaData = {
 	links: Record< 'self' | 'help' | 'site' | 'flags', URL >;
-	plans_reorder_abtest_variation?: string;
 	data?: {
 		flags: {
 			active_flags: string[];

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -37,7 +37,6 @@ import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import P2PlansMain from 'calypso/my-sites/plans/p2-plans-main';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
-import { isTreatmentPlansReorderTest } from 'calypso/state/marketing/selectors';
 import { getPlanSlug } from 'calypso/state/plans/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -278,7 +277,6 @@ class Plans extends Component {
 				discountEndDate={ this.props.discountEndDate }
 				site={ selectedSite }
 				plansWithScroll={ false }
-				showTreatmentPlansReorderTest={ this.props.showTreatmentPlansReorderTest }
 				hidePlansFeatureComparison={ this.props.isDomainAndPlanPackageFlow }
 				is2023PricingGridVisible={ is2023PricingGridVisible }
 			/>
@@ -469,7 +467,6 @@ const ConnectedPlans = connect( ( state, props ) => {
 		canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 		isWPForTeamsSite: isSiteWPForTeams( state, selectedSiteId ),
 		isSiteEligibleForMonthlyPlan: isEligibleForWpComMonthlyPlan( state, selectedSiteId ),
-		showTreatmentPlansReorderTest: isTreatmentPlansReorderTest( state ),
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
 		is2023PricingGridVisible:
 			props.is2023PricingGridVisible ?? is2023PricingGridActivePage( window ),

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -131,14 +131,8 @@ export function generateSteps( {
 			stepName: 'user',
 			apiRequestFunction: createAccount,
 			providesToken: true,
-			providesDependencies: [
-				'bearer_token',
-				'username',
-				'marketing_price_group',
-				'plans_reorder_abtest_variation',
-				'redirect',
-			],
-			optionalDependencies: [ 'plans_reorder_abtest_variation', 'redirect' ],
+			providesDependencies: [ 'bearer_token', 'username', 'marketing_price_group', 'redirect' ],
+			optionalDependencies: [ 'redirect' ],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 			},
@@ -148,14 +142,8 @@ export function generateSteps( {
 			stepName: 'user-hosting',
 			apiRequestFunction: createAccount,
 			providesToken: true,
-			providesDependencies: [
-				'bearer_token',
-				'username',
-				'marketing_price_group',
-				'plans_reorder_abtest_variation',
-				'redirect',
-			],
-			optionalDependencies: [ 'plans_reorder_abtest_variation', 'redirect' ],
+			providesDependencies: [ 'bearer_token', 'username', 'marketing_price_group', 'redirect' ],
+			optionalDependencies: [ 'redirect' ],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 				isPasswordless: true,
@@ -173,14 +161,12 @@ export function generateSteps( {
 				'bearer_token',
 				'username',
 				'marketing_price_group',
-				'plans_reorder_abtest_variation',
 				'allowUnauthenticated',
 			],
 			optionalDependencies: [
 				'bearer_token',
 				'username',
 				'marketing_price_group',
-				'plans_reorder_abtest_variation',
 				'allowUnauthenticated',
 			],
 			props: {
@@ -489,9 +475,7 @@ export function generateSteps( {
 				'oauth2_client_id',
 				'oauth2_redirect',
 				'marketing_price_group',
-				'plans_reorder_abtest_variation',
 			],
-			optionalDependencies: [ 'plans_reorder_abtest_variation' ],
 		},
 
 		'oauth2-name': {
@@ -504,9 +488,7 @@ export function generateSteps( {
 				'oauth2_client_id',
 				'oauth2_redirect',
 				'marketing_price_group',
-				'plans_reorder_abtest_variation',
 			],
-			optionalDependencies: [ 'plans_reorder_abtest_variation' ],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 				oauth2Signup: true,

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -24,7 +24,6 @@ import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { ExperimentalIntervalTypeToggle } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { isTreatmentPlansReorderTest } from 'calypso/state/marketing/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getPlanSlug } from 'calypso/state/plans/selectors';
 import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
@@ -102,7 +101,6 @@ export class PlansStep extends Component {
 			selectedSite,
 			planTypes,
 			flowName,
-			showTreatmentPlansReorderTest,
 			isInVerticalScrollingPlansExperiment,
 			isReskinned,
 			eligibleForProPlan,
@@ -176,7 +174,6 @@ export class PlansStep extends Component {
 								plansWithScroll={ this.state.isDesktop }
 								planTypes={ planTypes }
 								flowName={ flowName }
-								showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
 								isAllPaidPlansShown={ true }
 								isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 								shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
@@ -386,7 +383,6 @@ PlansStep.propTypes = {
 	translate: PropTypes.func.isRequired,
 	planTypes: PropTypes.array,
 	flowName: PropTypes.string,
-	isTreatmentPlansReorderTest: PropTypes.bool,
 };
 
 /**
@@ -406,10 +402,7 @@ export const isDotBlogDomainRegistration = ( domainItem ) => {
 };
 
 export default connect(
-	(
-		state,
-		{ path, signupDependencies: { siteSlug, domainItem, plans_reorder_abtest_variation } }
-	) => ( {
+	( state, { path, signupDependencies: { siteSlug, domainItem } } ) => ( {
 		// Blogger plan is only available if user chose either a free domain or a .blog domain registration
 		disableBloggerPlanWithNonBlogDomain:
 			domainItem && ! isSubdomain( domainItem.meta ) && ! isDotBlogDomainRegistration( domainItem ),
@@ -419,8 +412,6 @@ export default connect(
 		selectedSite: siteSlug ? getSiteBySlug( state, siteSlug ) : null,
 		customerType: parseQs( path.split( '?' ).pop() ).customerType,
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
-		showTreatmentPlansReorderTest:
-			'treatment' === plans_reorder_abtest_variation || isTreatmentPlansReorderTest( state ),
 		isLoadingExperiment: false,
 		// IMPORTANT NOTE: The following is always set to true. It's a hack to resolve the bug reported
 		// in https://github.com/Automattic/wp-calypso/issues/50896, till a proper cleanup and deploy of

--- a/client/state/marketing/selectors.ts
+++ b/client/state/marketing/selectors.ts
@@ -1,4 +1,3 @@
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import type { AppState } from 'calypso/types';
 import 'calypso/state/marketing/init';
 
@@ -8,10 +7,6 @@ export interface JetpackSaleCoupon {
 	expiry_date: string;
 	sale_title: string;
 	final_discount: number;
-}
-
-export function isTreatmentPlansReorderTest( state: AppState ): boolean {
-	return 'treatment' === getCurrentUser( state )?.meta?.plans_reorder_abtest_variation;
 }
 
 export function getJetpackSaleCoupon( state: AppState ): JetpackSaleCoupon | null {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Removes the experiment code added in #48358, since this test has been retired. The experiment props were just passed to components and not used anywhere. This will increase the readability of the plans-related components.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Search the code-base for references of the deleted variables, and confirm that there is no leftover usage.
* E2E tests should cover this, but try a few affected flows: `/start`, `/plans/<site slug>`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
