### PR TITLE
Add themeSlugWithRepo dep to plans-site-selected

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -101,7 +101,7 @@ export function generateSteps( {
 			stepName: 'plans-site-selected',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'cartItem' ],
+			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
 			props: {
 				hideFreePlan: true,
 				hideEnterprisePlan: true,
@@ -118,7 +118,7 @@ export function generateSteps( {
 			stepName: 'plans-site-selected-legacy',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'cartItem' ],
+			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
 		},
 
 		site: {


### PR DESCRIPTION
I got a Sentry notification that a JS error is being reported in the wild:
```
This step (plans-site-selected) provides an unspecified dependency [themeSlugWithRepo]. Make sure to specify it in /signup/config/steps-pure.js, using the providesDependencies property.
```
I was notified because I migrated the Signup code from Flux to Redux 4 years ago, and I am not familiar what's been done in Signup since then, but I think I was able to figure it out anyway:

In #68411 and #68417 @daledupreez and @mreishus merged a change that's adding a `themeSlugWithRepo` dep to several plans-selection steps, because the plans selection UI can specify a theme after selecting an eCommerce plan. But the `plans-site-selected` step didn't get the new dependency. And it seems it needs it.
