### PR TITLE
Help Center: Add fallback for back button behavior

### DIFF
--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import { Icon, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import type { FC } from 'react';
 import '../styles.scss';
 
@@ -9,9 +9,14 @@ export type Props = { onClick?: () => void; backToRoot?: boolean };
 
 export const BackButton: FC< Props > = ( { onClick, backToRoot = false } ) => {
 	const { __ } = useI18n();
+	const location = useLocation();
 	const navigate = useNavigate();
 	function defaultOnClick() {
 		if ( backToRoot ) {
+			navigate( '/' );
+		} else if ( location.key === 'default' ) {
+			// Workaround to detect when we don't have prior history
+			// https://github.com/remix-run/react-router/discussions/9922#discussioncomment-4722480
 			navigate( '/' );
 		} else {
 			navigate( -1 );

--- a/packages/help-center/src/components/test/back-button.tsx
+++ b/packages/help-center/src/components/test/back-button.tsx
@@ -6,16 +6,16 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { BackButton } from '../back-button';
 
 const mockNavigate = jest.fn();
 jest.mock( 'react-router-dom', () => ( {
 	...jest.requireActual( 'react-router-dom' ),
 	useNavigate: () => mockNavigate,
-	useLocation: jest.fn().mockImplementation( () => ( {
-		key: 'somethingrandom',
-	} ) ),
 } ) );
+
+const testEntries = [ { pathname: '/' }, { pathname: '/contact-form' } ];
 
 describe( 'BackButton', () => {
 	afterEach( () => {
@@ -25,7 +25,11 @@ describe( 'BackButton', () => {
 	it( 'navigates to the root when back to root is true', async () => {
 		const user = userEvent.setup();
 
-		render( <BackButton backToRoot /> );
+		render(
+			<MemoryRouter initialEntries={ testEntries }>
+				<BackButton backToRoot />
+			</MemoryRouter>
+		);
 
 		await user.click( screen.getByRole( 'button' ) );
 
@@ -35,7 +39,11 @@ describe( 'BackButton', () => {
 	it( 'navigates to the previous page by default', async () => {
 		const user = userEvent.setup();
 
-		render( <BackButton /> );
+		render(
+			<MemoryRouter initialEntries={ testEntries }>
+				<BackButton />
+			</MemoryRouter>
+		);
 
 		await user.click( screen.getByRole( 'button' ) );
 
@@ -44,13 +52,12 @@ describe( 'BackButton', () => {
 
 	it( "navigates to root when there's no history", async () => {
 		const user = userEvent.setup();
-		jest.mock( 'react-router-dom', () => ( {
-			useLocation: jest.fn().mockImplementation( () => ( {
-				key: 'default',
-			} ) ),
-		} ) );
 
-		render( <BackButton /> );
+		render(
+			<MemoryRouter>
+				<BackButton />
+			</MemoryRouter>
+		);
 
 		await user.click( screen.getByRole( 'button' ) );
 
@@ -61,7 +68,11 @@ describe( 'BackButton', () => {
 		const user = userEvent.setup();
 		const onClickSpy = jest.fn();
 
-		render( <BackButton onClick={ onClickSpy } /> );
+		render(
+			<MemoryRouter initialEntries={ testEntries }>
+				<BackButton onClick={ onClickSpy } />
+			</MemoryRouter>
+		);
 
 		await user.click( screen.getByRole( 'button' ) );
 

--- a/packages/help-center/src/components/test/back-button.tsx
+++ b/packages/help-center/src/components/test/back-button.tsx
@@ -12,6 +12,9 @@ const mockNavigate = jest.fn();
 jest.mock( 'react-router-dom', () => ( {
 	...jest.requireActual( 'react-router-dom' ),
 	useNavigate: () => mockNavigate,
+	useLocation: jest.fn().mockImplementation( () => ( {
+		key: 'somethingrandom',
+	} ) ),
 } ) );
 
 describe( 'BackButton', () => {
@@ -37,6 +40,21 @@ describe( 'BackButton', () => {
 		await user.click( screen.getByRole( 'button' ) );
 
 		expect( mockNavigate ).toHaveBeenCalledWith( -1 );
+	} );
+
+	it( "navigates to root when there's no history", async () => {
+		const user = userEvent.setup();
+		jest.mock( 'react-router-dom', () => ( {
+			useLocation: jest.fn().mockImplementation( () => ( {
+				key: 'default',
+			} ) ),
+		} ) );
+
+		render( <BackButton /> );
+
+		await user.click( screen.getByRole( 'button' ) );
+
+		expect( mockNavigate ).toHaveBeenCalledWith( '/' );
 	} );
 
 	it( 'calls a custom onClick handler when defined instead of modifying history', async () => {


### PR DESCRIPTION
When there's no prior history state, but we land on a page like `/contact-form` or `contact-options`, the `Back` button does nothing.

Using the workaround from
https://github.com/remix-run/react-router/discussions/9922#discussioncomment-4722480, I've added a fallback to go back to root.

Related to #76894

## Testing Instructions

- Trigger Help Center and make sure the `Back` button inside of it is working always as expected.
- Best tested with changes from #76894 that trigger a non-default initial route in Help Center from `/help`.