### PR TITLE
Add i18n comment for Gravatar's signup and login pages

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -199,7 +199,7 @@ const LayoutLoggedOut = ( {
 				/>
 			) }
 
-			{ isGravatar && <PoweredByWPFooter siteName={ oauth2Client.title } /> }
+			{ isGravatar && <PoweredByWPFooter clientTitle={ oauth2Client.title } /> }
 		</div>
 	);
 };

--- a/client/layout/powered-by-wp-footer/index.tsx
+++ b/client/layout/powered-by-wp-footer/index.tsx
@@ -4,10 +4,10 @@ import WordPressLogo from 'calypso/components/wordpress-logo';
 import './style.scss';
 
 interface Props {
-	siteName?: string;
+	clientTitle?: string;
 }
 
-export default function PoweredByWPFooter( { siteName }: Props ) {
+export default function PoweredByWPFooter( { clientTitle }: Props ) {
 	const translate = useTranslate();
 
 	function renderPoweredByWP() {
@@ -19,9 +19,11 @@ export default function PoweredByWPFooter( { siteName }: Props ) {
 		);
 	}
 
-	function renderPoweredByWPWithSiteName() {
-		const wording = translate( '%s is powered by <logo/> WordPress.com', {
-			args: siteName,
+	function renderPoweredByWPWithClientTitle() {
+		const wording = translate( '%(clientTitle)s is powered by <logo/> WordPress.com', {
+			args: { clientTitle },
+			comment:
+				"'clientTitle' is the name of the app that uses WordPress.com Connect (e.g. 'Crowdsignal' or 'Gravatar')",
 		} ) as string;
 
 		return createInterpolateElement( wording, {
@@ -32,7 +34,7 @@ export default function PoweredByWPFooter( { siteName }: Props ) {
 	return (
 		<footer className="powered-by-wp-footer">
 			<div className="powered-by-wp-footer__info">
-				{ siteName ? renderPoweredByWPWithSiteName() : renderPoweredByWP() }
+				{ clientTitle ? renderPoweredByWPWithClientTitle() : renderPoweredByWP() }
 			</div>
 		</footer>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 105164-gh-Automattic/gravatar

## Proposed Changes

* To add an i18n comment
* To replace the `siteName` with `clientTitle` for the purpose of code consistent

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to the branch and run it locally (check [the doc](https://github.com/Automattic/wp-calypso#getting-started) to setup your dev environment)
* Log out of your WP account
* Go to the log-in page by [this URL](http://calypso.localhost:3000/log-in?client_id=1854&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3Dad4b462bedc61ff0ee2b72b16252632bcf4f4ec2e9aaab25a169e49d565e87bf%26redirect_uri%3Dhttps%253A%252F%252Fen.gravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1) (you might need to modify your origin), and the footer still works the same.

<img width="1680" alt="login" src="https://github.com/Automattic/wp-calypso/assets/21308003/1c2c20bb-c1f6-4ba1-a81d-931bca8cf820">

* Go to the sign-up page by [this URL](http://calypso.localhost:3000/start/wpcc/oauth2-user?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4c419247334b07b3cb7adc7fbdfe0a723abe7296d6e38f19146f5353a3d88e69%26redirect_uri%3Dhttps%253A%252F%252Fen.gravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1&oauth2_client_id=1854) (you might need to modify your origin), and the footer still works the same.

<img width="1680" alt="signup" src="https://github.com/Automattic/wp-calypso/assets/21308003/5c0a039c-af49-4e72-bfd7-b7f1ad7871f8">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
