### PR TITLE
Mastodon: remove spinner next to input when invalid username

### DIFF
--- a/client/my-sites/marketing/connections/mastodon.tsx
+++ b/client/my-sites/marketing/connections/mastodon.tsx
@@ -1,4 +1,4 @@
-import { FormInputValidation, Spinner } from '@automattic/components';
+import { FormInputValidation } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useState, FormEvent, ChangeEvent } from 'react';
@@ -121,7 +121,6 @@ export const Mastodon: React.FC< Props > = ( {
 							isError={ showError }
 							onChange={ handleInstanceChange }
 						/>
-						{ showError && <Spinner /> }
 					</InstanceContainer>
 					{ showError && <FormInputValidation isError text={ error } /> }
 				</div>

--- a/client/my-sites/marketing/connections/test/mastodon.jsx
+++ b/client/my-sites/marketing/connections/test/mastodon.jsx
@@ -29,7 +29,7 @@ describe( 'Mastodon', () => {
 	} );
 
 	test( 'displays an error message when instance is invalid', async () => {
-		const { container } = render( <Mastodon { ...props } /> );
+		render( <Mastodon { ...props } /> );
 
 		await userEvent.type(
 			screen.getByLabelText( 'Enter your Mastodon username' ),
@@ -38,9 +38,6 @@ describe( 'Mastodon', () => {
 
 		// error message is displayed
 		expect( screen.getByRole( 'alert' ) ).toBeInTheDocument();
-
-		// spinner is shown
-		expect( container.getElementsByClassName( 'spinner' ).length ).toBe( 1 );
 
 		const btn = screen.getByRole( 'button', { name: /Connect account/i } );
 		expect( btn ).toBeDisabled();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76848

## Proposed Changes

In the _Marketing / Connections_ section of Calypso, entering an invalid username in the Mastodon section causes a spinner to show up. This is confusing since the input validation checks the username syntax and doesn't make any async call.

This PR removes the spinner.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Prerequisites

- Make sure you have a Mastodon account

### Testing

- Spin up Calypso by running this branch locally or by using a live link below
- If you're using a live link, enable the `mastodon` flag by adding the query parameter `?flags=mastodon`
- Visit `/marketing/connections/:site`
- Expand the Mastodon section
- Type something in the input
- Notice there's no spinner, only an error message
- Enter your Mastodon username
- Check that the error message is not shown anymore

| Before | After |
|--------|------|
|<img width="400" alt="Screenshot 2023-05-11 at 9 24 53 AM" src="https://github.com/Automattic/wp-calypso/assets/1620183/ff39e74d-fab0-473e-a30c-95652981fb9c">|<img width="400" alt="Screenshot 2023-05-11 at 9 32 36 AM" src="https://github.com/Automattic/wp-calypso/assets/1620183/066fb0f7-e6b3-4560-b42a-b99b7064d488">|






## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
