### PR TITLE
Checkout: hide Jetpack 14-day refund copy below CTA on onboarding flow

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -24,7 +24,6 @@ import {
 	CheckoutFormSubmit,
 	PaymentMethodStep,
 } from '@automattic/composite-checkout';
-import { isHostingFlow } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -48,7 +47,6 @@ import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkou
 import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/leave-checkout';
 import { prepareDomainContactValidationRequest } from 'calypso/my-sites/checkout/composite-checkout/types/wpcom-store-state';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { saveContactDetailsCache } from 'calypso/state/domains/management/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
@@ -633,9 +631,7 @@ const SubmitButtonFooter = () => {
 		isJetpackPurchasableItem( product.product_slug )
 	);
 
-	const signupFlowName = getSignupCompleteFlowName();
-
-	if ( ! hasCartJetpackProductsOnly && ! isHostingFlow( signupFlowName ) ) {
+	if ( ! hasCartJetpackProductsOnly ) {
 		return null;
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/76717. See p1683625556906589-slack-C04H4NY6STW.

## Proposed Changes

Since the copy below the CTA didn't provide the expected impact (pet6gk-qP-p2) and it's causing some issues (https://github.com/Automattic/wp-calypso/pull/76717, https://github.com/Automattic/wp-calypso/pull/76717#issuecomment-1541395642), let's hide it on `/start/hosting`.

## Testing Instructions

1. Browse `/start/hosting`;
2. Proceed to checkout;
3. Verify the "14 day refund guarantee" copy is not displayed below the "Pay X CTA".