### PR TITLE
Stats Widget: Add external link support to Top Referrer items

### DIFF
--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -36,6 +36,7 @@
 		"@tanstack/react-query": "4.29.1",
 		"@wordpress/base-styles": "^4.13.0",
 		"@wordpress/data": "^7.6.0",
+		"@wordpress/icons": "^9.23.0",
 		"calypso": "workspace:^",
 		"classnames": "^2.3.1",
 		"debug": "^4.3.4",

--- a/apps/odyssey-stats/src/hooks/use-referrers-query.js
+++ b/apps/odyssey-stats/src/hooks/use-referrers-query.js
@@ -10,12 +10,28 @@ export default function useReferrersQuery( siteId, period, num, date, summarize 
 		[ 'stats-widget', 'referrers', siteId, period, num, date, summarize, max ],
 		() => queryReferrers( siteId, { period, num, date, summarize, max } ),
 		{
-			select: ( data ) =>
-				data?.summary?.groups.map( ( group ) => ( {
-					...group,
-					title: group.name,
-					views: group.total,
-				} ) ),
+			select: ( data ) => {
+				// The groups' views count may not be in descending order
+				// since we use the first result for nest groups.
+				return data?.summary?.groups.map( ( group ) => {
+					// Get the first result as the nested group's data.
+					if ( Array.isArray( group.results ) && group.results.length > 0 ) {
+						const subGroup = group.results[ 0 ];
+
+						return {
+							...subGroup,
+							title: subGroup.name,
+							views: subGroup.views,
+						};
+					}
+
+					return {
+						...group,
+						title: group.name,
+						views: group.results.views,
+					};
+				} );
+			},
 			staleTime: 5 * 60 * 1000,
 		}
 	);

--- a/apps/odyssey-stats/src/widget/highlights.jsx
+++ b/apps/odyssey-stats/src/widget/highlights.jsx
@@ -1,4 +1,5 @@
 import { formattedNumber } from '@automattic/components';
