### PR TITLE
Subscription Management: Add focus outline on navigation tabs.

### DIFF
--- a/client/landing/subscriptions/components/tabs-switcher/styles.scss
+++ b/client/landing/subscriptions/components/tabs-switcher/styles.scss
@@ -39,6 +39,10 @@
 					&:hover {
 						background-color: transparent;
 					}
+
+					&:focus {
+						box-shadow: inset 0 0 0 2px var(--color-primary-light);
+					}
 				}
 
 				.section-nav-tab__text {


### PR DESCRIPTION

Fixes #76213

## Proposed Changes

* Add missing focus outline on navigation tabs.

## Testing Instructions

* Go to `/subscriptions`.
* Tab (or shift-tab) around and make sure the menu is accessible.

<img width="664" alt="2023-05-12_16-33-39" src="https://github.com/Automattic/wp-calypso/assets/1287077/c22a8434-1b85-4795-b57a-948693453b18">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
