### PR TITLE
Fix reader search redirect

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -698,7 +698,7 @@ function wpcomPages( app ) {
 
 	// redirect logged-out searches to en.search.wordpress.com
 	app.get( '/read/search', function ( req, res, next ) {
-		if ( ! req.context.isLoggedIn ) {
+		if ( ! req.context.isLoggedIn && calypsoEnv !== 'development' ) {
 			res.redirect( 'https://en.search.wordpress.com/?q=' + encodeURIComponent( req.query.q ) );
 		} else {
 			next();


### PR DESCRIPTION
This PR fixes a bug in Reader search where the search page redirects to https://en.search.wordpress.com when the page is redirected. This only happens in development. This PR adds a check to skip the redirect when in development, i.e calypso.localhost:3000/read/search

### Bug in Action

https://user-images.githubusercontent.com/5560595/236440330-c0a3bad6-e155-47ab-8e34-d24e03211805.mov

### Test
* Pull PR
* `yarn && yarn start`
* Go to Reader search and confirm you can refresh a search query without redirect