### PR TITLE
Subscription Management: Remove extra whitespace on the right side of lists.

### DIFF
--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -2,8 +2,6 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 
-$max-list-width: 1300px;
-
 %ellipsis {
 	white-space: nowrap;
 	text-overflow: ellipsis;
@@ -11,7 +9,6 @@ $max-list-width: 1300px;
 }
 
 .subscription-manager__comment-list {
-	max-width: $max-list-width;
 	min-width: 300px;
 
 	.row-wrapper {

--- a/client/landing/subscriptions/components/pending-list/styles.scss
+++ b/client/landing/subscriptions/components/pending-list/styles.scss
@@ -2,10 +2,7 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 
-$max-list-width: 1300px;
-
 .subscription-manager__pending-list {
-	max-width: $max-list-width;
 
 	.row {
 		border-bottom: 1px solid var(--color-border-subtle);

--- a/client/landing/subscriptions/components/site-list/styles.scss
+++ b/client/landing/subscriptions/components/site-list/styles.scss
@@ -2,10 +2,7 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 
-$max-list-width: 1300px;
-
 .subscription-manager__site-list {
-	max-width: $max-list-width;
 
 	.row {
 		border-block-end: 1px solid rgb(238, 238, 238);


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76211

## Proposed Changes

* This simple PR removes the extra whitespace that is visible on the right side of the lists in Subscription Management.

## Testing Instructions

**Setup:**

 1. For external users, add `subkey` to your cookie.
 2. For logged-in users, add `return true;` immediately right after `app.get( [ '/subscriptions', '/subscriptions/*' ]...` in `client/server/pages/index.js`.

**Test:**

 1. Test lists on sites page `/subscriptions/sites`, it should take up all available space.
 2. Test lists on comments page `/subscriptions/comments`, it should take up all available space.
 3. Test lists on pending page `/subscriptions/pending`, it should take up all available space.

**Before:**
<img width="1548" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/f6f23309-2c63-47b5-bd5c-4ef309f09320">

**After:**
<img width="1506" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/60cebb47-2c7a-44c1-97e9-7f79019c4ee5">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
