### PR TITLE
Pattern Assembler: Add box-shadow to pattern previews

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -212,20 +212,15 @@ $font-family: "SF Pro Text", $sans;
 			position: relative;
 			margin-bottom: 32px;
 			padding: 2px;
-			overflow-y: scroll;
-			scrollbar-width: none;
 
 			&:last-child {
 				margin-bottom: 0;
-			}
-
-			&::-webkit-scrollbar {
-				display: none;
 			}
 		}
 
 		.pattern-selector__block-list {
 			button {
+				box-shadow: 0 15px 25px rgba(0, 0, 0, 0.07);
 				display: block;
 				border: 1px solid rgba(0, 0, 0, 5%);
 				border-radius: 4px;
@@ -240,7 +235,9 @@ $font-family: "SF Pro Text", $sans;
 				}
 
 				&.pattern-selector__block-list--selected-pattern {
-					box-shadow: 0 0 0 2px var(--studio-gray);
+					box-shadow:
+						0 15px 25px rgba(0, 0, 0, 0.07),
+						0 0 0 2px var(--studio-gray);
 				}
 
 				&:focus,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76407

## Proposed Changes

This PR adds `box-shadow: 0 15px 25px rgba(0,0,0,.07);` to pattern previews. 

| Chrome | Firefox | Safari |
| --- | --- | --- |
| ![Screenshot 2023-05-10 at 5 37 37 PM](https://github.com/Automattic/wp-calypso/assets/797888/23640186-f8f2-4a3a-9d32-316bb2ecae6d) | ![Screenshot 2023-05-10 at 5 38 40 PM](https://github.com/Automattic/wp-calypso/assets/797888/658da091-0b6f-4edb-8b9e-4e84e64a2516) | ![Screenshot 2023-05-10 at 5 35 41 PM](https://github.com/Automattic/wp-calypso/assets/797888/ebfcaf40-ffd7-48e2-9b4f-43f91a35499c) |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to  `/setup/site-setup?siteSlug=${site_slug}`.
* Continue until you land on the Design Picker, and select the Pattern Assembler CTA.
* Once in the Pattern Assembler, click on the Sections button in the left sidebar.
* Then click on Add Patterns, and select any Category in the list.
* Ensure that the box shadow is added as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
