### PR TITLE
Plugins: Make plugin actions handle site data

### DIFF
--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -57,8 +57,8 @@ import 'calypso/state/plugins/init';
  *
  * @param {string} prop - The site property to check. One of 'active', 'autoupdate', 'update', or 'version'.
  * @param {Object} plugin - The plugin object
- * @param {number} siteId - The ID of the site if it exists
- * @returns {boolean} True if the site specific property is on the plugin, false otherwise.
+ * @param {number} siteId - The ID of the site
+ * @returns {any} The value of the prop being requested
  */
 const pluginHasTruthySiteProp = ( prop, plugin, siteId ) => {
 	if ( ! [ 'active', 'autoupdate', 'update', 'version' ].includes( prop ) ) {
@@ -66,7 +66,7 @@ const pluginHasTruthySiteProp = ( prop, plugin, siteId ) => {
 	}
 
 	return plugin.hasOwnProperty( prop )
-		? plugin?.[ prop ]
+		? plugin[ prop ]
 		: siteId && plugin.sites?.[ siteId ]?.[ prop ];
 };
 

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -59,9 +59,9 @@ import 'calypso/state/plugins/init';
  * @returns {boolean} True if any of the site specific properties are on the plugin, false otherwise.
  */
 const isSiteDataOnPluginObject = ( plugin ) => {
-	return [ 'active', 'autoupdate', 'update', 'version' ]
-		.map( ( prop ) => plugin.hasOwnProperty( prop ) )
-		.includes( true );
+	return [ 'active', 'autoupdate', 'update', 'version' ].some( ( prop ) =>
+		plugin.hasOwnProperty( prop )
+	);
 };
 
 /**

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -58,16 +58,16 @@ import 'calypso/state/plugins/init';
  * @param {string} prop - The site property to check. One of 'active', 'autoupdate', 'update', or 'version'.
  * @param {Object} plugin - The plugin object
  * @param {number} siteId - The ID of the site
- * @returns {any} The value of the prop being requested
+ * @returns {boolean} True if the plugin object has the prop, false otherwise.
  */
 const pluginHasTruthySiteProp = ( prop, plugin, siteId ) => {
 	if ( ! [ 'active', 'autoupdate', 'update', 'version' ].includes( prop ) ) {
 		throw new Error( `${ prop } is not a site property.` );
 	}
 
-	return plugin.hasOwnProperty( prop )
+	return !! ( plugin.hasOwnProperty( prop )
 		? plugin[ prop ]
-		: siteId && plugin.sites?.[ siteId ]?.[ prop ];
+		: siteId && plugin.sites?.[ siteId ]?.[ prop ] );
 };
 
 /**

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -53,7 +53,14 @@ import {
 	removePlugin,
 	handleDispatchSuccessCallback,
 } from '../actions';
-import { akismet, helloDolly, jetpack, jetpackUpdated } from './fixtures/plugins';
+import {
+	akismet,
+	akismetWithSites,
+	helloDolly,
+	jetpack,
+	jetpackWithSites,
+	jetpackUpdated,
+} from './fixtures/plugins';
 
 describe( 'actions', () => {
 	const spy = jest.fn();
@@ -79,7 +86,7 @@ describe( 'actions', () => {
 		spy.mockClear();
 	} );
 
-	describe( '#fetchAllSitePlugins()', () => {
+	describe( '#fetchAllPlugins()', () => {
 		describe( 'success', () => {
 			beforeAll( () => {
 				nock( 'https://public-api.wordpress.com:443' )
@@ -250,7 +257,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch request action when triggered', () => {
-			activatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet' } )( spy, getState );
+			activatePlugin( 2916284, {
+				...akismetWithSites,
+				sites: { [ 2916284 ]: { active: false } },
+			} )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_ACTIVATE_REQUEST,
@@ -261,18 +271,29 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch plugin activate request success action when request completes', async () => {
-			await activatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet' } )( spy, getState );
+			await activatePlugin( 2916284, {
+				...akismetWithSites,
+				sites: { [ 2916284 ]: { active: false } },
+			} )( spy, getState );
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_ACTIVATE_REQUEST_SUCCESS,
 				action: ACTIVATE_PLUGIN,
 				siteId: 2916284,
 				pluginId: 'akismet/akismet',
-				data: { ...akismet, active: true, log: [ 'Plugin activated.' ] },
+				data: {
+					...akismet,
+					active: true,
+					log: [ 'Plugin activated.' ],
+				},
 			} );
 		} );
 
 		test( 'should dispatch fail action when request fails', async () => {
-			await activatePlugin( 2916284, { slug: 'fake', id: 'fake/fake' } )( spy, getState );
+			await activatePlugin( 2916284, {
+				slug: 'fake',
+				id: 'fake/fake',
+				sites: { [ 2916284 ]: { active: false } },
+			} )( spy, getState );
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_ACTIVATE_REQUEST_FAILURE,
 				action: ACTIVATE_PLUGIN,
@@ -301,10 +322,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch request action when triggered', () => {
-			deactivatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet', active: true } )(
-				spy,
-				getState
-			);
+			deactivatePlugin( 2916284, akismetWithSites )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_DEACTIVATE_REQUEST,
@@ -315,10 +333,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch plugin deactivate request success action when request completes', async () => {
-			await deactivatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet', active: true } )(
-				spy,
-				getState
-			);
+			await deactivatePlugin( 2916284, akismetWithSites )( spy, getState );
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_DEACTIVATE_REQUEST_SUCCESS,
 				action: DEACTIVATE_PLUGIN,
@@ -369,10 +384,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch request action when triggered', () => {
-			updatePlugin( site.ID, { slug: 'jetpack', id: 'jetpack/jetpack', update: {} } )(
-				spy,
-				getState
-			);
+			updatePlugin( site.ID, jetpackWithSites )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_UPDATE_REQUEST,
@@ -383,11 +395,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch plugin update request success action when request completes', () => {
-			const response = updatePlugin( site.ID, {
-				slug: 'jetpack',
-				id: 'jetpack/jetpack',
-				update: {},
-			} )( spy, getState );
+			const response = updatePlugin( site.ID, jetpackWithSites )( spy, getState );
 			return response.then( () => {
 				expect( spy ).toHaveBeenCalledWith( {
 					type: PLUGIN_UPDATE_REQUEST_SUCCESS,
@@ -400,11 +408,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch site update action when request completes', () => {
-			const response = updatePlugin( site.ID, {
-				slug: 'jetpack',
-				id: 'jetpack/jetpack',
-				update: {},
-			} )( spy, getState );
+			const response = updatePlugin( site.ID, jetpackWithSites )( spy, getState );
 			return response.then( () => {
 				expect( spy ).toHaveBeenCalledWith( {
 					type: SITE_PLUGIN_UPDATED,
@@ -430,10 +434,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch site update actions when plugin already up-to-date', async () => {
-			await updatePlugin( site.ID, { slug: 'jetpack', id: 'jetpack/jetpack', update: true } )(
-				spy,
-				getState
-			);
+			await updatePlugin( site.ID, jetpackWithSites )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_UPDATE_REQUEST_SUCCESS,
@@ -477,10 +478,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch request action when triggered', () => {
-			enableAutoupdatePlugin( site.ID, { slug: 'akismet', id: 'akismet/akismet' } )(
-				spy,
-				getState
-			);
+			enableAutoupdatePlugin( site.ID, {
+				...akismetWithSites,
+				sites: { [ 2916284 ]: { autoupdate: false } },
+			} )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_AUTOUPDATE_ENABLE_REQUEST,
@@ -492,8 +493,8 @@ describe( 'actions', () => {
 
 		test( 'should dispatch plugin enable autoupdate request success action when request completes', async () => {
 			await enableAutoupdatePlugin( site.ID, {
-				slug: 'akismet',
-				id: 'akismet/akismet',
+				...akismetWithSites,
+				sites: { [ 2916284 ]: { autoupdate: false } },
 			} )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
@@ -519,9 +520,8 @@ describe( 'actions', () => {
 
 		test( 'should dispatch plugin update request', async () => {
 			await enableAutoupdatePlugin( site.ID, {
-				slug: 'jetpack',
-				id: 'jetpack/jetpack',
-				update: {},
+				...jetpackWithSites,
+				sites: { [ 2916284 ]: { autoupdate: false } },
 			} )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
@@ -561,11 +561,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch request action when triggered', () => {
-			disableAutoupdatePlugin( site.ID, {
-				slug: 'akismet',
-				id: 'akismet/akismet',
-				autoupdate: true,
-			} )( spy, getState );
+			disableAutoupdatePlugin( site.ID, akismetWithSites )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_AUTOUPDATE_DISABLE_REQUEST,
@@ -576,11 +572,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch plugin disable autoupdate request success action when request completes', async () => {
-			await disableAutoupdatePlugin( site.ID, {
-				slug: 'akismet',
-				id: 'akismet/akismet',
-				autoupdate: true,
-			} )( spy, getState );
+			await disableAutoupdatePlugin( site.ID, akismetWithSites )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_AUTOUPDATE_DISABLE_REQUEST_SUCCESS,
@@ -715,7 +707,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch request action when triggered', () => {
-			removePlugin( site.ID, { slug: 'akismet', id: 'akismet/akismet' } )( spy, getState );
+			removePlugin( site.ID, akismetWithSites )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_REMOVE_REQUEST,
@@ -726,7 +718,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch plugin remove request success action when request completes', async () => {
-			await removePlugin( site.ID, { slug: 'akismet', id: 'akismet/akismet' } )( spy, getState );
+			await removePlugin( site.ID, akismetWithSites )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_REMOVE_REQUEST_SUCCESS,

--- a/client/state/plugins/installed/test/fixtures/plugins.js
+++ b/client/state/plugins/installed/test/fixtures/plugins.js
@@ -19,15 +19,15 @@ const placeSitePropsOnSiteObject = ( pluginObject ) => {
 export const akismet = {
 	id: 'akismet/akismet',
 	slug: 'akismet',
+	active: true,
 	name: 'Akismet',
 	plugin_url: 'https://akismet.com/',
+	version: '3.1.11',
 	description:
 		'Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam</strong>. It keeps your site protected even while you sleep. To get started: 1) Click the "Activate" link to the left of this description, 2) <a href="https://akismet.com/get/">Sign up for an Akismet plan</a> to get an API key, and 3) Go to your Akismet configuration page, and save your API key.',
 	author: 'Automattic',
 	author_url: 'https://automattic.com/wordpress-plugins/',
 	network: false,
-	active: true,
-	version: '3.1.11',
 	autoupdate: true,
 };
 export const akismetWithSites = placeSitePropsOnSiteObject( akismet );
@@ -35,30 +35,30 @@ export const akismetWithSites = placeSitePropsOnSiteObject( akismet );
 export const helloDolly = {
 	id: 'hello-dolly/hello',
 	slug: 'hello-dolly',
+	active: false,
 	name: 'Hello Dolly',
 	plugin_url: 'https://wordpress.org/plugins/hello-dolly/',
+	version: '1.6',
 	description:
 		'This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from <cite>Hello, Dolly</cite> in the upper right of your admin screen on every page',
 	author: 'Matt Mullenweg',
 	author_url: 'http://ma.tt/',
 	network: false,
-	active: false,
-	version: '1.6',
 	autoupdate: true,
 };
 
 export const jetpack = {
 	id: 'jetpack/jetpack',
 	slug: 'jetpack',
+	active: true,
 	name: 'Jetpack by WordPress.com',
 	plugin_url: 'http://jetpack.com',
+	version: '4.1.1',
 	description:
 		'Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.',
 	author: 'Automattic',
 	author_url: 'http://jetpack.com',
 	network: false,
-	active: true,
-	version: '4.1.1',
 	autoupdate: true,
 	update: {
 		id: '20101',
@@ -80,17 +80,17 @@ export const jetpackWithSites = placeSitePropsOnSiteObject( jetpack );
 export const jetpackUpdated = {
 	id: 'jetpack/jetpack',
 	slug: 'jetpack',
+	active: true,
 	name: 'Jetpack by WordPress.com',
 	plugin_url: 'http://jetpack.com',
+	version: '4.2.2',
 	description:
 		'Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.',
 	author: 'Automattic',
 	author_url: 'http://jetpack.com',
 	network: false,
-	log: [ 'Array' ],
-	active: true,
-	version: '4.2.2',
 	autoupdate: true,
+	log: [ 'Array' ],
 };
 
 export const healthCheck = {

--- a/client/state/plugins/installed/test/fixtures/plugins.js
+++ b/client/state/plugins/installed/test/fixtures/plugins.js
@@ -1,48 +1,64 @@
-/**
- */
+const placeSitePropsOnSiteObject = ( pluginObject ) => {
+	const { active, version, autoupdate, update, ...rest } = pluginObject;
+
+	const siteObject = {};
+	[ 'active', 'version', 'autoupdate', 'update' ].forEach( ( propName ) => {
+		if ( pluginObject[ propName ] ) {
+			siteObject[ propName ] = pluginObject[ propName ];
+		}
+	} );
+
+	return {
+		sites: {
+			[ 2916284 ]: siteObject,
+		},
+		...rest,
+	};
+};
 
 export const akismet = {
 	id: 'akismet/akismet',
 	slug: 'akismet',
-	active: true,
 	name: 'Akismet',
 	plugin_url: 'https://akismet.com/',
-	version: '3.1.11',
 	description:
 		'Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam</strong>. It keeps your site protected even while you sleep. To get started: 1) Click the "Activate" link to the left of this description, 2) <a href="https://akismet.com/get/">Sign up for an Akismet plan</a> to get an API key, and 3) Go to your Akismet configuration page, and save your API key.',
 	author: 'Automattic',
 	author_url: 'https://automattic.com/wordpress-plugins/',
 	network: false,
+	active: true,
+	version: '3.1.11',
 	autoupdate: true,
 };
+export const akismetWithSites = placeSitePropsOnSiteObject( akismet );
 
 export const helloDolly = {
 	id: 'hello-dolly/hello',
 	slug: 'hello-dolly',
-	active: false,
 	name: 'Hello Dolly',
 	plugin_url: 'https://wordpress.org/plugins/hello-dolly/',
-	version: '1.6',
 	description:
 		'This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from <cite>Hello, Dolly</cite> in the upper right of your admin screen on every page',
 	author: 'Matt Mullenweg',
 	author_url: 'http://ma.tt/',
 	network: false,
+	active: false,
+	version: '1.6',
 	autoupdate: true,
 };
 
 export const jetpack = {
 	id: 'jetpack/jetpack',
 	slug: 'jetpack',
-	active: true,
 	name: 'Jetpack by WordPress.com',
 	plugin_url: 'http://jetpack.com',
-	version: '4.1.1',
 	description:
 		'Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.',
 	author: 'Automattic',
 	author_url: 'http://jetpack.com',
 	network: false,
+	active: true,
+	version: '4.1.1',
 	autoupdate: true,
 	update: {
 		id: '20101',
@@ -59,21 +75,22 @@ export const jetpack = {
 		},
 	},
 };
+export const jetpackWithSites = placeSitePropsOnSiteObject( jetpack );
 
 export const jetpackUpdated = {
 	id: 'jetpack/jetpack',
 	slug: 'jetpack',
-	active: true,
 	name: 'Jetpack by WordPress.com',
 	plugin_url: 'http://jetpack.com',
-	version: '4.2.2',
 	description:
 		'Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.',
 	author: 'Automattic',
 	author_url: 'http://jetpack.com',
 	network: false,
-	autoupdate: true,
 	log: [ 'Array' ],
+	active: true,
+	version: '4.2.2',
+	autoupdate: true,
 };
 
 export const healthCheck = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

When the TypeScript selectors in https://github.com/Automattic/wp-calypso/pull/76434 are used, the plugin actions will need to handle objects both with and without site data on them. This PR makes that change.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This PR should create no functional changes. Just regression test the plugin actions that correspond to these actions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
