### PR TITLE
Update loading of Pricing Plans block configuration

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/index.php
+++ b/apps/happy-blocks/block-library/pricing-plans/index.php
@@ -10,11 +10,12 @@
 /**
  * Load the necessary config data.
  *
+ * @param string $handle The handle of the script to add the config data to.
  * @return void
  */
-function happyblocks_pricing_plans_enqueue_config_data() {
+function happyblocks_pricing_plans_enqueue_config_data( $handle ) {
 	wp_add_inline_script(
-		'happy-blocks-pricing-plans-editor-script',
+		$handle,
 		sprintf(
 			'window.A8C_HAPPY_BLOCKS_CONFIG = %s;
 			window.configData ||= {
@@ -27,8 +28,19 @@ function happyblocks_pricing_plans_enqueue_config_data() {
 		'before'
 	);
 }
-add_action( 'enqueue_block_editor_assets', 'happyblocks_pricing_plans_enqueue_config_data' );
-add_action( 'wp_enqueue_scripts', 'happyblocks_pricing_plans_enqueue_config_data' );
+
+/**
+ * Include the necessary config data for both, the editor and the view of the block.
+ *
+ * @return void
+ */
+function happyblocks_pricing_plans_enqueue_config_data_for_handle() {
+	happyblocks_pricing_plans_enqueue_config_data( 'happy-blocks-pricing-plans-view-script' );
+	happyblocks_pricing_plans_enqueue_config_data( 'happy-blocks-pricing-plans-editor-script' );
+}
+
+add_action( 'enqueue_block_editor_assets', 'happyblocks_pricing_plans_enqueue_config_data_for_handle' );
+add_action( 'wp_enqueue_scripts', 'happyblocks_pricing_plans_enqueue_config_data_for_handle' );
 
 /**
  * Decide if the current logged in user is the topic author.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/76579

## Proposed Changes

This PR is a continuation of the work done in https://github.com/Automattic/wp-calypso/pull/76579. This change updates the loading of the configuration so that it is also loaded in the "view" of the block and not just in the editor.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync these changes with `yarn dev --sync`
* Ensure you can insert the Commerce block (and it reads like that) by typing in the editor `/` and then `upgrade`
* Ensure once the block is inserted and rendered it shows 'Commerce' as the plan name/header in the block.
* Submit the post and ensure when the block is rendered in the view it also shows as "Commerce" instead of "eCommerce"



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
