### PR TITLE
Add popular tags link to universal navigation

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -26,7 +26,9 @@ $happy_blocks_tabs = array(
 		'title' => __( 'Forums', 'happy-blocks' ),
 		'url'   => localized_wpcom_url( 'https://wordpress.com/forums/' ),
 	),
-)
+);
+
+$happy_blocks_is_english = ( 0 === stripos( get_locale(), 'en' ) );
 ?>
 <?php if ( ! is_user_logged_in() ) : ?>
 	<div id="lpc-header-nav" class="lpc lpc-header-nav">
@@ -96,7 +98,6 @@ $happy_blocks_tabs = array(
 					</div>
 				</div>
 				<!-- Nav bar ends here. -->
-
 				<!-- Desktop dropdowns start here. -->
 				<div class="x-dropdown">
 					<div class="x-dropdown-top">
@@ -200,6 +201,13 @@ $happy_blocks_tabs = array(
 									<?php esc_html_e( 'Logo Maker', 'happy-blocks' ); ?>
 								</a>
 							</li>
+							<?php if ( $happy_blocks_is_english ) : ?>
+								<li>
+									<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/tags/' ) ); ?>" title="<?php esc_attr_e( 'Popular Tags', 'happy-blocks' ); ?>" tabindex="-1">
+										<?php esc_html_e( 'Popular Tags', 'happy-blocks' ); ?>
+									</a>
+								</li>
+							<?php endif; ?>
 							<?php if ( time() >= strtotime( '2021-02-17' ) ) : ?>
 								<li>
 									<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/webinars/' ) ); ?>" title="<?php esc_attr_e( 'Daily Webinars', 'happy-blocks' ); ?>" tabindex="-1">
@@ -216,7 +224,6 @@ $happy_blocks_tabs = array(
 					</div>
 				</div>
 				<!-- Desktop dropdowns end here. -->
-
 				<!-- Mobile menu starts here. -->
 				<div class="x-menu" role="menu" aria-label="<?php esc_attr_e( 'WordPress.com Navigation Menu', 'happy-blocks' ); ?>" aria-hidden="true">
 					<div class="x-menu-overlay"></div>
@@ -356,6 +363,13 @@ $happy_blocks_tabs = array(
 										<?php esc_html_e( 'Logo Maker', 'happy-blocks' ); ?>
 									</a>
 								</li>
+								<?php if ( $happy_blocks_is_english ) : ?>
+									<li class="x-menu-grid-item">
+										<a role="menuitem" class="x-menu-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/tags/' ) ); ?>" title="<?php esc_attr_e( 'Popular Tags', 'happy-blocks' ); ?>" tabindex="-1">
+											<?php esc_html_e( 'Popular Tags', 'happy-blocks' ); ?>
+										</a>
+									</li>
+								<?php endif; ?>
 								<?php if ( time() >= strtotime( '2021-02-17' ) ) : ?>
 									<li class="x-menu-grid-item">
 										<a role="menuitem" class="x-menu-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/webinars/' ) ); ?>" title="<?php esc_attr_e( 'Daily Webinars', 'happy-blocks' ); ?>" tabindex="-1">
@@ -373,7 +387,6 @@ $happy_blocks_tabs = array(
 					</div>
 				</div>
 				<!-- Mobile menu ends here. -->
-
 			</div>
 		</div>
 	</div>

--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -212,6 +212,13 @@ export const PureUniversalNavbarFooter = ( {
 									</a>
 								</li>
 								<li>
+									{ isEnglishLocale && (
+										<a href={ localizeUrl( 'https://wordpress.com/tags/' ) } target="_self">
+											{ __( 'Popular Tags', __i18n_text_domain__ ) }
+										</a>
+									) }
+								</li>
+								<li>
 									<a href={ localizeUrl( 'https://wordpress.com/webinars/' ) } target="_self">
 										{ __( 'Daily Webinars', __i18n_text_domain__ ) }
 									</a>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -224,6 +224,15 @@ const UniversalNavbarHeader = ( {
 															type="dropdown"
 															target="_self"
 														/>
+														{ isEnglishLocale && (
+															<ClickableItem
+																titleValue={ __( 'Popular Tags', __i18n_text_domain__ ) }
+																content={ __( 'Popular Tags', __i18n_text_domain__ ) }
+																urlValue={ localizeUrl( '//wordpress.com/tags/' ) }
+																type="dropdown"
+																target="_self"
+															/>
+														) }
 														<ClickableItem
 															titleValue={ __( 'Daily Webinars', __i18n_text_domain__ ) }
 															content={ __( 'Daily Webinars', __i18n_text_domain__ ) }
@@ -476,6 +485,14 @@ const UniversalNavbarHeader = ( {
 												urlValue={ localizeUrl( '//wordpress.com/logo-maker/' ) }
 												type="menu"
 											/>
+											{ isEnglishLocale && (
+												<ClickableItem
+													titleValue={ __( 'Popular Tags', __i18n_text_domain__ ) }
+													content={ __( 'Popular Tags', __i18n_text_domain__ ) }
+													urlValue={ localizeUrl( '//wordpress.com/tags/' ) }
+													type="menu"
+												/>
+											) }
 											<ClickableItem
 												titleValue={ __( 'Daily Webinars', __i18n_text_domain__ ) }
 												content={ __( 'Daily Webinars', __i18n_text_domain__ ) }


### PR DESCRIPTION
## Proposed Changes
Part of pe7F0s-Ly-p2. Adds the "Popular Tags" link to the support pages in the universal header in calypso and happy-blocks
**Desktop**
<img width="967" alt="Screen Shot 2023-05-12 at 12 13 56 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/ac23fa50-ba67-44da-ac36-e629df95e4e2">
**Mobile**
<img width="522" alt="Screen Shot 2023-05-12 at 12 27 01 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/9258bedf-28be-43ab-84a6-861f787e90ca">


## Testing Instructions
#### Test happy-blocks
Sandbox `wordpress.com`
CD into `/apps/happy-blocks`
Sync to your sandbox `yarn dev --sync`
Go to https://wordpress.com/support/
The header link should be updated on mobile and desktop
The footer links appear to be controlled by other code, either in landpack or wpcom

#### Test universal header
In calypso, go to the logged out `/themes` page
The header link should be updated on mobile and desktop


