### PR TITLE
Fix social previews build error

### DIFF
--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.0.0-beta.0",
+	"version": "2.0.0-beta.2",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
@@ -31,6 +31,7 @@
 		"dist",
 		"src"
 	],
+	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
@@ -43,7 +44,8 @@
 		"@wordpress/components": "^22.1.0",
 		"@wordpress/i18n": "^4.22.0",
 		"classnames": "^2.3.1",
-		"prop-types": "^15.7.2"
+		"prop-types": "^15.7.2",
+		"tslib": "^2.3.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-build": "workspace:^",

--- a/packages/social-previews/src/facebook-preview/index.tsx
+++ b/packages/social-previews/src/facebook-preview/index.tsx
@@ -9,7 +9,7 @@ import type { FacebookPreviewProps } from './types';
 
 import './style.scss';
 
-const FacebookPreview: React.FC< FacebookPreviewProps > = ( props ) => {
+export const FacebookPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 	const { customImage } = props;
 	const isPostPreview = !! customImage;
 
@@ -57,5 +57,3 @@ const FacebookPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 		</div>
 	);
 };
-
-export default FacebookPreview;

--- a/packages/social-previews/src/facebook-preview/post/header/index.tsx
+++ b/packages/social-previews/src/facebook-preview/post/header/index.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useCallback, useState } from 'react';
 import FacebookPostIcon from '../icons';
 import defaultAvatar from './default-avatar.png';
@@ -38,10 +38,17 @@ const FacebookPostHeader: React.FC< Props > = ( { user, timeElapsed, hideOptions
 					<div className="facebook-preview__post-header-share">
 						<span className="facebook-preview__post-header-time">
 							{ timeElapsed
-								? // translators: short version of `1 hour`
-								  __( '1h', 'facebook-preview' )
-								: // translators: temporal indication of when a post was published
-								  __( 'Just now', 'facebook-preview' ) }
+								? __(
+										// translators: short version of `1 hour`
+										'1h',
+										'facebook-preview'
+								  )
+								: _x(
+										// translators: temporal indication of when a post was published
+										'Just now',
+										'',
+										'facebook-preview'
+								  ) }
 						</span>
 						<span className="facebook-preview__post-header-dot" aria-hidden="true">
 							·

--- a/packages/social-previews/src/index.ts
+++ b/packages/social-previews/src/index.ts
@@ -1,4 +1,4 @@
-export { default as FacebookPreview } from './facebook-preview';
+export * from './facebook-preview';
 export * from './google-search-preview';
 export * from './twitter-preview';
 export * from './linkedin-preview';

--- a/packages/social-previews/tsconfig.json
+++ b/packages/social-previews/tsconfig.json
@@ -2,8 +2,8 @@
 	"extends": "@automattic/calypso-typescript-config/ts-package.json",
 	"include": [ "src", "types.d.ts" ],
 	"compilerOptions": {
-		"allowJs": true,
 		"outDir": "dist/esm",
+		"declarationDir": "dist/types",
 		"rootDir": "src"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1463,6 +1463,7 @@ __metadata:
     prop-types: ^15.7.2
     react: ^17.0.2
     react-dom: ^17.0.2
+    tslib: ^2.3.0
     typescript: ^4.7.4
     webpack: ^5.68.0
   peerDependencies:


### PR DESCRIPTION
Folling #76581, this PR fixes the build errors in `social-previews` package and prepares for another beta release.

## Proposed Changes

* Fix translation minification error caused in Jetpack plugin, see p1683198038274859-slack-CBG1CP4EN

## Testing Instructions

Same as #76581

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?