### PR TITLE
Social Previews | Unify the props/types to make them consistent

### DIFF
--- a/client/components/share/linkedin-share-preview/index.jsx
+++ b/client/components/share/linkedin-share-preview/index.jsx
@@ -34,7 +34,7 @@ export class LinkedinSharePreview extends PureComponent {
 					name={ externalDisplay }
 					profileImage={ externalProfilePicture }
 					title={ decodeEntities( seoTitle ) }
-					text={ decodeEntities( articleSummary ) }
+					description={ decodeEntities( articleSummary ) }
 					url={ articleUrl }
 				/>
 			</div>

--- a/packages/social-previews/src/facebook-preview/hooks/use-image-hook.ts
+++ b/packages/social-previews/src/facebook-preview/hooks/use-image-hook.ts
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { useCallback, useState } from 'react';
 import { LANDSCAPE_MODE, PORTRAIT_MODE } from '../../constants';
-import type { ImageMode } from '../../types';
+import type { ImageMode } from '../types';
 
 type ImageEventHandler = ( event: React.SyntheticEvent< HTMLImageElement > ) => void;
 type ImgProps = {

--- a/packages/social-previews/src/facebook-preview/types.ts
+++ b/packages/social-previews/src/facebook-preview/types.ts
@@ -1,12 +1,19 @@
-import { TYPE_WEBSITE, TYPE_ARTICLE } from '../constants';
-import type { PreviewProps } from '../types';
+import { TYPE_WEBSITE, TYPE_ARTICLE, LANDSCAPE_MODE, PORTRAIT_MODE } from '../constants';
+import type { SectionHeadingProps } from '../shared/section-heading';
+import type { SocialPreviewBaseProps } from '../types';
+
+export type ImageMode = typeof LANDSCAPE_MODE | typeof PORTRAIT_MODE;
 
 export type FacebookUser = {
 	displayName: string;
 	avatarUrl?: string;
 };
 
-export type FacebookPreviewProps = PreviewProps & {
+export type FacebookPreviewProps = SocialPreviewBaseProps & {
 	user?: FacebookUser;
 	type?: typeof TYPE_WEBSITE | typeof TYPE_ARTICLE;
+	headingsLevel?: SectionHeadingProps[ 'level' ];
+	customText?: string;
+	customImage?: string;
+	imageMode?: ImageMode;
 };

--- a/packages/social-previews/src/google-search-preview/index.tsx
+++ b/packages/social-previews/src/google-search-preview/index.tsx
@@ -6,6 +6,7 @@ import {
 	stripHtmlTags,
 	baseDomain,
 } from '../helpers';
+import { SocialPreviewBaseProps } from '../types';
 
 import './style.scss';
 
@@ -35,10 +36,7 @@ const googleDescription = firstValid(
 	hardTruncation( DESCRIPTION_LENGTH )
 );
 
-export type GoogleSearchPreviewProps = {
-	title: string;
-	url: string;
-	description: string;
+export type GoogleSearchPreviewProps = Omit< SocialPreviewBaseProps, 'image' > & {
 	siteTitle?: string;
 };
 

--- a/packages/social-previews/src/index.ts
+++ b/packages/social-previews/src/index.ts
@@ -4,3 +4,4 @@ export * from './linkedin-preview';
 export * from './tumblr-preview';
 export * from './facebook-preview';
 export * from './constants';
+export * from './types';

--- a/packages/social-previews/src/linkedin-preview/index.tsx
+++ b/packages/social-previews/src/linkedin-preview/index.tsx
@@ -1,18 +1,15 @@
 import { __ } from '@wordpress/i18n';
 import { baseDomain, preparePreviewText } from '../helpers';
 import './style.scss';
+import { SocialPreviewBaseProps } from '../types';
 
 export const FEED_TEXT_MAX_LENGTH = 212;
 export const FEED_TEXT_MAX_LINES = 3;
 
-export type LinkedInPreviewProps = {
-	image: string;
+export type LinkedInPreviewProps = SocialPreviewBaseProps & {
 	jobTitle?: string;
 	name: string;
 	profileImage: string;
-	text?: string;
-	title: string;
-	url?: string;
 };
 
 export function LinkedInPreview( {
@@ -20,7 +17,7 @@ export function LinkedInPreview( {
 	jobTitle,
 	name,
 	profileImage,
-	text,
+	description,
 	title,
 	url,
 }: LinkedInPreviewProps ) {
@@ -60,13 +57,13 @@ export function LinkedInPreview( {
 				</div>
 			</div>
 			<div className="linkedin-preview__content">
-				{ text ? (
+				{ description ? (
 					<div
 						className="linkedin-preview__caption"
 						// TODO: Replace `dangerouslySetInnerHTML` with `createInterpolateElement` inside `preparePreviewText`
 						// eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={ {
-							__html: preparePreviewText( text, {
+							__html: preparePreviewText( description, {
 								platform: 'linkedin',
 								maxChars: FEED_TEXT_MAX_LENGTH,
 								maxLines: FEED_TEXT_MAX_LINES,

--- a/packages/social-previews/src/shared/section-heading/index.tsx
+++ b/packages/social-previews/src/shared/section-heading/index.tsx
@@ -1,18 +1,20 @@
-import { createElement } from 'react';
+const HEADING_LEVELS = [ 2, 3, 4, 5, 6 ] as const;
 
-type Props = {
+export type SectionHeadingProps = {
 	className?: string;
-	level?: number;
+	level?: ( typeof HEADING_LEVELS )[ number ];
 	children?: React.ReactNode;
 };
 
-const HEADING_LEVELS = [ 2, 3, 4, 5, 6 ];
+export const SectionHeading: React.FC< SectionHeadingProps > = ( {
+	className,
+	level,
+	children,
+} ) => {
+	const Tag = `h${ level && HEADING_LEVELS.includes( level ) ? level : 3 }` as const;
 
-const SectionHeading: React.FC< Props > = ( { className, level, children } ) => {
-	return createElement(
-		`h${ level && HEADING_LEVELS.indexOf( level ) > -1 ? level : 3 }`,
-		{ className: `social-preview__section-heading ${ className ?? '' }` },
-		children
+	return (
+		<Tag className={ `social-preview__section-heading ${ className ?? '' }` }>{ children }</Tag>
 	);
 };
 

--- a/packages/social-previews/src/tumblr-preview/full-preview.tsx
+++ b/packages/social-previews/src/tumblr-preview/full-preview.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import SectionHeading from '../shared/section-heading';
+import { SectionHeading } from '../shared/section-heading';
 import TumblrLinkPreview from './link-preview';
 import { TumblrPreviewProps } from './types';
 

--- a/packages/social-previews/src/tumblr-preview/types.ts
+++ b/packages/social-previews/src/tumblr-preview/types.ts
@@ -1,10 +1,13 @@
-import type { PreviewProps } from '../types';
+import type { SectionHeadingProps } from '../shared/section-heading';
+import type { SocialPreviewBaseProps } from '../types';
 
 export type TumblrUser = {
 	displayName: string;
 	avatarUrl?: string;
 };
 
-export type TumblrPreviewProps = PreviewProps & {
+export type TumblrPreviewProps = SocialPreviewBaseProps & {
 	user?: TumblrUser;
+	customText?: string;
+	headingsLevel?: SectionHeadingProps[ 'level' ];
 };

--- a/packages/social-previews/src/twitter-preview/types.ts
+++ b/packages/social-previews/src/twitter-preview/types.ts
@@ -1,3 +1,5 @@
+import { SocialPreviewBaseProps } from '../types';
+
 export type TwitterPreviewProps = TwitterCardProps & {
 	tweets: Array< TweetProps >;
 };
@@ -8,12 +10,8 @@ export type TwitterMedia = {
 	url: string;
 };
 
-export type TwitterCardProps = {
-	description: string;
-	image: string;
-	title: string;
+export type TwitterCardProps = SocialPreviewBaseProps & {
 	type: string;
-	url: string;
 };
 
 export type SidebarProps = {

--- a/packages/social-previews/src/types.ts
+++ b/packages/social-previews/src/types.ts
@@ -1,14 +1,21 @@
-import { LANDSCAPE_MODE, PORTRAIT_MODE } from './constants';
-
-export type ImageMode = typeof LANDSCAPE_MODE | typeof PORTRAIT_MODE;
-
-export type PreviewProps = {
+export interface SocialPreviewBaseProps {
+	/**
+	 * The URL of the post/page to preview.
+	 */
 	url: string;
+
+	/**
+	 * The title of the post/page to preview.
+	 */
 	title: string;
-	description?: string;
-	customText?: string;
+
+	/**
+	 * The description of the post/page to preview.
+	 */
+	description: string;
+
+	/**
+	 * The URL of the image to use in the post/page preview.
+	 */
 	image?: string;
-	customImage?: string;
-	headingsLevel?: number;
-	imageMode?: ImageMode;
-};
+}


### PR DESCRIPTION
The props for different components in Social Previews package are not consistent and the types are duplicated.

## Proposed Changes

* This PR aims to make the props consistent for all the preview components.

## Testing Instructions

- Make sure you have a self-hosted site connected to Jetpack, with a subscription that includes Social.
- Spin up Calypso, by running this branch locally or using a live link below.
- Go to `/marketing/traffic/:site` for a self hosted WP or a JN site.
- Scroll down to "Website Meta" section
- Click on "Show Previews" to open the previews modal
- Confirm that all the previews are same as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
