### PR TITLE
Revert "Launchpad: hide "edit design" overlay button for all flows"

### DIFF
--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -63,6 +63,8 @@ export class WebPreviewModal extends Component {
 		fixedViewportWidth: PropTypes.number,
 		// Prevents tabbing into the iframe.
 		disableTabbing: PropTypes.bool,
+		// Edit overlay that redirects to the Site Editor
+		enableEditOverlay: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -81,6 +83,7 @@ export class WebPreviewModal extends Component {
 		hasSidebar: false,
 		overridePost: null,
 		autoHeight: false,
+		enableEditOverlay: false,
 	};
 
 	constructor( props ) {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -411,6 +411,16 @@ export default class WebPreviewContent extends Component {
 					) }
 					{ 'seo' !== this.state.device && (
 						<div
+							onMouseEnter={ () => {
+								if ( this.props.enableEditOverlay ) {
+									this.setState( { showIFrameOverlay: true } );
+								}
+							} }
+							onMouseLeave={ () => {
+								if ( this.props.enableEditOverlay ) {
+									this.setState( { showIFrameOverlay: false } );
+								}
+							} }
 							className={ classNames( 'web-preview__frame-wrapper', {
 								'is-resizable': ! this.props.isModalWindow,
 							} ) }
@@ -421,7 +431,7 @@ export default class WebPreviewContent extends Component {
 								style={ {
 									...this.state.iframeStyle,
 									height: this.state.viewport?.height,
-									pointerEvents: 'all',
+									pointerEvents: this.props.enableEditOverlay ? 'auto' : 'all',
 								} }
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
@@ -430,6 +440,37 @@ export default class WebPreviewContent extends Component {
 								scrolling={ autoHeight ? 'no' : undefined }
 								tabIndex={ disableTabbing ? -1 : 0 }
 							/>
+							{ this.props.enableEditOverlay && (
+								<div
+									className="web-preview__frame-edit-overlay"
+									style={ {
+										opacity: this.state.showIFrameOverlay ? '1' : '0',
+										background: this.state.showIFrameOverlay
+											? `rgba(16, 21, 23, 0.5)`
+											: 'rgba(16, 21, 23, 0)',
+										transition: 'background 0.2s ease',
+										pointerEvents: 'none',
+									} }
+								>
+									<button
+										style={ {
+											position: 'relative',
+											top: this.state.showIFrameOverlay ? '0' : '15px',
+											transition: 'all 0.2s ease',
+											pointerEvents: 'all',
+										} }
+										aria-label="Edit your new site"
+										className="web-preview__frame-edit-button"
+										onClick={ () => {
+											window.location.assign( `/site-editor/${ this.props.externalUrl }` );
+										} }
+										onFocus={ () => this.setState( { showIFrameOverlay: true } ) }
+										onBlur={ () => this.setState( { showIFrameOverlay: false } ) }
+									>
+										{ translate( 'Edit design' ) }
+									</button>
+								</div>
+							) }
 						</div>
 					) }
 					{ 'seo' === this.state.device && (
@@ -516,6 +557,8 @@ WebPreviewContent.propTypes = {
 	inlineCss: PropTypes.string,
 	// Uses the CSS selector to scroll to it
 	scrollToSelector: PropTypes.string,
+	// Edit overlay that redirects to the Site Editor
+	enableEditOverlay: PropTypes.bool,
 };
 
 WebPreviewContent.defaultProps = {
@@ -541,4 +584,5 @@ WebPreviewContent.defaultProps = {
 	autoHeight: false,
 	inlineCss: null,
 	scrollToSelector: null,
+	enableEditOverlay: false,
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -5,7 +5,9 @@ import {
 	NEWSLETTER_FLOW,
 	BUILD_FLOW,
 	WRITE_FLOW,
+	isNewsletterFlow,
 	START_WRITING_FLOW,
+	isStartWritingFlow,
 } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -16,6 +18,23 @@ import { isVideoPressFlow } from 'calypso/signup/utils';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import PreviewToolbar from '../design-setup/preview-toolbar';
 import type { Device } from '@automattic/components';
+
+/**
+ * Determines whether the edit overlay should be enabled for a given flow.
+ *
+ * @function
+ * @param {string | null} flow - The flow identifier or null.
+ * @returns {boolean} - Returns true if the edit overlay should be enabled, otherwise returns false.
+ */
+export const getEnableEditOverlay = ( flow: string | null ) => {
+	if ( isNewsletterFlow( flow ) ) {
+		return false;
+	}
+	if ( isStartWritingFlow( flow ) ) {
+		return false;
+	}
+	return true;
+};
 
 const LaunchpadSitePreview = ( {
 	siteSlug,
@@ -28,6 +47,7 @@ const LaunchpadSitePreview = ( {
 	const site = useSite();
 	const { globalStylesInUse } = usePremiumGlobalStyles( site?.ID );
 	const isInVideoPressFlow = isVideoPressFlow( flow );
+	const enableEditOverlay = getEnableEditOverlay( flow );
 
 	let previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const devicesToShow: Device[] = [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.PHONE ];
@@ -114,6 +134,7 @@ const LaunchpadSitePreview = ( {
 				defaultViewportDevice={ defaultDevice }
 				devicesToShow={ devicesToShow }
 				showSiteAddressBar={ false }
+				enableEditOverlay={ enableEditOverlay }
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -540,6 +540,13 @@
 		@include break-large {
 			margin: 0 auto;
 		}
+
+		.web-preview__frame-edit-overlay {
+			@include break-large {
+				border-radius: 40px; /* stylelint-disable-line scales/radii */
+			}
+		}
+
 	}
 
 	.web-preview__frame-wrapper.is-resizable {
@@ -548,6 +555,36 @@
 		padding: 0;
 		background-color: transparent;
 		position: relative;
+
+
+		.web-preview__frame-edit-overlay {
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			border-radius: 40px;  /* stylelint-disable-line scales/radii */
+
+			display: flex;
+			justify-content: center;
+			align-items: center;
+
+			@include break-large {
+				border-radius: 20px; /* stylelint-disable-line scales/radii */
+			}
+
+			.web-preview__frame-edit-button {
+				font-size: 14px;  /* stylelint-disable-line declaration-property-unit-allowed-list */
+				line-height: 20px;
+				padding: 10px 24px;
+				color: #000;
+				background: #fff;
+				border-radius: 4px;
+				border-color: #c3c4c7;
+				border-width: 2px;
+				cursor: pointer;
+			}
+		}
 	}
 
 	.web-preview__frame {
@@ -573,6 +610,8 @@
 	.spinner-line {
 		display: none;
 	}
+
+
 }
 
 // Launchpad - Processing Screens

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/launchpad-site-preview.tsx
@@ -1,0 +1,20 @@
+import { NEWSLETTER_FLOW, START_WRITING_FLOW } from '@automattic/onboarding';
+import { getEnableEditOverlay } from '../launchpad-site-preview';
+
+describe( 'getEnableEditOverlay', () => {
+	test( 'should return false if flow is a newsletter flow', () => {
+		const flow = NEWSLETTER_FLOW;
+		expect( getEnableEditOverlay( flow ) ).toBe( false );
+	} );
+
+	test( 'should return false if flow is a start writing flow', () => {
+		const flow = START_WRITING_FLOW;
+		expect( getEnableEditOverlay( flow ) ).toBe( false );
+	} );
+
+	test( 'default return true if flow is not specified or null', () => {
+		const flow = 'nonexistent-flow';
+		expect( getEnableEditOverlay( null ) ).toBe( true );
+		expect( getEnableEditOverlay( flow ) ).toBe( true );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/site-preview.tsx
@@ -60,6 +60,7 @@ const StartWritingDoneSitePreview = ( { siteSlug }: { siteSlug: string | null } 
 				defaultViewportDevice={ DEVICE_TYPES.COMPUTER }
 				devicesToShow={ devicesToShow }
 				showSiteAddressBar={ false }
+				enableEditOverlay={ false }
 			/>
 		</div>
 	);


### PR DESCRIPTION
Reverts Automattic/wp-calypso#76820 due failure to build production build during deploy.