### PR TITLE
E2E: wait for previews to load before clicking on a site assembler component.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
@@ -32,6 +32,13 @@ export class SiteAssemblerFlow {
 	 */
 	async selectLayoutComponentType( type: LayoutType ): Promise< void > {
 		await this.page.getByRole( 'button', { name: type } ).click();
+
+		// Each header element contains an iframe that loads the preview in the card.
+		// These previews are lazy-loaded and thus only load if the card is in the
+		// viewport.
+		// By waiting for the network activity to cease for the lazy-load,
+		// mis-clicks and clicks being swallowed can be prevented.
+		await this.page.waitForLoadState( 'networkidle', { timeout: 15 * 1000 } );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #76806

## Proposed Changes

This PR adds a wait for `networkidle` state before clicking on a site assembler component. 

## Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Gutenberg E2E Simple production (desktop)
  - [ ] Gutenberg E2E Simple production (mobile)
  - [ ] Calypso E2E (desktop)
  - [ ] Calypso E2E (mobile)
  - [ ] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
