### PR TITLE
Launchpad: Fix domain copy icon spacing

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -211,6 +211,7 @@
 		align-items: center;
 		flex-grow: 1;
 		width: 0;
+		margin-right: 6px;
 	}
 
 	.launchpad__url-box-domain-text {
@@ -218,13 +219,15 @@
 		white-space: nowrap;
 		overflow: hidden;
 		padding: 4px 0;
-		padding-right: 8px;
+		padding-right: 6px;
 		letter-spacing: -0.24px;
 		font-size: $font-body-small;
 	}
 
 	.launchpad__url-box-domain:hover > .launchpad__clipboard-button {
 		opacity: 1;
+		margin-top: 2px;
+		flex-shrink: 0;
 	}
 
 	.launchpad__clipboard-button:focus {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -224,18 +224,15 @@
 		font-size: $font-body-small;
 	}
 
-	.launchpad__url-box-domain:hover > .launchpad__clipboard-button {
-		opacity: 1;
+	.launchpad__clipboard-button {
+		opacity: 0;
 		margin-top: 2px;
 		flex-shrink: 0;
 	}
 
+	.launchpad__url-box-domain:hover > .launchpad__clipboard-button,
 	.launchpad__clipboard-button:focus {
 		opacity: 1;
-	}
-
-	.launchpad__clipboard-button {
-		opacity: 0;
 	}
 }
 


### PR DESCRIPTION
Resolves: https://github.com/Automattic/wp-calypso/issues/75720

### Proposed Changes

Fixes some small spacing issues with the copy icon in the Launchpad > domain name box. The icon is appearing too close to the Customize badge when domain names are long. Note that we only show the customize badge now for newsletters, so you would not see this issue on other flows. 

<img width="806" alt="copy icon" src="https://user-images.githubusercontent.com/21228350/236952267-69112148-6048-48a5-a65e-7edd7d6ccc65.png">

### Testing Instructions

1. Checkout this branch and run yarn and yarn start if needed. 
2. Start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro and use a very long domain name. You can also use an existing, launchpad-enabled newsletter site, and just update the domain name. 
3. Go to launchpad at http://calypso.localhost:3000/setup/newsletter/launchpad?siteSlug=SITESLUG. If you don't have a long domain name, you can just update the domain name on the screen via the developer tools. 
4. Confirm that the icon always fits well with comfortable spacing. 