### PR TITLE
Jetpack Pro Dashboard: Update the add email validation UX

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -29,7 +29,9 @@ export default function EmailAddressEditor( {
 	const translate = useTranslate();
 
 	const [ showCodeVerification, setShowCodeVerification ] = useState< boolean >( false );
-	const [ validationError, setValidationError ] = useState< string >( '' );
+	const [ validationError, setValidationError ] = useState<
+		{ email?: string; code?: string } | undefined
+	>( {} );
 	const [ emailItem, setEmailItem ] = useState< { name: string; email: string; code?: string } >( {
 		name: '',
 		email: '',
@@ -53,21 +55,11 @@ export default function EmailAddressEditor( {
 
 	const onSave = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
-		setValidationError( '' );
-
-		if ( ! emailItem.name ) {
-			return setValidationError( translate( 'Please enter a name.' ) );
-		}
-		if ( ! emailItem.email ) {
-			return setValidationError( translate( 'Please enter an email address.' ) );
-		}
+		setValidationError( undefined );
 		if ( ! emailValidator.validate( emailItem.email ) ) {
-			return setValidationError( translate( 'Please enter a valid email address.' ) );
+			return setValidationError( { email: translate( 'Please enter a valid email address.' ) } );
 		}
 		if ( showCodeVerification ) {
-			if ( ! emailItem.code ) {
-				return setValidationError( translate( 'Please enter the verification code.' ) );
-			}
 			// TODO: verify email address with code
 		} else {
 			setShowCodeVerification( true );
@@ -134,6 +126,11 @@ export default function EmailAddressEditor( {
 						disabled={ showCodeVerification }
 						onChange={ handleChange( 'email' ) }
 					/>
+					{ validationError?.email && (
+						<div className="notification-settings__footer-validation-error">
+							{ validationError.email }
+						</div>
+					) }
 					{ ! isVerifyAction && (
 						<div className="configure-email-notification__help-text">
 							{ translate( 'We’ll send a code to verify your email address.' ) }
@@ -152,6 +149,11 @@ export default function EmailAddressEditor( {
 							value={ emailItem.code }
 							onChange={ handleChange( 'code' ) }
 						/>
+						{ validationError?.code && (
+							<div className="notification-settings__footer-validation-error">
+								{ validationError.code }
+							</div>
+						) }
 						<div className="configure-email-notification__help-text">
 							{ translate(
 								'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
@@ -172,16 +174,20 @@ export default function EmailAddressEditor( {
 					</FormFieldset>
 				) }
 				<div className="notification-settings__footer">
-					{ validationError && (
-						<div className="notification-settings__footer-validation-error">
-							{ validationError }
-						</div>
-					) }
 					<div className="notification-settings__footer-buttons">
 						<Button onClick={ toggleModal } aria-label={ translate( 'Cancel' ) }>
 							{ showCodeVerification ? translate( 'Later' ) : translate( 'Cancel' ) }
 						</Button>
-						<Button disabled={ false } type="submit" primary aria-label={ translate( 'Verify' ) }>
+						<Button
+							disabled={
+								! emailItem.name ||
+								! emailItem.email ||
+								( showCodeVerification && ! emailItem.code )
+							}
+							type="submit"
+							primary
+							aria-label={ translate( 'Verify' ) }
+						>
 							{ translate( 'Verify' ) }
 						</Button>
 					</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -175,7 +175,7 @@ export default function EmailAddressEditor( {
 				) }
 				<div className="notification-settings__footer">
 					<div className="notification-settings__footer-buttons">
-						<Button onClick={ toggleModal } aria-label={ translate( 'Cancel' ) }>
+						<Button onClick={ toggleModal }>
 							{ showCodeVerification ? translate( 'Later' ) : translate( 'Cancel' ) }
 						</Button>
 						<Button
@@ -186,7 +186,6 @@ export default function EmailAddressEditor( {
 							}
 							type="submit"
 							primary
-							aria-label={ translate( 'Verify' ) }
 						>
 							{ translate( 'Verify' ) }
 						</Button>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
@@ -106,6 +106,10 @@ button.configure-email-address__button {
 
 .configure-email-notification__form {
 	margin-block-start: 24px;
+
+	.notification-settings__footer-validation-error {
+		margin-block: 8px;
+	}
 }
 
 .configure-email-notification__resend-code-button {


### PR DESCRIPTION
Related to 1204408201748644-as-1204587462747629

## Proposed Changes

This PR updates the validation UX for adding an email.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/add-email-validation-ui` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Click the `+ Add email address` button and verify that you can now see the popup below. Also, verify if the validations work as expected. Please note the Later & Verify buttons does nothing. The logic for these buttons will be implemented later.

**Disable the verify button if the name or email address is not entered.**

<img width="450" alt="Screenshot 2023-05-12 at 5 23 41 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/df8c566c-201d-494f-9c11-c53556a8d0c1">

-----

**Error message when the entered email address is invalid**

<img width="448" alt="Screenshot 2023-05-12 at 5 24 02 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5db969cb-768f-458b-8b6e-e5d7a453c332">

-----

**Disable the verify button if the code is not entered**

<img width="446" alt="Screenshot 2023-05-12 at 5 24 15 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ec6812ff-dfef-420c-a52e-662e8af7b4a1">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?