### PR TITLE
Flaky E2E: pierce through the iframe holding the Site Assembler component preview.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
@@ -40,28 +40,13 @@ export class SiteAssemblerFlow {
 	 * @param {number} index Index of the item to choose. Defaults to 0.
 	 */
 	async selectLayoutComponent( index = 0 ): Promise< void > {
-		const target = this.page
+		await this.page
 			.getByRole( 'listbox', { name: 'Block patterns' } )
 			.getByRole( 'option' )
 			.nth( index )
-			.locator( 'iframe' );
-
-		// The iframe has an attribute of "height" that is present only if the preview has loaded.
-		// By checking for the presence of the "height" attribute on the last visible
-		// iframe, we can be sure that all visible component card has loaded.
-		// If the last iframe does not yet contain the "height" attribute, then wait
-		// for a predetermined timeout, then re-evaluate.
-		while (
-			! ( await target.evaluate( ( element ) => {
-				if ( element.style.height ) {
-					return true;
-				}
-				return false;
-			} ) )
-		) {
-			await this.page.waitForTimeout( 1000 );
-		}
-
-		await target.click();
+			// Pierce through the iframe holding the component preview.
+			.frameLocator( 'iframe' )
+			.locator( '.block-editor-iframe__body' )
+			.click();
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/wp-calypso/issues/76806.

## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/76816#discussion_r1193550764 @WunderBart suggested an alternative, to perform action on the `body` element within the iframe for a site assembler component. 

The idea is to use Playwright's auto-waiting mechanism to perform actions when Playwright deems the component is ready, instead of relying on implementation detail + discouraged used of `waitForTimeout`. 

## Testing Instructions

Upon first impression, the duration of wait introduced with this method is less than the existing approach introduced in https://github.com/Automattic/wp-calypso/pull/76816:

**New approach**
```
      ✓ Select "Start designing" and land on the Site Assembler (942 ms)
      ✓ Select "Header" (2936 ms)
```

**Existing approach**
```
      ✓ Select "Start designing" and land on the Site Assembler (897 ms)
      ✓ Select "Header" (7421 ms)
```

On CI, this PR passed 30 iterations.
<img width="896" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6549265/b861d651-89d6-4e45-b3a1-f701cf88b80d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
