### PR TITLE
Subscriber import: replace placeholder copy "mom"

### DIFF
--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -87,7 +87,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const emailControlPlaceholder = [
 		translate( 'bestie@email.com' ),
 		translate( 'chrisfromwork@email.com' ),
-		translate( 'mom@email.com' ),
+		translate( 'family@email.com' ),
 	];
 	const inProgress = useInProgressState();
 	const prevInProgress = useRef( inProgress );


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/76636 , we'll switch "mom" to "family" due feedback:

> I think "mom" is very US-centric ("mum" is preferred elsewhere), and can be too specific (vs. the more generic "family@email.com" or "coworker@email.com")

## Proposed Changes

Before

<img width="801" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/dec6c06f-dde9-4c94-907f-0387cb2567c1">

After
<img width="826" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/2d9b24d5-eb5b-4104-bf13-0f237f113b84">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check UI Users -> Subscribers -> Add subscribers
* Check subscriber step at /setup/newsletter

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
