### PR TITLE
Stepper: hide plans in the plans step according to the current flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -8,6 +8,7 @@ import {
 	TYPE_PREMIUM,
 	TYPE_BUSINESS,
 	TYPE_ECOMMERCE,
+	TYPE_ENTERPRISE_GRID_WPCOM,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
@@ -143,12 +144,18 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			return renderLoading();
 		}
 
+		const shouldHidePlan = ( planType: string ) =>
+			planTypes && ! planTypes.find( ( plan ) => plan === planType );
+
 		return (
 			<div>
 				<PlansFeaturesMain
 					isPlansInsideStepper={ true }
 					site={ site || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
-					hideFreePlan={ hideFreePlan }
+					hideFreePlan={ hideFreePlan || shouldHidePlan( TYPE_FREE ) }
+					hidePersonalPlan={ shouldHidePlan( TYPE_PERSONAL ) }
+					hidePremiumPlan={ shouldHidePlan( TYPE_PREMIUM ) }
+					hideEnterprisePlan={ shouldHidePlan( TYPE_ENTERPRISE_GRID_WPCOM ) }
 					isInSignup={ isInSignup }
 					isStepperUpgradeFlow={ true }
 					intervalType={ getIntervalType() }
@@ -157,7 +164,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					domainName={ getDomainName() }
 					customerType={ customerType }
 					plansWithScroll={ isDesktop }
-					planTypes={ planTypes }
 					flowName={ flowName }
 					showTreatmentPlansReorderTest={ false }
 					isAllPaidPlansShown={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -155,6 +155,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					hideFreePlan={ hideFreePlan || shouldHidePlan( TYPE_FREE ) }
 					hidePersonalPlan={ shouldHidePlan( TYPE_PERSONAL ) }
 					hidePremiumPlan={ shouldHidePlan( TYPE_PREMIUM ) }
+					hideBusinessPlan={ shouldHidePlan( TYPE_BUSINESS ) }
+					hideEcommercePlan={ shouldHidePlan( TYPE_ECOMMERCE ) }
 					hideEnterprisePlan={ shouldHidePlan( TYPE_ENTERPRISE_GRID_WPCOM ) }
 					isInSignup={ isInSignup }
 					isStepperUpgradeFlow={ true }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -457,6 +457,7 @@ export class PlansFeaturesMain extends Component {
 			hideFreePlan,
 			hidePersonalPlan,
 			hidePremiumPlan,
+			hideBusinessPlan,
 			hideEcommercePlan,
 		} = this.props;
 
@@ -487,6 +488,10 @@ export class PlansFeaturesMain extends Component {
 
 		if ( hidePremiumPlan ) {
 			plans = plans.filter( ( planSlug ) => ! isPremiumPlan( planSlug ) );
+		}
+
+		if ( hideBusinessPlan ) {
+			plans = plans.filter( ( planSlug ) => ! isBusinessPlan( planSlug ) );
 		}
 
 		if ( hideEcommercePlan ) {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/76657.

## Proposed Changes

Let's use the `hideXPlan` prop to hide the plans when using the stepper. Using it fixes the [comparison table](https://github.com/Automattic/wp-calypso/pull/76657#pullrequestreview-1418592479), just like it did in the `/start/hosting` flow.

Screenshot from the Link-in-Bio flow:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/84e45f62-d9d0-4018-9531-15a86179cb21)

It's actually possible to display the plan comparison table now:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/ca86bfc6-a765-49e4-ad2a-28b514498d6b)

## Testing Instructions

1. Checkout this branch;
2. Go to `/setup/link-in-bio`;
3. Proceed to the plans step;
4. Check that the plan comparison is hidden;
5. Comment [this line](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/link-in-bio.ts#L53);
6. Check that the plan comparison shows up and correctly renders the features according to the displayed plans.
