### PR TITLE
Launchpad: Move "Skip to dashboard" link to the top

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -105,7 +105,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 				goNext={ navigation.goNext }
 				isWideLayout={ true }
 				skipLabelText={ translate( 'Skip to dashboard' ) }
-				skipButtonAlign="bottom"
+				skipButtonAlign="top"
 				hideBack={ true }
 				stepContent={
 					<StepContent

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -6,14 +6,12 @@ import { Icon, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { useLaunchpadChecklist } from 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist';
-import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import Badge from 'calypso/components/badge';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Tooltip from 'calypso/components/tooltip';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
@@ -43,7 +41,7 @@ function getUrlInfo( url: string ) {
 	return [ siteName, topLevelDomain ];
 }
 
-const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: SidebarProps ) => {
+const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarProps ) => {
 	let siteName = '';
 	let topLevelDomain = '';
 	let showClipboardButton = false;
@@ -208,17 +206,6 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 				) : (
 					<Checklist.Placeholder />
 				) }
-			</div>
-			<div className="launchpad__sidebar-admin-link">
-				<StepNavigationLink
-					direction="forward"
-					handleClick={ () => {
-						recordTracksEvent( 'calypso_launchpad_go_to_admin_clicked', { flow: flow } );
-						goNext?.();
-					} }
-					label={ translate( 'Skip to dashboard' ) }
-					borderless={ true }
-				/>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
# Before

<img width="1231" alt="Screenshot 2023-05-05 at 16 29 16" src="https://user-images.githubusercontent.com/104869/236552387-8d03caa0-bc1a-46b6-898b-dd0244ad7dc9.png">

# After

<img width="1440" alt="Screenshot 2023-05-05 at 16 28 35" src="https://user-images.githubusercontent.com/104869/236552408-b1a71deb-c7e2-4a55-94dd-d6fd39167cb9.png">

Improves: https://github.com/Automattic/wp-calypso/issues/76641
