### PR TITLE
Earn: Adds underline to link text

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -129,7 +129,10 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		const cta = hasSimplePayments
 			? {
 					text: translate( 'Learn how to get started' ),
-					action: { url: supportLink, onClick: () => trackCtaButton( 'simple-payments' ) },
+					action: () => {
+						trackCtaButton( 'simple-payments' );
+						page( supportLink );
+					},
 			  }
 			: {
 					text: translate( 'Unlock this feature' ),

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -31,3 +31,10 @@
 		padding-right: 72px;
 	}
 }
+
+/* Adds a one-off link underline for accessibility.
+See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=AxeChrome */
+.earn .promo-card a,
+.earn .formatted-header__subtitle a {
+	text-decoration: underline;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75604

## Proposed Changes

* Add underline to any link text not in a button, to resolve this accessibility issue:
> When text links are surrounded by other text, they either need to have strong color contrast or styling like an underline to make them stand out from other text.

Note that the /earn page is also undergoing a redesign (p1683715874386849-slack-C029GN3KD). This is an interim fix to resolve an accessibility issue. cc @crisbusquets @vinimotaa

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /earn
* Inspect the links on the page or use an accessibility checker tool like the axe DevTools browser extension to check the "Links must be distinguishable without color" rule.
* Test with both free and paid plans for different content.
* Regression test: check that the "Collect PayPal payments" card link is correct, and tracked (for free plans it links to Plans, for paid plans that include the feature it links to https://wordpress.com/support/pay-with-paypal/). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?