### PR TITLE
Backup: Add render switch to validate multisites and backup feature on backup page

### DIFF
--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -105,11 +105,7 @@ export function showUnavailableForMultisites( context, next ) {
 	);
 
 	context.primary = (
-		<MultisiteNoBackupPlanSwitch
-			trueComponent={ message }
-			falseComponent={ context.primary }
-			loadingComponent={ <p>Loading..</p> }
-		/>
+		<MultisiteNoBackupPlanSwitch trueComponent={ message } falseComponent={ context.primary } />
 	);
 
 	next();

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -14,8 +14,8 @@ import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import BackupUpsell from './backup-upsell';
 import BackupCloneFlow from './clone-flow';
-import IsMultiSiteSwitch from './is-multisite-switch';
 import BackupsPage from './main';
+import MultisiteNoBackupPlanSwitch from './multisite-no-backup-plan-switch';
 import BackupRewindFlow, { RewindFlowPurpose } from './rewind-flow';
 import WPCOMBackupUpsell from './wpcom-backup-upsell';
 import WpcomBackupUpsellPlaceholder from './wpcom-backup-upsell-placeholder';
@@ -96,7 +96,7 @@ export function showUnavailableForVaultPressSites( context, next ) {
 export function showUnavailableForMultisites( context, next ) {
 	debug( 'controller: showUnavailableForMultisites', context.params );
 
-	// Only show "Multisite not supported" card if the multisite does Not already own a Backup subscription.
+	// Only show "Multisite not supported" card if the multisite does not already own a Backup subscription.
 	// https://href.li/?https://wp.me/pbuNQi-1jg
 	const message = isJetpackCloud() ? (
 		<BackupUpsell reason="multisite_not_supported" />
@@ -105,7 +105,7 @@ export function showUnavailableForMultisites( context, next ) {
 	);
 
 	context.primary = (
-		<IsMultiSiteSwitch
+		<MultisiteNoBackupPlanSwitch
 			trueComponent={ message }
 			falseComponent={ context.primary }
 			loadingComponent={ <p>Loading..</p> }

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -1,4 +1,4 @@
-import { isJetpackBackupSlug, WPCOM_FEATURES_BACKUPS } from '@automattic/calypso-products';
+import { isJetpackBackupSlug } from '@automattic/calypso-products';
 import Debug from 'debug';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import HasVaultPressSwitch from 'calypso/components/jetpack/has-vaultpress-switch';
@@ -11,11 +11,10 @@ import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { setFilter } from 'calypso/state/activity-log/actions';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import BackupUpsell from './backup-upsell';
 import BackupCloneFlow from './clone-flow';
+import IsMultiSiteSwitch from './is-multisite-switch';
 import BackupsPage from './main';
 import BackupRewindFlow, { RewindFlowPurpose } from './rewind-flow';
 import WPCOMBackupUpsell from './wpcom-backup-upsell';
@@ -97,21 +96,21 @@ export function showUnavailableForVaultPressSites( context, next ) {
 export function showUnavailableForMultisites( context, next ) {
 	debug( 'controller: showUnavailableForMultisites', context.params );
 
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
+	// Only show "Multisite not supported" card if the multisite does Not already own a Backup subscription.
+	// https://href.li/?https://wp.me/pbuNQi-1jg
+	const message = isJetpackCloud() ? (
+		<BackupUpsell reason="multisite_not_supported" />
+	) : (
+		<WPCOMBackupUpsell reason="multisite_not_supported" />
+	);
 
-	if (
-		isJetpackSiteMultiSite( state, siteId ) &&
-		! siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS )
-	) {
-		// Only show "Multisite not supported" card if the multisite does Not already own a Backup subscription.
-		// https://href.li/?https://wp.me/pbuNQi-1jg
-		context.primary = isJetpackCloud() ? (
-			<BackupUpsell reason="multisite_not_supported" />
-		) : (
-			<WPCOMBackupUpsell reason="multisite_not_supported" />
-		);
-	}
+	context.primary = (
+		<IsMultiSiteSwitch
+			trueComponent={ message }
+			falseComponent={ context.primary }
+			loadingComponent={ <p>Loading..</p> }
+		/>
+	);
 
 	next();
 }

--- a/client/my-sites/backup/is-multisite-switch.tsx
+++ b/client/my-sites/backup/is-multisite-switch.tsx
@@ -1,0 +1,58 @@
+import { WPCOM_FEATURES_BACKUPS } from '@automattic/calypso-products';
+import { FunctionComponent, ReactNode, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
+import RenderSwitch from 'calypso/components/jetpack/render-switch';
+import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
+import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+
+type Props = {
+	trueComponent: ReactNode;
+	falseComponent: ReactNode;
+	loadingComponent?: ReactNode;
+};
+
+const IsMultiSiteSwitch: FunctionComponent< Props > = ( {
+	trueComponent,
+	falseComponent,
+	loadingComponent,
+} ) => {
+	const siteId = useSelector( getSelectedSiteId );
+
+	const isMultiSite =
+		useSelector( ( state ) => siteId && isJetpackSiteMultiSite( state, siteId ) ) || false;
+
+	const hasBackupFeature = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS )
+	);
+
+	const isRequesting = useSelector( ( state ) => isRequestingSiteFeatures( state, siteId ) );
+	const siteFeatures = useSelector( ( state ) => getFeaturesBySiteId( state, siteId ) );
+	const loadingCondition = useCallback(
+		() => isRequesting && siteFeatures === null,
+		[ isRequesting, siteFeatures ]
+	);
+
+	const renderCondition = useCallback(
+		() => isMultiSite && ! hasBackupFeature,
+		[ hasBackupFeature, isMultiSite ]
+	);
+
+	return (
+		<>
+			<RenderSwitch
+				loadingCondition={ loadingCondition }
+				renderCondition={ renderCondition }
+				queryComponent={ <QuerySiteFeatures siteIds={ [ siteId ] } /> }
+				loadingComponent={ loadingComponent }
+				trueComponent={ trueComponent }
+				falseComponent={ falseComponent }
+			/>
+		</>
+	);
+};
+
+export default IsMultiSiteSwitch;

--- a/client/my-sites/backup/multisite-no-backup-plan-switch.tsx
+++ b/client/my-sites/backup/multisite-no-backup-plan-switch.tsx
@@ -44,13 +44,19 @@ const MultisiteNoBackupPlanSwitch: FunctionComponent< Props > = ( {
 		[ hasBackupFeature, isMultiSite ]
 	);
 
+	const loadingDefaultPlaceholder = (
+		<div className="loading">
+			<div className="loading__placeholder" />
+		</div>
+	);
+
 	return (
 		<>
 			<RenderSwitch
 				loadingCondition={ loadingCondition }
 				renderCondition={ renderCondition }
 				queryComponent={ <QuerySiteFeatures siteIds={ [ siteId ] } /> }
-				loadingComponent={ loadingComponent }
+				loadingComponent={ loadingComponent ?? loadingDefaultPlaceholder }
 				trueComponent={ trueComponent }
 				falseComponent={ falseComponent }
 			/>

--- a/client/my-sites/backup/multisite-no-backup-plan-switch.tsx
+++ b/client/my-sites/backup/multisite-no-backup-plan-switch.tsx
@@ -15,7 +15,7 @@ type Props = {
 	loadingComponent?: ReactNode;
 };
 
-const IsMultiSiteSwitch: FunctionComponent< Props > = ( {
+const MultisiteNoBackupPlanSwitch: FunctionComponent< Props > = ( {
 	trueComponent,
 	falseComponent,
 	loadingComponent,
@@ -31,11 +31,14 @@ const IsMultiSiteSwitch: FunctionComponent< Props > = ( {
 
 	const isRequesting = useSelector( ( state ) => isRequestingSiteFeatures( state, siteId ) );
 	const siteFeatures = useSelector( ( state ) => getFeaturesBySiteId( state, siteId ) );
+
+	// We should keep loading if we don't have site features yet and we are requesting them.
 	const loadingCondition = useCallback(
 		() => isRequesting && siteFeatures === null,
 		[ isRequesting, siteFeatures ]
 	);
 
+	// The idea is to render the `trueComponent` if the site is multisite and doesn't have the backup feature.
 	const renderCondition = useCallback(
 		() => isMultiSite && ! hasBackupFeature,
 		[ hasBackupFeature, isMultiSite ]
@@ -55,4 +58,4 @@ const IsMultiSiteSwitch: FunctionComponent< Props > = ( {
 	);
 };
 
-export default IsMultiSiteSwitch;
+export default MultisiteNoBackupPlanSwitch;


### PR DESCRIPTION
If a customer is trying to access the backup page directly in Calypso using a multisite with backup capabilities, they are getting a message saying "WordPress multi-sites are not supported".

This is because when accessing directly the page, we are not querying site features before. So the idea of this PR is to add a new switch component to validate if a site is part of a Jetpack multisite that can be used as part of the [showUnavailableForMultisites()](https://github.com/Automattic/wp-calypso/blob/0650cc21ec42c79e8c1536a4966d60976d0cf5a4/client/my-sites/backup/controller.js#L97) middleware.
## Proposed Changes

* Add new switch component to validate if a site is part of a Jetpack multisite
* Use new switch component on `showUnavailableForMultisites` backup controller middleware.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

First, we should grab a site that is part of a multisite and also has (or not) the backup feature. You can test this PR in your local environment by returning `true` on [`isJetpackSiteMultiSite` selector](https://github.com/Automattic/wp-calypso/blob/11e5d35381f271cf1c88d7af1f8d45cb820c1dc5/client/state/sites/selectors/is-jetpack-site-multi-site.js#L12) to simulate the multisite condition. 

Then navigate directly to http://jetpack.cloud.localhost:3000/backup/{site_slug}.

If your site has no backup feature, you should see the following message:

| Jetpack Cloud | Calypso Blue |
|---|---|
| <img width="500" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/0664f893-ac1d-499d-9db6-143ee7bc45e4" /> | <img width="500" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/05277fcd-1bb1-456c-a8ae-51fbef9562ee" /> |

If your site has the backup feature, you should see the backup section as usual:

<img width="500" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/0e90c73d-9efb-4031-ab15-fe80c16a0bb8">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
