### PR TITLE
Jetpack Pro Dashboard: show the verification status for downtime monitor notification email addresses.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
@@ -12,11 +12,37 @@ $help-text-color: #757575;
 	padding: 16px !important;
 }
 
+.configure-email-address__checkbox-content-container {
+	display: flex;
+	align-items: center;
+}
+
 .configure-email-address__checkbox-content {
-	display: inline-block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	flex: 1;
+	max-width: calc(100% - 30px);
+}
+
+.configure-email-address__verification-status {
+	margin-right: 42px;
+
+	.badge {
+		line-height: 14px;
+		font-size: 0.75rem;
+	}
+}
+
+.configure-email-address__edit-icon {
+	position: absolute;
+	right: 16px;
+	display: flex;
 }
 
 .configure-email-address__checkbox {
+	width: 100%;
+
 	.components-checkbox-control__input:checked {
 		background: var(--studio-gray-80);
 		border-color: var(--studio-gray-80);
@@ -24,6 +50,7 @@ $help-text-color: #757575;
 
 	.components-checkbox-control__label {
 		font-weight: 500;
+		min-width: 95%;
 	}
 
 	.components-base-control__field {
@@ -33,7 +60,14 @@ $help-text-color: #757575;
 	}
 }
 
+.handle-overflow {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 .configure-email-address__checkbox-heading {
+	@extend .handle-overflow;
 	font-weight: 500;
 	font-size: 0.875rem;
 	line-height: 18px;
@@ -41,6 +75,7 @@ $help-text-color: #757575;
 }
 
 .configure-email-address__checkbox-sub-heading {
+	@extend .handle-overflow;
 	font-weight: 400;
 	font-size: 0.75rem;
 	line-height: 18px;

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -45,7 +45,9 @@ export default function NotificationSettings( {
 	const [ selectedDuration, setSelectedDuration ] = useState< Duration | undefined >(
 		defaultDuration
 	);
-	const [ addedEmailAddresses, setAddedEmailAddresses ] = useState< string[] | [] >( [] );
+	const [ defaultUserEmailAddresses, setDefaultUserEmailAddresses ] = useState< string[] | [] >(
+		[]
+	);
 
 	const [ validationError, setValidationError ] = useState< string >( '' );
 	const [ isAddEmailModalOpen, setIsAddEmailModalOpen ] = useState< boolean >( false );
@@ -84,7 +86,7 @@ export default function NotificationSettings( {
 
 	useEffect( () => {
 		if ( settings ) {
-			setAddedEmailAddresses( settings.monitor_user_emails || [] );
+			setDefaultUserEmailAddresses( settings.monitor_user_emails || [] );
 			setEnableEmailNotification( !! settings.monitor_user_email_notifications );
 			setEnableMobileNotification( !! settings.monitor_user_wp_note_notifications );
 		}
@@ -92,7 +94,7 @@ export default function NotificationSettings( {
 
 	useEffect( () => {
 		if ( monitorUserEmails ) {
-			setAddedEmailAddresses( monitorUserEmails );
+			setDefaultUserEmailAddresses( monitorUserEmails );
 		}
 	}, [ monitorUserEmails ] );
 
@@ -210,7 +212,7 @@ export default function NotificationSettings( {
 									</div>
 									{ enableEmailNotification && (
 										<ConfigureEmailNotification
-											defaultEmailAddresses={ addedEmailAddresses }
+											defaultEmailAddresses={ defaultUserEmailAddresses }
 											toggleModal={ toggleAddEmailModal }
 										/>
 									) }
@@ -218,7 +220,7 @@ export default function NotificationSettings( {
 							) : (
 								<div className="notification-settings__content-sub-heading">
 									{ translate( 'Receive email notifications with your account email address %s.', {
-										args: addedEmailAddresses,
+										args: defaultUserEmailAddresses,
 									} ) }
 								</div>
 							) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -259,3 +259,9 @@ export type AllowedMonitorPeriods = 'day' | 'week' | '30 days' | '90 days';
 export interface MonitorUptimeAPIResponse {
 	[ key: string ]: { status: string; downtime_in_minutes?: number };
 }
+
+export interface MonitorSettingsEmail {
+	email: string;
+	name: string;
+	verified: boolean;
+}


### PR DESCRIPTION
Related to 1204408201748644-as-1204484225044519

## Proposed Changes

This PR implements the UI to show the verification status for downtime monitor notification email addresses.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/show-monitor-notification-email-verification-status` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Verify that you can see the verification status. You will have to set the below lines to `addedEmailAddresses`  in the `ConfigureEmailNotification` component to see the extra email addresses

```
addedEmailAddresses = [
		{
			email: 'test-email1@test.com',
			name: 'Test User 1',
			verified: true,
		},
		{
			email: 'test-email2@test.com',
			name: 'Test User 2',
			verified: false,
		},
	]
```

<img width="448" alt="Screenshot 2023-05-08 at 6 56 30 PM" src="https://user-images.githubusercontent.com/10586875/236844556-30665ba0-bc26-4c6a-9bb3-6321a196555d.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?