### PR TITLE
Marketing Connections: Add discernible text to help icon

### DIFF
--- a/client/components/external-link/test/index.js
+++ b/client/components/external-link/test/index.js
@@ -33,6 +33,11 @@ describe( 'External Link', () => {
 		expect( container.getElementsByTagName( 'a' )[ 0 ] ).toHaveAttribute( 'target', '_blank' );
 	} );
 
+	test( 'should have a title if given one', () => {
+		const { container } = render( <ExternalLink title="My Foo Bar" /> );
+		expect( container.getElementsByTagName( 'a' )[ 0 ] ).toHaveAttribute( 'title', 'My Foo Bar' );
+	} );
+
 	test( 'should have an icon className if specified', () => {
 		const { container } = render( <ExternalLink icon={ true } iconClassName="foo" /> );
 		expect( container.querySelectorAll( 'svg.foo' ) ).toHaveLength( 1 );

--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -51,6 +51,7 @@ const contextLinks = {
 - `showText` - _optional_ (bool) Whether or not to display the link text. Default `true`.
 - `showIcon` - _optional_ (bool) Whether or not to display the "help-outline" Gridicon. Default `true`.
 - `iconSize` - _optional_ (number) Gridicon size. Default `14`.
+- `linkTitle` - _optional_ (string) Text to use in the link's `title=` attribute.
 - `tracksEvent` - _optional_ (string) Tracks Analytics Event name
 - `tracksOptions` - _optional_ (object) Tracks Analytics options
 - `statsGroup` - _optional_ (string) Stat analytics group name

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -30,6 +30,7 @@ class InlineSupportLink extends Component {
 		showIcon: PropTypes.bool,
 		supportContext: PropTypes.string,
 		iconSize: PropTypes.number,
+		linkTitle: PropTypes.string,
 		tracksEvent: PropTypes.string,
 		tracksOptions: PropTypes.object,
 		statsGroup: PropTypes.string,
@@ -76,7 +77,8 @@ class InlineSupportLink extends Component {
 	}
 
 	render() {
-		const { className, showText, showIcon, iconSize, translate, children, noWrap } = this.props;
+		const { className, showText, showIcon, linkTitle, iconSize, translate, children, noWrap } =
+			this.props;
 
 		let { supportPostId, supportLink } = this.props;
 		if ( this.state.supportDataFromContext ) {
@@ -119,6 +121,7 @@ class InlineSupportLink extends Component {
 				onClick={ ( event ) => this.onSupportLinkClick( event, supportPostId, url ) }
 				target="_blank"
 				rel="noopener noreferrer"
+				title={ linkTitle }
 				{ ...externalLinkProps }
 			>
 				{ content }

--- a/client/my-sites/marketing/connections/connections.jsx
+++ b/client/my-sites/marketing/connections/connections.jsx
@@ -24,7 +24,13 @@ const SharingConnections = ( { translate, isP2Hub, siteId } ) => {
 					type="publicize"
 					title={ translate( 'Share posts with Jetpack Social {{learnMoreLink/}}', {
 						components: {
-							learnMoreLink: <InlineSupportLink supportContext="publicize" showText={ false } />,
+							learnMoreLink: (
+								<InlineSupportLink
+									linkTitle={ translate( 'Learn more about sharing posts with Jetpack Social' ) }
+									supportContext="publicize"
+									showText={ false }
+								/>
+							),
 						},
 					} ) }
 				/>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75600

## Proposed Changes

Adds a `title=` attribute to this support link on Marketing Connections:

<img width="710" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/1c383a79-1ea9-4c22-8627-5e853984c1a8">


## Testing Instructions

1. Navigate to the 'Marketing and Integrations' page.
2. Verify the `title=` attribute appears as expected.
3. Run the axe DevTools extension and verify the "Links must have discernible text" error no longer appears.