### PR TITLE
Odyssey Stats: Align the spam icon of Referrers list items

### DIFF
--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -1,4 +1,4 @@
-import { Button, Dialog } from '@automattic/components';
+import { Dialog } from '@automattic/components';
 import { Icon, warning } from '@wordpress/icons';
 import classNames from 'classnames';
 import debugFactory from 'debug';
@@ -86,8 +86,7 @@ class StatsActionSpam extends Component {
 
 		return (
 			<li className="stats-list__spam-action module-content-list-item-action">
-				<Button
-					href="#"
+				<button
 					onClick={ this.clickHandler }
 					className={ wrapperClass }
 					title={ title }
@@ -97,7 +96,7 @@ class StatsActionSpam extends Component {
 					<span className="stats-list__spam-label module-content-list-item-action-label">
 						{ label }
 					</span>
-				</Button>
+				</button>
 				{ this.props.inHorizontalBarList && (
 					<Dialog
 						isVisible={ this.state.showConfirmDialog }

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -494,6 +494,10 @@ ul.module-content-list-item-action-submenu {
 	display: inline-block;
 	margin: 0 1em 0 0;
 
+	button {
+		cursor: pointer;
+	}
+
 	// So that 'View' label is moved more to the right since icon has been dropped
 	@include breakpoint-deprecated( ">960px" ) {
 		.stats__module-list & {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #76909 

## Proposed Changes

* Use pure button element for the action to mark/unmark as spam to prevent append styles by the `Button` component.

|Before|After|
|-|-|
|<img width="524" alt="截圖 2023-05-15 下午3 40 32" src="https://github.com/Automattic/wp-calypso/assets/6869813/38efc30f-2b41-400b-a412-a47d20f4a435">|<img width="524" alt="截圖 2023-05-15 下午3 31 18" src="https://github.com/Automattic/wp-calypso/assets/6869813/9b2d8fac-a9ed-47a6-82c0-da31908bdfb1">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build Jetpack if necessary: `jetpack build plugins/jetpack`.
* Run `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev` under `calypso/apps/odyssey-stats`.
* Navigate to the `Stats` > `Insights` page and find the `Referrers` section.
* Ensure the mark/unmark as spam icon is aligned with the external link icon.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
