### PR TITLE
Jetpack Pro Dashboard: Add a hardcoded parameter to fetch prices in USD

### DIFF
--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -16,13 +16,13 @@ const request =
 		dispatch( requestProductsList( props ) );
 	};
 
-export function useQueryProductsList( { type = 'all', persist } = {} ) {
+export function useQueryProductsList( { type = 'all', currency, persist } = {} ) {
 	const dispatch = useDispatch();
 
 	// Only runs on mount.
 	useEffect( () => {
-		dispatch( request( { type, persist } ) );
-	}, [ dispatch, type, persist ] );
+		dispatch( request( { type, currency, persist } ) );
+	}, [ dispatch, type, persist, currency ] );
 
 	return null;
 }
@@ -32,9 +32,10 @@ export function useQueryProductsList( { type = 'all', persist } = {} ) {
  * @param {Object} props 			The list of component props.
  * @param {string} [props.type] 	The type of products to request:
  *									"jetpack" for Jetpack products only, or undefined for all products.
+ * @param {string} [props.currency] The currency code to override the currency used on the account.
  * @param {boolean} [props.persist] Set to true to persist the products list in the store.
  * @returns {null} 					No visible output.
  */
-export default function QueryProductsList( { type = 'all', persist } ) {
-	return useQueryProductsList( { type, persist } );
+export default function QueryProductsList( { type = 'all', currency, persist } ) {
+	return useQueryProductsList( { type, currency, persist } );
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -104,7 +104,7 @@ export default function Prices() {
 
 	return (
 		<Main wideLayout className="prices">
-			<QueryProductsList type="jetpack" />
+			<QueryProductsList type="jetpack" currency="USD" />
 
 			<DocumentHead title={ translate( 'Prices' ) } />
 			<SidebarNavigation />


### PR DESCRIPTION
## Proposed Changes

* Fix agency prices showing up as their store setting currency instead of USD only.
* The absolute amount of the prices on the pro dashboard pricing page would vary according to your wordpress.com account currency, it should only show amounts from USD prices.

## Testing Instructions
- Change the currency of your wordpress.com account to anything other than USD
- Login to the Jetpack Pro Dashboard - If you don't have an agency account, request one from Avalon.
- On the Pro Dashboard, go to Licensing > Prices. You should only see prices in USD.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/5550190/ec1cac42-33cb-4bec-8919-636f689cb33d) | ![image](https://github.com/Automattic/wp-calypso/assets/5550190/2d418f1d-ca07-4f80-bf98-92c15035ea95)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
