### PR TITLE
Components: Refactor uPlot component logic into hooks and libs

### DIFF
--- a/packages/components/src/chart-uplot/hooks/use-resize.ts
+++ b/packages/components/src/chart-uplot/hooks/use-resize.ts
@@ -1,0 +1,33 @@
+import throttle from 'lodash/throttle';
+import { useEffect } from 'react';
+
+const THROTTLE_DURATION = 400; // in ms
+
+export default function useResize(
+	uplotRef: React.RefObject< uPlot >,
+	containerRef: React.RefObject< HTMLDivElement >
+) {
+	useEffect( () => {
+		if ( ! uplotRef.current || ! containerRef.current ) {
+			return;
+		}
+
+		const resizeChart = throttle( () => {
+			// Repeat the check since resize can happen much later than event registration.
+			if ( ! uplotRef.current || ! containerRef.current ) {
+				return;
+			}
+
+			// Only update width, not height.
+			uplotRef.current.setSize( {
+				height: uplotRef.current.height,
+				width: containerRef.current.clientWidth,
+			} );
+		}, THROTTLE_DURATION );
+		resizeChart();
+		window.addEventListener( 'resize', resizeChart );
+
+		// Cleanup on unmount.
+		return () => window.removeEventListener( 'resize', resizeChart );
+	}, [ uplotRef, containerRef ] );
+}

--- a/packages/components/src/chart-uplot/hooks/use-scale-gradient.ts
+++ b/packages/components/src/chart-uplot/hooks/use-scale-gradient.ts
@@ -1,15 +1,17 @@
 import { useCallback } from 'react';
 import type uPlot from 'uplot';
 
