### PR TITLE
Stats Widget: Use component Button styling base for module buttons

### DIFF
--- a/apps/odyssey-stats/src/widget/modules.scss
+++ b/apps/odyssey-stats/src/widget/modules.scss
@@ -40,43 +40,29 @@ $jp-gray: #dcdcde;
 	}
 }
 
-.jetpack-emerald-button {
-	cursor: pointer;
-	padding: 4px 8px;
-	appearance: none;
-	text-align: center;
-
-	color: var(--studio-white);
-	background: var(--studio-black);
-	font-size: $font-body-extra-small;
+// Use base component styling of `@automattic/components/Button`
+.button.jetpack-emerald-button {
 	font-weight: 600;
-	text-decoration: none;
-	line-height: 20px;
 
-	border: 1px solid var(--studio-black);
-	border-radius: 4px;
-
-	&:hover:not(:disabled) {
-		border-color: $emerald-hover-color;
-		background: $emerald-hover-color;
+	&:focus {
+		box-shadow: none;
 	}
 
-	&:disabled {
-		background: $jp-gray;
-		color: var(--studio-gray-20);
-		border: 1px solid transparent;
+	&.is-primary {
+		color: var(--studio-white);
+		background: var(--studio-black);
 	}
 
 	&.is-secondary-jetpack-emerald {
 		color: var(--studio-black);
 		background: inset 0 0 0 1.5px var(--studio-white);
-		box-shadow: var(--studio-white);
 
-		&:hover:not(:disabled) {
+		&:hover:not(.is-busy) {
+			color: var(--studio-black);
 			background: var(--studio-gray-0);
 		}
 
-		&:disabled {
+		&.is-busy {
 			background: $jp-gray;
 			color: var(--studio-gray-20);
 			border: 1px solid transparent;

--- a/apps/odyssey-stats/src/widget/modules.scss
+++ b/apps/odyssey-stats/src/widget/modules.scss
@@ -53,7 +53,8 @@ $jp-gray: #dcdcde;
 		background: var(--studio-black);
 	}
 
-	&.is-secondary-jetpack-emerald {
+	// Use `transparent` styling as secondary styles
+	&.is-transparent {
 		color: var(--studio-black);
 		background: inset 0 0 0 1.5px var(--studio-white);
 

--- a/apps/odyssey-stats/src/widget/modules.tsx
+++ b/apps/odyssey-stats/src/widget/modules.tsx
@@ -82,7 +82,7 @@ const ModuleCard: FunctionComponent< ModuleCardProps > = ( {
 							{ error === 'not_installed' && (
 								<Button
 									transparent
-									className="jetpack-emerald-button is-secondary-jetpack-emerald"
+									className="jetpack-emerald-button"
 									busy={ disabled }
 									onClick={ onActivateProduct }
 								>

--- a/apps/odyssey-stats/src/widget/modules.tsx
+++ b/apps/odyssey-stats/src/widget/modules.tsx
@@ -1,4 +1,4 @@
-import { ShortenedNumber } from '@automattic/components';
+import { ShortenedNumber, Button } from '@automattic/components';
 import { protect, akismet } from '@automattic/components/src/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -70,22 +70,24 @@ const ModuleCard: FunctionComponent< ModuleCardProps > = ( {
 					{ isError && canManageModule && (
 						<div className="stats-widget-module__info">
 							{ error === 'not_active' && (
-								<button
+								<Button
+									primary
 									className="jetpack-emerald-button"
-									disabled={ disabled }
+									busy={ disabled }
 									onClick={ onActivateProduct }
 								>
 									Activate
-								</button>
+								</Button>
 							) }
 							{ error === 'not_installed' && (
-								<button
+								<Button
+									transparent
 									className="jetpack-emerald-button is-secondary-jetpack-emerald"
-									disabled={ disabled }
+									busy={ disabled }
 									onClick={ onActivateProduct }
 								>
 									Install
-								</button>
+								</Button>
 							) }
 							{ error === 'invalid_key' && (
 								<a href={ manageUrl } target="_self">

--- a/apps/odyssey-stats/src/widget/modules.tsx
+++ b/apps/odyssey-stats/src/widget/modules.tsx
@@ -76,7 +76,7 @@ const ModuleCard: FunctionComponent< ModuleCardProps > = ( {
 									busy={ disabled }
 									onClick={ onActivateProduct }
 								>
-									Activate
+									{ translate( 'Activate' ) }
 								</Button>
 							) }
 							{ error === 'not_installed' && (
@@ -86,12 +86,12 @@ const ModuleCard: FunctionComponent< ModuleCardProps > = ( {
 									busy={ disabled }
 									onClick={ onActivateProduct }
 								>
-									Install
+									{ translate( 'Install' ) }
 								</Button>
 							) }
 							{ error === 'invalid_key' && (
 								<a href={ manageUrl } target="_self">
-									Manage Akismet key
+									{ translate( 'Manage Akismet key' ) }
 								</a>
 							) }
 							{ ! [ 'not_active', 'not_installed', 'invalid_key' ].includes( error ) && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76115 

## Proposed Changes

* Use the Button component of `@automattic/components` to facilitate styles of module action buttons.
* The only different styling of the button is the `disabled` status of the Activate button, which applies the busy loading styles.

|Before|After|
|-|-|
|<img width="273" alt="old_activate_busy" src="https://github.com/Automattic/wp-calypso/assets/6869813/18d8db92-0179-4e83-b381-9ef29e8e934f">|<img width="273" alt="new_activate_busy" src="https://github.com/Automattic/wp-calypso/assets/6869813/674382da-d01d-4331-a79c-cba5d48aed4e">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build Jetpack if necessary: `jetpack build plugins/jetpack`.
* Run `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev` under `calypso/apps/odyssey-stats`.
* Uninstall Akismet if installed.
* Open `/wp-admin/index.php` on a site with Jetpack bleeding edge.
* Ensure the `Install` button shows on the `Akismet` card.
* Click the install button.
* Ensure the button is showing disabled styling and not able to click again as previously.
* Deactivate Akismet if activated.
* Ensure the `Activate` button shows on the `Akismet` card.
* Click the activate button.
* Ensure the button is showing loading styling and not able to click again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
