### PR TITLE
Enable Export button for still-Atomic expired eCommerce trial sites

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -12,14 +12,15 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { WooExpressPlans } from 'calypso/my-sites/plans/ecommerce-trial/wooexpress-plans';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 const ECommerceTrialExpired = (): JSX.Element => {
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
+	const selectedSite = useSelector( getSelectedSite );
+	const siteId = selectedSite?.ID ?? null;
+	const siteSlug = selectedSite?.slug ?? null;
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
 	const siteIsAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 
@@ -48,6 +49,12 @@ const ECommerceTrialExpired = (): JSX.Element => {
 			plan_slug: planSlug,
 		} );
 	}, [] );
+
+	// Note that the Calypso URL always works, so we only want the wp-admin URL when we have the site's URL.
+	const exportUrl =
+		siteIsAtomic && selectedSite?.URL
+			? `${ selectedSite.URL }/wp-admin/export.php`
+			: `/export/${ siteSlug }`;
 
 	return (
 		<>
@@ -91,12 +98,10 @@ const ECommerceTrialExpired = (): JSX.Element => {
 				/>
 
 				<div className="ecommerce-trial-expired__footer">
-					{ ! siteIsAtomic && (
-						<Button href={ `/export/${ siteSlug }` }>
-							<Gridicon icon="cloud-download" />
-							<span>{ translate( 'Export your content' ) }</span>
-						</Button>
-					) }
+					<Button href={ exportUrl }>
+						<Gridicon icon="cloud-download" />
+						<span>{ translate( 'Export your content' ) }</span>
+					</Button>
 					<Button href={ `/settings/delete-site/${ siteSlug }` } scary>
 						<Gridicon icon="trash" />
 						<span>{ translate( 'Delete your site permanently' ) }</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #76284

## Proposed Changes

* Now that we allow access to `/wp-admin/export.php` for expired trial sites (as of Automattic/wc-calypso-bridge#1104), we need to show the export button to users on the expired trial page. This PR does just that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Still-Atomic site

* Run this branch locally or via the live branch
* For a free trial site that is still on the Atomic platform (i.e. the site slug includes `.wpcomstaging.com`), navigate to `/plans/my-plan/trial-expired/:siteSlug`
  - Note that the site doesn't have to be expired yet - the expiration only enforces that we limit which pages are displayed
* Scroll down to the bottom of the page, and verify that there is an "Export your content" button
* Click on the button
* Verify that you are taken to `/wp-admin/export.php` for your site

### Site transferred to WPCOM Simple

* Run this branch locally or via the live branch
* For a site that was a free trial and is now on WPCOM Simple, i.e. the site slug/URL ends with `.wordpress.com`, navigate to `/plans/my-plan/trial-expired/:siteSlug`
* Scroll down to the bottom of the page, and verify that there is an "Export your content" button
* Click on the button
* Verify that you are taken to `/export/:siteSlug`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
