### PR TITLE
Query for purchases on the manage purchase page if no purchase is loaded

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1265,8 +1265,17 @@ class ManagePurchase extends Component<
 			isProductOwner,
 		} = this.props;
 
+		// If there is no purchase, query to load the purchases
 		if ( ! purchase ) {
-			return this.renderPlaceholder();
+			return (
+				<Fragment>
+					<PurchasesQueryComponent
+						isSiteLevel={ this.props.isSiteLevel ?? false }
+						selectedSiteId={ this.props.selectedSiteId ?? 0 }
+					/>
+					{ this.renderPlaceholder() }
+				</Fragment>
+			);
 		}
 
 		let changePaymentMethodPath: string | false = false;
@@ -1293,10 +1302,6 @@ class ManagePurchase extends Component<
 				<TrackPurchasePageView
 					eventName="calypso_manage_purchase_view"
 					purchaseId={ this.props.purchaseId }
-				/>
-				<PurchasesQueryComponent
-					isSiteLevel={ this.props.isSiteLevel ?? false }
-					selectedSiteId={ this.props.selectedSiteId ?? 0 }
 				/>
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 				{ isPurchaseTheme && (


### PR DESCRIPTION
## Proposed Changes

* This diff fixes a bug where single purchase pages would not load properly if linked to directly

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To reproduce the issue. log into your WPCOM account and navigate to `/me/purchases`
* From your purchase list, right click on a purchase and open it in a new tab
* The purchase management page will get "stuck" loading and never show any output.
* Now, with this patch applied locally, repeat the test of opening a purchase in a new tab - the purchase management page should load properly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
