### PR TITLE
Reader: Update related posts to pass variable size param

### DIFF
--- a/client/components/data/query-reader-related-posts/index.jsx
+++ b/client/components/data/query-reader-related-posts/index.jsx
@@ -5,18 +5,18 @@ import { requestRelatedPosts } from 'calypso/state/reader/related-posts/actions'
 import { shouldFetchRelated } from 'calypso/state/reader/related-posts/selectors';
 import { SCOPE_ALL, SCOPE_SAME, SCOPE_OTHER } from 'calypso/state/reader/related-posts/utils';
 
-const request = ( siteId, postId, scope ) => ( dispatch, getState ) => {
-	if ( shouldFetchRelated( getState(), siteId, postId, scope ) ) {
-		dispatch( requestRelatedPosts( siteId, postId, scope ) );
+const request = ( siteId, postId, scope, size ) => ( dispatch, getState ) => {
+	if ( shouldFetchRelated( getState(), siteId, postId, scope, size ) ) {
+		dispatch( requestRelatedPosts( siteId, postId, scope, size ) );
 	}
 };
 
-export default function QueryReaderRelatedPosts( { siteId, postId, scope = SCOPE_ALL } ) {
+export default function QueryReaderRelatedPosts( { siteId, postId, scope = SCOPE_ALL, size = 2 } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( request( siteId, postId, scope ) );
-	}, [ dispatch, siteId, postId, scope ] );
+		dispatch( request( siteId, postId, scope, size ) );
+	}, [ dispatch, siteId, postId, scope, size ] );
 
 	return null;
 }
@@ -25,4 +25,5 @@ QueryReaderRelatedPosts.propTypes = {
 	siteId: PropTypes.number,
 	postId: PropTypes.number,
 	scope: PropTypes.oneOf( [ SCOPE_ALL, SCOPE_SAME, SCOPE_OTHER ] ),
+	size: PropTypes.number,
 };

--- a/client/state/reader/related-posts/actions.js
+++ b/client/state/reader/related-posts/actions.js
@@ -11,7 +11,7 @@ import { SCOPE_ALL, SCOPE_SAME, SCOPE_OTHER } from './utils';
 
 import 'calypso/state/reader/init';
 
-export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL ) {
+export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL, size = 2 ) {
 	return function ( dispatch ) {
 		dispatch( {
 			type: READER_RELATED_POSTS_REQUEST,
@@ -33,11 +33,11 @@ export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL ) {
 		}
 
 		if ( scope === SCOPE_SAME ) {
-			query.size_local = 2;
+			query.size_local = size;
 			query.size_global = 0;
 		} else if ( scope === SCOPE_OTHER ) {
 			query.size_local = 0;
-			query.size_global = 2;
+			query.size_global = size;
 		}
 
 		return wpcom.req.get( `/read/site/${ siteId }/post/${ postId }/related`, query ).then(

--- a/client/state/reader/related-posts/selectors.js
+++ b/client/state/reader/related-posts/selectors.js
@@ -2,13 +2,13 @@ import { key, SCOPE_ALL } from './utils';
 
 import 'calypso/state/reader/init';
 
-export function shouldFetchRelated( state, siteId, postId, scope = SCOPE_ALL ) {
+export function shouldFetchRelated( state, siteId, postId, scope = SCOPE_ALL, size = 2 ) {
 	return (
-		state.reader.relatedPosts.items[ key( siteId, postId, scope ) ] === undefined &&
-		! state.reader.relatedPosts.queuedRequests[ key( siteId, postId, scope ) ]
+		state.reader.relatedPosts.items[ key( siteId, postId, scope, size ) ] === undefined &&
+		! state.reader.relatedPosts.queuedRequests[ key( siteId, postId, scope, size ) ]
 	);
 }
 
-export function relatedPostsForPost( state, siteId, postId, scope = SCOPE_ALL ) {
-	return state.reader.relatedPosts.items[ key( siteId, postId, scope ) ];
+export function relatedPostsForPost( state, siteId, postId, scope = SCOPE_ALL, size = 2 ) {
+	return state.reader.relatedPosts.items[ key( siteId, postId, scope, size ) ];
 }

--- a/client/state/reader/related-posts/test/reducer.js
+++ b/client/state/reader/related-posts/test/reducer.js
@@ -21,7 +21,7 @@ describe( 'items', () => {
 				}
 			)
 		).toEqual( {
-			'1-1-all': [ 2, 3, 4 ],
+			'1-1-all-2': [ 2, 3, 4 ],
 		} );
 	} );
 
@@ -29,7 +29,7 @@ describe( 'items', () => {
 		expect(
 			items(
 				{
-					'1-1-all': [ 2, 3, 4 ],
+					'1-1-all-2': [ 2, 3, 4 ],
 				},
 				{
 					type: READER_RELATED_POSTS_RECEIVE,
@@ -41,7 +41,7 @@ describe( 'items', () => {
 				}
 			)
 		).toEqual( {
-			'1-1-all': [ 3, 4, 9 ],
+			'1-1-all-2': [ 3, 4, 9 ],
 		} );
 	} );
 } );
@@ -60,7 +60,7 @@ describe( 'queuedRequests', () => {
 				}
 			)
 		).toEqual( {
-			'1-1-all': true,
+			'1-1-all-2': true,
 		} );
 	} );
 
