### PR TITLE
Use box-shadow instead of filter: drop-shadow

### DIFF
--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -52,7 +52,7 @@ $theme-card-info-margin-top: 16px;
 
 .theme-card__image-container {
 	border: 1px solid rgba(0, 0, 0, 0.1);
-	filter: drop-shadow(0 15px 25px rgba(0, 0, 0, 0.05));
+	box-shadow: 0 15px 25px rgba(0, 0, 0, 0.05);
 	overflow: hidden;
 	padding-top: 74%;
 	position: relative;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76821

## Proposed Changes

This PR fixes an issue with the `filter: drop-shadow()` rendering in Firefox. Might be related to this issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1772176.

See screenshot for reference:
<img width="1817" alt="237686816-fd662a9f-aa84-408e-8fe1-1db2df40bb5b" src="https://github.com/Automattic/wp-calypso/assets/797888/dbe16802-9753-4d47-8894-1c8b760152ca">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Firefox.
* Head to /setup/site-setup?siteSlug=${site_slug}.
* Continue until you land on the Onboarding Design Picker.
* Ensure that the gray boxes are no longer there.
* Also test that the Theme Showcase works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
