### PR TITLE
Jetpack Pro Dash: Add Starter bundle description to license issue screen

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/index.tsx
@@ -43,6 +43,10 @@ export default function LicenseBundleCardDescription( { product }: Props ) {
 				translate( 'Akismet Anti-spam*' )
 			);
 			break;
+		case 'jetpack-starter':
+			textDescription = translate( 'Includes VaultPress Backup 1GB and Akismet Anti-spam.' );
+			features.push( translate( 'VaultPress Backup 1GB' ), translate( 'Akismet Anti-spam*' ) );
+			break;
 		case 'jetpack-anti-spam':
 			textDescription = translate( 'Automatically clear spam from your comments and forms.' );
 			break;


### PR DESCRIPTION
## Proposed Changes

This PR adds a description and feature definitions to the license cards on the license issue screen for the Jetpack Starter bundle.

## Testing Instructions

* Sandbox the API and apply D110575-code.
* Load up the license issue screen and look for Jetpack Starter. You should see the description instead of a blank card.

<img width="338" alt="Screenshot 2023-05-11 at 9 22 16 AM" src="https://github.com/Automattic/wp-calypso/assets/5528445/6a442a68-40cd-4faa-a309-8c8915641de5">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
