### PR TITLE
Theme Showcase: Update theme card title overflow CSS

### DIFF
--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -1,5 +1,3 @@
-@import "@automattic/onboarding/styles/mixins";
-
 $theme-card-info-height: 48px;
 $theme-card-info-margin-top: 16px;
 
@@ -36,10 +34,6 @@ $theme-card-info-margin-top: 16px;
 
 		.theme-card__info-title {
 			color: var(--color-text-inverted);
-
-			&::before {
-				@include long-content-fade( $color: var( --color-primary-rgb ) );
-			}
 		}
 	}
 
@@ -271,10 +265,7 @@ $theme-card-info-margin-top: 16px;
 	overflow: hidden;
 	position: relative;
 	white-space: nowrap;
-
-	&::before {
-		@include long-content-fade();
-	}
+	width: 0;
 }
 
 .theme-card__info-pricing {


### PR DESCRIPTION
## Proposed Changes

This PR updates how theme card title handles overflow, since currently there's a visible white box visual glitch. Unfortunately, using linear-gradient to handle text overflow doesn't work great in this case since the background is not a sold color, but affected by the box-shadow of the theme thumbnail.

| Before | After |
| --- | --- |
| ![Screenshot 2023-05-11 at 10 25 26 AM](https://github.com/Automattic/wp-calypso/assets/797888/43332bad-d163-4e2f-b9df-b2f46be23e55) | ![Screenshot 2023-05-11 at 10 26 17 AM](https://github.com/Automattic/wp-calypso/assets/797888/def1f5e6-ead6-43e2-bd4e-f4f862d55ac8) |

This PR also fixes an issue where long titles would expand the theme card.

| Before | After |
| --- | --- |
| ![Screenshot 2023-05-11 at 10 29 47 AM](https://github.com/Automattic/wp-calypso/assets/797888/29c599c4-63f0-42d7-b120-001b6480ca11) | ![Screenshot 2023-05-11 at 10 30 23 AM](https://github.com/Automattic/wp-calypso/assets/797888/d86f51aa-1b74-49eb-92fc-5678a12f2542) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/site-setup?siteSlug=${site_slug}`.
* Continue until you land on the Onboarding Design Picker.
* Ensure that the white box is no longer there, and that the text overflow handling is as described above.
* Also test that the PR impacts the Theme Showcase in the same way.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
