### PR TITLE
Reading Settings: Allow default home and posts page to be set individually.

### DIFF
--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -80,8 +80,8 @@ const YourHomepageDisplaysSetting = ( {
 	const handlePageOnFrontChange: React.FormEventHandler = ( { target } ) => {
 		const selectedPageId: string = ( target as HTMLSelectElement ).value;
 		if ( selectedPageId === '' ) {
-			// Default was selected, so we need to set show_on_front to 'posts' and unset page_for_posts.
-			onChange?.( { show_on_front: 'posts', page_on_front: '', page_for_posts: '' } );
+			// Default was selected, so we need to set show_on_front to 'posts'
+			onChange?.( { show_on_front: 'posts', page_on_front: '' } );
 		} else {
 			onChange?.( { show_on_front: 'page', page_on_front: selectedPageId } );
 		}
@@ -126,7 +126,7 @@ const YourHomepageDisplaysSetting = ( {
 				<FormSelect
 					id="posts-page-select"
 					name="page_for_posts"
-					disabled={ disabled || isLoading || ! pages?.length || page_on_front === '' }
+					disabled={ disabled || isLoading || ! pages?.length }
 					value={ page_for_posts }
 					onChange={ handlePageForPostsChange }
 				>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Fixes #76681

## Proposed Changes

* Allow homepage and posts page to be set individually.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Reading Settings at `/settings/reading/yoursitehere.wordpress.com`.
* The "Your homepage display" dropdown, set homepage to `--- Default ---`.
* The "Default posts page" dropdown, should still be enabled.
  * You should be able to set any posts page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
