### PR TITLE
Social Previews | Unify text domain for i18n functions

### DIFF
--- a/packages/social-previews/src/facebook-preview/full-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/full-preview.tsx
@@ -19,11 +19,11 @@ const FacebookFullPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 				<SectionHeading level={ props.headingsLevel }>
 					{
 						// translators: refers to a social post on Facebook
-						__( 'Your post', 'facebook-preview' )
+						__( 'Your post', 'social-previews' )
 					}
 				</SectionHeading>
 				<p className="social-preview__section-desc">
-					{ __( 'This is what your social post will look like on Facebook:', 'facebook-preview' ) }
+					{ __( 'This is what your social post will look like on Facebook:', 'social-previews' ) }
 				</p>
 				{ isPostPreview ? (
 					<FacebookPostPreview { ...props } />
@@ -35,17 +35,17 @@ const FacebookFullPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 				<SectionHeading level={ props.headingsLevel }>
 					{
 						// translators: refers to a link to a Facebook post
-						__( 'Link preview', 'facebook-preview' )
+						__( 'Link preview', 'social-previews' )
 					}
 				</SectionHeading>
 				<p className="social-preview__section-desc">
 					{ __(
 						'This is what it will look like when someone shares the link to your WordPress post on Facebook.',
-						'facebook-preview'
+						'social-previews'
 					) }
 					&nbsp;
 					<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-						{ __( 'Learn more about links', 'facebook-preview' ) }
+						{ __( 'Learn more about links', 'social-previews' ) }
 					</ExternalLink>
 				</p>
 				{ isPostPreview ? (

--- a/packages/social-previews/src/facebook-preview/hooks/use-image-hook.ts
+++ b/packages/social-previews/src/facebook-preview/hooks/use-image-hook.ts
@@ -30,7 +30,7 @@ const useImage: UseImage = ( { mode: initialMode } ) => {
 		mode,
 		isLoadingImage,
 		{
-			alt: __( 'Facebook Preview Thumbnail', 'facebook-preview' ),
+			alt: __( 'Facebook Preview Thumbnail', 'social-previews' ),
 			onLoad,
 			onError,
 		},

--- a/packages/social-previews/src/facebook-preview/index.tsx
+++ b/packages/social-previews/src/facebook-preview/index.tsx
@@ -19,11 +19,11 @@ export const FacebookPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 				<SectionHeading level={ props.headingsLevel }>
 					{
 						// translators: refers to a social post on Facebook
-						__( 'Your post', 'facebook-preview' )
+						__( 'Your post', 'social-previews' )
 					}
 				</SectionHeading>
 				<p className="social-preview__section-desc">
-					{ __( 'This is what your social post will look like on Facebook:', 'facebook-preview' ) }
+					{ __( 'This is what your social post will look like on Facebook:', 'social-previews' ) }
 				</p>
 				{ isPostPreview ? (
 					<FacebookPostPreview { ...props } />
@@ -35,17 +35,17 @@ export const FacebookPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 				<SectionHeading level={ props.headingsLevel }>
 					{
 						// translators: refers to a link to a Facebook post
-						__( 'Link preview', 'facebook-preview' )
+						__( 'Link preview', 'social-previews' )
 					}
 				</SectionHeading>
 				<p className="social-preview__section-desc">
 					{ __(
 						'This is what it will look like when someone shares the link to your WordPress post on Facebook.',
-						'facebook-preview'
+						'social-previews'
 					) }
 					&nbsp;
 					<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-						{ __( 'Learn more about links', 'facebook-preview' ) }
+						{ __( 'Learn more about links', 'social-previews' ) }
 					</ExternalLink>
 				</p>
 				{ isPostPreview ? (

--- a/packages/social-previews/src/facebook-preview/link-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/link-preview.tsx
@@ -61,7 +61,7 @@ const FacebookLinkPreview: React.FC< Props > = ( {
 								{ isArticle &&
 									! description &&
 									// translators: Default description for a Facebook post
-									__( 'Visit the post for more.', 'facebook-preview' ) }
+									__( 'Visit the post for more.', 'social-previews' ) }
 							</div>
 							<div className="facebook-preview__info">
 								<FacebookPostIcon name="info" />

--- a/packages/social-previews/src/facebook-preview/post/actions/index.tsx
+++ b/packages/social-previews/src/facebook-preview/post/actions/index.tsx
@@ -9,17 +9,17 @@ const FacebookPostActions: React.FC = () => (
 			{
 				icon: 'like',
 				// translators: Facebook "Like" action
-				label: __( 'Like', 'facebook-preview' ),
+				label: __( 'Like', 'social-previews' ),
 			},
 			{
 				icon: 'comment',
 				// translators: Facebook "Comment" action
-				label: __( 'Comment', 'facebook-preview' ),
+				label: __( 'Comment', 'social-previews' ),
 			},
 			{
 				icon: 'share',
 				// translators: Facebook "Share" action
-				label: __( 'Share', 'facebook-preview' ),
+				label: __( 'Share', 'social-previews' ),
 			},
 		].map( ( { icon, label } ) => (
 			<li key={ icon }>

--- a/packages/social-previews/src/facebook-preview/post/header/index.tsx
+++ b/packages/social-previews/src/facebook-preview/post/header/index.tsx
@@ -35,7 +35,7 @@ const FacebookPostHeader: React.FC< Props > = ( { user, timeElapsed, hideOptions
 					<div className="facebook-preview__post-header-name">
 						{ user?.displayName ||
 							// translators: name of a fictional Facebook User
-							__( 'Anonymous User', 'facebook-preview' ) }
+							__( 'Anonymous User', 'social-previews' ) }
 					</div>
 					<div className="facebook-preview__post-header-share">
 						<span className="facebook-preview__post-header-time">
@@ -43,13 +43,13 @@ const FacebookPostHeader: React.FC< Props > = ( { user, timeElapsed, hideOptions
 								? __(
 										// translators: short version of `1 hour`
 										'1h',
-										'facebook-preview'
+										'social-previews'
 								  )
 								: _x(
 										// translators: temporal indication of when a post was published
 										'Just now',
 										'',
-										'facebook-preview'
+										'social-previews'
 								  ) }
 						</span>
 						<span className="facebook-preview__post-header-dot" aria-hidden="true">

--- a/packages/social-previews/src/tumblr-preview/full-preview.tsx
+++ b/packages/social-previews/src/tumblr-preview/full-preview.tsx
@@ -10,11 +10,11 @@ const TumblrFullPreview: React.FC< TumblrPreviewProps > = ( props ) => {
 				<SectionHeading level={ props.headingsLevel }>
 					{
 						// translators: refers to a social post on Tumblr
-						__( 'Your post', 'tumblr-preview' )
+						__( 'Your post', 'social-previews' )
 					}
 				</SectionHeading>
 				<p className="social-preview__section-desc">
-					{ __( 'This is what your social post will look like on Tumblr:', 'tumblr-preview' ) }
+					{ __( 'This is what your social post will look like on Tumblr:', 'social-previews' ) }
 				</p>
 				<TumblrLinkPreview { ...props } />
 			</section>

--- a/packages/social-previews/src/tumblr-preview/link-preview.tsx
+++ b/packages/social-previews/src/tumblr-preview/link-preview.tsx
@@ -31,11 +31,11 @@ const TumblrLinkPreview: React.FC< TumblrPreviewProps > = ( {
 						<img
 							className="tumblr-preview__image"
 							src={ image }
-							alt={ __( 'Tumblr preview thumbnail', 'tumblr-preview' ) }
+							alt={ __( 'Tumblr preview thumbnail', 'social-previews' ) }
 						/>
 					) }
 					<a className="tumblr-preview__url" href={ url } target="_blank" rel="noreferrer">
-						{ __( 'View On WordPress', 'tumblr-preview' ) }
+						{ __( 'View On WordPress', 'social-previews' ) }
 					</a>
 				</div>
 				<TumblrPostActions />

--- a/packages/social-previews/src/tumblr-preview/post/actions/index.tsx
+++ b/packages/social-previews/src/tumblr-preview/post/actions/index.tsx
@@ -15,12 +15,12 @@ const TumblrPostActions: React.FC = () => (
 					{
 						icon: 'delete',
 						// translators: "Delete" action on a Tumblr post
-						label: __( 'Delete', 'tumblr-preview' ),
+						label: __( 'Delete', 'social-previews' ),
 					},
 					{
 						icon: 'edit',
 						// translators: "Edit" action on a Tumblr post
-						label: __( 'Edit', 'tumblr-preview' ),
+						label: __( 'Edit', 'social-previews' ),
 					},
 				].map( ( { icon, label } ) => (
 					<li key={ icon } aria-label={ label }>
@@ -33,7 +33,7 @@ const TumblrPostActions: React.FC = () => (
 			<div>
 				{
 					// translators: count of notes on a Tumblr post
-					__( '0 notes', 'tumblr-preview' )
+					__( '0 notes', 'social-previews' )
 				}
 			</div>
 			<ul>
@@ -41,22 +41,22 @@ const TumblrPostActions: React.FC = () => (
 					{
 						icon: 'share',
 						// translators: "Share" action on a Tumblr post
-						label: __( 'Share', 'tumblr-preview' ),
+						label: __( 'Share', 'social-previews' ),
 					},
 					{
 						icon: 'reply',
 						// translators: "Reply" action on a Tumblr post
-						label: __( 'Reply', 'tumblr-preview' ),
+						label: __( 'Reply', 'social-previews' ),
 					},
 					{
 						icon: 'reblog',
 						// translators: "Reblog" action on a Tumblr post
-						label: __( 'Reblog', 'tumblr-preview' ),
+						label: __( 'Reblog', 'social-previews' ),
 					},
 					{
 						icon: 'like',
 						// translators: "Like" action on a Tumblr post
-						label: __( 'Like', 'tumblr-preview' ),
+						label: __( 'Like', 'social-previews' ),
 					},
 				].map( ( { icon, label } ) => (
 					<li key={ icon } aria-label={ label }>

--- a/packages/social-previews/src/tumblr-preview/post/header/index.tsx
+++ b/packages/social-previews/src/tumblr-preview/post/header/index.tsx
@@ -13,7 +13,7 @@ const TumblrPostHeader: React.FC< Props > = ( { user } ) => (
 		<div className="tumblr-preview__post-header-username">
 			{ user?.displayName ||
 				// translators: username of a fictional Tumblr User
-				__( 'anonymous-user', 'tumblr-preview' ) }
+				__( 'anonymous-user', 'social-previews' ) }
 		</div>
 		<TumblrPostIcon name="ellipsis" />
 	</div>

--- a/packages/social-previews/src/twitter-preview/sidebar.tsx
+++ b/packages/social-previews/src/twitter-preview/sidebar.tsx
@@ -5,7 +5,7 @@ export const Sidebar: React.FC< SidebarProps > = ( { profileImage, isLast } ) =>
 	return (
 		<div className="twitter-preview__sidebar">
 			<div className="twitter-preview__profile-image">
-				<img alt={ __( 'Twitter profile image' ) } src={ profileImage } />
+				<img alt={ __( 'Twitter profile image', 'social-previews' ) } src={ profileImage } />
 			</div>
 			{ ! isLast && <div className="twitter-preview__connector" /> }
 		</div>


### PR DESCRIPTION
In `social-previews` package, there are many different text domains used which is not ideal for people who want to use this package from npm because they will need to load too many text domains.
More discussion here p1683291335781929-slack-CBG1CP4EN

## Proposed Changes

* Unifiy the text domain for all the i18n strings and use `social-previews` for all the components.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just confirm hat everything works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?