### PR TITLE
Stats: change edit media link for odyssey

### DIFF
--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import getSiteAdminUrlFromState from 'calypso/state/sites/selectors/get-site-admin-url';
 import {
 	isRequestingSiteStatsForQuery,
 	getVideoPressPlaysComplete,
@@ -139,7 +140,14 @@ class VideoPressStatsModule extends Component {
 		} );
 
 		const editVideo = ( postId ) => {
-			page( `/media/${ siteSlug }/${ postId }` );
+			const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+			if ( ! isOdysseyStats ) {
+				page( `/media/${ siteSlug }/${ postId }` );
+			}
+			location.href = `${ getSiteAdminUrlFromState(
+				config( 'intial_state' ),
+				this.props.siteId
+			) }upload.php?item=${ postId }`;
 		};
 
 		const showStat = ( queryStatType, row ) => {

--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import getSiteAdminUrlFromState from 'calypso/state/sites/selectors/get-site-admin-url';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import {
 	isRequestingSiteStatsForQuery,
 	getVideoPressPlaysComplete,
@@ -110,6 +110,7 @@ class VideoPressStatsModule extends Component {
 			period,
 			siteSlug,
 			translate,
+			siteAdminUrl,
 		} = this.props;
 
 		let completeVideoStats = [];
@@ -143,11 +144,10 @@ class VideoPressStatsModule extends Component {
 			const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 			if ( ! isOdysseyStats ) {
 				page( `/media/${ siteSlug }/${ postId }` );
+				return;
 			}
-			location.href = `${ getSiteAdminUrlFromState(
-				config( 'intial_state' ),
-				this.props.siteId
-			) }upload.php?item=${ postId }`;
+			// If it's Odyssey, redirect user to media lib page.
+			location.href = `${ siteAdminUrl }upload.php?item=${ postId }`;
 		};
 
 		const showStat = ( queryStatType, row ) => {
@@ -342,6 +342,7 @@ export default connect( ( state, ownProps ) => {
 	return {
 		requesting: isRequestingSiteStatsForQuery( state, siteId, statType, query ),
 		data: getVideoPressPlaysComplete( state, siteId, statType, query ),
+		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		siteId,
 		siteSlug,
 	};


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/11983

## Proposed Changes

As /media route doesn't exist on Odyssey, we'll have to redirect user to Media lib page for Odyssey Stats. When VideoPress is active on the site, there would be a link for user to navigate to VideoPress dashboard.

## Testing Instructions

* Open a site with VideoPress and some videos
* Open `/wp-admin/admin.php?page=stats#!/stats/week/videoplays/{site}?startDate=2023-xx-xx` <- video `View details`
* Click a video on the title
* Ensure you are taken to attachment management page

<img width="1274" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/71a58cb5-2804-4786-ae8a-52239ec30138">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
