### PR TITLE
Stats: Omit base URL on children for clicks/refers

### DIFF
--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1347,6 +1347,11 @@ describe( 'utils', () => {
 													url: 'https://wordpress.com/support/',
 													views: 5,
 												},
+												{
+													name: 'wordpress.com/support/hello',
+													url: 'https://wordpress.com/support/hello',
+													views: 5,
+												},
 											],
 										},
 										{
@@ -1370,9 +1375,16 @@ describe( 'utils', () => {
 						children: [
 							{
 								children: null,
-								label: 'wordpress.com/support',
+								label: '/',
 								labelIcon: 'external',
 								link: 'https://wordpress.com/support/',
+								value: 5,
+							},
+							{
+								children: null,
+								label: '/hello',
+								labelIcon: 'external',
+								link: 'https://wordpress.com/support/hello',
 								value: 5,
 							},
 						],
@@ -1434,7 +1446,7 @@ describe( 'utils', () => {
 						children: [
 							{
 								children: null,
-								label: 'wordpress.com/support',
+								label: '/',
 								labelIcon: 'external',
 								link: 'https://wordpress.com/support/',
 								value: 50,
@@ -1495,6 +1507,11 @@ describe( 'utils', () => {
 										results: [
 											{ name: 'homepage', url: 'https://wordpress.com/support/', views: 200 },
 											{ name: 'start', url: 'https://wordpress.com/support/start/', views: 100 },
+											{
+												name: 'wordpress.com/support/hello',
+												url: 'https://wordpress.com/support/hello/',
+												views: 100,
+											},
 										],
 										total: 300,
 									},
@@ -1544,6 +1561,13 @@ describe( 'utils', () => {
 								label: 'start',
 								labelIcon: 'external',
 								link: 'https://wordpress.com/support/start/',
+								value: 100,
+							},
+							{
+								children: undefined,
+								label: '/hello',
+								labelIcon: 'external',
+								link: 'https://wordpress.com/support/hello/',
 								value: 100,
 							},
 						],

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -746,7 +746,7 @@ export const normalizers = {
 		const dataPath = query.summarize ? [ 'summary', 'clicks' ] : [ 'days', startOf, 'clicks' ];
 		const statsData = get( data, dataPath, [] );
 
-		return statsData.map( ( item ) => {
+		const output = statsData.map( ( item ) => {
 			const hasChildren = item.children && item.children.length > 0;
 			const newRecord = {
 				label: item.name,
@@ -760,7 +760,9 @@ export const normalizers = {
 			if ( item.children ) {
 				newRecord.children = item.children.map( ( child ) => {
 					return {
-						label: child.name,
+						// Remove the parent name from the child name.
+						// If the child name is the same as the parent name, use a slash instead.
+						label: child.name?.replace( item.name, '' ) || '/',
 						value: child.views,
 						children: null,
 						link: child.url,
@@ -771,6 +773,7 @@ export const normalizers = {
 
 			return newRecord;
 		} );
+		return output;
 	},
 
 	/*
@@ -793,7 +796,12 @@ export const normalizers = {
 		const parseItem = ( item ) => {
 			let children;
 			if ( item.children && item.children.length > 0 ) {
-				children = item.children.map( parseItem );
+				children = item.children.map( ( child ) => {
+					const parsed = parseItem( child );
+					// Remove the parent name from the child name.
+					// If the child name is the same as the parent name, use a slash instead.
+					parsed.label = child.name?.replace( item.name, '' ) || '/';
+				} );
 			}
 
 			const record = {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -801,6 +801,7 @@ export const normalizers = {
 					// Remove the parent name from the child name.
 					// If the child name is the same as the parent name, use a slash instead.
 					parsed.label = child.name?.replace( item.name, '' ) || '/';
+					return parsed;
 				} );
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #76922.

## Proposed Changes

Before|After
-|-
<img width="365" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/857d5c55-4e6f-430e-8334-a2e40f78cdf6">|<img width="363" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/08ff04eb-6219-41f6-b13a-42fdb229815f">

The child label will no longer begin with the parent's base URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch of this PR and navigate to the Stats Dashboard.
* Ensure that the child rows in the referrers module and clicks modules no longer begin with the parents' base URL.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
