### PR TITLE
Use Help Center in /help/contact

### DIFF
--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -1,10 +1,10 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import DocumentHead from 'calypso/components/data/document-head';
 import { login } from 'calypso/lib/paths';
 import { CONTACT, SUPPORT_ROOT } from 'calypso/lib/url/support';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import ContactComponent from './help-contact';
 import CoursesComponent from './help-courses';
 import HelpComponent from './main';
 
@@ -55,12 +55,6 @@ export function courses( context, next ) {
 	next();
 }
 
-export function contact( context, next ) {
-	// Scroll to the top
-	if ( typeof window !== 'undefined' ) {
-		window.scrollTo( 0, 0 );
-	}
-
-	context.primary = <ContactComponent />;
-	next();
+export function contactRedirect() {
+	page.redirect( '/help' );
 }

--- a/client/me/help/help-contact-us-footer.tsx
+++ b/client/me/help/help-contact-us-footer.tsx
@@ -1,0 +1,41 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button, CompactCard, Gridicon } from '@automattic/components';
+import { HelpCenter } from '@automattic/data-stores';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import type { FC } from 'react';
+
+import './style.scss';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+const HelpContactUsFooter: FC = () => {
+	const { __ } = useI18n();
+	const { setShowHelpCenter, setInitialRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
+
+	const onClick = () => {
+		recordTracksEvent( 'calypso_help_footer_button_click' );
+		setInitialRoute( '/contact-options' );
+		setShowHelpCenter( true );
+	};
+
+	return (
+		<>
+			<h2 className="help__section-title">{ __( 'Contact Us' ) }</h2>
+			<CompactCard className="help__contact-us-card" onClick={ onClick }>
+				<Gridicon icon="help" size={ 36 } />
+				<div className="help__contact-us-section">
+					<h3 className="help__contact-us-title">{ __( 'Contact support' ) }</h3>
+					<p className="help__contact-us-content">
+						{ __( "Can't find the answer? Drop us a line and we'll lend a hand." ) }
+					</p>
+				</div>
+				<Button primary className="help__contact-us-button">
+					{ __( 'Contact support' ) }
+				</Button>
+			</CompactCard>
+		</>
+	);
+};
+
+export default HelpContactUsFooter;

--- a/client/me/help/help-contact-us-header.tsx
+++ b/client/me/help/help-contact-us-header.tsx
@@ -1,0 +1,29 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@automattic/components';
+import { HelpCenter } from '@automattic/data-stores';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import type { FC } from 'react';
+
+import './style.scss';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+const HelpContactUsHeader: FC = () => {
+	const { __ } = useI18n();
+	const { setShowHelpCenter, setInitialRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
+
+	const onClick = () => {
+		recordTracksEvent( 'calypso_help_header_button_click' );
+		setInitialRoute( '/contact-options' );
+		setShowHelpCenter( true );
+	};
+
+	return (
+		<div className="help__contact-us-header-button">
+			<Button onClick={ onClick }>{ __( 'Contact support' ) }</Button>
+		</div>
+	);
+};
+
+export default HelpContactUsHeader;

--- a/client/me/help/index.js
+++ b/client/me/help/index.js
@@ -17,8 +17,7 @@ export default function () {
 		page(
 			'/help/contact',
 			helpController.loggedOut,
-			sidebar,
-			helpController.contact,
+			helpController.contactRedirect,
 			makeLayout,
 			clientRender
 		);

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -1,5 +1,5 @@
 import { isWpComBusinessPlan, isWpComEcommercePlan } from '@automattic/calypso-products';
-import { Button, CompactCard, Gridicon } from '@automattic/components';
+import { CompactCard, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -18,6 +18,8 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { getUserPurchases, isFetchingUserPurchases } from 'calypso/state/purchases/selectors';
+import HelpContactUsFooter from './help-contact-us-footer';
+import HelpContactUsHeader from './help-contact-us-header';
 import HelpResult from './help-results/item';
 import HelpSearch from './help-search';
 import HelpUnverifiedWarning from './help-unverified-warning';
@@ -174,26 +176,6 @@ class Help extends PureComponent {
 		</>
 	);
 
-	getContactUs = () => (
-		<>
-			<h2 className="help__section-title">{ this.props.translate( 'Contact Us' ) }</h2>
-			<CompactCard className="help__contact-us-card" href="/help/contact/">
-				<Gridicon icon="help" size={ 36 } />
-				<div className="help__contact-us-section">
-					<h3 className="help__contact-us-title">{ this.props.translate( 'Contact support' ) }</h3>
-					<p className="help__contact-us-content">
-						{ this.props.translate(
-							"Can't find the answer? Drop us a line and we'll lend a hand."
-						) }
-					</p>
-				</div>
-				<Button className="help__contact-us-button">
-					{ this.props.translate( 'Contact support' ) }
-				</Button>
-			</CompactCard>
-		</>
-	);
-
 	getCoursesTeaser = () => {
 		return (
 			<CompactCard
@@ -218,10 +200,6 @@ class Help extends PureComponent {
 		recordTracksEvent( 'calypso_help_courses_click', {
 			is_business_or_ecommerce_plan_user: isBusinessOrEcomPlanUser,
 		} );
-	};
-
-	trackContactUsClick = () => {
-		recordTracksEvent( 'calypso_help_header_button_click' );
 	};
 
 	getPlaceholders = () => (
@@ -257,11 +235,7 @@ class Help extends PureComponent {
 						subHeaderText={ translate( 'Get help with your WordPress.com site' ) }
 						align="left"
 					/>
-					<div className="help__contact-us-header-button">
-						<Button onClick={ this.trackContactUsClick } href="/help/contact/">
-							{ translate( 'Contact support' ) }
-						</Button>
-					</div>
+					<HelpContactUsHeader />
 				</div>
 				<HelpSearch onSearch={ this.setIsSearching } />
 				{ ! this.state.isSearching && (
@@ -271,7 +245,7 @@ class Help extends PureComponent {
 						{ this.getSupportLinks() }
 					</div>
 				) }
-				{ this.getContactUs() }
+				<HelpContactUsFooter />
 				<QueryUserPurchases />
 			</Main>
 		);

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -122,7 +122,7 @@
 	margin-bottom: 15px;
 }
 
-.help__contact-us-card.card.is-card-link {
+.help__contact-us-card.card {
 	padding: 16px;
 	display: flex;
 	align-items: flex-start;

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -49,6 +49,12 @@ export const setUnreadCount = ( count: number ) =>
 		count,
 	} as const );
 
+export const setInitialRoute = ( route?: InitialEntry ) =>
+	( {
+		type: 'HELP_CENTER_SET_INITIAL_ROUTE',
+		route,
+	} as const );
+
 export const setIsMinimized = ( minimized: boolean ) =>
 	( {
 		type: 'HELP_CENTER_SET_MINIMIZED',
@@ -57,7 +63,7 @@ export const setIsMinimized = ( minimized: boolean ) =>
 
 export const setShowHelpCenter = function* ( show: boolean ) {
 	if ( ! show ) {
-		// reset minimized state when the help center is closed
+		yield setInitialRoute( undefined );
 		yield setIsMinimized( false );
 	}
 
@@ -106,12 +112,6 @@ export const setUserDeclaredSite = ( site: SiteDetails | undefined ) =>
 	( {
 		type: 'HELP_CENTER_SET_USER_DECLARED_SITE',
 		site,
-	} as const );
-
-export const setInitialRoute = ( route: InitialEntry ) =>
-	( {
-		type: 'HELP_CENTER_SET_INITIAL_ROUTE',
-		route,
 	} as const );
 
 export const startHelpCenterChat = function* ( site: HelpCenterSite, message: string ) {

--- a/packages/help-center/src/components/test/back-button.tsx
+++ b/packages/help-center/src/components/test/back-button.tsx
@@ -13,9 +13,6 @@ const mockNavigate = jest.fn();
 jest.mock( 'react-router-dom', () => ( {
 	...jest.requireActual( 'react-router-dom' ),
 	useNavigate: () => mockNavigate,
-	useLocation: jest.fn().mockImplementation( () => ( {
-		key: 'somethingrandom',
-	} ) ),
 } ) );
 
 const testEntries = [ { pathname: '/' }, { pathname: '/contact-form' } ];

--- a/packages/help-center/src/components/test/back-button.tsx
+++ b/packages/help-center/src/components/test/back-button.tsx
@@ -13,6 +13,9 @@ const mockNavigate = jest.fn();
 jest.mock( 'react-router-dom', () => ( {
 	...jest.requireActual( 'react-router-dom' ),
 	useNavigate: () => mockNavigate,
+	useLocation: jest.fn().mockImplementation( () => ( {
+		key: 'somethingrandom',
+	} ) ),
 } ) );
 
 const testEntries = [ { pathname: '/' }, { pathname: '/contact-form' } ];


### PR DESCRIPTION
Implements pbvpgB-30O-p2.
Help Center should be our main focus and the old contact form at `/help/contact` is not being updated with newest deflection techniques, etc.

Let's redirect to `/help/` and nudge users to use Help Center from there.

I'll remove the old contact form in a separate PR - I want to keep this one small, to make reverts easy and painless in case of issues. But it has already decreased the size of `help` section by 30% 🎉 

## Testing Instructions

- Visit `/help` - verify the Contact support buttons on top and button trigger Help Center.
- Visit `/help/contact` (either directly or from a link like on the bottom of `/home`). Make sure you're redirected to `/help`.