### PR TITLE
Adjust jetpack connect screen for wpcom migration plugin case

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { capitalize, get, isEmpty } from 'lodash';
+import { capitalize, get, isEmpty, startsWith } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
@@ -72,6 +72,7 @@ class Login extends Component {
 		isJetpack: PropTypes.bool.isRequired,
 		isWhiteLogin: PropTypes.bool.isRequired,
 		isJetpackWooCommerceFlow: PropTypes.bool.isRequired,
+		isFromMigrationPlugin: PropTypes.bool,
 		isManualRenewalImmediateLoginAttempt: PropTypes.bool,
 		linkingSocialService: PropTypes.string,
 		oauth2Client: PropTypes.object,
@@ -258,6 +259,7 @@ class Login extends Component {
 			isJetpack,
 			isWhiteLogin,
 			isJetpackWooCommerceFlow,
+			isFromMigrationPlugin,
 			isP2Login,
 			wccomFrom,
 			isManualRenewalImmediateLoginAttempt,
@@ -440,6 +442,8 @@ class Login extends Component {
 					) }
 				</p>
 			);
+		} else if ( isFromMigrationPlugin ) {
+			headerText = translate( 'Log in to your account' );
 		} else if ( isJetpack ) {
 			const isJetpackMagicLinkSignUpFlow = config.isEnabled( 'jetpack/magic-link-signup' );
 			headerText = isJetpackMagicLinkSignUpFlow
@@ -710,6 +714,10 @@ export default connect(
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 		isAnchorFmSignup: getIsAnchorFmSignup(
 			get( getCurrentQueryArguments( state ), 'redirect_to' )
+		),
+		isFromMigrationPlugin: startsWith(
+			get( getCurrentQueryArguments( state ), 'from' ),
+			'wpcom-migration'
 		),
 		currentQuery: getCurrentQueryArguments( state ),
 		currentRoute: getCurrentRoute( state ),

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -464,3 +464,60 @@
 		}
 	}
 }
