### PR TITLE
Social Connections: Support connecting multiple accounts

### DIFF
--- a/client/my-sites/marketing/connections/account-dialog.jsx
+++ b/client/my-sites/marketing/connections/account-dialog.jsx
@@ -89,9 +89,11 @@ class AccountDialog extends Component {
 	}
 
 	areAccountsConflicting( account, otherAccount ) {
+		// Accounts are conflicting, if they have the same ID and keyringConnectionId, which
+		// means they are the same account. Otherwise it's a different site for the same account.
 		return (
 			account.keyringConnectionId === otherAccount.keyringConnectionId &&
-			account.ID !== otherAccount.ID
+			account.ID === otherAccount.ID
 		);
 	}
 

--- a/client/my-sites/marketing/connections/account-dialog.jsx
+++ b/client/my-sites/marketing/connections/account-dialog.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Dialog } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -91,10 +92,11 @@ class AccountDialog extends Component {
 	areAccountsConflicting( account, otherAccount ) {
 		// Accounts are conflicting, if they have the same ID and keyringConnectionId, which
 		// means they are the same account. Otherwise it's a different site for the same account.
-		return (
-			account.keyringConnectionId === otherAccount.keyringConnectionId &&
-			account.ID === otherAccount.ID
-		);
+		const isIdConflicting = isEnabled( 'jetpack-social/multiple-connections' )
+			? account.ID === otherAccount.ID
+			: account.ID !== otherAccount.ID;
+
+		return account.keyringConnectionId === otherAccount.keyringConnectionId && isIdConflicting;
 	}
 
 	isSelectedAccountConflicting() {

--- a/client/my-sites/marketing/connections/account-dialog.jsx
+++ b/client/my-sites/marketing/connections/account-dialog.jsx
@@ -90,13 +90,15 @@ class AccountDialog extends Component {
 	}
 
 	areAccountsConflicting( account, otherAccount ) {
-		// Accounts are conflicting, if they have the same ID and keyringConnectionId, which
-		// means they are the same account. Otherwise it's a different site for the same account.
-		const isIdConflicting = isEnabled( 'jetpack-social/multiple-connections' )
-			? account.ID === otherAccount.ID
-			: account.ID !== otherAccount.ID;
+		// If we support multiple connections, accounts should never conflict.
+		if ( isEnabled( 'jetpack-social/multiple-connections' ) ) {
+			return false;
+		}
 
-		return account.keyringConnectionId === otherAccount.keyringConnectionId && isIdConflicting;
+		return (
+			account.keyringConnectionId === otherAccount.keyringConnectionId &&
+			account.ID !== otherAccount.ID
+		);
 	}
 
 	isSelectedAccountConflicting() {

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import requestExternalAccess from '@automattic/request-external-access';
 import classnames from 'classnames';
@@ -224,6 +224,14 @@ export class SharingService extends Component {
 	 * @param {number} externalUserId      Optional. User ID for the service. Default: 0.
 	 */
 	createOrUpdateConnection = ( keyringConnectionId, externalUserId = 0 ) => {
+		if ( isEnabled( 'jetpack-social/multiple-connections' ) ) {
+			return this.props.createSiteConnection(
+				this.props.siteId,
+				keyringConnectionId,
+				externalUserId
+			);
+		}
+
 		const existingConnection = find( this.props.siteUserConnections, {
 			keyring_connection_ID: keyringConnectionId,
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This change updates the connections page in Calypso, so it is possible to connect multiple accounts.

## Proposed Changes

* Refactored the `createOrUpdateConnection ` function, as now we create a connection each time, because we support multiple pages per site.
* Changed the logic to determine conflicting connections. Before this change two connections were conflicting, if they had the same keyring ID, but had different connection ID-s. From now on, these won't be conflicts, as we support multiple connections / site. The only conflict now is they want to connect the same site again - This should not be possible from the UI for most sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this change and start Calypso with `yarn start`
* Go to `http://calypso.localhost:3000/marketing/connections/gmjuhasztest.jurassic.tube` for your site.
* Sandbox D109448-code patch, and point the wp api to your sandbox in your hosts file.
* Add this blog sticker to your site : `add_blog_sticker ('jetpack-social-allow-multiple-connections', null, null,  <blog-id>); `
Now test the patch:
- Try to add another connection for a site. You might have to change the API settings, to allow access to the second page too. For Facebook click settings in the popup, and tick the new site, then continue.
- You should see the new site, and your previous one as connected. There should be no warning of conflicts.
![CleanShot 2023-05-08 at 13 18 30 png](https://user-images.githubusercontent.com/36671565/236810629-fd0ac2e9-60fd-49ca-915b-6d32e2b4079c.png)

* After connecting, it should appear in a list
* Try disconnecting them 1 by 1.
* Try using the disconnect all button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?