### PR TITLE
Update e2e test support__popover-invalid

### DIFF
--- a/test/e2e/specs/support/support__popover-invalid.ts
+++ b/test/e2e/specs/support/support__popover-invalid.ts
@@ -43,10 +43,10 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover/Invalid Keywords' ), fu
 			await supportComponent.defaultStateShown();
 		} );
 
-		it( 'Enter empty search keyword and expect no results to be shown', async function () {
+		it( 'Enter empty search keyword and expect default entries to be shown', async function () {
 			const keyword = '        ';
 			await supportComponent.search( keyword );
-			await supportComponent.noResultsShown();
+			await supportComponent.defaultStateShown();
 		} );
 
 		it( 'Clear keyword', async function () {
@@ -56,10 +56,10 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover/Invalid Keywords' ), fu
 
 		// Invalid keyword search often takes more than 30s to resolve.
 		// See: https://github.com/Automattic/wp-calypso/issues/55478
-		it.skip( 'Enter invalid search keyword and expect no results to be shown', async function () {
+		it.skip( 'Enter invalid search keyword and default entries to be shown', async function () {
 			const keyword = ';;;ppp;;;';
 			await supportComponent.search( keyword );
-			await supportComponent.noResultsShown();
+			await supportComponent.defaultStateShown();
 		} );
 
 		it( 'Close support popover', async function () {


### PR DESCRIPTION
## Proposed Changes

This PR updates tests in `support__popover-invalid` so that invalid search query terms are expected to return default results instead of empty results. The endpoint payload change is tracked via D110664-code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that the updated tests no longer fail.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?