### PR TITLE
Blog onboarding: "Site Title" should not be populated in start-writing flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
@@ -92,6 +92,8 @@ const SetupForm = ( {
 					value={ siteTitle }
 					onChange={ ( value ) => setComponentSiteTitle( value ) }
 					placeholder={ translatedText?.titlePlaceholder || __( 'My Site Name' ) }
+					// eslint-disable-next-line jsx-a11y/no-autofocus
+					autoFocus
 				/>
 				{ invalidSiteTitle && (
 					<FormInputValidation

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-blog/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-blog/index.tsx
@@ -1,4 +1,4 @@
-import { StepContainer } from '@automattic/onboarding';
+import { StepContainer, isStartWritingFlow } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
@@ -37,8 +37,7 @@ const SetupBlog: Step = ( { navigation, flow } ) => {
 
 	useEffect( () => {
 		// Clear site title and show placeholder for the flows below
-		const isStartWritingFlow = 'start-writing' === flow;
-		if ( isStartWritingFlow ) {
+		if ( isStartWritingFlow( flow ) ) {
 			setComponentSiteTitle( '' );
 		}
 	}, [ flow, setComponentSiteTitle ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-blog/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-blog/index.tsx
@@ -12,7 +12,7 @@ import useSetupFormInitialValues from '../components/setup-form/hooks/use-setup-
 import type { Step } from '../../types';
 import './styles.scss';
 
-const SetupBlog: Step = ( { navigation } ) => {
+const SetupBlog: Step = ( { navigation, flow } ) => {
 	const { submit } = navigation;
 	const translate = useTranslate();
 	const site = useSite();
@@ -34,6 +34,14 @@ const SetupBlog: Step = ( { navigation } ) => {
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
 
 	const { siteTitle, setComponentSiteTitle, tagline, setTagline } = useSetupFormInitialValues();
+
+	useEffect( () => {
+		// Clear site title and show placeholder for the flows below
+		const isStartWritingFlow = 'start-writing' === flow;
+		if ( isStartWritingFlow ) {
+			setComponentSiteTitle( '' );
+		}
+	}, [ flow, setComponentSiteTitle ] );
 
 	useEffect( () => {
 		setIsSubmitError( false );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-blog/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-blog/index.tsx
@@ -37,10 +37,10 @@ const SetupBlog: Step = ( { navigation, flow } ) => {
 
 	useEffect( () => {
 		// Clear site title and show placeholder for the flows below
-		if ( isStartWritingFlow( flow ) ) {
+		if ( isStartWritingFlow( flow ) && siteTitle === 'Site Title' ) {
 			setComponentSiteTitle( '' );
 		}
-	}, [ flow, setComponentSiteTitle ] );
+	}, [ flow, setComponentSiteTitle, siteTitle ] );
 
 	useEffect( () => {
 		setIsSubmitError( false );
@@ -61,7 +61,6 @@ const SetupBlog: Step = ( { navigation, flow } ) => {
 					blogname: siteTitle,
 					blogdescription: tagline,
 				} );
-				setIsLoading( false );
 				submit?.();
 			}
 		} catch {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2337

## Proposed Changes

* "Site Title" should not be populated in start-writing flow

| Before  | After |
| :-------------: | :-------------: |
| ![before](https://github.com/Automattic/wp-calypso/assets/6586048/213f9587-2fff-422c-9325-f964174c6a2b)  | ![after](https://github.com/Automattic/wp-calypso/assets/6586048/4e6cc3d4-977a-4f36-adf3-ff6e4846d805) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/start-writing/launchpad?siteSlug={siteSlug}&start-writing=true` or create a new site from `/setup/start-writing`
* Check if it is blank with the placeholder

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
