### PR TITLE
Add two more props to calypso_signup_complete for mapping and transfer

### DIFF
--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -28,6 +28,8 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 				isBlankCanvas: theme?.includes( 'blank-canvas' ),
 				domainProductSlug: '',
 				planProductSlug: '',
+				isMapping: false,
+				isTransfer: false,
 			},
 			true
 		);

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -37,6 +37,8 @@ export function recordSignupComplete(
 		theme,
 		intent,
 		startingPoint,
+		isTransfer,
+		isMapping,
 	},
 	now
 ) {
@@ -59,6 +61,8 @@ export function recordSignupComplete(
 				theme,
 				intent,
 				startingPoint,
+				isTransfer,
+				isMapping,
 			},
 			true
 		);
@@ -80,6 +84,8 @@ export function recordSignupComplete(
 		theme,
 		intent,
 		starting_point: startingPoint,
+		is_transfer: isTransfer,
+		is_mapping: isMapping,
 	} );
 
 	// Google Analytics

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -518,8 +518,8 @@ class Signup extends Component {
 			intent,
 			startingPoint,
 			isBlankCanvas: isBlankCanvasDesign( dependencies.selectedDesign ),
-			isMapping: isDomainMapping( domainItem ),
-			isTransfer: isDomainTransfer( domainItem ),
+			isMapping: domainItem && isDomainMapping( domainItem ),
+			isTransfer: domainItem && isDomainTransfer( domainItem ),
 		} );
 	};
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -518,6 +518,8 @@ class Signup extends Component {
 			intent,
 			startingPoint,
 			isBlankCanvas: isBlankCanvasDesign( dependencies.selectedDesign ),
+			isMapping: isDomainMapping( domainItem ),
+			isTransfer: isDomainTransfer( domainItem ),
 		} );
 	};
 


### PR DESCRIPTION
Per request by @isatuncman-auto, this is a follow-up to #72970

## Proposed Changes

Add two more properties to calypso_signup_complete - the issue is that domain mappings and domain transfers are not domain registrations, and from an analytics point of view, it's impossible to figure out the exact case. Further analysis of transfers and mappings at this point will become inaccurate.

## Testing Instructions

* localStorage.setItem( 'debug', 'calypso.analytics*' );
* visit /start and sign up in an incognito window - you'll have to repeat the process 3 times, without necessarily logging out

### 1. Registration
* First time, select a domain registration and proceed to checkout without completing it. Check the console, the signup complete event should have 
    * is_transfer = false
    * is_mapping = false

<img width="460" alt="Screenshot 2023-05-12 at 15 56 30" src="https://github.com/Automattic/wp-calypso/assets/82778/66033e38-8952-4b89-b192-62a7c0c71441">

### 2. Transfer

* Then go to /start and try with a domain that you already own. @hambai politely provided a test domain that's available for transfer - hambai.dev
* With that domain, choose to transfer it and proceed to checkout without completing it
* The signup complete event should now have 
    * is_transfer = true
    * is_mapping = false

### 3. Mapping
* Repeat with Connect a domain, in that case
    * is_transfer = false
    * is_mapping = true

After doing this 3 times, you can make sure the same code works in the launchpad as well. In order to do that:
* Go to /home
* Launch your site (last step in the list of steps)
* Check the signup complete event - it's triggered again 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
