### PR TITLE
Blog onboarding: Remove start-writing patches

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -18,8 +18,7 @@ import { ResponseDomain } from 'calypso/lib/domains/types';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import Checklist from './checklist';
-import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
-import { tasks } from './tasks';
+import { getEnhancedTasks } from './task-helper';
 import { getLaunchpadTranslations } from './translations';
 import { Task } from './types';
 
@@ -81,16 +80,10 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 		[]
 	);
 
-	const startWritingFlowTasks: Task[] | null = getArrayOfFilteredTasks(
-		tasks,
-		flow,
-		isEmailVerified
-	);
-
 	const enhancedTasks: Task[] | null =
 		site &&
 		getEnhancedTasks(
-			flow === 'start-writing' ? startWritingFlowTasks : launchpadChecklist,
+			launchpadChecklist,
 			siteSlug,
 			site,
 			submit,
@@ -204,11 +197,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 						</p>
 					</div>
 				) }
-				{ isFetchedAfterMount || flow === 'start-writing' ? (
-					<Checklist tasks={ enhancedTasks } />
-				) : (
-					<Checklist.Placeholder />
-				) }
+				{ isFetchedAfterMount ? <Checklist tasks={ enhancedTasks } /> : <Checklist.Placeholder /> }
 			</div>
 			<div className="launchpad__sidebar-admin-link">
 				<StepNavigationLink

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -49,10 +49,6 @@ export function getEnhancedTasks(
 
 	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
 
-	// Todo: setupBlogCompleted should be updated to use a new checklistStatus instead of site_edited.
-	//  Explorers will update Jetpack definitions to make this possible, meanwhile we are using site_edited.
-	const setupBlogCompleted = checklistStatuses?.site_edited || false;
-
 	const firstPostPublishedCompleted =
 		site?.options?.launchpad_checklist_tasks_statuses?.first_post_published || false;
 
@@ -62,7 +58,7 @@ export function getEnhancedTasks(
 	);
 
 	const planCompleted =
-		Boolean( tasks?.find( ( task ) => task.id === 'plan_selected' )?.completed ) ||
+		Boolean( tasks?.find( ( task ) => task.id === 'plan_completed' )?.completed ) ||
 		! isStartWritingFlow( flow );
 
 	const videoPressUploadCompleted = Boolean(
@@ -103,15 +99,14 @@ export function getEnhancedTasks(
 				case 'setup_blog':
 					taskData = {
 						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, setupBlogCompleted, task.id );
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
 								addQueryArgs( `/setup/${ START_WRITING_FLOW }/setup-blog`, {
 									...{ siteSlug: siteSlug, 'start-writing': true },
 								} )
 							);
 						},
-						completed: setupBlogCompleted,
-						disabled: setupBlogCompleted,
+						disabled: task.completed,
 					};
 					break;
 				case 'setup_newsletter':
@@ -171,6 +166,20 @@ export function getEnhancedTasks(
 						completed: ( planCompleted ?? task.completed ) && ! shouldDisplayWarning,
 						disabled: isStartWritingFlow( flow ) && ( planCompleted || ! domainUpsellCompleted ),
 						warning: shouldDisplayWarning,
+					};
+					break;
+				case 'plan_completed':
+					taskData = {
+						actionDispatch: () => {
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							const plansUrl = addQueryArgs( `/setup/${ START_WRITING_FLOW }/plans`, {
+								...{ siteSlug: siteSlug, 'start-writing': true },
+							} );
+
+							window.location.assign( plansUrl );
+						},
+						badge_text: ! task.completed ? null : translatedPlanName,
+						disabled: task.completed || ! domainUpsellCompleted,
 					};
 					break;
 				case 'subscribers_added':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -62,7 +62,7 @@ export function getEnhancedTasks(
 	);
 
 	const planCompleted =
