### PR TITLE
Theme Showcase: Use mShots for first-party themes

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -1,6 +1,11 @@
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { Card, Button, Gridicon } from '@automattic/components';
-import { PremiumBadge, ThemeCard, WooCommerceBundledBadge } from '@automattic/design-picker';
+import {
+	DesignPreviewImage,
+	PremiumBadge,
+	ThemeCard,
+	WooCommerceBundledBadge,
+} from '@automattic/design-picker';
 import { Button as LinkButton } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -95,6 +100,7 @@ export class Theme extends Component {
 		isUpdated: PropTypes.bool,
 		errorOnUpdate: PropTypes.bool,
 		softLaunched: PropTypes.bool,
+		selectedStyleVariation: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -154,8 +160,9 @@ export class Theme extends Component {
 	}
 
 	renderScreenshot() {
-		const { index, theme } = this.props;
+		const { isExternallyManagedTheme, selectedStyleVariation, theme } = this.props;
 		const { description, screenshot } = theme;
+
 		if ( ! screenshot ) {
 			return (
 				<div className="theme__no-screenshot">
@@ -164,12 +171,25 @@ export class Theme extends Component {
 			);
 		}
 
+		// mShots don't work well with SSR, since it shows a placeholder image by default
+		// the snapshot request is completed.
+		//
+		// With that in mind, we only use mShots for non-default style variations to ensure
+		// that there is no flash of image transition from static image to mShots on page load.
+		if ( !! selectedStyleVariation && ! isExternallyManagedTheme ) {
+			const { id: themeId, stylesheet } = theme;
+
+			return (
+				<DesignPreviewImage
+					design={ { slug: themeId, recipe: { stylesheet } } }
+					styleVariation={ selectedStyleVariation }
+				/>
+			);
+		}
+
 		const fit = '479,360';
 		const themeImgSrc = photon( screenshot, { fit } ) || screenshot;
 		const themeImgSrcDoubleDpi = photon( screenshot, { fit, zoom: 2 } ) || screenshot;
-
-		// for performance testing
-		const screenshotID = index === 0 ? 'theme__firstscreenshot' : null;
 
 		return (
 			<img
@@ -177,7 +197,6 @@ export class Theme extends Component {
 				className="theme__img"
 				src={ themeImgSrc }
 				srcSet={ `${ themeImgSrcDoubleDpi } 2x` }
-				id={ screenshotID }
 			/>
 		);
 	}
@@ -519,8 +538,7 @@ export class Theme extends Component {
 	};
 
 	renderMoreButton = () => {
-		const { active, buttonContents, index, theme, onMoreButtonClick, onMoreButtonItemClick } =
-			this.props;
+		const { active, buttonContents, index, theme } = this.props;
 		if ( isEmpty( buttonContents ) ) {
 			return null;
 		}
@@ -531,15 +549,15 @@ export class Theme extends Component {
 				themeId={ theme.id }
 				themeName={ theme.name }
 				active={ active }
-				onMoreButtonClick={ onMoreButtonClick }
-				onMoreButtonItemClick={ onMoreButtonItemClick }
+				onMoreButtonClick={ this.props.onMoreButtonClick }
+				onMoreButtonItemClick={ this.props.onMoreButtonItemClick }
 				options={ buttonContents }
 			/>
 		);
 	};
 
 	render() {
-		const { theme } = this.props;
+		const { selectedStyleVariation, theme } = this.props;
 		const { name, description, style_variations = [] } = theme;
 		const themeDescription = decodeEntities( description );
 
@@ -558,6 +576,7 @@ export class Theme extends Component {
 				banner={ this.renderUpdateAlert() }
 				badge={ this.renderPricingBadge() }
 				styleVariations={ style_variations }
+				selectedStyleVariation={ selectedStyleVariation }
 				optionsMenu={ this.renderMoreButton() }
 				isActive={ this.props.active }
 				isInstalling={ this.props.installing }

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -192,9 +192,12 @@ ThemesList.defaultProps = {
 
 function ThemeBlock( props ) {
 	const { theme, index } = props;
+	const [ selectedStyleVariation, setSelectedStyleVariation ] = useState( null );
+
 	if ( isEmpty( theme ) ) {
 		return null;
 	}
+
 	// Decide if we should pass ref for bookmark.
 	const { themesBookmark, siteId } = props;
 	const bookmarkRef = themesBookmark === theme.id ? props.bookmarkRef : null;
@@ -202,10 +205,13 @@ function ThemeBlock( props ) {
 	return (
 		<Theme
 			key={ 'theme-' + theme.id }
-			buttonContents={ props.getButtonOptions( theme.id ) }
-			screenshotClickUrl={ props.getScreenshotUrl && props.getScreenshotUrl( theme.id ) }
+			buttonContents={ props.getButtonOptions( theme.id, selectedStyleVariation ) }
+			screenshotClickUrl={ props.getScreenshotUrl?.( theme.id, selectedStyleVariation ) }
 			onScreenshotClick={ props.onScreenshotClick }
-			onStyleVariationClick={ props.onStyleVariationClick }
+			onStyleVariationClick={ ( themeId, themeIndex, variation ) => {
+				setSelectedStyleVariation( variation );
+				props.onStyleVariationClick?.( themeId, themeIndex, variation );
+			} }
 			onMoreButtonClick={ props.onMoreButtonClick }
 			onMoreButtonItemClick={ props.onMoreButtonItemClick }
 			actionLabel={ props.getActionLabel( theme.id ) }
@@ -218,6 +224,7 @@ function ThemeBlock( props ) {
 			bookmarkRef={ bookmarkRef }
 			siteId={ siteId }
 			softLaunched={ theme.soft_launched }
+			selectedStyleVariation={ selectedStyleVariation }
 		/>
 	);
 }

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -69,6 +69,31 @@ export function localizeThemesPath( path, locale, isLoggedOut = true ) {
 	return path;
 }
 
+export function addStyleVariation( options, styleVariation, isLoggedIn ) {
+	return mapValues( options, ( option ) =>
+		Object.assign( {}, option, {
+			...( option.getUrl && {
+				getUrl: ( t ) =>
+					isLoggedIn
+						? option.getUrl( t, styleVariation )
+						: option.getUrl( t, null, styleVariation ),
+			} ),
+		} )
+	);
+}
+
+export function appendStyleVariationToThemesPath( path, styleVariation ) {
+	if ( ! styleVariation ) {
+		return path;
+	}
+
+	const [ base, query ] = path.split( '?' );
+	const params = new URLSearchParams( query );
+	params.set( 'style_variation', styleVariation.slug );
+
+	return `${ base }?${ params.toString() }`;
+}
+
 /**
  * Creates the billing product slug for a given theme ID.
  *

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -38,7 +38,13 @@ import {
 } from 'calypso/state/themes/selectors';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
 import EligibilityWarningModal from './atomic-transfer-dialog';
-import { addTracking, getSubjectsFromTermTable, trackClick, localizeThemesPath } from './helpers';
+import {
+	addTracking,
+	appendStyleVariationToThemesPath,
+	getSubjectsFromTermTable,
+	trackClick,
+	localizeThemesPath,
+} from './helpers';
 import InstallThemeButton from './install-theme-button';
 import ThemePreview from './theme-preview';
 import ThemesHeader from './themes-header';
@@ -453,13 +459,16 @@ class ThemeShowcase extends Component {
 			secondaryOption: this.props.secondaryOption,
 			placeholderCount: this.props.placeholderCount,
 			bookmarkRef: this.bookmarkRef,
-			getScreenshotUrl: ( theme ) => {
+			getScreenshotUrl: ( theme, styleVariation ) => {
 				if ( ! getScreenshotOption( theme ).getUrl ) {
 					return null;
 				}
 
 				return localizeThemesPath(
-					getScreenshotOption( theme ).getUrl( theme ),
+					appendStyleVariationToThemesPath(
+						getScreenshotOption( theme ).getUrl( theme ),
+						styleVariation
+					),
 					locale,
 					! isLoggedIn
 				);

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -25,7 +25,7 @@ import {
 	isInstallingTheme,
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
-import { trackClick } from './helpers';
+import { addStyleVariation, trackClick } from './helpers';
 import SearchThemesTracks from './search-themes-tracks';
 import './themes-selection.scss';
 
@@ -136,18 +136,8 @@ class ThemesSelection extends Component {
 				'calypso_themeshowcase_theme_style_variation_more_click',
 				tracksProps
 			);
-		}
 
-		const url = this.props.getThemeDetailsUrl( themeId );
-		if ( url ) {
-			const [ urlBase, urlQuery ] = url.split( '?' );
-			const params = new URLSearchParams( urlQuery );
-			if ( variation ) {
-				params.set( 'style_variation', variation.slug );
-			}
-
-			const paramsString = params.toString().length ? `?${ params.toString() }` : '';
-			pageRouter( `${ urlBase }${ paramsString }` );
+			pageRouter( this.props.getThemeDetailsUrl( themeId ) );
 		}
 	};
 
@@ -183,7 +173,7 @@ class ThemesSelection extends Component {
 
 	//intercept preview and add primary and secondary
 	getOptions = ( themeId, styleVariation, context ) => {
-		const options = this.props.getOptions( themeId );
+		let options = this.props.getOptions( themeId, styleVariation );
 		const wrappedPreviewAction = ( action ) => {
 			let defaultOption;
 			let secondaryOption = this.props.secondaryOption;
@@ -212,13 +202,21 @@ class ThemesSelection extends Component {
 				} else {
 					defaultOption = options.activate;
 				}
-				this.props.setThemePreviewOptions( themeId, defaultOption, secondaryOption, null );
+				this.props.setThemePreviewOptions(
+					themeId,
+					defaultOption,
+					secondaryOption,
+					styleVariation
+				);
 				return action( t, context );
 			};
 		};
 
-		if ( options && options.preview ) {
-			options.preview.action = wrappedPreviewAction( options.preview.action );
+		if ( options ) {
+			options = addStyleVariation( options, styleVariation, this.props.isLoggedIn );
+			if ( options.preview ) {
+				options.preview.action = wrappedPreviewAction( options.preview.action );
+			}
 		}
 
 		return options;

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -5,7 +5,10 @@ export { default as BadgeContainer } from './components/badge-container';
 export { default as StyleVariationBadges } from './components/style-variation-badges';
 export { default as ThemeCard } from './components/theme-card';
 export { default as ThemePreview } from './components/theme-preview';
-export { default as UnifiedDesignPicker } from './components/unified-design-picker';
+export {
+	default as UnifiedDesignPicker,
+	DesignPreviewImage,
+} from './components/unified-design-picker';
 export { default as WooCommerceBundledBadge } from './components/woocommerce-bundled-badge';
 export { default as PatternAssemblerCta } from './components/pattern-assembler-cta';
 export {


### PR DESCRIPTION
## Proposed Changes

This PR proposes to update the Theme Showcase to use mShots for first-party themes. This allows the Theme Showcase to align with the Onboarding Design Picker in two ways:

1. Use mShots to display theme thumbnails for style variations. Currently, the Theme Showcase uses a pre-defined image.
2. Change the theme thumbnails when a style variation is selected. Currently, the Theme Showcase opens the Theme Detail page when a style variation is selected.

https://github.com/Automattic/wp-calypso/assets/797888/a882bc73-2c3f-46bd-8bce-5a6f9caf5f22

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Find a theme with style variations, such as Storia.
* Ensure that the theme thumbnails change according to the selected style variation, as described above.
* Ensure that clicking the theme thumbnail lands users to the Theme Detail page, with the style variation preselected.
* Ensure that theme options, such as Live Demo, also have the selected style variation applied.
* Also test in the logged-out Theme Showcase.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
