### PR TITLE
Blog onboarding: Redirect paid domain selection to plans selection

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -2,8 +2,8 @@
 import { ProductsList } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { addQueryArgs, getQueryArg } from '@wordpress/url';
-import { START_WRITING_FLOW, StepContainer } from 'calypso/../packages/onboarding/src';
+import { getQueryArg } from '@wordpress/url';
+import { StepContainer } from 'calypso/../packages/onboarding/src';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -47,8 +47,14 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		return strippedHostname ?? String( siteSlug ).split( '.' )[ 0 ];
 	};
 
-	const onSkip = () => {
-		onAddDomain( null );
+	const onSkip = async () => {
+		if ( isStartWritingFlow ) {
+			setDomain( null );
+			setHideFreePlan( false );
+			submit?.( { freeDomain: true } );
+		} else {
+			onAddDomain( null );
+		}
 	};
 
 	const submitWithDomain = async ( suggestion: DomainSuggestion | undefined ) => {
@@ -57,7 +63,6 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		if ( suggestion?.is_free ) {
 			setHideFreePlan( false );
 			setDomainCartItem( undefined );
-			submit?.();
 		} else {
 			const domainCartItem = domainRegistration( {
 				domain: suggestion?.domain_name || '',
@@ -66,14 +71,9 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 
 			setHideFreePlan( true );
 			setDomainCartItem( domainCartItem );
-
-			window.location.assign(
-				addQueryArgs( `/setup/${ START_WRITING_FLOW }/plans`, {
-					siteSlug,
-					[ START_WRITING_FLOW ]: true,
-				} )
-			);
 		}
+
+		submit?.( { freeDomain: suggestion?.is_free } );
 	};
 
 	const getStartWritingFlowStepContent = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -2,8 +2,8 @@
 import { ProductsList } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { getQueryArg } from '@wordpress/url';
-import { StepContainer } from 'calypso/../packages/onboarding/src';
+import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import { START_WRITING_FLOW, StepContainer } from 'calypso/../packages/onboarding/src';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -30,6 +30,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		} ),
 		[]
 	);
+	const siteSlug = getQueryArg( window.location.search, 'siteSlug' );
 
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
 
@@ -40,8 +41,6 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	};
 
 	const getInitialSuggestion = function () {
-		const siteSlug = getQueryArg( window.location.search, 'siteSlug' );
-
 		const wpcomSubdomainWithRandomNumberSuffix = /^(.+?)([0-9]{5,})\.wordpress\.com$/i;
 		const [ , strippedHostname ] =
 			String( siteSlug ).match( wpcomSubdomainWithRandomNumberSuffix ) || [];
@@ -58,6 +57,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		if ( suggestion?.is_free ) {
 			setHideFreePlan( false );
 			setDomainCartItem( undefined );
+			submit?.();
 		} else {
 			const domainCartItem = domainRegistration( {
 				domain: suggestion?.domain_name || '',
@@ -66,9 +66,14 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 
 			setHideFreePlan( true );
 			setDomainCartItem( domainCartItem );
-		}
 
-		submit?.();
+			window.location.assign(
+				addQueryArgs( `/setup/${ START_WRITING_FLOW }/plans`, {
+					siteSlug,
+					[ START_WRITING_FLOW ]: true,
+				} )
+			);
+		}
 	};
 
 	const getStartWritingFlowStepContent = () => {

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -104,11 +104,17 @@ const startWriting: Flow = {
 							checklist_statuses: { domain_upsell_deferred: true },
 						} );
 					}
-					return navigate( 'launchpad' );
+
+					if ( providedDependencies?.freeDomain ) {
+						return navigate( 'launchpad' );
+					}
+
+					return navigate( 'plans' );
+
 				case 'plans':
 					if ( siteSlug ) {
 						await updateLaunchpadSettings( siteSlug, {
-							checklist_statuses: { plan_completed: true, domain_upsell_deferred: true },
+							checklist_statuses: { plan_completed: true },
 						} );
 					}
 					if ( providedDependencies?.goToCheckout ) {

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -108,7 +108,7 @@ const startWriting: Flow = {
 				case 'plans':
 					if ( siteSlug ) {
 						await updateLaunchpadSettings( siteSlug, {
-							checklist_statuses: { plan_completed: true },
+							checklist_statuses: { plan_completed: true, domain_upsell_deferred: true },
 						} );
 					}
 					if ( providedDependencies?.goToCheckout ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2369-gh-Automattic/dotcom-forge

## Proposed Changes

* When the user selects a paid domain, redirect them directly to plans selection
* For free domain selection or skip selection, redirect back to the launchpad


https://user-images.githubusercontent.com/1044309/236457175-329a6628-3023-432c-9f4e-e7ca158c58f7.mp4



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using a new user OR a user with no site, start the flow with [/setup/start-writing](http://calypso.localhost:3000/setup/start-writing).
* Select a paid domain and ensure you're redirected directly to the plans page
* Select a free domain (or `Decide later`) and ensure your're redirect back to the Launchpad

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?