### PR TITLE
Social: Add a multiple connections feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -97,6 +97,7 @@
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/offer-complete-after-activation": false,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
+		"jetpack-social/multiple-connections": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -61,6 +61,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/offer-complete-after-activation": false,
+		"jetpack-social/multiple-connections": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -68,7 +68,8 @@
 		"realtime-site-count": true,
 		"site-indicator": false,
 		"upgrades/redirect-payments": true,
-		"jetpack/pricing-page-cart": true
+		"jetpack/pricing-page-cart": true,
+		"jetpack-social/multiple-connections": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -61,7 +61,8 @@
 		"purchases/new-payment-methods": true,
 		"site-indicator": false,
 		"upgrades/redirect-payments": true,
-		"jetpack/pricing-page-cart": true
+		"jetpack/pricing-page-cart": true,
+		"jetpack-social/multiple-connections": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -64,7 +64,8 @@
 		"realtime-site-count": true,
 		"site-indicator": false,
 		"upgrades/redirect-payments": false,
-		"jetpack/pricing-page-cart": true
+		"jetpack/pricing-page-cart": true,
+		"jetpack-social/multiple-connections": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -65,7 +65,8 @@
 		"realtime-site-count": true,
 		"site-indicator": false,
 		"upgrades/redirect-payments": true,
-		"jetpack/pricing-page-cart": true
+		"jetpack/pricing-page-cart": true,
+		"jetpack-social/multiple-connections": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/production.json
+++ b/config/production.json
@@ -70,6 +70,7 @@
 		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
+		"jetpack-social/multiple-connections": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -67,6 +67,7 @@
 		"jetpack-social/advanced-plan": true,
 		"jetpack/offer-complete-after-activation": false,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
+		"jetpack-social/multiple-connections": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/test.json
+++ b/config/test.json
@@ -57,6 +57,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,
+		"jetpack-social/multiple-connections": false,
 		"jitms": true,
 		"lasagna": false,
 		"layout/app-banner": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -74,6 +74,7 @@
 		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
+		"jetpack-social/multiple-connections": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,


### PR DESCRIPTION
While we do the work to support multiple connections with the same user token we need to keep the UI changes behind a feature flag, so nothing breaks.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This addisg the feature flag configuration to all the environments.

## Testing Instructions

Probably the main way to test this is to just check through the config changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
