### PR TITLE
Storybook: Restore ability to boot stories only from packages/components

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,8 +5,8 @@ const storybookDefaultConfig = require( '@automattic/calypso-storybook' );
 const storybookConfig = storybookDefaultConfig( {
 	stories: [
 		'../client/**/*.stories.{ts,tsx}',
-		'../packages/design-picker/**/*.stories.{ts,tsx}',
-		'../packages/components/**/*.stories.{ts,tsx}',
+		'../packages/design-picker/src/**/*.stories.{ts,tsx}',
+		'../packages/components/src/**/*.stories.{js,jsx,ts,tsx}',
 	],
 } );
 

--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -1,0 +1,1 @@
+module.exports = require( '@automattic/calypso-storybook' )();

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -41,4 +41,6 @@ in the root of the repository to get the required `devDependencies`.
 
 ### Using [Storybook](https://storybook.js.org/)
 
-In the root of the repository, run `yarn storybook:start`.
+To see stories within this package, run `yarn workspace @automattic/components run start-storybook`.
+
+To see all stories within this repository, run `yarn storybook:start` at the root of the repository.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,6 +52,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",
+		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@storybook/addon-actions": "^6.4.19",
 		"@storybook/react": "^6.4.18",

--- a/packages/components/src/app-promo-card/stories/index.stories.jsx
+++ b/packages/components/src/app-promo-card/stories/index.stories.jsx
@@ -2,7 +2,7 @@ import AppPromoCard from '..';
 
 export default {
 	component: AppPromoCard,
-	title: 'App Promo Card',
+	title: 'packages/components/App Promo Card',
 };
 
 const Template = ( args ) => <AppPromoCard { ...args } />;

--- a/packages/components/src/button/index.stories.jsx
+++ b/packages/components/src/button/index.stories.jsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions';
 import Button from '.';
 import './stories.scss';
 
-export default { title: 'Button' };
+export default { title: 'packages/components/Button' };
 
 const helloWorld = `Hello World!`;
 const handleClick = action( 'click' );

--- a/packages/components/src/component-swapper/stories/index.stories.jsx
+++ b/packages/components/src/component-swapper/stories/index.stories.jsx
@@ -1,7 +1,7 @@
 import ComponentSwapper from '../.';
 import { Button } from '../../.';
 
