### PR TITLE
Hosting Onboarding: New site creation flow for users interested in "hosting"

### DIFF
--- a/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
@@ -10,6 +10,7 @@ import {
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { Flow, ProvidedDependencies } from './internals/types';
+import './internals/hosting-site-creation-flow.scss';
 
 const hosting: Flow = {
 	name: HOSTING_SITE_CREATION_FLOW,

--- a/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
@@ -1,0 +1,64 @@
+import { HOSTING_SITE_CREATION_FLOW } from '@automattic/onboarding';
+import { addQueryArgs } from '@wordpress/url';
+import {
+	setSignupCompleteSlug,
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+} from 'calypso/signup/storageUtils';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import type { Flow, ProvidedDependencies } from './internals/types';
+
+const hosting: Flow = {
+	name: HOSTING_SITE_CREATION_FLOW,
+	useSteps() {
+		return [
+			{ slug: 'plans', asyncComponent: () => import( './internals/steps-repository/plans' ) },
+			{
+				slug: 'siteCreationStep',
+				asyncComponent: () => import( './internals/steps-repository/site-creation-step' ),
+			},
+			{
+				slug: 'processing',
+				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
+			},
+		];
+	},
+	useStepNavigation( _currentStepSlug, navigate ) {
+		const flowName = this.name;
+
+		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
+			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
+
+			switch ( _currentStepSlug ) {
+				case 'plans':
+					return navigate( 'siteCreationStep' );
+
+				case 'siteCreationStep':
+					return navigate( 'processing' );
+
+				case 'processing': {
+					const destination = addQueryArgs( '/sites', {
+						'new-site': providedDependencies.siteSlug,
+					} );
+					persistSignupDestination( destination );
+					setSignupCompleteSlug( providedDependencies?.siteSlug );
+					setSignupCompleteFlowName( flowName );
+
+					return window.location.assign(
+						addQueryArgs(
+							`/checkout/${ encodeURIComponent(
+								( providedDependencies?.siteSlug as string ) ?? ''
+							) }`,
+							{ redirect_to: destination }
+						)
+					);
+				}
+			}
+			return providedDependencies;
+		};
+
+		return { submit };
+	},
+};
+
+export default hosting;

--- a/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
@@ -1,10 +1,13 @@
 import { HOSTING_SITE_CREATION_FLOW } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
+import { useEffect } from 'react';
 import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
+import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
@@ -58,6 +61,18 @@ const hosting: Flow = {
 		};
 
 		return { submit };
+	},
+	useSideEffect() {
+		const { setHideFreePlan } = useDispatch( ONBOARD_STORE );
+
+		useEffect(
+			() => {
+				setHideFreePlan( true );
+			},
+			// We only need to hide the free plan once, when the flow is mounted.
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+			[]
+		);
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
@@ -64,11 +64,12 @@ const hosting: Flow = {
 		return { submit };
 	},
 	useSideEffect() {
-		const { setHideFreePlan } = useDispatch( ONBOARD_STORE );
+		const { setHideFreePlan, setHidePlansFeatureComparison } = useDispatch( ONBOARD_STORE );
 
 		useEffect(
 			() => {
 				setHideFreePlan( true );
+				setHidePlansFeatureComparison( true );
 			},
 			// We only need to hide the free plan once, when the flow is mounted.
 			// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -1,5 +1,9 @@
 import { ProgressBar } from '@automattic/components';
-import { CONNECT_DOMAIN_FLOW, SITE_SETUP_FLOW } from '@automattic/onboarding';
+import {
+	CONNECT_DOMAIN_FLOW,
+	isHostingSiteCreationFlow,
+	SITE_SETUP_FLOW,
+} from '@automattic/onboarding';
 import classnames from 'classnames';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
 import SignupHeader from 'calypso/signup/signup-header';
@@ -26,7 +30,10 @@ const StepRoute = ( {
 	const renderProgressBar = () => {
 		// The progress bar is removed from the site-setup due to its fragility.
 		// See https://github.com/Automattic/wp-calypso/pull/73653
-		if ( [ SITE_SETUP_FLOW, CONNECT_DOMAIN_FLOW ].includes( flow.name ) ) {
+		if (
+			[ SITE_SETUP_FLOW, CONNECT_DOMAIN_FLOW ].includes( flow.name ) ||
+			isHostingSiteCreationFlow( flow.name )
+		) {
 			return null;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/hosting-site-creation-flow.scss
+++ b/client/landing/stepper/declarative-flow/internals/hosting-site-creation-flow.scss
@@ -1,0 +1,5 @@
+.new-hosted-site.plans div.plan-features-2023-grid__content {
+	max-width: 768px;
+	margin-left: auto !important;
+	margin-right: auto !important;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -7,6 +7,7 @@ import {
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
 	TYPE_BUSINESS,
+	TYPE_ECOMMERCE,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
@@ -18,6 +19,8 @@ import {
 	isStartWritingFlow,
 	NEWSLETTER_FLOW,
 	LINK_IN_BIO_FLOW,
+	HOSTING_SITE_CREATION_FLOW,
+	isHostingSiteCreationFlow,
 } from '@automattic/onboarding';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -53,6 +56,8 @@ function getPlanTypes( flowName: string | null ) {
 			return [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM ];
 		case LINK_IN_BIO_FLOW:
 			return [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM ];
+		case HOSTING_SITE_CREATION_FLOW:
+			return [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
 		default:
 			return undefined;
 	}
@@ -168,7 +173,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 
 	const getHeaderText = () => {
 		const { flowName } = props;
-		if ( flowName === DOMAIN_UPSELL_FLOW ) {
+		if ( flowName === DOMAIN_UPSELL_FLOW || isHostingSiteCreationFlow( flowName ) ) {
 			return __( 'Choose your flavor of WordPress' );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -12,6 +12,7 @@ import {
 	isMigrationFlow,
 	isStartWritingFlow,
 	isWooExpressFlow,
+	isHostingSiteCreationFlow,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -102,6 +103,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		isLinkInBioFlow( flow ) ||
 		isMigrationFlow( flow ) ||
 		isStartWritingFlow( flow ) ||
+		isHostingSiteCreationFlow( flow ) ||
 		wooFlows.includes( flow || '' )
 	) {
 		siteVisibility = Site.Visibility.PublicNotIndexed;

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -2,6 +2,7 @@ import {
 	LINK_IN_BIO_DOMAIN_FLOW,
 	START_WRITING_FLOW,
 	CONNECT_DOMAIN_FLOW,
+	HOSTING_SITE_CREATION_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -81,6 +82,11 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	[ CONNECT_DOMAIN_FLOW ]: () =>
 		import( /* webpackChunkName: "connect-domain" */ '../declarative-flow/connect-domain' ),
+
+	[ HOSTING_SITE_CREATION_FLOW ]: () =>
+		import(
+			/* webpackChunkName: "hosting-site-creation-flow" */ '../declarative-flow/hosting-site-creation-flow'
+		),
 };
 
 availableFlows[ 'plugin-bundle' ] = () =>

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -75,8 +75,11 @@ export const is2023PricingGridActivePage = (
 		return isPricingGridEnabled;
 	}
 
-	// Is this the hosting flow?
-	if ( currentRoutePath.startsWith( '/start/hosting' ) ) {
+	// Is this a hosting flow?
+	if (
+		currentRoutePath.startsWith( '/start/hosting' ) ||
+		currentRoutePath.startsWith( '/setup/new-hosted-site' )
+	) {
 		return isPricingGridEnabled;
 	}
 

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -69,6 +69,10 @@ export const isHostingFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && HOSTING_LP_FLOW === flowName );
 };
 
+export const isHostingSiteCreationFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && HOSTING_SITE_CREATION_FLOW === flowName );
+};
+
 export const isMigrationFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ MIGRATION_FLOW ].includes( flowName ) );
 };

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -1,6 +1,7 @@
 export const NEWSLETTER_FLOW = 'newsletter';
 export const NEWSLETTER_POST_SETUP_FLOW = 'newsletter-post-setup';
 export const HOSTING_LP_FLOW = 'hosting';
+export const HOSTING_SITE_CREATION_FLOW = 'new-hosted-site';
 export const LINK_IN_BIO_FLOW = 'link-in-bio';
 export const LINK_IN_BIO_DOMAIN_FLOW = 'link-in-bio-domain';
 export const LINK_IN_BIO_TLD_FLOW = 'link-in-bio-tld';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2362

## Proposed Changes

* Creates a new flow in the "stepper" framework for creating sites for users interested in "hosting" features
* This flow only shows plans which are compatible with WoA sites
* Ensure the plans grid is displayed using the 2023 style

Some implementation notes:
- The new flow uses it's own flow ID i.e. it uses `new-hosted-site` rather than re-using `hosting` which is already used to create accounts in the old signup framework. I kept them distinct otherwise the tracks events would get all mixed up.
- This gets the flow working, but we'll need to bring some of the style customisations we did for the `/start/hosting` flow (e.g. emphasising the refund period) over to this framework's "plans" step. This probably won't be too much work because it uses the same plan grid components under the hood.
- This PR doesn't include the new site setup step, that's coming in https://github.com/Automattic/dotcom-forge/issues/2360

Here's a video p1683599503739649-slack-C04H4NY6STW

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/new-hosted-site`
* It might not be styled perfectly, but you should be able to create a new site
* Ensure none of our changes bleed through to other flows e.g. we hide the free plan for our flow, ensure it's not hidden on other flows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?