### PR TITLE
Subscriber import: remove unclear follower notice

### DIFF
--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -438,16 +438,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		);
 	}
 
-	function renderFollowerNoticeLabel() {
-		return (
-			<p className="add-subscriber__form--disclaimer">
-				{ translate(
-					"If you enter an email address that has a WordPress.com account, they'll become a follower."
-				) }
-			</p>
-		);
-	}
-
 	return (
 		<div className="add-subscriber">
 			{ ( showTitle || showSubtitle ) && (
@@ -504,7 +494,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 					{ ! includesHandledError() && renderImportCsvSelectedFileLabel() }
 					{ showCsvUpload && ! includesHandledError() && renderImportCsvLabel() }
-					{ ! includesHandledError() && renderFollowerNoticeLabel() }
 
 					{ renderEmptyFormValidationMsg() }
 


### PR DESCRIPTION
I get why the follower notice is at subscriber importer form (added in https://github.com/Automattic/wp-calypso/pull/70083), but it's never gonna be clear to customers; they have no idea about technical nuances of "subscriber" or "follower". We shouldn't confuse them with this copy.

That said, it's also important we follow up by making all WP.com users receive emails by default and remove the follower/subscriber distinction. Will do that soon as well!

Came up in a Slack convo p1683288129638699-slack-C052XEUUBL4

## Proposed Changes

* Remove "follower" notice from subscriber import form

**After:**
<img width="1446" alt="image" src="https://user-images.githubusercontent.com/87168/236463075-bdb51415-ee65-4f59-9b41-72352fefb67f.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through `/setup/newsletter` and note subscriber form

    ![image](https://user-images.githubusercontent.com/87168/236459930-64b7c558-94cf-4b13-921f-4ae08c6f3cf1.png)

* Open Users -> Add users and note the subscriber form again

    <img width="1188" alt="image" src="https://user-images.githubusercontent.com/87168/236459905-fb6ea836-7594-4ad2-8a8e-5b614cac9519.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?