### PR TITLE
Subscription Management: Fix handling of invalid urls.

### DIFF
--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -32,7 +32,7 @@ export default function SiteRow( {
 	date_subscribed,
 	delivery_methods,
 }: SiteSubscription ) {
-	const hostname = useMemo( () => new URL( url ).hostname, [ url ] );
+	const hostname = useMemo( () => ( url ? new URL( url ).hostname : '' ), [ url ] );
 	const siteIcon = useMemo( () => {
 		if ( site_icon ) {
 			return <img className="icon" src={ site_icon } alt={ name } />;
@@ -88,7 +88,12 @@ export default function SiteRow( {
 
 	return (
 		<li className="row" role="row">
-			<a href={ url } rel="noreferrer noopener" className="title-box" target="_blank">
+			<a
+				{ ...( url && { href: url } ) }
+				rel="noreferrer noopener"
+				className="title-box"
+				target="_blank"
+			>
 				<span className="title-box" role="cell">
 					{ siteIcon }
 					<span className="title-column">

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -32,7 +32,13 @@ export default function SiteRow( {
 	date_subscribed,
 	delivery_methods,
 }: SiteSubscription ) {
-	const hostname = useMemo( () => ( url ? new URL( url ).hostname : '' ), [ url ] );
+	const hostname = useMemo( () => {
+		try {
+			return new URL( url ).hostname;
+		} catch ( e ) {
+			return '';
+		}
+	}, [ url ] );
 	const siteIcon = useMemo( () => {
 		if ( site_icon ) {
 			return <img className="icon" src={ site_icon } alt={ name } />;

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -55,7 +55,7 @@ export type SiteSubscription = {
 	ID: string;
 	blog_ID: string;
 	feed_ID: string;
-	URL: string | false;
+	URL: string;
 	date_subscribed: Date;
 	delivery_methods: SiteSubscriptionDeliveryMethods;
 	name: string;

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -55,7 +55,7 @@ export type SiteSubscription = {
 	ID: string;
 	blog_ID: string;
 	feed_ID: string;
-	URL: string;
+	URL: string | false;
 	date_subscribed: Date;
 	delivery_methods: SiteSubscriptionDeliveryMethods;
 	name: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/76898

## Proposed Changes

Site subscription with `false` in the url property causes WSOD. The `false` value may come from purged Jetpack-connected site (even though it doesn't seem to apply to other purged Jetpack-connected sites I've seen).

The fix is done on client-side instead of server-side because the server-side API endpoint is also shared with Reader, and I'd like to avoid diving into Reader's code to see how they are handling falsy URLs (and if they are handling it).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Setup**
1. On your sandbox, modify `class[...]read-following-mine-v1-2-endpoint.php` at line 423, make it return `false`.
2. Sandbox `public-api.wordpress.com`.

**Test**
1. Test as external user by setting `subkey` on the `calypso.localhost:3000` cookie.
2. Go to `/subscriptions`.
3. It should render the list just fine instead of WSOD'ing.

Screenshot of how it looks like when rendered:

<img width="1328" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/e28bc133-bc89-4a0e-b842-5245fa9ac648">


Error Reference:

<img width="533" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/56c3a604-44fa-4853-9148-53f0106a652a">

<img width="1268" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/6eb8ddc2-e8f6-422a-ad49-3a20007203cd">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
