### PR TITLE
Category updates - Revert changes to add all category

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -66,13 +66,6 @@ class Block_Patterns_From_API {
 		// Used to track which patterns we successfully register.
 		$results = array();
 
-		// The category 'All' is created dynamically so all patterns are always added automatically.
-		$category_all = array(
-			'slug'        => 'featured',
-			'label'       => __( 'All', 'full-site-editing' ),
-			'description' => __( 'Explore all patterns.', 'full-site-editing' ),
-		);
-
 		// For every pattern source site, fetch the patterns.
 		foreach ( $this->patterns_sources as $patterns_source ) {
 			$patterns_cache_key = $this->utils->get_patterns_cache_key( $patterns_source );
@@ -94,12 +87,6 @@ class Block_Patterns_From_API {
 			}
 
 			$pattern_categories = array_merge( $pattern_categories, $existing_categories );
-
-			// Add the category 'All' to $pattern_categories so its ordered and registered with the others.
-			$pattern_categories[ $category_all['slug'] ] = array(
-				'label'       => $category_all['label'],
-				'description' => $category_all['description'],
-			);
 
 			// Order categories alphabetically by their label.
 			uasort(
@@ -134,9 +121,6 @@ class Block_Patterns_From_API {
 					$viewport_width = $viewport_width < 320 ? 320 : $viewport_width;
 					$pattern_name   = self::PATTERN_NAMESPACE . $pattern['name'];
 					$block_types    = $this->utils->maybe_get_pattern_block_types_from_pattern_meta( $pattern );
-
-					// Add the category 'All' to all patterns.
-					$pattern['categories'][ $category_all['slug'] ] = $category_all;
 
 					$results[ $pattern_name ] = register_block_pattern(
 						$pattern_name,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76580

## Proposed Changes

* Revert changes to add all category

We are reverting because there are core tests that fail when these changes are released in the ETK plugin. We'll follow up with another PR using a different strategy because it seems to me that those core tests cannot be changed as the ETK extends core.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the changes added in #76580 are reverted

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
