### PR TITLE
Plugin Details: Update automanaged plugins sidebar

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -160,13 +160,17 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	if ( ! isJetpack && PREINSTALLED_PLUGINS.includes( plugin.slug ) ) {
 		return (
 			<div className="plugin-details-cta__container">
-				<div className="plugin-details-cta__installed-text">
-					{ translate( 'Installed and {{activation /}}', {
-						components: {
-							activation: activeText,
-						},
-					} ) }
-				</div>
+				{ selectedSite ? (
+					<div className="plugin-details-cta__installed-text">
+						{ translate( 'Installed and {{activation /}}', {
+							components: {
+								activation: activeText,
+							},
+						} ) }
+					</div>
+				) : (
+					<div className="plugin-details-cta__price">{ translate( 'Free' ) }</div>
+				) }
 				<span className="plugin-details-cta__preinstalled">
 					<p>{ translate( '%s is automatically managed for you.', { args: plugin.name } ) }</p>
 					{ selectedSite && shouldUpgrade && (

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -191,6 +191,18 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						{ translate( 'Upgrade my plan' ) }
 					</Button>
 				) }
+				{ ! selectedSite && ! isLoggedIn && (
+					<GetStartedButton
+						onClick={ () => {
+							dispatch(
+								recordTracksEvent( 'calypso_plugin_details_get_started_click', {
+									plugin: plugin?.slug,
+									is_logged_in: isLoggedIn,
+								} )
+							);
+						} }
+					/>
+				) }
 			</div>
 		);
 	}
@@ -399,7 +411,6 @@ function PrimaryButton( {
 	isWpcomStaging,
 } ) {
 	const dispatch = useDispatch();
-	const sectionName = useSelector( getSectionName );
 
 	const isMarketplaceProduct = useSelector( ( state ) =>
 		isMarketplaceProductSelector( state, plugin.slug )
@@ -417,23 +428,7 @@ function PrimaryButton( {
 	}, [ dispatch, plugin, isLoggedIn ] );
 
 	if ( ! isLoggedIn ) {
-		const startUrl = addQueryArgs(
-			{
-				ref: sectionName + '-lp',
-			},
-			'/start/business'
-		);
-		return (
-			<Button
-				type="a"
-				className="plugin-details-cta__install-button"
-				primary
-				onClick={ onClick }
-				href={ startUrl }
-			>
-				{ translate( 'Get started' ) }
-			</Button>
-		);
+		return <GetStartedButton onClick={ onClick } />;
 	}
 	if ( plugin.isSaasProduct ) {
 		return (
@@ -455,6 +450,29 @@ function PrimaryButton( {
 			hasEligibilityMessages={ hasEligibilityMessages }
 			disabled={ incompatiblePlugin || userCantManageTheSite || isDisabledForWpcomStaging }
 		/>
+	);
+}
+
+function GetStartedButton( { onClick } ) {
+	const translate = useTranslate();
+	const sectionName = useSelector( getSectionName );
+
+	const startUrl = addQueryArgs(
+		{
+			ref: sectionName + '-lp',
+		},
+		'/start/business'
+	);
+	return (
+		<Button
+			type="a"
+			className="plugin-details-cta__install-button"
+			primary
+			onClick={ onClick }
+			href={ startUrl }
+		>
+			{ translate( 'Get started' ) }
+		</Button>
 	);
 }
 

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -144,18 +144,38 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		setDisplayManageSitePluginsModal( ! displayManageSitePluginsModal );
 	}, [ displayManageSitePluginsModal ] );
 
+	// Activation and deactivation translations.
+	const activeText = translate( '{{span}}active{{/span}}', {
+		components: {
+			span: <span className="plugin-details-cta__installed-text-active"></span>,
+		},
+	} );
+	const inactiveText = translate( '{{span}}deactivated{{/span}}', {
+		components: {
+			span: <span className="plugin-details-cta__installed-text-inactive"></span>,
+		},
+	} );
+
 	// If we cannot retrieve plugin status through jetpack ( ! isJetpack ) and plugin is preinstalled.
 	if ( ! isJetpack && PREINSTALLED_PLUGINS.includes( plugin.slug ) ) {
 		return (
 			<div className="plugin-details-cta__container">
-				<div className="plugin-details-cta__price">{ translate( 'Free' ) }</div>
+				<div className="plugin-details-cta__installed-text">
+					{ translate( 'Installed and {{activation /}}', {
+						components: {
+							activation: activeText,
+						},
+					} ) }
+				</div>
 				<span className="plugin-details-cta__preinstalled">
-					{ selectedSite && shouldUpgrade
-						? translate(
-								'%s is automatically managed for you. Upgrade your plan and get access to another 50,000 WordPress plugins to extend functionality for your site.',
-								{ args: plugin.name }
-						  )
-						: translate( '%s is automatically managed for you.', { args: plugin.name } ) }
+					<p>{ translate( '%s is automatically managed for you.', { args: plugin.name } ) }</p>
+					{ selectedSite && shouldUpgrade && (
+						<p>
+							{ translate(
+								'Upgrade your plan and get access to another 50,000 WordPress plugins to extend functionality for your site.'
+							) }
+						</p>
+					) }
 				</span>
 
 				{ selectedSite && shouldUpgrade && (
@@ -190,16 +210,6 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 
 	if ( isPluginInstalledOnsiteWithSubscription && sitePlugin ) {
 		// Check if already instlaled on the site
-		const activeText = translate( '{{span}}active{{/span}}', {
-			components: {
-				span: <span className="plugin-details-cta__installed-text-active"></span>,
-			},
-		} );
-		const inactiveText = translate( '{{span}}deactivated{{/span}}', {
-			components: {
-				span: <span className="plugin-details-cta__installed-text-inactive"></span>,
-			},
-		} );
 		const { active } = sitePlugin;
 
 		return (


### PR DESCRIPTION
Resolves #76811

## Proposed Changes

Update the top part of the sidebar for preinstalled plugins such as Gutenberg.
* Below than Business plans:  Indicate the plugin is installed and update copy to have a clear separation between the plugin and upsell text
* Business and higher plans: Show options to manage and deactivate plugin
* No site selected: Show price as free and warns the plugin is automanaged
* Logged out: same as no site selected but with the option to `Get Started`

| Below than Business  | Business and higher | No site | Logged out|
| ------------- | ------------- | ------------- | ------------- |
|![CleanShot 2023-05-11 at 15 28 57@2x](https://github.com/Automattic/wp-calypso/assets/5039531/17b86cc0-3fe7-4f7b-8ed6-dcc7b0f7d83b)|![CleanShot 2023-05-11 at 15 29 28@2x](https://github.com/Automattic/wp-calypso/assets/5039531/7dd6cc02-c8f7-47ab-9a25-eee8d8febd77)|![CleanShot 2023-05-11 at 15 29 49@2x](https://github.com/Automattic/wp-calypso/assets/5039531/634ba7cb-aa07-4eed-baff-1790c85134a1)|![CleanShot 2023-05-11 at 15 30 11@2x](https://github.com/Automattic/wp-calypso/assets/5039531/fd1daaf0-2b30-47e4-a8c8-4bff7e9b1e72)|





## Testing Instructions
* Go to the Plugin Details page of a preinstalled plugin. Ex: `/plugins/gutenberg/`
* Check if all the cases above matches the specified layout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
