### PR TITLE
Stats: Fixing hover and focus CSS for the main navigation for small viewport

### DIFF
--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -85,9 +85,12 @@
 				font-size: $font-body-small;
 				line-height: 20px;
 
-				&:hover {
-					color: var(--color-neutral-60);
-					background-color: var(--color-surface);
+				@media ( min-width: $break-mobile ) {
+					&:hover,
+					&:focus {
+						color: var(--color-neutral-60);
+						background-color: var(--color-surface);
+					}
 				}
 
 				@media ( max-width: $break-medium ) {
@@ -96,6 +99,18 @@
 
 				@media ( max-width: $break-mobile ) {
 					padding: 8px;
+				}
+			}
+
+			@media ( max-width: $break-mobile ) {
+				&.is-selected {
+					.section-nav-tab__link {
+						&:hover,
+						&:focus {
+							color: var(--color-primary);
+							background-color: var(--color-surface);
+						}
+					}
 				}
 			}
 

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -108,7 +108,6 @@
 						&:hover,
 						&:focus {
 							color: var(--color-primary);
-							background-color: var(--color-surface);
 						}
 					}
 				}
@@ -136,6 +135,18 @@
 				color: var(--color-neutral-80);
 				margin: 0;
 				padding: 7px 12px;
+			}
+
+			@media ( max-width: $break-mobile ) {
+				&:hover,
+				&:focus {
+					background-color: var(--color-primary-0);
+					color: var(--color-primary);
+
+					.button {
+						color: var(--color-primary);
+					}
+				}
 			}
 
 			.count {

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -46,14 +46,24 @@
 			box-shadow: inset 0 -1px 0 #0000000d;
 
 			&.is-open {
-				.subscribers-count .button {
-					@media ( max-width: $break-mobile ) {
-						display: inline-block;
-						padding: 8px;
-						color: var(--color-neutral-60);
-						font-size: $font-body-small;
-						font-weight: 600;
-						line-height: 24px;
+				@media ( max-width: $break-mobile ) {
+					.subscribers-count {
+						&:hover,
+						&:focus {
+							.button {
+								color: var(--color-text-inverted);
+							}
+						}
+
+						.button {
+							display: inline-block;
+							padding: 8px;
+							color: var(--color-neutral-60);
+							font-size: $font-body-small;
+							font-weight: 600;
+							line-height: 24px;
+
+						}
 					}
 				}
 			}
@@ -103,12 +113,16 @@
 			}
 
 			@media ( max-width: $break-mobile ) {
-				&.is-selected {
-					.section-nav-tab__link {
-						&:hover,
-						&:focus {
-							color: var(--color-primary);
-						}
+				& + .section-nav-tab {
+					margin-top: 1px;
+				}
+
+				.section-nav-tab__link {
+					&:hover,
+					&:focus {
+						color: var(--color-text-inverted);
+						background-color: var(--color-primary);
+						opacity: 0.65;
 					}
 				}
 			}
@@ -138,13 +152,16 @@
 			}
 
 			@media ( max-width: $break-mobile ) {
+				margin-top: 1px; // TODO: remove this after enabling Subscribers page and all nav items are of the same type
+
 				&:hover,
 				&:focus {
-					background-color: var(--color-primary-0);
-					color: var(--color-primary);
+					color: var(--color-text-inverted);
+					background-color: var(--color-primary);
+					opacity: 0.65;
 
 					.button {
-						color: var(--color-primary);
+						color: var(--color-text-inverted);
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72173

## Proposed Changes

* Limit CSS from medium and large viewports from affecting small screens
* Add `focus` CSS to indicate elements highlighted during keyboard navigation
* Instead of another colour to indicate hover, apply opacity - this makes sure fovus works in the default theme

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the live branch
* navigate to Starts and decrease your screen size to a small viewport
* verify that the navigation can be highlighted by hovering or using keyboard navigation

| Before | After |
| --- | --- |
| <img width="434" alt="SCR-20230518-kxax" src="https://github.com/Automattic/wp-calypso/assets/112354940/57ff15ec-334e-4b5c-a1df-b381ae959b17"> | <img width="441" alt="SCR-20230518-kwvm" src="https://github.com/Automattic/wp-calypso/assets/112354940/0ceccdf5-e983-4ebb-bcc5-d23eb686fddf"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
