### PR TITLE
Odyssey Widget: link to Calypso Stats for Atomic sites

### DIFF
--- a/apps/odyssey-stats/src/lib/create-odyssey-config.ts
+++ b/apps/odyssey-stats/src/lib/create-odyssey-config.ts
@@ -26,10 +26,8 @@ export class ConfigApi extends Function {
 		}
 
 		if ( 'development' === process.env.NODE_ENV ) {
-			throw new ReferenceError(
-				`Could not find config value for key '${ key }'\n` +
-					"Please make sure that if you need it then it has a default value assigned in 'config/_shared.json'"
-			);
+			// eslint-disable-next-line no-console
+			console.warn( `Could not find config value for key '${ key }'\n` );
 		}
 
 		return undefined;

--- a/apps/odyssey-stats/src/lib/create-odyssey-config.ts
+++ b/apps/odyssey-stats/src/lib/create-odyssey-config.ts
@@ -26,8 +26,10 @@ export class ConfigApi extends Function {
 		}
 
 		if ( 'development' === process.env.NODE_ENV ) {
-			// eslint-disable-next-line no-console
-			console.warn( `Could not find config value for key '${ key }'\n` );
+			throw new ReferenceError(
+				`Could not find config value for key '${ key }'\n` +
+					"Please make sure that if you need it then it has a default value assigned in 'config/_shared.json'"
+			);
 		}
 
 		return undefined;

--- a/apps/odyssey-stats/src/lib/selectors/can-current-user.ts
+++ b/apps/odyssey-stats/src/lib/selectors/can-current-user.ts
@@ -1,6 +1,6 @@
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import config from './config-api';
+import getState from './get-state';
 
 export default ( siteId: number, capability: string ) =>
 	// TODO: fix `intial_state` typo.
-	canCurrentUser( config( 'intial_state' ) || {}, siteId, capability );
+	canCurrentUser( getState(), siteId, capability );

--- a/apps/odyssey-stats/src/lib/selectors/can-current-user.ts
+++ b/apps/odyssey-stats/src/lib/selectors/can-current-user.ts
@@ -2,5 +2,4 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getState from './get-state';
 
 export default ( siteId: number, capability: string ) =>
-	// TODO: fix `intial_state` typo.
 	canCurrentUser( getState(), siteId, capability );

--- a/apps/odyssey-stats/src/lib/selectors/get-odyssey-stats-base-url.ts
+++ b/apps/odyssey-stats/src/lib/selectors/get-odyssey-stats-base-url.ts
@@ -1,0 +1,5 @@
+import config from '../config-api';
+
+const getOdysseyStatsBaseUrl = () => config( 'odyssey_stats_base_url' ) || '';
+
+export default getOdysseyStatsBaseUrl;

--- a/apps/odyssey-stats/src/lib/selectors/get-site-admin-url.ts
+++ b/apps/odyssey-stats/src/lib/selectors/get-site-admin-url.ts
@@ -1,0 +1,7 @@
+import getSiteAdminUrlFromState from 'calypso/state/sites/selectors/get-site-admin-url';
+import getState from './get-state';
+
+const getSiteAdminUrl = ( siteId: number ): null | string =>
+	getSiteAdminUrlFromState( getState(), siteId );
+
+export default getSiteAdminUrl;

--- a/apps/odyssey-stats/src/lib/selectors/get-site-stats-base-url.ts
+++ b/apps/odyssey-stats/src/lib/selectors/get-site-stats-base-url.ts
@@ -1,9 +1,9 @@
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import config from '../config-api';
 import getOdysseyStatsBaseUrl from './get-odyssey-stats-base-url';
 
 const getSiteStatsBaseUrl = ( siteId: number ): string =>
-	isSiteAutomatedTransfer( config( 'intial_state' ), siteId )
+	isSiteWpcomAtomic( config( 'intial_state' ), siteId )
 		? 'https://wordpress.com'
 		: `${ getOdysseyStatsBaseUrl() }#!`;
 

--- a/apps/odyssey-stats/src/lib/selectors/get-site-stats-base-url.ts
+++ b/apps/odyssey-stats/src/lib/selectors/get-site-stats-base-url.ts
@@ -1,0 +1,10 @@
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import config from '../config-api';
+import getOdysseyStatsBaseUrl from './get-odyssey-stats-base-url';
+
+const getSiteStatsBaseUrl = ( siteId: number ): string =>
+	isSiteAutomatedTransfer( config( 'intial_state' ), siteId )
+		? 'https://wordpress.com'
+		: `${ getOdysseyStatsBaseUrl() }#!`;
+
+export default getSiteStatsBaseUrl;

