### PR TITLE
Launchpad: Update api requests my home controller

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,7 +1,6 @@
 import { isEcommerce } from '@automattic/calypso-products/src';
 import { fetchLaunchpad } from '@automattic/data-stores';
 import page from 'page';
-import { fetchLaunchpadChecklist } from 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
@@ -47,13 +46,12 @@ export async function maybeRedirect( context, next ) {
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 
 	try {
-		const { launchpad_screen: launchpadScreenOption, site_intent: siteIntentOption } =
-			await fetchLaunchpad( slug );
-		// We can remove this fetchLaunchpadChecklist call once we add the checklist data into the launchpad endpoint
-		const { checklist: launchpadChecklist } = await fetchLaunchpadChecklist(
-			slug,
-			siteIntentOption
-		);
+		const {
+			launchpad_screen: launchpadScreenOption,
+			site_intent: siteIntentOption,
+			checklist: launchpadChecklist,
+		} = await fetchLaunchpad( slug );
+
 		if (
 			launchpadScreenOption === 'full' &&
 			! areLaunchpadTasksCompleted( launchpadChecklist, isSiteLaunched )

--- a/packages/help-center/src/hooks/use-launchpad-checklist.tsx
+++ b/packages/help-center/src/hooks/use-launchpad-checklist.tsx
@@ -23,7 +23,7 @@ interface LaunchpadTasks {
 	checklist: Task[];
 }
 
-export const fetchLaunchpadChecklist = (
+const fetchLaunchpadChecklist = (
 	siteSlug: string | null,
 	siteIntent: string | null
 ): Promise< LaunchpadTasks > => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/75504

## Proposed Changes

We're consolidating all front end code to use shared methods/hooks from `data-stores` to fetch Launchpad data and checklists. This contributes to that effort by removing the temporary fetchLaunchpadChecklist hook from the my home controller.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this branch and run `yarn` and `yarn start` if needed. 
2. Start any new launchpad enabled site
   - Newsletter http://calypso.localhost:3000/setup/newsletter/intro 
   - Link-in-Bio http://calypso.localhost:3000/setup/link-in-bio/intro
   - VideoPress http://calypso.localhost:3000/setup/videopress/intro
   - Free http://calypso.localhost:3000/setup/free/intro
   - Build http://calypso.localhost:3000/start ( select `Other` as the site goal )
   - Write http://calypso.localhost:3000/start ( select `Write & Publish` as the site goal )
3. Navigate to the Launchpad by completing onboarding
4. Click on the Skip to Dashboard link at the bottom of the screen
5. Navigate to my home and verify that the user is redirected to the Launchpad screen
6. Complete all tasks in the Launchpad
7. Return to my home and verify that the user is _not_ redirected to the Launchpad screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
