### PR TITLE
Launchpad: Fix selecting virtual theme doesn't update the homepage

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -449,10 +449,12 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 		setSelectedDesign( _selectedDesign );
 		if ( siteSlugOrId && _selectedDesign ) {
-			const positionIndex = designs.findIndex( ( design ) => design.slug === _selectedDesign.slug );
+			const positionIndex = designs.findIndex(
+				( design ) => design.slug === _selectedDesign?.slug
+			);
 
 			setPendingAction( () => {
-				if ( _selectedDesign.is_virtual ) {
+				if ( _selectedDesign?.is_virtual ) {
 					return applyThemeWithPatterns( siteSlugOrId, _selectedDesign ).then(
 						( theme: ActiveTheme ) => reduxDispatch( setActiveTheme( site?.ID || -1, theme ) )
 					);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -441,18 +441,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			isEnabled( 'pattern-assembler/dotcompatterns' );
 
 		if ( shouldGoToAssembler ) {
-			const assemblerDesign = {
+			_selectedDesign = {
 				..._selectedDesign,
 				design_type: BLANK_CANVAS_DESIGN.design_type,
 			} as Design;
-
-			setSelectedDesign( assemblerDesign );
-
-			handleSubmit( {
-				selectedDesign: assemblerDesign,
-				selectedSiteCategory: categorization.selection,
-			} );
-			return;
 		}
 
 		setSelectedDesign( _selectedDesign );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/76530

## Proposed Changes

* If people select a virtual theme from the Design Picker, we should just overwrite the `design_type` and keep setting the pending actions. With this change, we're able to update the home page even if the next step is not the PA

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

** Launchpad**

* Go to `/setup/build/launchpad?siteSlug=<your_site>`
* Select `Select a design`
* Select a virtual theme
* Ensure that the preview of the Home page is the same as the selected one

**Site Setup Flow**

* Go to `/setup?siteSlug=<your_site>`
* Continue until you land on the Design Picker
* On the Design Picker screen, select a virtual theme and continue
* On the PA screen, continue
* When you land on the editor, ensure your homepage is the same as the selected one

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
