### PR TITLE
Newsletter: update processing bar background color

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -98,3 +98,15 @@
 		background-position-x: 0, 100%;
 	}
 }
+
+
+.is-section-stepper .newsletter.processing {
+	.processing-step {
+		.loading-bar {
+			background-color: var(--studio-blue-10);
+			&::before {
+				background: var(--studio-blue-50);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Based on slack convo p1683879518084759-slack-C052XEUUBL4


## Proposed Changes

* Update background color of the loading bar

## Testing Instructions

- Go through `/setup/newsletter`
- See processing step
- Other flows such as `/setup/free` or `/setup/link-in-bio` are not affected 

If you wanna get stuck at processing step, replace [processing code](https://github.com/Automattic/wp-calypso/blob/089ae1bdd51031dfdb14872b539111b144726193/client/landing/stepper/declarative-flow/newsletter.ts#L118-L145) with just `return;` and open `/setup/newsletter/processing`

### Before
<img width="1509" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/6a6e8ded-44a8-4c72-9736-04bed38c52fa">

### After
<img width="1510" alt="Screenshot 2023-05-12 at 12 27 57" src="https://github.com/Automattic/wp-calypso/assets/87168/2292e060-6e98-4c7d-a465-f9acd1be6e9a">
<img width="1509" alt="Screenshot 2023-05-12 at 12 28 07" src="https://github.com/Automattic/wp-calypso/assets/87168/6e01130c-3e70-4661-b0ed-b7923d564452">
<img width="1503" alt="Screenshot 2023-05-12 at 12 27 54" src="https://github.com/Automattic/wp-calypso/assets/87168/6c5790b2-d2a5-461c-88b4-937f90d1ecf0">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?