### PR TITLE
Reader tag pages: show prompt text for prompt tags

### DIFF
--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -18,6 +18,7 @@ button.follow-button {
 	.follow-button__label {
 		color: var(--color-text-subtle);
 		margin-left: 5px;
+		white-space: nowrap;
 	}
 
 	&:hover {

--- a/client/components/data/query-reader-followed-tags/index.jsx
+++ b/client/components/data/query-reader-followed-tags/index.jsx
@@ -1,24 +1,20 @@
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { requestTags } from 'calypso/state/reader/tags/items/actions';
 
 /**
  *  QueryReaderFollowedTags takes no parameters and will add all of a
  *  users tags to the state tree.
  */
-class QueryReaderFollowedTags extends Component {
-	static propTypes = {
-		requestFollowedTags: PropTypes.func.isRequired,
-	};
+const QueryReaderFollowedTags = () => {
+	const locale = useSelector( ( state ) => getCurrentUserLocale( state ) );
+	const dispatch = useDispatch();
 
-	componentDidMount() {
-		this.props.requestFollowedTags();
-	}
+	useEffect( () => {
+		dispatch( requestTags( null, locale ) );
+	}, [ dispatch, locale ] );
+	return null;
+};
 
-	render() {
-		return null;
-	}
-}
-
-export default connect( null, { requestFollowedTags: requestTags } )( QueryReaderFollowedTags );
+export default QueryReaderFollowedTags;

--- a/client/components/data/query-reader-tag/index.jsx
+++ b/client/components/data/query-reader-tag/index.jsx
@@ -1,18 +1,21 @@
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { requestTags } from 'calypso/state/reader/tags/items/actions';
 
-const QueryReaderTag = ( { tag, requestTags: request } ) => {
+const QueryReaderTag = ( { tag } ) => {
+	const locale = useSelector( ( state ) => getCurrentUserLocale( state ) );
+	const dispatch = useDispatch();
+
 	useEffect( () => {
-		request( tag );
-	}, [ request, tag ] );
+		dispatch( requestTags( tag, locale ) );
+	}, [ dispatch, locale, tag ] );
 	return null;
 };
 
 QueryReaderTag.propTypes = {
-	requestTags: PropTypes.func.isRequired,
 	tag: PropTypes.string.isRequired,
 };
 
-export default connect( null, { requestTags } )( QueryReaderTag );
+export default QueryReaderTag;

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -19,10 +19,16 @@ class TagStreamHeader extends Component {
 	render() {
 		const { title, description, isPlaceholder, showFollow, following, onFollowToggle, showBack } =
 			this.props;
+
+		// A bit of a hack: check for a prompt tag (which always have a description) from the slug before waiting for tag info to load,
+		// so we can set a smaller title size and prevent it from resizing as the page loads. Should be refactored if tag descriptions
+		// end up getting used for other things besides prompt tags.
+		const isPromptTag = new RegExp( /^dailyprompt-\d+$/ ).test( title );
+
 		const classes = classnames( {
 			'tag-stream__header': true,
 			'is-placeholder': isPlaceholder,
-			'has-description': description,
+			'has-description': isPromptTag || description,
 			'has-back-button': showBack,
 		} );
 

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -17,11 +17,20 @@ class TagStreamHeader extends Component {
 	};
 
 	render() {
-		const { title, isPlaceholder, showFollow, following, onFollowToggle, translate, showBack } =
-			this.props;
+		const {
+			title,
+			isPlaceholder,
+			hasLongTitle,
+			showFollow,
+			following,
+			onFollowToggle,
+			translate,
+			showBack,
+		} = this.props;
 		const classes = classnames( {
 			'tag-stream__header': true,
 			'is-placeholder': isPlaceholder,
+			'has-long-title': hasLongTitle,
 			'has-back-button': showBack,
 		} );
 

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -17,26 +17,21 @@ class TagStreamHeader extends Component {
 	};
 
 	render() {
-		const {
-			title,
-			isPlaceholder,
-			hasLongTitle,
-			showFollow,
-			following,
-			onFollowToggle,
-			translate,
-			showBack,
-		} = this.props;
+		const { title, description, isPlaceholder, showFollow, following, onFollowToggle, showBack } =
+			this.props;
 		const classes = classnames( {
 			'tag-stream__header': true,
 			'is-placeholder': isPlaceholder,
-			'has-long-title': hasLongTitle,
+			'has-description': description,
 			'has-back-button': showBack,
 		} );
 
 		return (
 			<div className={ classes }>
-				<h1 className="tag-stream__header-title">{ title }</h1>
+				<div className="tag-stream__header-title-group">
+					<h1 className="tag-stream__header-title">{ title }</h1>
+					{ description && <h2 className="tag-stream__header-description">{ description }</h2> }
+				</div>
 				<div className="tag-stream__header-follow">
 					{ showFollow && (
 						<FollowButton

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -45,8 +45,8 @@ class TagStream extends Component {
 			}
 		} );
 		asyncRequire( 'twemoji', function ( twemoji ) {
-			const title = self.props.decodedTagSlug;
 			if ( self._isMounted ) {
+				const title = self.props.decodedTagSlug;
 				self.setState( {
 					twemoji,
 					isEmojiTitle: title && twemoji.test( title ),

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -45,10 +45,11 @@ class TagStream extends Component {
 			}
 		} );
 		asyncRequire( 'twemoji', function ( twemoji ) {
+			const title = self.props.decodedTagSlug;
 			if ( self._isMounted ) {
 				self.setState( {
 					twemoji,
-					isEmojiTitle: self.props.title && twemoji.test( self.props.title ),
+					isEmojiTitle: title && twemoji.test( title ),
 				} );
 			}
 		} );
@@ -99,13 +100,14 @@ class TagStream extends Component {
 
 	render() {
 		const emptyContent = <EmptyContent decodedTagSlug={ this.props.decodedTagSlug } />;
+		const title = this.props.decodedTagSlug;
 		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );
 
 		let imageSearchString = this.props.encodedTagSlug;
 
 		// If the tag contains emoji, convert to text equivalent
 		if ( this.state.emojiText && this.state.isEmojiTitle ) {
-			imageSearchString = this.state.emojiText.convert( this.props.title, {
+			imageSearchString = this.state.emojiText.convert( title, {
 				delimiter: '',
 			} );
 		}
@@ -117,7 +119,7 @@ class TagStream extends Component {
 					<QueryReaderTag tag={ this.props.decodedTagSlug } />
 					{ this.props.showBack && <HeaderBack /> }
 					<TagStreamHeader
-						title={ this.props.title }
+						title={ title }
 						imageSearchString={ imageSearchString }
 						showFollow={ false }
 						showBack={ this.props.showBack }
@@ -130,7 +132,7 @@ class TagStream extends Component {
 		return (
 			<Stream
 				{ ...this.props }
-				listName={ this.props.title }
+				listName={ title }
 				emptyContent={ emptyContent }
 				showFollowInHeader={ true }
 				forcePlaceholders={ ! tag } // if tag has not loaded yet, then make everything a placeholder
@@ -139,23 +141,19 @@ class TagStream extends Component {
 				<QueryReaderTag tag={ this.props.decodedTagSlug } />
 				<DocumentHead
 					title={ this.props.translate( '%s ‹ Reader', {
-						args: this.props.title,
+						args: title,
 						comment: '%s is the section name. For example: "My Likes"',
 					} ) }
 				/>
 				{ this.props.showBack && <HeaderBack /> }
 				<TagStreamHeader
-					title={
-						this.props.isPromptTag && this.props.description
-							? this.props.description
-							: this.props.title
-					}
+					title={ title }
+					description={ this.props.description }
 					imageSearchString={ imageSearchString }
 					showFollow={ !! ( tag && tag.id ) }
 					following={ this.isSubscribed() }
 					onFollowToggle={ this.toggleFollowing }
 					showBack={ this.props.showBack }
-					hasLongTitle={ this.props.isPromptTag }
 				/>
 			</Stream>
 		);
@@ -169,9 +167,7 @@ export default connect(
 			description: tag?.description,
 			followedTags: getReaderFollowedTags( state ),
 			tags: getReaderTags( state ),
-			title: tag?.displayName || decodedTagSlug,
 			isLoggedIn: isUserLoggedIn( state ),
-			isPromptTag: new RegExp( /^dailyprompt-\d+$/ ).test( decodedTagSlug ),
 		};
 	},
 	{

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -6,14 +6,26 @@
 	margin-bottom: 10px;
 }
 
+.tag-stream__header-title-group {
+	display: flex;
+	flex-wrap: wrap;
+	margin-right: 6px;
+}
+
 .tag-stream__header-title {
 	font-size: 2rem;
 	text-transform: capitalize;
 	font-weight: 600;
+	margin-bottom: 4px;
 }
 
-.has-long-title .tag-stream__header-title {
-	font-size: 1.5rem;
+.has-description .tag-stream__header-title {
+	font-size: 1.25rem;
+}
+
+.tag-stream__header-description {
+	font-size: 2rem;
+	font-weight: 600;
 }
 
 // Back button in Tag streams

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -12,6 +12,10 @@
 	font-weight: 600;
 }
 
+.has-long-title .tag-stream__header-title {
+	font-size: 1.5rem;
+}
+
 // Back button in Tag streams
 .is-reader-page .card.header-cake {
 	background: none;

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -13,6 +13,7 @@
 }
 
 .tag-stream__header-title {
+	font-family: "Noto Serif", Georgia, "Times New Roman", Times, serif;
 	font-size: 2rem;
 	text-transform: capitalize;
 	font-weight: 600;
@@ -24,6 +25,7 @@
 }
 
 .tag-stream__header-description {
+	font-family: "Noto Serif", Georgia, "Times New Roman", Times, serif;
 	font-size: 2rem;
 	font-weight: 600;
 }

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -14,9 +14,10 @@
 
 .tag-stream__header-title {
 	font-family: "Noto Serif", Georgia, "Times New Roman", Times, serif;
-	font-size: 2rem;
+	font-size: $font-title-small;
 	text-transform: capitalize;
 	font-weight: 600;
+	line-height: 24px;
 	margin-bottom: 4px;
 }
 

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -26,8 +26,9 @@
 
 .tag-stream__header-description {
 	font-family: "Noto Serif", Georgia, "Times New Roman", Times, serif;
-	font-size: 2rem;
+	font-size: $font-headline-small;
 	font-weight: 600;
+	line-height: 48px;
 }
 
 // Back button in Tag streams

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -14,7 +14,7 @@
 
 .tag-stream__header-title {
 	font-family: "Noto Serif", Georgia, "Times New Roman", Times, serif;
-	font-size: $font-title-small;
+	font-size: 2rem;
 	text-transform: capitalize;
 	font-weight: 600;
 	line-height: 24px;
@@ -22,7 +22,7 @@
 }
 
 .has-description .tag-stream__header-title {
-	font-size: 1.25rem;
+	font-size: $font-title-small;
 }
 
 .tag-stream__header-description {

--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -9,11 +9,11 @@ import { READER_TAGS_REQUEST } from 'calypso/state/reader/action-types';
 import { receiveTags } from 'calypso/state/reader/tags/items/actions';
 
 export function requestTags( action ) {
-	const path =
-		action.payload && action.payload.slug ? `/read/tags/${ action.payload.slug }` : '/read/tags';
+	const path = action.payload.slug ? `/read/tags/${ action.payload.slug }` : '/read/tags';
 
 	return http( {
 		path,
+		query: { locale: action.payload.locale },
 		method: 'GET',
 		apiVersion: '1.2',
 		onSuccess: action,

--- a/client/state/data-layer/wpcom/read/tags/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/utils.js
@@ -28,6 +28,7 @@ export function fromApi( apiResponse ) {
 
 	return map( tags, ( tag ) => ( {
 		id: tag.ID,
+		description: decodeEntities( tag.description ),
 		displayName: decodeEntities( tag.display_name ),
 		url: `/tag/${ tag.slug }`,
 		title: decodeEntities( tag.title ),

--- a/client/state/reader/tags/items/actions.js
+++ b/client/state/reader/tags/items/actions.js
@@ -22,15 +22,13 @@ import 'calypso/state/reader/init';
 export const slugify = ( tag ) =>
 	encodeURIComponent( trim( tag ).toLowerCase().replace( /\s+/g, '-' ).replace( /-{2,}/g, '-' ) );
 
-export const requestTags = ( tag ) => {
-	if ( ! tag ) {
-		return { type: READER_TAGS_REQUEST };
-	}
+export const requestTags = ( tag, locale = null ) => {
+	const slug = tag ? slugify( tag ) : null;
+	const payload = { locale, slug, tag };
 
-	const slug = slugify( tag );
 	return {
 		type: READER_TAGS_REQUEST,
-		payload: { tag, slug },
+		payload,
 	};
 };
 

--- a/client/state/reader/tags/selectors/get-reader-tag-by-slug.js
+++ b/client/state/reader/tags/selectors/get-reader-tag-by-slug.js
@@ -1,0 +1,14 @@
+import 'calypso/state/reader/init';
+
+/**
+ * Returns all of the reader tags cached in calypso
+ *
+ *
+ * @param {Object}  state  Global state tree
+ * @returns {Array}        Reader Tags
+ */
+
+export default function getReaderTagBySlug( state, slug ) {
+	const tags = state.reader.tags.items;
+	return tags ? Object.values( tags ).find( ( tag ) => tag.slug === slug ) : null;
+}


### PR DESCRIPTION
## Proposed Changes

* For Reader tag pages associated with a writing prompt, shows the (translated) prompt text as the title, rather than the tag slug

<img width="1103" alt="Screenshot 2023-05-09 at 11 11 30" src="https://github.com/Automattic/wp-calypso/assets/1699996/3080899c-11ff-49bf-8fdf-f7beb1adff1c">

Companion diff: D110121-code (has been merged)

## Testing Instructions

* Visit a prompt tag page, such as `/tag/dailyprompt-1928`. You should see the text of the writing prompt as the title.
* Go to `/me/account` and change your interface language. Reload the prompt page and you should see the translated prompt text.
