### PR TITLE
Fix post-login redirect path for Sensei flow

### DIFF
--- a/client/landing/stepper/declarative-flow/sensei.ts
+++ b/client/landing/stepper/declarative-flow/sensei.ts
@@ -70,8 +70,8 @@ const sensei: Flow = {
 		const locale = useLocale();
 		const logInUrl =
 			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?redirect_to=/setup/?flow=${ flowName }`
-				: `/start/account/user?redirect_to=/setup/?flow=${ flowName }`;
+				? `/start/account/user/${ locale }?redirect_to=/setup/${ flowName }`
+				: `/start/account/user?redirect_to=/setup/${ flowName }`;
 		if ( ! userIsLoggedIn ) {
 			window.location.assign( logInUrl );
 			return {


### PR DESCRIPTION
## Proposed Changes

* In the post-login redirect, the new stepper URL structure for the Sensei flow.

## Testing Instructions

* In a logged out state, visit `/setup/sensei`.
* You should be redirected to login/registration page.
* Register a new user or click `Log in`.
* Confirm that on actual login you're redirected to the Sensei flow.
  * note: with testing, sometimes with email confirmation it gets messy moving back to production so might be easier to login from logged out state

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
