### PR TITLE
Remove feature flag as it's not necessary while API being the source …

### DIFF
--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -107,7 +106,7 @@ const SharingServiceAction = ( {
 		);
 	}
 
-	if ( 'mastodon' === service.ID && config.isEnabled( 'mastodon' ) ) {
+	if ( 'mastodon' === service.ID ) {
 		return (
 			<Button
 				scary={ warning }

--- a/client/my-sites/marketing/connections/service-examples.jsx
+++ b/client/my-sites/marketing/connections/service-examples.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { includes } from 'lodash';
@@ -452,7 +451,7 @@ class SharingServiceExamples extends Component {
 			return <GooglePlusDeprication />;
 		}
 
-		if ( 'mastodon' === this.props.service.ID && config.isEnabled( 'mastodon' ) ) {
+		if ( 'mastodon' === this.props.service.ID ) {
 			return (
 				<Mastodon
 					service={ this.props.service }

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -508,9 +508,6 @@ export class SharingService extends Component {
 	};
 
 	isMastodonService = () => {
-		if ( ! config.isEnabled( 'mastodon' ) ) {
-			return false;
-		}
 		return get( this, 'props.service.ID' ) === 'mastodon';
 	};
 

--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
@@ -27,7 +26,7 @@ import './services-group.scss';
 /**
  * Module constants
  */
-const NUMBER_OF_PLACEHOLDERS = config.isEnabled( 'mastodon' ) ? 5 : 4;
+const NUMBER_OF_PLACEHOLDERS = 4;
 
 const serviceWarningLevelToNoticeStatus = ( level ) => {
 	switch ( level ) {

--- a/config/client.json
+++ b/config/client.json
@@ -18,7 +18,6 @@
 	"lasagna_url",
 	"login_url",
 	"logout_url",
-	"mastodon",
 	"mc_analytics_enabled",
 	"oauth_client_id",
 	"oauth_response_type",

--- a/config/development.json
+++ b/config/development.json
@@ -117,7 +117,6 @@
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
-		"mastodon": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -77,7 +77,6 @@
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
-		"mastodon": false,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"my-sites/add-ons": true,

--- a/config/production.json
+++ b/config/production.json
@@ -88,7 +88,6 @@
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
-		"mastodon": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -84,7 +84,6 @@
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
-		"mastodon": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,

--- a/config/test.json
+++ b/config/test.json
@@ -69,7 +69,6 @@
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
-		"mastodon": false,
 		"me/account-close": true,
 		"me/vat-details": true,
 		"my-sites/add-ons": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -92,7 +92,6 @@
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
-		"mastodon": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,


### PR DESCRIPTION
…of truth

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
