### PR TITLE
Promo card component: render empty alt if no alt provided

### DIFF
--- a/client/components/promo-section/promo-card/index.tsx
+++ b/client/components/promo-section/promo-card/index.tsx
@@ -75,7 +75,7 @@ const PromoCard: FunctionComponent< Props > = ( {
 			{ image && (
 				<ActionPanelFigure inlineBodyText={ false } align={ imageActionPanelAlignment }>
 					{ isImage( image ) ? (
-						<img src={ image.path } alt={ image.alt } className={ image.className } />
+						<img src={ image.path } alt={ image.alt || '' } className={ image.className } />
 					) : (
 						image
 					) }


### PR DESCRIPTION
Render empty alt tag in promo card images when no alt text is provided. This is better for accessibility than omitting the alt entirely.

Fixes https://github.com/Automattic/wp-calypso/issues/75603

<img width="1512" alt="Screenshot 2023-05-13 at 19 47 56" src="https://github.com/Automattic/wp-calypso/assets/87168/a7a839db-880a-4f7d-b448-df6e8c063b64">

## Proposed Changes

* Render empty alt tag in promo card images when no alt text is provided.

## Testing Instructions

1. Go to earn page (http://calypso.localhost:3000/earn) and confirm that the promo card image has empty alt
2. Confirm that by adding `alt` prop to image, it appears in HTML, here's the place in Earn page for testing:

    https://github.com/Automattic/wp-calypso/blob/7323a4ecd7659f1cf93a6b088e5fb0e409ed71f1/client/my-sites/earn/home.tsx#L516-L519

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
