### PR TITLE
Reader: Set static height in search area

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -36,11 +36,11 @@ const updateQueryArg = ( params ) =>
 
 const pickSort = ( sort ) => ( sort === 'date' ? SORT_BY_LAST_UPDATED : SORT_BY_RELEVANCE );
 
-const SpacerDiv = withDimensions( ( { width, height } ) => (
+const SpacerDiv = withDimensions( ( { width } ) => (
 	<div
 		style={ {
 			width: `${ width }px`,
-			height: `${ height }px`,
+			height: `60px`,
 		} }
 	/>
 ) );


### PR DESCRIPTION
This PR fixes the space between the search input and the results. 

At the moment the space is filled by a `SpacerDiv` component with a dynamic width and height. This PR just sets the height to a static value.

![CleanShot 2023-05-08 at 16 40 28@2x](https://user-images.githubusercontent.com/5560595/237054295-e3c222ed-6315-4ea4-b814-2cc6c947e953.png)
