### PR TITLE
Stats: Display the most popular at full width when the latest post is also the most popular

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
@@ -5,7 +5,6 @@ import { useSelector } from 'react-redux';
 import QueryPostStats from 'calypso/components/data/query-post-stats';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import { getPostsForQuery, isRequestingPostsForQuery } from 'calypso/state/posts/selectors';
 import { getPostStat, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 
 const POST_STATS_CARD_TITLE_LIMIT = 60;
@@ -22,36 +21,42 @@ const textTruncator = ( text: string, limit = 48 ) => {
 	return `${ truncatedText }${ text.length > limit ? '...' : '' } `;
 };
 
+interface LatestPost {
+	ID: number;
+	date: string;
+	post_thumbnail: {
+		URL: string;
+	};
+	title: string;
+	like_count: number;
+	discussion: {
+		comment_count: number;
+	};
+}
+
 export default function LatestPostCard( {
 	siteId,
 	siteSlug,
+	latestPost,
+	isLoading,
 }: {
 	siteId: number;
 	siteSlug: string;
+	latestPost: LatestPost;
+	isLoading: boolean;
 } ) {
 	const translate = useTranslate();
 	const userLocale = useSelector( getCurrentUserLocale );
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
-	const posts = useSelector( ( state ) =>
-		getPostsForQuery( state, siteId, { status: 'publish', number: 1 } )
-	);
-
-	const isRequestingPosts = useSelector( ( state ) =>
-		isRequestingPostsForQuery( state, siteId, { status: 'publish', number: 1 } )
-	);
-
-	const latestPost = posts && posts.length ? posts[ 0 ] : null;
-
 	const lastesPostViewCount = useSelector( ( state ) =>
 		getPostStat( state, siteId, latestPost?.ID, 'views' )
 	);
-
 	const isRequestingLatestPostViewCount = useSelector( ( state ) =>
 		isRequestingPostStats( state, siteId, latestPost?.ID, [ 'views' ] )
 	);
 
-	const isLoadingLatestPost = isRequestingPosts || isRequestingLatestPostViewCount;
+	const isLoadingLatestPost = isLoading || isRequestingLatestPostViewCount;
 
 	const latestPostData = {
 		date: latestPost?.date,

--- a/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
@@ -9,7 +9,12 @@ import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import DotPager from 'calypso/components/dot-pager';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import { getSitePost, isRequestingSitePost } from 'calypso/state/posts/selectors';
+import {
+	getSitePost,
+	isRequestingSitePost,
+	getPostsForQuery,
+	isRequestingPostsForQuery,
+} from 'calypso/state/posts/selectors';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import {
 	getTopPostAndPage,
@@ -83,29 +88,28 @@ export default function PostCardsGroup( {
 	const userLocale = useSelector( getCurrentUserLocale );
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
-	const { topPostsQuery } = useSelector( ( state ) => getStatsQueries( state, siteId ) );
+	// Prepare the latest post card.
+	const posts = useSelector( ( state ) =>
+		getPostsForQuery( state, siteId, { status: 'publish', number: 1 } )
+	);
+	const isRequestingPosts = useSelector( ( state ) =>
+		isRequestingPostsForQuery( state, siteId, { status: 'publish', number: 1 } )
+	);
+	const latestPost = posts && posts.length ? posts[ 0 ] : null;
 
+	// Get the most `viewed` post from the past period defined in the `topPostsQuery`.
+	const { topPostsQuery } = useSelector( ( state ) => getStatsQueries( state, siteId ) );
 	const isTopViewedPostRequesting = useSelector( ( state ) =>
 		isRequestingSiteStatsForQuery( state, siteId, 'statsTopPosts', topPostsQuery )
 	);
-
-	const hasTopViewedPostQueryFinished = useSelector( ( state ) =>
-		hasSiteStatsForQueryFinished( state, siteId, 'statsTopPosts', topPostsQuery )
-	);
-
-	// Get the most `viewed` post from the past period defined in the `topPostsQuery`.
 	const { topPost: topViewedPost } = useSelector( ( state ) =>
 		getStatsData( state, siteId, topPostsQuery, isTopViewedPostRequesting )
 	);
 
+	// Prepare the most popular post card.
 	const mostPopularPost = useSelector( ( state ) =>
 		getSitePost( state, siteId, topViewedPost?.id )
 	);
-
-	const isRequestingMostPopularPost = useSelector( ( state ) =>
-		isRequestingSitePost( state, siteId, topViewedPost?.id )
-	);
-
 	const mostPopularPostData = {
 		date: mostPopularPost?.date,
 		post_thumbnail: mostPopularPost?.post_thumbnail?.URL || null,
@@ -117,10 +121,32 @@ export default function PostCardsGroup( {
 		commentCount: mostPopularPost?.discussion?.comment_count,
 	};
 
-	const cards = [ <LatestPostCard key="latestPostCard" siteId={ siteId } siteSlug={ siteSlug } /> ];
-	const isLoadingMostPopularPost = ! hasTopViewedPostQueryFinished || isRequestingMostPopularPost;
+	// Check if the most popular post is ready to be displayed.
+	const hasTopViewedPostQueryFinished = useSelector( ( state ) =>
+		hasSiteStatsForQueryFinished( state, siteId, 'statsTopPosts', topPostsQuery )
+	);
+	const isRequestingMostPopularPost = useSelector( ( state ) =>
+		isRequestingSitePost( state, siteId, topViewedPost?.id )
+	);
+	const isPreparingMostPopularPost = ! hasTopViewedPostQueryFinished || isRequestingMostPopularPost;
 
-	if ( isLoadingMostPopularPost || mostPopularPost ) {
+	const cards = [];
+
+	// Show two cards when the latest post is not the most popular post or both cards are loading.
+	if ( isRequestingPosts || isPreparingMostPopularPost || latestPost?.ID !== mostPopularPost?.ID ) {
+		cards.push(
+			<LatestPostCard
+				key="latestPostCard"
+				siteId={ siteId }
+				siteSlug={ siteSlug }
+				isLoading={ isRequestingPosts }
+				latestPost={ latestPost }
+			/>
+		);
+	}
+
+	// Show the most popular post card when it's ready or loading.
+	if ( isPreparingMostPopularPost || mostPopularPost ) {
 		cards.push(
 			<PostStatsCard
 				key="mostPopularPostCard"
@@ -132,7 +158,7 @@ export default function PostCardsGroup( {
 				titleLink={ `/stats/post/${ mostPopularPost?.ID }/${ siteSlug }` }
 				uploadHref={ ! isOdysseyStats ? `/post/${ siteSlug }/${ mostPopularPost?.ID }` : undefined }
 				locale={ userLocale }
-				isLoading={ isLoadingMostPopularPost }
+				isLoading={ isPreparingMostPopularPost }
 			/>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74008 

## Proposed Changes

* Fetch the latest post earlier to determine the displayed cards when the latest post is the same as the most popular one.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Lanuch a new JN site connected with Jetpack.
* Spin up the change with the Live Branch.
* Navigate to the Stats `Insights` page of the created JN site.
* Ensure the `Latest post` card is displayed with the default post `Hello world!`.
* View the default post `Hello world!` on other browsers.
* Wait a minute and ensure only the `Most popular post` card is displayed when the latest post is the same as the most popular one.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
