### PR TITLE
E2E: extend timeout when navigating to the Legacy Widgets page.

### DIFF
--- a/test/e2e/specs/appearance/widgets__legacy-visibility.ts
+++ b/test/e2e/specs/appearance/widgets__legacy-visibility.ts
@@ -41,7 +41,8 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC || envVariables.VIEWPORT_NAME === 'm
 
 		it( 'Navigate to Appearance > Widgets', async function () {
 			await page.goto(
-				`https://${ testAccount.credentials.testSites?.primary.url }/wp-admin/widgets.php`
+				`https://${ testAccount.credentials.testSites?.primary.url }/wp-admin/widgets.php`,
+				{ timeout: 25 * 1000 }
 			);
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/76592.

## Proposed Changes

This PR adds extended timeout as the first step in addressing the navigation issue to Legacy Widgets page.

I believe this change should address the high flakiness of this step as when viewing the video replay for failed specs, the page takes more than 10 seconds to load, by which time the timeout has been reached.

## Testing Instructions

Ensure the following build configurations are passing:
Ensure the following build configurations are passing:
  - [x] Gutenberg E2E Simple production (desktop)
  - [x] Gutenberg E2E Simple production (mobile)

Also ran this locally 30 times in a loop:
```
 PASS  specs/appearance/widgets__legacy-visibility.ts (8.55 s)
  Widget (Legacy): Visibility option is present
    ✓ Navigate to Appearance > Widgets (1969 ms)
    ✓ Dismiss the Welcome modals (1003 ms)
    ✓ Insert a Legacy Widget (281 ms)
    ✓ Visibility options are shown for the Legacy Widget (1166 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        8.648 s, estimated 9 s
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
