### PR TITLE
Remove iframe type check for youtube embeddings

### DIFF
--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -68,10 +68,6 @@ const isValidYoutubeEmbed = ( node ) => {
 		return false;
 	}
 
-	if ( node.getAttribute( 'type' ) !== 'text/html' ) {
-		return false;
-	}
-
 	const link = root.document.createElement( 'a' );
 	link.href = node.getAttribute( 'src' );
 


### PR DESCRIPTION
Fixes #73488

## Proposed Changes

Remove the iframe type check to identify if it's a youtube embedding, keeping only the checks by type (iframe) and class.
The type property is not one described as a property (not even deprecated) for iframes on [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe), which made me believe it's ok to remove this check from here.

## Testing Instructions
* Go to the plugin's page of a plugin with a youtube video in the description. Ex: give(`/plugins/give/:site`)
* Check if the youtube video is being rendered

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-05-09 at 10 27 48@2x](https://github.com/Automattic/wp-calypso/assets/5039531/8e5c7953-db18-4837-a21b-d16387543c69)|![CleanShot 2023-05-09 at 10 28 14@2x](https://github.com/Automattic/wp-calypso/assets/5039531/6c61e9b8-b39b-4e28-b407-da48899760b5)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
