### PR TITLE
Button on Posts Categories (/settings/taxonomies/category) is missing discernible text 

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -146,12 +146,18 @@ class TaxonomyManagerListItem extends Component {
 					tabIndex={ 0 }
 					onKeyUp={ onKeyUp }
 					onClick={ onClick }
+					aria-label={ name }
 				>
 					<Gridicon icon={ isDefault ? 'checkmark-circle' : 'folder' } />
 				</span>
-				{ /* FIXME: jsx-a11y issues */ }
-				{ /* eslint-disable-next-line */ }
-				<span className="taxonomy-manager__label" onClick={ onClick }>
+				<span
+					className="taxonomy-manager__label"
+					role="button"
+					tabIndex={ 0 }
+					onKeyUp={ onKeyUp }
+					onClick={ onClick }
+					aria-label={ name }
+				>
 					<span>{ name }</span>
 					{ isDefault && (
 						<span className="taxonomy-manager__default-label">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #75596

## Proposed Changes

* Fix a11y in posts category buttons by adding role, aria-label, tab-index and keyboard support

|BEFORE|AFTER|
|---|---|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/e2b8713b-3247-4ff0-b78b-932e4d5ff583.mp4" />|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/49874c25-d208-4bf7-8697-7b8559dcba91.mp4" />|

|BEFORE|AFTER|
|---|---|
|<img width="372" alt="Screenshot 2566-05-15 at 14 02 21" src="https://github.com/Automattic/wp-calypso/assets/1881481/6e8ee9bc-45a7-4923-80ec-d3c2addd15d6">|<img width="407" alt="Screenshot 2566-05-15 at 14 00 36" src="https://github.com/Automattic/wp-calypso/assets/1881481/6ce7b788-b35e-43e4-85cb-c16b0f4ae047">|


|BEFORE|AFTER|
|---|---|
|<img width="417" alt="Screenshot 2566-05-15 at 14 13 55" src="https://github.com/Automattic/wp-calypso/assets/1881481/1c2074f8-aeb2-434a-bc74-a267247ed109">|<img width="416" alt="Screenshot 2566-05-15 at 14 01 21" src="https://github.com/Automattic/wp-calypso/assets/1881481/b3ccbddd-befb-49b6-93fe-484611dcfa6e">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `wordpress.com/settings/taxonomies/category/{ SITE SLUG }`
* Using a screen reader navigate the category list with the keyboard
* Verify the category name and icon get the focus and the reader reads the category name
* Verify the modal to edit a category opens when you press `Enter` on your keyboard

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
