### PR TITLE
Pricing Page: Fix duplicate Backup product card showing when Jetpack Starter Plan is owned.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
@@ -1,5 +1,7 @@
 import {
 	JETPACK_ANTI_SPAM_PRODUCTS,
+	PRODUCT_JETPACK_BACKUP_T0_YEARLY,
+	PRODUCT_JETPACK_BACKUP_T0_MONTHLY,
 	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 	PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
 	PRODUCT_JETPACK_BACKUP_T2_YEARLY,
@@ -56,6 +58,9 @@ const useSelectorPageProducts = ( siteId: number | null ): PlanGridProducts => {
 
 	const backupProductsToShow: string[] = [];
 
+	const ownsBackupT0 =
+		ownedProducts.includes( PRODUCT_JETPACK_BACKUP_T0_YEARLY ) ||
+		ownedProducts.includes( PRODUCT_JETPACK_BACKUP_T0_MONTHLY );
 	const ownsBackupT1 =
 		ownedProducts.includes( PRODUCT_JETPACK_BACKUP_T1_YEARLY ) ||
 		ownedProducts.includes( PRODUCT_JETPACK_BACKUP_T1_MONTHLY );
@@ -65,7 +70,7 @@ const useSelectorPageProducts = ( siteId: number | null ): PlanGridProducts => {
 
 	// If neither T1 or T2 backups are owned, then show T1 backups.
 	// Otherwise the one owned will be displayed via purchasedProducts.
-	if ( ! ownsBackupT1 && ! ownsBackupT2 ) {
+	if ( ! ownsBackupT0 && ! ownsBackupT1 && ! ownsBackupT2 ) {
 		backupProductsToShow.push(
 			PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 			PRODUCT_JETPACK_BACKUP_T1_MONTHLY

--- a/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
@@ -68,7 +68,7 @@ const useSelectorPageProducts = ( siteId: number | null ): PlanGridProducts => {
 		ownedProducts.includes( PRODUCT_JETPACK_BACKUP_T2_YEARLY ) ||
 		ownedProducts.includes( PRODUCT_JETPACK_BACKUP_T2_MONTHLY );
 
-	// If neither T1 or T2 backups are owned, then show T1 backups.
+	// If neither T0 or T1 or T2 backups are owned, then show T1 backups.
 	// Otherwise the one owned will be displayed via purchasedProducts.
 	if ( ! ownsBackupT0 && ! ownsBackupT1 && ! ownsBackupT2 ) {
 		backupProductsToShow.push(


### PR DESCRIPTION
Now that the Jetpack Starter plan has been added as a [new purchasable product on the pricing page](https://github.com/Automattic/wp-calypso/pull/76611), There was a bug that was causing duplicate VaultPress Backup product cards to show on the pricing page (when logged-in and the site is in context) when the Jetpack Starter plan is owned.  See Screenshot:

.
![Markup 2023-05-05 at 14 25 35](https://user-images.githubusercontent.com/11078128/236560854-56f77b29-acb3-4543-954e-1610ee52cfa3.png)
.

<hr/>

.
This PR fixes this bug whereas when a site has a subscription for the Jetpack Starter plan, The VaultPress Backup product card will only show once, and it will be labeled "Part of the current plan" with a "Manage subscription" CTA button, instead of showing 2 VaultPress Backup product cards.
(See **After** screenshot:)

![Markup 2023-05-05 at 16 33 02](https://user-images.githubusercontent.com/11078128/236563512-f915eca4-22af-4ce2-8cc7-e36feed71a3f.png)

Asana Task: 1198218726984184-as-1204541714823225/f

## Proposed Changes

* Allowed `JETPACK_BACKUP_T0` to be recognized as an "owned" product on the pricing page.

## Testing Instructions

- Spin up this PR: `git fetch && git checkout add/backupT0-product-to-owned-products-pricing-page && yarn start-jetpack-cloud`
- If you don't already have a site that owns a subscription to the new Jetpack Starter plan, the you'll need to Purchase Jetpack Starter create an ephemeral or Jurassic Ninja site, connect Jetpack, and activate the product on the site.
- Next go to `http://jetpack.cloud.localhost:3000/pricing/:SITE` (replace `:SITE` with the site-slug of the site you have your Jetpack Starter plan on.
- Make sure you are logged-in.  If not, log in and reload the `/pricing/:SITE` page.
- Verify that the VaultPress Backup product card is not duplicated and it is showing as "Part of the current plan" (like the "After" screenshot shown above)..


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?