### PR TITLE
Theme Showcase: Add config to enable BCPA CTA for logged-in users

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -59,10 +59,12 @@ export const ThemesList = ( props ) => {
 		};
 	}, [ updateShowSecondUpsellNudge ] );
 
+	const selectedSite = useSelector( getSelectedSite );
+
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const isPatternAssemblerCTAEnabled =
-		isEnabled( 'pattern-assembler/logged-out-showcase' ) && ! isLoggedIn;
+		! isLoggedIn || isEnabled( 'pattern-assembler/logged-in-showcase' );
 
 	const fetchNextPage = useCallback(
 		( options ) => {
@@ -76,11 +78,17 @@ export const ThemesList = ( props ) => {
 			goes_to_assembler_step: shouldGoToAssemblerStep,
 		} );
 
+		const basePathname = isLoggedIn ? '/setup' : '/start';
 		const params = new URLSearchParams( {
 			ref: 'calypshowcase',
 			theme: BLANK_CANVAS_DESIGN.slug,
 		} );
-		window.location.assign( `/start/${ WITH_THEME_ASSEMBLER_FLOW }?${ params }` );
+
+		if ( selectedSite?.slug ) {
+			params.set( 'siteSlug', selectedSite.slug );
+		}
+
+		window.location.assign( `${ basePathname }/${ WITH_THEME_ASSEMBLER_FLOW }?${ params }` );
 	};
 
 	const matchingWpOrgThemes = useMemo( () => {

--- a/client/components/themes-list/test/__snapshots__/index.jsx.snap
+++ b/client/components/themes-list/test/__snapshots__/index.jsx.snap
@@ -11,6 +11,35 @@ exports[`ThemesList should render a div with a className of "themes-list" 1`] = 
     <div
       data-testid="theme-2"
     />
+    <div
+      class="pattern-assembler-cta-wrapper"
+    >
+      <div
+        class="pattern-assembler-cta__image-wrapper"
+      >
+        <img
+          alt="Blank Canvas"
+          class="pattern-assembler-cta__image"
+          src="blank-canvas-cta.svg"
+        />
+      </div>
+      <h3
+        class="pattern-assembler-cta__title"
+      >
+        Design your own
+      </h3>
+      <p
+        class="pattern-assembler-cta__subtitle"
+      >
+        Can't find something you like? Jump right into the editor to design your homepage from scratch.
+      </p>
+      <button
+        class="button pattern-assembler-cta__button is-primary"
+        type="button"
+      >
+        Open the editor
+      </button>
+    </div>
     <div />
   </div>
 </div>

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
 import { isSiteAssemblerFlow } from '@automattic/onboarding';
 import { isDesktop } from '@automattic/viewport';
@@ -111,11 +110,7 @@ function getThankYouNoSiteDestination() {
 }
 
 function getChecklistThemeDestination( { flowName, siteSlug, themeParameter } ) {
-	if (
-		isSiteAssemblerFlow( flowName ) &&
-		themeParameter === BLANK_CANVAS_DESIGN.slug &&
-		config.isEnabled( 'pattern-assembler/logged-out-showcase' )
-	) {
+	if ( isSiteAssemblerFlow( flowName ) && themeParameter === BLANK_CANVAS_DESIGN.slug ) {
 		// Go to the site assembler flow if viewport width >= 960px as the layout doesn't support small
 		// screen for now
 		if ( isDesktop() ) {

--- a/config/development.json
+++ b/config/development.json
@@ -142,7 +142,7 @@
 		"pattern-assembler/all-patterns-category": true,
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/dotcompatterns": true,
-		"pattern-assembler/logged-out-showcase": true,
+		"pattern-assembler/logged-in-showcase": true,
 		"pattern-assembler/inline-styles": true,
 		"pattern-assembler/notices": true,
 		"pattern-assembler/show-waitlist-patterns": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -91,7 +91,7 @@
 		"pattern-assembler/all-patterns-category": true,
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/dotcompatterns": true,
-		"pattern-assembler/logged-out-showcase": true,
+		"pattern-assembler/logged-in-showcase": true,
 		"pattern-assembler/inline-styles": true,
 		"pattern-assembler/notices": true,
 		"pattern-assembler/show-waitlist-patterns": true,

--- a/config/production.json
+++ b/config/production.json
@@ -109,7 +109,7 @@
 		"pattern-assembler/all-patterns-category": false,
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/dotcompatterns": true,
-		"pattern-assembler/logged-out-showcase": true,
+		"pattern-assembler/logged-in-showcase": false,
 		"pattern-assembler/inline-styles": false,
 		"pattern-assembler/notices": true,
 		"pattern-assembler/show-waitlist-patterns": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -105,7 +105,7 @@
 		"pattern-assembler/all-patterns-category": false,
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/dotcompatterns": true,
-		"pattern-assembler/logged-out-showcase": true,
+		"pattern-assembler/logged-in-showcase": false,
 		"pattern-assembler/inline-styles": true,
 		"pattern-assembler/notices": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -115,7 +115,7 @@
 		"pattern-assembler/all-patterns-category": true,
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/dotcompatterns": true,
-		"pattern-assembler/logged-out-showcase": true,
+		"pattern-assembler/logged-in-showcase": true,
 		"pattern-assembler/inline-styles": true,
 		"pattern-assembler/notices": true,
 		"pattern-assembler/show-waitlist-patterns": false,

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -42,3 +42,14 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 global.structuredClone = jest.fn( ( value ) => {
 	return JSON.parse( JSON.stringify( value ) );
 } );
+
+global.matchMedia = jest.fn( ( query ) => ( {
+	matches: false,
+	media: query,
+	onchange: null,
+	addListener: jest.fn(), // deprecated
+	removeListener: jest.fn(), // deprecated
+	addEventListener: jest.fn(),
+	removeEventListener: jest.fn(),
+	dispatchEvent: jest.fn(),
+} ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/76748

## Proposed Changes

* Deprecated the `pattern-assembler/logged-out-showcase` flag as it's released for a while.
* Introduced a new flag called `pattern-assembler/logged-in-showcase` to control whether to display the BCPA CTA on the Logged-in Theme Showcase

https://github.com/Automattic/wp-calypso/assets/13596067/80662ddc-44ba-4bd9-894d-07875dbafe80

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/themes` on Desktop
* Scroll to the middle and select the BCPA CTA
* Ensure you're able to land on the Pattern Assembler

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
