### PR TITLE
`/subscriptions/pending`: Open pending page to users of ALL locale.

### DIFF
--- a/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
@@ -23,8 +23,6 @@ const TabsSwitcher = () => {
 	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 	const shouldEnableCommentsTab =
 		config.isEnabled( 'subscription-management-comments-view' ) && locale === 'en' && ! isLoggedIn;
-	const shouldEnablePendingTab =
-		config.isEnabled( 'subscription-management-pending-view' ) && locale === 'en' && ! isLoggedIn;
 
 	const getFullPath = ( subpath: string ) =>
 		`/subscriptions/${ subpath }${ locale !== 'en' ? '/' + locale : '' }`;
@@ -63,13 +61,7 @@ const TabsSwitcher = () => {
 
 					{ counts?.pending || pathname.includes( 'pending' ) ? (
 						<NavItem
-							onClick={ () => {
-								shouldEnablePendingTab
-									? navigate( pendingPath )
-									: window.location.replace(
-											`https://wordpress.com/email-subscriptions/?option=pending&locale=${ locale }`
-									  );
-							} }
+							onClick={ () => navigate( pendingPath ) }
 							count={ counts?.pending || undefined }
 							selected={ pathname.startsWith( pendingPath ) }
 						>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #76756

## Proposed Changes

* Open pending page to users of ALL locale.

## Testing Instructions

* Go to `/subscriptions/pending/nl`.
* It should not redirect to old reskinned page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
