### PR TITLE
Only allow post, page and product to show for blaze

### DIFF
--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -84,6 +84,8 @@ const today = moment().locale( 'en' );
 const period = 'year';
 const topPostsQuery = memoizedQuery( period, 'month', 20, today.format( 'YYYY-MM-DD' ), -1 );
 
+const allowedPostTypes = [ 'post', 'page', 'product' ];
+
 export default function PromotedPosts( { tab }: Props ) {
 	const selectedTab = tab === 'campaigns' ? 'campaigns' : 'posts';
 	const selectedSite = useSelector( getSelectedSite );
@@ -98,12 +100,16 @@ export default function PromotedPosts( { tab }: Props ) {
 
 	const postAndPagesByComments = useSelector( ( state ) => {
 		const postsAndPages = getPostsForQuery( state, selectedSiteId, queryPageAndPostsByComments );
-		return postsAndPages?.filter( ( product: any ) => ! product.password );
+		return postsAndPages?.filter(
+			( product: any ) => ! product.password && allowedPostTypes.includes( product.type )
+		);
 	} );
 
 	const postAndPagesByIDs = useSelector( ( state ) => {
 		const postsAndPages = getPostsForQuery( state, selectedSiteId, queryPageAndPostsByIDs );
-		return postsAndPages?.filter( ( product: any ) => ! product.password );
+		return postsAndPages?.filter(
+			( product: any ) => ! product.password && allowedPostTypes.includes( product.type )
+		);
 	} );
 
 	const isLoadingProducts = useSelector( ( state ) =>

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -81,6 +81,8 @@ const today = moment().locale( 'en' );
 const period = 'year';
 const topPostsQuery = memoizedQuery( period, 'month', 20, today.format( 'YYYY-MM-DD' ), -1 );
 
+const allowedPostTypes = [ 'post', 'page', 'product' ];
+
 export default function PromotedPosts( { tab }: Props ) {
 	const selectedTab = tab === 'campaigns' ? 'campaigns' : 'posts';
 	const selectedSite = useSelector( getSelectedSite );
@@ -95,12 +97,16 @@ export default function PromotedPosts( { tab }: Props ) {
 
 	const postAndPagesByComments = useSelector( ( state ) => {
 		const postsAndPages = getPostsForQuery( state, selectedSiteId, queryPageAndPostsByComments );
-		return postsAndPages?.filter( ( product: any ) => ! product.password );
+		return postsAndPages?.filter(
+			( product: any ) => ! product.password && allowedPostTypes.includes( product.type )
+		);
 	} );
 
 	const postAndPagesByIDs = useSelector( ( state ) => {
 		const postsAndPages = getPostsForQuery( state, selectedSiteId, queryPageAndPostsByIDs );
-		return postsAndPages?.filter( ( product: any ) => ! product.password );
+		return postsAndPages?.filter(
+			( product: any ) => ! product.password && allowedPostTypes.includes( product.type )
+		);
 	} );
 
 	const isLoadingProducts = useSelector( ( state ) =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2132

## Proposed Changes

* Only show [blazable post types](https://github.com/Automattic/dotcom-forge/issues/2132#issuecomment-1514520010)

| Before  | After |
| :-------------: | :-------------: |
| ![before](https://user-images.githubusercontent.com/6586048/236750979-b016527c-341d-4c07-b502-3e261aad1d04.png)  | ![after](https://user-images.githubusercontent.com/6586048/236750805-0c8a0970-960f-42ce-9955-5600a41951c0.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/advertising/:siteSlug?flags=-promote-post/redesign-i2` (old version) and `/advertising/:siteSlug?flags=promote-post/redesign-i2` (new version)
* Check if only allowed post types (post, page, product) are showing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
