### PR TITLE
Subscriptions management: Fix the URL for querying post subscriptions for logged-in users

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -11,20 +11,21 @@ type CommentRowProps = PostSubscription & {
 	style: React.CSSProperties;
 };
 
-const CommentRow = ( {
-	id,
-	post_id,
-	post_title,
-	post_excerpt,
-	post_url,
-	blog_id,
-	site_title,
-	site_icon,
-	site_url,
-	date_subscribed,
-	forwardedRef,
-	style,
-}: CommentRowProps ) => {
+const CommentRow = ( props: CommentRowProps ) => {
+	const {
+		id,
+		post_id,
+		post_title,
+		post_excerpt,
+		post_url,
+		blog_id,
+		site_title,
+		site_icon,
+		site_url,
+		date_subscribed,
+		forwardedRef,
+		style,
+	} = props;
 	const translate = useTranslate();
 	const hostname = useMemo( () => new URL( site_url ).hostname, [ site_url ] );
 	const siteIcon = useMemo( () => {

--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -11,21 +11,20 @@ type CommentRowProps = PostSubscription & {
 	style: React.CSSProperties;
 };
 
-const CommentRow = ( props: CommentRowProps ) => {
-	const {
-		id,
-		post_id,
-		post_title,
-		post_excerpt,
-		post_url,
-		blog_id,
-		site_title,
-		site_icon,
-		site_url,
-		date_subscribed,
-		forwardedRef,
-		style,
-	} = props;
+const CommentRow = ( {
+	id,
+	post_id,
+	post_title,
+	post_excerpt,
+	post_url,
+	blog_id,
+	site_title,
+	site_icon,
+	site_url,
+	date_subscribed,
+	forwardedRef,
+	style,
+}: CommentRowProps ) => {
 	const translate = useTranslate();
 	const hostname = useMemo( () => new URL( site_url ).hostname, [ site_url ] );
 	const siteIcon = useMemo( () => {

--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -10,12 +10,12 @@ export enum PostSubscriptionsSortBy {
 	RecentlySubscribed = 'recently_subscribed',
 }
 
-type SubscriptionManagerPostSubscriptions = {
+type PostSubscriptions = {
 	comment_subscriptions: PostSubscription[];
 	total_comment_subscriptions_count: number;
 };
 
-type SubscriptionManagerPostSubscriptionsQueryProps = {
+type PostSubscriptionsQueryProps = {
 	searchTerm?: string;
 	filter?: ( item?: PostSubscription ) => boolean;
 	sortTerm?: PostSubscriptionsSortBy;
@@ -45,19 +45,20 @@ const usePostSubscriptionsQuery = ( {
 	filter = defaultFilter,
 	sortTerm = PostSubscriptionsSortBy.RecentlySubscribed,
 	number = 500,
-}: SubscriptionManagerPostSubscriptionsQueryProps = {} ) => {
+}: PostSubscriptionsQueryProps = {} ) => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 	const cacheKey = useCacheKey( [ 'read', 'post-subscriptions' ] );
 
 	const { data, isFetching, isFetchingNextPage, fetchNextPage, hasNextPage, ...rest } =
-		useInfiniteQuery< SubscriptionManagerPostSubscriptions >(
+		useInfiniteQuery< PostSubscriptions >(
 			cacheKey,
 			async ( { pageParam = 1 } ) => {
-				return await callApi< SubscriptionManagerPostSubscriptions >( {
+				return await callApi< PostSubscriptions >( {
 					path: `/post-comment-subscriptions?per_page=${ number }&page=${ pageParam }`,
 					isLoggedIn,
 					apiVersion: '2',
+					apiNamespace: 'wpcom/v2',
 				} );
 			},
 			{
@@ -80,8 +81,13 @@ const usePostSubscriptionsQuery = ( {
 		// Flatten all the pages into a single array containing all subscriptions
 		const flattenedData = data?.pages?.map( ( page ) => page.comment_subscriptions ).flat();
 
+		// There is an issue that some post subscriptions have a post_id: 0, post_title: null, post_excerpt: "", post_url: false
+		const filteredData = flattenedData?.filter(
+			( comment_subscription ) => typeof comment_subscription.post_url === 'string'
+		);
+
 		// Transform the dates into Date objects
-		const transformedData = flattenedData?.map( ( comment_subscription ) => ( {
+		const transformedData = filteredData?.map( ( comment_subscription ) => ( {
 			...comment_subscription,
 			date_subscribed: new Date( comment_subscription.date_subscribed ),
 		} ) );

--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -81,7 +81,7 @@ const usePostSubscriptionsQuery = ( {
 		// Flatten all the pages into a single array containing all subscriptions
 		const flattenedData = data?.pages?.map( ( page ) => page.comment_subscriptions ).flat();
 
-		// There is an issue that some post subscriptions have a post_id: 0, post_title: null, post_excerpt: "", post_url: false
+		// TODO: Temporary fix for https://github.com/Automattic/wp-calypso/issues/76678, remove once fixed
 		const filteredData = flattenedData?.filter(
 			( comment_subscription ) => typeof comment_subscription.post_url === 'string'
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/76677

## Proposed Changes

* Fix the URL being called for logged-in user by providing the correct namespace of the API call, i.e. `wpcom/v2`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Check out the PR.
2. Navigate to `client/server/pages/index.js` and temporarily add `return next();` to the line `833`:

![Markup on 2023-04-28 at 17:50:44](https://user-images.githubusercontent.com/25105483/235195033-4902bb9d-db57-43a4-b295-2d90feb6731f.png)

3. Build the app.
4. Log in to a test WordPress.com account that has some Comments subscriptions.
5. Navigate to http://calypso.localhost:3000/subscriptions/comments.
6. You should now see the list of your Comments subscriptions. 

_Credits to @ivan-ottinger for the above testing instructions 🙇_ 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
