### PR TITLE
Experiment: Hide free if paid domain is selected

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -13,6 +13,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
 import { getTld, isSubdomain } from 'calypso/lib/domains';
+import { ProvideExperimentData } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { buildUpgradeFunction } from 'calypso/lib/signup/step-actions';
 import wp from 'calypso/lib/wp';
@@ -151,34 +152,48 @@ export class PlansStep extends Component {
 			);
 		}
 
+		const domainName = getDomainName( this.props.signupDependencies.domainItem );
+
 		return (
 			<div>
 				{ errorDisplay }
-				<PlansFeaturesMain
-					site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
-					showFAQ={ this.state.isDesktop }
-					hideFreePlan={ hideFreePlan }
-					hideEcommercePlan={ this.shouldHideEcommercePlan() }
-					isInSignup={ true }
-					isLaunchPage={ isLaunchPage }
-					intervalType={ intervalType }
-					onUpgradeClick={ ( cartItem ) => this.onSelectPlan( cartItem ) }
-					domainName={ getDomainName( this.props.signupDependencies.domainItem ) }
-					customerType={ this.getCustomerType() }
-					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-					plansWithScroll={ this.state.isDesktop }
-					planTypes={ planTypes }
-					flowName={ flowName }
-					showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
-					isAllPaidPlansShown={ true }
-					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
-					shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
-					isReskinned={ isReskinned }
-					hidePremiumPlan={ this.props.hidePremiumPlan }
-					hidePersonalPlan={ this.props.hidePersonalPlan }
-					hideEnterprisePlan={ this.props.hideEnterprisePlan }
-					replacePaidDomainWithFreeDomain={ this.replacePaidDomainWithFreeDomain }
-				/>
+				<ProvideExperimentData
+					name="calypso_wpcom_onboarding_plans_hide_free_202305"
+					options={ { isEligible: 'onboarding' === flowName && !! domainName } }
+				>
+					{ ( isLoading, experimentAssignment ) => {
+						if ( isLoading ) {
+							return this.renderLoading();
+						}
+						return (
+							<PlansFeaturesMain
+								site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+								showFAQ={ this.state.isDesktop }
+								hideFreePlan={ hideFreePlan || 'treatment' === experimentAssignment?.variationName }
+								hideEcommercePlan={ this.shouldHideEcommercePlan() }
+								isInSignup={ true }
+								isLaunchPage={ isLaunchPage }
+								intervalType={ intervalType }
+								onUpgradeClick={ ( cartItem ) => this.onSelectPlan( cartItem ) }
+								domainName={ domainName }
+								customerType={ this.getCustomerType() }
+								disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+								plansWithScroll={ this.state.isDesktop }
+								planTypes={ planTypes }
+								flowName={ flowName }
+								showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
+								isAllPaidPlansShown={ true }
+								isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
+								shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
+								isReskinned={ isReskinned }
+								hidePremiumPlan={ this.props.hidePremiumPlan }
+								hidePersonalPlan={ this.props.hidePersonalPlan }
+								hideEnterprisePlan={ this.props.hideEnterprisePlan }
+								replacePaidDomainWithFreeDomain={ this.replacePaidDomainWithFreeDomain }
+							/>
+						);
+					} }
+				</ProvideExperimentData>
 			</div>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbxNRc-2xh-p2, Automattic/martech#1716

## Proposed Changes

* Sets the `hideFreePlan` prop to true for the treatment variation of the experiment. See the linked post above for more details.

| Control | Treatment |
|--------|--------|
|![image](https://user-images.githubusercontent.com/5436027/236400960-761558f6-4dac-4bf6-b694-f4b370671483.png)| ![image](https://user-images.githubusercontent.com/5436027/236400991-e12af546-bf00-419a-bd26-4c4281480992.png) |

Code review tip: Use the "Hide whitespace" option for an easier review.
<img width="538" alt="image" src="https://user-images.githubusercontent.com/5436027/236398448-5e8536b3-4005-4b3c-8ad1-b8d946d3cfe8.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Abacus link: 21190-explat-experiment

#### Onboarding Flow: Control + Paid Domain
* Assign yourself to the control variant. 
* Go to `/start` and select a paid domain.
* On the plans step, confirm that the free plan is visible.

#### Onboarding Flow: Control + Free Domain
* Assign yourself to the control variant. 
* Go to `/start` and select a free domain.
* On the plans step, confirm that the free plan is visible.

#### Onboarding Flow: Treatment + Paid Domain
* Assign yourself to the treatment variant. 
* Go to `/start` and select a paid domain.
* On the plans step, confirm that the free plan is **not** visible.

#### Onboarding Flow: Treatment + Free Domain
* Assign yourself to the treatment variant. 
* Go to `/start` and select a free domain.
* On the plans step, confirm that the free plan is visible.

* Also test a few other signup flows like `/start/hosting`, `/start/onboarding-pm`, etc to confirm that they work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?