### PR TITLE
Fix/jetpack chat missing from agency dashboard

### DIFF
--- a/client/components/jetpack/portal-nav/index.tsx
+++ b/client/components/jetpack/portal-nav/index.tsx
@@ -18,6 +18,7 @@ import { isPartnerPortal } from 'calypso/state/partner-portal/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPrimarySiteIsJetpack from 'calypso/state/selectors/get-primary-site-is-jetpack';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { ZendeskJetpackChat } from '../jetpack-presales-chat-widget';
 
 import './style.scss';
 
@@ -113,6 +114,7 @@ export default function PortalNav( { className = '' }: Props ) {
 							{ translate( 'Licensing' ) }
 						</NavItem>
 					</NavTabs>
+					<ZendeskJetpackChat keyType="jpAgency" />
 				</SectionNav>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { Icon, plugins } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
-import { ZendeskJetpackChat } from 'calypso/components/jetpack/jetpack-presales-chat-widget';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import SiteSelector from 'calypso/components/site-selector';
 import Sidebar from 'calypso/layout/sidebar';
@@ -81,7 +80,6 @@ const DashboardSidebar: FunctionComponent< Props > = ( { path } ) => {
 							onNavigate={ onNavigate( 'Jetpack Cloud / Support' ) }
 						/>
 					</SidebarMenu>
-					<ZendeskJetpackChat keyType="jpAgency" />
 				</SidebarFooter>
 			</Sidebar>
 		</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { Icon, plugins } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
+import { ZendeskJetpackChat } from 'calypso/components/jetpack/jetpack-presales-chat-widget';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import SiteSelector from 'calypso/components/site-selector';
 import Sidebar from 'calypso/layout/sidebar';
@@ -80,6 +81,7 @@ const DashboardSidebar: FunctionComponent< Props > = ( { path } ) => {
 							onNavigate={ onNavigate( 'Jetpack Cloud / Support' ) }
 						/>
 					</SidebarMenu>
+					<ZendeskJetpackChat keyType="jpAgency" />
 				</SidebarFooter>
 			</Sidebar>
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { localize, translate as TranslateType } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { ZendeskJetpackChat } from 'calypso/components/jetpack/jetpack-presales-chat-widget';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import Sidebar from 'calypso/layout/sidebar';
 import SidebarItem from 'calypso/layout/sidebar/item';
@@ -106,7 +105,6 @@ class PartnerPortalSidebar extends Component< Props > {
 						) }
 					</SidebarMenu>
 				</SidebarRegion>
-				<ZendeskJetpackChat keyType="jpAgency" />
 			</Sidebar>
 		);
 	}


### PR DESCRIPTION
Related to # p7pQDF-8iG-p2

## Proposed Changes

* I[ previously enabled Chat for the partner portal](https://github.com/Automattic/wp-calypso/pull/76218), but it only appeared in the licensing tab, not in the Dashboard or manage site tab
* That previous method involved adding the chat widget component to the partner portal sidebar
* I missed the Dashboard tab because my account wasn't set as an agency partner.
* After further exploration, I discovered adding the widget would be difficult for the Manage Sites tab as that component is not exclusive to partners.  Adding a check there to see if an account is a partner would have required major refactoring to a shared component.
* As an alternative, the Partner menu is unique to partners and appears on all the dashboard sections (dashboard, site and licensing).  Although I don't generally like to add Javascript that high up on the page, this seems like the most simple alternative to target the exact sections we need.

## Testing Instructions

* make sure your account is an agency partner
* apply this PR or use the Jetpack Cloud Live link below and add /dashboard to the URL to get to the portal and select a site
* If chat is staffed, you will see a chat widget in the lower right corner of the screen.  If it is not nothing appears.
* You can check in the jpop-presales channel if you are unsure about staffing

![Screenshot 2023-05-05 at 12 15 04 PM](https://user-images.githubusercontent.com/12895386/236511928-ee13c68c-ab23-4334-98ba-9e550be103fe.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204562825631272