### PR TITLE
Checkout: Convert CheckoutThankYou to TypeScript

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/features-header.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/features-header.tsx
@@ -8,8 +8,19 @@ import {
 import classNames from 'classnames';
 import i18n from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
-const FeaturesHeader = ( { isDataLoaded, isGenericReceipt, purchases, hasFailedPurchases } ) => {
+const FeaturesHeader = ( {
+	isDataLoaded,
+	isGenericReceipt,
+	purchases,
+	hasFailedPurchases,
+}: {
+	isDataLoaded?: boolean;
+	isGenericReceipt?: boolean;
+	purchases?: ReceiptPurchase[];
+	hasFailedPurchases?: boolean;
+} ) => {
 	const classes = classNames( 'checkout-thank-you__features-header', {
 		'is-placeholder': ! isDataLoaded,
 	} );
@@ -24,11 +35,11 @@ const FeaturesHeader = ( { isDataLoaded, isGenericReceipt, purchases, hasFailedP
 
 	const shouldHideFeaturesHeading =
 		hasFailedPurchases ||
-		purchases.some( isGSuiteOrExtraLicenseOrGoogleWorkspace ) ||
-		purchases.some( isDomainRegistration ) ||
-		purchases.some( isDomainMapping ) ||
-		purchases.some( isDomainTransfer ) ||
-		purchases.some( isTitanMail );
+		purchases?.some( isGSuiteOrExtraLicenseOrGoogleWorkspace ) ||
+		purchases?.some( isDomainRegistration ) ||
+		purchases?.some( isDomainMapping ) ||
+		purchases?.some( isDomainTransfer ) ||
+		purchases?.some( isTitanMail );
 
 	if ( shouldHideFeaturesHeading ) {
 		return <div />;

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -661,6 +661,23 @@ export class CheckoutThankYou extends Component<
 		return [ 'TRANSFER', isDomainTransfer ];
 	}
 
+	startTransfer = ( event: { preventDefault: () => void } ) => {
+		event.preventDefault();
+
+		const { selectedSite } = this.props;
+		const purchases = getPurchases( this.props );
+		const delayedTransferPurchase = purchases.find( isDelayedDomainTransfer );
+
+		this.props.recordStartTransferClickInThankYou( delayedTransferPurchase?.meta ?? '' );
+
+		page(
+			domainManagementTransferInPrecheck(
+				selectedSite?.slug ?? '',
+				delayedTransferPurchase?.meta ?? ''
+			)
+		);
+	};
+
 	/**
 	 * Retrieves the component (and any corresponding data) that should be displayed according to the type of purchase
 	 * just performed by the user.
@@ -730,23 +747,6 @@ export class CheckoutThankYou extends Component<
 			return [ 'chargeback-details', purchases.find( isChargeback ) ];
 		}
 		return [];
-	};
-
-	startTransfer = ( event: { preventDefault: () => void } ) => {
-		event.preventDefault();
-
-		const { selectedSite } = this.props;
-		const purchases = getPurchases( this.props );
-		const delayedTransferPurchase = purchases.find( isDelayedDomainTransfer );
-
-		this.props.recordStartTransferClickInThankYou( delayedTransferPurchase?.meta ?? '' );
-
-		page(
-			domainManagementTransferInPrecheck(
-				selectedSite?.slug ?? '',
-				delayedTransferPurchase?.meta ?? ''
-			)
-		);
 	};
 
 	productRelatedMessages = () => {

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
@@ -6,7 +6,7 @@ import PurchaseDetail from 'calypso/components/purchase-detail';
 import { getSiteFileModDisableReason } from 'calypso/lib/site/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
-class EnhancedDetails extends Component {
+class JetpackPlanDetails extends Component {
 	componentDidMount() {
 		this.props.trackAutoconfigHalt();
 	}
@@ -101,4 +101,4 @@ const mapDispatchToProps = ( dispatch, { selectedSite } ) => ( {
 	},
 } );
 
-export default localize( connect( null, mapDispatchToProps )( EnhancedDetails ) );
+export default localize( connect( null, mapDispatchToProps )( JetpackPlanDetails ) );

--- a/client/my-sites/checkout/checkout-thank-you/starter-plan-details.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/starter-plan-details.tsx
@@ -13,7 +13,7 @@ const StarterPlanDetails = ( {
 	sitePlans,
 	purchases,
 }: {
-	selectedSite: false | { slug: string };
+	selectedSite: null | false | { slug: string };
 	sitePlans: SitesPlansResult;
 	purchases: Array< WithSnakeCaseSlug | WithCamelCaseSlug >;
 } ) => {

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -9,6 +9,7 @@ import {
 	isDotComPlan,
 	WPCOM_DIFM_LITE,
 	isDIFMProduct,
+	PLAN_PERSONAL,
 } from '@automattic/calypso-products';
 import { render, screen } from '@testing-library/react';
 import CheckoutThankYouHeader from '../header';
@@ -28,6 +29,7 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 jest.mock( '../domain-registration-details', () => () => 'component--domain-registration-details' );
 jest.mock( '../google-apps-details', () => () => 'component--google-apps-details' );
 jest.mock( '../jetpack-plan-details', () => () => 'component--jetpack-plan-details' );
+jest.mock( '../personal-plan-details', () => () => 'component--personal-plan-details' );
 jest.mock( '../atomic-store-thank-you-card', () => () => (
 	<div data-testid="atomic-store-thank-you-card" />
 ) );
@@ -232,5 +234,81 @@ describe( 'CheckoutThankYou', () => {
 			);
 			expect( screen.queryByTestId( 'difm-lite-thank-you' ) ).not.toBeInTheDocument();
 		} );
+	} );
+
+	it( 'renders the failed purchases content if there are failed purchases', async () => {
+		const props = {
+			...defaultProps,
+			receiptId: 12,
+			selectedSite: {
+				ID: 12,
+			},
+			sitePlans: {
+				hasLoadedFromServer: true,
+			},
+			receipt: {
+				hasLoadedFromServer: true,
+				data: {
+					purchases: [],
+					failedPurchases: [ { productSlug: PLAN_PREMIUM } ],
+				},
+			},
+			refreshSitePlans: ( selectedSite ) => selectedSite,
+			planSlug: PLAN_PREMIUM,
+		};
+
+		render( <CheckoutThankYou { ...props } /> );
+
+		expect( await screen.findByText( /These items could not be added/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the Jetpack plan content if the purchases include a Jetpack plan', async () => {
+		const props = {
+			...defaultProps,
+			receiptId: 12,
+			selectedSite: {
+				ID: 12,
+			},
+			sitePlans: {
+				hasLoadedFromServer: true,
+			},
+			receipt: {
+				hasLoadedFromServer: true,
+				data: {
+					purchases: [ { productSlug: 'jetpack_personal' } ],
+				},
+			},
+			refreshSitePlans: ( selectedSite ) => selectedSite,
+			planSlug: PLAN_PREMIUM,
+		};
+
+		render( <CheckoutThankYou { ...props } /> );
+
+		expect( await screen.findByText( 'component--jetpack-plan-details' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the Personal plan content if the purchases include a Personal plan', async () => {
+		const props = {
+			...defaultProps,
+			receiptId: 12,
+			selectedSite: {
+				ID: 12,
+			},
+			sitePlans: {
+				hasLoadedFromServer: true,
+			},
+			receipt: {
+				hasLoadedFromServer: true,
+				data: {
+					purchases: [ { productSlug: PLAN_PERSONAL } ],
+				},
+			},
+			refreshSitePlans: ( selectedSite ) => selectedSite,
+			planSlug: PLAN_PREMIUM,
+		};
+
+		render( <CheckoutThankYou { ...props } /> );
+
+		expect( await screen.findByText( 'component--personal-plan-details' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -52,6 +52,9 @@ export interface SitePlanData {
 
 export interface SitesPlansResult {
 	data: SitePlanData[] | null;
+	hasLoadedFromServer: boolean;
+	isRequesting: boolean;
+	error: unknown;
 }
 
 export type VariantFilterCallback = ( variant: WPCOMProductVariant ) => boolean;

--- a/client/my-sites/customize/panels.ts
+++ b/client/my-sites/customize/panels.ts
@@ -1,11 +1,7 @@
 /**
  * Mapping from Calypso panel slug to tuple of focus key and value.
- *
- *
- * @type {Object}
  */
-
-export const PANEL_MAPPINGS = {
+export const PANEL_MAPPINGS: Record< string, [ string, string ] > = {
 	widgets: [ 'panel', 'widgets' ],
 	fonts: [ 'section', 'jetpack_fonts' ],
 	identity: [ 'section', 'title_tagline' ],
@@ -24,7 +20,7 @@ export const PANEL_MAPPINGS = {
  * @param  {string}  panel Calypso panel slug
  * @returns {?Object}       WordPress autofocus argument object
  */
-export function getCustomizerFocus( panel ) {
+export function getCustomizerFocus( panel: string ) {
 	if ( PANEL_MAPPINGS.hasOwnProperty( panel ) ) {
 		const [ key, value ] = PANEL_MAPPINGS[ panel ];
 		return { [ `autofocus[${ key }]` ]: value };

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -74,14 +74,14 @@ export function domainManagementRoot() {
 }
 
 /**
- * @param {string?} siteName
- * @param {string?} relativeTo
+ * @param {string|undefined} siteName
+ * @param {string|undefined} relativeTo
  */
 export function domainManagementList( siteName, relativeTo = null ) {
 	if ( isUnderDomainManagementAll( relativeTo ) || isUnderEmailManagementAll( relativeTo ) ) {
 		return domainManagementRoot();
 	}
-	return domainManagementRoot() + '/' + siteName;
+	return domainManagementRoot() + '/' + siteName ?? '';
 }
 
 export function domainManagementEdit( siteName, domainName, relativeTo ) {

--- a/client/state/editor/selectors.ts
+++ b/client/state/editor/selectors.ts
@@ -3,6 +3,7 @@ import { addQueryArgs } from 'calypso/lib/route';
 import { getEditedPost } from 'calypso/state/posts/selectors';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import type { AppState } from 'calypso/types';
 
 import 'calypso/state/editor/init';
 
@@ -12,7 +13,7 @@ import 'calypso/state/editor/init';
  * @param  {Object} state Global state tree
  * @returns {?number}      Current editor post ID
  */
-export function getEditorPostId( state ) {
+export function getEditorPostId( state: AppState ): number | undefined {
 	return state.editor.postId;
 }
 
@@ -22,7 +23,7 @@ export function getEditorPostId( state ) {
  * @param  {Object}  state Global state tree
  * @returns {boolean}       Whether editing new post in editor
  */
-export function isEditorNewPost( state ) {
+export function isEditorNewPost( state: AppState ): boolean {
 	return ! getEditorPostId( state );
 }
 
@@ -35,7 +36,12 @@ export function isEditorNewPost( state ) {
  * @param  {string} type        Post type
  * @returns {string}             Editor URL path
  */
-export function getEditorDuplicatePostPath( state, siteId, postId, type = 'post' ) {
+export function getEditorDuplicatePostPath(
+	state: AppState,
+	siteId: number,
+	postId: number,
+	type = 'post'
+): string {
 	return addQueryArgs(
 		{
 			'jetpack-copy': postId,
@@ -52,7 +58,7 @@ export function getEditorDuplicatePostPath( state, siteId, postId, type = 'post'
  * @param  {number} type        Post type
  * @returns {string}             Editor URL path
  */
-export function getEditorNewPostPath( state, siteId, type = 'post' ) {
+export function getEditorNewPostPath( state: AppState, siteId: number, type = 'post' ): string {
 	let path;
 	switch ( type ) {
 		case 'post':
@@ -85,7 +91,12 @@ export function getEditorNewPostPath( state, siteId, type = 'post' ) {
  * @param  {string} defaultType Fallback post type if post not found
  * @returns {string}             Editor URL path
  */
-export function getEditorPath( state, siteId, postId, defaultType = 'post' ) {
+export function getEditorPath(
+	state: AppState,
+	siteId: number,
+	postId: number | string,
+	defaultType = 'post'
+): string {
 	if ( ! siteId ) {
 		return 'post';
 	}
@@ -100,10 +111,10 @@ export function getEditorPath( state, siteId, postId, defaultType = 'post' ) {
 	return path;
 }
 
-export function isEditorIframeLoaded( state ) {
+export function isEditorIframeLoaded( state: AppState ): boolean {
 	return state.editor.isIframeLoaded;
 }
 
-export function getEditorIframePort( state ) {
+export function getEditorIframePort( state: AppState ): boolean {
 	return state.editor.iframePort;
 }

--- a/client/state/selectors/get-customize-or-edit-front-page-url.ts
+++ b/client/state/selectors/get-customize-or-edit-front-page-url.ts
@@ -2,6 +2,7 @@ import getFrontPageEditorUrl from 'calypso/state/selectors/get-front-page-editor
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import shouldCustomizeHomepageWithGutenberg from 'calypso/state/selectors/should-customize-homepage-with-gutenberg';
 import { getThemeCustomizeUrl, isThemeActive } from 'calypso/state/themes/selectors';
+import { AppState } from 'calypso/types';
 
 /**
  * Returns the URL for opening customizing the given site in either the block editor with
@@ -16,7 +17,12 @@ import { getThemeCustomizeUrl, isThemeActive } from 'calypso/state/themes/select
  * @param  {boolean}  isFSEActive Whether full-site editing is enabled for the site
  * @returns {string}              Customizer or Block Editor URL
  */
-export default function getCustomizeOrEditFrontPageUrl( state, themeId, siteId, isFSEActive ) {
+export default function getCustomizeOrEditFrontPageUrl(
+	state: AppState,
+	themeId: string,
+	siteId: number,
+	isFSEActive?: boolean
+): string | undefined | null {
 	if ( isFSEActive ) {
 		return getSiteEditorUrl( state, siteId );
 	}

--- a/client/state/selectors/get-editor-url.ts
+++ b/client/state/selectors/get-editor-url.ts
@@ -4,8 +4,14 @@ import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { shouldCalypsoifyJetpack } from 'calypso/state/selectors/should-calypsoify-jetpack';
 import shouldLoadGutenframe from 'calypso/state/selectors/should-load-gutenframe';
 import { getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
+import { AppState } from 'calypso/types';
 
-export const getEditorUrl = ( state, siteId, postId = '', postType = 'post' ) => {
+export const getEditorUrl = (
+	state: AppState,
+	siteId: number,
+	postId: string | number | null | undefined = '',
+	postType = 'post'
+): string => {
 	if ( ! shouldLoadGutenframe( state, siteId, postType ) ) {
 		const siteAdminUrl = getSiteAdminUrl( state, siteId );
 		let url = `${ siteAdminUrl }post-new.php?post_type=${ postType }`;

--- a/client/state/selectors/get-front-page-editor-url.ts
+++ b/client/state/selectors/get-front-page-editor-url.ts
@@ -2,6 +2,7 @@ import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor.js';
 import getSiteFrontPage from 'calypso/state/sites/selectors/get-site-front-page';
+import { AppState } from 'calypso/types';
 
 /**
  * Gets the editor URL for the current site's home page
@@ -10,7 +11,7 @@ import getSiteFrontPage from 'calypso/state/sites/selectors/get-site-front-page'
  * @param {Object} siteId Site ID
  * @returns {(boolean|string)} false if there is no homepage set, the editor URL if there is one
  */
-export default function getFrontPageEditorUrl( state, siteId ) {
+export default function getFrontPageEditorUrl( state: AppState, siteId: number ): false | string {
 	const frontPageId = getSiteFrontPage( state, siteId );
 	// this will be zero if no homepage is set
 	if ( 0 === frontPageId ) {

--- a/client/state/selectors/should-customize-homepage-with-gutenberg.ts
+++ b/client/state/selectors/should-customize-homepage-with-gutenberg.ts
@@ -1,4 +1,5 @@
 import getSiteFrontPageType from 'calypso/state/sites/selectors/get-site-front-page-type';
+import { AppState } from 'calypso/types';
 import { getActiveTheme, isThemeGutenbergFirst } from '../themes/selectors';
 
 /**
@@ -7,12 +8,15 @@ import { getActiveTheme, isThemeGutenbergFirst } from '../themes/selectors';
  * Used to open the block editor instead of the customizer for some themes.
  *
  * @param {Object} state  The global state object.
- * @param {string} siteId The ID of the selected site.
+ * @param {number} siteId The ID of the selected site.
  * @returns {boolean} True if Gutenberg should be opened.
  */
-export default function shouldCustomizeHomepageWithGutenberg( state, siteId ) {
+export default function shouldCustomizeHomepageWithGutenberg(
+	state: AppState,
+	siteId: number
+): boolean {
 	const theme = getActiveTheme( state, siteId );
-	const isGutenbergTheme = isThemeGutenbergFirst( state, theme );
+	const isGutenbergTheme = theme ? isThemeGutenbergFirst( state, theme ) : false;
 	const isHomepageAPage = 'page' === getSiteFrontPageType( state, siteId );
 	return isGutenbergTheme && isHomepageAPage;
 }

--- a/client/state/sites/plans/selectors/get-plans-by-site.ts
+++ b/client/state/sites/plans/selectors/get-plans-by-site.ts
@@ -2,7 +2,10 @@ import { initialSiteState } from 'calypso/state/sites/plans/reducer';
 import type { SitesPlansResult } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
 import type { AppState } from 'calypso/types';
 
-export function getPlansBySite( state: AppState, site: { ID: number | undefined } ) {
+export function getPlansBySite(
+	state: AppState,
+	site: undefined | null | { ID: number | undefined }
+) {
 	if ( ! site ) {
 		return initialSiteState;
 	}

--- a/client/state/sites/selectors/get-customizer-url.ts
+++ b/client/state/sites/selectors/get-customizer-url.ts
@@ -1,5 +1,7 @@
+import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { addQueryArgs } from 'calypso/lib/url';
 import { getCustomizerFocus } from 'calypso/my-sites/customize/panels';
+import { AppState } from 'calypso/types';
 import getSiteAdminUrl from './get-site-admin-url';
 import getSiteSlug from './get-site-slug';
 import isJetpackSite from './is-jetpack-site';
@@ -15,10 +17,18 @@ import isJetpackSite from './is-jetpack-site';
  *                                 'add-menu' and 'social-media' show custom guides, any other value shows the default guide
  * @returns {string}               Customizer URL
  */
-export default function getCustomizerUrl( state, siteId, panel, returnUrl, guide ) {
+export default function getCustomizerUrl(
+	state: AppState,
+	siteId: number | undefined | null,
+	panel?: string | undefined | null,
+	returnUrl?: string | undefined | null,
+	guide?: string | undefined | null
+): string | null {
 	if ( ! isJetpackSite( state, siteId ) ) {
 		const siteSlug = getSiteSlug( state, siteId );
-		const url = [ '' ].concat( [ 'customize', panel, siteSlug ].filter( Boolean ) ).join( '/' );
+		const url = [ '' ]
+			.concat( [ 'customize', panel, siteSlug ].filter( isValueTruthy ) )
+			.join( '/' );
 		return addQueryArgs(
 			{
 				return: returnUrl,
@@ -41,7 +51,7 @@ export default function getCustomizerUrl( state, siteId, panel, returnUrl, guide
 	return addQueryArgs(
 		{
 			return: returnUrl,
-			...getCustomizerFocus( panel ),
+			...( panel ? getCustomizerFocus( panel ) : {} ),
 			guide,
 		},
 		adminUrl

--- a/client/state/sites/selectors/get-site-admin-url.ts
+++ b/client/state/sites/selectors/get-site-admin-url.ts
@@ -1,3 +1,4 @@
+import { AppState } from 'calypso/types';
 import getSiteOption from './get-site-option';
 
 /**
@@ -10,7 +11,11 @@ import getSiteOption from './get-site-option';
  * @param  {?string} path   Admin screen path
  * @returns {?string}        Admin URL
  */
-export default function getSiteAdminUrl( state, siteId, path = '' ) {
+export default function getSiteAdminUrl(
+	state: AppState,
+	siteId: number | null | undefined,
+	path = ''
+): string | null {
 	const adminUrl = getSiteOption( state, siteId, 'admin_url' );
 	if ( ! adminUrl ) {
 		return null;

--- a/client/state/sites/selectors/get-site-home-url.ts
+++ b/client/state/sites/selectors/get-site-home-url.ts
@@ -10,7 +10,7 @@ import type { AppState } from 'calypso/types';
  * @param  {?number} siteId Site ID.
  * @returns {string}         Url of the site home.
  */
-export default function getSiteHomeUrl( state: AppState, siteId?: number ): string {
+export default function getSiteHomeUrl( state: AppState, siteId?: number | null ): string {
 	const selectedSiteId = siteId || getSelectedSiteId( state );
 	const siteSlug = getSiteSlug( state, selectedSiteId );
 

--- a/client/state/themes/selectors/get-active-theme.ts
+++ b/client/state/themes/selectors/get-active-theme.ts
@@ -12,10 +12,13 @@ import type { AppState } from 'calypso/types';
  * the checkout-thank-you component always redirects to the theme showcase for the current site.
  * One possible fix would be to get rid of that redirect (related: https://github.com/Automattic/wp-calypso/issues/8262).
  */
-export function getActiveTheme( state: AppState, siteId: number ): string | undefined {
+export function getActiveTheme( state: AppState, siteId: number | undefined ): string | null {
+	if ( ! siteId ) {
+		return null;
+	}
 	const activeTheme = state.themes.activeThemes[ siteId ] ?? null;
 	// If the theme ID is suffixed with -wpcom, remove that string. This is because
 	// we want to treat WP.com themes identically, whether or not they're installed
 	// on a given Jetpack site (where the -wpcom suffix would be appended).
-	return activeTheme ? activeTheme.replace( '-wpcom', '' ) : undefined;
+	return activeTheme ? activeTheme.replace( '-wpcom', '' ) : null;
 }

--- a/client/state/themes/selectors/get-active-theme.ts
+++ b/client/state/themes/selectors/get-active-theme.ts
@@ -1,4 +1,5 @@
 import 'calypso/state/themes/init';
+import type { AppState } from 'calypso/types';
 
 /**
  * Returns the currently active theme on a given site.
@@ -10,15 +11,11 @@ import 'calypso/state/themes/init';
  * This happens in particular after purchasing a premium theme in single-site mode since after a theme purchase,
  * the checkout-thank-you component always redirects to the theme showcase for the current site.
  * One possible fix would be to get rid of that redirect (related: https://github.com/Automattic/wp-calypso/issues/8262).
- *
- * @param  {Object}  state   Global state tree
- * @param  {number}  siteId  Site ID
- * @returns {?string}         Theme ID
  */
-export function getActiveTheme( state, siteId ) {
+export function getActiveTheme( state: AppState, siteId: number ): string | undefined {
 	const activeTheme = state.themes.activeThemes[ siteId ] ?? null;
 	// If the theme ID is suffixed with -wpcom, remove that string. This is because
 	// we want to treat WP.com themes identically, whether or not they're installed
 	// on a given Jetpack site (where the -wpcom suffix would be appended).
-	return activeTheme && activeTheme.replace( '-wpcom', '' );
+	return activeTheme ? activeTheme.replace( '-wpcom', '' ) : undefined;
 }

--- a/client/state/themes/selectors/get-canonical-theme.js
+++ b/client/state/themes/selectors/get-canonical-theme.js
@@ -38,7 +38,7 @@ export const knownConflictingThemes = new Set( [ 'bistro' ] );
  *
  * @param  {Object}  state   Global state tree
  * @param  {number}  siteId  Jetpack Site ID to fall back to
- * @param  {string | null}  themeId Theme ID
+ * @param  {string|null|undefined}  themeId Theme ID
  * @returns {?Theme}         Theme object
  */
 export function getCanonicalTheme( state, siteId, themeId ) {

--- a/client/state/themes/selectors/get-theme-customize-url.ts
+++ b/client/state/themes/selectors/get-theme-customize-url.ts
@@ -1,6 +1,7 @@
 import { getCustomizerUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 import { isThemeActive } from 'calypso/state/themes/selectors/is-theme-active';
+import type { AppState } from 'calypso/types';
 
 import 'calypso/state/themes/init';
 
@@ -12,7 +13,11 @@ import 'calypso/state/themes/init';
  * @param  {?number}  siteId  Site ID to open the customizer for
  * @returns {?string}          Customizer URL
  */
-export function getThemeCustomizeUrl( state, themeId, siteId ) {
+export function getThemeCustomizeUrl(
+	state: AppState,
+	themeId: string,
+	siteId: number | null | undefined
+): string | undefined | null {
 	const customizerUrl = getCustomizerUrl( state, siteId );
 
 	if ( ! ( siteId && themeId ) || isThemeActive( state, themeId, siteId ) ) {

--- a/client/state/themes/selectors/is-theme-gutenberg-first.ts
+++ b/client/state/themes/selectors/is-theme-gutenberg-first.ts
@@ -1,6 +1,7 @@
 import { intersection } from 'lodash';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 import { getThemeTaxonomySlugs } from 'calypso/state/themes/utils';
+import type { AppState } from 'calypso/types';
 
 import 'calypso/state/themes/init';
 
@@ -15,7 +16,7 @@ import 'calypso/state/themes/init';
  *                         `independent-publisher-2` or `maywood`.
  * @returns {boolean} True if the theme should be edited with gutenberg.
  */
-export function isThemeGutenbergFirst( state, themeId ) {
+export function isThemeGutenbergFirst( state: AppState, themeId: string ): boolean {
 	const theme = getTheme( state, 'wpcom', themeId );
 	const themeFeatures = getThemeTaxonomySlugs( theme, 'theme_feature' );
 	const neededFeatures = [ 'global-styles', 'auto-loading-homepage' ];


### PR DESCRIPTION
## Proposed Changes

This PR converts the `CheckoutThankYou` component and several of its dependencies to TypeScript with as few functional changes as possible.

This required one large refactor because the component had a very hard-to-read and highly dynamic method called `getComponentAndPrimaryPurchaseAndDomain()` that TypeScript wouldn't even allow to exist. The method should really be replaced but to simplify this PR, I retained the method's original functionality after removing its component class return value. The wrapper `PurchaseDetailsWrapper` now should handle the actual rendering it used to be used for.

<img width="963" alt="Screenshot 2023-05-10 at 4 03 50 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/8941db34-fa33-4c8f-ae43-6ccd543d586f">

## Testing Instructions

I added some tests but there are a lot of complicated logic patterns in this component that are hard to understand. I have a feeling that much of the code this component contains can be refactored or removed, but this step should simplify doing so.

For example, as far as I can tell we cannot ever render the [generic domain registration details component](https://github.com/Automattic/wp-calypso/blob/4903ab03c1ed33f0b759ae1312b99e3e5547f2e9/client/my-sites/checkout/checkout-thank-you/index.tsx#L947) because it is only rendered [if there is a receipt ID](https://github.com/Automattic/wp-calypso/blob/4903ab03c1ed33f0b759ae1312b99e3e5547f2e9/client/my-sites/checkout/checkout-thank-you/index.tsx#L733) and [a different component is rendered](https://github.com/Automattic/wp-calypso/blob/4903ab03c1ed33f0b759ae1312b99e3e5547f2e9/client/my-sites/checkout/checkout-thank-you/index.tsx#L589) when [a domain registration was purchased](https://github.com/Automattic/wp-calypso/blob/4903ab03c1ed33f0b759ae1312b99e3e5547f2e9/client/my-sites/checkout/checkout-thank-you/index.tsx#L484).

Some checkout URLs to test follow. Each one should look the same before and after this change:

- `/checkout/thank-you/no-site`
- `/thank-you/example.com/unknown-receipt` (where `example.com` should be changed to a real site hostname.)
- The thank-you page for a domain-only purchase (begin the purchase process at `/domains`).
- The thank-you page for a plan (begin the purchase process at `/plans`).