### PR TITLE
Happy blocks: Adjust search box on inner pages for support

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -390,14 +390,14 @@ $happy_blocks_tabs = array(
 				</div>
 			</div>
 			<hr />
-			<?php if ( $args['include_site_title'] ) : ?>
 			<div class="happy-blocks-global-header-site__title">
-				<div class="happy-blocks-global-header-site__title__wrapper">
-					<h1><?php echo esc_html( $args['site_title'] ); ?></h1>
-					<p><?php echo esc_html( $args['site_tagline'] ); ?></p>
-				</div>
-				<form role="search" method="get" action=""><label for="wp-block-search__input-1" class="screen-reader-text"><?php echo esc_html( $args['search_placeholder'] ); ?></label><div class="happy-blocks-search__inside-wrapper"><input type="search" id="wp-block-search__input-1" name="s" value="" placeholder="<?php echo esc_html( $args['search_placeholder'] ); ?>"></div></form>
+				<?php if ( $args['include_site_title'] ) : ?>
+					<div class="happy-blocks-global-header-site__title__wrapper">
+						<h1><?php echo esc_html( $args['site_title'] ); ?></h1>
+						<p><?php echo esc_html( $args['site_tagline'] ); ?></p>
+					</div>
+				<?php endif; ?>
+				<form class="<?php echo ! $args['include_site_title'] ? 'happy-blocks_inner_search' : ''; ?>"  role="search" method="get" action=""><label for="wp-block-search__input-1" class="screen-reader-text"><?php echo esc_html( $args['search_placeholder'] ); ?></label><div class="happy-blocks-search__inside-wrapper"><input type="search" id="wp-block-search__input-1" name="s" value="" placeholder="<?php echo esc_html( $args['search_placeholder'] ); ?>"></div></form>
 			</div>
-			<?php endif; ?>
 	</div>
 </div>

--- a/apps/happy-blocks/block-library/universal-header/style.scss
+++ b/apps/happy-blocks/block-library/universal-header/style.scss
@@ -588,6 +588,36 @@ body.logged-in .x-dropdown {
 	}
 }
 
+// Only for categories page, tablet or bellow viewport, set the search box width to 100%.
+body.archive {
+	@media only screen and ( max-width: $breakpoint-tablet ) {
+		div.happy-blocks-search__inside-wrapper {
+			width: 100%;
+		}
+	}
+}
+
+.happy-blocks_inner_search {
+	height: 0;
+	.happy-blocks-search__inside-wrapper {
+		height: 57px;
+	}
+
+	@media only screen and ( max-width: $breakpoint-tablet ) {
+		height: 57px;
+		margin-bottom: 16px !important;
+		justify-content: flex-start !important;
+
+		div.happy-blocks-search__inside-wrapper {
+			width: var(--wp--style--global--content-size);
+		}
+	}
+	@media only screen and ( max-width: $breakpoint-mobile ) {
+		margin: 16px 0 !important;
+	}
+
+}
+
 .happy-blocks-search {
 	min-height: 399px;
 	position: relative;


### PR DESCRIPTION

## Proposed changes

This PR makes the search box visible on `/support` inner pages. We are still not sure what is the best UX/Design to provide this to the user, so this is a temporary but valuable solution IMO.

## How to test

- Pull and run this branch
- Navigate to `cd apps/happy-blocks` and `run yarn dev --sync`
- Sandbox `wordpress.com/support` 
- Follow the [steps here](https://github.com/Automattic/wpsupport3/pull/438)