### PR TITLE
Jetpack Pro Dashboard: Implement UI to add email addresses to downtime monitor notification settings

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/add-new-email-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/add-new-email-modal.tsx
@@ -1,0 +1,119 @@
+import { Button } from '@automattic/components';
+import { Modal } from '@wordpress/components';
+import emailValidator from 'email-validator';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+
+export default function AddNewEmailModal( { toggleModal }: { toggleModal: () => void } ) {
+	const translate = useTranslate();
+
+	const [ showCodeVerification, setShowCodeVerification ] = useState< boolean >( false );
+	const [ validationError, setValidationError ] = useState< string >( '' );
+
+	function onSave( event: React.FormEvent< HTMLFormElement > ) {
+		event.preventDefault();
+		setValidationError( '' );
+		const { name, email, code } = (
+			event.target as typeof event.target & {
+				elements: { name: HTMLInputElement; email: HTMLInputElement; code?: HTMLInputElement };
+			}
+		 ).elements;
+		if ( ! name.value ) {
+			return setValidationError( translate( 'Please enter a name.' ) );
+		}
+		if ( ! email.value ) {
+			return setValidationError( translate( 'Please enter an email address.' ) );
+		}
+		if ( ! emailValidator.validate( email.value ) ) {
+			return setValidationError( translate( 'Please enter a valid email address.' ) );
+		}
+		if ( showCodeVerification ) {
+			if ( ! code?.value ) {
+				return setValidationError( translate( 'Please enter the verification code.' ) );
+			}
+			// TODO: verify email address with code
+		} else {
+			setShowCodeVerification( true );
+			// TODO: implement sending verification code
+		}
+	}
+
+	function handleResendCode() {
+		// TODO: implement resending verification code
+	}
+
+	return (
+		<Modal
+			open={ true }
+			onRequestClose={ toggleModal }
+			title={ translate( 'Add your email address' ) }
+			className="notification-settings__modal"
+		>
+			<div className="notification-settings__sub-title">
+				{ translate( 'Please use only your number or one you have access to. ' ) }
+			</div>
+
+			<form className="configure-email-notification__form" onSubmit={ onSave }>
+				<FormFieldset>
+					<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
+					<FormTextInput id="name" name="name" disabled={ showCodeVerification } />
+					<div className="configure-email-notification__help-text">
+						{ translate( 'Give this email a nickname for your personal reference' ) }
+					</div>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel htmlFor="email">{ translate( 'Email' ) }</FormLabel>
+					<FormTextInput id="email" name="email" disabled={ showCodeVerification } />
+					<div className="configure-email-notification__help-text">
+						{ translate( 'We’ll send a code to verify your email address.' ) }
+					</div>
+				</FormFieldset>
+
+				{ showCodeVerification && (
+					<FormFieldset>
+						<FormLabel htmlFor="code">
+							{ translate( 'Please enter the code you received via email' ) }
+						</FormLabel>
+						<FormTextInput id="code" name="code" />
+						<div className="configure-email-notification__help-text">
+							{ translate(
+								'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
+								{
+									components: {
+										button: (
+											<Button
+												className="configure-email-notification__resend-code-button"
+												borderless
+												onClick={ handleResendCode }
+												aria-label={ translate( 'Resend Code' ) }
+											/>
+										),
+									},
+								}
+							) }
+						</div>
+					</FormFieldset>
+				) }
+				<div className="notification-settings__footer">
+					{ validationError && (
+						<div className="notification-settings__footer-validation-error">
+							{ validationError }
+						</div>
+					) }
+					<div className="notification-settings__footer-buttons">
+						<Button onClick={ toggleModal } aria-label={ translate( 'Cancel' ) }>
+							{ showCodeVerification ? translate( 'Later' ) : translate( 'Cancel' ) }
+						</Button>
+						<Button disabled={ false } type="submit" primary aria-label={ translate( 'Verify' ) }>
+							{ translate( 'Verify' ) }
+						</Button>
+					</div>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -1,5 +1,7 @@
-import { Card } from '@automattic/components';
+import { Card, Button } from '@automattic/components';
 import { CheckboxControl } from '@wordpress/components';
+import { Icon, plus } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 
 import './style.scss';
@@ -11,9 +13,15 @@ interface EmailItem {
 }
 interface Props {
 	defaultEmailAddresses: Array< string >;
+	toggleModal: () => void;
 }
 
-export default function ConfigureEmailNotification( { defaultEmailAddresses = [] }: Props ) {
+export default function ConfigureEmailNotification( {
+	defaultEmailAddresses = [],
+	toggleModal,
+}: Props ) {
+	const translate = useTranslate();
+
 	const [ allEmailItems, setAllEmailItems ] = useState< EmailItem[] >( [] );
 
 	useEffect( () => {
@@ -43,7 +51,7 @@ export default function ConfigureEmailNotification( { defaultEmailAddresses = []
 	);
 
 	return (
-		<>
+		<div className="configure-email-address__card-container">
 			{ allEmailItems.map( ( item ) => (
 				<Card className="configure-email-address__card" key={ item.email } compact>
 					<CheckboxControl
@@ -54,6 +62,15 @@ export default function ConfigureEmailNotification( { defaultEmailAddresses = []
 					/>
 				</Card>
 			) ) }
-		</>
+			<Button
+				compact
+				className="configure-email-address__button"
+				onClick={ toggleModal }
+				aria-label={ translate( 'Add email address' ) }
+			>
+				<Icon size={ 18 } icon={ plus } />
+				{ translate( 'Add email address' ) }
+			</Button>
+		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
@@ -1,5 +1,11 @@
-.configure-email-address__card {
+$help-text-color: #757575;
+
+.configure-email-address__card-container {
 	margin: 16px 0 0;
+}
+
+.configure-email-address__card {
+	margin: 0;
 	height: 60px;
 	display: flex;
 	align-items: center;
@@ -39,4 +45,33 @@
 	font-size: 0.75rem;
 	line-height: 18px;
 	color: var(--studio-gray-50);
+}
+
+button.configure-email-address__button {
+	margin-block-start: 16px;
+	border-radius: 20px; /* stylelint-disable-line scales/radii */
+	color: var(--studio-gray-80) !important;
+	display: flex;
+	align-items: center;
+	width: fit-content;
+	border-color: var(--studio-gray-80);
+	padding: 4px 8px !important;
+}
+
+.configure-email-notification__help-text {
+	font-weight: 400;
+	font-size: 0.75rem;
+	line-height: 15px;
+	color: var(--studio-gray-40);
+}
+
+.configure-email-notification__form {
+	margin-block-start: 24px;
+}
+
+.configure-email-notification__resend-code-button {
+	@extend .configure-email-notification__help-text;
+	padding: 0;
+	color: var(--studio-green-50) !important;
+	text-decoration: underline;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -12,6 +12,7 @@ import {
 	mobileAppLink,
 } from '../../sites-overview/utils';
 import ConfigureEmailNotification from '../configure-email-notification';
+import AddNewEmailModal from '../configure-email-notification/add-new-email-modal';
 import type { MonitorSettings, Site } from '../../sites-overview/types';
 
 import './style.scss';
@@ -45,7 +46,13 @@ export default function NotificationSettings( {
 		defaultDuration
 	);
 	const [ addedEmailAddresses, setAddedEmailAddresses ] = useState< string[] | [] >( [] );
+
 	const [ validationError, setValidationError ] = useState< string >( '' );
+	const [ isAddEmailModalOpen, setIsAddEmailModalOpen ] = useState< boolean >( false );
+
+	const toggleAddEmailModal = () => {
+		setIsAddEmailModalOpen( ( isAddEmailModalOpen ) => ! isAddEmailModalOpen );
+	};
 
 	function onSave( event: React.FormEvent< HTMLFormElement > ) {
 		event.preventDefault();
@@ -104,6 +111,10 @@ export default function NotificationSettings( {
 	const isMultipleEmailEnabled = isEnabled(
 		'jetpack/pro-dashboard-monitor-multiple-email-recipients'
 	);
+
+	if ( isAddEmailModalOpen ) {
+		return <AddNewEmailModal toggleModal={ toggleAddEmailModal } />;
+	}
 
 	return (
 		<Modal
@@ -198,7 +209,10 @@ export default function NotificationSettings( {
 										{ translate( 'Receive email notifications with one or more recipients.' ) }
 									</div>
 									{ enableEmailNotification && (
-										<ConfigureEmailNotification defaultEmailAddresses={ addedEmailAddresses } />
+										<ConfigureEmailNotification
+											defaultEmailAddresses={ addedEmailAddresses }
+											toggleModal={ toggleAddEmailModal }
+										/>
 									) }
 								</>
 							) : (


### PR DESCRIPTION
Related to 1204408201748644-as-1204429677167721

## Proposed Changes

This PR implements the UI to add email addresses to downtime monitor notification settings.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-add-monitor-settings-email` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Verify that you can see the `+ Add email address button`.

<img width="448" alt="Screenshot 2023-05-05 at 3 04 40 PM" src="https://user-images.githubusercontent.com/10586875/236453357-facfc076-2e17-4572-9314-eef1893aa5ea.png">

6. Click the. button and verify that you can now see the popup below. Also, verify if the validations work as expected. Please note the Later & Verify buttons does nothing. The logic for these buttons will be implemented later.

**Default view**

<img width="447" alt="Screenshot 2023-05-05 at 3 04 48 PM" src="https://user-images.githubusercontent.com/10586875/236453456-b60fa56d-1d07-4889-824d-ad1493179153.png">

**When the name is not entered**

<img width="445" alt="Screenshot 2023-05-05 at 3 05 20 PM" src="https://user-images.githubusercontent.com/10586875/236453469-c69c5e25-f86c-4911-b0c5-26a2e5684d1d.png">

**When the email is not entered**

<img width="449" alt="Screenshot 2023-05-05 at 3 05 35 PM" src="https://user-images.githubusercontent.com/10586875/236453475-9817bff0-a1dc-4834-a704-8c071c06101c.png">

**When an invalid email is entered**

<img width="446" alt="Screenshot 2023-05-05 at 3 05 55 PM" src="https://user-images.githubusercontent.com/10586875/236453480-91849c21-4fe8-49b2-b520-9f9d0f96dae7.png">

**Default view with verification code**

<img width="442" alt="Screenshot 2023-05-05 at 4 05 52 PM" src="https://user-images.githubusercontent.com/10586875/236453487-899b054a-d5a8-4382-95f6-44bc6cd9cbff.png">

**When the verification code is not entered**

<img width="446" alt="Screenshot 2023-05-05 at 5 39 39 PM" src="https://user-images.githubusercontent.com/10586875/236453952-ec772331-b49c-4ea4-bb6a-85a70d1dd273.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?