### PR TITLE
Reader tag pages: update column styles

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -28,6 +28,10 @@
 
 	@include breakpoint-deprecated( ">660px" ) {
 		border-bottom: 1px solid #e9e9ea;
+
+		&:first-of-type {
+			border-top: 1px solid #e9e9ea;
+		}
 	}
 
 	&.is-selected {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -28,10 +28,6 @@
 
 	@include breakpoint-deprecated( ">660px" ) {
 		border-bottom: 1px solid #e9e9ea;
-
-		&:first-of-type {
-			border-top: 1px solid #e9e9ea;
-		}
 	}
 
 	&.is-selected {

--- a/client/components/search-card/style.scss
+++ b/client/components/search-card/style.scss
@@ -5,3 +5,8 @@
 .search-card .search {
 	margin: 0;
 }
+
+.stream__right-column {
+	max-width: 270px;
+	margin-left: 0;
+}

--- a/client/components/search-card/style.scss
+++ b/client/components/search-card/style.scss
@@ -6,7 +6,7 @@
 	margin: 0;
 }
 
-.stream__right-column {
+.stream__right-column .search-card.card {
 	max-width: 270px;
 	margin-left: 0;
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -85,7 +85,7 @@
 
 	@include breakpoint-deprecated( "<660px" ) {
 		flex-flow: row wrap;
-		padding: 15px 5px 15px 15px;
+		padding-top: 15px;
 	}
 
 	@include breakpoint-deprecated( "<480px" ) {
@@ -109,21 +109,10 @@
 	box-sizing: border-box;
 	border-bottom: 1px solid var(--color-neutral-10);
 	display: flex;
-	margin: 0 0 0 15px;
+	margin: 0;
 	padding: 20px 0;
 	width: 100%;
 
-	@include breakpoint-deprecated( "<960px" ) {
-		margin: 0;
-	}
-
-	@include breakpoint-deprecated( "<660px" ) {
-		margin: 0 0 0 15px;
-	}
-
-	@include breakpoint-deprecated( "<480px" ) {
-		margin: 0 5px 0 0;
-	}
 
 	.reader-related-card__post {
 		max-height: 16px * 1.6 * 11;

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -460,7 +460,7 @@ class ReaderStream extends Component {
 	};
 
 	render() {
-		const { translate, forcePlaceholders, lastPage, streamKey, tag } = this.props;
+		const { translate, forcePlaceholders, lastPage, streamHeader, streamKey, tag } = this.props;
 		const wideDisplay = this.props.width > WIDE_DISPLAY_CUTOFF;
 		let { items, isRequesting } = this.props;
 		const hasNoPosts = items.length === 0 && ! isRequesting;
@@ -492,7 +492,6 @@ class ReaderStream extends Component {
 			const bodyContent = (
 				<InfiniteList
 					ref={ this.listRef }
-					className="reader__content"
 					items={ items }
 					lastPage={ lastPage }
 					fetchingNextPage={ isRequesting }
@@ -521,7 +520,10 @@ class ReaderStream extends Component {
 			} else if ( wideDisplay ) {
 				body = (
 					<div className="stream__two-column">
-						{ bodyContent }
+						<div className="reader-content">
+							{ streamHeader }
+							{ bodyContent }
+						</div>
 						<div className="stream__right-column">{ sidebarContent }</div>
 					</div>
 				);
@@ -529,6 +531,7 @@ class ReaderStream extends Component {
 			} else {
 				body = (
 					<>
+						{ streamHeader }
 						<div className="stream__header">
 							<SectionNav selectedText={ this.state.selectedTab }>
 								<NavTabs label={ translate( 'Status' ) }>
@@ -549,7 +552,9 @@ class ReaderStream extends Component {
 								</NavTabs>
 							</SectionNav>
 						</div>
-						{ this.state.selectedTab === 'posts' && bodyContent }
+						{ this.state.selectedTab === 'posts' && (
+							<div className="reader-content">{ bodyContent }</div>
+						) }
 						{ this.state.selectedTab === 'sites' && (
 							<div className="stream__two-column">
 								<div className="stream__right-column">{ sidebarContent }</div>

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -509,6 +509,7 @@ class ReaderStream extends Component {
 			if ( isTagPage ) {
 				sidebarContent = <ReaderTagSidebar tag={ tag } />;
 				tabTitle = translate( 'Related' );
+				baseClassnames = classnames( 'tag-stream__main', this.props.className );
 			} else if ( isSearchPage ) {
 				sidebarContent = <ReaderSearchSidebar items={ items } />;
 			} else {
@@ -520,7 +521,7 @@ class ReaderStream extends Component {
 			} else if ( wideDisplay ) {
 				body = (
 					<div className="stream__two-column">
-						<div className="reader-content">
+						<div className="reader__content">
 							{ streamHeader }
 							{ bodyContent }
 						</div>
@@ -553,12 +554,10 @@ class ReaderStream extends Component {
 							</SectionNav>
 						</div>
 						{ this.state.selectedTab === 'posts' && (
-							<div className="reader-content">{ bodyContent }</div>
+							<div className="reader__content">{ bodyContent }</div>
 						) }
 						{ this.state.selectedTab === 'sites' && (
-							<div className="stream__two-column">
-								<div className="stream__right-column">{ sidebarContent }</div>
-							</div>
+							<div className="stream__right-column">{ sidebarContent }</div>
 						) }
 					</>
 				);

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -517,7 +517,7 @@ class ReaderStream extends Component {
 			}
 
 			if ( excludesSidebar.includes( streamType ) ) {
-				body = bodyContent;
+				body = <div className="reader__content">{ bodyContent }</div>;
 			} else if ( wideDisplay ) {
 				body = (
 					<div className="stream__two-column">

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -584,16 +584,12 @@
 	align-items: flex-start;
 	display: flex;
 	flex-wrap: nowrap;
+	gap: 80px;
 	justify-content: flex-start;
+}
 
-	.reader__content {
-		padding-right: 56px;
-		position: relative;
-	}
-
-	stream__right-column {
-		padding-left: 24px;
-	}
+.reader__content {
+	position: relative;
 }
 
 .stream__right-column {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1,7 +1,8 @@
 // Reader-specific tweaks to components
 
 // Overrides default 720px width
-.is-reader-page .following.main {
+.is-reader-page .following.main,
+.is-reader-page .tag-stream__main.main {
 	max-width: 600px;
 
 	&.reader-two-column {
@@ -569,14 +570,12 @@
 }
 
 .search-stream__results {
-	.stream__two-column {
-		.stream__right-column {
-			.reader-sidebar-site_url {
-				display: block;
-			}
-			.reader-sidebar-site_description {
-				display: -webkit-box;
-			}
+	.stream__right-column {
+		.reader-sidebar-site_url {
+			display: block;
+		}
+		.reader-sidebar-site_description {
+			display: -webkit-box;
 		}
 	}
 }
@@ -585,8 +584,21 @@
 	align-items: flex-start;
 	display: flex;
 	flex-wrap: nowrap;
-	gap: 80px;
 	justify-content: flex-start;
+
+	.reader__content {
+		padding-right: 56px;
+		position: relative;
+	}
+
+	stream__right-column {
+		padding-left: 24px;
+	}
+}
+
+.stream__right-column {
+	margin: 16px 0 0;
+	min-width: 270px;
 
 	.reader-sidebar-site,
 	.reader-sidebar-more {
@@ -631,19 +643,8 @@
 			display: block;
 			display: -webkit-box;
 			overflow: hidden;
-			width: 227px;
 			-webkit-line-clamp: 1;
 			-webkit-box-orient: vertical;
-		}
-	}
-
-	.reader-tag-sidebar-related-sites {
-		.reader-sidebar-site_nameurl {
-			margin: 6px 0;
-		}
-
-		.reader-sidebar-site_link {
-			margin-bottom: 2px;
 		}
 	}
 
@@ -655,96 +656,91 @@
 		line-height: 18px;
 	}
 
-	.stream__right-column {
-		margin: 16px 0 0;
-		min-width: 270px;
+	h2 {
+		align-items: flex-end;
+		color: var(--color-neutral-100);
+		display: flex;
+		font-weight: 600;
+		font-size: $font-title-small;
+		gap: 16px;
+		line-height: 24px;
+		margin-bottom: 32px;
 
-		h2 {
-			align-items: flex-end;
-			color: var(--color-neutral-100);
-			display: flex;
-			font-weight: 600;
-			font-size: $font-title-small;
-			gap: 16px;
-			line-height: 24px;
-			margin-bottom: 32px;
-
-			a {
-				font-weight: 500;
-				font-size: $font-body-small;
-				line-height: 20px;
-			}
-		}
-		.sidebar-streams__following-load-more {
-			color: var(--color-neutral-100);
-			font-size: $font-body-small;
+		a {
 			font-weight: 500;
-			padding: 0;
-			text-align: left;
-			width: unset;
-			&:hover {
-				color: var(--color-text-subtle);
-			}
+			font-size: $font-body-small;
+			line-height: 20px;
 		}
-		ul {
-			margin-left: 0;
-			width: 100%;
-		}
-		.reader-post-card__tag {
-			background: var(--color-surface);
-			border: 1px solid var(--color-neutral-5);
-			padding: 0 12px 3px;
-		}
-		.reader-tag-sidebar-related-tags,
-		.reader-tag-sidebar-related-sites {
-			h2 {
-				font-size: $font-body-small;
-				margin-bottom: 14px;
-			}
-		}
-
-		.reader-tag-sidebar-stats {
-			display: flex;
-			flex-direction: row;
-			gap: 20px;
-			margin-bottom: 32px;
-
-			.reader-tag-sidebar-stats__item {
-				display: flex;
-				flex-direction: column;
-			}
-
-			.reader-tag-sidebar-stats__count {
-				font-size: $font-title-small;
-				font-weight: bold;
-				width: 90px;
-			}
-
-			.reader-tag-sidebar-stats__title {
-				font-size: $font-body-extra-small;
-				color: var(--color-text-subtle);
-			}
-		}
-
-		.reader-sidebar-site_url {
-			display: none;
+	}
+	.sidebar-streams__following-load-more {
+		color: var(--color-neutral-100);
+		font-size: $font-body-small;
+		font-weight: 500;
+		padding: 0;
+		text-align: left;
+		width: unset;
+		&:hover {
 			color: var(--color-text-subtle);
-			font-weight: 400;
-			font-size: $font-body-extra-small;
-			line-height: 18px;
+		}
+	}
+	ul {
+		margin-left: 0;
+		width: 100%;
+	}
+	.reader-post-card__tag {
+		background: var(--color-surface);
+		border: 1px solid var(--color-neutral-5);
+		padding: 0 12px 3px;
+	}
+	.reader-tag-sidebar-related-tags,
+	.reader-tag-sidebar-related-sites {
+		h2 {
+			font-size: $font-body-small;
+			margin-bottom: 14px;
+		}
+	}
+
+	.reader-tag-sidebar-stats {
+		display: flex;
+		flex-direction: row;
+		gap: 20px;
+		margin-bottom: 32px;
+
+		.reader-tag-sidebar-stats__item {
+			display: flex;
+			flex-direction: column;
 		}
 
-		.reader-sidebar-site_description {
-			display: none;
-			color: var(--color-neutral-70);
-			font-weight: 600;
-			font-size: $font-body-extra-small;
-			line-height: 18px;
-			overflow: hidden;
-			width: auto;
-			-webkit-line-clamp: 1;
-			-webkit-box-orient: vertical;
+		.reader-tag-sidebar-stats__count {
+			font-size: $font-title-medium;
+			font-weight: bold;
+			width: 90px;
 		}
+
+		.reader-tag-sidebar-stats__title {
+			font-size: $font-body-extra-small;
+			color: var(--color-text-subtle);
+		}
+	}
+
+	.reader-sidebar-site_url {
+		display: none;
+		color: var(--color-text-subtle);
+		font-weight: 400;
+		font-size: $font-body-extra-small;
+		line-height: 18px;
+	}
+
+	.reader-sidebar-site_description {
+		display: none;
+		color: var(--color-neutral-70);
+		font-weight: 600;
+		font-size: $font-body-extra-small;
+		line-height: 18px;
+		overflow: hidden;
+		width: auto;
+		-webkit-line-clamp: 1;
+		-webkit-box-orient: vertical;
 	}
 
 	.reader-post-card__tag-link {

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -129,6 +129,19 @@ class TagStream extends Component {
 			);
 		}
 
+		// Put the tag stream header at the top of the body, so it can be even with the sidebar in the two column layout.
+		const tagHeader = (
+			<TagStreamHeader
+				title={ title }
+				description={ this.props.description }
+				imageSearchString={ imageSearchString }
+				showFollow={ !! ( tag && tag.id ) }
+				following={ this.isSubscribed() }
+				onFollowToggle={ this.toggleFollowing }
+				showBack={ this.props.showBack }
+			/>
+		);
+
 		return (
 			<Stream
 				{ ...this.props }
@@ -136,6 +149,7 @@ class TagStream extends Component {
 				emptyContent={ emptyContent }
 				showFollowInHeader={ true }
 				forcePlaceholders={ ! tag } // if tag has not loaded yet, then make everything a placeholder
+				streamHeader={ tagHeader }
 			>
 				<QueryReaderFollowedTags />
 				<QueryReaderTag tag={ this.props.decodedTagSlug } />
@@ -146,15 +160,6 @@ class TagStream extends Component {
 					} ) }
 				/>
 				{ this.props.showBack && <HeaderBack /> }
-				<TagStreamHeader
-					title={ title }
-					description={ this.props.description }
-					imageSearchString={ imageSearchString }
-					showFollow={ !! ( tag && tag.id ) }
-					following={ this.isSubscribed() }
-					onFollowToggle={ this.toggleFollowing }
-					showBack={ this.props.showBack }
-				/>
 			</Stream>
 		);
 	}

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -83,14 +83,14 @@
 
 // Tag page only shows site titles in the sidebar, so spacing needs to be tighter
 .tag-stream__main {
-	.stream__two-column .reader__content::after {
+	.stream__two-column .reader__content::before {
 		content: "";
 		background-color: #e9e9ea;
 		position: absolute;
-		right: 0;
+		right: -56px;
 		top: 0;
-		height: 200%;
-		margin-top: -80px;
+		height: calc(100% + 180px);
+		margin-top: -200px;
 		width: 1px;
 	}
 

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -48,17 +48,6 @@
 	box-shadow: none;
 	padding: 0;
 	position: relative;
-	left: -3px;
-	top: 8px;
-
-	@include breakpoint-deprecated( "<660px" ) {
-		left: 13px;
-		top: 20px;
-	}
-
-	@include breakpoint-deprecated( "<480px" ) {
-		top: 14px;
-	}
 
 	.button.header-cake__back {
 		padding: 0;

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -6,6 +6,12 @@
 	margin-bottom: 10px;
 }
 
+.reader__content .tag-stream__header {
+	border-bottom: 1px solid #e9e9ea;
+	margin-bottom: 0;
+	padding-bottom: 55px;
+}
+
 .tag-stream__header-title-group {
 	display: flex;
 	flex-wrap: wrap;
@@ -59,11 +65,6 @@
 	margin-top: 15px;
 }
 
-// Overrides default 720px width
-.is-reader-page .tag-stream__main.main {
-	max-width: 800px;
-}
-
 // specific rule to override existing rules
 .layout.has-header-section.is-section-reader .layout__header-section-content .tag-stream__page-header {
 	text-align: center;
@@ -77,5 +78,28 @@
 	h1 {
 		font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		font-weight: 500;
+	}
+}
+
+// Tag page only shows site titles in the sidebar, so spacing needs to be tighter
+.tag-stream__main {
+	.stream__two-column .reader__content::after {
+		content: "";
+		background-color: #e9e9ea;
+		position: absolute;
+		right: 0;
+		top: 0;
+		height: 200%;
+		margin-top: -80px;
+		width: 1px;
+	}
+
+	.stream__two-column .stream__right-column {
+		margin-top: 0;
+	}
+
+	.reader-sidebar-site_link {
+		align-items: center;
+		margin-bottom: 12px;
 	}
 }

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -12,6 +12,10 @@
 	padding-bottom: 55px;
 }
 
+.reader__content .tag-stream__header.has-description {
+	padding-bottom: 16px;
+}
+
 .tag-stream__header-title-group {
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/75730

## Proposed Changes

Updates the column styles on the newly designed reader tag pages to better match the design.

Additional markup changes to support the design include:

- Adding a `streamHeader` prop to `ReaderStream`, so a custom header can be added at the top of the main column in the two-column view, rather than above both columns.
- Modifies `ReaderStream` so the `.stream__two-column` class is only present when two columns are displayed side-by-side, for styles that only apply to the two column layout.
- Adds the `.tag-stream__main` class to the `main` element on the tag page to more easily customize the tag page (it appears this was present before, but removed at some point).

<img width="1353" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1699996/13b6ca46-3ca7-4958-a22d-7a0e3ab00c97">

## Testing Instructions

* Visit `/tag/{tag-slug}` and compare with designs (pe7F0s-IS-p2)
* Check both large (two column) and small screens (tabbed layout)
* Spot check other Reader pages: Following, Search, etc to check for regressions