### PR TITLE
Jetpack Pro Dashboard: Add jetpack-starter to the list of Jetpack bundles

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -193,7 +193,12 @@ export function selectAlphabeticallySortedProductOptions(
 	return sortBy( selectProductOptions( families ), ( product ) => product.name );
 }
 
-export const JETPACK_BUNDLES = [ 'jetpack-complete', 'jetpack-security-t1', 'jetpack-security-t2' ];
+export const JETPACK_BUNDLES = [
+	'jetpack-complete',
+	'jetpack-security-t1',
+	'jetpack-security-t2',
+	'jetpack-starter',
+];
 
 export function isJetpackBundle( product: APIProductFamilyProduct | string ) {
 	if ( typeof product === 'string' ) {


### PR DESCRIPTION
## Proposed Changes

* The Jetpack Starter bundle is not currently recognized as a bundle in the license issue context. This PR adds the slug to the list of bundles so that licenses are issue upon selection.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the API and override your billing scheme to 871. Visit the `/partner-portal/issue-license` and ensure that clicking on the select button for Jetpack Starter results in an issued license and navigation to the attachment screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
