### PR TITLE
Jetpack Pro Dashboard: Implement UI to verify the previously added email addresses later to the monitor notification settings

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/add-new-email-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/add-new-email-modal.tsx
@@ -2,36 +2,69 @@ import { Button } from '@automattic/components';
 import { Modal } from '@wordpress/components';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import type {
+	MonitorSettingsEmail,
+	AllowedMonitorContactActions,
+} from '../../sites-overview/types';
+interface StateEmailItem extends MonitorSettingsEmail {
+	checked: boolean;
+	isDefault?: boolean;
+}
 
-export default function AddNewEmailModal( { toggleModal }: { toggleModal: () => void } ) {
+interface Props {
+	toggleModal: () => void;
+	selectedEmail?: StateEmailItem;
+	selectedAction?: AllowedMonitorContactActions;
+}
+
+export default function AddNewEmailModal( {
+	toggleModal,
+	selectedEmail,
+	selectedAction = 'add',
+}: Props ) {
 	const translate = useTranslate();
 
 	const [ showCodeVerification, setShowCodeVerification ] = useState< boolean >( false );
 	const [ validationError, setValidationError ] = useState< string >( '' );
+	const [ emailItem, setEmailItem ] = useState< { name: string; email: string; code?: string } >( {
+		name: '',
+		email: '',
+		code: '',
+	} );
+
+	const isVerifyAction = selectedAction === 'verify';
+
+	useEffect( () => {
+		if ( isVerifyAction ) {
+			setShowCodeVerification( true );
+		}
+	}, [ isVerifyAction ] );
+
+	useEffect( () => {
+		if ( selectedEmail ) {
+			setEmailItem( { name: selectedEmail.name, email: selectedEmail.email } );
+		}
+	}, [ selectedEmail ] );
 
 	function onSave( event: React.FormEvent< HTMLFormElement > ) {
 		event.preventDefault();
 		setValidationError( '' );
-		const { name, email, code } = (
-			event.target as typeof event.target & {
-				elements: { name: HTMLInputElement; email: HTMLInputElement; code?: HTMLInputElement };
-			}
-		 ).elements;
-		if ( ! name.value ) {
+
+		if ( ! emailItem.name ) {
 			return setValidationError( translate( 'Please enter a name.' ) );
 		}
-		if ( ! email.value ) {
+		if ( ! emailItem.email ) {
 			return setValidationError( translate( 'Please enter an email address.' ) );
 		}
-		if ( ! emailValidator.validate( email.value ) ) {
+		if ( ! emailValidator.validate( emailItem.email ) ) {
 			return setValidationError( translate( 'Please enter a valid email address.' ) );
 		}
 		if ( showCodeVerification ) {
-			if ( ! code?.value ) {
+			if ( ! emailItem.code ) {
 				return setValidationError( translate( 'Please enter the verification code.' ) );
 			}
 			// TODO: verify email address with code
@@ -39,6 +72,14 @@ export default function AddNewEmailModal( { toggleModal }: { toggleModal: () => 
 			setShowCodeVerification( true );
 			// TODO: implement sending verification code
 		}
+	}
+
+	let title = translate( 'Add new email address' );
+	let subTitle = translate( 'Please use only your number or one you have access to. ' );
+
+	if ( isVerifyAction ) {
+		title = translate( 'Verify your email address' );
+		subTitle = translate( 'We’ll send a code to verify your email address.' );
 	}
 
 	function handleResendCode() {
@@ -49,28 +90,46 @@ export default function AddNewEmailModal( { toggleModal }: { toggleModal: () => 
 		<Modal
 			open={ true }
 			onRequestClose={ toggleModal }
-			title={ translate( 'Add your email address' ) }
+			title={ title }
 			className="notification-settings__modal"
 		>
-			<div className="notification-settings__sub-title">
-				{ translate( 'Please use only your number or one you have access to. ' ) }
-			</div>
+			<div className="notification-settings__sub-title">{ subTitle }</div>
 
 			<form className="configure-email-notification__form" onSubmit={ onSave }>
 				<FormFieldset>
 					<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
-					<FormTextInput id="name" name="name" disabled={ showCodeVerification } />
-					<div className="configure-email-notification__help-text">
-						{ translate( 'Give this email a nickname for your personal reference' ) }
-					</div>
+					<FormTextInput
+						id="name"
+						name="name"
+						value={ emailItem.name }
+						disabled={ showCodeVerification }
+						onChange={ ( event: { target: { value: string } } ) =>
+							setEmailItem( { ...emailItem, name: event.target.value } )
+						}
+					/>
+					{ ! isVerifyAction && (
+						<div className="configure-email-notification__help-text">
+							{ translate( 'Give this email a nickname for your personal reference' ) }
+						</div>
+					) }
 				</FormFieldset>
 
 				<FormFieldset>
 					<FormLabel htmlFor="email">{ translate( 'Email' ) }</FormLabel>
-					<FormTextInput id="email" name="email" disabled={ showCodeVerification } />
-					<div className="configure-email-notification__help-text">
-						{ translate( 'We’ll send a code to verify your email address.' ) }
-					</div>
+					<FormTextInput
+						id="email"
+						name="email"
+						value={ emailItem.email }
+						disabled={ showCodeVerification }
+						onChange={ ( event: { target: { value: string } } ) =>
+							setEmailItem( { ...emailItem, email: event.target.value } )
+						}
+					/>
+					{ ! isVerifyAction && (
+						<div className="configure-email-notification__help-text">
+							{ translate( 'We’ll send a code to verify your email address.' ) }
+						</div>
+					) }
 				</FormFieldset>
 
 				{ showCodeVerification && (
@@ -78,7 +137,14 @@ export default function AddNewEmailModal( { toggleModal }: { toggleModal: () => 
 						<FormLabel htmlFor="code">
 							{ translate( 'Please enter the code you received via email' ) }
 						</FormLabel>
-						<FormTextInput id="code" name="code" />
+						<FormTextInput
+							id="code"
+							name="code"
+							value={ emailItem.code }
+							onChange={ ( event: { target: { value: string } } ) =>
+								setEmailItem( { ...emailItem, code: event.target.value } )
+							}
+						/>
 						<div className="configure-email-notification__help-text">
 							{ translate(
 								'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/add-new-email-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/add-new-email-modal.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { Modal } from '@wordpress/components';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -50,7 +50,7 @@ export default function AddNewEmailModal( {
 		}
 	}, [ selectedEmail ] );
 
-	function onSave( event: React.FormEvent< HTMLFormElement > ) {
+	const onSave = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
 		setValidationError( '' );
 
@@ -72,7 +72,7 @@ export default function AddNewEmailModal( {
 			setShowCodeVerification( true );
 			// TODO: implement sending verification code
 		}
-	}
+	};
 
 	let title = translate( 'Add new email address' );
 	let subTitle = translate( 'Please use only your number or one you have access to. ' );
@@ -82,9 +82,16 @@ export default function AddNewEmailModal( {
 		subTitle = translate( 'We’ll send a code to verify your email address.' );
 	}
 
-	function handleResendCode() {
+	const handleResendCode = () => {
 		// TODO: implement resending verification code
-	}
+	};
+
+	const handleChange = useCallback(
+		( key ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {
+			setEmailItem( ( prevState ) => ( { ...prevState, [ key ]: event.target.value } ) );
+		},
+		[]
+	);
 
 	return (
 		<Modal
@@ -103,9 +110,7 @@ export default function AddNewEmailModal( {
 						name="name"
 						value={ emailItem.name }
 						disabled={ showCodeVerification }
-						onChange={ ( event: { target: { value: string } } ) =>
-							setEmailItem( { ...emailItem, name: event.target.value } )
-						}
+						onChange={ handleChange( 'name' ) }
 					/>
 					{ ! isVerifyAction && (
 						<div className="configure-email-notification__help-text">
@@ -121,9 +126,7 @@ export default function AddNewEmailModal( {
 						name="email"
 						value={ emailItem.email }
 						disabled={ showCodeVerification }
-						onChange={ ( event: { target: { value: string } } ) =>
-							setEmailItem( { ...emailItem, email: event.target.value } )
-						}
+						onChange={ handleChange( 'email' ) }
 					/>
 					{ ! isVerifyAction && (
 						<div className="configure-email-notification__help-text">
@@ -141,9 +144,7 @@ export default function AddNewEmailModal( {
 							id="code"
 							name="code"
 							value={ emailItem.code }
-							onChange={ ( event: { target: { value: string } } ) =>
-								setEmailItem( { ...emailItem, code: event.target.value } )
-							}
+							onChange={ handleChange( 'code' ) }
 						/>
 						<div className="configure-email-notification__help-text">
 							{ translate(

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -4,21 +4,20 @@ import { Icon, plus, pencil } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import Badge from 'calypso/components/badge';
-import type { MonitorSettingsEmail } from '../../sites-overview/types';
+import type {
+	MonitorSettingsEmail,
+	StateMonitorSettingsEmail,
+	AllowedMonitorContactActions,
+} from '../../sites-overview/types';
 
 import './style.scss';
 
-interface StateEmailItem extends MonitorSettingsEmail {
-	checked: boolean;
-	isDefault?: boolean;
-}
-
 interface Props {
 	defaultEmailAddresses: Array< string >;
-	toggleModal: () => void;
+	toggleModal: ( item?: StateMonitorSettingsEmail, action?: AllowedMonitorContactActions ) => void;
 	addedEmailAddresses?: Array< MonitorSettingsEmail >;
-	allEmailItems: Array< StateEmailItem >;
-	setAllEmailItems: ( emailAddresses: Array< StateEmailItem > ) => void;
+	allEmailItems: Array< StateMonitorSettingsEmail >;
+	setAllEmailItems: ( emailAddresses: Array< StateMonitorSettingsEmail > ) => void;
 }
 
 export default function ConfigureEmailNotification( {
@@ -48,7 +47,7 @@ export default function ConfigureEmailNotification( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	const handleOnChange = ( item: StateEmailItem, checked: boolean ) => {
+	const handleOnChange = ( item: StateMonitorSettingsEmail, checked: boolean ) => {
 		if ( item.isDefault ) {
 			return;
 			// FIXME: We need to show a custom error message here or a tooltip.
@@ -71,7 +70,14 @@ export default function ConfigureEmailNotification( {
 
 	const showVerified = true; // FIXME: This should be dynamic.
 
-	const getCheckboxContent = ( item: StateEmailItem ) => (
+	const handleToggleModal = (
+		item: StateMonitorSettingsEmail,
+		action: AllowedMonitorContactActions
+	) => {
+		toggleModal( item, action );
+	};
+
+	const getCheckboxContent = ( item: StateMonitorSettingsEmail ) => (
 		<div className="configure-email-address__checkbox-content-container">
 			<span className="configure-email-address__checkbox-content">
 				<div className="configure-email-address__checkbox-heading">{ item.email }</div>
@@ -80,7 +86,13 @@ export default function ConfigureEmailNotification( {
 			{ ! item.isDefault && (
 				<>
 					{ ! item.verified && (
-						<span className="configure-email-address__verification-status">
+						<span
+							role="button"
+							tabIndex={ 0 }
+							onKeyPress={ () => handleToggleModal( item, 'verify' ) }
+							onClick={ () => handleToggleModal( item, 'verify' ) }
+							className="configure-email-address__verification-status cursor-pointer"
+						>
 							<Badge type="warning">{ translate( 'Pending Verification' ) }</Badge>
 						</span>
 					) }
@@ -112,7 +124,7 @@ export default function ConfigureEmailNotification( {
 			<Button
 				compact
 				className="configure-email-address__button"
-				onClick={ toggleModal }
+				onClick={ () => toggleModal() }
 				aria-label={ translate( 'Add email address' ) }
 			>
 				<Icon size={ 18 } icon={ plus } />

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -13,7 +13,12 @@ import {
 } from '../../sites-overview/utils';
 import ConfigureEmailNotification from '../configure-email-notification';
 import AddNewEmailModal from '../configure-email-notification/add-new-email-modal';
-import type { MonitorSettings, Site, MonitorSettingsEmail } from '../../sites-overview/types';
+import type {
+	MonitorSettings,
+	Site,
+	StateMonitorSettingsEmail,
+	AllowedMonitorContactActions,
+} from '../../sites-overview/types';
 
 import './style.scss';
 
@@ -25,11 +30,6 @@ interface Props {
 	settings?: MonitorSettings;
 	monitorUserEmails?: Array< string >;
 	isLargeScreen?: boolean;
-}
-
-interface StateEmailItem extends MonitorSettingsEmail {
-	checked: boolean;
-	isDefault?: boolean;
 }
 
 export default function NotificationSettings( {
@@ -53,12 +53,25 @@ export default function NotificationSettings( {
 	const [ defaultUserEmailAddresses, setDefaultUserEmailAddresses ] = useState< string[] | [] >(
 		[]
 	);
-	const [ allEmailItems, setAllEmailItems ] = useState< StateEmailItem[] | [] >( [] );
+	const [ allEmailItems, setAllEmailItems ] = useState< StateMonitorSettingsEmail[] | [] >( [] );
 	const [ validationError, setValidationError ] = useState< string >( '' );
 	const [ isAddEmailModalOpen, setIsAddEmailModalOpen ] = useState< boolean >( false );
+	const [ selectedEmail, setSelectedEmail ] = useState< StateMonitorSettingsEmail | undefined >();
+	const [ selectedAction, setSelectedAction ] = useState< AllowedMonitorContactActions >();
 
-	const toggleAddEmailModal = () => {
+	const toggleAddEmailModal = (
+		item?: StateMonitorSettingsEmail,
+		action?: AllowedMonitorContactActions
+	) => {
+		if ( item && action ) {
+			setSelectedEmail( item );
+			setSelectedAction( action );
+		}
 		setIsAddEmailModalOpen( ( isAddEmailModalOpen ) => ! isAddEmailModalOpen );
+		if ( isAddEmailModalOpen ) {
+			setSelectedEmail( undefined );
+			setSelectedAction( undefined );
+		}
 	};
 
 	function onSave( event: React.FormEvent< HTMLFormElement > ) {
@@ -120,7 +133,13 @@ export default function NotificationSettings( {
 	);
 
 	if ( isAddEmailModalOpen ) {
-		return <AddNewEmailModal toggleModal={ toggleAddEmailModal } />;
+		return (
+			<AddNewEmailModal
+				toggleModal={ toggleAddEmailModal }
+				selectedEmail={ selectedEmail }
+				selectedAction={ selectedAction }
+			/>
+		);
 	}
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -452,3 +452,6 @@
 	min-width: 140px !important;
 }
 
+.cursor-pointer {
+	cursor: pointer;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -265,3 +265,10 @@ export interface MonitorSettingsEmail {
 	name: string;
 	verified: boolean;
 }
+
+export interface StateMonitorSettingsEmail extends MonitorSettingsEmail {
+	checked: boolean;
+	isDefault?: boolean;
+}
+
+export type AllowedMonitorContactActions = 'add' | 'verify';


### PR DESCRIPTION
Related to 1204408201748644-as-1204430020957762

## Proposed Changes

This PR implements UI to verify the previously added email addresses later to the monitor notification settings

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-monitor-email-verify-later` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Set the below lines to `addedEmailAddresses`  in the `ConfigureEmailNotification` component to see the extra email addresses. 

```
addedEmailAddresses = [
		{
			email: 'test-email1@test.com',
			name: 'Test User 1',
			verified: true,
		},
		{
			email: 'test-email2@test.com',
			name: 'Test User 2',
			verified: false,
		},
	]
```

<img width="451" alt="Screenshot 2023-05-11 at 12 02 20 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/7ed3e9a6-8a39-4927-b1cb-191672cbc272">

6. Click on the `Pending Verification` badge & verify that the verification modal is shown as below. Please note the Later & Verify buttons does nothing. The logic for these buttons will be implemented later.

<img width="450" alt="Screenshot 2023-05-11 at 12 15 02 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/62844612-973a-4f89-93b5-fbea4c0ffcd6">

7. Click the `+ Add email address` button and verify the heading/sub-heading is as shown below. 

<img width="447" alt="Screenshot 2023-05-11 at 12 15 34 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/cd419936-0d1e-4c8e-b839-66c5ff756ed9">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?