@@ -68,7 +68,7 @@ describe( 'queuedRequests', () => {
 		expect(
 			queuedRequests(
 				{
-					'1-1-all': true,
+					'1-1-all-2': true,
 				},
 				{
 					type: READER_RELATED_POSTS_REQUEST_SUCCESS,
@@ -79,7 +79,7 @@ describe( 'queuedRequests', () => {
 				}
 			)
 		).toEqual( {
-			'1-1-all': false,
+			'1-1-all-2': false,
 		} );
 	} );
 
@@ -96,7 +96,7 @@ describe( 'queuedRequests', () => {
 				}
 			)
 		).toEqual( {
-			'1-1-all': false,
+			'1-1-all-2': false,
 		} );
 	} );
 } );

--- a/client/state/reader/related-posts/test/selectors.js
+++ b/client/state/reader/related-posts/test/selectors.js
@@ -25,7 +25,7 @@ describe( 'selectors', () => {
 						reader: {
 							relatedPosts: {
 								queuedRequests: {
-									'1-1-all': true,
+									'1-1-all-2': true,
 								},
 								items: {},
 							},
@@ -45,7 +45,7 @@ describe( 'selectors', () => {
 							relatedPosts: {
 								queuedRequests: {},
 								items: {
-									'1-1-all': [],
+									'1-1-all-2': [],
 								},
 							},
 						},
@@ -65,7 +65,7 @@ describe( 'selectors', () => {
 						reader: {
 							relatedPosts: {
 								items: {
-									'1-1-all': [ 1, 2 ],
+									'1-1-all-2': [ 1, 2 ],
 								},
 							},
 						},
@@ -83,7 +83,7 @@ describe( 'selectors', () => {
 						reader: {
 							relatedPosts: {
 								items: {
-									'1-2-all': [ 1, 2 ],
+									'1-2-all-2': [ 1, 2 ],
 								},
 							},
 						},

--- a/client/state/reader/related-posts/utils.js
+++ b/client/state/reader/related-posts/utils.js
@@ -2,6 +2,6 @@ export const SCOPE_ALL = 'all';
 export const SCOPE_SAME = 'same';
 export const SCOPE_OTHER = 'other';
 
-export function key( siteId, postId, scope = SCOPE_ALL ) {
-	return `${ siteId }-${ postId }-${ scope }`;
+export function key( siteId, postId, scope = SCOPE_ALL, size = 2 ) {
+	return `${ siteId }-${ postId }-${ scope }-${ size }`;
 }


### PR DESCRIPTION
This PR is some ground work for the suggested follows project - https://github.com/Automattic/wp-calypso/pull/76812

We intend to use the related post endpoint to help us figure out suggested follows. At the moment, calypso only requests 2 related posts. This PR will make that variable so we can request more.

There should be no change to behaviour with this PR.

### Test
Go to a Reader post and confirm related posts still shows 2 related posts;

http://calypso.localhost:3000/read/feeds/94606731/posts/4701442242

<img width="647" alt="Screenshot 2023-05-12 at 17 03 22" src="https://github.com/Automattic/wp-calypso/assets/5560595/7fd35f2f-6ff1-4aba-bc44-e6f74ed4f0c8">

Project Ref: pe7F0s-O2-p2
