### PR TITLE
Onboarding: Newsletters: Paid subscribers option to Staging

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,6 +83,7 @@
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
+		"newsletter/paid-subscribers": true,
 		"newsletter/stats": true,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/2023-pricing-grid": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -90,6 +90,7 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
+		"newsletter/paid-subscribers": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,


### PR DESCRIPTION
Adds this checkbox during Onboarding:

<img width="707" alt="Screenshot 2023-05-11 at 13 35 02" src="https://github.com/Automattic/wp-calypso/assets/104869/4687e810-6636-42b3-a178-955a8b4e6a46">

And this tasks to the LaunchPad:

<img width="467" alt="Screenshot 2023-05-11 at 13 36 37" src="https://github.com/Automattic/wp-calypso/assets/104869/c96d5dc0-6a57-4b2c-9106-fdbf50bdc25d">
