### PR TITLE
Blog onboarding: redirecting user back to start-writing Launchpad if it's incomplete

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -160,6 +160,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		}
 
 		return {
+			siteId: site?.siteId,
 			siteSlug: site?.siteSlug,
 			goToCheckout: Boolean( planCartItem ),
 		};

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -1,6 +1,6 @@
 import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
-import { START_WRITING_FLOW, WRITE_FLOW, replaceProductsInCart } from '@automattic/onboarding';
+import { START_WRITING_FLOW, replaceProductsInCart } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useSelector } from 'react-redux';
@@ -81,8 +81,7 @@ const startWriting: Flow = {
 						} );
 
 						setSelectedSite( providedDependencies?.siteId );
-						// TODO: Replace to START_WRITING_FLOW once it's available in our backend code.
-						setIntentOnSite( providedDependencies?.siteSlug, WRITE_FLOW );
+						setIntentOnSite( providedDependencies?.siteSlug, START_WRITING_FLOW );
 						saveSiteSettings( providedDependencies?.siteId, {
 							launchpad_screen: 'full',
 						} );

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -1,8 +1,8 @@
 import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
-import { START_WRITING_FLOW, replaceProductsInCart } from '@automattic/onboarding';
+import { START_WRITING_FLOW, WRITE_FLOW, replaceProductsInCart } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useSelector } from 'react-redux';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
@@ -13,7 +13,7 @@ import {
 	ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const startWriting: Flow = {
@@ -63,6 +63,8 @@ const startWriting: Flow = {
 			} ),
 			[]
 		);
+		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
+		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );
@@ -76,6 +78,13 @@ const startWriting: Flow = {
 					if ( ! providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
 						await updateLaunchpadSettings( String( providedDependencies?.siteSlug ), {
 							checklist_statuses: { first_post_published: true },
+						} );
+
+						setSelectedSite( providedDependencies?.siteId );
+						// TODO: Replace to START_WRITING_FLOW once it's available in our backend code.
+						setIntentOnSite( providedDependencies?.siteSlug, WRITE_FLOW );
+						saveSiteSettings( providedDependencies?.siteId, {
+							launchpad_screen: 'full',
 						} );
 
 						const siteOrigin = window.location.origin;

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -62,9 +62,7 @@ export async function maybeRedirect( context, next ) {
 			// client-side router, so page.redirect won't work. We need to use the
 			// traditional window.location Web API.
 			const verifiedParam = getQueryArgs()?.verified;
-			// TODO: replace start-writing for siteIntentOption once it's available in our backend and
-			// we have it in setIntentOnSite( providedDependencies?.siteSlug, START_WRITING_FLOW );
-			redirectToLaunchpad( slug, 'start-writing', verifiedParam );
+			redirectToLaunchpad( slug, siteIntentOption, verifiedParam );
 			return;
 		}
 	} catch ( error ) {}

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -62,7 +62,9 @@ export async function maybeRedirect( context, next ) {
 			// client-side router, so page.redirect won't work. We need to use the
 			// traditional window.location Web API.
 			const verifiedParam = getQueryArgs()?.verified;
-			redirectToLaunchpad( slug, siteIntentOption, verifiedParam );
+			// TODO: replace start-writing for siteIntentOption once it's available in our backend and
+			// we have it in setIntentOnSite( providedDependencies?.siteSlug, START_WRITING_FLOW );
+			redirectToLaunchpad( slug, 'start-writing', verifiedParam );
 			return;
 		}
 	} catch ( error ) {}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2412-gh-Automattic/dotcom-forge

## Proposed Changes

* Redirect user back to start-writing Launchpad if the flow is incomplete

https://github.com/Automattic/wp-calypso/assets/1044309/1402bd14-0cca-4dd1-98e8-669481341849


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this jetpack code in your sandbox: https://github.com/Automattic/jetpack/pull/30369
* From a new user or a user without any site, access: http://calypso.localhost:3000/setup/start-writing
* After publishing the blog post, try to access http://calypso.localhost:3000/ and note you'll be redirected back to the Launchpad


**Note**: selecting a plan stopped to work after the previous refactors on the Launchpad. Fixing that is not part of this PR's scope.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?