+export type ScaleGradientFunction = (
+	u: uPlot,
+	scaleKey: string,
+	ori: number,
+	scaleStops: [ number, string ][],
+	discrete?: boolean
+) => CanvasRenderingContext2D[ 'fillStyle' ];
+
 export default function useScaleGradient( backupColor: string ) {
-	return useCallback(
-		(
-			u: uPlot,
-			scaleKey: string,
-			ori: number,
-			scaleStops: [ number, string ][],
-			discrete = false
-		): CanvasRenderingContext2D[ 'fillStyle' ] => {
+	return useCallback< ScaleGradientFunction >(
+		( u, scaleKey, ori, scaleStops, discrete = false ) => {
 			const ctx = document.createElement( 'canvas' ).getContext( '2d' );
 
 			const scale = u.scales[ scaleKey ];

--- a/packages/components/src/chart-uplot/hooks/use-scale-gradient.ts
+++ b/packages/components/src/chart-uplot/hooks/use-scale-gradient.ts
@@ -1,0 +1,113 @@
+import { useCallback } from 'react';
+import type uPlot from 'uplot';
+
+export default function useScaleGradient( backupColor: string ) {
+	return useCallback(
+		(
+			u: uPlot,
+			scaleKey: string,
+			ori: number,
+			scaleStops: [ number, string ][],
+			discrete = false
+		): CanvasRenderingContext2D[ 'fillStyle' ] => {
+			const ctx = document.createElement( 'canvas' ).getContext( '2d' );
+
+			const scale = u.scales[ scaleKey ];
+			// we want the stop below or at the scaleMax
+			// and the stop below or at the scaleMin, else the stop above scaleMin
+			let minStopIdx;
+			let maxStopIdx;
+
+			if ( scale.min === undefined ) {
+				scale.min = 0;
+			}
+
+			if ( scale.max === undefined ) {
+				scale.max = 0;
+			}
+
+			for ( let i = 0; i < scaleStops.length; i++ ) {
+				const stopVal = scaleStops[ i ][ 0 ];
+
+				if ( stopVal <= scale.min || minStopIdx == null ) {
+					minStopIdx = i;
+				}
+
+				maxStopIdx = i;
+
+				if ( stopVal >= scale.max ) {
+					break;
+				}
+			}
+
+			if ( minStopIdx === undefined ) {
+				minStopIdx = 0;
+			}
+
+			if ( maxStopIdx === undefined ) {
+				maxStopIdx = 0;
+			}
+
+			if ( minStopIdx === maxStopIdx ) {
+				return scaleStops[ minStopIdx ][ 1 ];
+			}
+
+			let minStopVal = scaleStops[ minStopIdx ][ 0 ];
+			let maxStopVal = scaleStops[ maxStopIdx ][ 0 ];
+
+			if ( minStopVal === -Infinity ) {
+				minStopVal = scale.min;
+			}
+
+			if ( maxStopVal === Infinity ) {
+				maxStopVal = scale.max;
+			}
+
+			const minStopPos = u.valToPos( minStopVal, scaleKey, true );
+			const maxStopPos = u.valToPos( maxStopVal, scaleKey, true );
+
+			const range = minStopPos - maxStopPos;
+
+			let x0;
+			let y0;
+			let x1;
+			let y1;
+
+			if ( ori === 1 ) {
+				x0 = x1 = 0;
+				y0 = minStopPos;
+				y1 = maxStopPos;
+			} else {
+				y0 = y1 = 0;
+				x0 = minStopPos;
+				x1 = maxStopPos;
+			}
+
+			const gradient = ctx?.createLinearGradient( x0, y0, x1, y1 );
+
+			let prevColor;
+
+			for ( let i = minStopIdx || 0; i <= maxStopIdx; i++ ) {
+				const s = scaleStops[ i ];
+				let stopPos;
+
+				if ( i === minStopIdx ) {
+					stopPos = minStopPos;
+				} else {
+					stopPos = i === maxStopIdx ? maxStopPos : u.valToPos( s[ 0 ], scaleKey, true );
+				}
+
+				const pct = ( minStopPos - stopPos ) / range; // % of max value
+
+				if ( discrete && i > minStopIdx ) {
+					gradient?.addColorStop( pct, prevColor || 'rgba(0, 0, 0, 0)' );
+				}
+
+				gradient?.addColorStop( pct, ( prevColor = s[ 1 ] ) );
+			}
+
+			return gradient || backupColor;
+		},
+		[ backupColor ]
+	);
+}

--- a/packages/components/src/chart-uplot/index.tsx
+++ b/packages/components/src/chart-uplot/index.tsx
@@ -4,6 +4,7 @@ import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
 import useResize from './hooks/use-resize';
 import useScaleGradient from './hooks/use-scale-gradient';
+import getGradientFill from './lib/get-gradient-fill';
 
 import './style.scss';
 
@@ -90,42 +91,7 @@ export default function UplotChart( {
 						},
 					},
 					{
-						fill: solidFill
-							? fillColor
-							: ( u, seriesIdx ) => {
-									// Find min and max values for the visible parts of all y axis' and map it to color values to draw a gradient.
-									const s = u.series[ seriesIdx ]; // data set
-									const sc = u.scales[ s.scale || 1 ]; // y axis values
-
-									// if values are not initialised default to a solid color
-									if ( s.min === Infinity || s.max === -Infinity ) {
-										return fillColor;
-									}
-
-									let min = Infinity;
-									let max = -Infinity;
-
-									// get in-view y range for this scale
-									u.series.forEach( ( ser ) => {
-										if ( ser.show && ser.scale === s.scale ) {
-											min = Math.min( min, ser.min || 0 );
-											max = Math.max( max, ser.max || 0 );
-										}
-									} );
-
-									let range = max - min;
-
-									// if `range` from data is 0, apply axis range
-									if ( range === 0 ) {
-										range = sc?.max !== undefined && sc?.min !== undefined ? sc.max - sc.min : 0;
-										min = sc?.min || 0;
-									}
-
-									return scaleGradient( u, s.scale || 'y', 1, [
-										[ min + range * 0.0, 'rgba(48, 87, 220, 0)' ],
-										[ min + range * 1.0, 'rgba(48, 87, 220, 0.4)' ],
-									] );
-							  },
+						fill: solidFill ? fillColor : getGradientFill( fillColor, scaleGradient ),
 						label: translate( 'Subscribers' ),
 						stroke: '#3057DC',
 						width: 2,

--- a/packages/components/src/chart-uplot/index.tsx
+++ b/packages/components/src/chart-uplot/index.tsx
@@ -1,8 +1,8 @@
 import { getLocaleSlug, numberFormat, useTranslate } from 'i18n-calypso';
-import throttle from 'lodash/throttle';
-import { useCallback, useMemo, useState, useRef, useEffect } from 'react';
+import { useCallback, useMemo, useState, useRef } from 'react';
 import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
+import useResize from './hooks/use-resize';
 
 import './style.scss';
 
@@ -13,37 +13,6 @@ const DEFAULT_DIMENSIONS = {
 	height: 300,
 	width: 1224,
 };
-
-const THROTTLE_DURATION = 400; // in ms
-
-function useResize(
-	uplotRef: React.RefObject< uPlot >,
-	containerRef: React.RefObject< HTMLDivElement >
-) {
-	useEffect( () => {
-		if ( ! uplotRef.current || ! containerRef.current ) {
-			return;
-		}
-
-		const resizeChart = throttle( () => {
-			// Repeat the check since resize can happen much later than event registration.
-			if ( ! uplotRef.current || ! containerRef.current ) {
-				return;
-			}
-
-			// Only update width, not height.
-			uplotRef.current.setSize( {
-				height: uplotRef.current.height,
-				width: containerRef.current.clientWidth,
-			} );
-		}, THROTTLE_DURATION );
-		resizeChart();
-		window.addEventListener( 'resize', resizeChart );
-
-		// Cleanup on unmount.
-		return () => window.removeEventListener( 'resize', resizeChart );
-	}, [ uplotRef, containerRef ] );
-}
 
 interface UplotChartProps {
 	data: uPlot.AlignedData;

--- a/packages/components/src/chart-uplot/index.tsx
+++ b/packages/components/src/chart-uplot/index.tsx
@@ -1,8 +1,9 @@
 import { getLocaleSlug, numberFormat, useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useState, useRef } from 'react';
+import { useMemo, useState, useRef } from 'react';
 import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
 import useResize from './hooks/use-resize';
+import useScaleGradient from './hooks/use-scale-gradient';
 
 import './style.scss';
 
@@ -35,116 +36,7 @@ export default function UplotChart( {
 	const uplotContainer = useRef( null );
 	const { spline } = uPlot.paths;
 
-	// TODO: Refactor this into a separate hook function file.
-	const scaleGradient = useCallback(
-		(
-			u: uPlot,
-			scaleKey: string,
-			ori: number,
-			scaleStops: [ number, string ][],
-			discrete = false
-		): string | CanvasGradient => {
-			const ctx = document.createElement( 'canvas' ).getContext( '2d' );
-
-			const scale = u.scales[ scaleKey ];
-			// we want the stop below or at the scaleMax
-			// and the stop below or at the scaleMin, else the stop above scaleMin
-			let minStopIdx;
-			let maxStopIdx;
-
-			if ( scale.min === undefined ) {
-				scale.min = 0;
-			}
-
-			if ( scale.max === undefined ) {
-				scale.max = 0;
-			}
-
-			for ( let i = 0; i < scaleStops.length; i++ ) {
-				const stopVal = scaleStops[ i ][ 0 ];
-
-				if ( stopVal <= scale.min || minStopIdx == null ) {
-					minStopIdx = i;
-				}
-
-				maxStopIdx = i;
-
-				if ( stopVal >= scale.max ) {
-					break;
-				}
-			}
-
-			if ( minStopIdx === undefined ) {
-				minStopIdx = 0;
-			}
-
-			if ( maxStopIdx === undefined ) {
-				maxStopIdx = 0;
-			}
-
-			if ( minStopIdx === maxStopIdx ) {
-				return scaleStops[ minStopIdx ][ 1 ];
-			}
-
-			let minStopVal = scaleStops[ minStopIdx ][ 0 ];
-			let maxStopVal = scaleStops[ maxStopIdx ][ 0 ];
-
-			if ( minStopVal === -Infinity ) {
-				minStopVal = scale.min;
-			}
-
-			if ( maxStopVal === Infinity ) {
-				maxStopVal = scale.max;
-			}
-
-			const minStopPos = u.valToPos( minStopVal, scaleKey, true );
-			const maxStopPos = u.valToPos( maxStopVal, scaleKey, true );
-
-			const range = minStopPos - maxStopPos;
-
-			let x0;
-			let y0;
-			let x1;
-			let y1;
-
-			if ( ori === 1 ) {
-				x0 = x1 = 0;
-				y0 = minStopPos;
-				y1 = maxStopPos;
-			} else {
-				y0 = y1 = 0;
-				x0 = minStopPos;
-				x1 = maxStopPos;
-			}
-
-			const grd = ctx?.createLinearGradient( x0, y0, x1, y1 );
-
-			let prevColor;
-
-			for ( let i = minStopIdx || 0; i <= maxStopIdx; i++ ) {
-				const s = scaleStops[ i ];
-				let stopPos;
-
-				if ( i === minStopIdx ) {
-					stopPos = minStopPos;
-				} else {
-					stopPos = i === maxStopIdx ? maxStopPos : u.valToPos( s[ 0 ], scaleKey, true );
-				}
-
-				const pct = ( minStopPos - stopPos ) / range; // % of max value
-
-				if ( discrete && i > minStopIdx ) {
-					grd?.addColorStop( pct, prevColor || 'rgba(0, 0, 0, 0)' );
-				}
-
-				grd?.addColorStop( pct, ( prevColor = s[ 1 ] ) );
-			}
-
-			return grd || fillColor;
-		},
-		[ fillColor ]
-	);
-
+	const scaleGradient = useScaleGradient( fillColor );
 	const [ options ] = useState< uPlot.Options >(
 		useMemo( () => {
 			const defaultOptions: uPlot.Options = {

--- a/packages/components/src/chart-uplot/index.tsx
+++ b/packages/components/src/chart-uplot/index.tsx
@@ -47,6 +47,7 @@ function useResize(
 
 interface UplotChartProps {
 	data: uPlot.AlignedData;
+	fillColor?: string;
 	options?: Partial< uPlot.Options >;
 	legendContainer?: React.RefObject< HTMLDivElement >;
 	solidFill?: boolean;
@@ -54,14 +55,14 @@ interface UplotChartProps {
 
 export default function UplotChart( {
 	data,
-	options: propOptions,
+	fillColor = 'rgba(48, 87, 220, 0.4)',
 	legendContainer,
+	options: propOptions,
 	solidFill = false,
 }: UplotChartProps ) {
 	const translate = useTranslate();
 	const uplot = useRef< uPlot | null >( null );
 	const uplotContainer = useRef( null );
-	const defaultFillColor = 'rgba(48, 87, 220, 0.4)';
 	const { spline } = uPlot.paths;
 
 	// TODO: Refactor this into a separate hook function file.
@@ -169,9 +170,9 @@ export default function UplotChart( {
 				grd?.addColorStop( pct, ( prevColor = s[ 1 ] ) );
 			}
 
-			return grd || defaultFillColor;
+			return grd || fillColor;
 		},
-		[ defaultFillColor ]
+		[ fillColor ]
 	);
 
 	const [ options ] = useState< uPlot.Options >(
@@ -228,7 +229,7 @@ export default function UplotChart( {
 					},
 					{
 						fill: solidFill
-							? defaultFillColor
+							? fillColor
 							: ( u, seriesIdx ) => {
 									// Find min and max values for the visible parts of all y axis' and map it to color values to draw a gradient.
 									const s = u.series[ seriesIdx ]; // data set
@@ -236,7 +237,7 @@ export default function UplotChart( {
 
 									// if values are not initialised default to a solid color
 									if ( s.min === Infinity || s.max === -Infinity ) {
-										return defaultFillColor;
+										return fillColor;
 									}
 
 									let min = Infinity;
@@ -295,15 +296,7 @@ export default function UplotChart( {
 				...defaultOptions,
 				...( typeof propOptions === 'object' ? propOptions : {} ),
 			};
-		}, [
-			defaultFillColor,
-			legendContainer,
-			propOptions,
-			scaleGradient,
-			solidFill,
-			spline,
-			translate,
-		] )
+		}, [ fillColor, legendContainer, propOptions, scaleGradient, solidFill, spline, translate ] )
 	);
 
 	useResize( uplot, uplotContainer );

--- a/packages/components/src/chart-uplot/index.tsx
+++ b/packages/components/src/chart-uplot/index.tsx
@@ -6,8 +6,9 @@ import useResize from './hooks/use-resize';
 
 import './style.scss';
 
-// NOTE: Do not include this component in the package entry bundle!
-// Doing so will unnecessarily bloat the package bundle size.
+// NOTE: Do not include this component in the package entry bundle.
+//       Doing so will cause tests of the consumer package to break due to uPlot's reliance on matchMedia.
+//       https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom.
 
 const DEFAULT_DIMENSIONS = {
 	height: 300,

--- a/packages/components/src/chart-uplot/index.tsx
+++ b/packages/components/src/chart-uplot/index.tsx
@@ -1,6 +1,6 @@
 import { getLocaleSlug, numberFormat, useTranslate } from 'i18n-calypso';
 import throttle from 'lodash/throttle';
-import { useMemo, useState, useRef, useEffect } from 'react';
+import { useCallback, useMemo, useState, useRef, useEffect } from 'react';
 import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
 
@@ -64,112 +64,115 @@ export default function UplotChart( {
 	const defaultFillColor = 'rgba(48, 87, 220, 0.4)';
 	const { spline } = uPlot.paths;
 
-	const can = document.createElement( 'canvas' );
-	const ctx = can.getContext( '2d' );
+	// TODO: Refactor this into a separate hook function file.
+	const scaleGradient = useCallback(
+		(
+			u: uPlot,
+			scaleKey: string,
+			ori: number,
+			scaleStops: [ number, string ][],
+			discrete = false
+		): string | CanvasGradient => {
+			const ctx = document.createElement( 'canvas' ).getContext( '2d' );
 
-	const scaleGradient = (
-		u: uPlot,
-		scaleKey: string,
-		ori: number,
-		scaleStops: [ number, string ][],
-		discrete = false
-	): string | CanvasGradient => {
-		const scale = u.scales[ scaleKey ];
-		// we want the stop below or at the scaleMax
-		// and the stop below or at the scaleMin, else the stop above scaleMin
-		let minStopIdx;
-		let maxStopIdx;
+			const scale = u.scales[ scaleKey ];
+			// we want the stop below or at the scaleMax
+			// and the stop below or at the scaleMin, else the stop above scaleMin
+			let minStopIdx;
+			let maxStopIdx;
 
-		if ( scale.min === undefined ) {
-			scale.min = 0;
-		}
-
-		if ( scale.max === undefined ) {
-			scale.max = 0;
-		}
-
-		for ( let i = 0; i < scaleStops.length; i++ ) {
-			const stopVal = scaleStops[ i ][ 0 ];
-
-			if ( stopVal <= scale.min || minStopIdx == null ) {
-				minStopIdx = i;
+			if ( scale.min === undefined ) {
+				scale.min = 0;
 			}
 
-			maxStopIdx = i;
-
-			if ( stopVal >= scale.max ) {
-				break;
+			if ( scale.max === undefined ) {
+				scale.max = 0;
 			}
-		}
 
-		if ( minStopIdx === undefined ) {
-			minStopIdx = 0;
-		}
+			for ( let i = 0; i < scaleStops.length; i++ ) {
+				const stopVal = scaleStops[ i ][ 0 ];
 
-		if ( maxStopIdx === undefined ) {
-			maxStopIdx = 0;
-		}
+				if ( stopVal <= scale.min || minStopIdx == null ) {
+					minStopIdx = i;
+				}
 
-		if ( minStopIdx === maxStopIdx ) {
-			return scaleStops[ minStopIdx ][ 1 ];
-		}
+				maxStopIdx = i;
 
-		let minStopVal = scaleStops[ minStopIdx ][ 0 ];
-		let maxStopVal = scaleStops[ maxStopIdx ][ 0 ];
+				if ( stopVal >= scale.max ) {
+					break;
+				}
+			}
 
-		if ( minStopVal === -Infinity ) {
-			minStopVal = scale.min;
-		}
+			if ( minStopIdx === undefined ) {
+				minStopIdx = 0;
+			}
 
-		if ( maxStopVal === Infinity ) {
-			maxStopVal = scale.max;
-		}
+			if ( maxStopIdx === undefined ) {
+				maxStopIdx = 0;
+			}
 
-		const minStopPos = u.valToPos( minStopVal, scaleKey, true );
-		const maxStopPos = u.valToPos( maxStopVal, scaleKey, true );
+			if ( minStopIdx === maxStopIdx ) {
+				return scaleStops[ minStopIdx ][ 1 ];
+			}
 
-		const range = minStopPos - maxStopPos;
+			let minStopVal = scaleStops[ minStopIdx ][ 0 ];
+			let maxStopVal = scaleStops[ maxStopIdx ][ 0 ];
 
-		let x0;
-		let y0;
-		let x1;
-		let y1;
+			if ( minStopVal === -Infinity ) {
+				minStopVal = scale.min;
+			}
 
-		if ( ori === 1 ) {
-			x0 = x1 = 0;
-			y0 = minStopPos;
-			y1 = maxStopPos;
-		} else {
-			y0 = y1 = 0;
-			x0 = minStopPos;
-			x1 = maxStopPos;
-		}
+			if ( maxStopVal === Infinity ) {
+				maxStopVal = scale.max;
+			}
 
-		const grd = ctx?.createLinearGradient( x0, y0, x1, y1 );
+			const minStopPos = u.valToPos( minStopVal, scaleKey, true );
+			const maxStopPos = u.valToPos( maxStopVal, scaleKey, true );
 
-		let prevColor;
+			const range = minStopPos - maxStopPos;
 
-		for ( let i = minStopIdx || 0; i <= maxStopIdx; i++ ) {
-			const s = scaleStops[ i ];
-			let stopPos;
+			let x0;
+			let y0;
+			let x1;
+			let y1;
 
-			if ( i === minStopIdx ) {
-				stopPos = minStopPos;
+			if ( ori === 1 ) {
+				x0 = x1 = 0;
+				y0 = minStopPos;
+				y1 = maxStopPos;
 			} else {
-				stopPos = i === maxStopIdx ? maxStopPos : u.valToPos( s[ 0 ], scaleKey, true );
+				y0 = y1 = 0;
+				x0 = minStopPos;
+				x1 = maxStopPos;
 			}
 
-			const pct = ( minStopPos - stopPos ) / range; // % of max value
+			const grd = ctx?.createLinearGradient( x0, y0, x1, y1 );
 
-			if ( discrete && i > minStopIdx ) {
-				grd?.addColorStop( pct, prevColor || 'rgba(0, 0, 0, 0)' );
+			let prevColor;
+
+			for ( let i = minStopIdx || 0; i <= maxStopIdx; i++ ) {
+				const s = scaleStops[ i ];
+				let stopPos;
+
+				if ( i === minStopIdx ) {
+					stopPos = minStopPos;
+				} else {
+					stopPos = i === maxStopIdx ? maxStopPos : u.valToPos( s[ 0 ], scaleKey, true );
+				}
+
+				const pct = ( minStopPos - stopPos ) / range; // % of max value
+
+				if ( discrete && i > minStopIdx ) {
+					grd?.addColorStop( pct, prevColor || 'rgba(0, 0, 0, 0)' );
+				}
+
+				grd?.addColorStop( pct, ( prevColor = s[ 1 ] ) );
 			}
 
-			grd?.addColorStop( pct, ( prevColor = s[ 1 ] ) );
-		}
-
-		return grd || defaultFillColor;
-	};
+			return grd || defaultFillColor;
+		},
+		[ defaultFillColor ]
+	);
 
 	const [ options ] = useState< uPlot.Options >(
 		useMemo( () => {
@@ -292,7 +295,15 @@ export default function UplotChart( {
 				...defaultOptions,
 				...( typeof propOptions === 'object' ? propOptions : {} ),
 			};
-		}, [ legendContainer, propOptions, translate ] )
+		}, [
+			defaultFillColor,
+			legendContainer,
+			propOptions,
+			scaleGradient,
+			solidFill,
+			spline,
+			translate,
+		] )
 	);
 
 	useResize( uplot, uplotContainer );

--- a/packages/components/src/chart-uplot/lib/get-gradient-fill.ts
+++ b/packages/components/src/chart-uplot/lib/get-gradient-fill.ts
@@ -1,0 +1,47 @@
+import type uPlot from 'uplot';
+
+export default function getGradientFill(
+	fillColor: string,
+	scaleGradient: (
+		u: uPlot,
+		scaleKey: string,
+		ori: number,
+		scaleStops: [ number, string ][],
+		discrete?: boolean
+	) => CanvasRenderingContext2D[ 'fillStyle' ]
+): ( self: uPlot, seriesIdx: number ) => CanvasRenderingContext2D[ 'fillStyle' ] {
+	return ( u, seriesIdx ) => {
+		// Find min and max values for the visible parts of all y axis' and map it to color values to draw a gradient.
+		const s = u.series[ seriesIdx ]; // data set
+		const sc = u.scales[ s.scale || 1 ]; // y axis values
+
+		// if values are not initialised default to a solid color
+		if ( s.min === Infinity || s.max === -Infinity ) {
+			return fillColor;
+		}
+
+		let min = Infinity;
+		let max = -Infinity;
+
+		// get in-view y range for this scale
+		u.series.forEach( ( ser ) => {
+			if ( ser.show && ser.scale === s.scale ) {
+				min = Math.min( min, ser.min || 0 );
+				max = Math.max( max, ser.max || 0 );
+			}
+		} );
+
+		let range = max - min;
+
+		// if `range` from data is 0, apply axis range
+		if ( range === 0 ) {
+			range = sc?.max !== undefined && sc?.min !== undefined ? sc.max - sc.min : 0;
+			min = sc?.min || 0;
+		}
+
+		return scaleGradient( u, s.scale || 'y', 1, [
+			[ min + range * 0.0, 'rgba(48, 87, 220, 0)' ],
+			[ min + range * 1.0, 'rgba(48, 87, 220, 0.4)' ],
+		] );
+	};
+}

--- a/packages/components/src/chart-uplot/lib/get-gradient-fill.ts
+++ b/packages/components/src/chart-uplot/lib/get-gradient-fill.ts
@@ -1,14 +1,9 @@
+import type { ScaleGradientFunction } from '../hooks/use-scale-gradient';
 import type uPlot from 'uplot';
 
 export default function getGradientFill(
 	fillColor: string,
-	scaleGradient: (
-		u: uPlot,
-		scaleKey: string,
-		ori: number,
-		scaleStops: [ number, string ][],
-		discrete?: boolean
-	) => CanvasRenderingContext2D[ 'fillStyle' ]
+	scaleGradient: ScaleGradientFunction
 ): ( self: uPlot, seriesIdx: number ) => CanvasRenderingContext2D[ 'fillStyle' ] {
 	return ( u, seriesIdx ) => {
 		// Find min and max values for the visible parts of all y axis' and map it to color values to draw a gradient.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76328.

## Proposed Changes

* Moves the chart resize hook outside of the component file.
* Creates a new hook wrapping the existing logic for creating a scale gradient.
* Creates a new lib for defining a gradient fill which is used for a series' stroke.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch for this PR.
* Navigate to `/stats/day/:siteSlug`.
* Add `?flags=stats/subscribers-section` to the URL to enable the subscriber stats page.
* Ensure that the chart loads as expected.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
