### PR TITLE
Extend stickypanel to support mobile and absolute position

### DIFF
--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -63,12 +63,18 @@ function renderStickyPanel( props, state ) {
 			<div className="sticky-panel__content" style={ getBlockStyle( state ) }>
 				{ props.children }
 			</div>
-			<div className="sticky-panel__spacer" style={ { height: state.spacerHeight } } />
+			<div
+				className="sticky-panel__spacer"
+				style={ { height: state.spacerHeight, width: state.blockWidth } }
+			/>
 		</div>
 	);
 }
 
 function isWindowTooSmall( minLimit ) {
+	if ( minLimit === 0 ) {
+		return false;
+	}
 	return ( minLimit !== false && minLimit >= window.innerWidth ) || isMobile();
 }
 

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -1,6 +1,6 @@
 import { isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
-import { throttle, defer } from 'lodash';
+import { throttle, debounce, defer } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReactDom from 'react-dom';
@@ -72,6 +72,7 @@ function renderStickyPanel( props, state ) {
 }
 
 function isWindowTooSmall( minLimit ) {
+	// if minLimit is 0, we don't want to check for window size
 	if ( minLimit === 0 ) {
 		return false;
 	}
@@ -105,15 +106,16 @@ class StickyPanelWithIntersectionObserver extends Component {
 	);
 
 	// backup in case the user scrolls past the panel too quickly
+	// debounce triggers after the scroll event has finished firing
 	// see https://github.com/Automattic/wp-calypso/issues/76743
-	throttleOnScroll = throttle(
+	throttleOnScroll = debounce(
 		afterLayoutFlush( () => {
 			// Determine vertical threshold from rendered element's offset relative the document
 			const threshold = ReactDom.findDOMNode( this ).getBoundingClientRect().top;
 			const isSticky = threshold < calculateOffset();
 			this.updateStickyState( isSticky );
 		} ),
-		500
+		50
 	);
 
 	componentDidMount() {

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect, createRef } from 'react';
+import { createRef } from 'react';
 import titlecase from 'to-title-case';
 import StickyPanel from 'calypso/components/sticky-panel';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -89,23 +89,7 @@ const scrollToLetter = ( letter: string ) => {
 
 export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps ) {
 	const translate = useTranslate();
-	const [ isSticky, setIsSticky ] = useState( false );
 	const tagsTableRef = createRef< HTMLDivElement >();
-
-	useEffect( () => {
-		const handleScroll = () => {
-			if ( ! tagsTableRef.current ) {
-				return;
-			}
-			const tableATop = tagsTableRef.current.getBoundingClientRect().top;
-			setIsSticky( tableATop < 0 );
-		};
-
-		window.addEventListener( 'scroll', handleScroll );
-		return () => {
-			window.removeEventListener( 'scroll', handleScroll );
-		};
-	}, [ tagsTableRef, setIsSticky ] );
 
 	if ( ! alphabeticTags ) {
 		return null;
@@ -124,7 +108,7 @@ export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps 
 	return (
 		<>
 			<div className="sticky-container">
-				<StickyPanel className={ isSticky ? 'sticky-panel-fixed' : 'sticky-panel-absolute' }>
+				<StickyPanel minLimit={ 0 }>
 					<div className="alphabetic-tags__header">
 						<h2>{ translate( 'Tags from A — Z' ) }</h2>
 						<div className="alphabetic-tags__tag-links">

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -189,16 +189,11 @@
 		position: relative;
 	}
 	.sticky-panel {
-		top: 24px;
 		position: absolute;
 		right: -12px;
 	}
-	.sticky-panel-absolute {
-		position: absolute;
-	}
-	.sticky-panel-fixed {
-		position: fixed;
-		right: 12px;
+	.sticky-panel__content {
+		padding-top: 24px;
 	}
 }
 


### PR DESCRIPTION
Fixes #https://github.com/Automattic/wp-calypso/issues/76743 by modifying the `<StickyPanel>` component to always use the `scroll` event rather than relying on the IntersectionObserver. see also slack discusion p1683679396865339-slack-C03NLNTPZ2T

The issue with using the IntersectionObserver for sticky panels seems to be fundamental [Stackoverflow link](https://stackoverflow.com/questions/61951380/intersection-observer-fails-sometimes-when-i-scroll-fast ). Basically, if you scroll very quickly over the starting location of the panel, the IntersectionObserver won't report any events, and the panel will stay shown.

The IntersectionObserver was only added for performance reasons, so we can simply fall back to the window.scroll implementation.

I also extended the sticky panel to use the width of the original element for the spacer, this is still needed to fix alignment for absolute positioned elements (the mobile view of the /tags page)

I also enabled the sticky panel component to work with mobile devices if minWidth=0 is passed in.

### Testing instructions

* go to the /tags page on mobile and desktop, the panel should stick as before and the bug in https://github.com/Automattic/wp-calypso/issues/76743 should no longer be reproducable.
* Go to the media gallery page, the stickypanel should still work on desktop (not mobile) /media/$site_slug