### PR TITLE
Newsletter: update subscribers step copy to reflect paid plan

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -20,6 +20,16 @@ const Subscribers: Step = function ( { navigation } ) {
 		submit?.();
 	};
 
+	const isSiteOnFreePlan = !! site?.plan?.is_free;
+
+	const subtitleText = isSiteOnFreePlan
+		? translate(
+				'Bring your subscribers with you — or add some individually — to start spreading the news.'
+		  )
+		: translate(
+				'Bring up to 100 subscribers for free — or add some individually — to start spreading the news.'
+		  );
+
 	const submitButtonText = isImportValid
 		? translate( 'Add and continue' )
 		: translate( 'Skip for now' );
@@ -37,7 +47,7 @@ const Subscribers: Step = function ( { navigation } ) {
 					{ site?.ID && (
 						<AddSubscriberForm
 							siteId={ site.ID }
-							isSiteOnFreePlan={ !! site?.plan?.is_free }
+							isSiteOnFreePlan={ isSiteOnFreePlan }
 							flowName="onboarding_subscribers"
 							submitBtnName={ submitButtonText }
 							onImportFinished={ handleSubmit }
@@ -47,9 +57,7 @@ const Subscribers: Step = function ( { navigation } ) {
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 							recordTracksEvent={ recordTracksEvent }
 							titleText={ translate( 'Ready to add your first subscribers?' ) }
-							subtitleText={ translate(
-								'Bring up to 100 subscribers for free — or add some individually — to start spreading the news.'
-							) }
+							subtitleText={ subtitleText }
 							showSubtitle={ true }
 						/>
 					) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -24,10 +24,10 @@ const Subscribers: Step = function ( { navigation } ) {
 
 	const subtitleText = isSiteOnFreePlan
 		? translate(
-				'Bring your subscribers with you — or add some individually — to start spreading the news.'
+				'Bring up to 100 subscribers for free — or add some individually — to start spreading the news.'
 		  )
 		: translate(
-				'Bring up to 100 subscribers for free — or add some individually — to start spreading the news.'
+				'Bring your subscribers with you — or add some individually — to start spreading the news.'
 		  );
 
 	const submitButtonText = isImportValid


### PR DESCRIPTION
Based on Slack convo p1683822203856259-slack-C052XEUUBL4

## Proposed Changes

* Add different "subscriber import" heading copy when customer purchased paid plan — they no longer have 100 users limitation.

## Testing Instructions

* Go though `/setup/newsletter`, twice
* One time pick paid plan, another time pick free
* Note the copy at subscribe step

**Before**

<img width="1150" alt="Screenshot 2023-05-12 at 12 58 37" src="https://github.com/Automattic/wp-calypso/assets/87168/5fcd503a-9135-4662-b28d-021fd8afc045">
<img width="1152" alt="Screenshot 2023-05-12 at 12 57 58" src="https://github.com/Automattic/wp-calypso/assets/87168/c4c3adb9-9251-4e6f-b6a8-b7fbed8957cf">


**After**

<img width="1145" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/2df8f7fa-d240-436a-840b-20f860989dd2">
<img width="1147" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/4d34ec44-0db8-4617-9318-188ba71c78ea">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?