### PR TITLE
Remove uses of aspect ratio since height is known

### DIFF
--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -24,7 +24,11 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	flex: 1;
 
 	@include break-medium {
-		width: calc((65svh - 50px) * 1.5);
+		width: calc((65vh - 50px) * 1.5);
+
+		@supports (min-height: 65svh) {
+			width: calc((65svh - 50px) * 1.5);
+		}
 	}
 
 	&.design-carousel__item-mobile {
@@ -53,7 +57,7 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	overflow: hidden;
 	height: calc(65vh - 50px);
 	// iPhone aspect ratio
-	width: calc((65svh - 50px) * 0.48);
+	width: calc((65vh - 50px) * 0.48);
 	outline: none;
 
 	// needed for iOS Safari.

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -24,7 +24,7 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	flex: 1;
 
 	@include break-medium {
-		aspect-ratio: 1.5;
+		width: calc((65svh - 50px) * 1.5);
 	}
 
 	&.design-carousel__item-mobile {
@@ -40,8 +40,6 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 		}
 	}
 
-	// iPhone aspect ratio
-	aspect-ratio: 0.48;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -54,12 +52,14 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	padding: 0;
 	overflow: hidden;
 	height: calc(65vh - 50px);
+	// iPhone aspect ratio
+	width: calc((65svh - 50px) * 0.48);
 	outline: none;
-	max-width: 100%;
 
 	// needed for iOS Safari.
 	@supports (min-height: 65svh) {
 		height: calc(65svh - 50px);
+		width: calc((65svh - 50px) * 1.5);
 	}
 
 	opacity: 0.5;

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -23,14 +23,6 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 .design-carousel__item {
 	flex: 1;
 
-	@include break-medium {
-		width: calc((65vh - 50px) * 1.5);
-
-		@supports (min-height: 65svh) {
-			width: calc((65svh - 50px) * 1.5);
-		}
-	}
-
 	&.design-carousel__item-mobile {
 		@include break-medium {
 			display: none;
@@ -56,14 +48,21 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	padding: 0;
 	overflow: hidden;
 	height: calc(65vh - 50px);
-	// iPhone aspect ratio
 	width: calc((65vh - 50px) * 0.48);
 	outline: none;
 
 	// needed for iOS Safari.
 	@supports (min-height: 65svh) {
 		height: calc(65svh - 50px);
-		width: calc((65svh - 50px) * 1.5);
+		width: calc((65svh - 50px) * 0.48);
+	}
+
+	@include break-medium {
+		width: calc((65vh - 50px) * 1.5);
+
+		@supports (height: 65svh) {
+			width: calc((65svh - 50px) * 1.5);
+		}
 	}
 
 	opacity: 0.5;

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -122,6 +122,7 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	opacity: 0.5;
 	display: flex;
 	box-shadow: 1px 1px 3px 0 rgb(0 0 0 / 18%);
+	justify-content: center;
 	transition: opacity 0.3s ease-in-out;
 	pointer-events: all;
 	z-index: 2;


### PR DESCRIPTION
## Proposed Changes
`aspect-ratio` prop is new and I’m not familiar with its quirks. My theory is that it works to infer the height from the width, not vice versa, since guessing the height is the common problem. In the carousel, we used it to infer the width.
Luckily, it’s not needed at all since we hardcode the height anyway, and can calculate the width using the aspect ratio.
## Testing Instructions

**In both Chrome and Safari:** 

1. Go to `/setup/ecommerce/designCarousel`.
2. Make sure the item size makes sense on Desktop and Mobile. 
3. The chevrons should be centered vertically and horizontally.
