### PR TITLE
Fix/default currency

### DIFF
--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -32,7 +32,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
  * https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
  * @type { [currency: string]: number }
  */
-const MINIMUM_CURRENCY_AMOUNT = {
+const STRIPE_MINIMUM_CURRENCY_AMOUNT = {
 	USD: 0.5,
 	AUD: 0.5,
 	BRL: 0.5,
@@ -55,7 +55,7 @@ const MINIMUM_CURRENCY_AMOUNT = {
 /**
  * @type Array<{ code: string }>
  */
-const currencyList = Object.keys( MINIMUM_CURRENCY_AMOUNT ).map( ( code ) => ( { code } ) );
+const currencyList = Object.keys( STRIPE_MINIMUM_CURRENCY_AMOUNT ).map( ( code ) => ( { code } ) );
 
 /**
  * Return the minimum transaction amount for a currency.
@@ -64,8 +64,12 @@ const currencyList = Object.keys( MINIMUM_CURRENCY_AMOUNT ).map( ( code ) => ( {
  * @param {string} currency - Currency.
  * @returns {number} Minimum transaction amount for given currency.
  */
-function minimumCurrencyTransactionAmount( currency ) {
-	return MINIMUM_CURRENCY_AMOUNT[ currency ];
+function minimumCurrencyTransactionAmount( currency, connectedAccountDefaultCurrency ) {
+	if ( connectedAccountDefaultCurrency.toLowerCase() === currency.toLowerCase() ) {
+		return STRIPE_MINIMUM_CURRENCY_AMOUNT[ currency ];
+	}
+
+	return STRIPE_MINIMUM_CURRENCY_AMOUNT[ currency ] * 2;
 }
 
 /**

--- a/client/state/memberships/earnings/selectors.js
+++ b/client/state/memberships/earnings/selectors.js
@@ -13,7 +13,7 @@ export function getEarningsWithDefaultsForSiteId( state, siteId ) {
 		total: earnings.total ?? 0,
 		last_month: earnings.last_month ?? 0,
 		forecast: earnings.forecast ?? 0,
-		currency: earnings.currency ?? 'USD',
+		currency: earnings.currency ?? 'USD', // For the record, this is never sent by the backend
 		commission: earnings.commission ?? null,
 	};
 }

--- a/client/state/memberships/settings/reducer.js
+++ b/client/state/memberships/settings/reducer.js
@@ -10,6 +10,10 @@ export default ( state = {}, action ) => {
 				[ action.siteId ]: {
 					connectedAccountId: get( action, 'data.connected_account_id', null ),
 					connectedAccountDescription: get( action, 'data.connected_account_description', null ),
+						action,
+						'data.connected_account_default_currency',
+						null
+					),
 					connectUrl: get( action, 'data.connect_url', null ),
 				},
 			};

--- a/client/state/memberships/settings/reducer.js
+++ b/client/state/memberships/settings/reducer.js
@@ -10,6 +10,7 @@ export default ( state = {}, action ) => {
 				[ action.siteId ]: {
 					connectedAccountId: get( action, 'data.connected_account_id', null ),
 					connectedAccountDescription: get( action, 'data.connected_account_description', null ),
+					connectedAccountDefaultCurrency: get(
 						action,
 						'data.connected_account_default_currency',
 						null

--- a/client/state/memberships/settings/selectors.js
+++ b/client/state/memberships/settings/selectors.js
@@ -10,6 +10,13 @@ export function getConnectedAccountDescriptionForSiteId( state, siteId ) {
 	return get( state, [ 'memberships', 'settings', siteId, 'connectedAccountDescription' ], null );
 }
 
+export function getconnectedAccountDefaultCurrencyForSiteId( state, siteId ) {
+	return get(
+		state,
+		[ 'memberships', 'settings', siteId, 'connectedAccountDefaultCurrency' ],
+		null
+	);
+}
 export function getConnectUrlForSiteId( state, siteId ) {
 	return get( state, [ 'memberships', 'settings', siteId, 'connectUrl' ], '' );
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/gold/issues/27
Goes along D110717-code


## Proposed Changes

* Retrieve default Stripe currency for the connected account
* Display the default currency when creating a new plan
* Minimum prices now depend on the  connected account default currency and will double if the selected currency is not the default oner to prevent issue discussed in p81Rsd-1hN-p2

## Testing Instructions

* Patch D110717-code on your sandbox
* Sandbox public-api.wordpress.com
* Use sandbox Store
* Launch this
* Disconnect the Stripe account and connect to a new one by selected some random currency (You can also modify the line from D110717-coden your sandbox to return a random currency)
-> When adding a new payment plan, the default seelcted currency should be the one from the stripe account
-> Empty the value. The minimum amount should the one referenced [in this list](https://github.com/Automattic/wp-calypso/blob/29527baf12c7c57bf4e0df4bf392f3071c587d9e/client/my-sites/earn/memberships/add-edit-plan-modal.jsx#L38). 
-> Change the currency to another one 
-> Empty the value. The minimum amount should be **the double of the one referenced [in this list](https://github.com/Automattic/wp-calypso/blob/29527baf12c7c57bf4e0df4bf392f3071c587d9e/client/my-sites/earn/memberships/add-edit-plan-modal.jsx#L38). ** 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?