### PR TITLE
Add agency dashboard survey banner

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -28,6 +28,7 @@ import SiteAddLicenseNotification from './site-add-license-notification';
 import SiteContent from './site-content';
 import SiteContentHeader from './site-content-header';
 import SiteSearchFilterContainer from './site-search-filter-container/SiteSearchFilterContainer';
+import SiteSurveyBanner from './site-survey-banner';
 import SiteWelcomeBanner from './site-welcome-banner';
 import { getProductSlugFromProductType } from './utils';
 import type { Site } from '../sites-overview/types';
@@ -229,6 +230,7 @@ export default function SitesOverview() {
 				<div className="sites-overview__tabs">
 					<div className="sites-overview__content-wrapper">
 						<SiteWelcomeBanner isDashboardView />
+						<SiteSurveyBanner />
 						{ data?.sites && <SiteAddLicenseNotification /> }
 						<SiteContentHeader
 							content={ renderIssueLicenseButton() }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner/index.tsx
@@ -1,0 +1,82 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import commentIcon from 'calypso/assets/images/jetpack/block-post-comments.svg';
+import Banner from 'calypso/components/banner';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import {
+	JETPACK_DASHBOARD_SURVEY_BANNER_PREFERENCE as preferenceName,
+	JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE_HOME_PAGE as homePagePreferenceName,
+	getJetpackDashboardPreference as getPreference,
+} from 'calypso/state/jetpack-agency-dashboard/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
+import type { PreferenceType } from '../types';
+
+import './style.scss';
+
+export default function SiteSurveyBanner() {
+	const surveyHref = 'https://automattic.survey.fm/jetpack-pro-survey-hosting-needs';
+
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const preference = useSelector( ( state ) => getPreference( state, preferenceName ) );
+	const homePagePreference = useSelector( ( state ) =>
+		getPreference( state, homePagePreferenceName )
+	);
+
+	const savePreferenceType = useCallback(
+		( type: PreferenceType ) => {
+			dispatch( savePreference( preferenceName, { ...preference, [ type ]: true } ) );
+		},
+		[ dispatch, preference ]
+	);
+
+	const handleTrackEvent = useCallback(
+		( eventName: string ) => {
+			dispatch( recordTracksEvent( eventName ) );
+		},
+		[ dispatch ]
+	);
+
+	const dismissBanner = useCallback( () => {
+		savePreferenceType( 'dismiss' );
+		handleTrackEvent( 'calypso_jetpack_agency_dashboard_survey_banner_dismiss' );
+	}, [ handleTrackEvent, savePreferenceType ] );
+
+	const isDismissed = preference?.dismiss;
+	const isWelcomeBannerDismissed = homePagePreference?.dismiss;
+	const hideBanner = isDismissed || ! isWelcomeBannerDismissed;
+
+	useEffect( () => {
+		if ( ! hideBanner ) {
+			savePreferenceType( 'view' );
+			handleTrackEvent( 'calypso_jetpack_agency_dashboard_survey_banner_view' );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	const trackClickEvent = () => {
+		handleTrackEvent( 'calypso_jetpack_agency_dashboard_survey_banner_click' );
+	};
+
+	// Hide the banner if it has already been dismissed or if the welcome banner is showing
+	if ( hideBanner ) {
+		return null;
+	}
+
+	return (
+		<Banner
+			className="dashboard__site-survey-banner"
+			title={ translate( 'Interested in better hosting?' ) }
+			description={ translate( 'Let us know what would make your ideal hosting experience.' ) }
+			horizontal
+			iconPath={ commentIcon }
+			callToAction={ translate( 'Take our quick survey' ) }
+			href={ surveyHref }
+			onClick={ trackClickEvent }
+			onDismiss={ dismissBanner }
+			dismissPreferenceName={ preferenceName }
+		/>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner/index.tsx
@@ -58,6 +58,9 @@ export default function SiteSurveyBanner() {
 
 	const trackClickEvent = () => {
 		handleTrackEvent( 'calypso_jetpack_agency_dashboard_survey_banner_click' );
+
+		// Dismiss banner but don't track "dismiss" event since we are automatically dismissing it after CTA click
+		savePreferenceType( 'dismiss' );
 	};
 
 	// Hide the banner if it has already been dismissed or if the welcome banner is showing

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner/index.tsx
@@ -80,6 +80,7 @@ export default function SiteSurveyBanner() {
 			onClick={ trackClickEvent }
 			onDismiss={ dismissBanner }
 			dismissPreferenceName={ preferenceName }
+			target="_blank"
 		/>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner/style.scss
@@ -1,0 +1,14 @@
+.dashboard__site-survey-banner {
+	&.banner.card {
+		border-left-color: var(--color-jetpack);
+
+		.banner__icon-circle {
+			background-color: var(--color-jetpack);
+		}
+
+		.banner__icon-circle > img {
+			width: 19px;
+			height: 19px;
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
@@ -8,7 +8,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE,
 	JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE_HOME_PAGE as homePagePreferenceName,
-	getJetpackDashboardWelcomeBannerPreference as getPreference,
+	getJetpackDashboardPreference as getPreference,
 } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import type { PreferenceType } from '../types';

--- a/client/state/jetpack-agency-dashboard/selectors.ts
+++ b/client/state/jetpack-agency-dashboard/selectors.ts
@@ -13,13 +13,13 @@ export const JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE =
 export const JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE_HOME_PAGE =
 	'jetpack-dashboard-welcome-banner-preference-home-page';
 
+export const JETPACK_DASHBOARD_SURVEY_BANNER_PREFERENCE =
+	'jetpack-dashboard-survey-banner-preference';
+
 /**
- * Returns preference associated with the welcome banner.
+ * Returns preference associated with the key provided.
  */
-export function getJetpackDashboardWelcomeBannerPreference(
-	state: AppState,
-	key: string
-): Preference {
+export function getJetpackDashboardPreference( state: AppState, key: string ): Preference {
 	const preference = getPreference( state, key );
 	return preference;
 }


### PR DESCRIPTION
## Proposed Changes

This PR adds an Banner that shows up on the Pro Dashboard after the welcome banner has been dismissed. It links to a survey for agencies to take

## Testing Instructions

1. Checkout this branch
2. Start Jetpack Cloud via `yarn start-jetpack-cloud`
3. If you are not already marked as an agency, you can mark yourself with these instructions: PCYsg-KIj-p2
4. Go to the Pro Dashboard at http://jetpack.cloud.localhost:3000/dashboard
5. If this is your first time here, you should see the welcome banner
![image](https://github.com/Automattic/wp-calypso/assets/65001528/18914942-47cc-4419-82b4-b8be5c27b97e)
6. Click "Got it". The new survey banner should appear
![image](https://github.com/Automattic/wp-calypso/assets/65001528/f2b6c84d-d510-4721-aefa-94fffab65bd4)
7. Once dismissed, it shouldn't ever come back

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?