### PR TITLE
Reader post sharing / Press This - remove title from created post

### DIFF
--- a/apps/wpcom-block-editor/src/default/features/press-this.js
+++ b/apps/wpcom-block-editor/src/default/features/press-this.js
@@ -37,6 +37,5 @@ if ( url ) {
 		}
 
 		dispatch( 'core/editor' ).resetEditorBlocks( blocks );
-		dispatch( 'core/editor' ).editPost( { title: title } );
 	} )();
 }

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -62,7 +62,6 @@ function buildQuerystringForPost( post ) {
 		args.image = post.canonical_image.uri;
 	}
 
-	args.title = `${ post.title } — ${ post.site_name }`;
 	args.text = post.excerpt;
 	args.url = post.URL;
 	args.is_post_share = true; // There is a dependency on this here https://github.com/Automattic/wp-calypso/blob/a69ded693a99fa6a957b590b1a538f32a581eb8a/client/gutenberg/editor/controller.js#L209

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -62,6 +62,7 @@ function buildQuerystringForPost( post ) {
 		args.image = post.canonical_image.uri;
 	}
 
+	args.title = `${ post.title } — ${ post.site_name }`;
 	args.text = post.excerpt;
 	args.url = post.URL;
 	args.is_post_share = true; // There is a dependency on this here https://github.com/Automattic/wp-calypso/blob/a69ded693a99fa6a957b590b1a538f32a581eb8a/client/gutenberg/editor/controller.js#L209


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves item 1 of pe7F0s-P6-p2

## Proposed Changes

* This removes the title from the post that is started from sharing a post from the reader/press-this. Rather than copy the original posts title when we take a user to the editor, we leave the title empty and allow then to enter whatever title they want. We continue pass this title as a query arg to the editor as before, as it is used in the quote block citation link.

<img width="400" alt="Screenshot 2023-05-10 at 10 46 20 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/70ab6fad-0a19-4caf-93c1-f5866712a1c7">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build and sync this branch for the `wpcom-block-editor` app to your sandbox.  ( PCYsg-l4k-p2 for info on this step for wpcom-block-editor )
* sandbox public-api, widgets, and the site you will test sharing from.
* Go to the reader, find a post to share.
* Use the sharing (curved arrow) icon to open the sharing popover.
* select the site you would like to share this from.
* <img width="300" alt="Screenshot 2023-05-09 at 1 40 49 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/42a9afd4-6e62-41eb-9bc8-80f15af677c6">
* when the editor loads, verify there is no title in the post.
* verify the post title is still used in the link to the original article in the quote block citation.




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?