### PR TITLE
Blog onboarding: Disable edit overlay in launchpad preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -7,6 +7,7 @@ import {
 	WRITE_FLOW,
 	isNewsletterFlow,
 	START_WRITING_FLOW,
+	isStartWritingFlow,
 } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -17,6 +18,23 @@ import { isVideoPressFlow } from 'calypso/signup/utils';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import PreviewToolbar from '../design-setup/preview-toolbar';
 import type { Device } from '@automattic/components';
+
+/**
+ * Determines whether the edit overlay should be enabled for a given flow.
+ *
+ * @function
+ * @param {string | null} flow - The flow identifier or null.
+ * @returns {boolean} - Returns true if the edit overlay should be enabled, otherwise returns false.
+ */
+export const getEnableEditOverlay = ( flow: string | null ) => {
+	if ( isNewsletterFlow( flow ) ) {
+		return false;
+	}
+	if ( isStartWritingFlow( flow ) ) {
+		return false;
+	}
+	return true;
+};
 
 const LaunchpadSitePreview = ( {
 	siteSlug,
@@ -29,7 +47,7 @@ const LaunchpadSitePreview = ( {
 	const site = useSite();
 	const { globalStylesInUse } = usePremiumGlobalStyles( site?.ID );
 	const isInVideoPressFlow = isVideoPressFlow( flow );
-	const enableEditOverlay = ! isNewsletterFlow( flow );
+	const enableEditOverlay = getEnableEditOverlay( flow );
 
 	let previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const devicesToShow: Device[] = [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.PHONE ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/launchpad-site-preview.tsx
@@ -1,0 +1,20 @@
+import { NEWSLETTER_FLOW, START_WRITING_FLOW } from '@automattic/onboarding';
+import { getEnableEditOverlay } from '../launchpad-site-preview';
+
+describe( 'getEnableEditOverlay', () => {
+	test( 'should return false if flow is a newsletter flow', () => {
+		const flow = NEWSLETTER_FLOW;
+		expect( getEnableEditOverlay( flow ) ).toBe( false );
+	} );
+
+	test( 'should return false if flow is a start writing flow', () => {
+		const flow = START_WRITING_FLOW;
+		expect( getEnableEditOverlay( flow ) ).toBe( false );
+	} );
+
+	test( 'default return true if flow is not specified or null', () => {
+		const flow = 'nonexistent-flow';
+		expect( getEnableEditOverlay( null ) ).toBe( true );
+		expect( getEnableEditOverlay( flow ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2356

## Proposed Changes

* Created a util function for `getEnableEditOverlay`
* Added tests for `getEnableEditOverlay`
* Disable edit overlay in launchpad preview 

Before

https://user-images.githubusercontent.com/6586048/236394358-78731786-2fef-4ca5-bce0-d81d6eadf4a2.mp4

After

https://user-images.githubusercontent.com/6586048/236394046-09051a73-1835-461c-9f73-e7f011d78c50.mp4


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through /setup/start-writing
* Check the launchpad screen and make sure it's the same as the After video above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
