### PR TITLE
Fix notice anchor invisible hyperlink

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -318,6 +318,17 @@ a.notice__action {
 
 	.notice__content {
 		padding: 13px 0;
+		.notice__text {
+			a,
+			a:visited,
+			button.is-link {
+				color: var(--color-link);
+
+				&:hover {
+					color: var(--color-link);
+				}
+			}
+		}
 	}
 
 	.notice__icon-wrapper {

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -322,10 +322,10 @@ a.notice__action {
 			a,
 			a:visited,
 			button.is-link {
-				color: var(--color-link);
+				color: inherit;
 
 				&:hover {
-					color: var(--color-link);
+					color: inherit;
 				}
 			}
 		}


### PR DESCRIPTION
Related to #75725

## Proposed Changes

Broken anchor link color inside notice

### Bug
![image](https://github.com/Automattic/wp-calypso/assets/3422709/a98f29c8-ee41-4ac2-911e-edbb097af2e3)

### Fix
![image](https://github.com/Automattic/wp-calypso/assets/3422709/43286801-5dbc-4d60-9345-cbe6e92ec00e)


## Testing Instructions

- Purchase a non WooCommerce plan
- Go to the `/plans` page 
- Make sure the plan upgrade credit notice does not have any issues

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
