### PR TITLE
Reader: adds view count, when available, to posts in feed

### DIFF
--- a/client/assets/images/icons/bar-chart.svg
+++ b/client/assets/images/icons/bar-chart.svg
@@ -1,0 +1,5 @@
+<svg id="bar-chart" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M15 16.6666V8.33325" stroke="#606A73" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="round"/>
+	<path d="M10 16.6666V3.33325" stroke="#606A73" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="round"/>
+	<path d="M5 16.6667V11.6667" stroke="#606A73" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="round"/>
+</svg>

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -6,6 +6,7 @@ import { shouldShowComments } from 'calypso/blocks/comments/helper';
 import PostEditButton from 'calypso/blocks/post-edit-button';
 import ShareButton from 'calypso/blocks/reader-share';
 import { shouldShowShare } from 'calypso/blocks/reader-share/helper';
+import ReaderViews from 'calypso/blocks/reader-views';
 import ReaderVisitLink from 'calypso/blocks/reader-visit-link';
 import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
 import ReaderFollowButton from 'calypso/reader/follow-button';
@@ -22,6 +23,7 @@ const ReaderPostActions = ( props ) => {
 		site,
 		onCommentClick,
 		showEdit,
+		showViews,
 		showVisit,
 		iconSize,
 		className,
@@ -54,6 +56,11 @@ const ReaderPostActions = ( props ) => {
 					>
 						{ translate( 'Visit' ) }
 					</ReaderVisitLink>
+				</li>
+			) }
+			{ showViews && (
+				<li className="reader-post-actions__item reader-post-actions__views">
+					<ReaderViews viewCount={ post.views } />
 				</li>
 			) }
 			{ showEdit && site && userCan( 'edit_post', post ) && (
@@ -114,6 +121,7 @@ ReaderPostActions.propTypes = {
 	site: PropTypes.object,
 	onCommentClick: PropTypes.func,
 	showEdit: PropTypes.bool,
+	showViews: PropTypes.bool,
 	iconSize: PropTypes.number,
 	visitUrl: PropTypes.string,
 	fullPost: PropTypes.bool,
@@ -121,6 +129,7 @@ ReaderPostActions.propTypes = {
 
 ReaderPostActions.defaultProps = {
 	showEdit: true,
+	showViews: false,
 	showVisit: false,
 	iconSize: 20,
 };

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -42,7 +42,10 @@ const ReaderPostActions = ( props ) => {
 		stats.recordPermalinkClick( 'card', post );
 	}
 
-	const listClassnames = classnames( 'reader-post-actions', className );
+	const listClassnames = classnames( className, {
+		'reader-post-actions': true,
+		'has-views': showViews,
+	} );
 
 	/* eslint-disable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
 	return (

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -15,14 +15,16 @@
 	margin-right: 24px;
 
 	&.reader-post-actions__visit {
-		flex: 1;
-
 		.reader-visit-link {
 			align-items: center;
 			box-sizing: border-box;
 			display: flex;
 			gap: 4px;
 		}
+	}
+
+	&.reader-post-actions__views {
+		flex: 1;
 	}
 
 	&:last-child {

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -10,6 +10,12 @@
 	margin: 10px 0 0;
 }
 
+.reader-post-actions:not(.has-views) .reader-post-actions__item {
+	&.reader-post-actions__visit {
+		flex: 1;
+	}
+}
+
 .reader-post-actions .reader-post-actions__item {
 	height: 20px;
 	margin-right: 24px;

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -180,6 +180,7 @@ class ReaderPostCard extends Component {
 				fullPost={ false }
 				onCommentClick={ onCommentClick }
 				showEdit={ false }
+				showViews={ ( post.views || 0 ) > 0 }
 				className="ignore-click"
 				iconSize={ 20 }
 			/>

--- a/client/blocks/reader-views/index.jsx
+++ b/client/blocks/reader-views/index.jsx
@@ -1,0 +1,14 @@
+import BarChart from 'calypso/assets/images/icons/bar-chart.svg';
+import SVGIcon from 'calypso/components/svg-icon';
+import './style.scss';
+
+const ReaderViews = ( { viewCount } ) => {
+	return (
+		<div className="reader-views">
+			<SVGIcon classes="reader-views__icon" name="bar-chart" size="24" icon={ BarChart } />
+			<span className="reader-views__view-count">{ viewCount }</span>
+		</div>
+	);
+};
+
+export default ReaderViews;

--- a/client/blocks/reader-views/style.scss
+++ b/client/blocks/reader-views/style.scss
@@ -1,0 +1,8 @@
+.reader-views {
+	display: flex;
+}
+
+.reader-views__view-count {
+	color: var(--color-text-subtle);
+	font-size: 0.875rem;
+}


### PR DESCRIPTION
## Proposed Changes

Adds a view count for each post in the reader feed, when available.

<img width="684" alt="Screenshot 2023-05-10 at 22 16 30" src="https://github.com/Automattic/wp-calypso/assets/1699996/00d1f637-0efd-46af-bcb1-eba4e03551fe">


## Testing Instructions

- Apply D110502-code and sandbox public-api site
- Load a feed in the reader (e.g. `/read`)
- You should see a view count at the bottom of each post card, when available.
