### PR TITLE
Help Center: fix support history call on Atomic

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -206,6 +206,10 @@ class Help_Center {
 		require_once __DIR__ . '/class-wp-rest-help-center-forum.php';
 		$controller = new WP_REST_Help_Center_Forum();
 		$controller->register_rest_route();
+
+		require_once __DIR__ . '/class-wp-rest-help-center-support-history.php';
+		$controller = new WP_REST_Help_Center_Support_History();
+		$controller->register_rest_route();
 	}
 	/**
 	 * Returns true if the current site is a support site.

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-history.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-history.php
@@ -47,9 +47,11 @@ class WP_REST_Help_Center_Support_History extends \WP_REST_Controller {
 	 * @param \WP_REST_Request $request Request object.
 	 */
 	public function support_history_ticket( $request ) {
-		$email = $request['email'];
-
-		$params = array( 'email' => $email );
+		if ( isset( $request['email'] ) ) {
+			$params = array( 'email' => $request['email'] );
+		} else {
+			$params = array();
+		}
 
 		$body = Client::wpcom_json_api_request_as_user(
 			'/support-history/ticket?' . http_build_query( $params ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-history.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-history.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WP_REST_Help_Center_Ticket file.
+ * WP_REST_Help_Center_Support_History file.
  *
  * @package A8C\FSE
  */
@@ -10,11 +10,11 @@ namespace A8C\FSE;
 use Automattic\Jetpack\Connection\Client;
 
 /**
- * Class WP_REST_Help_Center_Ticket.
+ * Class WP_REST_Help_Center_Support_History.
  */
 class WP_REST_Help_Center_Support_History extends \WP_REST_Controller {
 	/**
-	 * WP_REST_Help_Center_Ticket constructor.
+	 * WP_REST_Help_Center_Support_History constructor.
 	 */
 	public function __construct() {
 		$this->namespace = 'help-center';
@@ -31,7 +31,7 @@ class WP_REST_Help_Center_Support_History extends \WP_REST_Controller {
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'support_history_ticket' ),
-				'permission_callback' => array( $this, 'permission_callback' ),
+				'permission_callback' => 'is_user_logged_in',
 				'args'                => array(
 					'email' => array(
 						'type' => 'string',
@@ -42,7 +42,7 @@ class WP_REST_Help_Center_Support_History extends \WP_REST_Controller {
 	}
 
 	/**
-	 * Get support history tickets through Jeptack.
+	 * Get support history tickets through Jetpack.
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 */
@@ -68,14 +68,5 @@ class WP_REST_Help_Center_Support_History extends \WP_REST_Controller {
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
 		return rest_ensure_response( $response );
-	}
-
-	/**
-	 * Callback to determine whether the request can proceed.
-	 *
-	 * @return boolean
-	 */
-	public function permission_callback() {
-		return is_user_logged_in();
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-history.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-history.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * WP_REST_Help_Center_Ticket file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_Help_Center_Ticket.
+ */
+class WP_REST_Help_Center_Support_History extends \WP_REST_Controller {
+	/**
+	 * WP_REST_Help_Center_Ticket constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'help-center';
+		$this->rest_base = '/support-history';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/ticket',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'support_history_ticket' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+				'args'                => array(
+					'email' => array(
+						'type' => 'string',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get support history tickets through Jeptack.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 */
+	public function support_history_ticket( $request ) {
+		$email = $request['email'];
+
+		$params = array( 'email' => $email );
+
+		$body = Client::wpcom_json_api_request_as_user(
+			'/support-history/ticket?' . http_build_query( $params ),
+			'2',
+			array(
+				'method' => 'GET',
+			)
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Callback to determine whether the request can proceed.
+	 *
+	 * @return boolean
+	 */
+	public function permission_callback() {
+		return is_user_logged_in();
+	}
+}

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -20,6 +20,7 @@ export { useSiteIntent } from './queries/use-site-intent';
 export { useSupportAvailability } from './support-queries/use-support-availability';
 export { useSubmitTicketMutation } from './support-queries/use-submit-support-ticket';
 export { useSubmitForumsMutation } from './support-queries/use-submit-forums-topic';
+export { useHasActiveSupport } from './support-queries/use-support-history';
 export * from './starter-designs-queries';
 export { useSibylQuery } from './support-queries/use-sibyl-query';
 export * from './site/types';

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -23,6 +23,7 @@ export { useSubmitForumsMutation } from './support-queries/use-submit-forums-top
 export { useHasActiveSupport } from './support-queries/use-support-history';
 export * from './starter-designs-queries';
 export { useSibylQuery } from './support-queries/use-sibyl-query';
+export * from './support-queries/types';
 export * from './site/types';
 export * from './templates';
 export * from './onboard/types';

--- a/packages/data-stores/src/support-queries/types.ts
+++ b/packages/data-stores/src/support-queries/types.ts
@@ -26,3 +26,14 @@ export interface OtherSupportAvailability {
 	is_user_eligible_for_tickets: boolean;
 	is_user_eligible_for_chat: boolean;
 }
+
+export interface SupportSession {
+	id?: number;
+	status: string;
+	subject: string;
+	time: Date;
+	timestamp: number;
+	type: string;
+	url: string;
+	when: string;
+}

--- a/packages/data-stores/src/support-queries/use-support-history.ts
+++ b/packages/data-stores/src/support-queries/use-support-history.ts
@@ -16,7 +16,7 @@ const ACTIVE_STATUSES = [ 'New', 'Open', 'Hold' ];
  */
 export function useHasActiveSupport( type: 'chat' | 'ticket', email: string, show = true ) {
 	return useQuery< Response | SupportSession | boolean >(
-		[ 'help-support-history', type, show ],
+		[ 'help-support-history', type, show, email ],
 		() =>
 			canAccessWpcomApis()
 				? wpcomRequest( {

--- a/packages/data-stores/src/support-queries/use-support-history.ts
+++ b/packages/data-stores/src/support-queries/use-support-history.ts
@@ -16,7 +16,7 @@ const ACTIVE_STATUSES = [ 'New', 'Open', 'Hold' ];
  */
 export function useHasActiveSupport( type: 'chat' | 'ticket', email: string, show = true ) {
 	return useQuery< Response | SupportSession | boolean >(
-		[ 'help-support-history', type, show, email ],
+		[ 'help-support-history', type, email ],
 		() =>
 			canAccessWpcomApis()
 				? wpcomRequest( {

--- a/packages/data-stores/src/support-queries/use-support-history.ts
+++ b/packages/data-stores/src/support-queries/use-support-history.ts
@@ -17,21 +17,21 @@ const ACTIVE_STATUSES = [ 'New', 'Open', 'Hold' ];
 export function useHasActiveSupport( type: 'chat' | 'ticket', email: string, show = true ) {
 	return useQuery< Response | SupportSession | boolean >(
 		[ 'help-support-history', type, show ],
-		async () =>
+		() =>
 			canAccessWpcomApis()
-				? await wpcomRequest( {
+				? wpcomRequest( {
 						path: `support-history/${ encodeURIComponent( type ) }/?email=${ encodeURIComponent(
 							email
 						) }`,
 						apiNamespace: 'wpcom/v2/',
 						apiVersion: '2',
 				  } )
-				: ( ( await apiFetch( {
+				: apiFetch< Response >( {
 						path: `help-center/support-history/${ encodeURIComponent(
 							type
 						) }/?email=${ encodeURIComponent( email ) }`,
 						global: true,
-				  } as APIFetchOptions ) ) as Response ),
+				  } as APIFetchOptions ),
 		{
 			refetchOnWindowFocus: false,
 			keepPreviousData: false,

--- a/packages/data-stores/src/support-queries/use-support-history.ts
+++ b/packages/data-stores/src/support-queries/use-support-history.ts
@@ -20,16 +20,15 @@ export function useHasActiveSupport( type: 'chat' | 'ticket', email: string, sho
 		() =>
 			canAccessWpcomApis()
 				? wpcomRequest( {
-						path: `support-history/${ encodeURIComponent( type ) }/?email=${ encodeURIComponent(
-							email
-						) }`,
+						path: `support-history/${ encodeURIComponent( type ) }`,
 						apiNamespace: 'wpcom/v2/',
 						apiVersion: '2',
+						query: email ? `email=${ encodeURIComponent( email ) }` : '',
 				  } )
 				: apiFetch< Response >( {
-						path: `help-center/support-history/${ encodeURIComponent(
-							type
-						) }/?email=${ encodeURIComponent( email ) }`,
+						path:
+							`help-center/support-history/${ encodeURIComponent( type ) }/` +
+							( email ? `?email=${ encodeURIComponent( email ) }` : '' ),
 						global: true,
 				  } as APIFetchOptions ),
 		{

--- a/packages/data-stores/src/support-queries/use-support-history.ts
+++ b/packages/data-stores/src/support-queries/use-support-history.ts
@@ -15,11 +15,11 @@ const ACTIVE_STATUSES = [ 'New', 'Open', 'Hold' ];
  * NOTE: Chat mode isn't functional at the moment.
  */
 export function useHasActiveSupport( type: 'chat' | 'ticket', email: string, show = true ) {
-	return useQuery< Response | SupportSession | boolean >(
+	return useQuery(
 		[ 'help-support-history', type, email ],
 		() =>
 			canAccessWpcomApis()
-				? wpcomRequest( {
+				? wpcomRequest< Response >( {
 						path: `support-history/${ encodeURIComponent( type ) }`,
 						apiNamespace: 'wpcom/v2/',
 						apiVersion: '2',
@@ -37,8 +37,8 @@ export function useHasActiveSupport( type: 'chat' | 'ticket', email: string, sho
 			refetchOnMount: true,
 			enabled: show,
 			select: ( response ) => {
-				const recentSession = ( response as Response ).data[ 0 ];
-				return ACTIVE_STATUSES.includes( recentSession.status ) ? recentSession : false;
+				const recentSession = response.data[ 0 ];
+				return ACTIVE_STATUSES.includes( recentSession.status ) ? recentSession : null;
 			},
 			staleTime: 30 * 60 * 1000,
 		}

--- a/packages/data-stores/src/support-queries/use-support-history.ts
+++ b/packages/data-stores/src/support-queries/use-support-history.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import type { SupportSession } from './types';
+
+interface Response {
+	data: SupportSession[];
+}
+
+const ACTIVE_STATUSES = [ 'New', 'Open', 'Hold' ];
+
+/**
+ * Checks if the user has an active support session or a recent ticket.
+ *
+ * NOTE: Chat mode isn't functional at the moment.
+ */
+export function useHasActiveSupport( type: 'chat' | 'ticket', email: string, show = true ) {
+	return useQuery< Response | SupportSession | boolean >(
+		[ 'help-support-history', type, show ],
+		async () =>
+			canAccessWpcomApis()
+				? await wpcomRequest( {
+						path: `support-history/${ encodeURIComponent( type ) }/?email=${ encodeURIComponent(
+							email
+						) }`,
+						apiNamespace: 'wpcom/v2/',
+						apiVersion: '2',
+				  } )
+				: ( ( await apiFetch( {
+						path: `help-center/support-history/${ encodeURIComponent(
+							type
+						) }/?email=${ encodeURIComponent( email ) }`,
+						global: true,
+				  } as APIFetchOptions ) ) as Response ),
+		{
+			refetchOnWindowFocus: false,
+			keepPreviousData: false,
+			refetchOnMount: true,
+			enabled: show,
+			select: ( response ) => {
+				const recentSession = ( response as Response ).data[ 0 ];
+				return ACTIVE_STATUSES.includes( recentSession.status ) ? recentSession : false;
+			},
+			staleTime: 30 * 60 * 1000,
+		}
+	);
+}

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -324,7 +324,7 @@ export const HelpCenterContactForm = () => {
 							setTimeout( () => {
 								// wait 30 seconds until support-history endpoint actually updates
 								// yup, it takes that long (tried 5, and 10)
-								queryClient.invalidateQueries( [ `activeSupportTickets`, email ] );
+								queryClient.invalidateQueries( [ 'help-support-history', 'ticket', email ] );
 							}, 30000 );
 						} )
 						.catch( () => {

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -5,11 +5,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Spinner, GMClosureNotice } from '@automattic/components';
-import {
-	useSupportAvailability,
-	useHasActiveSupport,
-	SupportSession,
-} from '@automattic/data-stores';
+import { useSupportAvailability, useHasActiveSupport } from '@automattic/data-stores';
 import { isDefaultLocale, getLanguage, useLocale } from '@automattic/i18n-utils';
 import { Notice } from '@wordpress/components';
 import { useEffect, useMemo } from '@wordpress/element';
@@ -126,9 +122,7 @@ export const HelpCenterContactPage: FC = () => {
 			<BackButton />
 			<div className="help-center-contact-page__content">
 				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
-				{ hasActiveTickets && (
-					<HelpCenterActiveTicketNotice tickets={ [ hasActiveTickets as SupportSession ] } />
-				) }
+				{ hasActiveTickets && <HelpCenterActiveTicketNotice tickets={ [ hasActiveTickets ] } /> }
 				{ /* Easter */ }
 				<GMClosureNotice
 					displayAt="2023-04-03 00:00Z"

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -5,7 +5,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Spinner, GMClosureNotice } from '@automattic/components';
-import { useSupportAvailability } from '@automattic/data-stores';
+import { useSupportAvailability, useHasActiveSupport } from '@automattic/data-stores';
 import { isDefaultLocale, getLanguage, useLocale } from '@automattic/i18n-utils';
 import { Notice } from '@wordpress/components';
 import { useEffect, useMemo } from '@wordpress/element';
@@ -16,7 +16,6 @@ import classnames from 'classnames';
 import { FC } from 'react';
 import { useSelector } from 'react-redux';
 import { Link, LinkProps } from 'react-router-dom';
-import { useActiveSupportTicketsQuery } from 'calypso/data/help/use-active-support-tickets-query';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { getSectionName } from 'calypso/state/ui/selectors';
 /**
@@ -44,9 +43,10 @@ export const HelpCenterContactPage: FC = () => {
 	const renderEmail = useShouldRenderEmailOption();
 	const renderChat = useShouldRenderChatOption();
 	const email = useSelector( getCurrentUserEmail );
-	const { data: tickets, isLoading: isLoadingTickets } = useActiveSupportTicketsQuery( email, {
-		staleTime: 30 * 60 * 1000,
-	} );
+	const { data: hasActiveTickets, isLoading: isLoadingTickets } = useHasActiveSupport(
+		'ticket',
+		email
+	);
 	const { data: supportAvailability } = useSupportAvailability( 'CHAT' );
 	const isLoading = renderChat.isLoading || renderEmail.isLoading || isLoadingTickets;
 
@@ -122,7 +122,7 @@ export const HelpCenterContactPage: FC = () => {
 			<BackButton />
 			<div className="help-center-contact-page__content">
 				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
-				<HelpCenterActiveTicketNotice tickets={ tickets } />
+				{ hasActiveTickets && <HelpCenterActiveTicketNotice tickets={ [ hasActiveTickets ] } /> }
 				{ /* Easter */ }
 				<GMClosureNotice
 					displayAt="2023-04-03 00:00Z"

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -5,7 +5,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Spinner, GMClosureNotice } from '@automattic/components';
-import { useSupportAvailability, useHasActiveSupport } from '@automattic/data-stores';
+import {
+	useSupportAvailability,
+	useHasActiveSupport,
+	SupportSession,
+} from '@automattic/data-stores';
 import { isDefaultLocale, getLanguage, useLocale } from '@automattic/i18n-utils';
 import { Notice } from '@wordpress/components';
 import { useEffect, useMemo } from '@wordpress/element';
@@ -122,7 +126,9 @@ export const HelpCenterContactPage: FC = () => {
 			<BackButton />
 			<div className="help-center-contact-page__content">
 				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
-				{ hasActiveTickets && <HelpCenterActiveTicketNotice tickets={ [ hasActiveTickets ] } /> }
+				{ hasActiveTickets && (
+					<HelpCenterActiveTicketNotice tickets={ [ hasActiveTickets as SupportSession ] } />
+				) }
 				{ /* Easter */ }
 				<GMClosureNotice
 					displayAt="2023-04-03 00:00Z"

--- a/packages/help-center/src/components/help-center-notice.tsx
+++ b/packages/help-center/src/components/help-center-notice.tsx
@@ -1,9 +1,9 @@
+import { SupportSession } from '@automattic/data-stores';
 import { localizeUrl, useLocale, getRelativeTimeString } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
-import type { SupportTicket } from '../types';
 import type { AnalysisReport } from '@automattic/data-stores';
 import type { ReactNode } from 'react';
 
@@ -97,7 +97,7 @@ export function HelpCenterOwnershipNotice( { ownershipResult }: Props ) {
 export function HelpCenterActiveTicketNotice( {
 	tickets,
 }: {
-	tickets: SupportTicket[] | undefined;
+	tickets: SupportSession[] | undefined;
 } ) {
 	const locale = useLocale();
 

--- a/packages/help-center/src/components/help-center-notice.tsx
+++ b/packages/help-center/src/components/help-center-notice.tsx
@@ -119,7 +119,6 @@ export function HelpCenterActiveTicketNotice( {
 						} )
 					) }
 				</strong>{ ' ' }
-				&nbsp;
 				{ __(
 					`Rest assured that we got your message and we'll be in touch as soon as we can.`,
 					__i18n_text_domain__


### PR DESCRIPTION
## Proposed Changes

- This moves the Help Center support sessions check to the endpoint that was added recently but never used. This endpoint is much faster. It was added here: D94755-code
- This adds a proxy endpoint for Atomic users, so they can access the new endpoint.

## Testing Instructions

### Atomic

1. In apps/editing-toolkit, run `yarn build`.
2. In your atomic site, deactivate Editing Toolkit plugin.
3. Compress `editing-toolkit-plugin` folder (`apps/editing-toolkit/editing-toolkit-plugin/`) and upload it as a plugin to your atomic site.
4. Test the Help Center
     - Click "Still need help".
     - The page should load and quickly.

### Simple and Calypso
1. Access the live link below and open the Help Center.
2. Open the Help Center.
3. Test the Help Center
     - Click "Still need help".
     - The page should load and quickly.
