### PR TITLE
Remove pseudo focus-with to release hover styling

### DIFF
--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -900,8 +900,7 @@ ul.module-content-list-legend {
 
 .horizontal-bar-list-item {
 	&:hover,
-	&:focus,
-	&:focus-within {
+	&:focus {
 		.stats-list-actions__mobile-toggle .gridicon,
 		.stats-list-actions__mobile-toggle .stats-icon {
 			fill: var(--color-text);

--- a/packages/components/src/horizontal-bar-list/style.scss
+++ b/packages/components/src/horizontal-bar-list/style.scss
@@ -26,8 +26,7 @@
 		}
 
 		&:hover,
-		&:focus,
-		&:focus-within {
+		&:focus {
 			background-color: var(--theme-highlight-color);
 			color: var(--studio-white);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #76924 

## Proposed Changes

* Remove the pseudo selector `:focus-within` to prevent displaying not hovered `.horizontal-bar-list-item` with focused descendant follow/unfollow buttons.

<img width="574" alt="截圖 2023-05-15 上午9 46 58" src="https://github.com/Automattic/wp-calypso/assets/6869813/d5a98ee8-4072-4e23-a89b-800c8b46b0e8">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the live branch link.
* Navigate to the `Insights` page and go to the `Comments` section.
* Follow/Unfollow the author of comments.
* Hover on another list item.
* Ensure the previously hovered item is not marked as hovered anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
