### PR TITLE
Licensing Portal: Hide the Assign button for standard licenses

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -64,14 +64,9 @@ export default function LicenseDetailsActions( {
 			) }
 
 			{ licenseState === LicenseState.Attached && licenseType === LicenseType.Partner && (
-				<>
-					<Button compact onClick={ openUnassignDialog }>
-						{ translate( 'Unassign' ) }
-					</Button>
-					<Button compact onClick={ openRevokeDialog } scary>
-						{ translate( 'Revoke' ) }
-					</Button>
-				</>
+				<Button compact onClick={ openUnassignDialog }>
+					{ translate( 'Unassign' ) }
+				</Button>
 			) }
 
 			{ licenseState === LicenseState.Detached && licenseType === LicenseType.Partner && (
@@ -80,7 +75,7 @@ export default function LicenseDetailsActions( {
 				</Button>
 			) }
 
-			{ licenseState === LicenseState.Detached && (
+			{ licenseState === LicenseState.Detached && licenseType === LicenseType.Partner && (
 				<Button
 					compact
 					primary

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -124,14 +124,16 @@ export default function LicensePreview( {
 					{ ! domain && licenseState === LicenseState.Detached && (
 						<span>
 							<Badge type="warning">{ translate( 'Unassigned' ) }</Badge>
-							<Button
-								className="license-preview__assign-button"
-								borderless
-								compact
-								onClick={ assign }
-							>
-								{ translate( 'Assign' ) }
-							</Button>
+							{ licenseType === LicenseType.Partner && (
+								<Button
+									className="license-preview__assign-button"
+									borderless
+									compact
+									onClick={ assign }
+								>
+									{ translate( 'Assign' ) }
+								</Button>
+							) }
 						</span>
 					) }
 					{ revokedAt && (


### PR DESCRIPTION
## Proposed Changes

* Licensing Portal: Hide the Assign button for standard licenses as those are not assignable via the API right now.

## Testing Instructions

* Apply this patch and run Jetpack Cloud
* Open up http://jetpack.cloud.localhost:3000/partner-portal/licenses/standard - if you don't have an unassigned standard licenses you can check out with this link to get one: https://wordpress.com/checkout/jetpack/jetpack_starter_yearly?source=jetpack-plans&checkoutBackUrl=https%3A%2F%2Fcloud.jetpack.com%2Fpricing#step2

| Before | After |
| --- | --- |
| ![Screen Shot 2023-05-12 at 12 10 20](https://github.com/Automattic/wp-calypso/assets/22746396/ffef7bc2-c1cb-4b9f-9d46-1d17ac804a39) | ![Screen Shot 2023-05-12 at 12 47 46](https://github.com/Automattic/wp-calypso/assets/22746396/73e1e161-a356-43ef-a84b-1d998af069c8) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
