### PR TITLE
Use more granular feature checks in Hosting Configuration page

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -5,8 +5,7 @@ import {
 	FEATURE_SITE_STAGING_SITES,
 	WPCOM_FEATURES_ATOMIC,
 } from '@automattic/calypso-products';
-import { englishLocales } from '@automattic/i18n-utils';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { Component, Fragment, useMemo } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
@@ -208,7 +207,6 @@ class Hosting extends Component {
 			isSiteAtomic,
 			isTransferring,
 			isWpcomStagingSite,
-			locale,
 			requestSiteById,
 			siteId,
 			siteSlug,
@@ -272,18 +270,17 @@ class Hosting extends Component {
 					/>
 				);
 
-				// Don't imply additional access if site doesn't have the SFTP feature.
-				const noticeText =
-					isBasicHostingDisabled &&
-					( englishLocales.includes( locale ) ||
-						i18n.hasTranslation( 'Please activate your hosting access.' ) )
-						? translate( 'Please activate your hosting access.' )
-						: translate( 'Please activate the hosting access to begin using these features.' );
-
 				return (
 					<>
 						{ failureNotice }
-						<Notice status="is-info" showDismiss={ false } text={ noticeText } icon="globe">
+						<Notice
+							status="is-info"
+							showDismiss={ false }
+							text={ translate(
+								'Please activate the hosting access to begin using these features.'
+							) }
+							icon="globe"
+						>
 							<TrackComponentView eventName="calypso_hosting_configuration_activate_impression" />
 							<NoticeAction
 								onClick={ clickActivate }

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -6,7 +6,7 @@ import {
 	WPCOM_FEATURES_ATOMIC,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
-import { Component, Fragment, useMemo } from 'react';
+import { Component, Fragment } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -86,65 +86,56 @@ const MainCards = ( {
 	isWpcomStagingSite,
 	siteId,
 } ) => {
-	const mainCards = useMemo( () => {
-		return [
-			{
-				feature: 'sftp',
-				content: <SFTPCard disabled={ isAdvancedHostingDisabled } />,
-				type: 'advanced',
-			},
-			{
-				feature: 'phpmyadmin',
-				content: <PhpMyAdminCard disabled={ isAdvancedHostingDisabled } />,
-				type: 'advanced',
-			},
-			! isWpcomStagingSite && hasStagingSitesFeature
-				? {
-						feature: 'staging-site',
-						content: <StagingSiteCard disabled={ isAdvancedHostingDisabled } />,
-						type: 'advanced',
-				  }
-				: null,
-			isWpcomStagingSite && siteId
-				? {
-						feature: 'staging-production-site',
-						content: (
-							<StagingSiteProductionCard siteId={ siteId } disabled={ isAdvancedHostingDisabled } />
-						),
-						type: 'advanced',
-				  }
-				: null,
-			isGithubIntegrationEnabled
-				? {
-						feature: 'github',
-						content: <GitHubCard />,
-						type: 'advanced',
-				  }
-				: null,
-			{
-				feature: 'web-server-settings',
-				content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
-				type: 'advanced',
-			},
-			{
-				feature: 'restore-plan-software',
-				content: <RestorePlanSoftwareCard disabled={ isBasicHostingDisabled } />,
-				type: 'basic',
-			},
-			{
-				feature: 'cache',
-				content: <CacheCard disabled={ isBasicHostingDisabled } />,
-				type: 'basic',
-			},
-		].filter( ( card ) => card !== null );
-	}, [
-		hasStagingSitesFeature,
-		isAdvancedHostingDisabled,
-		isBasicHostingDisabled,
-		isGithubIntegrationEnabled,
-		isWpcomStagingSite,
-		siteId,
-	] );
+	const mainCards = [
+		{
+			feature: 'sftp',
+			content: <SFTPCard disabled={ isAdvancedHostingDisabled } />,
+			type: 'advanced',
+		},
+		{
+			feature: 'phpmyadmin',
+			content: <PhpMyAdminCard disabled={ isAdvancedHostingDisabled } />,
+			type: 'advanced',
+		},
+		! isWpcomStagingSite && hasStagingSitesFeature
+			? {
+					feature: 'staging-site',
+					content: <StagingSiteCard disabled={ isAdvancedHostingDisabled } />,
+					type: 'advanced',
+			  }
+			: null,
+		isWpcomStagingSite && siteId
+			? {
+					feature: 'staging-production-site',
+					content: (
+						<StagingSiteProductionCard siteId={ siteId } disabled={ isAdvancedHostingDisabled } />
+					),
+					type: 'advanced',
+			  }
+			: null,
+		isGithubIntegrationEnabled
+			? {
+					feature: 'github',
+					content: <GitHubCard />,
+					type: 'advanced',
+			  }
+			: null,
+		{
+			feature: 'web-server-settings',
+			content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
+			type: 'advanced',
+		},
+		{
+			feature: 'restore-plan-software',
+			content: <RestorePlanSoftwareCard disabled={ isBasicHostingDisabled } />,
+			type: 'basic',
+		},
+		{
+			feature: 'cache',
+			content: <CacheCard disabled={ isBasicHostingDisabled } />,
+			type: 'basic',
+		},
+	].filter( ( card ) => card !== null );
 
 	const availableTypes = [
 		! isAdvancedHostingDisabled ? 'advanced' : null,
@@ -155,19 +146,17 @@ const MainCards = ( {
 };
 
 const SidebarCards = ( { isBasicHostingDisabled } ) => {
-	const sidebarCards = useMemo( () => {
-		return [
-			{
-				feature: 'site-backup',
-				content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
-				type: 'basic',
-			},
-			{
-				feature: 'support',
-				content: <SupportCard />,
-			},
-		];
-	}, [ isBasicHostingDisabled ] );
+	const sidebarCards = [
+		{
+			feature: 'site-backup',
+			content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
+			type: 'basic',
+		},
+		{
+			feature: 'support',
+			content: <SupportCard />,
+		},
+	];
 
 	const availableTypes = isBasicHostingDisabled ? [] : [ 'basic' ];
 

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -262,7 +262,7 @@ class Hosting extends Component {
 				);
 			}
 
-			if ( isBasicHostingDisabled && ! isTransferring ) {
+			if ( hasAtomicFeature && ! isSiteAtomic && ! isTransferring ) {
 				const failureNotice = FAILURE === transferState && (
 					<Notice
 						status="is-error"

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -67,11 +67,13 @@ const ShowEnabledFeatureCards = ( { availableTypes, cards } ) => {
 			{ enabledCards.map( ( card ) => {
 				return <Fragment key={ card.feature }>{ card.content }</Fragment>;
 			} ) }
-			<FeatureExample>
-				{ disabledCards.map( ( card ) => {
-					return <Fragment key={ card.feature }>{ card.content }</Fragment>;
-				} ) }
-			</FeatureExample>
+			{ disabledCards.length > 0 && (
+				<FeatureExample>
+					{ disabledCards.map( ( card ) => {
+						return <Fragment key={ card.feature }>{ card.content }</Fragment>;
+					} ) }
+				</FeatureExample>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -334,11 +334,13 @@ class Hosting extends Component {
 		 *  2. The site is Atomic, is not transferring, and doesn't have advanced hosting features.
 		 * Otherwise, we show the activation notice, which may be empty.
 		 */
-		const banner =
+		const shouldShowUpgradeBanner =
 			! hasAtomicFeature ||
-			( isSiteAtomic && ! isTransferInProgress() && isAdvancedHostingDisabled )
-				? getUpgradeBanner()
-				: getAtomicActivationNotice();
+			( isSiteAtomic &&
+				! isTransferInProgress() &&
+				isAdvancedHostingDisabled &&
+				! isWpcomStagingSite );
+		const banner = shouldShowUpgradeBanner ? getUpgradeBanner() : getAtomicActivationNotice();
 
 		return (
 			<Main wideLayout className="hosting">

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -54,7 +54,7 @@ import './style.scss';
 
 const HEADING_OFFSET = 30;
 
-const CardsByEnabledFeatures = ( { availableTypes, cards } ) => {
+const ShowEnabledFeatureCards = ( { availableTypes, cards } ) => {
 	const enabledCards = cards.filter(
 		( card ) => ! card.type || availableTypes.includes( card.type )
 	);
@@ -149,7 +149,7 @@ const MainCards = ( {
 		! isBasicHostingDisabled ? 'basic' : null,
 	].filter( ( type ) => type !== null );
 
-	return <CardsByEnabledFeatures cards={ mainCards } availableTypes={ availableTypes } />;
+	return <ShowEnabledFeatureCards cards={ mainCards } availableTypes={ availableTypes } />;
 };
 
 const SidebarCards = ( { isBasicHostingDisabled } ) => {
@@ -169,7 +169,7 @@ const SidebarCards = ( { isBasicHostingDisabled } ) => {
 
 	const availableTypes = isBasicHostingDisabled ? [] : [ 'basic' ];
 
-	return <CardsByEnabledFeatures cards={ sidebarCards } availableTypes={ availableTypes } />;
+	return <ShowEnabledFeatureCards cards={ sidebarCards } availableTypes={ availableTypes } />;
 };
 
 class Hosting extends Component {

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -1,6 +1,11 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 
 .hosting {
+	/* Rely on the standard spacing for the underlying elements. */
+	.feature-example {
+		margin-top: 0;
+	}
+
 	.card > .material-icon,
 	.card > .gridicon {
 		display: inline-block;

--- a/client/my-sites/hosting/test/index.js
+++ b/client/my-sites/hosting/test/index.js
@@ -1,0 +1,332 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock( 'calypso/components/data/document-head', () => 'document-head' );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'page-view-tracker' );
+jest.mock( 'calypso/components/feature-example', () => ( { children } ) => {
+	return <div data-testid="feature-example-wrapper">{ children }</div>;
+} );
+jest.mock( '../staging-site-card/staging-site-production-card', () => () => (
+	<div data-testid="staging-site-production-card" />
+) );
+
+import {
+	FEATURE_SFTP,
+	FEATURE_SITE_STAGING_SITES,
+	PLAN_BUSINESS_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	WPCOM_FEATURES_ATOMIC,
+} from '@automattic/calypso-products';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import Hosting from '../main';
+
+const getTestConfig = ( {
+	isAtomicSite = false,
+	isWpcomStagingSite = false,
+	planSlug = PLAN_FREE,
+	siteFeatures = [],
+	transferState = transferStates.NONE,
+} ) => {
+	return {
+		isAtomicSite,
+		isWpcomStagingSite,
+		planSlug,
+		siteFeatures,
+		transferState,
+	};
+};
+
+const createTestStore = ( {
+	isAtomicSite,
+	isWpcomStagingSite,
+	planSlug,
+	siteFeatures,
+	transferState,
+} ) => {
+	const TEST_SITE_ID = 1;
+	return createStore( ( state ) => state, {
+		atomicHosting: {
+			[ TEST_SITE_ID ]: {
+				isLoadingSftpUsers: false,
+			},
+		},
+		automatedTransfer: {
+			[ TEST_SITE_ID ]: {
+				status: transferState,
+			},
+		},
+		documentHead: { unreadCount: 0 },
+		ui: { selectedSiteId: TEST_SITE_ID },
+		currentUser: {
+			capabilities: {
+				[ TEST_SITE_ID ]: {
+					manage_options: true,
+				},
+			},
+			id: 1,
+		},
+		sites: {
+			features: {
+				[ TEST_SITE_ID ]: {
+					data: {
+						active: siteFeatures,
+					},
+				},
+			},
+			items: {
+				[ TEST_SITE_ID ]: {
+					is_wpcom_staging_site: isWpcomStagingSite,
+					jetpack: false,
+					options: {
+						is_automated_transfer: isAtomicSite,
+					},
+					URL: 'test-site-example.wordpress.com',
+				},
+			},
+			plans: {
+				[ TEST_SITE_ID ]: {
+					data: [
+						{
+							currentPlan: true,
+							productSlug: planSlug,
+						},
+					],
+				},
+			},
+		},
+	} );
+};
+
+const renderComponentWithStoreAndQueryClient = ( store ) => {
+	render(
+		<Provider store={ store }>
+			<QueryClientProvider client={ new QueryClient() }>
+				<Hosting />
+			</QueryClientProvider>
+		</Provider>
+	);
+};
+
+const stringsForAdvancedFeatureCards = [ 'Database access', 'Web server settings' ];
+
+const stringsForBasicFeatureCards = [ 'Restore plugins and themes', 'Clear cache' ];
+
+const stringsForAllAtomicFeatureCards = [
+	...stringsForAdvancedFeatureCards,
+	...stringsForBasicFeatureCards,
+];
+
+const getExpectedStringsForTestConfig = ( testConfig, { enabledOnly = false } = {} ) => {
+	let expectedStrings = [];
+
+	if ( enabledOnly ) {
+		if ( testConfig.siteFeatures.includes( FEATURE_SFTP ) ) {
+			expectedStrings = stringsForAllAtomicFeatureCards;
+		} else if ( testConfig.siteFeatures.includes( WPCOM_FEATURES_ATOMIC ) ) {
+			expectedStrings = stringsForBasicFeatureCards;
+		}
+	} else {
+		expectedStrings = stringsForAllAtomicFeatureCards;
+	}
+
+	if (
+		testConfig.siteFeatures.includes( FEATURE_SITE_STAGING_SITES ) &&
+		! testConfig.isWpcomStagingSite
+	) {
+		expectedStrings.push( 'Staging site' );
+	}
+
+	return expectedStrings;
+};
+
+const verifyStringsAreWithinFeatureExample = ( strings, featureExampleElement ) => {
+	strings.forEach( ( string ) => {
+		expect( featureExampleElement ).toContainElement( screen.getByText( string ) );
+	} );
+};
+
+describe( 'Hosting Configuration', () => {
+	beforeAll( () => {
+		// Mock the missing `window.matchMedia` function that's not even in JSDOM
+		Object.defineProperty( window, 'matchMedia', {
+			writable: true,
+			value: jest.fn().mockImplementation( ( query ) => ( {
+				matches: false,
+				media: query,
+				onchange: null,
+				addListener: jest.fn(), // deprecated
+				removeListener: jest.fn(), // deprecated
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+				dispatchEvent: jest.fn(),
+			} ) ),
+		} );
+	} );
+
+	describe( 'Site on free plan', () => {
+		it( 'should show upsell banner and all cards should be within FeatureExample', () => {
+			const testConfig = getTestConfig( { planSlug: PLAN_FREE } );
+
+			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+
+			expect(
+				screen.getByText( 'Upgrade to the Business plan to access all hosting features:' )
+			).toBeVisible();
+			expect( screen.getByText( 'Upgrade to Business Plan' ) ).toBeVisible();
+
+			const [ mainFeatureExampleElement ] = screen.getAllByTestId( 'feature-example-wrapper' );
+
+			expect( mainFeatureExampleElement ).toBeVisible();
+
+			const expectedStrings = getExpectedStringsForTestConfig( testConfig );
+			verifyStringsAreWithinFeatureExample( expectedStrings, mainFeatureExampleElement );
+		} );
+	} );
+
+	describe( 'Site on Personal plan', () => {
+		it( 'should show upsell banner and all cards should be within FeatureExample', () => {
+			const testConfig = getTestConfig( { planSlug: PLAN_PERSONAL } );
+			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+
+			expect(
+				screen.getByText( 'Upgrade to the Business plan to access all hosting features:' )
+			).toBeVisible();
+			expect( screen.getByText( 'Upgrade to Business Plan' ) ).toBeVisible();
+
+			const [ mainFeatureExampleElement ] = screen.getAllByTestId( 'feature-example-wrapper' );
+
+			expect( mainFeatureExampleElement ).toBeVisible();
+
+			const expectedStrings = getExpectedStringsForTestConfig( testConfig );
+			verifyStringsAreWithinFeatureExample( expectedStrings, mainFeatureExampleElement );
+		} );
+	} );
+
+	describe( 'Site on Business plan', () => {
+		it( 'should show activation notice when the site is not Atomic', () => {
+			const testConfig = getTestConfig( {
+				planSlug: PLAN_BUSINESS_MONTHLY,
+				siteFeatures: [ WPCOM_FEATURES_ATOMIC, FEATURE_SFTP, FEATURE_SITE_STAGING_SITES ],
+			} );
+
+			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+
+			expect(
+				screen.getByText( 'Please activate the hosting access to begin using these features.' )
+			).toBeVisible();
+			expect( screen.getByText( 'Activate' ) ).toBeVisible();
+
+			const [ mainFeatureExampleElement ] = screen.getAllByTestId( 'feature-example-wrapper' );
+
+			expect( mainFeatureExampleElement ).toBeVisible();
+
+			const expectedStrings = getExpectedStringsForTestConfig( testConfig );
+			verifyStringsAreWithinFeatureExample( expectedStrings, mainFeatureExampleElement );
+		} );
+
+		it( 'should not show the activation notice when the site is Atomic', () => {
+			const testConfig = getTestConfig( {
+				isAtomicSite: true,
+				planSlug: PLAN_BUSINESS_MONTHLY,
+				siteFeatures: [ WPCOM_FEATURES_ATOMIC, FEATURE_SFTP, FEATURE_SITE_STAGING_SITES ],
+				transferState: transferStates.COMPLETE,
+			} );
+
+			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+
+			expect(
+				screen.queryByText( 'Please activate the hosting access to begin using these features.' )
+			).toBeNull();
+			expect( screen.queryByText( 'Activate' ) ).toBeNull();
+			expect( screen.queryByTestId( 'feature-example-wrapper' ) ).toBeNull();
+
+			const expectedStrings = getExpectedStringsForTestConfig( testConfig, { enabledOnly: true } );
+			expectedStrings.forEach( ( string ) => {
+				expect( screen.getByText( string ) ).toBeVisible();
+			} );
+		} );
+
+		it( 'should show the transferring notice when the site is transferring to Atomic', () => {
+			const testConfig = getTestConfig( {
+				isAtomicSite: false,
+				planSlug: PLAN_BUSINESS_MONTHLY,
+				siteFeatures: [ WPCOM_FEATURES_ATOMIC, FEATURE_SFTP, FEATURE_SITE_STAGING_SITES ],
+				transferState: transferStates.START,
+			} );
+
+			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+
+			expect(
+				screen.getByText( 'Please wait while we activate the hosting features.' )
+			).toBeVisible();
+
+			const [ mainFeatureExampleElement ] = screen.getAllByTestId( 'feature-example-wrapper' );
+
+			expect( mainFeatureExampleElement ).toBeVisible();
+
+			const expectedStrings = getExpectedStringsForTestConfig( testConfig );
+			verifyStringsAreWithinFeatureExample( expectedStrings, mainFeatureExampleElement );
+		} );
+	} );
+
+	describe( 'Site on Woo Express/eCommerce Trial plan', () => {
+		it( 'should show the upsell banner with alternate text and show the basic features', () => {
+			const testConfig = getTestConfig( {
+				isAtomicSite: true,
+				planSlug: PLAN_ECOMMERCE_TRIAL_MONTHLY,
+				siteFeatures: [ WPCOM_FEATURES_ATOMIC ],
+				transferState: transferStates.COMPLETE,
+			} );
+
+			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+
+			expect(
+				screen.getByText( 'Upgrade your plan to access all hosting features' )
+			).toBeVisible();
+			expect( screen.getByText( 'Upgrade your plan' ) ).toBeVisible();
+
+			const [ mainFeatureExampleElement ] = screen.getAllByTestId( 'feature-example-wrapper' );
+
+			expect( mainFeatureExampleElement ).toBeVisible();
+
+			verifyStringsAreWithinFeatureExample(
+				stringsForAdvancedFeatureCards,
+				mainFeatureExampleElement
+			);
+
+			stringsForBasicFeatureCards.forEach( ( string ) => {
+				const elementForString = screen.getByText( string );
+
+				expect( elementForString ).toBeVisible();
+				expect( mainFeatureExampleElement ).not.toContainElement( elementForString );
+			} );
+		} );
+	} );
+
+	describe( 'Staging site', () => {
+		it( 'should show the primary site card and not show the upsell nudge', () => {
+			const testConfig = getTestConfig( {
+				isAtomicSite: true,
+				isWpcomStagingSite: true,
+				planSlug: PLAN_BUSINESS_MONTHLY,
+				siteFeatures: [ WPCOM_FEATURES_ATOMIC, FEATURE_SFTP, FEATURE_SITE_STAGING_SITES ],
+				transferState: transferStates.COMPLETE,
+			} );
+
+			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+
+			expect(
+				screen.queryByText( 'Upgrade to the Business plan to access all hosting features:' )
+			).toBeNull();
+			expect( screen.queryByText( 'Upgrade to Business Plan' ) ).toBeNull();
+
+			expect( screen.getByTestId( 'staging-site-production-card' ) ).toBeVisible();
+		} );
+	} );
+} );

--- a/client/my-sites/hosting/test/index.js
+++ b/client/my-sites/hosting/test/index.js
@@ -6,8 +6,15 @@ jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'page-view-tracker' 
 jest.mock( 'calypso/components/feature-example', () => ( { children } ) => {
 	return <div data-testid="feature-example-wrapper">{ children }</div>;
 } );
+jest.mock( '../staging-site-card', () => () => (
+	<div data-testid="staging-site-card">
+		<span>Staging site</span>
+	</div>
+) );
 jest.mock( '../staging-site-card/staging-site-production-card', () => () => (
-	<div data-testid="staging-site-production-card" />
+	<div data-testid="staging-site-production-card">
+		<span>Staging site</span>
+	</div>
 ) );
 
 import {
@@ -135,10 +142,7 @@ const getExpectedStringsForTestConfig = ( testConfig, { enabledOnly = false } = 
 		expectedStrings = stringsForAllAtomicFeatureCards;
 	}
 
-	if (
-		testConfig.siteFeatures.includes( FEATURE_SITE_STAGING_SITES ) &&
-		! testConfig.isWpcomStagingSite
-	) {
+	if ( testConfig.siteFeatures.includes( FEATURE_SITE_STAGING_SITES ) ) {
 		expectedStrings.push( 'Staging site' );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR tackles a number of changes stemming from some assumptions that were made when building the Hosting Configuration page in Calypso. The core issue was that all Atomic features were assumed to be controlled via the SFTP feature, but the recent introduction of free eCommerce trials invalidates that assumption, as those sites should have access to Atomic features but not SSH or SFTP access. As such, this PR tackles a few things:
 * We split out hosting features into `basic` and `advanced` buckets, with the following features falling into the basic Atomic bucket behind the `WPCOM_FEATURES_ATOMIC` feature:
    - Transferring the site to Atomic (which has come up in some cases where initial transfers failed)
    - Restoring plugins and themes from the plan
    - Clearing the site cache
      * **Note:** We currently don't include PHP version and web server configuration in this bucket, as it's not clear that free trials should get access to that functionality - it would be better if we have a dedicated feature for this, but we don't currently have that.
 * The logic for showing the activation and upsell banners has been updated:
    - If the site doesn't have the Atomic feature, we show the upsell banner
    - If the site is Atomic, is not transferring, and doesn't have advanced features (as identified by the SFTP feature), we show the upsell banner
       * This is a departure from the old logic, as we still want an upsell for sites that don't have full hosting access (which is currently limited to Woo Express trials)
    - Otherwise we show the activation banner (which may be null/empty)
 * We keep the existing card sequence in the main part of the page and the sidebar, but we re-order them such that any cards for unavailable features are pushed to a `FeatureExample` that appears below the features that are available.
   - This makes it easier for users to access the features they do have access to, and if there are unavailable features, the upsell banner updates in #76783 should make it clearer what those features are.

This PR depends on #76783 to ensure we show consistent upsell banner content for all site types.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Unit tests

Review the test cases covered by the unit tests, and verify that the unit tests succeed:
```
yarn test-client client/my-sites/hosting/test/index.js
```

### Manual testing

* Run this branch locally or via Calypso.live using the link in [this comment](https://github.com/Automattic/wp-calypso/pull/76667#issuecomment-1538213633).
* For each of the test cases below, we want to navigate to _Settings_ -> _Hosting Configuration_ (i.e. `/hosting-config/:siteSlug`, and confirm that the expectations are met.

#### Test cases

  - A site on WPCOM Simple that doesn't have Atomic features, i.e. the site is free, or has a Personal or Premium plan
    * You should see the upsell banner and the _Support_ card, and all other feature cards should be obscured
<img width="1080" alt="Screenshot 2023-05-17 at 11 53 29" src="https://github.com/Automattic/wp-calypso/assets/3376401/6d4b74b3-aae9-4cf5-b9bc-d0683bca3b43">

  - A site on WPCOM Simple that can go Atomic, e.g. a Simple site with the WordPress.com Business plan
    * You should see the activation banner that allows you to enable hosting features, and the _Support_ card should be visible. All other cards should be obscured.
<img width="1080" alt="Screenshot 2023-05-17 at 12 48 07" src="https://github.com/Automattic/wp-calypso/assets/3376401/cc06a2c6-8035-47e5-b455-6f8d8bc36b6b">

  - An Atomic site that already has access to all Atomic features - this includes the Business, eCommerce, and paid Woo Express plans
    * You should see all cards, and no upsell or activation banner
<img width="1080" alt="Screenshot 2023-05-17 at 11 53 12" src="https://github.com/Automattic/wp-calypso/assets/3376401/0ca79515-4a55-4447-8fa8-5359323ab2e7"> 

  - An Atomic site with access to limited features, which specifically requires a site with the Woo Express trial plan added -- you can create such a site by working through the flow from https://woocommerce.com/start.
    * You should see the upsell banner, the _Restore plugins and themes_ card, the _Cache_ card, the _Site backup card, and the _Support_ card. All other cards in the main section should be obscured.
<img width="1080" alt="Screenshot 2023-05-17 at 11 52 56" src="https://github.com/Automattic/wp-calypso/assets/3376401/d7b100d3-65d0-4636-bf8e-244ac64547b5">

  - Use the Atomic revert tool to revert your Woo Express trial site to WordPress.com Simple.
  - Once the revert completes, navigate to _Settings_ -> _Hosting Configuration_
  - Verify that you are shown the activation banner which allows you to request activation of the site's Atomic features
<img width="1080" alt="Screenshot 2023-05-17 at 12 14 38" src="https://github.com/Automattic/wp-calypso/assets/3376401/f77bc446-c021-4ce7-92e7-707e32513b3a">

  - Click on the "Activate" CTA in the banner, and proceed with the transfer
  - Verify that you see the "Please wait" message in the activation banner while the site transfers to Atomic
<img width="1080" alt="Screenshot 2023-05-17 at 12 14 57" src="https://github.com/Automattic/wp-calypso/assets/3376401/e08bd3e9-8867-42e2-b4ab-8dd9deb39135">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?