### PR TITLE
Earn Page: Fix toggle under warning 

### DIFF
--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -1,7 +1,6 @@
 import { Dialog, FormInputValidation } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { ToggleControl } from '@wordpress/components';
-import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -414,19 +413,8 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				</SectionNavTabs>
 			</SectionNav>
 			<div className="memberships__dialog-sections">
-				<div
-					className={ classnames( 'memberships__dialog-section', {
-						'is-visible': currentDialogTab === TAB_GENERAL,
-					} ) }
-				>
-					{ renderGeneralTab() }
-				</div>
-				<div
-					className={ classnames( 'memberships__dialog-section', {
-						'is-visible': currentDialogTab === TAB_EMAIL,
-					} ) }
-				>
-					{ renderEmailTab() }
+				<div className="memberships__dialog-section is-visible">
+					{ currentDialogTab === TAB_EMAIL ? renderEmailTab() : renderGeneralTab() }
 				</div>
 			</div>
 		</Dialog>


### PR DESCRIPTION
> There is something weird there. Clicking behind the info checks the checkbox in the other panel? Or is there a duplicated checkbox that is lying there by mistake?

https://github.com/Automattic/wp-calypso/assets/104869/d1f19000-e934-49ef-9a95-1cee51b173f3

