### PR TITLE
Blog onboarding: Auto save in the editor doesn't break the flow anymore

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -36,7 +36,9 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 			}, [] );
 
 			const isStartWritingFlow =
-				getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
+				getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true' ||
+				sessionStorage.getItem( 'declarative-flow' ) === START_WRITING_FLOW;
+
 			const [ clickGuardRoot ] = useState( () => document.createElement( 'div' ) );
 			useEffect( () => {
 				document.body.appendChild( clickGuardRoot );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -37,7 +37,7 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 
 			const isStartWritingFlow =
 				getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true' ||
-				sessionStorage.getItem( 'declarative-flow' ) === START_WRITING_FLOW;
+				window.sessionStorage.getItem( 'declarative-flow' ) === START_WRITING_FLOW;
 
 			const [ clickGuardRoot ] = useState( () => document.createElement( 'div' ) );
 			useEffect( () => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -49,7 +49,9 @@ function LaunchWpcomWelcomeTour() {
 	const { siteIntent, siteIntentFetched } = useSiteIntent();
 	const localeSlug = useLocale();
 	const editorType = getEditorType();
-	const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
+	const isStartWritingFlow =
+		getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true' ||
+		sessionStorage.getItem( 'declarative-flow' ) === START_WRITING_FLOW;
 
 	// Preload first card image (others preloaded after open state confirmed)
 	usePrefetchTourAssets( [ getTourSteps( localeSlug, false, false, null, siteIntent )[ 0 ] ] );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -51,7 +51,7 @@ function LaunchWpcomWelcomeTour() {
 	const editorType = getEditorType();
 	const isStartWritingFlow =
 		getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true' ||
-		sessionStorage.getItem( 'declarative-flow' ) === START_WRITING_FLOW;
+		window.sessionStorage.getItem( 'declarative-flow' ) === START_WRITING_FLOW;
 
 	// Preload first card image (others preloaded after open state confirmed)
 	usePrefetchTourAssets( [ getTourSteps( localeSlug, false, false, null, siteIntent )[ 0 ] ] );

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -6,13 +6,20 @@ const START_WRITING_FLOW = 'start-writing';
 
 export function redirectOnboardingUserAfterPublishingPost() {
 	const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
+	const isStartWritingFlowInSessionStorage =
+		sessionStorage.getItem( 'declarative-flow' ) === START_WRITING_FLOW;
 
-	if ( ! isStartWritingFlow ) {
+	if ( ! isStartWritingFlow && ! isStartWritingFlowInSessionStorage ) {
 		return false;
 	}
 
-	const siteOrigin = getQueryArg( window.location.search, 'origin' );
+	const siteOrigin =
+		getQueryArg( window.location.search, 'origin' ) || sessionStorage.getItem( 'site-origin' );
 	const siteSlug = window.location.hostname;
+
+	// Save site origin and flow in session storage to be used in editor refresh.
+	sessionStorage.setItem( 'site-origin', siteOrigin );
+	sessionStorage.setItem( 'declarative-flow', START_WRITING_FLOW );
 
 	const unsubscribeSidebar = subscribe( () => {
 		const isComplementaryAreaVisible = select( 'core/preferences' ).get(
@@ -29,9 +36,8 @@ export function redirectOnboardingUserAfterPublishingPost() {
 	const unsubscribe = subscribe( () => {
 		const isSavingPost = select( 'core/editor' ).isSavingPost();
 		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
-		const getCurrentPostRevisionsCount = select( 'core/editor' ).getCurrentPostRevisionsCount();
 
-		if ( ! isSavingPost && isCurrentPostPublished && getCurrentPostRevisionsCount === 1 ) {
+		if ( ! isSavingPost && isCurrentPostPublished ) {
 			unsubscribe();
 
 			dispatch( 'core/edit-post' ).closePublishSidebar();

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -7,19 +7,20 @@ const START_WRITING_FLOW = 'start-writing';
 export function redirectOnboardingUserAfterPublishingPost() {
 	const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
 	const isStartWritingFlowInSessionStorage =
-		sessionStorage.getItem( 'declarative-flow' ) === START_WRITING_FLOW;
+		window.sessionStorage.getItem( 'declarative-flow' ) === START_WRITING_FLOW;
 
 	if ( ! isStartWritingFlow && ! isStartWritingFlowInSessionStorage ) {
 		return false;
 	}
 
 	const siteOrigin =
-		getQueryArg( window.location.search, 'origin' ) || sessionStorage.getItem( 'site-origin' );
+		getQueryArg( window.location.search, 'origin' ) ||
+		window.sessionStorage.getItem( 'site-origin' );
 	const siteSlug = window.location.hostname;
 
 	// Save site origin and flow in session storage to be used in editor refresh.
-	sessionStorage.setItem( 'site-origin', siteOrigin );
-	sessionStorage.setItem( 'declarative-flow', START_WRITING_FLOW );
+	window.sessionStorage.setItem( 'site-origin', siteOrigin );
+	window.sessionStorage.setItem( 'declarative-flow', START_WRITING_FLOW );
 
 	const unsubscribeSidebar = subscribe( () => {
 		const isComplementaryAreaVisible = select( 'core/preferences' ).get(

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -5,11 +5,11 @@ import { getQueryArg } from '@wordpress/url';
 const START_WRITING_FLOW = 'start-writing';
 
 export function redirectOnboardingUserAfterPublishingPost() {
-	const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
-	const isStartWritingFlowInSessionStorage =
+	const isStartWritingFlow =
+		getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true' ||
 		window.sessionStorage.getItem( 'declarative-flow' ) === START_WRITING_FLOW;
 
-	if ( ! isStartWritingFlow && ! isStartWritingFlowInSessionStorage ) {
+	if ( ! isStartWritingFlow ) {
 		return false;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -58,13 +58,14 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		window.location.replace( '/home' );
 	}
 
-	// This is temporary until we can use the launchpad inside the editor.
-	const newWriterFlow = 'true' === getQueryArg( window.location.search, START_WRITING_FLOW );
+	const isStartWritingFlow =
+		getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true' ||
+		window.sessionStorage.getItem( 'declarative-flow' ) === START_WRITING_FLOW;
 
 	if (
 		! isLoggedIn ||
 		launchpadScreenOption === 'off' ||
-		( launchpadScreenOption === false && 'videopress' !== flow && ! newWriterFlow )
+		( launchpadScreenOption === false && 'videopress' !== flow && ! isStartWritingFlow )
 	) {
 		redirectToSiteHome( siteSlug, flow );
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
@@ -24,7 +24,7 @@ const StartWritingDone: Step = () => {
 	);
 
 	// Clear the declarative flow from session storage.
-	sessionStorage.setItem( 'declarative-flow', '' );
+	window.sessionStorage.setItem( 'declarative-flow', '' );
 
 	if ( ! site ) {
 		return null;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
@@ -23,6 +23,9 @@ const StartWritingDone: Step = () => {
 		[]
 	);
 
+	// Clear the declarative flow from session storage.
+	sessionStorage.setItem( 'declarative-flow', '' );
+
 	if ( ! site ) {
 		return null;
 	}

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -66,6 +66,9 @@ const startWriting: Flow = {
 
 			switch ( currentStep ) {
 				case 'site-creation-step':
+					// Saving in the session so even after losing start-writing parameter
+					// at the URL (once users saves a post) we still know we're at the start-writing flow.
+					sessionStorage.setItem( 'declarative-flow', START_WRITING_FLOW );
 					return navigate( 'processing' );
 				case 'processing': {
 					// If we just created a new site.

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -68,7 +68,7 @@ const startWriting: Flow = {
 				case 'site-creation-step':
 					// Saving in the session so even after losing start-writing parameter
 					// at the URL (once users saves a post) we still know we're at the start-writing flow.
-					sessionStorage.setItem( 'declarative-flow', START_WRITING_FLOW );
+					window.sessionStorage.setItem( 'declarative-flow', START_WRITING_FLOW );
 					return navigate( 'processing' );
 				case 'processing': {
 					// If we just created a new site.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2370-gh-Automattic/dotcom-forge

## Proposed Changes

* Auto save in the editor doesn't break the flow anymore
* This is probably a temporary solution while we find a better approach by reusing site intent. More context: p1683626713212019/1683543837.971059-slack-CKZHG0QCR


https://github.com/Automattic/wp-calypso/assets/1044309/dbc4c9f4-1477-4fdf-8056-0265fe539c30



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch on your local Calypso
- Go to apps/editing-toolkit
- Run yarn dev --sync (to sync it to your sandbox)
- In a new tab Go to apps/wpcom-block-editor/src
- Run yarn dev --sync
- Create a new site using our start-writing flow: http://calypso.localhost:3000/setup/start-writing
- Make sure the site that was created is sandboxed (like yoursite.wordpress.com).
- Verify if these features work as expected:
  - [ ] W is hidden
  - [ ] Tour doesn't show
  - [ ] Auto-save or Save draft won't break the flow
  - [ ] Refresh while editing won't break the flow
  - [ ] Redirect to Launchpad after publishing works in all cases
  - [ ] After publishing your site, the `window.sessionStorage.getItem('declarative-flow')` should be empty

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?