### PR TITLE
Launchpad: update typography

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -152,17 +152,19 @@
 		.step-container__content h1,
 		.step-container__content h1.launchpad__sidebar-h1 {
 			color: var(--studio-gray-100);
-			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+			font-family: $brand-serif;
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			font-size: 28px;
+			font-size: 32px;
 			font-weight: 400;
-			line-height: 1.1;
+			line-height: 40px;
 			margin: 0 0 10px;
 			padding: 0;
 			letter-spacing: -0.32px;
 
 			@include break-large {
-				font-size: $font-headline-medium;
+				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+				font-size: 44px;
+				line-height: 52px;
 			}
 		}
 	}
@@ -179,7 +181,7 @@
 }
 
 .launchpad__sidebar-header-flow-name {
-	font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+	font-family: $brand-serif;
 	font-style: normal;
 	font-weight: 400;
 	font-size: $font-body-large;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -153,18 +153,16 @@
 		.step-container__content h1.launchpad__sidebar-h1 {
 			color: var(--studio-gray-100);
 			font-family: $brand-serif;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			font-size: 32px;
+			font-size: rem(32px);
 			font-weight: 400;
-			line-height: 40px;
+			line-height: rem(40px);
 			margin: 0 0 10px;
 			padding: 0;
 			letter-spacing: -0.32px;
 
 			@include break-large {
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-				font-size: 44px;
-				line-height: 52px;
+				font-size: rem(44px);
+				line-height: rem(52px);
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -153,7 +153,7 @@
 		.step-container__content h1.launchpad__sidebar-h1 {
 			color: var(--studio-gray-100);
 			font-family: $brand-serif;
-			font-size: rem(32px);
+			font-size: $font-title-large;
 			font-weight: 400;
 			line-height: rem(40px);
 			margin: 0 0 10px;


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/75692

## Proposed Changes

* Adjust heading font size and line-height according to design
* Use variables for font-families

## Testing Instructions

* Go through different onboarding flows, e.g. `/setup/newsletter` and reach the launchpad.
* Test desktop, mobile, different browsers. Compare with design.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