-		Boolean( tasks?.find( ( task ) => task.id === 'site_launched' )?.completed ) ||
+		Boolean( tasks?.find( ( task ) => task.id === 'plan_selected' )?.completed ) ||
 		! isStartWritingFlow( flow );
 
 	const videoPressUploadCompleted = Boolean(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -142,7 +142,7 @@ export function getEnhancedTasks(
 									'calypso_launchpad_global_styles_gating_plan_selected_task_clicked'
 								);
 							}
-							let plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
+							const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
 								...( shouldDisplayWarning && {
 									plan: PLAN_PREMIUM,
 									feature: isVideoPressFlowWithUnsupportedPlan
@@ -150,21 +150,10 @@ export function getEnhancedTasks(
 										: FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
 								} ),
 							} );
-							if ( isStartWritingFlow( flow ) && site?.plan?.is_free ) {
-								plansUrl = addQueryArgs( `/setup/${ START_WRITING_FLOW }/plans`, {
-									...{ siteSlug: siteSlug, 'start-writing': true },
-								} );
-							}
-
 							window.location.assign( plansUrl );
 						},
-						badge_text:
-							isVideoPressFlowWithUnsupportedPlan ||
-							( isStartWritingFlow( flow ) && ! planCompleted )
-								? null
-								: translatedPlanName,
-						completed: ( planCompleted ?? task.completed ) && ! shouldDisplayWarning,
-						disabled: isStartWritingFlow( flow ) && ( planCompleted || ! domainUpsellCompleted ),
+						badgeText: isVideoPressFlowWithUnsupportedPlan ? null : translatedPlanName,
+						completed: task.completed && ! shouldDisplayWarning,
 						warning: shouldDisplayWarning,
 					};
 					break;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -49,13 +49,7 @@ export function getEnhancedTasks(
 
 	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
 
-	const firstPostPublishedCompleted =
-		site?.options?.launchpad_checklist_tasks_statuses?.first_post_published || false;
-
 	const domainUpsellCompleted = isDomainUpsellCompleted( site, checklistStatuses );
-	const siteLaunchCompleted = Boolean(
-		tasks?.find( ( task ) => task.id === 'site_launched' )?.completed
-	);
 
 	const planCompleted =
 		Boolean( tasks?.find( ( task ) => task.id === 'plan_completed' )?.completed ) ||
@@ -183,7 +177,6 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published':
 					taskData = {
-						completed: isStartWritingFlow( flow ) ? firstPostPublishedCompleted : task.completed,
 						disabled: mustVerifyEmailBeforePosting || isStartWritingFlow( flow || null ) || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -272,7 +265,7 @@ export function getEnhancedTasks(
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									recordTaskClickTracksEvent( flow, siteLaunchCompleted, task.id );
+									recordTaskClickTracksEvent( flow, task.completed, task.id );
 									return { goToHome: true, siteSlug };
 								} );
 
@@ -283,9 +276,7 @@ export function getEnhancedTasks(
 					break;
 				case 'blog_launched':
 					taskData = {
-						completed: siteLaunchCompleted,
 						disabled: isStartWritingFlow( flow ) && ! planCompleted,
-						isLaunchTask: true,
 						actionDispatch: () => {
 							if ( site?.ID ) {
 								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -102,7 +102,6 @@ export function getEnhancedTasks(
 					break;
 				case 'setup_blog':
 					taskData = {
-						title: translate( 'Set up your blog' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, setupBlogCompleted, task.id );
 							window.location.assign(
@@ -141,7 +140,6 @@ export function getEnhancedTasks(
 					break;
 				case 'plan_selected':
 					taskData = {
-						title: isStartWritingFlow( flow ) ? translate( 'Choose a plan' ) : task.title,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							if ( displayGlobalStylesWarning ) {
@@ -187,7 +185,6 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published':
 					taskData = {
-						title: isStartWritingFlow( flow ) ? translate( 'Write your first post' ) : task.title,
 						completed: isStartWritingFlow( flow ) ? firstPostPublishedCompleted : task.completed,
 						disabled: mustVerifyEmailBeforePosting || isStartWritingFlow( flow || null ) || false,
 						actionDispatch: () => {
@@ -288,7 +285,6 @@ export function getEnhancedTasks(
 					break;
 				case 'blog_launched':
 					taskData = {
-						title: translate( 'Launch your blog' ),
 						completed: siteLaunchCompleted,
 						disabled: isStartWritingFlow( flow ) && ! planCompleted,
 						isLaunchTask: true,
@@ -349,7 +345,6 @@ export function getEnhancedTasks(
 					break;
 				case 'domain_upsell':
 					taskData = {
-						title: isStartWritingFlow( flow ) ? translate( 'Choose a domain' ) : task.title,
 						completed: domainUpsellCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -18,7 +18,7 @@ const mockSite = {
 	...defaultSiteDetails,
 	options: {
 		...defaultSiteDetails.options,
-		site_intent: 'newsletter',
+		site_intent: '',
 	},
 };
 
@@ -34,9 +34,7 @@ const stepContentProps = {
 };
 
 jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
-	useSite: () => ( {
-		site: mockSite,
-	} ),
+	useSite: () => mockSite,
 } ) );
 
 jest.mock( 'react-router-dom', () => ( {
@@ -52,52 +50,58 @@ jest.mock( 'react-router-dom', () => ( {
 jest.mock( '@automattic/data-stores', () => ( {
 	...jest.requireActual( '@automattic/data-stores' ),
 	useLaunchpad: ( siteSlug, siteIntentOption ) => {
-		let checklist = [
-			{
-				id: 'setup_newsletter',
-				completed: true,
-				disabled: false,
-				title: 'Personalize newsletter',
-			},
-			{ id: 'plan_selected', completed: true, disabled: false, title: 'Choose a plan' },
-			{ id: 'subscribers_added', completed: true, disabled: true, title: 'Add subscribers' },
-			{
-				id: 'verify_email',
-				completed: true,
-				disabled: true,
-				title: 'Confirm email (check your inbox)',
-			},
-			{
-				id: 'first_post_published_newsletter',
-				completed: true,
-				disabled: true,
-				title: 'Start writing',
-			},
-		];
+		let checklist = [];
 
-		if ( siteIntentOption === 'start-writing' ) {
-			checklist = [
-				{
-					id: 'first_post_published',
-					completed: true,
-					disabled: false,
-					title: 'Write your first post',
-				},
-				{ id: 'setup_free', completed: true, disabled: false, title: 'Choose a plan' },
-				{ id: 'domain_upsell', completed: false, disabled: false, title: 'Choose a domain' },
-				{
-					id: 'plan_selected',
-					completed: false,
-					disabled: false,
-					title: 'Choose a plan',
-				},
-				{
-					id: 'blog_launched',
-					completed: false,
-					disabled: false,
-					title: 'Launch your blog',
-				},
-			];
+		switch ( siteIntentOption ) {
+			case 'newsletter':
+				checklist = [
+					{
+						id: 'setup_newsletter',
+						completed: true,
+						disabled: false,
+						title: 'Personalize newsletter',
+					},
+					{ id: 'plan_selected', completed: true, disabled: false, title: 'Choose a plan' },
+					{ id: 'subscribers_added', completed: true, disabled: true, title: 'Add subscribers' },
+					{
+						id: 'verify_email',
+						completed: true,
+						disabled: true,
+						title: 'Confirm email (check your inbox)',
+					},
+					{
+						id: 'first_post_published_newsletter',
+						completed: true,
+						disabled: true,
+						title: 'Start writing',
+					},
+				];
+				break;
+
+			case 'start-writing':
+				checklist = [
+					{
+						id: 'first_post_published',
+						completed: false,
+						disabled: false,
+						title: 'Write your first post',
+					},
+					{ id: 'setup_blog', completed: false, disabled: false, title: 'Name your blog' },
+					{ id: 'domain_upsell', completed: false, disabled: false, title: 'Choose a domain' },
+					{
+						id: 'plan_completed',
+						completed: false,
+						disabled: false,
+						title: 'Choose a plan',
+					},
+					{
+						id: 'blog_launched',
+						completed: false,
+						disabled: false,
+						title: 'Launch your blog',
+					},
+				];
+				break;
 		}
 
 		return {
@@ -161,6 +165,9 @@ describe( 'StepContent', () => {
 	// To get things started, test basic rendering for Newsletter flow
 	// In future, we can add additional flows and test interactivity of items
 	describe( 'when flow is Newsletter', () => {
+		beforeEach( () => {
+			mockSite.options.site_intent = NEWSLETTER_FLOW;
+		} );
 		it( 'renders correct sidebar header content', () => {
 			renderStepContent( false, NEWSLETTER_FLOW );
 
@@ -213,6 +220,9 @@ describe( 'StepContent', () => {
 	} );
 
 	describe( 'when flow is Start writing', () => {
+		beforeEach( () => {
+			mockSite.options.site_intent = START_WRITING_FLOW;
+		} );
 		it( 'renders correct sidebar header content', () => {
 			renderStepContent( false, START_WRITING_FLOW );
 
@@ -223,22 +233,10 @@ describe( 'StepContent', () => {
 		} );
 
 		it( 'renders correct sidebar tasks', () => {
-			const mockStartWritingSite = {
-				...mockSite,
-				options: {
-					...mockSite.options,
-					site_intent: 'start-writing',
-				},
-			};
-			jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
-				useSite: () => ( {
-					site: mockStartWritingSite,
-				} ),
-			} ) );
 			renderStepContent( false, START_WRITING_FLOW );
 
 			expect( screen.getByText( 'Write your first post' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Set up your blog' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Name your blog' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Choose a domain' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Choose a plan' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Launch your blog' ) ).toBeInTheDocument();
@@ -247,7 +245,7 @@ describe( 'StepContent', () => {
 		it( 'renders correct status for each task', () => {
 			renderStepContent( false, START_WRITING_FLOW );
 
-			const setupBlogListItem = screen.getByText( 'Set up your blog' ).closest( 'li' );
+			const setupBlogListItem = screen.getByText( 'Name your blog' ).closest( 'li' );
 			expect( setupBlogListItem ).toHaveClass( 'pending' );
 
 			const choosePlanListItem = screen.getByText( 'Choose a plan' ).closest( 'li' );

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -66,6 +66,12 @@ const startWriting: Flow = {
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
 		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
 
+		// Calling it here just to try and make plan_selected false work.
+		updateLaunchpadSettings( siteSlug, {
+			checklist_statuses: { plan_selected: false },
+		} );
+		console.log( 'plan_selected should be set to false' );
+
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );
 			const returnUrl = `/setup/start-writing/start-writing-done?siteSlug=${ siteSlug }`;
@@ -76,8 +82,9 @@ const startWriting: Flow = {
 				case 'processing': {
 					// If we just created a new site.
 					if ( ! providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
+						// This is how I thought setting plan_selected to false would work. But it doesn't seem to work.
 						await updateLaunchpadSettings( String( providedDependencies?.siteSlug ), {
-							checklist_statuses: { first_post_published: true },
+							checklist_statuses: { first_post_published: true, plan_selected: false },
 						} );
 
 						setSelectedSite( providedDependencies?.siteId );

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -66,12 +66,6 @@ const startWriting: Flow = {
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
 		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
 
-		// Calling it here just to try and make plan_selected false work.
-		updateLaunchpadSettings( siteSlug, {
-			checklist_statuses: { plan_selected: false },
-		} );
-		console.log( 'plan_selected should be set to false' );
-
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );
 			const returnUrl = `/setup/start-writing/start-writing-done?siteSlug=${ siteSlug }`;
@@ -82,9 +76,8 @@ const startWriting: Flow = {
 				case 'processing': {
 					// If we just created a new site.
 					if ( ! providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
-						// This is how I thought setting plan_selected to false would work. But it doesn't seem to work.
 						await updateLaunchpadSettings( String( providedDependencies?.siteSlug ), {
-							checklist_statuses: { first_post_published: true, plan_selected: false },
+							checklist_statuses: { first_post_published: true },
 						} );
 
 						setSelectedSite( providedDependencies?.siteId );
@@ -143,7 +136,7 @@ const startWriting: Flow = {
 				case 'plans':
 					if ( siteSlug ) {
 						await updateLaunchpadSettings( siteSlug, {
-							checklist_statuses: { plan_selected: true },
+							checklist_statuses: { plan_completed: true },
 						} );
 					}
 					if ( providedDependencies?.goToCheckout ) {

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -136,7 +136,7 @@ const startWriting: Flow = {
 				case 'plans':
 					if ( siteSlug ) {
 						await updateLaunchpadSettings( siteSlug, {
-							checklist_statuses: { plan_completed: true },
+							checklist_statuses: { plan_selected: true },
 						} );
 					}
 					if ( providedDependencies?.goToCheckout ) {

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -151,7 +151,7 @@ const startWriting: Flow = {
 				case 'setup-blog':
 					if ( siteSlug ) {
 						await updateLaunchpadSettings( siteSlug, {
-							checklist_statuses: { site_edited: true },
+							checklist_statuses: { setup_blog: true },
 						} );
 					}
 					return navigate( 'launchpad' );

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -76,10 +76,6 @@ const startWriting: Flow = {
 				case 'processing': {
 					// If we just created a new site.
 					if ( ! providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
-						await updateLaunchpadSettings( String( providedDependencies?.siteSlug ), {
-							checklist_statuses: { first_post_published: true },
-						} );
-
 						setSelectedSite( providedDependencies?.siteId );
 						setIntentOnSite( providedDependencies?.siteSlug, START_WRITING_FLOW );
 						saveSiteSettings( providedDependencies?.siteId, {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2275-gh-Automattic/dotcom-forge

## Proposed Changes

* This PR removes patches created for the `start-writing` flow so that `start-writing` is using the Jetpack backend API.
* It undoes this PR https://github.com/Automattic/wp-calypso/pull/76432
* It removes `start-writing` conditional logic from the `plan_selected` task and creates a new `plan_completed` task for use by `start-writing`.
* It removes a lot of `isStartWritingFlow` conditions.
* It swaps `start-writing` use of the `site_edited` task for `setup_blog`.

Happy path:

https://github.com/Automattic/wp-calypso/assets/140841/5548f75c-ca52-45a0-9ebe-5116be36ba1c


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply [this Jetpack code](https://github.com/Automattic/jetpack/pull/30686) to your sandbox and "sandbox your wpcom API"
* Apply this PR to your Calypso dev environment
* Log out or open a private browser window and go to calypso.localhost:3000/setup/start-writing/
* Create a new account
* As you step through the start-writing flow, confirm the steps are marked complete in the API dev console.
![completed-status](https://github.com/Automattic/wp-calypso/assets/140841/b3b50e65-38f3-4aa8-aa3d-41a0cd3d530f)
* The UI experience should match the video above.

We also need to confirm that flows that use the `plan_selected` and `first_post_published` tasks do not suffer regressions. We can do that by testing the "link-in-bio flow" and the "write" flow.

- Create a new account and head to http://calypso.localhost:3000/setup/link-in-bio/intro has the `plan_selected` task for testing
- Create a new account and head to http://calypso.localhost:3000/start/user, be sure to select "writing" as your site goal. You'll find the `first_post_published` on the launchpad.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?