### PR TITLE
Improve localization of urls in jetpack cloud

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
@@ -99,7 +100,7 @@ const IntroPricingBanner: React.FC = () => {
 							onClick={ () =>
 								recordTracksEvent( 'calypso_jpcom_agencies_page_intro_banner_link_click' )
 							}
-							href="https://jetpack.com/for/agencies/"
+							href={ localizeUrl( 'https://jetpack.com/for/agencies/' ) }
 							target="_blank"
 							rel="noreferrer"
 						>

--- a/client/jetpack-cloud/sections/comparison/table/links.ts
+++ b/client/jetpack-cloud/sections/comparison/table/links.ts
@@ -1,10 +1,12 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+
 export const links = {
 	activity_log: 'https://jetpack.com/features/security/activity-log/',
 	ad_network: 'https://jetpack.com/features/traffic/ads/',
-	akismet_antispam: 'https://jetpack.com/upgrade/anti-spam/',
+	akismet_antispam: localizeUrl( 'https://jetpack.com/upgrade/anti-spam/' ),
 	auto_plugin_updates: 'https://jetpack.com/features/security/automatic-plugin-updates/',
-	backup: 'https://jetpack.com/upgrade/backup/',
-	boost: 'https://jetpack.com/boost/',
+	backup: localizeUrl( 'https://jetpack.com/upgrade/backup/' ),
+	boost: localizeUrl( 'https://jetpack.com/boost/' ),
 	brute_force_attack_protection:
 		'https://jetpack.com/features/security/brute-force-attack-protection/',
 	cdn: 'https://jetpack.com/features/traffic/content-delivery-network/',
@@ -21,11 +23,11 @@ export const links = {
 	payments_block: 'https://jetpack.com/support/jetpack-blocks/payments-block/',
 	priority_support: 'https://jetpack.com/features/security/expert-priority-support/',
 	related_posts: 'https://jetpack.com/features/traffic/related-posts/',
-	scan: 'https://jetpack.com/upgrade/scan/',
-	search: 'https://jetpack.com/upgrade/search/',
+	scan: localizeUrl( 'https://jetpack.com/upgrade/scan/' ),
+	search: localizeUrl( 'https://jetpack.com/upgrade/search/' ),
 	secure_authentication: 'https://jetpack.com/features/security/secure-authentication/',
 	seo: 'https://jetpack.com/features/traffic/search-engine-optimization/',
-	social: 'https://jetpack.com/social/',
+	social: localizeUrl( 'https://jetpack.com/social/' ),
 	stats: 'https://jetpack.com/features/traffic/site-stats/',
 	subscriptions: 'https://jetpack.com/features/discussion/subscriptions/',
 	themes: 'https://jetpack.com/features/design/themes/',

--- a/client/my-sites/plans-features-main/components/jetpack-faq.jsx
+++ b/client/my-sites/plans-features-main/components/jetpack-faq.jsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import FAQ from 'calypso/components/faq';
 import FAQItem from 'calypso/components/faq/faq-item';
@@ -11,7 +12,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 export const getHelpLink = ( context ) => {
 	return (
 		<a
-			href="https://jetpack.com/contact-support/?rel=support&hpi=1"
+			href={ localizeUrl( 'https://jetpack.com/contact-support/?rel=support&hpi=1' ) }
 			target="_blank"
 			rel="noopener noreferrer"
 			onClick={ () => {
@@ -38,7 +39,7 @@ export const getSupportLink = ( doc ) => {
 export const getAgenciesLink = () => {
 	return (
 		<a
-			href="https://jetpack.com/for/agencies/"
+			href={ localizeUrl( 'https://jetpack.com/for/agencies/' ) }
 			target="_blank"
 			rel="noopener noreferrer"
 			onClick={ () => {

--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -29,7 +30,7 @@ const jetpackGettingStartedLink = () => {
 const jetpackGDPRLink = () => {
 	return (
 		<a
-			href="https://jetpack.com/gdpr/"
+			href={ localizeUrl( 'https://jetpack.com/gdpr/' ) }
 			target="_blank"
 			rel="noopener noreferrer"
 			onClick={ () => {

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/items-included/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/items-included/utils.ts
@@ -16,6 +16,7 @@ import {
 	JETPACK_VIDEOPRESS_PRODUCT_LANDING_PAGE_URL,
 	JETPACK_CRM_PRODUCT_LANDING_PAGE_URL,
 } from '@automattic/calypso-products';
+import { localizeUrl } from '@automattic/i18n-utils';
 
 const PRODUCT_URL_MAP: { [ key: string ]: string } = {
 	[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL,
@@ -28,4 +29,5 @@ const PRODUCT_URL_MAP: { [ key: string ]: string } = {
 	[ PRODUCT_JETPACK_CRM ]: JETPACK_CRM_PRODUCT_LANDING_PAGE_URL,
 };
 
-export const getProductUrl = ( productSlug: string ) => PRODUCT_URL_MAP[ productSlug ];
+export const getProductUrl = ( productSlug: string ) =>
+	localizeUrl( PRODUCT_URL_MAP[ productSlug ] );

--- a/client/my-sites/plans/jetpack-plans/product-store/need-more-info/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/need-more-info/index.tsx
@@ -1,4 +1,4 @@
-import { useLocale } from '@automattic/i18n-utils';
+import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -22,25 +22,10 @@ const usePlanComparisonUrl = () => {
 	}, [ locale ] );
 };
 
-const useForAgenciesUrl = () => {
-	const locale = useLocale();
-
-	return useMemo( () => {
-		// Locale is guaranteed to be 'en' if no locale is defined;
-		// see @automattic/i18n-utils/src/locale-context.tsx:35
-		if ( locale === 'en' ) {
-			return 'https://jetpack.com/for/agencies';
-		}
-
-		return `https://${ locale }.jetpack.com/for/agencies`;
-	}, [ locale ] );
-};
-
 export const NeedMoreInfo: React.FC = () => {
 	const translate = useTranslate();
 
 	const planComparisonUrl = usePlanComparisonUrl();
-	const forAgenciesUrl = useForAgenciesUrl();
 
 	return (
 		<div className="jetpack-product-store__need-more-info">
@@ -55,7 +40,7 @@ export const NeedMoreInfo: React.FC = () => {
 				/>
 				<MoreInfoBox
 					buttonLabel={ translate( 'Explore Jetpack for Agencies' ) }
-					buttonLink={ forAgenciesUrl }
+					buttonLink={ localizeUrl( 'https://jetpack.com/for/agencies/' ) }
 					trackEventName="calypso_jpcom_agencies_page_more_info_button_link_click"
 				/>
 			</div>

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -127,7 +127,7 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com/tos/': prefixLocalizedUrlPath( magnificentNonEnLocales ),
 	'wordpress.com/wp-admin/': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
 	'wordpress.com/wp-login.php': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
-	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', jetpackComLocales ),
+	'jetpack.com': prefixLocalizedUrlPath( jetpackComLocales ),
 	'en.support.wordpress.com': setLocalizedWpComPath( '/support', supportSiteLocales ),
 	'en.blog.wordpress.com': setLocalizedWpComPath( '/blog', localesWithBlog, /^\/$/ ),
 	'apps.wordpress.com': prefixLocalizedUrlPath( magnificentNonEnLocales ),

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -457,13 +457,13 @@ describe( '#localizeUrl', () => {
 			'https://jetpack.com/features/comparison/'
 		);
 		expect( localizeUrl( 'https://jetpack.com/features/comparison/', 'de' ) ).toEqual(
-			'https://de.jetpack.com/features/comparison/'
+			'https://jetpack.com/de/features/comparison/'
 		);
 		expect( localizeUrl( 'https://jetpack.com/features/comparison/', 'pt-br' ) ).toEqual(
-			'https://br.jetpack.com/features/comparison/'
+			'https://jetpack.com/pt-br/features/comparison/'
 		);
 		expect( localizeUrl( 'https://jetpack.com/features/comparison/', 'zh-tw' ) ).toEqual(
-			'https://zh-tw.jetpack.com/features/comparison/'
+			'https://jetpack.com/zh-tw/features/comparison/'
 		);
 		expect( localizeUrl( 'https://jetpack.com/features/comparison/', 'pl' ) ).toEqual(
 			'https://jetpack.com/features/comparison/'


### PR DESCRIPTION
Related to D106031-code

## Proposed Changes

After migrating the jetpack.com URL structure from locale subdomains to subdirectories - we investigate Jetpack Cloud to ensure links follow the updated structure. This PR makes changes to ensure links are correct in the most visible spots.

## Testing Instructions

* Checkout this PR
* Go to `http://jetpack.cloud.localhost:3001/es/pricing`
* Click around and make sure the general structure of links to `jetpack.com` pages follow `https://jetpack.com/<locale>`
* Go to `https://jetpack.cloud.localhost:3001/es/features/comparison`
* Click around and make sure that (product page) URLs follow new structure; whilst support links are still linking to EN (unfortunately these have many 404s for localized versions)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?