### PR TITLE
Theme Showcase: Add typeof window check

### DIFF
--- a/client/state/selectors/get-site-editor-url.js
+++ b/client/state/selectors/get-site-editor-url.js
@@ -12,8 +12,8 @@ export const getSiteEditorUrl = ( state, siteId ) => {
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 	const queryArgs = {};
 	// Only add the origin if it's not wordpress.com.
-	if ( location.origin !== 'https://wordpress.com' ) {
-		queryArgs.calypso_origin = location.origin;
+	if ( typeof window !== 'undefined' && window.location.origin !== 'https://wordpress.com' ) {
+		queryArgs.calypso_origin = window.location.origin;
 	}
 	return addQueryArgs( queryArgs, `${ siteAdminUrl }site-editor.php` );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76371

## Proposed Changes

This PR adds the check `typeof window !== 'undefined'` to fix the following error that prevents the page from rendering server-side:

![Screenshot 2023-05-08 at 9 56 26 AM](https://user-images.githubusercontent.com/797888/236717180-93d5c757-900c-4f4b-91a4-dc59d34e39e6.png)

| Before | After |
| --- | --- |
| ![Screenshot 2023-05-08 at 9 47 03 AM](https://user-images.githubusercontent.com/797888/236717209-d5c57bd7-8f1d-4353-8221-2869afc94e1d.png) | ![Screenshot 2023-05-08 at 9 48 18 AM](https://user-images.githubusercontent.com/797888/236717221-1306a8f6-2299-4bb5-8b45-1aa601923cca.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to any theme's detail page, such as `/theme/paimio`.
* Ensure that the page renders correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
