### PR TITLE
Plugin Details Notices: Remove selectedSite as required as it will be null for multisite visualization

### DIFF
--- a/client/my-sites/plugins/plugin-details-notices.jsx
+++ b/client/my-sites/plugins/plugin-details-notices.jsx
@@ -54,7 +54,7 @@ const PluginDetailsNotices = ( { selectedSite, plugin, translate } ) => {
 };
 
 PluginDetailsNotices.propTypes = {
-	selectedSite: PropTypes.object.isRequired,
+	selectedSite: PropTypes.object,
 	plugin: PropTypes.object.isRequired,
 };
 


### PR DESCRIPTION
## Proposed Changes

Mark `selectedSite` as not required as it can be null on multisite visualization.
This should fix the console error on the Plugin Details page for multisite view.

<img width="869" alt="CleanShot 2023-05-11 at 15 10 48@2x" src="https://github.com/Automattic/wp-calypso/assets/5039531/24b40527-cb19-4eeb-95fd-7d72359b7694">


## Testing Instructions
* From trunk branch
* Go to a plugins page (`/plugins/:plugin-slug`). Ex: `/plugins/woocommerce`
* Check the console, there SHOULD BE an error as stated above
* From this branch
* Go to the same page
* There SHOULD NOT be any errors on the console 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