+
+.is-wpcom-migration.main {
+	--color-accent: var(--studio-blue);
+	--color-accent-light: var(--studio-blue-20);
+	--color-accent-dark: var(--studio-blue-60);
+	--color-accent-60: var(--studio-blue-60);
+	--color-primary: var(--studio-blue-40);
+	--color-primary-light: var(--studio-blue-20);
+	--color-primary-dark: var(--studio-blue-60);
+
+	max-width: 472px !important;
+	$login-border-radius: 4px;
+
+	.login {
+		.login__form {
+			border-top-left-radius: $login-border-radius;
+			border-top-right-radius: $login-border-radius;
+		}
+
+		.login__social {
+			border-bottom-left-radius: $login-border-radius;
+			border-bottom-right-radius: $login-border-radius;
+		}
+
+		.login__divider {
+			margin-top: -12px;
+		}
+
+		.login__form-header {
+			font-size: rem(44px);
+			line-height: rem(48px);
+			font-family: $brand-serif;
+		}
+
+		.login__form-terms {
+			text-align: left;
+			font-size: 0.875rem;
+			margin-bottom: 2rem;
+		}
+
+		.button.is-primary {
+			border: none !important;
+			background-color: var(--color-accent) !important;
+			box-shadow: 0 0 0 2px var(--color-accent) !important;
+
+			&:hover,
+			&:focus {
+				background-color: var(--color-accent-dark) !important;
+				box-shadow: 0 0 0 2px var(--color-accent-dark) !important;
+			}
+
+			.accessible-focus &:focus {
+				box-shadow: 0 0 0 2px var(--color-accent) !important;
+			}
+		}
+	}
+}

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -478,30 +478,89 @@
 	$login-border-radius: 4px;
 
 	.login {
+		form {
+			max-width: 400px;
+			margin: 0 auto;
+
+			.login__form-userdata input:last-of-type {
+				margin-bottom: 10px;
+			}
+		}
+
+		.card {
+			padding-left: 0;
+			padding-right: 0;
+		}
+
+		.login__form,
+		.login__social {
+			border: none;
+			background: none;
+			box-shadow: none;
+		}
+
 		.login__form {
-			border-top-left-radius: $login-border-radius;
-			border-top-right-radius: $login-border-radius;
+			margin-top: 1.5rem;
+			margin-bottom: 1.5rem;
 		}
 
 		.login__social {
-			border-bottom-left-radius: $login-border-radius;
-			border-bottom-right-radius: $login-border-radius;
+			border-top: 1px solid #eaeaeb;
+			padding-top: 2rem;
+			padding-bottom: 2rem;
+
+			.login__social-button {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				flex-direction: column;
+			}
+
+			.login__social-buttons {
+				align-items: center;
+			}
+
+			.login__social-buttons-container {
+				display: flex;
+				flex-direction: column;
+			}
+
+			.social-buttons__button {
+				border: none;
+				background: none;
+				text-align: unset;
+
+				svg {
+					border: 1px solid var(--studio-gray-10);
+					padding: 12px;
+					border-radius: 24px; /* stylelint-disable-line scales/radii */
+				}
+			}
 		}
 
 		.login__divider {
 			margin-top: -12px;
+
+			span {
+				background: var(--studio-gray-0);
+				padding: 0 24px;
+				font-size: 0.75rem;
+				color: var(--studio-gray-50);
+			}
 		}
 
 		.login__form-header {
 			font-size: rem(44px);
 			line-height: rem(48px);
 			font-family: $brand-serif;
+			margin-bottom: 0;
 		}
 
 		.login__form-terms {
 			text-align: left;
 			font-size: 0.875rem;
 			margin-bottom: 2rem;
+			color: var(--studio-gray-50);
 		}
 
 		.button.is-primary {

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -17,6 +17,7 @@ export class AuthFormHeader extends Component {
 	static propTypes = {
 		authQuery: authQueryPropTypes.isRequired,
 		isWoo: PropTypes.bool,
+		isWpcomMigration: PropTypes.bool,
 		wooDnaConfig: PropTypes.object,
 
 		// Connected props
@@ -47,7 +48,7 @@ export class AuthFormHeader extends Component {
 	}
 
 	getHeaderText() {
-		const { translate, partnerSlug, isWoo, wooDnaConfig } = this.props;
+		const { translate, partnerSlug, isWoo, wooDnaConfig, isWpcomMigration } = this.props;
 
 		if ( wooDnaConfig && wooDnaConfig.isWooDnaFlow() ) {
 			return wooDnaConfig.getServiceName();
@@ -90,6 +91,13 @@ export class AuthFormHeader extends Component {
 			}
 		}
 
+		if ( isWpcomMigration ) {
+			switch ( currentState ) {
+				case 'logged-in':
+					return translate( 'Log in to your account' );
+			}
+		}
+
 		switch ( currentState ) {
 			case 'logged-out':
 				return translate( 'Create an account to set up Jetpack' );
@@ -102,7 +110,7 @@ export class AuthFormHeader extends Component {
 	}
 
 	getSubHeaderText() {
-		const { translate, isWoo, wooDnaConfig } = this.props;
+		const { translate, isWoo, wooDnaConfig, isWpcomMigration } = this.props;
 		const currentState = this.getState();
 
 		if ( isWoo ) {
@@ -131,6 +139,13 @@ export class AuthFormHeader extends Component {
 			}
 		}
 
+		if ( isWpcomMigration ) {
+			switch ( currentState ) {
+				case 'logged-in':
+					return translate( 'Connect your site with your WordPress.com account' );
+			}
+		}
+
 		switch ( currentState ) {
 			case 'logged-out':
 				return translate( 'You are moments away from a better WordPress.' );
@@ -145,8 +160,13 @@ export class AuthFormHeader extends Component {
 	}
 
 	getSiteCard() {
+		const { isWpcomMigration } = this.props;
 		const { jpVersion } = this.props.authQuery;
 		if ( ! versionCompare( jpVersion, '4.0.3', '>' ) ) {
+			return null;
+		}
+
+		if ( isWpcomMigration ) {
 			return null;
 		}
 

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -658,6 +658,14 @@ export class JetpackAuthorize extends Component {
 		const { authorizeError, authorizeSuccess, isAuthorizing } = this.props.authorizationData;
 		const { alreadyAuthorized } = this.props.authQuery;
 
+		if ( this.isFromMigrationPlugin() ) {
+			if ( this.props.isFetchingAuthorizationSite ) {
+				return translate( 'Preparing authorization' );
+			}
+
+			return translate( 'Continue' );
+		}
+
 		if ( ! this.props.isAlreadyOnSitesList && ! this.props.isFetchingSites && alreadyAuthorized ) {
 			return translate( 'Go back to your site' );
 		}
@@ -697,6 +705,18 @@ export class JetpackAuthorize extends Component {
 	getUserText() {
 		const { translate } = this.props;
 		const { authorizeSuccess } = this.props.authorizationData;
+		const isWpcomMigration = this.isFromMigrationPlugin();
+
+		if ( isWpcomMigration ) {
+			const { display_name, email } = this.props.user;
+			return (
+				<>
+					<strong>{ display_name }</strong>
+					<br />
+					<small>{ email }</small>
+				</>
+			);
+		}
 
 		// Accounts created through the new Magic Link-based signup flow (enabled with the
 		// 'jetpack/magic-link-signup' feature flag) are created with a username based on the user's
@@ -920,10 +940,12 @@ export class JetpackAuthorize extends Component {
 		const { translate } = this.props;
 		const wooDna = this.getWooDnaConfig();
 		const authSiteId = this.props.authQuery.clientId;
+		const gravatarSize = this.isFromMigrationPlugin() ? 94 : 64;
 
 		return (
 			<MainWrapper
 				isWoo={ this.isWooOnboarding() }
+				isWpcomMigration={ this.isFromMigrationPlugin() }
 				wooDnaConfig={ wooDna }
 				pageTitle={
 					wooDna.isWooDnaFlow() ? wooDna.getServiceName() + ' — ' + translate( 'Connect' ) : ''
@@ -940,10 +962,11 @@ export class JetpackAuthorize extends Component {
 						<AuthFormHeader
 							authQuery={ this.props.authQuery }
 							isWoo={ this.isWooOnboarding() }
+							isWpcomMigration={ this.isFromMigrationPlugin() }
 							wooDnaConfig={ wooDna }
 						/>
 						<Card className="jetpack-connect__logged-in-card">
-							<Gravatar user={ this.props.user } size={ 64 } />
+							<Gravatar user={ this.props.user } size={ gravatarSize } />
 							<p className="jetpack-connect__logged-in-form-user-text">{ this.getUserText() }</p>
 							{ this.renderNotices() }
 							{ this.renderStateAction() }

--- a/client/jetpack-connect/colors.scss
+++ b/client/jetpack-connect/colors.scss
@@ -38,3 +38,10 @@
 		background: var(--color-accent);
 	}
 }
+
+@mixin wpcom-migration-colors() {
+	--color-accent: var(--studio-blue);
+	--color-primary: var(--studio-blue-40);
+	--color-accent-dark: var(--studio-blue-60);
+	--color-accent-60: var(--studio-blue-60);
+}

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -13,6 +13,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 	static propTypes = {
 		isWide: PropTypes.bool,
 		isWoo: PropTypes.bool,
+		isWpcomMigration: PropTypes.bool,
 		wooDnaConfig: PropTypes.object,
 		partnerSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
@@ -26,8 +27,17 @@ export class JetpackConnectMainWrapper extends PureComponent {
 	};
 
 	render() {
-		const { isWide, isWoo, className, children, partnerSlug, translate, wooDnaConfig, pageTitle } =
-			this.props;
+		const {
+			isWide,
+			isWoo,
+			isWpcomMigration,
+			className,
+			children,
+			partnerSlug,
+			translate,
+			wooDnaConfig,
+			pageTitle,
+		} = this.props;
 
 		const isWooDna = wooDnaConfig && wooDnaConfig.isWooDnaFlow();
 
@@ -35,6 +45,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 			'is-wide': isWide,
 			'is-woocommerce': isWoo || isWooDna,
 			'is-mobile-app-flow': !! retrieveMobileRedirect(),
+			'is-wpcom-migration': isWpcomMigration,
 		} );
 
 		const width = isWoo || isWooDna ? 200 : undefined;
@@ -47,13 +58,15 @@ export class JetpackConnectMainWrapper extends PureComponent {
 					skipTitleFormatting={ Boolean( pageTitle ) }
 				/>
 				<div className="jetpack-connect__main-logo">
-					<JetpackHeader
-						partnerSlug={ partnerSlug }
-						isWoo={ isWoo }
-						isWooDna={ isWooDna }
-						width={ width }
-						darkColorScheme={ darkColorScheme }
-					/>
+					{ ! isWpcomMigration && (
+						<JetpackHeader
+							partnerSlug={ partnerSlug }
+							isWoo={ isWoo }
+							isWooDna={ isWooDna }
+							width={ width }
+							darkColorScheme={ darkColorScheme }
+						/>
+					) }
 				</div>
 				{ children }
 			</Main>

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1178,11 +1178,13 @@ body.is-section-jetpack-connect {
 
 	.jetpack-connect__logged-in-form-user-text {
 		font-size: $font-title-small;
+		margin-bottom: 0;
 	}
 
 	.jetpack-connect__tos-link {
 		font-size: $font-body-small;
 		margin-bottom: rem(50px);
+		color: var(--studio-gray-50);
 
 		a {
 			text-decoration: underline;
@@ -1194,6 +1196,10 @@ body.is-section-jetpack-connect {
 		min-width: 170px;
 		margin: auto;
 		display: block;
+	}
+
+	.logged-out-form__links::before {
+		background: #c3c4c7;
 	}
 
 	.logged-out-form__link-item {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -3,7 +3,8 @@
 $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__main:not(.is-woocommerce),
-.layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow):not(.is-jetpack-woocommerce-flow):not(.is-jetpack-woo-dna-flow) {
+.jetpack-connect__main:not(.is-wpcom-migration),
+.layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow):not(.is-jetpack-woocommerce-flow):not(.is-jetpack-woo-dna-flow):not(.is-wpcom-migration) {
 	@include jetpack-connect-colors();
 }
 
@@ -1145,4 +1146,62 @@ body.is-section-jetpack-connect {
 .is-section-jetpack-connect .selector__main {
 	--color-accent: var(--studio-jetpack-green-40);
 	--color-primary: var(--studio-jetpack-green-40);
+}
+
+// wpcom migration plugin adjustments
+.jetpack-connect__main.is-wpcom-migration {
+	@include wpcom-migration-colors();
+	max-width: 472px;
+
+	.formatted-header__title {
+		color: var(--studio-gray-100);
+		font-size: rem(44px);
+		font-family: $brand-serif;
+	}
+
+	.formatted-header__subtitle {
+		font-size: rem(16px);
+		margin-bottom: rem(40px);
+	}
+
+	.jetpack-connect__site.card,
+	.jetpack-connect__logged-in-card.card {
+		max-width: 472px;
+		border-radius: 4px;
+		box-shadow: 0 0 0 1px #c3c4c7;
+	}
+
+	.gravatar {
+		border: solid 1px #a7aaad;
+		padding: 8px;
+	}
+
+	.jetpack-connect__logged-in-form-user-text {
+		font-size: $font-title-small;
+	}
+
+	.jetpack-connect__tos-link {
+		font-size: $font-body-small;
+		margin-bottom: rem(50px);
+
+		a {
+			text-decoration: underline;
+		}
+	}
+
+	.button {
+		width: auto;
+		min-width: 170px;
+		margin: auto;
+		display: block;
+	}
+
+	.logged-out-form__link-item {
+		color: var(--color-accent-dark);
+
+		&:hover,
+		&:focus {
+			color: var(--color-accent);
+		}
+	}
 }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -3,6 +3,7 @@ import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { get, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -37,6 +38,7 @@ export class Login extends Component {
 		isLoggedIn: PropTypes.bool.isRequired,
 		isLoginView: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
+		isFromMigrationPlugin: PropTypes.bool,
 		isWhiteLogin: PropTypes.bool.isRequired,
 		isPartnerSignup: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
@@ -296,12 +298,16 @@ export class Login extends Component {
 	}
 
 	render() {
-		const { locale, translate } = this.props;
+		const { locale, translate, isFromMigrationPlugin } = this.props;
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
+		const mainClassNames = classNames( 'wp-login__main', {
+			'is-wpcom-migration': isFromMigrationPlugin,
+		} );
+
 		return (
 			<div>
 				{ this.props.isP2Login && this.renderP2Logo() }
-				<Main className="wp-login__main">
+				<Main className={ mainClassNames }>
 					{ this.renderI18nSuggestions() }
 
 					<DocumentHead
@@ -330,6 +336,10 @@ export default connect(
 			getCurrentQueryArguments( state ).email_address ||
 			getInitialQueryArguments( state ).email_address,
 		isPartnerSignup: isPartnerSignupQuery( getCurrentQueryArguments( state ) ),
+		isFromMigrationPlugin: startsWith(
+			get( getCurrentQueryArguments( state ), 'from' ),
+			'wpcom-migration'
+		),
 	} ),
 	{
 		recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),


### PR DESCRIPTION
Related to #76331

## Proposed Changes

* Adjusted jetpack connect screen for wpcom migration plugin case

![Markup on 2023-05-09 at 00:09:44](https://user-images.githubusercontent.com/1241413/236949064-a66d3f9a-d3ca-40f3-adb0-6d06d69a9625.png)

<img width="543" alt="Screenshot 2023-05-10 at 16 27 53" src="https://github.com/Automattic/wp-calypso/assets/1241413/22114e92-6594-4fe3-81ee-54cd484cf658">

## Testing Instructions

* Create a `jurassic ninja` website with the installed `Move to WordPress.com` plugin
* Click on "Get Started" button
* Replace `wordpress.com` with `http://calypso.localhost:3000/` if you are testing it locally
* or replace it with the live link domain
* Check the new adapted design of the authorization screen
* Click on `Sign in as a different user`
* Check if the new adapted design of the login screen (without Jetpack branding)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
