### PR TITLE
Jetpack Pro Dashboard: Implement edit monitor notification email address

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/add-new-email-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/add-new-email-modal.tsx
@@ -37,6 +37,7 @@ export default function AddNewEmailModal( {
 	} );
 
 	const isVerifyAction = selectedAction === 'verify';
+	const isEditAction = selectedAction === 'edit';
 
 	useEffect( () => {
 		if ( isVerifyAction ) {
@@ -75,11 +76,16 @@ export default function AddNewEmailModal( {
 	};
 
 	let title = translate( 'Add new email address' );
-	let subTitle = translate( 'Please use only your number or one you have access to. ' );
+	let subTitle = translate( 'Please use only your number or one you have access to.' );
 
 	if ( isVerifyAction ) {
 		title = translate( 'Verify your email address' );
 		subTitle = translate( 'We’ll send a code to verify your email address.' );
+	}
+
+	if ( isEditAction ) {
+		title = translate( 'Edit your email address' );
+		subTitle = translate( 'If you update your email address, you’ll need to verify it.' );
 	}
 
 	const handleResendCode = () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -21,7 +21,7 @@ interface Props {
 	selectedAction?: AllowedMonitorContactActions;
 }
 
-export default function AddNewEmailModal( {
+export default function EmailAddressEditor( {
 	toggleModal,
 	selectedEmail,
 	selectedAction = 'add',

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -50,6 +50,7 @@ export default function ConfigureEmailNotification( {
 		<div className="configure-email-address__card-container">
 			{ allEmailItems.map( ( item ) => (
 				<SelectEmailCheckbox
+					key={ item.email }
 					item={ item }
 					toggleModal={ toggleModal }
 					allEmailItems={ allEmailItems }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -1,9 +1,8 @@
-import { Card, Button } from '@automattic/components';
-import { CheckboxControl } from '@wordpress/components';
-import { Icon, plus, pencil } from '@wordpress/icons';
+import { Button } from '@automattic/components';
+import { Icon, plus } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import Badge from 'calypso/components/badge';
+import SelectEmailCheckbox from './select-email-checkbox';
 import type {
 	MonitorSettingsEmail,
 	StateMonitorSettingsEmail,
@@ -47,79 +46,15 @@ export default function ConfigureEmailNotification( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	const handleOnChange = ( item: StateMonitorSettingsEmail, checked: boolean ) => {
-		if ( item.isDefault ) {
-			return;
-			// FIXME: We need to show a custom error message here or a tooltip.
-		}
-		if ( ! item.verified ) {
-			return;
-			// FIXME: We can open the verification modal here.
-		}
-		const updatedEmailItems = allEmailItems.map( ( emailItem ) => {
-			if ( emailItem.email === item.email ) {
-				return {
-					...emailItem,
-					checked,
-				};
-			}
-			return emailItem;
-		} );
-		setAllEmailItems( updatedEmailItems );
-	};
-
-	const showVerified = true; // FIXME: This should be dynamic.
-
-	const handleToggleModal = (
-		item: StateMonitorSettingsEmail,
-		action: AllowedMonitorContactActions
-	) => {
-		toggleModal( item, action );
-	};
-
-	const getCheckboxContent = ( item: StateMonitorSettingsEmail ) => (
-		<div className="configure-email-address__checkbox-content-container">
-			<span className="configure-email-address__checkbox-content">
-				<div className="configure-email-address__checkbox-heading">{ item.email }</div>
-				<div className="configure-email-address__checkbox-sub-heading">{ item.name }</div>
-			</span>
-			{ ! item.isDefault && (
-				<>
-					{ ! item.verified && (
-						<span
-							role="button"
-							tabIndex={ 0 }
-							onKeyPress={ () => handleToggleModal( item, 'verify' ) }
-							onClick={ () => handleToggleModal( item, 'verify' ) }
-							className="configure-email-address__verification-status cursor-pointer"
-						>
-							<Badge type="warning">{ translate( 'Pending Verification' ) }</Badge>
-						</span>
-					) }
-					{ showVerified && item.verified && (
-						<span className="configure-email-address__verification-status">
-							<Badge type="success">{ translate( 'Verified' ) }</Badge>
-						</span>
-					) }
-					<span className="configure-email-address__edit-icon">
-						<Icon size={ 18 } icon={ pencil } />
-					</span>
-				</>
-			) }
-		</div>
-	);
-
 	return (
 		<div className="configure-email-address__card-container">
 			{ allEmailItems.map( ( item ) => (
-				<Card className="configure-email-address__card" key={ item.email } compact>
-					<CheckboxControl
-						className="configure-email-address__checkbox"
-						checked={ item.checked }
-						onChange={ ( checked ) => handleOnChange( item, checked ) }
-						label={ getCheckboxContent( item ) }
-					/>
-				</Card>
+				<SelectEmailCheckbox
+					item={ item }
+					toggleModal={ toggleModal }
+					allEmailItems={ allEmailItems }
+					setAllEmailItems={ setAllEmailItems }
+				/>
 			) ) }
 			<Button
 				compact

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/select-email-checkbox.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/select-email-checkbox.tsx
@@ -1,0 +1,145 @@
+import { Card, Button } from '@automattic/components';
+import { CheckboxControl } from '@wordpress/components';
+import { Icon, pencil, moreHorizontal } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useRef } from 'react';
+import Badge from 'calypso/components/badge';
+import PopoverMenu from 'calypso/components/popover-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import type {
+	StateMonitorSettingsEmail,
+	AllowedMonitorContactActions,
+} from '../../sites-overview/types';
+
+interface Props {
+	item: StateMonitorSettingsEmail;
+	toggleModal: ( item?: StateMonitorSettingsEmail, action?: AllowedMonitorContactActions ) => void;
+	allEmailItems: Array< StateMonitorSettingsEmail >;
+	setAllEmailItems: ( emailAddresses: Array< StateMonitorSettingsEmail > ) => void;
+}
+
+export default function SelectEmailCheckbox( {
+	item,
+	toggleModal,
+	allEmailItems,
+	setAllEmailItems,
+}: Props ) {
+	const translate = useTranslate();
+
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
+
+	const showActions = () => {
+		setIsOpen( true );
+	};
+
+	const closeDropdown = () => {
+		setIsOpen( false );
+	};
+
+	const showVerified = true; // FIXME: This should be dynamic.
+
+	const handleOnChange = ( checked: boolean ) => {
+		if ( item.isDefault ) {
+			return;
+			// FIXME: We need to show a custom error message here or a tooltip.
+		}
+		if ( ! item.verified ) {
+			return;
+			// FIXME: We can open the verification modal here.
+		}
+		const updatedEmailItems = allEmailItems.map( ( emailItem ) => {
+			if ( emailItem.email === item.email ) {
+				return {
+					...emailItem,
+					checked,
+				};
+			}
+			return emailItem;
+		} );
+		setAllEmailItems( updatedEmailItems );
+	};
+
+	const handleToggleModal = ( action: AllowedMonitorContactActions ) => {
+		toggleModal( item, action );
+	};
+
+	const checkboxContent = (
+		<div className="configure-email-address__checkbox-content-container">
+			<span className="configure-email-address__checkbox-content">
+				<div className="configure-email-address__checkbox-heading">{ item.email }</div>
+				<div className="configure-email-address__checkbox-sub-heading">{ item.name }</div>
+			</span>
+			{ ! item.isDefault && (
+				<>
+					{ ! item.verified && (
+						<span
+							role="button"
+							tabIndex={ 0 }
+							onKeyPress={ () => handleToggleModal( 'verify' ) }
+							onClick={ () => handleToggleModal( 'verify' ) }
+							className="configure-email-address__verification-status cursor-pointer"
+						>
+							<Badge type="warning">{ translate( 'Pending Verification' ) }</Badge>
+						</span>
+					) }
+					{ showVerified && item.verified && (
+						<span className="configure-email-address__verification-status">
+							<Badge type="success">{ translate( 'Verified' ) }</Badge>
+						</span>
+					) }
+					{ item.verified ? (
+						<Button
+							compact
+							borderless
+							className="configure-email-address__edit-icon"
+							onClick={ () => handleToggleModal( 'edit' ) }
+							aria-label={ translate( 'Edit email address' ) }
+						>
+							<Icon size={ 18 } icon={ pencil } />
+						</Button>
+					) : (
+						<>
+							<Button
+								compact
+								borderless
+								className="configure-email-address__edit-icon"
+								onClick={ showActions }
+								aria-label={ translate( 'More actions' ) }
+								ref={ buttonActionRef }
+							>
+								<Icon size={ 18 } icon={ moreHorizontal } />
+							</Button>
+							<PopoverMenu
+								className="configure-email-address__popover-menu"
+								context={ buttonActionRef.current }
+								isVisible={ isOpen }
+								onClose={ closeDropdown }
+								position="bottom left"
+							>
+								<PopoverMenuItem onClick={ () => handleToggleModal( 'verify' ) }>
+									{ translate( 'Verify' ) }
+								</PopoverMenuItem>
+								<PopoverMenuItem onClick={ () => handleToggleModal( 'edit' ) }>
+									{ translate( 'Edit' ) }
+								</PopoverMenuItem>
+							</PopoverMenu>
+						</>
+					) }
+				</>
+			) }
+		</div>
+	);
+
+	return (
+		<Card className="configure-email-address__card" key={ item.email } compact>
+			<CheckboxControl
+				className="configure-email-address__checkbox"
+				checked={ item.checked }
+				onChange={ handleOnChange }
+				label={ checkboxContent }
+			/>
+		</Card>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
@@ -34,10 +34,14 @@ $help-text-color: #757575;
 	}
 }
 
-.configure-email-address__edit-icon {
+button.configure-email-address__edit-icon {
 	position: absolute;
-	right: 16px;
+	right: 8px;
 	display: flex;
+	background: rgba(255, 255, 255, 0.9) !important;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+	border-radius: 2px;
+	padding: 4px !important;
 }
 
 .configure-email-address__checkbox {
@@ -109,4 +113,8 @@ button.configure-email-address__button {
 	padding: 0;
 	color: var(--studio-green-50) !important;
 	text-decoration: underline;
+}
+
+.configure-email-address__popover-menu {
+	z-index: 999999;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -12,7 +12,7 @@ import {
 	mobileAppLink,
 } from '../../sites-overview/utils';
 import ConfigureEmailNotification from '../configure-email-notification';
-import AddNewEmailModal from '../configure-email-notification/add-new-email-modal';
+import EmailAddressEditor from '../configure-email-notification/email-address-editor';
 import type {
 	MonitorSettings,
 	Site,
@@ -134,7 +134,7 @@ export default function NotificationSettings( {
 
 	if ( isAddEmailModalOpen ) {
 		return (
-			<AddNewEmailModal
+			<EmailAddressEditor
 				toggleModal={ toggleAddEmailModal }
 				selectedEmail={ selectedEmail }
 				selectedAction={ selectedAction }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -271,4 +271,4 @@ export interface StateMonitorSettingsEmail extends MonitorSettingsEmail {
 	isDefault?: boolean;
 }
 
-export type AllowedMonitorContactActions = 'add' | 'verify';
+export type AllowedMonitorContactActions = 'add' | 'verify' | 'edit';


### PR DESCRIPTION
Related to 1204408201748644-as-1204484225044529

## Proposed Changes

This PR implements UI to edit the added email addresses to the monitor notification settings

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-monitor-email-edit` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Set the below lines to `addedEmailAddresses`  in the `ConfigureEmailNotification` component to see the extra email addresses. 

```
addedEmailAddresses = [
		{
			email: 'test-email1@test.com',
			name: 'Test User 1',
			verified: true,
		},
		{
			email: 'test-email2@test.com',
			name: 'Test User 2',
			verified: false,
		},
	]
```
6. An edit icon should be shown next to the verified email, and more icon(`...`) should be shown next to the unverified email.

<img width="438" alt="Screenshot 2023-05-11 at 2 27 37 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/eaa429a3-4d5c-4861-9f52-d7c245e77998">

7. Click the edit icon and verify that the popup opens, as shown below. Verify that you can edit the fields and continue. Please note no changes will be made on saving changes.

<img width="450" alt="Screenshot 2023-05-11 at 2 27 55 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/1dd2abd0-a5fe-45c0-b65b-487d3ce5bc36">

8. Click the more icon and verify actions - `Verify` and `Edit` is shown, and clicking these actions opens the popup to verify and edit.

<img width="632" alt="Screenshot 2023-05-11 at 2 27 45 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/608411fb-ecac-4dbe-888a-f9f6c5d17c9b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?