### PR TITLE
`/subscriptions`: Enable sites & comments sorting for all locale.

### DIFF
--- a/client/landing/subscriptions/components/tab-views/comments/comments.tsx
+++ b/client/landing/subscriptions/components/tab-views/comments/comments.tsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { SubscriptionManager } from '@automattic/data-stores';
-import { useLocale } from '@automattic/i18n-utils';
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -27,9 +26,9 @@ const Comments = () => {
 	const [ sortTerm, setSortTerm ] = useState( SortBy.RecentlySubscribed );
 	const { searchTerm, handleSearch } = useSearch();
 	const sortOptions = useSortOptions();
-	const locale = useLocale();
-	const isListControlsEnabled =
-		config.isEnabled( 'subscription-management/comments-list-controls' ) && locale === 'en';
+	const isListControlsEnabled = config.isEnabled(
+		'subscription-management/comments-list-controls'
+	);
 
 	const {
 		data: { posts, totalCount },

--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { SubscriptionManager } from '@automattic/data-stores';
-import { useLocale } from '@automattic/i18n-utils';
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
@@ -34,9 +33,7 @@ const Sites = () => {
 	const sortOptions = useSortOptions( translate );
 	// todo: translate when we have agreed on the error message
 	const errorMessage = error ? 'An error occurred while fetching your subscriptions.' : '';
-	const locale = useLocale();
-	const isListControlsEnabled =
-		config.isEnabled( 'subscription-management/sites-list-controls' ) && locale === 'en';
+	const isListControlsEnabled = config.isEnabled( 'subscription-management/sites-list-controls' );
 
 	if ( ! isLoading && ! totalCount ) {
 		return <Notice type="warning">{ translate( 'You are not subscribed to any sites.' ) }</Notice>;

--- a/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
@@ -21,8 +21,6 @@ const TabsSwitcher = () => {
 	const { data: counts } = SubscriptionManager.useSubscriptionsCountQuery();
 	const locale = useLocale();
 	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
-	const shouldEnableCommentsTab =
-		config.isEnabled( 'subscription-management-comments-view' ) && locale === 'en' && ! isLoggedIn;
 	const shouldEnablePendingTab =
 		config.isEnabled( 'subscription-management-pending-view' ) && locale === 'en' && ! isLoggedIn;
 
@@ -48,13 +46,7 @@ const TabsSwitcher = () => {
 					</NavItem>
 
 					<NavItem
-						onClick={ () => {
-							shouldEnableCommentsTab
-								? navigate( commentsPath )
-								: window.location.replace(
-										`https://wordpress.com/email-subscriptions/?option=comments&locale=${ locale }`
-								  );
-						} }
+						onClick={ () => navigate( commentsPath ) }
 						count={ counts?.comments || undefined }
 						selected={ pathname.startsWith( commentsPath ) }
 					>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #76755

## Proposed Changes

* Enable sites and comments sorting for all locale.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/subscriptions/sites/nl`.
2. It should have search input & sorting dropdown.
3. Go to `/subscriptions/comments/nl`.
4. It should have search input & sorting dropdown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
