### PR TITLE
Blog onboarding: Utilize site intent for start-writing flow

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
 import { useEffect, createPortal, useState } from '@wordpress/element';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
-import { getQueryArg } from '@wordpress/url';
+import useSiteIntent from '../../dotcom-fse/lib/site-intent/use-site-intent';
 import WpcomBlockEditorNavSidebar from './components/nav-sidebar';
 import ToggleSidebarButton from './components/toggle-sidebar-button';
 
@@ -35,8 +35,9 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 				// eslint-disable-next-line react-hooks/exhaustive-deps
 			}, [] );
 
-			const isStartWritingFlow =
-				getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
+			const { siteIntent: intent } = useSiteIntent();
+			const isStartWritingFlow = intent === START_WRITING_FLOW;
+
 			const [ clickGuardRoot ] = useState( () => document.createElement( 'div' ) );
 			useEffect( () => {
 				document.body.appendChild( clickGuardRoot );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -5,7 +5,6 @@ import { WpcomTourKit, usePrefetchTourAssets } from '@automattic/tour-kit';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { useEffect, useMemo } from '@wordpress/element';
-import { getQueryArg } from '@wordpress/url';
 import useSiteIntent from '../../../dotcom-fse/lib/site-intent/use-site-intent';
 import useSitePlan from '../../../dotcom-fse/lib/site-plan/use-site-plan';
 import { selectors as starterPageTemplatesSelectors } from '../../../starter-page-templates/store';
@@ -49,7 +48,8 @@ function LaunchWpcomWelcomeTour() {
 	const { siteIntent, siteIntentFetched } = useSiteIntent();
 	const localeSlug = useLocale();
 	const editorType = getEditorType();
-	const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
+	const { siteIntent: intent } = useSiteIntent();
+	const isStartWritingFlow = intent === START_WRITING_FLOW;
 
 	// Preload first card image (others preloaded after open state confirmed)
 	usePrefetchTourAssets( [ getTourSteps( localeSlug, false, false, null, siteIntent )[ 0 ] ] );

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -24,6 +24,7 @@
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@babel/runtime": "^7.17.2",
+		"@wordpress/api-fetch": "^6.19.0",
 		"@wordpress/base-styles": "^4.13.0",
 		"@wordpress/block-editor": "^10.5.0",
 		"@wordpress/blocks": "^11.21.0",

--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -6,13 +6,19 @@ import './features/reorder-block-categories';
 import './features/override-edit-site-back-button';
 import './features/tracking';
 import './features/use-classic-block-guide';
+import { RedirectOnboardingUserAfterPublishingPost } from './features/redirect-onboarding-user-after-publishing-post';
 import InserterMenuTrackingEvent from './features/tracking/wpcom-inserter-menu-search-term';
 import './features/site-editor-env-consistency';
 import './editor.scss';
-import './features/redirect-onboarding-user-after-publishing-post';
 
 registerPlugin( 'track-inserter-menu-events', {
 	render() {
 		return <InserterMenuTrackingEvent />;
+	},
+} );
+
+registerPlugin( 'start-writing-flow', {
+	render() {
+		return <RedirectOnboardingUserAfterPublishingPost />;
 	},
 } );

--- a/apps/wpcom-block-editor/src/wpcom/editor.scss
+++ b/apps/wpcom-block-editor/src/wpcom/editor.scss
@@ -1,1 +1,7 @@
 @import "./features/use-classic-block-guide";
+
+.start-writing-hide {
+	.components-external-link {
+		display: none !important;
+	}
+}

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -7,7 +7,7 @@ const START_WRITING_FLOW = 'start-writing';
 export function RedirectOnboardingUserAfterPublishingPost() {
 	const { siteIntent: intent } = useSiteIntent();
 
-	if ( intent !== 'write' ) {
+	if ( intent !== START_WRITING_FLOW ) {
 		return false;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -5,13 +5,11 @@ import useSiteIntent from './use-site-intent';
 const START_WRITING_FLOW = 'start-writing';
 
 export function RedirectOnboardingUserAfterPublishingPost() {
-	const { intent } = useSiteIntent();
-	console.log( 'intent', intent );
+	const { siteIntent: intent } = useSiteIntent();
 
 	if ( intent !== 'write' ) {
 		return false;
 	}
-	console.log( 'we made it' );
 
 	const siteOrigin = getQueryArg( window.location.search, 'origin' );
 	const siteSlug = window.location.hostname;

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -1,15 +1,17 @@
 import { dispatch, select, subscribe } from '@wordpress/data';
-import domReady from '@wordpress/dom-ready';
 import { getQueryArg } from '@wordpress/url';
+import useSiteIntent from './use-site-intent';
 
 const START_WRITING_FLOW = 'start-writing';
 
-export function redirectOnboardingUserAfterPublishingPost() {
-	const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
+export function RedirectOnboardingUserAfterPublishingPost() {
+	const { intent } = useSiteIntent();
+	console.log( 'intent', intent );
 
-	if ( ! isStartWritingFlow ) {
+	if ( intent !== 'write' ) {
 		return false;
 	}
+	console.log( 'we made it' );
 
 	const siteOrigin = getQueryArg( window.location.search, 'origin' );
 	const siteSlug = window.location.hostname;
@@ -39,5 +41,3 @@ export function redirectOnboardingUserAfterPublishingPost() {
 		}
 	} );
 }
-
-domReady( redirectOnboardingUserAfterPublishingPost );

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -21,7 +21,7 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 
 	// Save site origin in session storage to be used in editor refresh.
 	const siteOriginParam = getQueryArg( window.location.search, 'origin' );
-	if ( getQueryArg( window.location.search, 'origin' ) ) {
+	if ( siteOriginParam ) {
 		window.sessionStorage.setItem( 'site-origin', siteOriginParam );
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -11,8 +11,14 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 		return false;
 	}
 
-	const siteOrigin = getQueryArg( window.location.search, 'origin' );
+	const siteOrigin =
+		getQueryArg( window.location.search, 'origin' ) ||
+		window.sessionStorage.getItem( 'site-origin' ) ||
+		'https://wordpress.com';
 	const siteSlug = window.location.hostname;
+
+	// Save site origin in session storage to be used in editor refresh.
+	window.sessionStorage.setItem( 'site-origin', siteOrigin );
 
 	const unsubscribeSidebar = subscribe( () => {
 		const isComplementaryAreaVisible = select( 'core/preferences' ).get(
@@ -29,9 +35,14 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 	const unsubscribe = subscribe( () => {
 		const isSavingPost = select( 'core/editor' ).isSavingPost();
 		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
+		const isCurrentPostScheduled = select( 'core/editor' ).isCurrentPostScheduled();
 		const getCurrentPostRevisionsCount = select( 'core/editor' ).getCurrentPostRevisionsCount();
 
-		if ( ! isSavingPost && isCurrentPostPublished && getCurrentPostRevisionsCount === 1 ) {
+		if (
+			! isSavingPost &&
+			( isCurrentPostPublished || isCurrentPostScheduled ) &&
+			getCurrentPostRevisionsCount === 1
+		) {
 			unsubscribe();
 
 			dispatch( 'core/edit-post' ).closePublishSidebar();

--- a/apps/wpcom-block-editor/src/wpcom/features/use-site-intent.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/use-site-intent.js
@@ -1,0 +1,28 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect, useCallback } from '@wordpress/element';
+
+// FIXME: We can use `useSiteIntent` from `@automattic/data-stores` and remove this.
+// https://github.com/Automattic/wp-calypso/pull/73565#discussion_r1113839120
+const useSiteIntent = () => {
+	const [ siteIntent, setSiteIntent ] = useState( undefined );
+	const [ siteIntentFetched, setSiteIntentFetched ] = useState( false );
+
+	const fetchSiteIntent = useCallback( () => {
+		apiFetch( { path: '/wpcom/v2/site-intent' } )
+			.then( ( result ) => {
+				console.log( 'result', result );
+				setSiteIntent( result.site_intent );
+				setSiteIntentFetched( true );
+			} )
+			.catch( () => {
+				setSiteIntent( undefined );
+				setSiteIntentFetched( true );
+			} );
+	}, [] );
+
+	useEffect( () => {
+		fetchSiteIntent();
+	}, [ fetchSiteIntent ] );
+	return { siteIntent, siteIntentFetched };
+};
+export default useSiteIntent;

--- a/apps/wpcom-block-editor/src/wpcom/features/use-site-intent.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/use-site-intent.js
@@ -10,7 +10,6 @@ const useSiteIntent = () => {
 	const fetchSiteIntent = useCallback( () => {
 		apiFetch( { path: '/wpcom/v2/site-intent' } )
 			.then( ( result ) => {
-				console.log( 'result', result );
 				setSiteIntent( result.site_intent );
 				setSiteIntentFetched( true );
 			} )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -163,6 +163,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			siteId: site?.siteId,
 			siteSlug: site?.siteSlug,
 			goToCheckout: Boolean( planCartItem ),
+			siteId: site?.siteId,
 		};
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -163,7 +163,6 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			siteId: site?.siteId,
 			siteSlug: site?.siteSlug,
 			goToCheckout: Boolean( planCartItem ),
-			siteId: site?.siteId,
 		};
 	}
 

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -12,6 +12,7 @@ export enum SiteGoal {
 
 export enum SiteIntent {
 	Write = 'write',
+	StartWriting = 'start-writing',
 	Sell = 'sell',
 	Build = 'build',
 	DIFM = 'difm', // "Do It For Me"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1712,6 +1712,7 @@ __metadata:
     "@automattic/calypso-url": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@babel/runtime": ^7.17.2
+    "@wordpress/api-fetch": ^6.29.0
     "@wordpress/base-styles": ^4.13.0
     "@wordpress/block-editor": ^10.5.0
     "@wordpress/blocks": ^11.21.0
@@ -8345,6 +8346,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/api-fetch@npm:^6.29.0":
+  version: 6.29.0
+  resolution: "@wordpress/api-fetch@npm:6.29.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/i18n": ^4.32.0
+    "@wordpress/url": ^3.33.0
+  checksum: a34db9ce372a3f049d603085a5f9e61908661aec8654b2843beb3f739a8abc6375978b62d0e08f43942fa9882625451231b5a4f00ec8b05cd11c4e20f1a5ef10
+  languageName: node
+  linkType: hard
+
 "@wordpress/autop@npm:^3.22.0":
   version: 3.27.0
   resolution: "@wordpress/autop@npm:3.27.0"
@@ -9111,7 +9123,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/i18n@npm:^4.13.0, @wordpress/i18n@npm:^4.2.4, @wordpress/i18n@npm:^4.22.0, @wordpress/i18n@npm:^4.27.0":
+"@wordpress/i18n@npm:^4.13.0, @wordpress/i18n@npm:^4.2.4, @wordpress/i18n@npm:^4.22.0, @wordpress/i18n@npm:^4.27.0, @wordpress/i18n@npm:^4.32.0":
   version: 4.32.0
   resolution: "@wordpress/i18n@npm:4.32.0"
   dependencies:
@@ -9586,6 +9598,16 @@ __metadata:
     "@babel/runtime": ^7.16.0
     remove-accents: ^0.4.2
   checksum: 861a517939731984500ac4e89594b5b0bf83a47096b3d581c800dd40cc5d2335857ca5e46c892c3144ba457fd11ffe762dbd36c49a51dd186b2a978b44f7b255
+  languageName: node
+  linkType: hard
+
+"@wordpress/url@npm:^3.33.0":
+  version: 3.33.0
+  resolution: "@wordpress/url@npm:3.33.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    remove-accents: ^0.4.2
+  checksum: 68a907039f45061a0174861196b5d6a03ca0f3e49d2c43563721994424a59de01ee2a02fc24f67d62e4bdc17618b82298f386f7d596832d1d7ff584523824a58
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1712,7 +1712,7 @@ __metadata:
     "@automattic/calypso-url": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@babel/runtime": ^7.17.2
-    "@wordpress/api-fetch": ^6.29.0
+    "@wordpress/api-fetch": ^6.19.0
     "@wordpress/base-styles": ^4.13.0
     "@wordpress/block-editor": ^10.5.0
     "@wordpress/blocks": ^11.21.0
@@ -8346,17 +8346,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/api-fetch@npm:^6.29.0":
-  version: 6.29.0
-  resolution: "@wordpress/api-fetch@npm:6.29.0"
-  dependencies:
-    "@babel/runtime": ^7.16.0
-    "@wordpress/i18n": ^4.32.0
-    "@wordpress/url": ^3.33.0
-  checksum: a34db9ce372a3f049d603085a5f9e61908661aec8654b2843beb3f739a8abc6375978b62d0e08f43942fa9882625451231b5a4f00ec8b05cd11c4e20f1a5ef10
-  languageName: node
-  linkType: hard
-
 "@wordpress/autop@npm:^3.22.0":
   version: 3.27.0
   resolution: "@wordpress/autop@npm:3.27.0"
@@ -9123,7 +9112,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/i18n@npm:^4.13.0, @wordpress/i18n@npm:^4.2.4, @wordpress/i18n@npm:^4.22.0, @wordpress/i18n@npm:^4.27.0, @wordpress/i18n@npm:^4.32.0":
+"@wordpress/i18n@npm:^4.13.0, @wordpress/i18n@npm:^4.2.4, @wordpress/i18n@npm:^4.22.0, @wordpress/i18n@npm:^4.27.0":
   version: 4.32.0
   resolution: "@wordpress/i18n@npm:4.32.0"
   dependencies:
@@ -9598,16 +9587,6 @@ __metadata:
     "@babel/runtime": ^7.16.0
     remove-accents: ^0.4.2
   checksum: 861a517939731984500ac4e89594b5b0bf83a47096b3d581c800dd40cc5d2335857ca5e46c892c3144ba457fd11ffe762dbd36c49a51dd186b2a978b44f7b255
-  languageName: node
-  linkType: hard
-
-"@wordpress/url@npm:^3.33.0":
-  version: 3.33.0
-  resolution: "@wordpress/url@npm:3.33.0"
-  dependencies:
-    "@babel/runtime": ^7.16.0
-    remove-accents: ^0.4.2
-  checksum: 68a907039f45061a0174861196b5d6a03ca0f3e49d2c43563721994424a59de01ee2a02fc24f67d62e4bdc17618b82298f386f7d596832d1d7ff584523824a58
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2370

## Proposed Changes

* Site intent is already being set [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/start-writing.ts#L80-L81).
* This PR checks for site-intent inside the ETK and Block Editor plugins instead of looking in the URL params.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch on your local Calypso
- Go to apps/editing-toolkit
- Run yarn dev --sync (to sync it to your sandbox)
- In a new tab Go to apps/wpcom-block-editor/src
- Run yarn dev --sync
- Create a new site using our start-writing flow: http://calypso.localhost:3000/setup/start-writing
- Make sure the site that was created is sandboxed (like yoursite.wordpress.com).
- Verify if these features work as expected:
  - [ ] W is hidden
  - [ ] Tour doesn't show
  - [ ] Auto-save or Save draft won't break the flow
  - [ ] Refresh while editing won't break the flow
  - [ ] Redirect to Launchpad after publishing works in all cases

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
