### PR TITLE
Support chat using Zendesk Messaging

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -210,6 +210,10 @@ class Help_Center {
 		require_once __DIR__ . '/class-wp-rest-help-center-support-history.php';
 		$controller = new WP_REST_Help_Center_Support_History();
 		$controller->register_rest_route();
+
+		require_once __DIR__ . '/class-wp-rest-help-center-user-fields.php';
+		$controller = new WP_REST_Help_Center_User_Fields();
+		$controller->register_rest_route();
 	}
 	/**
 	 * Returns true if the current site is a support site.

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
@@ -33,9 +33,14 @@ class WP_REST_Help_Center_Authenticate extends \WP_REST_Controller {
 				'callback'            => array( $this, 'get_chat_authentication' ),
 				'permission_callback' => array( $this, 'permission_callback' ),
 				'args'                => array(
-					'type' => array(
+					'type'      => array(
 						'type'     => 'string',
 						'default'  => 'happychat',
+						'required' => false,
+					),
+					'test_mode' => array(
+						'type'     => 'boolean',
+						'default'  => false,
 						'required' => false,
 					),
 				),
@@ -52,11 +57,12 @@ class WP_REST_Help_Center_Authenticate extends \WP_REST_Controller {
 	 */
 	public function get_chat_authentication( \WP_REST_Request $request ) {
 		$query_parameters = array(
-			'type' => $request['type'],
+			'test_mode' => $request['test_mode'],
+			'type'      => $request['type'],
 		);
 
 		$body = Client::wpcom_json_api_request_as_user(
-			'help/authenticate/chat' . http_build_query( $query_parameters ),
+			'help/authenticate/chat?' . http_build_query( $query_parameters ),
 			'2',
 			array(
 				'method' => 'POST',

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
@@ -32,16 +32,31 @@ class WP_REST_Help_Center_Authenticate extends \WP_REST_Controller {
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'get_chat_authentication' ),
 				'permission_callback' => array( $this, 'permission_callback' ),
+				'args'                => array(
+					'type' => array(
+						'type'     => 'string',
+						'default'  => 'happychat',
+						'required' => false,
+					),
+				),
 			)
 		);
 	}
 
 	/**
 	 * Callback to authorize user for chat.
+	 *
+	 * @param \WP_REST_Request $request The request sent to the API.
+	 *
+	 * @return WP_REST_Response
 	 */
