### PR TITLE
Signup: Fix incorrect domain upsell alignment

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -10,6 +10,8 @@ import type { TransformedFeatureObject } from '../types';
 
 const SubdomainSuggestion = styled.div`
 	.is-domain-name {
+		position: absolute;
+		top: -15px;
 		color: var( --studio-gray-50 );
 		text-decoration: line-through;
 		max-width: 80%;

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -10,8 +10,6 @@ import type { TransformedFeatureObject } from '../types';
 
 const SubdomainSuggestion = styled.div`
 	.is-domain-name {
-		position: absolute;
-		top: -15px;
 		color: var( --studio-gray-50 );
 		text-decoration: line-through;
 		max-width: 80%;
@@ -75,7 +73,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 						<PlanFeaturesItem>
 							<span className={ spanClasses } key={ key }>
 								<span className={ itemTitleClasses }>
-									{ isFreePlanAndCustomDomainFeature ? (
+									{ isFreePlanAndCustomDomainFeature && domainName ? (
 										<Plans2023Tooltip
 											text={ translate( '%s is not included', {
 												args: [ domainName ],

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -53,6 +53,10 @@ const PlanFeatures2023GridFeatures: React.FC< {
 				const isFreePlanAndCustomDomainFeature =
 					currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN && isFreePlan( planName );
 
+				if ( isFreePlanAndCustomDomainFeature && ! domainName ) {
+					return null;
+				}
+
 				const divClasses = classNames( '', getPlanClass( planName ), {
 					'is-last-feature': featureIndex + 1 === features.length,
 				} );
@@ -73,7 +77,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 						<PlanFeaturesItem>
 							<span className={ spanClasses } key={ key }>
 								<span className={ itemTitleClasses }>
-									{ isFreePlanAndCustomDomainFeature && domainName ? (
+									{ isFreePlanAndCustomDomainFeature ? (
 										<Plans2023Tooltip
 											text={ translate( '%s is not included', {
 												args: [ domainName ],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1683284770327009-slack-C9EJ7KSGH and https://github.com/Automattic/wp-calypso/pull/75526

## Proposed Changes

In this diff, I propose to fix misaligned feature items on the plan comparison page.

Based on Figma mockups, all "Everything in X" texts should be in one line, and then all features below should be positioned in one line.

## Testing Instructions

### Plan comparison for existing site

1. Navigate to any site
2. Navigate to Upgrades -> Plans
3. Confirm that "Beautiful themes and patterns" and "Free domain for one year" features are displayed in one line across plans

<img width="1259" alt="Screenshot 2023-05-08 at 13 29 28" src="https://user-images.githubusercontent.com/727413/236813855-75074a00-32b4-4da4-a351-ee77f5b2cecb.png">


### Plan selector for a new site with a free domain

1. Click "Switch site" and then "Add new site"
2. Enter any slug and choose the free domain
3. Confirm that "Beautiful themes and patterns" and "Free domain for one year" features are displayed in one line across plans

<img width="1174" alt="Screenshot 2023-05-08 at 13 29 45" src="https://user-images.githubusercontent.com/727413/236814039-c19ab35f-5d47-4f7a-9517-ee25ec67ad8b.png">


### Plan selector for a new site with a custom domain

1. Click "Switch site" and then "Add new site"
2. Enter any slug and choose the custom domain, e.g., example.maison
3. Confirm that the "example.wordpress.com" and "example.maison is included" features are still displayed in one line across plans

![Screenshot 2023-05-09 at 09 50 16](https://user-images.githubusercontent.com/727413/237030484-0369833a-fd72-4971-a076-f27428568e40.png)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?