### PR TITLE
Fix: planType variable breaks features in 2023 Plans Comparison Grid

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -622,9 +622,21 @@ export class PlansFeaturesMain extends Component {
 		 * we pass `visiblePlans` to its `plans` prop.
 		 */
 		const term = this.getPlanBillingPeriod( intervalType, getPlan( selectedPlan )?.term );
-		const planTypes = this.props.planTypes || this.getDefaultPlanTypes();
-		const plans = this.getPlansFromTypes( planTypes, GROUP_WPCOM, term );
-		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
+		const defaultPlanTypes = this.getDefaultPlanTypes();
+		const planTypes = this.props.planTypes || defaultPlanTypes;
+		let plans = this.getPlansFromTypes( planTypes, GROUP_WPCOM, term );
+		const filteredPlans = plans;
+
+		/*
+		 * We need to keep all the plans in the plans variable,
+		 * The filtered planTypes should be reflected in visible plans only.
+		 */
+		if ( is2023PricingGridVisible ) {
+			plans = this.getPlansFromTypes( defaultPlanTypes, GROUP_WPCOM, term );
+		}
+
+		const visiblePlans = this.getVisiblePlansForPlanFeatures( filteredPlans );
+
 		const kindOfPlanTypeSelector = this.getKindOfPlanTypeSelector( this.props );
 
 		// If advertising plans for a certain feature, ensure user has pressed "View all plans" before they can see others

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -457,6 +457,7 @@ export class PlansFeaturesMain extends Component {
 			hideFreePlan,
 			hidePersonalPlan,
 			hidePremiumPlan,
+			hideBusinessPlan,
 			hideEcommercePlan,
 		} = this.props;
 
@@ -487,6 +488,10 @@ export class PlansFeaturesMain extends Component {
 
 		if ( hidePremiumPlan ) {
 			plans = plans.filter( ( planSlug ) => ! isPremiumPlan( planSlug ) );
+		}
+
+		if ( hideBusinessPlan ) {
+			plans = plans.filter( ( planSlug ) => ! isBusinessPlan( planSlug ) );
 		}
 
 		if ( hideEcommercePlan ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76557 

## Proposed Changes

This is an alternative fix to #76722 by addressing adjustin how `<PlansFeaturesMain>` handles filtered plans.
The plans are filtered using the `planTypes` based on flows [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx#L51). 
In the case of the 2023 Plans Grid, the features are compounded from plan to plan, meaning that if a a lower-tie plan is missing, the higher plans don't inherit its features (resulting into [this issue](https://github.com/Automattic/wp-calypso/pull/76657#pullrequestreview-1418592479)).

The proposed fix ensures the `plans` variable always gets the default `planTypes` whereas the `visiblePlans` respect the `planTypes` property. These changes are only applied to the 2023 Plans Grid.

## Testing Instructions 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You can follow the steps from #76722 :
1. Checkout this branch;
2. Go to `/setup/link-in-bio`;
3. Proceed to the plans step;
4. Check that the plan comparison is hidden;
5. Comment [this line](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/link-in-bio.ts#L53);
6. Check that the plan comparison shows up and correctly renders the features according to the displayed plans.

7. Also double-check for regressions on `/start/plans` and `/plans/{SITE_ID}`


