### PR TITLE
Jetpack Pro Dashboard: Implement check/uncheck the downtime monitor notification settings email address

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -2,7 +2,7 @@ import { Card, Button } from '@automattic/components';
 import { CheckboxControl } from '@wordpress/components';
 import { Icon, plus, pencil } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import Badge from 'calypso/components/badge';
 import type { MonitorSettingsEmail } from '../../sites-overview/types';
 
@@ -12,20 +12,23 @@ interface StateEmailItem extends MonitorSettingsEmail {
 	checked: boolean;
 	isDefault?: boolean;
 }
+
 interface Props {
 	defaultEmailAddresses: Array< string >;
 	toggleModal: () => void;
 	addedEmailAddresses?: Array< MonitorSettingsEmail >;
+	allEmailItems: Array< StateEmailItem >;
+	setAllEmailItems: ( emailAddresses: Array< StateEmailItem > ) => void;
 }
 
 export default function ConfigureEmailNotification( {
 	defaultEmailAddresses = [],
 	toggleModal,
 	addedEmailAddresses = [], // FIXME: This value will come from the API.
+	allEmailItems,
+	setAllEmailItems,
 }: Props ) {
 	const translate = useTranslate();
-
-	const [ allEmailItems, setAllEmailItems ] = useState< StateEmailItem[] >( [] );
 
 	useEffect( () => {
 		if ( defaultEmailAddresses ) {
@@ -45,12 +48,25 @@ export default function ConfigureEmailNotification( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	const handleOnChange = () => {
-		if ( defaultEmailAddresses.length === 1 ) {
+	const handleOnChange = ( item: StateEmailItem, checked: boolean ) => {
+		if ( item.isDefault ) {
 			return;
-			// FIXME: We need to show a custom error message here.
+			// FIXME: We need to show a custom error message here or a tooltip.
 		}
-		// FIXME: Onselect of checkbox, we need to update the state of the checkbox.
+		if ( ! item.verified ) {
+			return;
+			// FIXME: We can open the verification modal here.
+		}
+		const updatedEmailItems = allEmailItems.map( ( emailItem ) => {
+			if ( emailItem.email === item.email ) {
+				return {
+					...emailItem,
+					checked,
+				};
+			}
+			return emailItem;
+		} );
+		setAllEmailItems( updatedEmailItems );
 	};
 
 	const showVerified = true; // FIXME: This should be dynamic.
@@ -88,7 +104,7 @@ export default function ConfigureEmailNotification( {
 					<CheckboxControl
 						className="configure-email-address__checkbox"
 						checked={ item.checked }
-						onChange={ handleOnChange }
+						onChange={ ( checked ) => handleOnChange( item, checked ) }
 						label={ getCheckboxContent( item ) }
 					/>
 				</Card>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../sites-overview/utils';
 import ConfigureEmailNotification from '../configure-email-notification';
 import AddNewEmailModal from '../configure-email-notification/add-new-email-modal';
-import type { MonitorSettings, Site } from '../../sites-overview/types';
+import type { MonitorSettings, Site, MonitorSettingsEmail } from '../../sites-overview/types';
 
 import './style.scss';
 
@@ -25,6 +25,11 @@ interface Props {
 	settings?: MonitorSettings;
 	monitorUserEmails?: Array< string >;
 	isLargeScreen?: boolean;
+}
+
+interface StateEmailItem extends MonitorSettingsEmail {
+	checked: boolean;
+	isDefault?: boolean;
 }
 
 export default function NotificationSettings( {
@@ -48,7 +53,7 @@ export default function NotificationSettings( {
 	const [ defaultUserEmailAddresses, setDefaultUserEmailAddresses ] = useState< string[] | [] >(
 		[]
 	);
-
+	const [ allEmailItems, setAllEmailItems ] = useState< StateEmailItem[] | [] >( [] );
 	const [ validationError, setValidationError ] = useState< string >( '' );
 	const [ isAddEmailModalOpen, setIsAddEmailModalOpen ] = useState< boolean >( false );
 
@@ -214,6 +219,8 @@ export default function NotificationSettings( {
 										<ConfigureEmailNotification
 											defaultEmailAddresses={ defaultUserEmailAddresses }
 											toggleModal={ toggleAddEmailModal }
+											setAllEmailItems={ setAllEmailItems }
+											allEmailItems={ allEmailItems }
 										/>
 									) }
 								</>


### PR DESCRIPTION
Related to 1204408201748644-as-1204484225044515

## Proposed Changes

This PR implements a checkbox to allow users to check/uncheck the downtime monitor notification settings email address.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-monitor-email-selection-checkbox` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Verify that you can check/uncheck only verified email addresses, not the default and unverified email addresses. You will have to set the below lines to `addedEmailAddresses`  in the `ConfigureEmailNotification` component to see the extra email addresses. 

```
addedEmailAddresses = [
		{
			email: 'test-email1@test.com',
			name: 'Test User 1',
			verified: true,
		},
		{
			email: 'test-email2@test.com',
			name: 'Test User 2',
			verified: false,
		},
	]
```

<img width="449" alt="Screenshot 2023-05-09 at 2 23 02 PM" src="https://user-images.githubusercontent.com/10586875/237056321-1c91b67d-f167-41c0-a17e-58335e332ef9.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?