### PR TITLE
Fix php warnings in get_current_site()

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -141,21 +141,20 @@ class Help_Center {
 
 		$logo_id  = get_option( 'site_logo' );
 		$products = wpcom_get_site_purchases();
-		$plan     = array_pop(
-			array_filter(
-				$products,
-				function ( $product ) {
-					return 'bundle' === $product->product_type;
-				}
-			)
+		$plans     = array_filter(
+			$products,
+			function ( $product ) {
+				return 'bundle' === $product->product_type;
+			}
 		);
+		$plan     = array_pop( $plans );
 
 		$return_data = array(
 			'ID'               => $site,
 			'name'             => get_bloginfo( 'name' ),
 			'URL'              => get_bloginfo( 'url' ),
 			'plan'             => array(
-				'product_slug' => $plan->product_slug,
+				'product_slug' => $plan->product_slug ?? null,
 			),
 			'is_wpcom_atomic'  => defined( 'IS_ATOMIC' ) && IS_ATOMIC,
 			'jetpack'          => true === apply_filters( 'is_jetpack_site', false, $site ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -141,7 +141,7 @@ class Help_Center {
 
 		$logo_id  = get_option( 'site_logo' );
 		$products = wpcom_get_site_purchases();
-		$plans     = array_filter(
+		$plans = array_filter(
 			$products,
 			function ( $product ) {
 				return 'bundle' === $product->product_type;
@@ -149,19 +149,27 @@ class Help_Center {
 		);
 		$plan     = array_pop( $plans );
 
+		$logo_url = null;
+		if ( $logo_id ) {
+			$attachment_src = wp_get_attachment_image_src( $logo_id, 'thumbnail' );
+			if ( is_array( $attachment_src ) ) {
+				$logo_url = $attachment_src[0];
+			}
+		}
+
 		$return_data = array(
 			'ID'               => $site,
 			'name'             => get_bloginfo( 'name' ),
 			'URL'              => get_bloginfo( 'url' ),
 			'plan'             => array(
-				'product_slug' => $plan->product_slug ?? null,
+				'product_slug' => ( $plan ) ? $plan->product_slug : null,
 			),
 			'is_wpcom_atomic'  => defined( 'IS_ATOMIC' ) && IS_ATOMIC,
 			'jetpack'          => true === apply_filters( 'is_jetpack_site', false, $site ),
 			'logo'             => array(
 				'id'    => $logo_id,
 				'sizes' => array(),
-				'url'   => wp_get_attachment_image_src( $logo_id, 'thumbnail' )[0],
+				'url'   => $logo_url,
 			),
 			'launchpad_screen' => get_option( 'launchpad_screen' ),
 			'site_intent'      => get_option( 'site_intent' ),


### PR DESCRIPTION
Related to #76639

## Proposed Changes

* Fix PHP warnings in `Help_Center::get_current_site()`

The use of `array_pop()` needs to be run against a variable that is passed by reference, not a function result.

Also, if there are no plans, we need to validate that `$plan` is an object before attempting to get data from it.

## Testing Instructions

* Load the admin of a site without a plan set while watching for errors in strict mode.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
