### PR TITLE
`/subscriptions`: Handle negative dates in subscription management.

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -56,7 +56,12 @@ const CommentRow = ( {
 					</span>
 				</a>
 				<span className="date" role="cell">
-					<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
+					<TimeSince
+						date={
+							( date_subscribed.valueOf() ? date_subscribed : new Date( 0 ) ).toISOString?.() ??
+							date_subscribed
+						}
+					/>
 				</span>
 				<span className="actions" role="cell">
 					<CommentSettings

--- a/client/landing/subscriptions/components/pending-list/pending-post-list/pending-post-row.tsx
+++ b/client/landing/subscriptions/components/pending-list/pending-post-list/pending-post-row.tsx
@@ -49,7 +49,12 @@ export default function PendingPostRow( {
 					</span>
 				</a>
 				<span className="date" role="cell">
-					<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
+					<TimeSince
+						date={
+							( date_subscribed.valueOf() ? date_subscribed : new Date( 0 ) ).toISOString?.() ??
+							date_subscribed
+						}
+					/>
 				</span>
 				<span className="actions" role="cell">
 					<PendingPostSettings

--- a/client/landing/subscriptions/components/pending-list/pending-site-list/pending-site-row.tsx
+++ b/client/landing/subscriptions/components/pending-list/pending-site-list/pending-site-row.tsx
@@ -38,7 +38,12 @@ export default function PendingSiteRow( {
 				</span>
 			</a>
 			<span className="date" role="cell">
-				<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
+				<TimeSince
+					date={
+						( date_subscribed.valueOf() ? date_subscribed : new Date( 0 ) ).toISOString?.() ??
+						date_subscribed
+					}
+				/>
 			</span>
 			<span className="actions" role="cell">
 				<PendingSiteSettings

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -98,7 +98,12 @@ export default function SiteRow( {
 				</span>
 			</a>
 			<span className="date" role="cell">
-				<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
+				<TimeSince
+					date={
+						( date_subscribed.valueOf() ? date_subscribed : new Date( 0 ) ).toISOString?.() ??
+						date_subscribed
+					}
+				/>
 			</span>
 			{ isLoggedIn && (
 				<span className="new-posts" role="cell">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1683747816367929-slack-C02DQP0FP

## Proposed Changes

Sometimes a negative date `-0001-11-30T00:00:00` may present itself which causes WSOD on Subscription Management page. This error should be fixed in the backend but for now a hotfix in Calypso is faster to get the page working while we see how to fix it in the backend and how many subscription entries yield negative dates.

## Testing Instructions

* Try manually replace the `date_subscribed` value with `-0001-11-30T00:00:00` in any of those files changed.
* It should not break.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?