-export default { title: 'Component swapper' };
+export default { title: 'packages/components/Component swapper' };
 
 const ComponentSwapperVariations = () => {
 	return (

--- a/packages/components/src/dialog/index.stories.jsx
+++ b/packages/components/src/dialog/index.stories.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import Dialog from '.';
 
-export default { title: 'Dialog' };
+export default { title: 'packages/components/Dialog' };
 
 export const Default = () => {
 	const [ isVisible, setVisible ] = useState( false );

--- a/packages/components/src/highlight-cards/stories/card.stories.jsx
+++ b/packages/components/src/highlight-cards/stories/card.stories.jsx
@@ -2,7 +2,7 @@ import { Icon, institution } from '@wordpress/icons';
 import BaseCard from '../base-card';
 import CountCard from '../count-card';
 
-export default { title: 'Highlight Card' };
+export default { title: 'packages/components/Highlight Card' };
 
 export const BaseCard_ = () => (
 	<>

--- a/packages/components/src/highlight-cards/stories/cards.stories.jsx
+++ b/packages/components/src/highlight-cards/stories/cards.stories.jsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions';
 import AnnualCards from '../annual-highlight-cards';
 import WeeklyCards from '../weekly-highlight-cards';
 
-export default { title: 'Highlight Cards' };
+export default { title: 'packages/components/Highlight Cards' };
 
 const handleClick = action( 'click' );
 

--- a/packages/components/src/horizontal-bar-list/stories/index.stories.jsx
+++ b/packages/components/src/horizontal-bar-list/stories/index.stories.jsx
@@ -5,7 +5,7 @@ import HorizontalBarListItem from '../horizontal-bar-grid-item';
 import StatsCard from '../stats-card';
 import './stories.scss';
 
-export default { title: 'Horizontal bar list' };
+export default { title: 'packages/components/Horizontal bar list' };
 
 const handleClick = action( 'click' );
 

--- a/packages/components/src/icons/stories/index.stories.jsx
+++ b/packages/components/src/icons/stories/index.stories.jsx
@@ -2,7 +2,7 @@ import { Icon } from '@wordpress/icons';
 import blaze from '../blaze';
 import eye from '../eye';
 
-export default { title: 'Icons' };
+export default { title: 'packages/components/Icons' };
 
 export const Default = () => (
 	<div className="icons-story">

--- a/packages/components/src/notice-banner/notice-banner.stories.jsx
+++ b/packages/components/src/notice-banner/notice-banner.stories.jsx
@@ -3,7 +3,7 @@ import Button from '../button';
 import NoticeBanner from './index';
 
 export default {
-	title: 'Notice Banner',
+	title: 'packages/components/Notice Banner',
 	component: NoticeBanner,
 	argTypes: {
 		level: {

--- a/packages/components/src/number-formatters/stories/index.stories.jsx
+++ b/packages/components/src/number-formatters/stories/index.stories.jsx
@@ -1,7 +1,7 @@
 import ShortenedNumber from '..';
 import formattedNumber from '../formatted-number';
 
-export default { title: 'Shortened Number' };
+export default { title: 'packages/components/Shortened Number' };
 
 const ShortenedNumberExample = ( { value } ) => (
 	<p>

--- a/packages/components/src/post-stats-card/stories/index.stories.jsx
+++ b/packages/components/src/post-stats-card/stories/index.stories.jsx
@@ -1,6 +1,6 @@
 import PostStatsCard from '../';
 
-export default { title: 'Post Stats Card' };
+export default { title: 'packages/components/Post Stats Card' };
 
 const PostStatsCardVariations = ( props ) => (
 	<PostStatsCard

--- a/packages/components/src/product-icon/index.stories.jsx
+++ b/packages/components/src/product-icon/index.stories.jsx
@@ -4,15 +4,15 @@ import ProductIcon from '.';
 
 const supportedSlugs = Object.values( iconToProductSlugMap ).flat();
 
-export default { title: 'ProductIcon' };
+export default { title: 'packages/components/ProductIcon' };
 
 export const Default = () => {
 	return (
 		<>
 			{ supportedSlugs.map( ( slug ) => (
-				<div className="index.stories__icon-tile">
-					<ProductIcon slug={ slug } className="index.stories__icon-image" />
-					<pre className="index.stories__icon-slug">{ slug }</pre>
+				<div className="product-icon-stories__icon-tile">
+					<ProductIcon slug={ slug } className="product-icon-stories__icon-image" />
+					<pre className="product-icon-stories__icon-slug">{ slug }</pre>
 				</div>
 			) ) }
 		</>

--- a/packages/components/src/product-icon/index.stories.scss
+++ b/packages/components/src/product-icon/index.stories.scss
@@ -1,5 +1,5 @@
 
-.index\.stories {
+.product-icon-stories {
 
 	&__icon-tile {
 		display: inline-flex;

--- a/packages/components/src/screen-reader-text/index.stories.jsx
+++ b/packages/components/src/screen-reader-text/index.stories.jsx
@@ -1,6 +1,6 @@
 import ScreenReaderText from '.';
 
-export default { title: 'ScreenReaderText' };
+export default { title: 'packages/components/ScreenReaderText' };
 
 export const Default = () => {
 	return <ScreenReaderText>Important information to convey</ScreenReaderText>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,6 +418,7 @@ __metadata:
   resolution: "@automattic/components@workspace:packages/components"
   dependencies:
     "@automattic/calypso-color-schemes": "workspace:^"
+    "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
     "@automattic/data-stores": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76007.

## Proposed Changes

* Updates repository storybook configuration to include JS & JSX stories from the components package.
* Updates story titles for JS/JSX stories from the components package.
* Restores standalone storybook functionality for `@automattic/components`.

My reason for restoring the components package's storybook functionality is simple: It boots much more quickly than the repository-wide storybook. @Automattic/red frequently works on components within `@automattic/components` and would benefit from this quicker boot time. See these two screenshots:

Repository-wide|Components Package
-|-
![SCR-20230510-m1w](https://github.com/Automattic/wp-calypso/assets/4044428/6b9ea7e2-bd6e-4ed6-ba38-a6d6a5563f4b)|![SCR-20230510-m23](https://github.com/Automattic/wp-calypso/assets/4044428/5dcb9214-a0c1-4486-ad80-2ddc20f14545)
**215s** to boot|**15.7s** to boot

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Repository-wide Storybook
* Boot the repo-wide storybook via `yarn storybook:start`.
* Ensure that all stories, including previously excluded ones like the "Component swapper", work as expected.

### Components Package Storybook
* Boot the components package storybook via `yarn workspace @automattic/components run start-storybook`
* Ensure that all stories for the components package work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?