--- a/apps/odyssey-stats/src/lib/selectors/get-state.ts
+++ b/apps/odyssey-stats/src/lib/selectors/get-state.ts
@@ -1,0 +1,3 @@
+import config from '../config-api';
+
+export default () => config( 'intial_state' ) ?? {};

--- a/apps/odyssey-stats/src/lib/selectors/get-state.ts
+++ b/apps/odyssey-stats/src/lib/selectors/get-state.ts
@@ -1,3 +1,4 @@
 import config from '../config-api';
 
+// TODO: fix `intial_state` typo.
 export default () => config( 'intial_state' ) ?? {};

--- a/apps/odyssey-stats/src/widget/highlights.tsx
+++ b/apps/odyssey-stats/src/widget/highlights.tsx
@@ -13,7 +13,7 @@ import './highlights.scss';
 
 interface ItemWrapperProps {
 	siteId: number;
-	odysseyStatsBaseUrl: string;
+	statsBaseUrl: string;
 	isItemLink: boolean;
 	item: HighLightItem;
 	isItemLinkExternal: boolean;
@@ -25,7 +25,7 @@ interface TopColumnProps {
 	viewAllText: string;
 	title: string;
 	isLoading: boolean;
-	odysseyStatsBaseUrl: string;
+	statsBaseUrl: string;
 	siteId: number;
 	isItemLinkExternal?: boolean;
 	isItemLink?: boolean;
@@ -35,7 +35,7 @@ interface TopColumnProps {
 interface HighlightsProps {
 	siteId: number;
 	gmtOffset: number;
-	odysseyStatsBaseUrl: string;
+	statsBaseUrl: string;
 }
 
 const HIGHLIGHT_ITEMS_LIMIT = 5;
@@ -43,7 +43,7 @@ const HIGHLIGHT_TAB_TOP_POSTS_PAGES = 'topPostsAndPages';
 const HIGHLIGHT_TAB_TOP_REFERRERS = 'topReferrers';
 
 const postAndPageLink = ( baseUrl: string, siteId: number, postId: number ) => {
-	return `${ baseUrl }#!/stats/post/${ postId }/${ siteId }`;
+	return `${ baseUrl }/stats/post/${ postId }/${ siteId }`;
 };
 
 const externalLink = ( item: HighLightItem ) => {
@@ -52,7 +52,7 @@ const externalLink = ( item: HighLightItem ) => {
 };
 
 const ItemWrapper: FunctionComponent< ItemWrapperProps > = ( {
-	odysseyStatsBaseUrl,
+	statsBaseUrl,
 	siteId,
 	isItemLink,
 	item,
@@ -74,9 +74,7 @@ const ItemWrapper: FunctionComponent< ItemWrapperProps > = ( {
 	return isItemLink ? (
 		<a
 			href={
-				isItemLinkExternal
-					? externalLink( item )
-					: postAndPageLink( odysseyStatsBaseUrl, siteId, item.id )
+				isItemLinkExternal ? externalLink( item ) : postAndPageLink( statsBaseUrl, siteId, item.id )
 			}
 			target={ isItemLinkExternal ? '_blank' : '_self' }
 			rel="noopener noreferrer"
@@ -102,7 +100,7 @@ const TopColumn: FunctionComponent< TopColumnProps > = ( {
 	viewAllText,
 	title,
 	isLoading,
-	odysseyStatsBaseUrl,
+	statsBaseUrl,
 	siteId,
 	isItemLink = false,
 	isItemLinkExternal = false,
@@ -124,7 +122,7 @@ const TopColumn: FunctionComponent< TopColumnProps > = ( {
 						<li key={ idx }>
 							<ItemWrapper
 								item={ item }
-								odysseyStatsBaseUrl={ odysseyStatsBaseUrl }
+								statsBaseUrl={ statsBaseUrl }
 								siteId={ siteId }
 								isItemLink={ isItemLink }
 								isItemLinkExternal={ isItemLinkExternal }
@@ -140,7 +138,7 @@ const TopColumn: FunctionComponent< TopColumnProps > = ( {
 	);
 };
 
-export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl }: HighlightsProps ) {
+export default function Highlights( { siteId, gmtOffset, statsBaseUrl }: HighlightsProps ) {
 	const translate = useTranslate();
 
 	const headingTitle = translate( '7 Day Highlights' );
@@ -164,8 +162,8 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl }: 
 	const queryDate = moment()
 		.utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 )
 		.format( 'YYYY-MM-DD' );
-	const viewAllPostsStatsUrl = `${ odysseyStatsBaseUrl }#!/stats/day/posts/${ siteId }?startDate=${ queryDate }&summarize=1&num=7`;
-	const viewAllReferrerStatsUrl = `${ odysseyStatsBaseUrl }#!/stats/day/referrers/${ siteId }?startDate=${ queryDate }&summarize=1&num=7`;
+	const viewAllPostsStatsUrl = `${ statsBaseUrl }/stats/day/posts/${ siteId }?startDate=${ queryDate }&summarize=1&num=7`;
+	const viewAllReferrerStatsUrl = `${ statsBaseUrl }/stats/day/referrers/${ siteId }?startDate=${ queryDate }&summarize=1&num=7`;
 
 	const { data: topPostsAndPages = [], isFetching: isFetchingPostsAndPages } = useTopPostsQuery(
 		siteId,
@@ -212,7 +210,7 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl }: 
 					viewAllText={ translate( 'View all posts & pages stats' ) }
 					items={ topPostsAndPages }
 					isLoading={ isFetchingPostsAndPages }
-					odysseyStatsBaseUrl={ odysseyStatsBaseUrl }
+					statsBaseUrl={ statsBaseUrl }
 					siteId={ siteId }
 					isItemLink
 				/>
@@ -226,7 +224,7 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl }: 
 					viewAllText={ translate( 'View all referrer stats' ) }
 					items={ topReferrers }
 					isLoading={ isFetchingReferrers }
-					odysseyStatsBaseUrl={ odysseyStatsBaseUrl }
+					statsBaseUrl={ statsBaseUrl }
 					siteId={ siteId }
 					isItemLink
 					isItemLinkExternal

--- a/apps/odyssey-stats/src/widget/index.tsx
+++ b/apps/odyssey-stats/src/widget/index.tsx
@@ -50,7 +50,9 @@ export function init() {
 							>
 								<JetpackLogo size={ 20 } monochrome full />
 							</a>
-							<a href={ statsBaseUrl }>{ translate( 'View all stats' ) }</a>
+							<a href={ `${ statsBaseUrl }/stats/day/${ currentSiteId }` }>
+								{ translate( 'View all stats' ) }
+							</a>
 						</div>
 					</div>
 				</div>

--- a/apps/odyssey-stats/src/widget/index.tsx
+++ b/apps/odyssey-stats/src/widget/index.tsx
@@ -4,6 +4,8 @@ import { translate } from 'i18n-calypso';
 import { render } from 'react-dom';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import config from '../lib/config-api';
+import getSiteAdminUrl from '../lib/selectors/get-site-admin-url';
+import getSiteStatsBaseUrl from '../lib/selectors/get-site-stats-base-url';
 import setLocale from '../lib/set-locale';
 import Highlights from './highlights';
 import MiniChart from './mini-chart';
@@ -17,7 +19,10 @@ import './index.scss';
 export function init() {
 	const currentSiteId = config( 'blog_id' );
 	const localeSlug = config( 'i18n_locale_slug' ) || config( 'i18n_default_locale_slug' ) || 'en';
-	const odysseyStatsBaseUrl = config( 'odyssey_stats_base_url' );
+
+	const statsBaseUrl = getSiteStatsBaseUrl( currentSiteId );
+	const adminBaseUrl = getSiteAdminUrl( currentSiteId );
+
 	const queryClient = new QueryClient();
 
 	// Ensure locale files are loaded before rendering.
@@ -28,15 +33,15 @@ export function init() {
 					<MiniChart
 						siteId={ currentSiteId }
 						gmtOffset={ config( 'gmt_offset' ) }
-						odysseyStatsBaseUrl={ odysseyStatsBaseUrl }
+						statsBaseUrl={ statsBaseUrl }
 					/>
 					<div className="stats-widget-wrapper">
 						<Highlights
 							siteId={ currentSiteId }
 							gmtOffset={ config( 'gmt_offset' ) }
-							odysseyStatsBaseUrl={ odysseyStatsBaseUrl }
+							statsBaseUrl={ statsBaseUrl }
 						/>
-						<Modules siteId={ currentSiteId } odysseyStatsBaseUrl={ odysseyStatsBaseUrl } />
+						<Modules siteId={ currentSiteId } adminBaseUrl={ adminBaseUrl } />
 						<div className="stats-widget-footer">
 							<a
 								href="https://jetpack.com/redirect/?source=jetpack-stats-widget-logo-link"
@@ -45,7 +50,7 @@ export function init() {
 							>
 								<JetpackLogo size={ 20 } monochrome full />
 							</a>
-							<a href={ odysseyStatsBaseUrl }>{ translate( 'View all stats' ) }</a>
+							<a href={ statsBaseUrl }>{ translate( 'View all stats' ) }</a>
 						</div>
 					</div>
 				</div>

--- a/apps/odyssey-stats/src/widget/mini-chart.tsx
+++ b/apps/odyssey-stats/src/widget/mini-chart.tsx
@@ -18,7 +18,7 @@ interface MiniChartProps {
 	siteId: number;
 	quantity?: number;
 	gmtOffset: number;
-	odysseyStatsBaseUrl: string;
+	statsBaseUrl: string;
 }
 
 interface BarData {
@@ -29,7 +29,7 @@ interface BarData {
 const MiniChart: FunctionComponent< MiniChartProps > = ( {
 	siteId,
 	gmtOffset,
-	odysseyStatsBaseUrl,
+	statsBaseUrl,
 	quantity = 7,
 } ) => {
 	const translate = useTranslate();
@@ -53,7 +53,7 @@ const MiniChart: FunctionComponent< MiniChartProps > = ( {
 	const { isLoading, data } = useVisitsQuery( siteId, period, quantity, queryDate );
 
 	const barClick = ( bar: { data: BarData } ) => {
-		window.location.href = `${ odysseyStatsBaseUrl }#!/stats/${ period }/${ siteId }?startDate=${ bar.data.period }`;
+		window.location.href = `${ statsBaseUrl }/stats/${ period }/${ siteId }?startDate=${ bar.data.period }`;
 	};
 
 	const chartData = buildChartData(

--- a/apps/odyssey-stats/src/widget/modules.tsx
+++ b/apps/odyssey-stats/src/widget/modules.tsx
@@ -5,7 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, FunctionComponent } from 'react';
 import wpcom from 'calypso/lib/wp';
 import useModuleDataQuery from '../hooks/use-module-data-query';
-import canCurrentUser from '../lib/can-current-user';
+import canCurrentUser from '../lib/selectors/can-current-user';
 
 import './modules.scss';
 
@@ -27,7 +27,7 @@ interface ProtectModuleProps {
 }
 
 interface ModulesProps extends ProtectModuleProps {
-	odysseyStatsBaseUrl: string;
+	adminBaseUrl: null | string;
 }
 
 interface AkismetModuleProps extends ProtectModuleProps {
@@ -178,17 +178,14 @@ const ProtectModule: FunctionComponent< ProtectModuleProps > = ( { siteId } ) =>
 	);
 };
 
-export default function Modules( { siteId, odysseyStatsBaseUrl }: ModulesProps ) {
+export default function Modules( { siteId, adminBaseUrl }: ModulesProps ) {
 	return (
 		<div className="stats-widget-modules">
 			<ProtectModule siteId={ siteId } />
 			<AkismetModule
 				siteId={ siteId }
 				// The URL is used to redirect the user to the Akismet Key configuration page.
-				manageUrl={
-					odysseyStatsBaseUrl &&
-					odysseyStatsBaseUrl.replaceAll( /page=stats/g, 'page=akismet-key-config' )
-				}
+				manageUrl={ adminBaseUrl + 'admin.php?page=akismet-key-config' }
 			/>
 		</div>
 	);


### PR DESCRIPTION
Related to #76690 

## Proposed Changes

The PR proposes to link to Calypso Stats for Atomic sites where Odyssey Stats is not enabled.

- Renamed `odysseyStatsBaseUrl` to `statsBaseUrl` in the components
- Use site admin url to compose Akismet key management URL
- Moved selector (not for redux really) to a `lib/selectors`

## Testing Instructions

* Build Jetpack if necessary: `jetpack build plugins/jetpack`.
* Run `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev` under `calypso/apps/odyssey-stats`.
- Open `/wp-admin/index.php` on a site with Jetpack `trunk` branch
- Ensure the widget links to Odyssey Stats Dashboard
- Test with https://github.com/Automattic/jetpack/pull/30573
- Change `is_automated_transfer` to `true`
- Open `/wp-admin/index.php`
- Ensure the widget links to Calypso Stats
- Best to test on a WoA site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
