### PR TITLE
Help Center: Remove shouldShowHelpCenterToUser

### DIFF
--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -1,6 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
-import { shouldShowHelpCenterToUser } from '@automattic/help-center';
 import { isMobile } from '@automattic/viewport';
 import { withDispatch } from '@wordpress/data';
 import classnames from 'classnames';
@@ -59,7 +58,7 @@ export class HappychatButton extends Component {
 	};
 
 	onClick = ( event ) => {
-		if ( this.props.openHelpCenter || shouldShowHelpCenterToUser( this.props.userId ) ) {
+		if ( this.props.openHelpCenter ) {
 			this.props.setHelpCenterVisible( true );
 		} else if ( this.props.allowMobileRedirect && isMobile() ) {
 			// For mobile clients, happychat will always use the

--- a/client/components/happychat/connection-connected.jsx
+++ b/client/components/happychat/connection-connected.jsx
@@ -1,8 +1,5 @@
-import config from '@automattic/calypso-config';
-import { shouldShowHelpCenterToUser } from '@automattic/help-center';
 import { connect } from 'react-redux';
 import { HappychatConnection } from 'calypso/components/happychat/connection';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { initConnection } from 'calypso/state/happychat/connection/actions';
 import isHappychatConnectionUninitialized from 'calypso/state/happychat/selectors/is-happychat-connection-uninitialized';
 import { getHappychatAuth } from 'calypso/state/happychat/utils';
@@ -11,10 +8,6 @@ export default connect(
 	( state, ownProps ) => ( {
 		getAuth: ownProps.getAuth || getHappychatAuth( state ),
 		isConnectionUninitialized: isHappychatConnectionUninitialized( state ),
-		isHappychatEnabled:
-			ownProps.isHappychatEnabled ||
-			( config.isEnabled( 'happychat' ) &&
-				! shouldShowHelpCenterToUser( getCurrentUserId( state ) ) ),
 	} ),
 	{ initConnection }
 )( HappychatConnection );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { HelpCenter } from '@automattic/data-stores';
-import { shouldShowHelpCenterToUser, shouldLoadInlineHelp } from '@automattic/help-center';
+import { shouldLoadInlineHelp } from '@automattic/help-center';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useDispatch } from '@wordpress/data';
@@ -29,7 +29,6 @@ import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { isOffline } from 'calypso/state/application/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -424,9 +423,7 @@ export default withCurrentRoute(
 		const sidebarIsHidden = ! secondary || isWcMobileApp() || isDomainAndPlanPackageFlow;
 		const chatIsDocked = ! [ 'reader', 'theme' ].includes( sectionName ) && ! sidebarIsHidden;
 
-		const userAllowedToHelpCenter =
-			config.isEnabled( 'calypso/help-center' ) &&
-			shouldShowHelpCenterToUser( getCurrentUserId( state ) );
+		const userAllowedToHelpCenter = config.isEnabled( 'calypso/help-center' );
 
 		return {
 			masterbarIsHidden,

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -3,7 +3,6 @@ import { getPlanTermLabel } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
 import {
-	shouldShowHelpCenterToUser,
 	SUPPORT_CHAT_OVERFLOW,
 	SUPPORT_FORUM,
 	SUPPORT_HAPPYCHAT,
@@ -36,20 +35,14 @@ import HelpContactForm from 'calypso/me/help/help-contact-form';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import {
 	getCurrentUser,
-	getCurrentUserId,
 	getCurrentUserLocale,
 	getCurrentUserSiteCount,
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
-import {
-	sendMessage as sendHappychatMessage,
-	sendUserInfo,
-} from 'calypso/state/happychat/connection/actions';
 import getHappychatEnv from 'calypso/state/happychat/selectors/get-happychat-env';
 import getHappychatUserInfo from 'calypso/state/happychat/selectors/get-happychat-userinfo';
 import hasHappychatLocalizedSupport from 'calypso/state/happychat/selectors/has-happychat-localized-support';
 import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
-import { openChat as openHappychat } from 'calypso/state/happychat/ui/actions';
 import { getHelpSelectedSite } from 'calypso/state/help/selectors';
 import {
 	isTicketSupportConfigurationReady,
@@ -108,14 +101,7 @@ class HelpContact extends Component {
 		this.recordCompactSubmit( 'happychat' );
 		this.recordSubmitWithActiveTickets( 'chat' );
 
-		if ( this.props.shouldShowHelpCenterToUser ) {
-			this.props.startHelpCenterChat( site, message );
-		} else {
-			this.props.openHappychat();
-
-			this.props.sendUserInfo( this.props.getUserInfo( { site } ) );
-			this.props.sendHappychatMessage( message, { includeInSummary: true } );
-		}
+		this.props.startHelpCenterChat( site, message );
 
 		recordTracksEvent( 'calypso_help_live_chat_begin', {
 			site_plan_product_id: site ? site.plan.product_id : null,
@@ -645,16 +631,12 @@ export default withDispatch( ( dispatch ) => {
 				shouldStartHappychatConnection: ! isRequestingSites( state ) && isChatEligible,
 				isRequestingSites: isRequestingSites( state ),
 				supportVariation: getInlineHelpSupportVariation( state ),
-				shouldShowHelpCenterToUser: shouldShowHelpCenterToUser( getCurrentUserId( state ) ),
 				happychatEnv: getHappychatEnv( state ),
 			};
 		},
 		{
 			errorNotice,
-			openHappychat,
 			recordTracksEventAction,
-			sendHappychatMessage,
-			sendUserInfo,
 		}
 	)( localize( withActiveSupportTickets( HelpContact ) ) )
 );

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
-import { SUPPORT_FORUM, shouldShowHelpCenterToUser } from '@automattic/help-center';
+import { SUPPORT_FORUM } from '@automattic/help-center';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { ResponseCartMessage, useShoppingCart } from '@automattic/shopping-cart';
 import { keyframes } from '@emotion/react';
@@ -173,11 +173,7 @@ export default function CheckoutHelpLink() {
 		};
 	} );
 
-	const userAllowedToHelpCenter = !! (
-		userId &&
-		config.isEnabled( 'calypso/help-center' ) &&
-		shouldShowHelpCenterToUser( userId )
-	);
+	const userAllowedToHelpCenter = !! ( userId && config.isEnabled( 'calypso/help-center' ) );
 
 	const handleHelpButtonClicked = () => {
 		reduxDispatch( userAllowedToHelpCenter ? setShowHelpCenter( true ) : showInlineHelpPopover() );

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -18,7 +18,6 @@ import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { useJpPresalesAvailabilityQuery } from 'calypso/lib/jetpack/use-jp-presales-availability-query';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getSupportLevel from 'calypso/state/happychat/selectors/get-support-level';
 import isPresalesZendeskChatAvailable from 'calypso/state/happychat/selectors/is-presales-zendesk-chat-available';
 import { showInlineHelpPopover } from 'calypso/state/inline-help/actions';
@@ -157,23 +156,17 @@ export default function CheckoutHelpLink() {
 		( error: ResponseCartMessage ) => error.code === 'blocked'
 	);
 
-	const {
-		presalesZendeskChatAvailable,
-		section,
-		userId,
-		supportVariationDetermined,
-		supportVariation,
-	} = useSelector( ( state ) => {
-		return {
-			presalesZendeskChatAvailable: isPresalesZendeskChatAvailable( state ),
-			section: getSectionName( state ),
-			userId: getCurrentUserId( state ),
-			supportVariationDetermined: isSupportVariationDetermined( state ),
-			supportVariation: getSupportVariation( state ),
-		};
-	} );
+	const { presalesZendeskChatAvailable, section, supportVariationDetermined, supportVariation } =
+		useSelector( ( state ) => {
+			return {
+				presalesZendeskChatAvailable: isPresalesZendeskChatAvailable( state ),
+				section: getSectionName( state ),
+				supportVariationDetermined: isSupportVariationDetermined( state ),
+				supportVariation: getSupportVariation( state ),
+			};
+		} );
 
-	const userAllowedToHelpCenter = !! ( userId && config.isEnabled( 'calypso/help-center' ) );
+	const userAllowedToHelpCenter = config.isEnabled( 'calypso/help-center' );
 
 	const handleHelpButtonClicked = () => {
 		reduxDispatch( userAllowedToHelpCenter ? setShowHelpCenter( true ) : showInlineHelpPopover() );

--- a/packages/help-center/src/index.ts
+++ b/packages/help-center/src/index.ts
@@ -8,4 +8,4 @@ export { useHCWindowCommunicator } from './happychat-window-communicator';
 export { default as Mail } from './icons/mail';
 export { default as NewReleases } from './icons/new-releases';
 export * from './support-variations';
-export { shouldShowHelpCenterToUser, shouldLoadInlineHelp } from './utils';
+export { shouldLoadInlineHelp } from './utils';

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -1,13 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 
-// function that tells us if we want to show the Help Center to the user, given that we're showing it to
-// only a certain percentage of users.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function shouldShowHelpCenterToUser( _userId: number ) {
-	return true;
-}
-
 export function shouldLoadInlineHelp( sectionName: string, currentRoute: string ) {
 	if ( isWpMobileApp() ) {
 		return false;


### PR DESCRIPTION
`shouldShowHelpCenterToUser` always returns `true` and there's no plans to change this behaviour. By removing it, we clean up the code and make the logic for when Help Center is shown simpler.

Related to #76777 

## Proposed Changes

* Remove `shouldShowHelpCenterToUser` and all its references.

## Testing Instructions

- Try first without logging to Happy Chat staging. Verify that live chat option is disabled in Help Center and `/help/contact` defaults to email (the CTA is `Email us`).
- Log in to Happy Chat HUD Staging, make yourself available.
    - Live chat option is enabled in Help Center.
    - CTA on `/help/contact` is `Chat with us`.
- Verify that Help Center is shown were you'd expect it (admin bar, checkout, etc.).