### PR TITLE
Logged-in Theme Showcase: Add translation context to "Paid" themes

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -177,7 +177,12 @@ class ThemeShowcase extends Component {
 			{ value: 'all', label: this.props.translate( 'All' ) },
 			{ value: 'free', label: this.props.translate( 'Free' ) },
 			{ value: 'premium', label: this.props.translate( 'Premium' ) },
-			{ value: 'marketplace', label: this.props.translate( 'Paid' ) },
+			{
+				value: 'marketplace',
+				label: this.props.translate( 'Paid', {
+					context: 'Refers to paid service, such as paid theme',
+				} ),
+			},
 		];
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 611-gh-Automattic/i18n-issues, 582-gh-Automattic/i18n-issues, https://github.com/Automattic/wp-calypso/pull/74690, https://github.com/Automattic/wp-calypso/pull/74811.

## Proposed Changes

This improves the translations of the “Paid” filter option in the logged-in theme showcase by setting the right context. The same change was made in https://github.com/Automattic/wp-calypso/pull/74811 about 1.5 months ago.

Since the original with context already exists, the translations should be fixed right away. Here are the originals on [translate.wordpress.com](http://translate.wordpress.com/):
* Without context: https://translate.wordpress.com/projects/wpcom/-all-translated/89231/
* With context: https://translate.wordpress.com/projects/wpcom/-all-translated/869831/

![image](https://github.com/Automattic/wp-calypso/assets/75777864/a0cb5006-4de2-47aa-93a0-36ea67235721)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set your WPCOM UI language to Spanish (the translation is different with the added context).
2. Go to the logged-in theme showcase (https://wordpress.com/themes) and verify that the "Paid" filter's translation is “De pago“ instead of “Pagado”.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
