### PR TITLE
Price Page Optimization: Add tax exclusion copy to billing timeframe

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -84,9 +84,11 @@ function usePerMonthDescription( {
 		// TODO: Remove check once text is translated
 		const displayNewPriceText =
 			isEnglishLocale ||
-			( i18n.hasTranslation(
-				'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes'
-			) &&
+			( i18n.hasTranslation( 'per month, %(rawPrice)s billed annually, Excl. Taxes' ) &&
+				i18n.hasTranslation( 'per month, %(rawPrice)s billed every two years, Excl. Taxes' ) &&
+				i18n.hasTranslation(
+					'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes'
+				) &&
 				i18n.hasTranslation(
 					'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes'
 				) );
@@ -140,15 +142,25 @@ function usePerMonthDescription( {
 			}
 		} else if ( rawPrice ) {
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-				return translate( 'per month, %(rawPrice)s billed annually', {
-					args: { rawPrice },
-				} );
+				return displayNewPriceText
+					? translate( 'per month, %(rawPrice)s billed annually, Excl. Taxes', {
+							args: { rawPrice },
+							comment: 'Excl. Taxes is short for excluding taxes',
+					  } )
+					: translate( 'per month, %(rawPrice)s billed annually', {
+							args: { rawPrice },
+					  } );
 			}
 
 			if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-				return translate( 'per month, %(rawPrice)s billed every two years.', {
-					args: { rawPrice },
-				} );
+				return displayNewPriceText
+					? translate( 'per month, %(rawPrice)s billed every two years, Excl. Taxes', {
+							args: { rawPrice },
+							comment: 'Excl. Taxes is short for excluding taxes',
+					  } )
+					: translate( 'per month, %(rawPrice)s billed every two years.', {
+							args: { rawPrice },
+					  } );
 			}
 		}
 	}

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -80,15 +80,21 @@ function usePerMonthDescription( {
 			currencyCode && planPrices.rawPrice
 				? formatCurrency( planPrices.rawPrice, currencyCode, { stripZeros: true } )
 				: null;
+
+		// TODO: Remove check once text is translated
+		const displayNewPriceText =
+			isEnglishLocale ||
+			( i18n.hasTranslation(
+				'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes'
+			) &&
+				i18n.hasTranslation(
+					'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes'
+				) );
 		if ( fullTermDiscountedPriceText ) {
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
 				//per month, $96 billed annually $84 for the first year
 
-				// TODO: Remove check once text is translated
-				return isEnglishLocale ||
-					i18n.hasTranslation(
-						'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes'
-					)
+				return displayNewPriceText
 					? translate(
 							'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
 							{
@@ -111,11 +117,7 @@ function usePerMonthDescription( {
 			}
 
 			if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-				// TODO: Remove check once text is translated
-				return isEnglishLocale ||
-					i18n.hasTranslation(
-						'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes'
-					)
+				return displayNewPriceText
 					? translate(
 							'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
 							{

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -96,6 +96,7 @@ function usePerMonthDescription( {
 								components: {
 									discount: <StrikethroughText />,
 								},
+								comment: 'Excl. Taxes is short for excluding taxes',
 							}
 					  )
 					: translate(
@@ -122,6 +123,7 @@ function usePerMonthDescription( {
 								components: {
 									discount: <StrikethroughText />,
 								},
+								comment: 'Excl. Taxes is short for excluding taxes',
 							}
 					  )
 					: translate(

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -9,7 +9,7 @@ import {
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import styled from '@emotion/styled';
-import i18n, { localize, TranslateResult, useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import usePlanPrices from 'calypso/my-sites/plans/hooks/use-plan-prices';
@@ -33,7 +33,7 @@ function usePerMonthDescription( {
 	billingPeriod,
 }: Omit< Props, 'billingTimeframe' > ) {
 	const translate = useTranslate();
-	const currentLocale = i18n.getLocaleSlug();
+	const currentLocale = getLocaleSlug();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const planPrices = usePlanPrices( {
 		planSlug: planName as PlanSlug,

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -9,7 +9,7 @@ import {
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import styled from '@emotion/styled';
-import { localize, TranslateResult, useTranslate } from 'i18n-calypso';
+import i18n, { localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import usePlanPrices from 'calypso/my-sites/plans/hooks/use-plan-prices';
@@ -33,6 +33,7 @@ function usePerMonthDescription( {
 	billingPeriod,
 }: Omit< Props, 'billingTimeframe' > ) {
 	const translate = useTranslate();
+	const currentLocale = i18n.getLocaleSlug();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const planPrices = usePlanPrices( {
 		planSlug: planName as PlanSlug,
@@ -78,31 +79,60 @@ function usePerMonthDescription( {
 			currencyCode && planPrices.rawPrice
 				? formatCurrency( planPrices.rawPrice, currencyCode, { stripZeros: true } )
 				: null;
+		const isEnglishLocale = currentLocale === 'en' || currentLocale?.startsWith( 'en-' );
 		if ( fullTermDiscountedPriceText ) {
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
 				//per month, $96 billed annually $84 for the first year
 
-				return translate(
-					'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year',
-					{
-						args: { fullTermDiscountedPriceText, rawPrice },
-						components: {
-							discount: <StrikethroughText />,
-						},
-					}
-				);
+				// TODO: Remove check once text is translated
+				return isEnglishLocale ||
+					i18n.hasTranslation(
+						'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes'
+					)
+					? translate(
+							'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
+							{
+								args: { fullTermDiscountedPriceText, rawPrice },
+								components: {
+									discount: <StrikethroughText />,
+								},
+							}
+					  )
+					: translate(
+							'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year',
+							{
+								args: { fullTermDiscountedPriceText, rawPrice },
+								components: {
+									discount: <StrikethroughText />,
+								},
+							}
+					  );
 			}
 
 			if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-				return translate(
-					'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year',
-					{
-						args: { fullTermDiscountedPriceText, rawPrice },
-						components: {
-							discount: <StrikethroughText />,
-						},
-					}
-				);
+				// TODO: Remove check once text is translated
+				return isEnglishLocale ||
+					i18n.hasTranslation(
+						'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes'
+					)
+					? translate(
+							'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
+							{
+								args: { fullTermDiscountedPriceText, rawPrice },
+								components: {
+									discount: <StrikethroughText />,
+								},
+							}
+					  )
+					: translate(
+							'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year',
+							{
+								args: { fullTermDiscountedPriceText, rawPrice },
+								components: {
+									discount: <StrikethroughText />,
+								},
+							}
+					  );
 			}
 		} else if ( rawPrice ) {
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -8,8 +8,9 @@ import {
 	TERM_ANNUALLY,
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
-import i18n, { getLocaleSlug, localize, TranslateResult, useTranslate } from 'i18n-calypso';
+import i18n, { localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import usePlanPrices from 'calypso/my-sites/plans/hooks/use-plan-prices';
@@ -33,8 +34,8 @@ function usePerMonthDescription( {
 	billingPeriod,
 }: Omit< Props, 'billingTimeframe' > ) {
 	const translate = useTranslate();
-	const currentLocale = getLocaleSlug();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const isEnglishLocale = useIsEnglishLocale();
 	const planPrices = usePlanPrices( {
 		planSlug: planName as PlanSlug,
 		returnMonthly: isMonthlyPlan,
@@ -79,7 +80,6 @@ function usePerMonthDescription( {
 			currencyCode && planPrices.rawPrice
 				? formatCurrency( planPrices.rawPrice, currencyCode, { stripZeros: true } )
 				: null;
-		const isEnglishLocale = currentLocale === 'en' || currentLocale?.startsWith( 'en-' );
 		if ( fullTermDiscountedPriceText ) {
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
 				//per month, $96 billed annually $84 for the first year


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1580

For EU users, the current pricing page doesn't communicate that the prices are VAT-excluded, and they will know only upon checkout. It may be frustrating, and even be illegal in some regions. We want to clarify this. We also need to be clear that prices are exclusive of taxes globally, not just for the EU region. There will be other areas where tax is added during checkout outside the EU.

## Proposed Changes

* Adds text "Excl. taxes" to plans billing timeframe subtext
* _Does not_ display the new text for non-english locales **until translations are in place**

## Screenshots

### New Text with Tax Exclusion
<img width="1496" alt="Screenshot 2023-05-09 at 10 02 29 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/9001b4e0-d442-49fc-ad95-5cd921280b9d">

### Non-english locale
<img width="1129" alt="Screenshot 2023-05-09 at 9 48 53 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/a0f8a7e6-1147-491d-803c-e29799ebea79">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this branch and run `yarn` and `yarn start`
2. Start onboarding http://calypso.localhost:3000/start
3. Select a domain and navigate to the plans page
4. Verify that "Excl. taxes" is now added to billing timeframe
5. Navigate to http://calypso.localhost:3000/me/account and switch to a non-english locale like Español
6. Repeat steps 2 + 3
7. Verify that the billing timeframe is still translated in the native language. ( There will be no "Excl taxes" until translations are created )

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
