### PR TITLE
Checkout: display 14-day refund copy below CTA for biennially and triennially products

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -1,4 +1,10 @@
-import { isYearly, isJetpackPurchasableItem, isMonthlyProduct } from '@automattic/calypso-products';
+import {
+	isYearly,
+	isJetpackPurchasableItem,
+	isMonthlyProduct,
+	isBiennially,
+	isTriennially,
+} from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
 	MainContentWrapper,
@@ -634,7 +640,9 @@ const SubmitButtonFooter = () => {
 	}
 
 	const show7DayGuarantee = responseCart?.products?.every( isMonthlyProduct );
-	const show14DayGuarantee = responseCart?.products?.every( isYearly );
+	const show14DayGuarantee = responseCart?.products?.every(
+		( product ) => isYearly( product ) || isBiennially( product ) || isTriennially( product )
+	);
 	const content =
 		show7DayGuarantee || show14DayGuarantee ? (
 			translate( '%(dayCount)s day money back guarantee', {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/75542. See p1683625556906589-slack-C04H4NY6STW.

## Proposed Changes

If the user is buying a product with a multi-year tenure, we should display only the 14-day refund copy.

| Before | After |
| ------- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/2d7ec5bb-4556-4c02-ae62-a3f25f222a1f) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/8d41a487-8ce9-4540-a0f4-a0a89e2c43b3) |

## Testing Instructions

1. Go to `/start/hosting`;
2. Choose a monthly plan;
3. Proceed to checkout;
4. Verify that the "7 day money back guarantee" copy shows up below the checkout CTA;
5. Change to a yearly plan;
6. Verify that the "14 day money back guarantee" copy shows up below the checkout CTA;
7. Change to biyearly, then triyearly plan;
8. Verify that you still see the "7 day money back guarantee" copy below the checkout CTA.