### PR TITLE
Earn: Fix z-index issue on Plans dialog

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -227,7 +227,7 @@ $z-layers: (
 		".editor-media-modal .section-nav": 10,
 		".editor-media-modal .notice": 10,
 		".editor-media-modal-gallery__preview-toggle": 100,
-		".memberships__dialog-section.is-visible": 1,
+		".memberships__dialog-section.is-visible": 2,
 	),
 	".site-settings__taxonomies": (
 		".card__link-indicator": 1,


### PR DESCRIPTION
Resolves 26-gh-Automattic/gold

### Proposed Changes

There's an odd issue on the Earn > Add Payment Plan dialogue where one of the toggles is clickable even when a separate tab is loaded on top. This seems to be a z-index / layering issue. While there are a range of ways to approach, I opted for the simplest I could find which is upping the z-index of the active tab content from 1 to 2.

### Testing Instructions

**You will need a test site that has stripe connected.**

1. Checkout this branch and run yarn and yarn start if needed. 
2. Go to http://calypso.localhost:3000/earn/payments-plans/YOURDOMAIN for your stripe-connected site.
4. Click the button to Add a New plan. It will open on the 'General' tab. Click the 'Email' tab and click the toggle for 'Email newly published posts to your customers.' Now go back to the 'General' tab and confirm you can no longer click or access that toggle in any way. 
   - See issue linked above for additional context if needed. 