### PR TITLE
Blog onboarding: Allow the user to change their domain on writing flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -413,8 +413,7 @@ export function getEnhancedTasks(
 					taskData = {
 						title: translate( 'Choose a domain' ),
 						completed: domainUpsellCompleted,
-						disabled:
-							isStartWritingFlow( flow ) && ( domainUpsellCompleted || ! setupBlogCompleted ),
+						disabled: false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id );
 

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -113,7 +113,7 @@ const startWriting: Flow = {
 				case 'plans':
 					if ( siteSlug ) {
 						await updateLaunchpadSettings( siteSlug, {
-							checklist_statuses: { plan_completed: true },
+							checklist_statuses: { plan_completed: true, domain_upsell_deferred: true },
 						} );
 					}
 					if ( providedDependencies?.goToCheckout ) {

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -123,7 +123,7 @@ const startWriting: Flow = {
 				case 'plans':
 					if ( siteSlug ) {
 						await updateLaunchpadSettings( siteSlug, {
-							checklist_statuses: { plan_completed: true, domain_upsell_deferred: true },
+							checklist_statuses: { plan_completed: true },
 						} );
 					}
 					if ( providedDependencies?.goToCheckout ) {

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -205,6 +205,23 @@ export async function addPlanToCart(
 	);
 }
 
+export async function replaceProductsInCart(
+	siteSlug: string,
+	cartItems: MinimalRequestCartProduct[]
+) {
+	const cartKey = await cartManagerClient.getCartKeyForSiteSlug( siteSlug );
+
+	try {
+		const updatedCart = await cartManagerClient
+			.forCartKey( cartKey )
+			.actions.replaceProductsInCart( cartItems );
+
+		debug( 'product replace request complete', updatedCart );
+	} catch ( error ) {
+		debug( 'product replace request had an error', error );
+	}
+}
+
 const addToCartAndProceed = async (
 	newCartItem: MinimalRequestCartProduct,
 	siteSlug: string,

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -7,7 +7,12 @@ export {
 	SkipButton,
 	ArrowButton,
 } from './action-buttons';
-export { createSiteWithCart, addPlanToCart, addProductsToCart } from './cart';
+export {
+	createSiteWithCart,
+	addPlanToCart,
+	addProductsToCart,
+	replaceProductsInCart,
+} from './cart';
 export { setupSiteAfterCreation, base64ImageToBlob } from './setup-tailored-site-after-creation';
 export { uploadAndSetSiteLogo } from './upload-and-set-site-logo';
 export { default as FeatureIcon } from './feature-icon';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2357-gh-Automattic/dotcom-forge

## Proposed Changes

* Allowed user to get back to `Choose a domain` selection
* In case the user changes the domain, remove the old one from the cart
* Remove a paid domain from the cart after a free domain selection (or `Decide later` action)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using a new user OR a user with no site, start the flow with [/setup/start-writing](http://calypso.localhost:3000/setup/start-writing)
* Follow the steps, add a paid domain and select a plan
* Ensure both paid domain and plan are in the cart (you can use a new tab, browsing your WordPress home and see the cart content)
* Replace your domain with another paid one and ensure the cart gets updated (after selecting a new domain and some plan)
* Replace your paid domain to a free one, or click in `Decide later` and once you're redirected back to the Launchpad. In a new tab, browsing your WordPress home, you can see the cart content and you should see only the paid plan on it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?