### PR TITLE
Social preview: fix no selected service edge case

### DIFF
--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -64,7 +64,13 @@ class SharingPreviewPane extends PureComponent {
 		const { post, site, message, connections, translate, seoTitle, siteSlug, siteIcon } =
 			this.props;
 		const { selectedService } = this.state;
+
+		if ( ! selectedService ) {
+			return null;
+		}
+
 		const connection = find( connections, { service: selectedService } );
+
 		if ( ! connection ) {
 			return (
 				<Notice


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76849

## Proposed Changes

Previewing a post in Calypso before sharing causes a confusing notice to be displayed, when a Mastodon account only is connected.

This PR solves this.

## Testing Instructions

### Prerequisites

- Make sure you have a Mastodon account
- Connect your test site to Mastodon in the `/marketing/connections/:site` section
- Mastodon must be the only connected account
- Make sure your site has at least one post

### Testing

- Spin up Calypso by running this branch locally or by using a live link below
- If you're using a live link, enable the `mastodon` flag by adding the query parameter `?flags=mastodon`
- Visit `/posts/:site`
- In your post actions, click _Share_, then click _Preview_
- Notice you don't see any notice

_Note: the Mastodon preview is yet to be implemented_

| Before | After |
|--------|------|
|<img width="400" alt="Screenshot 2023-05-11 at 9 24 53 AM" src="https://github.com/Automattic/wp-calypso/assets/1620183/71d51884-7bbf-49d5-8565-12baa42f03da">|<img width="400" alt="Screenshot 2023-05-11 at 9 32 36 AM" src="https://github.com/Automattic/wp-calypso/assets/1620183/72c355ca-02ea-42db-90c1-56b58e382674">|






## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
