### PR TITLE
Stepper: restore plan comparison on `/setup/new-hosted-site`

### DIFF
--- a/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
@@ -1,13 +1,10 @@
 import { HOSTING_SITE_CREATION_FLOW } from '@automattic/onboarding';
-import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
-import { useEffect } from 'react';
 import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
-import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { Flow, ProvidedDependencies } from './internals/types';
 import './internals/hosting-site-creation-flow.scss';
@@ -62,19 +59,6 @@ const hosting: Flow = {
 		};
 
 		return { submit };
-	},
-	useSideEffect() {
-		const { setHideFreePlan, setHidePlansFeatureComparison } = useDispatch( ONBOARD_STORE );
-
-		useEffect(
-			() => {
-				setHideFreePlan( true );
-				setHidePlansFeatureComparison( true );
-			},
-			// We only need to hide the free plan once, when the flow is mounted.
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-			[]
-		);
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -64,7 +64,11 @@ function getPlanTypes( flowName: string | null ) {
 }
 
 const PlansWrapper: React.FC< Props > = ( props ) => {
-	const { hideFreePlan, domainCartItem, hidePlansFeatureComparison } = useSelect( ( select ) => {
+	const {
+		hideFreePlan: reduxHideFreePlan,
+		domainCartItem,
+		hidePlansFeatureComparison,
+	} = useSelect( ( select ) => {
 		return {
 			hideFreePlan: ( select( ONBOARD_STORE ) as OnboardSelect ).getHideFreePlan(),
 			domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
@@ -87,6 +91,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const planTypes = getPlanTypes( props?.flowName );
 	const headerText = __( 'Choose a plan' );
 	const isInSignup = props?.flowName === DOMAIN_UPSELL_FLOW ? false : true;
+
+	const hideFreePlan = planTypes ? ! planTypes.includes( TYPE_FREE ) : reduxHideFreePlan;
 
 	const translate = useTranslate();
 


### PR DESCRIPTION
## Proposed Changes

The plan comparison was hidden in specific onboarding flows because of a bug where the comparison table was misleading. More explanation [here](https://github.com/Automattic/wp-calypso/pull/76763).

Since the bug was fixed, it makes sense to restore the comparison table.

## Testing Instructions

1. Open `/setup/new-hosted-site`;
2. Check that the "Compare Plans" button is back below the plans grid;
3. Click the button and check that the plan comparison table is displaying accurate results relative to the visible plans.
