### PR TITLE
Pattern Assembler: Update hover/focus state border color for consistency

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -99,7 +99,7 @@
 		}
 
 		&::after {
-			box-shadow: 0 0 0 2px var(--studio-blue-50);
+			box-shadow: 0 0 0 2px var(--color-primary-light);
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -316,6 +316,13 @@ $font-family: "SF Pro Text", $sans;
 		flex-grow: 1;
 		overflow-x: visible;
 	}
+
+	/**
+	 * Calypso Components
+	 */
+	.components-button:focus:not(:disabled) {
+		box-shadow: 0 0 0 2px var(--color-primary-light);
+	}
 }
 
 .popover.is-right.pattern-layout__add-button-popover {

--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -45,7 +45,7 @@
 	&:hover,
 	&:focus-visible {
 		&::after {
-			box-shadow: 0 0 0 2px var(--studio-blue-50);
+			box-shadow: 0 0 0 2px var(--color-primary-light);
 		}
 	}
 }

--- a/packages/global-styles/src/components/font-pairing-variations/style.scss
+++ b/packages/global-styles/src/components/font-pairing-variations/style.scss
@@ -45,7 +45,7 @@
 	&:hover,
 	&:focus-visible {
 		&::after {
-			box-shadow: 0 0 0 2px var(--studio-blue-50);
+			box-shadow: 0 0 0 2px var(--color-primary-light);
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76002

## Proposed Changes

This PR updates the Pattern Assembler to have a consistent border color focus/hover state. The updated components are:

The large preview + large preview action bar.
| Before | After |
| --- | --- |
| ![Screenshot 2023-05-10 at 3 28 24 PM](https://github.com/Automattic/wp-calypso/assets/797888/96477f25-51d5-40db-af1d-40a5a2bb8e5f) | ![Screenshot 2023-05-10 at 3 28 31 PM](https://github.com/Automattic/wp-calypso/assets/797888/b8694813-19bc-477a-8dd4-c12f42f8c826)

The section panel's action bar.
| Before | After |
| --- | --- |
| ![Screenshot 2023-05-10 at 3 26 59 PM](https://github.com/Automattic/wp-calypso/assets/797888/9bc13e77-9be1-47f7-8961-7a908b7706d3) |  ![Screenshot 2023-05-10 at 3 27 10 PM](https://github.com/Automattic/wp-calypso/assets/797888/c0a4deb3-759f-4071-b979-20b488cdb751) |

The global styles preview (colors and fonts).
| Before | After |
| --- | --- |
| ![Screenshot 2023-05-10 at 3 29 45 PM](https://github.com/Automattic/wp-calypso/assets/797888/677fbd70-67b0-4d6e-91b9-e26e9dfea1ed) |  ![Screenshot 2023-05-10 at 3 30 58 PM](https://github.com/Automattic/wp-calypso/assets/797888/6c375219-9ea3-4211-afcb-ab3741f89b96) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Pattern Assembler.
* Ensure that the hover/focus state is updated as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
