### PR TITLE
Mastodon: hide connection item when flag disabled

### DIFF
--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -121,6 +121,11 @@ export function getEligibleKeyringServices( state, siteId, type ) {
 			return false;
 		}
 
+		// Enforce feature flag behaviour for Mastodon
+		if ( 'mastodon' === service.ID ) {
+			return config.isEnabled( 'mastodon' );
+		}
+
 		return true;
 	} );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

When the Mastodon connection is eligible, the Mastodon component in _Marketing and Integrations_ is displayed despite the `mastodon` feature flag being set to `false`. This PR fixes it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Prerequisites

- Make `public-api.wordpress.com` point to your sandbox, and patch D93584-code
- In Calypso, set the `mastodon` feature flag to `false` in `config/development.json`
- Visit `/marketing/connections/:site` and make sure connections are enabled

### Regression Testing

- Don't checkout this branch just yet
- Spin up this Calypso locally
- Visit `/marketing/connections/:site`
- You should see the Mastodon connection component

<img width="1062" alt="Screenshot 2023-05-09 at 12 19 01 PM" src="https://github.com/Automattic/wp-calypso/assets/1620183/f6bba629-b7cf-4a6f-9aad-f28a3b1c4d7e">


### Testing

- Checkout this branch
- Make sure the feature flag is still disabled
- Spin up Calypso again
- Visit `/marketing/connections/:site`
- You should not see the Mastodon connection component

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?