### PR TITLE
Stats: Fix header link color for the "Default" color scheme

### DIFF
--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -88,10 +88,6 @@
 				line-height: 20px;
 				color: var(--color-neutral-60);
 			}
-
-			.inline-support-link {
-				color: var(--color-primary);
-			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76701 

## Proposed Changes

* Use variable `--color-link` to defer to the color scheme on the header link color.

|Before|After|
|-|-|
|<img width="536" alt="截圖 2023-05-09 下午3 56 06" src="https://user-images.githubusercontent.com/6869813/237032030-9b8361fb-485f-4d3b-b655-7e1fb860bcf5.png">|<img width="527" alt="截圖 2023-05-09 下午3 56 14" src="https://user-images.githubusercontent.com/6869813/237032070-0f08873d-6f1b-4c24-9798-9812c916d3ff.png">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the change with the Live Branch.
* Navigate to the Stats `Traffic` page.
* Ensure the header link color is highlighted as other pages for the `Default` color scheme.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
