### PR TITLE
Update the subtitle of Gravatar's signup and login pages

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -415,7 +415,7 @@ class Login extends Component {
 				} );
 				postHeader = (
 					<p className="login__header-subtitle">
-						{ translate( 'Log in to your WordPress.com account' ) }
+						{ translate( 'Log in with your WordPress.com account' ) }
 					</p>
 				);
 			}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -232,10 +232,7 @@ export class UserStep extends Component {
 		if ( isReskinned && 0 === positionInFlow ) {
 			const { queryObject } = this.props;
 
-			if (
-				( queryObject?.variationName && isNewsletterFlow( queryObject.variationName ) ) ||
-				isGravatarOAuth2Client( oauth2Client )
-			) {
+			if ( queryObject?.variationName && isNewsletterFlow( queryObject.variationName ) ) {
 				subHeaderText = translate( 'Already have a WordPress.com account? {{a}}Log in{{/a}}', {
 					components: { a: <a href={ loginUrl } rel="noopener noreferrer" /> },
 				} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4H3ND-1uy-p2

## Proposed Changes

Adjust the subtitle of Gravatar's signup and login pages

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to the branch and run it locally (check [the doc](https://github.com/Automattic/wp-calypso#getting-started) to setup your dev environment)
* Log out of your WP account
* Go to the log-in page by [this URL](http://calypso.localhost:3000/log-in?client_id=1854&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3Dad4b462bedc61ff0ee2b72b16252632bcf4f4ec2e9aaab25a169e49d565e87bf%26redirect_uri%3Dhttps%253A%252F%252Fen.gravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1) (you might need to modify your origin), and you will see the subtitle has been updated as below:

| Before | After |
| - | - |
| <img width="1681" alt="login_0" src="https://github.com/Automattic/wp-calypso/assets/21308003/7e70af88-e6a9-46c9-945d-628f971689ca"> | <img width="1681" alt="login" src="https://github.com/Automattic/wp-calypso/assets/21308003/ec40dc14-95f0-4e4e-9a71-25a00606aed9"> |

* Go to the sign-up page by [this URL](http://calypso.localhost:3000/start/wpcc/oauth2-user?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4c419247334b07b3cb7adc7fbdfe0a723abe7296d6e38f19146f5353a3d88e69%26redirect_uri%3Dhttps%253A%252F%252Fen.gravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1&oauth2_client_id=1854) (you might need to modify your origin), and you will see the subtitle has been updated as below:

| Before | After |
| - | - |
| <img width="1681" alt="signup_0" src="https://github.com/Automattic/wp-calypso/assets/21308003/dce889ac-1df9-4caf-a52a-e1a5af3c9d76"> | <img width="1681" alt="signup" src="https://github.com/Automattic/wp-calypso/assets/21308003/253a6a3b-0f46-4787-9809-81f2d6962196"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
