### PR TITLE
Earn: Add max height and scroll to subscriber list

### DIFF
--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -20,6 +20,22 @@
 	width: auto;
 }
 
+.memberships__module-content {
+	max-height: 560px;
+	overflow-y: scroll;
+}
+
+.memberships__module-content::-webkit-scrollbar {
+	-webkit-appearance: none;
+	width: 7px;
+}
+
+.memberships__module-content::-webkit-scrollbar-thumb {
+	border-radius: 4px;
+	background-color: rgba(0, 0, 0, 0.5);
+	-webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+}
+
 .memberships__onboarding-wrapper {
 	display: flex;
 	flex-direction: row;

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -21,19 +21,10 @@
 }
 
 .memberships__module-content {
-	max-height: 560px;
+	max-height: 520px;
 	overflow-y: scroll;
-}
-
-.memberships__module-content::-webkit-scrollbar {
-	-webkit-appearance: none;
-	width: 7px;
-}
-
-.memberships__module-content::-webkit-scrollbar-thumb {
-	border-radius: 4px;
-	background-color: rgba(0, 0, 0, 0.5);
-	-webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+	margin-top: -24px;
+	border-bottom: 1px solid var(--color-neutral-5);
 }
 
 .memberships__onboarding-wrapper {


### PR DESCRIPTION
Resolves 30-gh-Automattic/gold

### Proposed Changes

On the Tools > Earn page, if you have a long list of subscribers, we show all of them. This PR applies a max height and scroll bar. I've implemented a simple version and this may need more design input. The scroll bar is not highly visible, and on Firefox, does not show at all until you start scrolling.

**Before**
<img width="365" alt="subscribers 1" src="https://github.com/Automattic/wp-calypso/assets/21228350/65082584-edbc-41d3-a988-7abf944ef0ec">

**After**
<img width="902" alt="subscribers 2" src="https://github.com/Automattic/wp-calypso/assets/21228350/66ac377a-fd5b-4225-862e-cd484aa01d14">

### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. You will need a test site with Stripe connected. 
2. Check out this branch and run yarn and yarn start if needed.
3. Go to http://calypso.localhost:3000/earn/payments/YOURDOMAIN
4. You will need to have a list of subscribers. If you don't already have a site with many subscribers, here is a way to mimic the html: 
   - Right click on Customers and Subscribers box and click to Inspect to open dev tools. 
   - Find the `<div class=card>` element, right click on it, and select Edit as Html
   - Delete the entire card div. 
   - In it's place, paste and apply the markup from this gist: https://gist.github.com/edanzer/b9ddb80d438fbfeedba332e72e7a7b37
   

https://github.com/Automattic/wp-calypso/assets/21228350/f4abdfa2-7757-4abc-8bcf-101ad65ff50a


5. Confirm that the Customers and Subscribers list loads like the **After** image above. 
   - If you want to compare before after, you can replace http://calypso.localhost:3000 with https://wordpress.com

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?