### PR TITLE
Happy blocks: Add new title line-height

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/style.scss
+++ b/apps/happy-blocks/block-library/universal-header/style.scss
@@ -728,7 +728,7 @@ body.logged-in .x-dropdown {
 	h1 {
 		font-family: $recoleta-font-family;
 		font-size: 2.75rem;
-		line-height: 40px;
+		line-height: 52px;
 		margin: 0;
 		@media ( max-width: $breakpoint-tablet ) {
 			font-size: 1.75rem;


### PR DESCRIPTION
## Proposed Changes

Increase the title line height to 52px.

Before:
<img width="523" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/2034bab2-9d19-49a4-952d-cfb2752b4919">


After:
<img width="500" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/a2499500-2b1f-4136-8056-342ecbf30d76">


## Testing Instructions

- Pull and run this branch
- Navigate to `cd apps/happy-blocks` and `run yarn dev --sync`
- Sandbox `wordpress.com/support` and visit the site
- Check if the title line height is 52px;