+import { Icon, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
@@ -17,7 +18,12 @@ const postAndPageLink = ( baseUrl, siteId, postId ) => {
 	return `${ baseUrl }#!/stats/post/${ postId }/${ siteId }`;
 };
 
-function ItemWrapper( { odysseyStatsBaseUrl, siteId, isItemLink, item } ) {
+const externalLink = ( item ) => {
+	// Url is for referrers and href is for top posts and pages.
+	return item.url || item.href;
+};
+
+function ItemWrapper( { odysseyStatsBaseUrl, siteId, item, isItemLink, isItemLinkExternal } ) {
 	const translate = useTranslate();
 
 	const renderedItem = (
@@ -33,7 +39,12 @@ function ItemWrapper( { odysseyStatsBaseUrl, siteId, isItemLink, item } ) {
 
 	return isItemLink ? (
 		<a
-			href={ postAndPageLink( odysseyStatsBaseUrl, siteId, item.id ) }
+			href={
+				isItemLinkExternal
+					? externalLink( item )
+					: postAndPageLink( odysseyStatsBaseUrl, siteId, item.id )
+			}
+			target={ isItemLinkExternal ? '_blank' : '_self' }
 			rel="noopener noreferrer"
 			title={ translate( 'View detailed stats for %(title)s', {
 				args: {
@@ -44,6 +55,7 @@ function ItemWrapper( { odysseyStatsBaseUrl, siteId, isItemLink, item } ) {
 			} ) }
 		>
 			{ renderedItem }
+			{ isItemLinkExternal && <Icon className="stats-icon" icon={ external } size={ 18 } /> }
 		</a>
 	) : (
 		renderedItem
@@ -59,6 +71,7 @@ function TopColumn( {
 	odysseyStatsBaseUrl,
 	siteId,
 	isItemLink = false,
+	isItemLinkExternal = false,
 	className = null,
 } ) {
 	const translate = useTranslate();
@@ -80,6 +93,7 @@ function TopColumn( {
 								odysseyStatsBaseUrl={ odysseyStatsBaseUrl }
 								siteId={ siteId }
 								isItemLink={ isItemLink }
+								isItemLinkExternal={ isItemLinkExternal }
 							/>
 						</li>
 					) ) }
@@ -166,7 +180,7 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 					isLoading={ isFetchingPostsAndPages }
 					odysseyStatsBaseUrl={ odysseyStatsBaseUrl }
 					siteId={ siteId }
-					isItemLink={ true }
+					isItemLink
 				/>
 				<TopColumn
 					className={ classNames( 'stats-widget-highlights__column', {
@@ -180,6 +194,8 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 					isLoading={ isFetchingReferrers }
 					odysseyStatsBaseUrl={ odysseyStatsBaseUrl }
 					siteId={ siteId }
+					isItemLink
+					isItemLinkExternal
 				/>
 			</div>
 		</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,6 +1142,7 @@ __metadata:
     "@wordpress/base-styles": ^4.13.0
     "@wordpress/data": ^7.6.0
     "@wordpress/dependency-extraction-webpack-plugin": ^4.5.0
+    "@wordpress/icons": ^9.23.0
     "@wordpress/scripts": ^24.6.0
     autoprefixer: ^10.2.5
     babel-jest: ^27.5
@@ -9134,6 +9135,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/icons@npm:^9.23.0":
+  version: 9.23.0
+  resolution: "@wordpress/icons@npm:9.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/element": ^5.9.0
+    "@wordpress/primitives": ^3.30.0
+  checksum: 33c33a6042224f9976c81e9b4811dd0598468ae1dd10c63b05646d3f1c178b7183eb9bcd7a4b8d01f685d5cc7df5334edea3b6dbbfa372e731091ac72ed4943e
+  languageName: node
+  linkType: hard
+
 "@wordpress/interface@npm:^4.21.0":
   version: 4.21.0
   resolution: "@wordpress/interface@npm:4.21.0"
@@ -9334,6 +9346,17 @@ __metadata:
     "@wordpress/element": ^5.8.0
     classnames: ^2.3.1
   checksum: e0e6113fcc0b6fba13ab34e6a277dae6b91ab08a98929358e5ba64dff658f046ed8d0e267cd54ebfe1da477e814da6c21d288d76a6cdf0103d70489f2434ad0d
+  languageName: node
+  linkType: hard
+
+"@wordpress/primitives@npm:^3.30.0":
+  version: 3.30.0
+  resolution: "@wordpress/primitives@npm:3.30.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/element": ^5.9.0
+    classnames: ^2.3.1
+  checksum: 7adcf77b78f1c4dcd9796f329c5156bcf7e4e3ee158594b6221da65ae6190ab35fd75aa7c572fd78d1db6ccd7e6fb30006437e2a27b744c34301f30f54921622
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9124,18 +9124,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/icons@npm:^9.13.0, @wordpress/icons@npm:^9.22.0, @wordpress/icons@npm:^9.4.0":
-  version: 9.22.0
-  resolution: "@wordpress/icons@npm:9.22.0"
-  dependencies:
-    "@babel/runtime": ^7.16.0
-    "@wordpress/element": ^5.8.0
-    "@wordpress/primitives": ^3.29.0
-  checksum: 9dea77b6981951987629c84e6c8e7a2170eb47a57407b78b49f602b3c6cdae65bf659ef85796c62d36cf943b3564f494f4cd63db9bd4d504a01ef85c6ae1480c
-  languageName: node
-  linkType: hard
-
-"@wordpress/icons@npm:^9.23.0":
+"@wordpress/icons@npm:^9.13.0, @wordpress/icons@npm:^9.22.0, @wordpress/icons@npm:^9.23.0, @wordpress/icons@npm:^9.4.0":
   version: 9.23.0
   resolution: "@wordpress/icons@npm:9.23.0"
   dependencies:
@@ -9338,18 +9327,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/primitives@npm:^3.1.1, @wordpress/primitives@npm:^3.11.0, @wordpress/primitives@npm:^3.20.0, @wordpress/primitives@npm:^3.29.0":
-  version: 3.29.0
-  resolution: "@wordpress/primitives@npm:3.29.0"
-  dependencies:
-    "@babel/runtime": ^7.16.0
-    "@wordpress/element": ^5.8.0
-    classnames: ^2.3.1
-  checksum: e0e6113fcc0b6fba13ab34e6a277dae6b91ab08a98929358e5ba64dff658f046ed8d0e267cd54ebfe1da477e814da6c21d288d76a6cdf0103d70489f2434ad0d
-  languageName: node
-  linkType: hard
-
-"@wordpress/primitives@npm:^3.30.0":
+"@wordpress/primitives@npm:^3.1.1, @wordpress/primitives@npm:^3.11.0, @wordpress/primitives@npm:^3.20.0, @wordpress/primitives@npm:^3.30.0":
   version: 3.30.0
   resolution: "@wordpress/primitives@npm:3.30.0"
   dependencies:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76567 

## Proposed Changes

* Add external link support for `Top Referrers` items URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build Jetpack if necessary: `jetpack build plugins/jetpack`.
* Run `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev` under `calypso/apps/odyssey-stats`.
* Navigate to `/wp-admin/index.php`.
* Ensure links of `Top Referrers` display with external icons and could be opened via a new tab.

<img width="555" alt="截圖 2023-05-05 下午9 27 14" src="https://user-images.githubusercontent.com/6869813/236479406-6b5f1ebe-8f41-4b6c-b51e-c992a14c53ac.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
