### PR TITLE
Update the Hosting Configuration upsell for eCommerce trials

### DIFF
--- a/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
+++ b/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
@@ -1,4 +1,4 @@
-import { FEATURE_SFTP, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { FEATURE_SFTP, PLAN_BUSINESS, WPCOM_PLANS } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -8,6 +8,8 @@ import iconDatabase from './icons/icon-database.svg';
 import iconServerRacks from './icons/icon-server-racks.svg';
 import iconSSH from './icons/icon-ssh.svg';
 import iconTerminal from './icons/icon-terminal.svg';
+import type { TranslateResult } from 'i18n-calypso';
+
 import './style.scss';
 
 interface FeatureListItem {
@@ -16,21 +18,44 @@ interface FeatureListItem {
 	icon: string;
 }
 
-export function HostingUpsellNudge( { siteId }: { siteId: number | null } ) {
+interface HostingUpsellNudgeTargetPlan {
+	callToAction: TranslateResult;
+	feature?: string;
+	href: string;
+	plan?: typeof WPCOM_PLANS;
+	title: TranslateResult;
+}
+
+interface HostingUpsellNudgeProps {
+	siteId: number | null;
+	targetPlan?: HostingUpsellNudgeTargetPlan;
+}
+
+export function HostingUpsellNudge( { siteId, targetPlan }: HostingUpsellNudgeProps ) {
 	const translate = useTranslate();
 
 	const features = useFeatureList();
+
+	const callToAction = targetPlan
+		? targetPlan.callToAction
+		: translate( 'Upgrade to Business Plan' );
+	const feature = targetPlan ? targetPlan.feature : FEATURE_SFTP;
+	const href = targetPlan ? targetPlan.href : `/checkout/${ siteId }/business`;
+	const plan = targetPlan ? targetPlan.plan : PLAN_BUSINESS;
+	const title = targetPlan
+		? targetPlan.title
+		: translate( 'Upgrade to the Business plan to access all hosting features:' );
 
 	return (
 		<UpsellNudge
 			className="hosting-upsell-nudge"
 			compactButton={ false }
-			title={ translate( 'Upgrade to the Business plan to access all hosting features:' ) }
+			title={ title }
 			event="calypso_hosting_configuration_upgrade_click"
-			href={ `/checkout/${ siteId }/business` }
-			callToAction={ translate( 'Upgrade to Business Plan' ) }
-			plan={ PLAN_BUSINESS }
-			feature={ FEATURE_SFTP }
+			href={ href }
+			callToAction={ callToAction }
+			plan={ plan }
+			feature={ feature }
 			showIcon={ true }
 			list={ features }
 			renderListItem={ ( { icon, title, description }: FeatureListItem ) => (

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -8,7 +8,6 @@ import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
-import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
@@ -97,20 +96,17 @@ class Hosting extends Component {
 		} = this.props;
 
 		const getUpgradeBanner = () => {
-			//eCommerce Trial requires different wording because Business is not the obvious upgrade path
-			if ( isECommerceTrial ) {
-				return (
-					<UpsellNudge
-						title={ translate( 'Upgrade your plan to access all hosting features' ) }
-						event="calypso_hosting_configuration_upgrade_click"
-						href={ `/plans/${ siteSlug }?feature=${ encodeURIComponent( FEATURE_SFTP_DATABASE ) }` }
-						feature={ FEATURE_SFTP_DATABASE }
-						showIcon={ true }
-					/>
-				);
-			}
+			// The eCommerce Trial requires a different upsell path.
+			const targetPlan = ! isECommerceTrial
+				? undefined
+				: {
+						callToAction: translate( 'Upgrade your plan' ),
+						feature: FEATURE_SFTP_DATABASE,
+						href: `/plans/${ siteSlug }?feature=${ encodeURIComponent( FEATURE_SFTP_DATABASE ) }`,
+						title: translate( 'Upgrade your plan to access all hosting features' ),
+				  };
 
-			return <HostingUpsellNudge siteId={ siteId } />;
+			return <HostingUpsellNudge siteId={ siteId } targetPlan={ targetPlan } />;
 		};
 
 		const getAtomicActivationNotice = () => {


### PR DESCRIPTION
Related to #76667 - this PR breaks out one aspect of that larger exploration into improvements for the Hosting Configuration page.

## Proposed Changes

This PR makes two closely related changes:
* The `HostingUpsellNudge` component used by the Hosting Configuration page now accepts a new `targetPlan` prop that allows for various properties of the upsell content to be passed in, specifically the `callToAction`, `feature`, `href`, `plan`, and `title` props of the underlying `UpsellNudge` component
* The main Hosting Configuration page at `/hosting-config/:siteSlug` will now show the standard nudge that describes all the hosting features for eCommerce trial sites, with props that otherwise match the more anaemic upsell we were showing before this change.

### Screenshots

#### Before

<img width="1421" alt="Screenshot 2023-05-10 at 21 20 35" src="https://github.com/Automattic/wp-calypso/assets/3376401/e6a7fe4c-34b2-475d-865f-f92deabf5c78">

#### After 

<img width="1421" alt="Screenshot 2023-05-10 at 21 20 09" src="https://github.com/Automattic/wp-calypso/assets/3376401/49d999a8-f849-4273-869f-ad5565b28d47">

## Testing Instructions

* Run this branch locally or via [the Calypso.live branch](https://github.com/Automattic/wp-calypso/pull/76783#issuecomment-1542699933)
* For a WPCOM Simple site that is either free or has a plan that doesn't allow the site to go Atomic, navigate to _Settings_ -> _Hosting Configuration_
* Verify that the upsell nudge includes the header text "Upgrade to the Business plan to access all hosting features:" and a CTA of "Upgrade to Business Plan", where the CTA points to `/checkout/:siteId/business`
* For a site with an active Woo Express trial (aka eCommerce trial), navigate to _Settings_ -> _Hosting Configuration_
  - If you don't have such a site, you can create one by visiting `/setup/wooexpress`
* Verify that you see the full upsell nudge content for the trial, with the card title of "Upgrade your plan to access all hosting features" and a CTA of "Upgrade your plan".
* Click on the "Upgrade your plan" CTA.
* Verify that you are taken to `/plans/:siteSlug` and are shown the Woo Express plans

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?