### PR TITLE
a11y: add `alt` text to the image of coins in `/earn`.

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -516,6 +516,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		image: {
 			path: earnSectionImage,
 			align: 'right' as Image[ 'align' ],
+			alt: translate( 'Monetize with your site.' ),
 		},
 		body: translate(
 			'Accept credit card payments today for just about anything – physical and digital goods, services, donations and tips, or access to your exclusive content. {{a}}Watch our tutorial videos to get started{{/a}}.',


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75603.

## Proposed Changes

This PR adds `alt` text to the [informative image](https://www.w3.org/WAI/tutorials/images/informative/) in `/earn`.

<img width="1302" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6549265/af274226-6e91-4819-9ed5-cba9ffe65f3f">


## Testing Instructions



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
