### PR TITLE
Introduce new feature flag and update plans and ready page

### DIFF
--- a/client/blocks/import/style/base.scss
+++ b/client/blocks/import/style/base.scss
@@ -118,6 +118,12 @@
 	}
 }
 
+.import__onboarding-page--redesign {
+	.components-button.action-buttons__next.is-primary {
+		padding: 10px 20px;
+	}
+}
+
 [dir="rtl"] {
 	.import__details-list {
 		svg {

--- a/client/blocks/importer/types.ts
+++ b/client/blocks/importer/types.ts
@@ -17,6 +17,7 @@ export type StepNavigator = {
 	goToWpAdminWordPressPluginPage?: () => void;
 	navigate?: ( path: string ) => void;
 	goToAddDomainPage?: () => void;
+	goToImportListStep?: () => void;
 };
 
 export interface ImportError {

--- a/client/blocks/importer/wordpress/import-everything/confirm-upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm-upgrade-plan.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import { getPlan, PLAN_BUSINESS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
 import { sprintf } from '@wordpress/i18n';
 import { check, plus, Icon } from '@wordpress/icons';
@@ -69,15 +70,17 @@ export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
 	return (
 		<div className={ classnames( 'import__upgrade-plan' ) }>
 			<QueryPlans />
-			<p>
-				{ sprintf(
-					/* translators: the website could be any domain (eg: "yourname.com") */
-					__(
-						'To import your themes, plugins, users, and settings from %(website)s we need to upgrade your WordPress.com site. Select a plan below:'
-					),
-					{ website: sourceSite?.slug }
-				) }
-			</p>
+			{ ! isEnabled( 'onboarding/import-redesign' ) && (
+				<p>
+					{ sprintf(
+						/* translators: the website could be any domain (eg: "yourname.com") */
+						__(
+							'To import your themes, plugins, users, and settings from %(website)s we need to upgrade your WordPress.com site. Select a plan below:'
+						),
+						{ website: sourceSite?.slug }
+					) }
+				</p>
+			) }
 
 			<div className={ classnames( 'import__upgrade-plan-container' ) }>
 				<div className={ classnames( 'import__upgrade-plan-price' ) }>

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -148,13 +148,11 @@ export class ImportEverything extends SectionMigrate {
 				return (
 					<MigrateReady
 						startImport={ this.startMigration }
-						isMigrateFromWp={ isMigrateFromWp }
 						isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
 						targetSite={ targetSite }
 						targetSiteSlug={ targetSiteSlug }
 						sourceSite={ sourceSite }
 						sourceSiteUrl={ sourceSite.URL }
-						sourceUrlAnalyzedData={ sourceUrlAnalyzedData }
 						onContentOnlyClick={ stepNavigator?.goToImportListStep }
 					/>
 				);

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { ProgressBar } from '@automattic/components';
 import { Hooray, Progress, SubTitle, Title, NextButton } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
@@ -23,6 +24,7 @@ import { isTargetSitePlanCompatible } from '../../util';
 import { MigrationStatus } from '../types';
 import { retrieveMigrateSource, clearMigrateSource } from '../utils';
 import { Confirm } from './confirm';
+import { MigrateReady } from './migrate-ready';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { StepNavigator } from 'calypso/blocks/importer/types';
 
@@ -142,6 +144,21 @@ export class ImportEverything extends SectionMigrate {
 		} = this.props;
 
 		if ( sourceSite ) {
+			if ( isEnabled( 'onboarding/import-redesign' ) ) {
+				return (
+					<MigrateReady
+						startImport={ this.startMigration }
+						isMigrateFromWp={ isMigrateFromWp }
+						isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
+						targetSite={ targetSite }
+						targetSiteSlug={ targetSiteSlug }
+						sourceSite={ sourceSite }
+						sourceSiteUrl={ sourceSite.URL }
+						sourceUrlAnalyzedData={ sourceUrlAnalyzedData }
+						onContentOnlyClick={ stepNavigator?.goToImportListStep }
+					/>
+				);
+			}
 			return (
 				<Confirm
 					startImport={ this.startMigration }

--- a/client/blocks/importer/wordpress/import-everything/migrate-ready.tsx
+++ b/client/blocks/importer/wordpress/import-everything/migrate-ready.tsx
@@ -1,0 +1,156 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
+import { Title, SubTitle, NextButton } from '@automattic/onboarding';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
+import React, { useEffect } from 'react';
+import { convertToFriendlyWebsiteName } from 'calypso/blocks/import/util';
+import ConfirmUpgradePlan from './confirm-upgrade-plan';
+import type { SiteDetails } from '@automattic/data-stores';
+
+import './style.scss';
+
+interface Props {
+	sourceSite: SiteDetails | null;
+	sourceSiteUrl: string;
+	targetSite: SiteDetails | null;
+	targetSiteSlug: string;
+	isTargetSitePlanCompatible: boolean;
+	startImport: () => void;
+	onContentOnlyClick: () => void;
+}
+
+export const MigrateReady: React.FunctionComponent< Props > = ( props ) => {
+	const { __ } = useI18n();
+	const plan = getPlan( PLAN_BUSINESS );
+	/**
+	 ↓ Fields
+	 */
+	const {
+		sourceSite,
+		sourceSiteUrl,
+		targetSite,
+		targetSiteSlug,
+		isTargetSitePlanCompatible,
+		startImport,
+		onContentOnlyClick,
+	} = props;
+
+	/**
+	 ↓ Effects
+	 */
+	useEffect( () => {
+		recordTracksEvent( 'calypso_site_importer_migration_confirmation' );
+	}, [] );
+
+	/**
+	 ↓ Functions
+	 */
+	function startImportCta() {
+		recordTracksEvent( 'calypso_signup_step_start', {
+			flow: 'importer',
+			step: 'importerWordpress',
+			action: 'startImport',
+		} );
+		startImport();
+	}
+
+	function onMigrationMethodToggle() {
+		// place holder for future use
+	}
+
+	return (
+		<>
+			<div
+				className={ classnames( 'import__import-everything', {
+					'import__import-everything--redesign': isEnabled( 'onboarding/import-redesign' ),
+				} ) }
+			>
+				<>
+					{ ! isTargetSitePlanCompatible && (
+						<>
+							<div className="import__heading-title">
+								<Title>Upgrade your plan</Title>
+								<SubTitle>
+									{ sprintf(
+										/* translators: the `plan` should be the title of the plan */
+										__( 'Migrating themes, plugins, users, and settings requires a %(plan)s plan' ),
+										{
+											plan: plan?.getTitle(),
+										}
+									) }
+								</SubTitle>
+							</div>
+							<p>
+								{ sprintf(
+									/* translators: the `from` and `to` fields could be any site URL (eg: "yourname.com") */
+									__(
+										'Your entire site %(from)s will be migrated to %(to)s, overriding the content in your destination site'
+									),
+									{
+										from: convertToFriendlyWebsiteName( sourceSiteUrl ),
+										to: convertToFriendlyWebsiteName( targetSiteSlug ),
+									}
+								) }
+							</p>
+							<ConfirmUpgradePlan sourceSite={ sourceSite } targetSite={ targetSite } />
+							<div className="import__footer-button-container">
+								<NextButton onClick={ () => startImport() }>
+									{ __( 'Upgrade and migrate' ) }
+								</NextButton>
+								<Button
+									borderless={ true }
+									className="action-buttons__importer-list"
+									onClick={ onContentOnlyClick }
+								>
+									{ __( 'Use the content-only import option' ) }
+								</Button>
+							</div>
+						</>
+					) }
+
+					{ isTargetSitePlanCompatible && (
+						<>
+							<div className="import__heading-title">
+								<Title>You are ready to migrate</Title>
+								<SubTitle>
+									{ sprintf(
+										/* translators: the `from` and `to` fields could be any site URL (eg: "yourname.com") */
+										__( 'Your entire site %(from)s will be migrated to %(to)s' ),
+										{
+											from: convertToFriendlyWebsiteName( sourceSiteUrl ),
+											to: convertToFriendlyWebsiteName( targetSiteSlug ),
+										}
+									) }
+								</SubTitle>
+							</div>
+							<p className="import__note">
+								{ translate(
+									'Optionally, {{serverCredentialCta}}provide the server credentials{{/serverCredentialCta}} of your site to speed up the migration.',
+									{
+										components: {
+											serverCredentialCta: (
+												<Button
+													className="action-buttons__migration-method-cta"
+													borderless={ true }
+													onClick={ onMigrationMethodToggle }
+												/>
+											),
+										},
+									}
+								) }
+							</p>
+							<div className="import__footer-button-container">
+								<NextButton onClick={ startImportCta }>{ __( 'Start migration' ) }</NextButton>
+							</div>
+						</>
+					) }
+				</>
+			</div>
+		</>
+	);
+};

--- a/client/blocks/importer/wordpress/import-everything/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/style.scss
@@ -1,6 +1,8 @@
+@import "@automattic/typography/styles/fonts";
+@import "@automattic/onboarding/styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
+// @include onboarding-font-recoleta;
 [dir="rtl"] {
 	.import__import-everything {
 		.import_site-mapper-name .site-icon {
@@ -89,6 +91,67 @@
 			color: var(--studio-gray-40);
 		}
 	}
+}
+
+.import__import-everything--redesign {
+	.onboarding-title {
+		@include onboarding-font-recoleta;
+		color: var(--studio-gray-100);
+		font-size: 2.75rem;
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		line-height: 3rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.import__heading-title {
+		text-align: center;
+	}
+
+	.onboarding-subtitle {
+		margin-bottom: 2.5rem;
+	}
+
+	.import__upgrade-plan {
+		margin-top: 2.5rem;
+		margin-bottom: 2.5rem;
+	}
+
+	.action-buttons__importer-list {
+		font-weight: 500;
+		text-decoration: underline;
+		color: var(--studio-gray-100);
+	}
+
+	.action-buttons__migration-method-cta {
+		text-decoration: underline;
+		color: var(--studio-gray-100);
+		padding: 0;
+		font-size: 1rem;
+	}
+
+	.import__note {
+		text-align: center;
+		margin-bottom: 2.5rem;
+	}
+
+	.import__footer-button-container {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+
+		@include break-medium {
+			flex-direction: row;
+			justify-content: center;
+		}
+
+		button {
+			margin: 8px 0;
+			@include break-medium {
+				margin: 0 8px;
+			}
+		}
+	}
+
 }
 
 .import__upgrade-plan {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
@@ -29,6 +29,10 @@ export function useStepNavigator(
 		navigation.goToStep?.( 'import' );
 	}
 
+	function goToImportListStep() {
+		navigation.goToStep?.( `importList?siteSlug=${ siteSlug }` );
+	}
+
 	function goToSiteViewPage() {
 		navigation.submit?.( {
 			type: 'redirect',
@@ -98,6 +102,7 @@ export function useStepNavigator(
 		goToWpAdminImportPage,
 		goToWpAdminWordPressPluginPage,
 		goToAddDomainPage,
+		goToImportListStep,
 		navigate: ( path ) => navigator( path ),
 	};
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -174,7 +175,10 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 						'import__onboarding-page',
 						'import-layout__center',
 						'importer-wrapper',
-						{ [ `importer-wrapper__${ importer }` ]: !! importer }
+						{
+							[ `importer-wrapper__${ importer }` ]: !! importer,
+							'import__onboarding-page--redesign': isEnabled( 'onboarding/import-redesign' ),
+						}
 					) }
 					stepName="importer-step"
 					hideSkip={ true }

--- a/config/development.json
+++ b/config/development.json
@@ -137,6 +137,7 @@
 		"onboarding/import-light": false,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
+		"onboarding/import-redesign": true,
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"page/export": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76723

## Proposed Changes

* Introduce new feature flag `onboarding/import-redesign`
* Update Upgrade Your Plan page
* Update Your site is ready to migrate page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to http://calypso.localhost:3000/setup/import-focused/importerWordpress?siteSlug=${target_site}&from=${source_site}&option=everything
* Check with an Atomic site and see if you see the `Your migrate is ready` page
<img width="894" alt="Screen Shot 2023-05-15 at 2 17 21 PM" src="https://github.com/Automattic/wp-calypso/assets/4074459/1546e16d-4c30-4865-aece-c49f6bc4ea0a">

* Check with a simple site and see if you can see the Upgrade your plan page
<img width="950" alt="Screen Shot 2023-05-15 at 2 17 42 PM" src="https://github.com/Automattic/wp-calypso/assets/4074459/047b6b9b-548c-4c4a-b12b-9e2c5ee06f33">
* Click on the content-only option and see if it redirects to the import list

Note: Back button is not handled in this PR, once we discuss how we want to navigate we'll update the back button step.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
