### PR TITLE
Add reseller in domain verification endpoint request

### DIFF
--- a/client/landing/domains/registrant-verification/index.jsx
+++ b/client/landing/domains/registrant-verification/index.jsx
@@ -19,9 +19,9 @@ class RegistrantVerificationPage extends Component {
 	state = this.getLoadingState();
 
 	componentDidMount() {
-		const { domain, email, token } = this.props;
+		const { domain, email, token, reseller } = this.props;
 		wp.req
-			.get( `/domains/${ domain }/verify-email`, { email, token } )
+			.get( `/domains/${ domain }/verify-email`, { email, token, reseller } )
 			.then( ( response ) => {
 				this.setState( this.getVerificationSuccessState( response?.domains ?? [ domain ] ) );
 			} )


### PR DESCRIPTION
## Proposed Changes

This PR updates the domain contact verification endpoint call, adding `reseller` parameter.

If the reseller is not null, backend perform validation logic using Domain Services API.

## Testing Instructions

Before testing the api, ensure that the required wpcom code is updated (D110203-code).

Then register a new domain in the reseller OTE account, using a new unverified email, and click on the link in the verification email (it should arrive in a few minutes).

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?