-	public function get_chat_authentication() {
+	public function get_chat_authentication( \WP_REST_Request $request ) {
+		$query_parameters = array(
+			'type' => $request['type'],
+		);
+
 		$body = Client::wpcom_json_api_request_as_user(
-			'help/authenticate/chat',
+			'help/authenticate/chat' . http_build_query( $query_parameters ),
 			'2',
 			array(
 				'method' => 'POST',

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
@@ -44,6 +44,26 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 				'permission_callback' => array( $this, 'permission_callback' ),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/messaging',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_messaging_support_eligibility' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+				'args'                => array(
+					'group'       => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'environment' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -84,6 +104,27 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 			}
 			$response = json_decode( wp_remote_retrieve_body( $body ) );
 		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Should return messaging eligibility
+	 *
+	 * @param \WP_REST_Request $request    The request sent to the API.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_messaging_support_eligibility( \WP_REST_Request $request ) {
+		$query_parameters = array(
+			'group'       => $request['group'],
+			'environment' => $request['environment'],
+		);
+		$body             = Client::wpcom_json_api_request_as_user( 'help/messaging/is-available?' . http_build_query( $query_parameters ) );
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
 		return rest_ensure_response( $response );
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-user-fields.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-user-fields.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * WP_REST_Help_Center_User_Fields file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_Help_Center_User_Fields.
+ */
+class WP_REST_Help_Center_User_Fields extends \WP_REST_Controller {
+	/**
+	 * WP_REST_Help_Center_User_Fields constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'help-center';
+		$this->rest_base = '/zendesk/user-fields';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'update_user_fields' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+				'args'                => array(
+					'fields' => array(
+						'type'     => 'object',
+						'required' => true,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Callback to update user fields in Zendesk
+	 *
+	 * @param \WP_REST_Request $request    The request sent to the API.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function update_user_fields( \WP_REST_Request $request ) {
+		$body = Client::wpcom_json_api_request_as_user(
+			'help/zendesk/update-user-fields',
+			'2',
+			array(
+				'method' => 'POST',
+			),
+			$request['fields']
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Callback to determine whether the user has permission to access.
+	 */
+	public function permission_callback() {
+		return is_user_logged_in();
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
@@ -2,6 +2,7 @@ window.configData = {
 	env_id: 'development',
 	i18n_default_locale_slug: 'en',
 	google_analytics_key: 'UA-10673494-15',
+	zendesk_support_chat_key: 'cec07bc9-4da6-4dd2-afa7-c7e01ae73584',
 	client_slug: 'browser',
 	twemoji_cdn_url: 'https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/',
 	site_filter: [],

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
@@ -39,7 +39,7 @@ window.configData = {
 	is_running_in_jetpack_site: false,
 	gutenboarding_url: '/new',
 	features: {
-		happychat: true,
+		happychat: false,
 	},
 	signup_url: '/',
 	discover_blog_id: 53424024,

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
@@ -1,8 +1,8 @@
 window.configData = {
-	env_id: 'development',
+	env_id: 'production',
 	i18n_default_locale_slug: 'en',
 	google_analytics_key: 'UA-10673494-15',
-	zendesk_support_chat_key: '715f17a8-4a28-4a7f-8447-0ef8f06c70d7',
+	zendesk_support_chat_key: 'cec07bc9-4da6-4dd2-afa7-c7e01ae73584',
 	client_slug: 'browser',
 	twemoji_cdn_url: 'https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/',
 	site_filter: [],

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
@@ -2,7 +2,7 @@ window.configData = {
 	env_id: 'development',
 	i18n_default_locale_slug: 'en',
 	google_analytics_key: 'UA-10673494-15',
-	zendesk_support_chat_key: 'cec07bc9-4da6-4dd2-afa7-c7e01ae73584',
+	zendesk_support_chat_key: '715f17a8-4a28-4a7f-8447-0ef8f06c70d7',
 	client_slug: 'browser',
 	twemoji_cdn_url: 'https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/',
 	site_filter: [],

--- a/apps/happychat/src/index.ejs
+++ b/apps/happychat/src/index.ejs
@@ -39,7 +39,7 @@
 				gutenboarding_url: '/new',
 				hostname: 'widgets.wp.com',
 				features: {
-					happychat: true,
+					happychat: false,
 				},
 			};
 		</script>

--- a/client/components/presales-zendesk-chat/index.tsx
+++ b/client/components/presales-zendesk-chat/index.tsx
@@ -5,16 +5,22 @@ interface Props {
 	chatKey: string | false;
 }
 
+const ZENDESK_SCRIPT_ID = 'ze-snippet';
+
 const ZendeskChat = ( { chatKey }: Props ) => {
 	useEffect( () => {
 		if ( ! chatKey ) {
 			return;
 		}
 
+		if ( document.getElementById( ZENDESK_SCRIPT_ID ) ) {
+			return;
+		}
+
 		loadScript(
 			'https://static.zdassets.com/ekr/snippet.js?key=' + encodeURIComponent( chatKey ),
 			undefined,
-			{ id: 'ze-snippet' }
+			{ id: ZENDESK_SCRIPT_ID }
 		);
 	}, [ chatKey ] );
 

--- a/client/me/happychat/index.jsx
+++ b/client/me/happychat/index.jsx
@@ -1,25 +1,11 @@
-import config from '@automattic/calypso-config';
-import { translate } from 'i18n-calypso';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { sidebar } from 'calypso/me/controller';
-import { setDocumentHeadTitle } from 'calypso/state/document-head/actions';
-import Happychat from './main';
 
-const renderChat = ( context, next ) => {
-	context.store.dispatch( setDocumentHeadTitle( translate( 'Chat', { textOnly: true } ) ) );
-	context.primary = (
-		<div>
-			<PageViewTracker path="/me/chat" title="Chat" />
-			<Happychat />
-		</div>
-	);
-	next();
+const redirectToHelp = () => {
+	page.redirect( '/help' );
 };
 
 export default () => {
-	if ( config.isEnabled( 'happychat' ) ) {
-		page( '/me/chat', sidebar, renderChat, makeLayout, clientRender );
-	}
+	page( '/me/chat', sidebar, redirectToHelp, makeLayout, clientRender );
 };

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -39,6 +39,7 @@
 	"zendesk_presales_chat_key_akismet": false,
 	"zendesk_presales_chat_key_jp_checkout": false,
 	"zendesk_presales_chat_key_jp_agency_dashboard": false,
+	"zendesk_support_chat_key": false,
 	"upwork_support_locales": [
 		"de",
 		"de-at",

--- a/config/development.json
+++ b/config/development.json
@@ -27,6 +27,7 @@
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
+	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,

--- a/config/development.json
+++ b/config/development.json
@@ -27,7 +27,7 @@
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
-	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
+	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,

--- a/config/development.json
+++ b/config/development.json
@@ -27,7 +27,7 @@
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
-	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
+	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,

--- a/config/development.json
+++ b/config/development.json
@@ -68,7 +68,7 @@
 		"google-drive": true,
 		"google-my-business": true,
 		"gutenboarding/alpha-templates": false,
-		"happychat": true,
+		"happychat": false,
 		"help": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,

--- a/config/production.json
+++ b/config/production.json
@@ -17,6 +17,7 @@
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
+	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
 		"ad-tracking": true,
 		"akismet/siteless-checkout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -15,6 +15,7 @@
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
+	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -50,7 +50,7 @@
 		"cookie-banner": true,
 		"google-my-business": true,
 		"gutenboarding/alpha-templates": false,
-		"happychat": true,
+		"happychat": false,
 		"help": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -15,6 +15,7 @@
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
+	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -73,6 +73,18 @@ export const setShowHelpCenter = function* ( show: boolean ) {
 	} as const;
 };
 
+export const setShowMessagingLauncher = ( show: boolean ) =>
+	( {
+		type: 'HELP_CENTER_SET_SHOW_MESSAGING_LAUNCHER',
+		show,
+	} as const );
+
+export const setShowMessagingWidget = ( show: boolean ) =>
+	( {
+		type: 'HELP_CENTER_SET_SHOW_MESSAGING_WIDGET',
+		show,
+	} as const );
+
 export const setSubject = ( subject: string ) =>
 	( {
 		type: 'HELP_CENTER_SET_SUBJECT',
@@ -128,6 +140,8 @@ export const resetStore = () =>
 
 export type HelpCenterAction =
 	| ReturnType<
+			| typeof setShowMessagingLauncher
+			| typeof setShowMessagingWidget
 			| typeof setSite
 			| typeof setSubject
 			| typeof resetStore

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -93,12 +93,6 @@ export const setSubject = ( subject: string ) =>
 		subject,
 	} as const );
 
-export const setThirdPartyCookiesAllowed = ( areAllowed: boolean ) =>
-	( {
-		type: 'HELP_CENTER_SET_THIRD_PARTY_COOKIES_ALLOWED',
-		areAllowed,
-	} as const );
-
 export const setMessage = ( message: string ) =>
 	( {
 		type: 'HELP_CENTER_SET_MESSAGE',
@@ -163,6 +157,5 @@ export type HelpCenterAction =
 			| typeof setUnreadCount
 			| typeof setIsMinimized
 			| typeof setInitialRoute
-			| typeof setThirdPartyCookiesAllowed
 	  >
 	| GeneratorReturnType< typeof setShowHelpCenter | typeof setHasSeenWhatsNewModal >;

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -93,6 +93,12 @@ export const setSubject = ( subject: string ) =>
 		subject,
 	} as const );
 
+export const setThirdPartyCookiesAllowed = ( areAllowed: boolean ) =>
+	( {
+		type: 'HELP_CENTER_SET_THIRD_PARTY_COOKIES_ALLOWED',
+		areAllowed,
+	} as const );
+
 export const setMessage = ( message: string ) =>
 	( {
 		type: 'HELP_CENTER_SET_MESSAGE',
@@ -157,5 +163,6 @@ export type HelpCenterAction =
 			| typeof setUnreadCount
 			| typeof setIsMinimized
 			| typeof setInitialRoute
+			| typeof setThirdPartyCookiesAllowed
 	  >
 	| GeneratorReturnType< typeof setShowHelpCenter | typeof setHasSeenWhatsNewModal >;

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -61,18 +61,6 @@ export const setIsMinimized = ( minimized: boolean ) =>
 		minimized,
 	} as const );
 
-export const setShowHelpCenter = function* ( show: boolean ) {
-	if ( ! show ) {
-		yield setInitialRoute( undefined );
-		yield setIsMinimized( false );
-	}
-
-	return {
-		type: 'HELP_CENTER_SET_SHOW',
-		show,
-	} as const;
-};
-
 export const setShowMessagingLauncher = ( show: boolean ) =>
 	( {
 		type: 'HELP_CENTER_SET_SHOW_MESSAGING_LAUNCHER',
@@ -84,6 +72,20 @@ export const setShowMessagingWidget = ( show: boolean ) =>
 		type: 'HELP_CENTER_SET_SHOW_MESSAGING_WIDGET',
 		show,
 	} as const );
+
+export const setShowHelpCenter = function* ( show: boolean ) {
+	if ( ! show ) {
+		yield setInitialRoute( undefined );
+		yield setIsMinimized( false );
+	} else {
+		yield setShowMessagingWidget( false );
+	}
+
+	return {
+		type: 'HELP_CENTER_SET_SHOW',
+		show,
+	} as const;
+};
 
 export const setSubject = ( subject: string ) =>
 	( {

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -13,6 +13,25 @@ const showHelpCenter: Reducer< boolean | undefined, HelpCenterAction > = ( state
 	return state;
 };
 
+const showMessagingLauncher: Reducer< boolean | undefined, HelpCenterAction > = (
+	state,
+	action
+) => {
+	switch ( action.type ) {
+		case 'HELP_CENTER_SET_SHOW_MESSAGING_LAUNCHER':
+			return action.show;
+	}
+	return state;
+};
+
+const showMessagingWidget: Reducer< boolean | undefined, HelpCenterAction > = ( state, action ) => {
+	switch ( action.type ) {
+		case 'HELP_CENTER_SET_SHOW_MESSAGING_WIDGET':
+			return action.show;
+	}
+	return state;
+};
+
 const hasSeenWhatsNewModal: Reducer< boolean | undefined, HelpCenterAction > = (
 	state,
 	action
@@ -119,6 +138,8 @@ const initialRoute: Reducer< InitialEntry | undefined, HelpCenterAction > = ( st
 
 const reducer = combineReducers( {
 	showHelpCenter,
+	showMessagingLauncher,
+	showMessagingWidget,
 	site,
 	subject,
 	message,

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -136,17 +136,6 @@ const initialRoute: Reducer< InitialEntry | undefined, HelpCenterAction > = ( st
 	return state;
 };
 
-const thirdPartyCookiesAllowed: Reducer< boolean | undefined, HelpCenterAction > = (
-	state,
-	action
-) => {
-	switch ( action.type ) {
-		case 'HELP_CENTER_SET_THIRD_PARTY_COOKIES_ALLOWED':
-			return action.areAllowed;
-	}
-	return state;
-};
-
 const reducer = combineReducers( {
 	showHelpCenter,
 	showMessagingLauncher,
@@ -162,7 +151,6 @@ const reducer = combineReducers( {
 	unreadCount,
 	iframe,
 	initialRoute,
-	thirdPartyCookiesAllowed,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -136,6 +136,17 @@ const initialRoute: Reducer< InitialEntry | undefined, HelpCenterAction > = ( st
 	return state;
 };
 
+const thirdPartyCookiesAllowed: Reducer< boolean | undefined, HelpCenterAction > = (
+	state,
+	action
+) => {
+	switch ( action.type ) {
+		case 'HELP_CENTER_SET_THIRD_PARTY_COOKIES_ALLOWED':
+			return action.areAllowed;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	showHelpCenter,
 	showMessagingLauncher,
@@ -151,6 +162,7 @@ const reducer = combineReducers( {
 	unreadCount,
 	iframe,
 	initialRoute,
+	thirdPartyCookiesAllowed,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -1,6 +1,8 @@
 import type { State } from './reducer';
 
 export const isHelpCenterShown = ( state: State ) => state.showHelpCenter;
+export const isMessagingLauncherShown = ( state: State ) => state.showMessagingLauncher;
+export const isMessagingWidgetShown = ( state: State ) => state.showMessagingWidget;
 export const getSite = ( state: State ) => state.site;
 export const getSubject = ( state: State ) => state.subject;
 export const getMessage = ( state: State ) => state.message;

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -1,6 +1,5 @@
 import type { State } from './reducer';
 
-export const areThirdPartyCookiesAllowed = ( state: State ) => state.thirdPartyCookiesAllowed;
 export const isHelpCenterShown = ( state: State ) => state.showHelpCenter;
 export const isMessagingLauncherShown = ( state: State ) => state.showMessagingLauncher;
 export const isMessagingWidgetShown = ( state: State ) => state.showMessagingWidget;

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -1,5 +1,6 @@
 import type { State } from './reducer';
 
+export const areThirdPartyCookiesAllowed = ( state: State ) => state.thirdPartyCookiesAllowed;
 export const isHelpCenterShown = ( state: State ) => state.showHelpCenter;
 export const isMessagingLauncherShown = ( state: State ) => state.showMessagingLauncher;
 export const isMessagingWidgetShown = ( state: State ) => state.showMessagingWidget;

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -21,6 +21,7 @@ export { useSiteIntent } from './queries/use-site-intent';
 export { useSupportAvailability } from './support-queries/use-support-availability';
 export { useSubmitTicketMutation } from './support-queries/use-submit-support-ticket';
 export { useSubmitForumsMutation } from './support-queries/use-submit-forums-topic';
+export { useUpdateZendeskUserFieldsMutation } from './support-queries/use-update-zendesk-user-fields';
 export { useHasActiveSupport } from './support-queries/use-support-history';
 export * from './starter-designs-queries';
 export { useSibylQuery } from './support-queries/use-sibyl-query';

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -22,7 +22,7 @@ export { useSupportAvailability } from './support-queries/use-support-availabili
 export { useSubmitTicketMutation } from './support-queries/use-submit-support-ticket';
 export { useSubmitForumsMutation } from './support-queries/use-submit-forums-topic';
 export { useUpdateZendeskUserFieldsMutation } from './support-queries/use-update-zendesk-user-fields';
-export { useHasActiveSupport } from './support-queries/use-support-history';
+export { useSupportHistory } from './support-queries/use-support-history';
 export * from './starter-designs-queries';
 export { useSibylQuery } from './support-queries/use-sibyl-query';
 export * from './support-queries/types';

--- a/packages/data-stores/src/support-queries/types.ts
+++ b/packages/data-stores/src/support-queries/types.ts
@@ -36,4 +36,5 @@ export interface SupportSession {
 	type: string;
 	url: string;
 	when: string;
+	channel: string;
 }

--- a/packages/data-stores/src/support-queries/use-support-history.ts
+++ b/packages/data-stores/src/support-queries/use-support-history.ts
@@ -14,7 +14,7 @@ const ACTIVE_STATUSES = [ 'New', 'Open', 'Hold' ];
  *
  * NOTE: Chat mode isn't functional at the moment.
  */
-export function useHasActiveSupport( type: 'chat' | 'ticket', email: string, show = true ) {
+export function useSupportHistory( type: 'chat' | 'ticket', email: string, show = true ) {
 	return useQuery(
 		[ 'help-support-history', type, email ],
 		() =>
@@ -37,10 +37,12 @@ export function useHasActiveSupport( type: 'chat' | 'ticket', email: string, sho
 			refetchOnMount: true,
 			enabled: show,
 			select: ( response ) => {
-				const recentSession = response.data[ 0 ];
-				return ACTIVE_STATUSES.includes( recentSession.status ) ? recentSession : null;
+				return response.data.filter( ( session ) => ACTIVE_STATUSES.includes( session.status ) );
 			},
 			staleTime: 30 * 60 * 1000,
+			meta: {
+				persist: false,
+			},
 		}
 	);
 }

--- a/packages/data-stores/src/support-queries/use-update-zendesk-user-fields.ts
+++ b/packages/data-stores/src/support-queries/use-update-zendesk-user-fields.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+
+type ZendeskUserFields = {
+	route?: string;
+};
+
+export function useUpdateZendeskUserFieldsMutation() {
+	return useMutation( ( userFields: ZendeskUserFields ) => {
+		return canAccessWpcomApis()
+			? wpcomRequest( {
+					path: 'help/zendesk/update-user-fields',
+					apiNamespace: 'wpcom/v2/',
+					apiVersion: '2',
+					method: 'POST',
+					body: { fields: userFields },
+			  } )
+			: apiFetch( {
+					global: true,
+					path: '/help-center/ticket/new',
+					method: 'POST',
+					data: { fields: userFields },
+			  } as APIFetchOptions );
+	} );
+}

--- a/packages/data-stores/src/support-queries/use-update-zendesk-user-fields.ts
+++ b/packages/data-stores/src/support-queries/use-update-zendesk-user-fields.ts
@@ -3,7 +3,10 @@ import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 
 type ZendeskUserFields = {
-	route?: string;
+	messaging_initial_message?: string;
+	messaging_plan?: string;
+	messaging_source?: string;
+	messaging_url?: string;
 };
 
 export function useUpdateZendeskUserFieldsMutation() {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -255,10 +255,6 @@ export const HelpCenterContactForm = () => {
 		Boolean( supportSite?.is_wpcom_atomic )
 	);
 
-	if ( ! thirdPartyCookiesAllowed ) {
-		return <ThirdPartyCookiesNotice />;
-	}
-
 	const enableGPTResponse = config.isEnabled( 'help/gpt-response' );
 	const showingSibylResults = params.get( 'show-results' ) === 'true';
 	const showingGPTResponse = params.get( 'show-gpt' ) === 'true';
@@ -311,7 +307,6 @@ export const HelpCenterContactForm = () => {
 						section: sectionName,
 					} );
 
-					//navigate( '/inline-chat' );
 					setShowHelpCenter( false );
 					setShowMessagingLauncher( true );
 					setShowMessagingWidget( true );
@@ -500,6 +495,10 @@ export const HelpCenterContactForm = () => {
 
 		return isSubmitting ? formTitles.buttonSubmittingLabel : formTitles.buttonLabel;
 	};
+
+	if ( ! thirdPartyCookiesAllowed ) {
+		return <ThirdPartyCookiesNotice />;
+	}
 
 	// TODO: A/B test
 	if ( enableGPTResponse && showingGPTResponse ) {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -309,6 +309,7 @@ export const HelpCenterContactForm = () => {
 					setShowHelpCenter( false );
 					setShowMessagingLauncher( true );
 					setShowMessagingWidget( true );
+					resetStore();
 					break;
 				}
 				break;

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -310,7 +310,12 @@ export const HelpCenterContactForm = () => {
 						section: sectionName,
 					} );
 
-					submitZendeskUserFields( { route: sectionName } )
+					submitZendeskUserFields( {
+						messaging_source: sectionName,
+						messaging_initial_message: message,
+						messaging_plan: '', // Will be filled out by backend
+						messaging_url: supportSite?.URL,
+					} )
 						.then( () => {
 							setShowHelpCenter( false );
 							setShowMessagingLauncher( true );

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -510,7 +510,7 @@ export const HelpCenterContactForm = () => {
 		return isSubmitting ? formTitles.buttonSubmittingLabel : formTitles.buttonLabel;
 	};
 
-	if ( mode === 'CHAT' && ! thirdPartyCookiesAllowed ) {
+	if ( mode === 'CHAT' && thirdPartyCookiesAllowed === false ) {
 		return <ThirdPartyCookiesNotice />;
 	}
 

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -9,6 +9,7 @@ import { FormInputValidation, Popover } from '@automattic/components';
 import {
 	useSubmitTicketMutation,
 	useSubmitForumsMutation,
+	useUpdateZendeskUserFieldsMutation,
 	useSiteAnalysis,
 	useUserSites,
 	AnalysisReport,
@@ -161,6 +162,8 @@ export const HelpCenterContactForm = () => {
 	const locale = useLocale();
 	const { isLoading: submittingTicket, mutateAsync: submitTicket } = useSubmitTicketMutation();
 	const { isLoading: submittingTopic, mutateAsync: submitTopic } = useSubmitForumsMutation();
+	const { isLoading: submittingZendeskUserFields, mutateAsync: submitZendeskUserFields } =
+		useUpdateZendeskUserFieldsMutation();
 	const userId = useSelector( getCurrentUserId );
 	const { data: userSites } = useUserSites( userId );
 	const userWithNoSites = userSites?.sites.length === 0;
@@ -219,7 +222,7 @@ export const HelpCenterContactForm = () => {
 	);
 
 	const ownershipStatusLoading = ownershipResult?.result === 'LOADING';
-	const isSubmitting = submittingTicket || submittingTopic;
+	const isSubmitting = submittingTicket || submittingTopic || submittingZendeskUserFields;
 
 	// if the user picked a site from the picker, we don't need to analyze the ownership
 	if ( currentSite && sitePickerChoice === 'CURRENT_SITE' ) {
@@ -307,10 +310,16 @@ export const HelpCenterContactForm = () => {
 						section: sectionName,
 					} );
 
-					setShowHelpCenter( false );
-					setShowMessagingLauncher( true );
-					setShowMessagingWidget( true );
-					resetStore();
+					submitZendeskUserFields( { route: sectionName } )
+						.then( () => {
+							setShowHelpCenter( false );
+							setShowMessagingLauncher( true );
+							setShowMessagingWidget( true );
+							resetStore();
+						} )
+						.catch( () => {
+							setHasSubmittingError( true );
+						} );
 					break;
 				}
 				break;

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -42,6 +42,7 @@ import { BackButton } from './back-button';
 import { HelpCenterGPT } from './help-center-gpt';
 import { HelpCenterOwnershipNotice } from './help-center-notice';
 import { SibylArticles } from './help-center-sibyl-articles';
+import ThirdPartyCookiesNotice from './help-center-third-party-cookies-notice';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 import './help-center-contact-form.scss';
 
@@ -168,15 +169,17 @@ export const HelpCenterContactForm = () => {
 	const [ sitePickerChoice, setSitePickerChoice ] = useState< 'CURRENT_SITE' | 'OTHER_SITE' >(
 		'CURRENT_SITE'
 	);
-	const { currentSite, subject, message, userDeclaredSiteUrl } = useSelect( ( select ) => {
-		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
-		return {
-			currentSite: helpCenterSelect.getSite(),
-			subject: helpCenterSelect.getSubject(),
-			message: helpCenterSelect.getMessage(),
-			userDeclaredSiteUrl: helpCenterSelect.getUserDeclaredSiteUrl(),
-		};
-	}, [] );
+	const { currentSite, subject, message, userDeclaredSiteUrl, thirdPartyCookiesAllowed } =
+		useSelect( ( select ) => {
+			const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
+			return {
+				currentSite: helpCenterSelect.getSite(),
+				subject: helpCenterSelect.getSubject(),
+				message: helpCenterSelect.getMessage(),
+				userDeclaredSiteUrl: helpCenterSelect.getUserDeclaredSiteUrl(),
+				thirdPartyCookiesAllowed: helpCenterSelect.areThirdPartyCookiesAllowed(),
+			};
+		}, [] );
 
 	const {
 		setSite,
@@ -252,8 +255,11 @@ export const HelpCenterContactForm = () => {
 		Boolean( supportSite?.is_wpcom_atomic )
 	);
 
-	const enableGPTResponse = config.isEnabled( 'help/gpt-response' );
+	if ( ! thirdPartyCookiesAllowed ) {
+		return <ThirdPartyCookiesNotice />;
+	}
 
+	const enableGPTResponse = config.isEnabled( 'help/gpt-response' );
 	const showingSibylResults = params.get( 'show-results' ) === 'true';
 	const showingGPTResponse = params.get( 'show-gpt' ) === 'true';
 

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -185,6 +185,9 @@ export const HelpCenterContactForm = () => {
 		setUserDeclaredSite,
 		setSubject,
 		setMessage,
+		setShowHelpCenter,
+		setShowMessagingLauncher,
+		setShowMessagingWidget,
 	} = useDispatch( HELP_CENTER_STORE );
 
 	useEffect( () => {
@@ -288,7 +291,7 @@ export const HelpCenterContactForm = () => {
 			case 'CHAT':
 				if ( supportSite ) {
 					recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
-						support_variation: 'happychat',
+						support_variation: 'messaging',
 						force_site_id: true,
 						location: 'help-center',
 						section: sectionName,
@@ -301,7 +304,11 @@ export const HelpCenterContactForm = () => {
 						location: 'help-center',
 						section: sectionName,
 					} );
-					navigate( '/inline-chat' );
+
+					//navigate( '/inline-chat' );
+					setShowHelpCenter( false );
+					setShowMessagingLauncher( true );
+					setShowMessagingWidget( true );
 					break;
 				}
 				break;

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -496,7 +496,7 @@ export const HelpCenterContactForm = () => {
 		return isSubmitting ? formTitles.buttonSubmittingLabel : formTitles.buttonLabel;
 	};
 
-	if ( ! thirdPartyCookiesAllowed ) {
+	if ( mode === 'CHAT' && ! thirdPartyCookiesAllowed ) {
 		return <ThirdPartyCookiesNotice />;
 	}
 

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -7,7 +7,6 @@ import config from '@automattic/calypso-config';
 import { Spinner, GMClosureNotice } from '@automattic/components';
 import { useSupportAvailability, useHasActiveSupport } from '@automattic/data-stores';
 import { isDefaultLocale, getLanguage, useLocale } from '@automattic/i18n-utils';
-import { Notice } from '@wordpress/components';
 import { useEffect, useMemo } from '@wordpress/element';
 import { hasTranslation, sprintf } from '@wordpress/i18n';
 import { comment, Icon } from '@wordpress/icons';
@@ -130,16 +129,6 @@ export const HelpCenterContactPage: FC = () => {
 					reopensAt="2023-04-10 07:00Z"
 					enabled={ hasAccessToLivechat }
 				/>
-				{ renderChat.env === 'staging' && (
-					<Notice
-						status="warning"
-						actions={ [ { label: 'Learn more', url: 'https://wp.me/PCYsg-Q7X' } ] }
-						className="help-center-contact-page__staging-notice"
-						isDismissible={ false }
-					>
-						Targeting HappyChat staging
-					</Notice>
-				) }
 
 				<div className={ classnames( 'help-center-contact-page__boxes' ) }>
 					<Link to="/contact-form?mode=FORUM">

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -5,7 +5,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Spinner, GMClosureNotice } from '@automattic/components';
-import { useSupportAvailability, useHasActiveSupport } from '@automattic/data-stores';
+import { useSupportAvailability, useSupportHistory } from '@automattic/data-stores';
 import { isDefaultLocale, getLanguage, useLocale } from '@automattic/i18n-utils';
 import { useEffect, useMemo } from '@wordpress/element';
 import { hasTranslation, sprintf } from '@wordpress/i18n';
@@ -42,12 +42,12 @@ export const HelpCenterContactPage: FC = () => {
 	const renderEmail = useShouldRenderEmailOption();
 	const renderChat = useShouldRenderChatOption();
 	const email = useSelector( getCurrentUserEmail );
-	const { data: hasActiveTickets, isLoading: isLoadingTickets } = useHasActiveSupport(
+	const { data: supportHistory, isLoading: isLoadingSupportHistory } = useSupportHistory(
 		'ticket',
 		email
 	);
 	const { data: supportAvailability } = useSupportAvailability( 'CHAT' );
-	const isLoading = renderChat.isLoading || renderEmail.isLoading || isLoadingTickets;
+	const isLoading = renderChat.isLoading || renderEmail.isLoading || isLoadingSupportHistory;
 
 	useEffect( () => {
 		if ( isLoading ) {
@@ -121,7 +121,7 @@ export const HelpCenterContactPage: FC = () => {
 			<BackButton />
 			<div className="help-center-contact-page__content">
 				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
-				{ hasActiveTickets && <HelpCenterActiveTicketNotice tickets={ [ hasActiveTickets ] } /> }
+				{ supportHistory && <HelpCenterActiveTicketNotice tickets={ supportHistory } /> }
 				{ /* Easter */ }
 				<GMClosureNotice
 					displayAt="2023-04-03 00:00Z"

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -1,15 +1,13 @@
 /**
  * External Dependencies
  */
-import { useSupportAvailability } from '@automattic/data-stores';
-import { useHappychatAvailable } from '@automattic/happychat-connection';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Card } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
-import { useState, useRef, FC, useEffect } from 'react';
+import { useState, useRef, FC } from 'react';
 import Draggable, { DraggableProps } from 'react-draggable';
-import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 /**
  * Internal Dependencies
  */
@@ -32,20 +30,6 @@ const OptionalDraggable: FC< OptionalDraggableProps > = ( { draggable, ...props 
 	return <Draggable { ...props } />;
 };
 
-const RedirectAssigned = ( { status }: { status?: string } ) => {
-	const navigate = useNavigate();
-	const { pathname } = useLocation();
-	const assigned = status === 'assigned';
-
-	useEffect( () => {
-		if ( assigned && ! pathname.startsWith( '/inline-chat' ) ) {
-			navigate( '/inline-chat?session=continued', { replace: true } );
-		}
-	}, [ assigned, navigate, pathname ] );
-
-	return null;
-};
-
 const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const { show, isMinimized, initialRoute } = useSelect(
 		( select ) => ( {
@@ -63,8 +47,6 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) =
 	const classNames = classnames( 'help-center__container', isMobile ? 'is-mobile' : 'is-desktop', {
 		'is-minimized': isMinimized,
 	} );
-	const { data: supportAvailability } = useSupportAvailability( 'CHAT' );
-	const { data } = useHappychatAvailable( Boolean( supportAvailability?.is_user_eligible ) );
 
 	const onDismiss = () => {
 		setIsVisible( false );
@@ -94,7 +76,6 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) =
 
 	return (
 		<MemoryRouter initialEntries={ initialRoute ? [ initialRoute ] : undefined }>
-			<RedirectAssigned status={ data?.status } />
 			<FeatureFlagProvider>
 				<OptionalDraggable
 					draggable={ ! isMobile && ! isMinimized }

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -456,6 +456,17 @@
 	}
 
 	/**
+	 * Third Party Cookies Notice
+	 */
+	.help-center-third-party-cookies-notice {
+		h1 {
+			font-size: $font-body;
+			font-weight: 500;
+			margin: 1em 0;
+		}
+	}
+
+	/**
  	 * ARTICLE EMBED
  	 */
 	.help-center-embed-result article.help-center-article-content__story {

--- a/packages/help-center/src/components/help-center-third-party-cookies-notice.tsx
+++ b/packages/help-center/src/components/help-center-third-party-cookies-notice.tsx
@@ -11,13 +11,13 @@ const ThirdPartyCookiesNotice: React.FC = () => {
 	const { __ } = useI18n();
 	const sectionName = useSelector( getSectionName );
 
-	useEffect( () =>
+	useEffect( () => {
 		recordTracksEvent( 'calypso_helpcenter_third_party_cookies_notice_open', {
 			force_site_id: true,
 			location: 'help-center',
 			section: sectionName,
-		} )
-	);
+		} );
+	}, [] ); // Dependencies do not include sectionName on purpose - we just care about reporting it once
 
 	return (
 		<div className="help-center-third-party-cookies-notice">

--- a/packages/help-center/src/components/help-center-third-party-cookies-notice.tsx
+++ b/packages/help-center/src/components/help-center-third-party-cookies-notice.tsx
@@ -26,7 +26,7 @@ const ThirdPartyCookiesNotice: React.FC = () => {
 				<h1>{ __( 'Action needed', __i18n_text_domain__ ) }</h1>
 				<p>
 					{ __(
-						'Your browser has third-party cookies disabled for WordPress.com. This is preventing our livechat widget from loading.',
+						'In order to access the live chat widget, you will need to enable third-party cookies for WordPress.com.',
 						__i18n_text_domain__
 					) }
 					&nbsp;
@@ -35,10 +35,7 @@ const ThirdPartyCookiesNotice: React.FC = () => {
 						rel="noopener noreferrer"
 						href="https://wordpress.com/support/third-party-cookies/"
 					>
-						{ __(
-							'Please adjust your settings as described here to proceed.',
-							__i18n_text_domain__
-						) }
+						{ __( 'Learn more in this support guide.', __i18n_text_domain__ ) }
 					</a>
 				</p>
 			</div>

--- a/packages/help-center/src/components/help-center-third-party-cookies-notice.tsx
+++ b/packages/help-center/src/components/help-center-third-party-cookies-notice.tsx
@@ -1,0 +1,49 @@
+/* eslint-disable no-restricted-imports */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useEffect } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { getSectionName } from 'calypso/state/ui/selectors';
+import { BackButton } from './back-button';
+
+const ThirdPartyCookiesNotice: React.FC = () => {
+	const { __ } = useI18n();
+	const sectionName = useSelector( getSectionName );
+
+	useEffect( () =>
+		recordTracksEvent( 'calypso_helpcenter_third_party_cookies_notice_open', {
+			force_site_id: true,
+			location: 'help-center',
+			section: sectionName,
+		} )
+	);
+
+	return (
+		<div className="help-center-third-party-cookies-notice">
+			<BackButton />
+			<div>
+				<h1>{ __( 'Action needed', __i18n_text_domain__ ) }</h1>
+				<p>
+					{ __(
+						'Your browser has third-party cookies disabled for WordPress.com. This is preventing our livechat widget from loading.',
+						__i18n_text_domain__
+					) }
+					&nbsp;
+					<a
+						target="_blank"
+						rel="noopener noreferrer"
+						href="https://wordpress.com/support/third-party-cookies/"
+					>
+						{ __(
+							'Please adjust your settings as described here to proceed.',
+							__i18n_text_domain__
+						) }
+					</a>
+				</p>
+			</div>
+		</div>
+	);
+};
+
+export default ThirdPartyCookiesNotice;

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -16,6 +16,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
  */
 import useMessagingAuth from '../hooks/use-messaging-auth';
 import { useStillNeedHelpURL } from '../hooks/use-still-need-help-url';
+import useZendeskConfig from '../hooks/use-zendesk-config';
 import { HELP_CENTER_STORE, USER_STORE, SITE_STORE } from '../stores';
 import { Container } from '../types';
 import HelpCenterContainer from './help-center-container';
@@ -29,6 +30,16 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
 	const { setSite } = useDispatch( HELP_CENTER_STORE );
 	const { setShowMessagingWidget } = useDispatch( HELP_CENTER_STORE );
+	const { setThirdPartyCookiesAllowed } = useDispatch( HELP_CENTER_STORE );
+
+	const { status: zendeskStatus } = useZendeskConfig();
+	useEffect( () => {
+		if ( zendeskStatus === 'success' ) {
+			setThirdPartyCookiesAllowed( true );
+		} else if ( zendeskStatus === 'error' ) {
+			setThirdPartyCookiesAllowed( false );
+		}
+	}, [ setThirdPartyCookiesAllowed, zendeskStatus ] );
 
 	useEffect( () => {
 		const zendeskKey: string | false = config( 'zendesk_presales_chat_key' );

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -28,6 +28,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
 	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
 	const { setSite } = useDispatch( HELP_CENTER_STORE );
+	const { setShowMessagingLauncher } = useDispatch( HELP_CENTER_STORE );
 	const { setShowMessagingWidget } = useDispatch( HELP_CENTER_STORE );
 	const { setThirdPartyCookiesAllowed } = useDispatch( HELP_CENTER_STORE );
 
@@ -67,6 +68,11 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 			window.zE( 'messenger:on', 'close', function () {
 				setShowMessagingWidget( false );
 			} );
+			window.zE( 'messenger:on', 'unreadMessages', function ( count ) {
+				if ( Number( count ) > 0 ) {
+					setShowMessagingLauncher( true );
+				}
+			} );
 		}
 
 		loadScript(
@@ -74,7 +80,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 			setUpMessagingEventHandlers,
 			{ id: ZENDESK_SCRIPT_ID }
 		);
-	}, [ setShowMessagingWidget, chatStatus ] );
+	}, [ setShowMessagingLauncher, setShowMessagingWidget, chatStatus ] );
 
 	const { data: messagingAuth } = useMessagingAuth( Boolean( chatStatus?.is_user_eligible ) );
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -3,11 +3,12 @@
  * External Dependencies
  */
 import config from '@automattic/calypso-config';
-import { useSupportAvailability } from '@automattic/data-stores';
+import { useSupportAvailability, useSupportHistory } from '@automattic/data-stores';
 import { loadScript } from '@automattic/load-script';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createPortal, useEffect, useRef } from '@wordpress/element';
 import { useSelector } from 'react-redux';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
@@ -123,6 +124,15 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 			window.zE( 'messenger', 'close' );
 		}
 	}, [ showMessagingWidget ] );
+
+	const email = useSelector( getCurrentUserEmail );
+	const { data: supportHistory } = useSupportHistory( 'ticket', email );
+	useEffect( () => {
+		if ( supportHistory?.some( ( ticket ) => ticket.channel === 'native_messaging' ) ) {
+			setShowMessagingLauncher( true );
+			setShowMessagingWidget( true );
+		}
+	}, [ setShowMessagingLauncher, setShowMessagingWidget, supportHistory ] );
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const primarySiteId = useSelector( ( state ) => getPrimarySiteId( state ) );

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -42,7 +42,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	}, [ setThirdPartyCookiesAllowed, zendeskStatus ] );
 
 	useEffect( () => {
-		const zendeskKey: string | false = config( 'zendesk_presales_chat_key' );
+		const zendeskKey: string | false = config( 'zendesk_support_chat_key' );
 		if ( ! zendeskKey ) {
 			return;
 		}

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -130,9 +130,8 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	useEffect( () => {
 		if ( supportHistory?.some( ( ticket ) => ticket.channel === 'native_messaging' ) ) {
 			setShowMessagingLauncher( true );
-			setShowMessagingWidget( true );
 		}
-	}, [ setShowMessagingLauncher, setShowMessagingWidget, supportHistory ] );
+	}, [ setShowMessagingLauncher, supportHistory ] );
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const primarySiteId = useSelector( ( state ) => getPrimarySiteId( state ) );

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -31,16 +31,6 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const { setSite } = useDispatch( HELP_CENTER_STORE );
 	const { setShowMessagingLauncher } = useDispatch( HELP_CENTER_STORE );
 	const { setShowMessagingWidget } = useDispatch( HELP_CENTER_STORE );
-	const { setThirdPartyCookiesAllowed } = useDispatch( HELP_CENTER_STORE );
-
-	const { status: zendeskStatus } = useZendeskConfig( Boolean( chatStatus?.is_user_eligible ) );
-	useEffect( () => {
-		if ( zendeskStatus === 'success' ) {
-			setThirdPartyCookiesAllowed( true );
-		} else if ( zendeskStatus === 'error' ) {
-			setThirdPartyCookiesAllowed( false );
-		}
-	}, [ setThirdPartyCookiesAllowed, zendeskStatus ] );
 
 	useEffect( () => {
 		if ( ! chatStatus?.is_user_eligible ) {
@@ -132,6 +122,8 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 			setShowMessagingLauncher( true );
 		}
 	}, [ setShowMessagingLauncher, supportHistory ] );
+
+	useZendeskConfig( Boolean( chatStatus?.is_user_eligible ) ); // Pre-fetch
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const primarySiteId = useSelector( ( state ) => getPrimarySiteId( state ) );

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -23,6 +23,8 @@ import HelpCenterContainer from './help-center-container';
 import type { HelpCenterSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
 import '../styles.scss';
 
+const ZENDESK_SCRIPT_ID = 'ze-snippet';
+
 const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
 	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
@@ -47,6 +49,10 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 			return;
 		}
 
+		if ( document.getElementById( ZENDESK_SCRIPT_ID ) ) {
+			return;
+		}
+
 		function setUpMessagingEventHandlers() {
 			if ( typeof window.zE !== 'function' ) {
 				return;
@@ -65,7 +71,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 		loadScript(
 			'https://static.zdassets.com/ekr/snippet.js?key=' + encodeURIComponent( zendeskKey ),
 			setUpMessagingEventHandlers,
-			{ id: 'ze-snippet' }
+			{ id: ZENDESK_SCRIPT_ID }
 		);
 	}, [ setShowMessagingWidget ] );
 

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -81,17 +81,13 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 		} );
 	}, [ messagingAuth ] );
 
-	const { showMessagingLauncher, showMessagingWidget } = useSelect(
-		( select ) => ( {
-			showMessagingLauncher: (
-				select( HELP_CENTER_STORE ) as HelpCenterSelect
-			 ).isMessagingLauncherShown(),
-			showMessagingWidget: (
-				select( HELP_CENTER_STORE ) as HelpCenterSelect
-			 ).isMessagingWidgetShown(),
-		} ),
-		[]
-	);
+	const { showMessagingLauncher, showMessagingWidget } = useSelect( ( select ) => {
+		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
+		return {
+			showMessagingLauncher: helpCenterSelect.isMessagingLauncherShown(),
+			showMessagingWidget: helpCenterSelect.isMessagingWidgetShown(),
+		};
+	}, [] );
 
 	useEffect( () => {
 		if ( typeof window.zE !== 'function' ) {

--- a/packages/help-center/src/components/types.d.ts
+++ b/packages/help-center/src/components/types.d.ts
@@ -5,6 +5,6 @@ interface Window {
 	zE?: (
 		action: string,
 		value: string,
-		handler?: ( callback: ( data: string ) => void ) => void
+		handler?: ( callback: ( data: string | number ) => void ) => void
 	) => void;
 }

--- a/packages/help-center/src/components/types.d.ts
+++ b/packages/help-center/src/components/types.d.ts
@@ -2,4 +2,9 @@
 declare const __i18n_text_domain__: string;
 interface Window {
 	helpCenterData: any;
+	zE?: (
+		action: string,
+		value: string,
+		handler?: ( callback: ( data: string ) => void ) => void
+	) => void;
 }

--- a/packages/help-center/src/hooks/use-messaging-auth.ts
+++ b/packages/help-center/src/hooks/use-messaging-auth.ts
@@ -27,11 +27,12 @@ async function requestMessagingAuth() {
 		  } as APIFetchOptions ) ) as MessagingAuth );
 }
 
-export default function useMessagingAuth() {
+export default function useMessagingAuth( enabled: boolean ) {
 	return useQuery< MessagingAuth >( [ 'getMessagingAuth' ], requestMessagingAuth, {
 		staleTime: 10 * 60 * 1000, // 10 minutes
 		meta: {
 			persist: false,
 		},
+		enabled,
 	} );
 }

--- a/packages/help-center/src/hooks/use-messaging-auth.ts
+++ b/packages/help-center/src/hooks/use-messaging-auth.ts
@@ -10,23 +10,23 @@ interface APIFetchOptions {
 	path: string;
 }
 
-async function requestMessagingAuth() {
+function requestMessagingAuth() {
 	const currentEnvironment = config( 'env_id' );
 	const params = { type: 'zendesk', test_mode: String( currentEnvironment === 'development' ) };
 	const wpcomParams = new URLSearchParams( params );
 	return canAccessWpcomApis()
-		? ( ( await wpcomRequest( {
+		? wpcomRequest< MessagingAuth >( {
 				path: '/help/authenticate/chat',
 				query: wpcomParams.toString(),
 				apiNamespace: 'wpcom/v2',
 				apiVersion: '2',
 				method: 'POST',
-		  } ) ) as MessagingAuth )
-		: ( ( await apiFetch( {
+		  } )
+		: apiFetch< MessagingAuth >( {
 				path: addQueryArgs( '/help-center/authenticate/chat', params ),
 				method: 'POST',
 				global: true,
-		  } as APIFetchOptions ) ) as MessagingAuth );
+		  } as APIFetchOptions );
 }
 
 export default function useMessagingAuth( enabled: boolean ) {

--- a/packages/help-center/src/hooks/use-messaging-auth.ts
+++ b/packages/help-center/src/hooks/use-messaging-auth.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
@@ -10,7 +11,8 @@ interface APIFetchOptions {
 }
 
 async function requestMessagingAuth() {
-	const params = { type: 'zendesk' };
+	const currentEnvironment = config( 'env_id' );
+	const params = { type: 'zendesk', test_mode: String( currentEnvironment === 'development' ) };
 	const wpcomParams = new URLSearchParams( params );
 	return canAccessWpcomApis()
 		? ( ( await wpcomRequest( {

--- a/packages/help-center/src/hooks/use-messaging-auth.ts
+++ b/packages/help-center/src/hooks/use-messaging-auth.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import type { MessagingAuth } from '../types';
 
@@ -9,18 +10,18 @@ interface APIFetchOptions {
 }
 
 async function requestMessagingAuth() {
-	const params = new URLSearchParams( { type: 'zendesk' } );
+	const params = { type: 'zendesk' };
+	const wpcomParams = new URLSearchParams( params );
 	return canAccessWpcomApis()
 		? ( ( await wpcomRequest( {
 				path: '/help/authenticate/chat',
-				query: params.toString(),
+				query: wpcomParams.toString(),
 				apiNamespace: 'wpcom/v2',
 				apiVersion: '2',
 				method: 'POST',
 		  } ) ) as MessagingAuth )
 		: ( ( await apiFetch( {
-				path: '/help-center/authenticate/chat',
-				query: params.toString(),
+				path: addQueryArgs( '/help-center/authenticate/chat', params ),
 				method: 'POST',
 				global: true,
 		  } as APIFetchOptions ) ) as MessagingAuth );

--- a/packages/help-center/src/hooks/use-messaging-auth.ts
+++ b/packages/help-center/src/hooks/use-messaging-auth.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import type { MessagingAuth } from '../types';
+
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
+
+async function requestMessagingAuth() {
+	const params = new URLSearchParams( { type: 'zendesk' } );
+	return canAccessWpcomApis()
+		? ( ( await wpcomRequest( {
+				path: '/help/authenticate/chat',
+				query: params.toString(),
+				apiNamespace: 'wpcom/v2',
+				apiVersion: '2',
+				method: 'POST',
+		  } ) ) as MessagingAuth )
+		: ( ( await apiFetch( {
+				path: '/help-center/authenticate/chat',
+				query: params.toString(),
+				method: 'POST',
+				global: true,
+		  } as APIFetchOptions ) ) as MessagingAuth );
+}
+
+export default function useMessagingAuth() {
+	return useQuery< MessagingAuth >( [ 'getMessagingAuth' ], requestMessagingAuth, {
+		staleTime: 10 * 60 * 1000, // 10 minutes
+		meta: {
+			persist: false,
+		},
+	} );
+}

--- a/packages/help-center/src/hooks/use-messaging-availability.ts
+++ b/packages/help-center/src/hooks/use-messaging-availability.ts
@@ -9,8 +9,7 @@ interface APIFetchOptions {
 }
 
 async function requestMessagingAvailability() {
-	// TODO: use correct group
-	const params = new URLSearchParams( { group: 'wpcom_presales', environment: 'production' } );
+	const params = new URLSearchParams( { group: 'wpcom_messaging', environment: 'production' } );
 	return canAccessWpcomApis()
 		? ( ( await wpcomRequest( {
 				path: '/help/messaging/is-available',

--- a/packages/help-center/src/hooks/use-messaging-availability.ts
+++ b/packages/help-center/src/hooks/use-messaging-availability.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import type { MessagingAvailability } from '../types';
 
@@ -9,18 +10,18 @@ interface APIFetchOptions {
 }
 
 async function requestMessagingAvailability() {
-	const params = new URLSearchParams( { group: 'wpcom_messaging', environment: 'production' } );
+	const params = { group: 'wpcom_messaging', environment: 'production' };
+	const wpcomParams = new URLSearchParams( params );
 	return canAccessWpcomApis()
 		? ( ( await wpcomRequest( {
 				path: '/help/messaging/is-available',
-				query: params.toString(),
+				query: wpcomParams.toString(),
 				apiNamespace: 'wpcom/v2',
 				apiVersion: '2',
 				method: 'GET',
 		  } ) ) as MessagingAvailability )
 		: ( ( await apiFetch( {
-				path: '/help-center/support-availability/messaging',
-				query: params.toString(),
+				path: addQueryArgs( '/help-center/support-availability/messaging', params ),
 				method: 'GET',
 				global: true,
 		  } as APIFetchOptions ) ) as MessagingAvailability );

--- a/packages/help-center/src/hooks/use-messaging-availability.ts
+++ b/packages/help-center/src/hooks/use-messaging-availability.ts
@@ -19,7 +19,7 @@ async function requestMessagingAvailability() {
 				method: 'GET',
 		  } ) ) as MessagingAvailability )
 		: ( ( await apiFetch( {
-				path: '/help-center/messaging/is-available',
+				path: '/help-center/support-availability/messaging',
 				query: params.toString(),
 				method: 'GET',
 				global: true,

--- a/packages/help-center/src/hooks/use-messaging-availability.ts
+++ b/packages/help-center/src/hooks/use-messaging-availability.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import type { MessagingAvailability } from '../types';
+
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
+
+async function requestMessagingAvailability() {
+	// TODO: use correct group
+	const params = new URLSearchParams( { group: 'wpcom_presales', environment: 'production' } );
+	return canAccessWpcomApis()
+		? ( ( await wpcomRequest( {
+				path: '/help/messaging/is-available',
+				query: params.toString(),
+				apiNamespace: 'wpcom/v2',
+				apiVersion: '2',
+				method: 'GET',
+		  } ) ) as MessagingAvailability )
+		: ( ( await apiFetch( {
+				path: '/help-center/messaging/is-available',
+				query: params.toString(),
+				method: 'GET',
+				global: true,
+		  } as APIFetchOptions ) ) as MessagingAvailability );
+}
+
+export default function useMessagingAvailability( enabled = true ) {
+	return useQuery< MessagingAvailability >(
+		[ 'getMessagingAvailability' ],
+		requestMessagingAvailability,
+		{
+			staleTime: 60 * 1000, // 1 minute
+			meta: {
+				persist: false,
+			},
+			enabled,
+		}
+	);
+}

--- a/packages/help-center/src/hooks/use-messaging-availability.ts
+++ b/packages/help-center/src/hooks/use-messaging-availability.ts
@@ -10,7 +10,7 @@ interface APIFetchOptions {
 	path: string;
 }
 
-async function requestMessagingAvailability() {
+function requestMessagingAvailability() {
 	const currentEnvironment = config( 'env_id' );
 	const params = {
 		group: 'wpcom_messaging',
@@ -18,18 +18,18 @@ async function requestMessagingAvailability() {
 	};
 	const wpcomParams = new URLSearchParams( params );
 	return canAccessWpcomApis()
-		? ( ( await wpcomRequest( {
+		? wpcomRequest< MessagingAvailability >( {
 				path: '/help/messaging/is-available',
 				query: wpcomParams.toString(),
 				apiNamespace: 'wpcom/v2',
 				apiVersion: '2',
 				method: 'GET',
-		  } ) ) as MessagingAvailability )
-		: ( ( await apiFetch( {
+		  } )
+		: apiFetch< MessagingAvailability >( {
 				path: addQueryArgs( '/help-center/support-availability/messaging', params ),
 				method: 'GET',
 				global: true,
-		  } as APIFetchOptions ) ) as MessagingAvailability );
+		  } as APIFetchOptions );
 }
 
 export default function useMessagingAvailability( enabled = true ) {

--- a/packages/help-center/src/hooks/use-messaging-availability.ts
+++ b/packages/help-center/src/hooks/use-messaging-availability.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
@@ -10,7 +11,11 @@ interface APIFetchOptions {
 }
 
 async function requestMessagingAvailability() {
-	const params = { group: 'wpcom_messaging', environment: 'production' };
+	const currentEnvironment = config( 'env_id' );
+	const params = {
+		group: 'wpcom_messaging',
+		environment: currentEnvironment === 'development' ? 'development' : 'production',
+	};
 	const wpcomParams = new URLSearchParams( params );
 	return canAccessWpcomApis()
 		? ( ( await wpcomRequest( {

--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -1,22 +1,16 @@
 import { useSupportAvailability } from '@automattic/data-stores';
-import { useHappychatAvailable } from '@automattic/happychat-connection';
+import useMessagingAvailability from './use-messaging-availability';
 
 type Result = {
 	render: boolean;
 	state: 'AVAILABLE' | 'UNAVAILABLE' | 'CLOSED';
 	isLoading: boolean;
 	eligible: boolean;
-	env?: 'staging' | 'production';
 };
 
 export function useShouldRenderChatOption(): Result {
 	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
-	// when the user is looking at the help page, we want to be extra sure they don't start a chat without available operators
-	// so in this case, let's make stale time 1 minute.
-	const { data, isLoading } = useHappychatAvailable(
-		Boolean( chatStatus?.is_user_eligible ),
-		60 * 1000
-	);
+	const { data, isLoading } = useMessagingAvailability( Boolean( chatStatus?.is_user_eligible ) );
 
 	if ( ! chatStatus?.is_user_eligible ) {
 		return {
@@ -24,7 +18,6 @@ export function useShouldRenderChatOption(): Result {
 			isLoading,
 			state: chatStatus?.is_chat_closed ? 'CLOSED' : 'UNAVAILABLE',
 			eligible: false,
-			env: data?.env,
 		};
 	} else if ( chatStatus?.is_chat_closed ) {
 		return {
@@ -32,15 +25,13 @@ export function useShouldRenderChatOption(): Result {
 			state: 'CLOSED',
 			isLoading,
 			eligible: true,
-			env: data?.env,
 		};
-	} else if ( data?.available ) {
+	} else if ( data?.is_available ) {
 		return {
 			render: true,
 			state: 'AVAILABLE',
 			isLoading,
 			eligible: true,
-			env: data.env,
 		};
 	}
 	return {
@@ -48,6 +39,5 @@ export function useShouldRenderChatOption(): Result {
 		state: 'UNAVAILABLE',
 		isLoading,
 		eligible: true,
-		env: data?.env,
 	};
 }

--- a/packages/help-center/src/hooks/use-zendesk-config.ts
+++ b/packages/help-center/src/hooks/use-zendesk-config.ts
@@ -5,9 +5,12 @@ function requestZendeskConfig() {
 }
 
 export default function useZendeskConfig( enabled: boolean ) {
-	return useQuery< Response >( [ 'getZendeskConfig' ], requestZendeskConfig, {
+	return useQuery( [ 'getZendeskConfig' ], requestZendeskConfig, {
 		staleTime: Infinity,
 		retry: false,
+		refetchOnMount: false,
+		retryOnMount: false,
+		refetchOnWindowFocus: false,
 		meta: {
 			persist: false,
 		},

--- a/packages/help-center/src/hooks/use-zendesk-config.ts
+++ b/packages/help-center/src/hooks/use-zendesk-config.ts
@@ -6,12 +6,13 @@ async function requestZendeskConfig() {
 	} );
 }
 
-export default function useZendeskConfig() {
+export default function useZendeskConfig( enabled: boolean ) {
 	return useQuery< Response >( [ 'getZendeskConfig' ], requestZendeskConfig, {
 		staleTime: Infinity,
 		retry: false,
 		meta: {
 			persist: false,
 		},
+		enabled,
 	} );
 }

--- a/packages/help-center/src/hooks/use-zendesk-config.ts
+++ b/packages/help-center/src/hooks/use-zendesk-config.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+
+async function requestZendeskConfig() {
+	return await window.fetch( 'https://wpcom.zendesk.com/embeddable/config', {
+		method: 'GET',
+	} );
+}
+
+export default function useZendeskConfig() {
+	return useQuery< Response >( [ 'getZendeskConfig' ], requestZendeskConfig, {
+		staleTime: Infinity,
+		retry: false,
+		meta: {
+			persist: false,
+		},
+	} );
+}

--- a/packages/help-center/src/hooks/use-zendesk-config.ts
+++ b/packages/help-center/src/hooks/use-zendesk-config.ts
@@ -1,9 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
-async function requestZendeskConfig() {
-	return await window.fetch( 'https://wpcom.zendesk.com/embeddable/config', {
-		method: 'GET',
-	} );
+function requestZendeskConfig() {
+	return window.fetch( 'https://wpcom.zendesk.com/embeddable/config' );
 }
 
 export default function useZendeskConfig( enabled: boolean ) {

--- a/packages/help-center/src/index.ts
+++ b/packages/help-center/src/index.ts
@@ -4,7 +4,6 @@ export { SuccessIcon } from './components/success-icon';
 export { SuccessScreen } from './components/ticket-success-screen';
 export { BackButton } from './components/back-button';
 export { HelpCenterContactForm } from './components/help-center-contact-form';
-export { useHCWindowCommunicator } from './happychat-window-communicator';
 export { default as Mail } from './icons/mail';
 export { default as NewReleases } from './icons/new-releases';
 export * from './support-variations';

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -59,3 +59,13 @@ export interface SupportTicket {
 	url: string;
 	when: string;
 }
+
+export interface MessagingAuth {
+	user: {
+		jwt: string;
+	};
+}
+
+export interface MessagingAvailability {
+	is_available: boolean;
+}


### PR DESCRIPTION
Well, this one is a doozy.

We're switching from Happy Chat to Zendesk Messaging for live chat support. This PR is big, but it's also the smallest I could get given the scope of the project. Any cleanup of Happy Chat code, old contact forms, etc. will be done as a follow-up. I want to keep this PR as easy to revert as possible if needed.

## Proposed Changes

* Disable Happy Chat feature flag and any availability checks that trigger connections to the websocket.
* Load the Zendesk Messaging script instead.
* Authenticate using already established endpoint (just with `type=zendesk`).
* Check availability using the `/help/messaging/is-available` endpoint.
* Pass the initial chat data using Zendesk user fields.
* Use the support history to figure out if the user has ongoing conversations or not (thankfully, a Messaging conversation is a "ticket"!).
* Additionally, make sure the Zendesk launcher is visible if any unread messages are reported by Zendesk's APIs directly. This is a good safeguard and makes it more dynamic.
* If the browser is blocking requests to Zendesk, show a notice and link to relevant support doc.

## Testing Instructions

The live chat support flow should feel the same up to the point where you click the chat CTA (`Chat with us`/`Still chat with us`). At that point, the Help Center should get hidden, while the Zendesk launch and widget should become visible.

<img width="558" alt="Screenshot 2023-05-16 at 19 05 25" src="https://github.com/Automattic/wp-calypso/assets/3392497/ad8af6a2-0bd5-4aa5-b3ea-3c34060b85c9">

Trying to show the Help Center should automatically minimize the Zendesk widget, to avoid clutter and confusing UI. The Zendesk launcher remains visible, so the user can come back to the conversation at any time.

If you have Enhanced Tracking Protection (or similar strict privacy settings and/or ad-blockers), you will see this notice when choosing the Live Chat support option:
<img width="432" alt="Screenshot 2023-05-16 at 19 07 32" src="https://github.com/Automattic/wp-calypso/assets/3392497/53281511-d24d-4ed0-9a5e-878acef9a7a3">

Other support options should not show this notice, of course.

Verify that the Zendesk widget follows you on different paths in Calypso. Where Help Center is, the widget should also be there.

If you have an active, ongoing conversation, it should be detected and on refreshes the launcher should appear. If new messages arrive, it will be reflected with a count/notification on the launcher as well.

<img width="265" alt="Screenshot 2023-05-16 at 17 41 35" src="https://github.com/Automattic/wp-calypso/assets/3392497/6c7a1738-88fd-4613-9fed-7624eb9d0995">

Verify these behaviors in different environments that Help Center has to work in:
 - Simple sites
 - Atomic sites
 - Editor

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
