### PR TITLE
Launchpad: Check for FSE compatibility before showing the Edit Design overlay

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -24,30 +24,37 @@ import type { Device } from '@automattic/components';
  *
  * @function
  * @param {string | null} flow - The flow identifier or null.
+ * @param {boolean} isFullSiteEditingTheme - Whether the current theme is a full site editing theme.
  * @returns {boolean} - Returns true if the edit overlay should be enabled, otherwise returns false.
  */
-export const getEnableEditOverlay = ( flow: string | null ) => {
+export const getEnableEditOverlay = ( flow: string | null, isFullSiteEditingTheme: boolean ) => {
 	if ( isNewsletterFlow( flow ) ) {
 		return false;
 	}
 	if ( isStartWritingFlow( flow ) ) {
 		return false;
 	}
+	if ( ! isFullSiteEditingTheme ) {
+		return false;
+	}
+
 	return true;
 };
 
 const LaunchpadSitePreview = ( {
 	siteSlug,
 	flow,
+	isFullSiteEditingTheme,
 }: {
 	siteSlug: string | null;
 	flow: string | null;
+	isFullSiteEditingTheme: boolean;
 } ) => {
 	const translate = useTranslate();
 	const site = useSite();
 	const { globalStylesInUse } = usePremiumGlobalStyles( site?.ID );
 	const isInVideoPressFlow = isVideoPressFlow( flow );
-	const enableEditOverlay = getEnableEditOverlay( flow );
+	const enableEditOverlay = getEnableEditOverlay( flow, isFullSiteEditingTheme );
 
 	let previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const devicesToShow: Device[] = [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.PHONE ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -1,4 +1,5 @@
 import { useSelect } from '@wordpress/data';
+import { useSelector } from 'react-redux';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -6,6 +7,7 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';
+import { getActiveTheme, isFullSiteEditingTheme } from 'calypso/state/themes/selectors';
 import LaunchpadSitePreview from './launchpad-site-preview';
 import Sidebar from './sidebar';
 import { getLaunchpadTranslations } from './translations';
@@ -26,6 +28,10 @@ function sortByRegistrationDate( domainObjectA: ResponseDomain, domainObjectB: R
 const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentProps ) => {
 	const { flowName } = getLaunchpadTranslations( flow );
 	const site = useSite();
+	const activeTheme = useSelector( ( state ) => site && getActiveTheme( state, site.ID ) );
+	const isFSETheme = useSelector(
+		( state ) => isFullSiteEditingTheme( state, activeTheme ) as boolean
+	);
 	const adminUrl = useSelect(
 		( select ) =>
 			site && ( select( SITE_STORE ) as SiteSelect ).getSiteOption( site.ID, 'admin_url' ),
@@ -65,7 +71,11 @@ const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentP
 					goToStep={ goToStep }
 					flow={ flow }
 				/>
-				<LaunchpadSitePreview flow={ flow } siteSlug={ iFrameURL } />
+				<LaunchpadSitePreview
+					flow={ flow }
+					siteSlug={ iFrameURL }
+					isFullSiteEditingTheme={ isFSETheme }
+				/>
 			</div>
 		</main>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -1,5 +1,6 @@
 import { useSelect } from '@wordpress/data';
 import { useSelector } from 'react-redux';
+import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -58,6 +59,7 @@ const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentP
 
 	return (
 		<main className="launchpad__container">
+			{ site && <QueryActiveTheme siteId={ site.ID } /> }
 			<div className="launchpad__sidebar-header">
 				<WordPressLogo className="launchpad__sidebar-header-logo" size={ 24 } />
 				<span className="launchpad__sidebar-header-flow-name">{ flowName }</span>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/launchpad-site-preview.tsx
@@ -4,17 +4,25 @@ import { getEnableEditOverlay } from '../launchpad-site-preview';
 describe( 'getEnableEditOverlay', () => {
 	test( 'should return false if flow is a newsletter flow', () => {
 		const flow = NEWSLETTER_FLOW;
-		expect( getEnableEditOverlay( flow ) ).toBe( false );
+		const isFSETheme = true;
+		expect( getEnableEditOverlay( flow, isFSETheme ) ).toBe( false );
 	} );
 
 	test( 'should return false if flow is a start writing flow', () => {
 		const flow = START_WRITING_FLOW;
-		expect( getEnableEditOverlay( flow ) ).toBe( false );
+		const isFSETheme = true;
+		expect( getEnableEditOverlay( flow, isFSETheme ) ).toBe( false );
+	} );
+
+	test( 'should return false if theme is not FSE enabled', () => {
+		const isFSETheme = false;
+		expect( getEnableEditOverlay( null, isFSETheme ) ).toBe( false );
 	} );
 
 	test( 'default return true if flow is not specified or null', () => {
 		const flow = 'nonexistent-flow';
-		expect( getEnableEditOverlay( null ) ).toBe( true );
-		expect( getEnableEditOverlay( flow ) ).toBe( true );
+		const isFSETheme = true;
+		expect( getEnableEditOverlay( null, isFSETheme ) ).toBe( true );
+		expect( getEnableEditOverlay( flow, isFSETheme ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #76819

## Proposed Changes

* Don't show "Edit design" in the Launchpad site preview if the active theme is not full-site-editing compatible. This prevents users from seeing an error when they try to visit the site editor with a non-FSE theme.

Without FSE:

<img width="1664" alt="Screen Shot 2023-05-11 at 11 16 26 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/9cfab5e2-05c5-434f-b9fb-dfcaa4b31ef7">

With FSE:

<img width="1664" alt="Screen Shot 2023-05-11 at 11 06 07 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/f43525bf-c701-49ff-aaa1-ebb2c95b3618">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Create a new Free site from `/start`
* At the Launchpad step, skip to the Dashboard and go to Appearance -> Themes
* Activate a non-FSE theme like Twenty Fifteen
* Go back to Launchpad (click on inline help, click the progress notice there, or go to the front end of your site and click "Next steps" in the upper left launch bar)
* You should see Twenty Fifteen active in the site preview; hovering over the site preview should show no "Edit design" button. You shouldn't be able to click on the site preview, either.
* Skip to dashboard again and go to Appearance -> Themes
* Switch to a theme that supports FSE like Iotix
* Go back to the Launchpad
* Hovering over the site preview should show the "Edit design" button, and clicking it should bring you to the site editor.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
