### PR TITLE
General Settings: Add accessible name to timezone drop down

### DIFF
--- a/client/components/timezone/README.md
+++ b/client/components/timezone/README.md
@@ -22,12 +22,11 @@ export default class extends React.Component {
 
 ## Props
 
-`selectedZone` - **optional** String value to define the selected timezone.
-
-`includeManualOffsets` - **optional** Boolean value to include/exclude the manual offsets from the
+* `selectedZone` - **optional** String value to define the selected timezone.
+* `id` - **optional** String value to add an `id=` attribute to the `<select>` element.
+* `includeManualOffsets` - **optional** Boolean value to include/exclude the manual offsets from the
 list of timezones, the default value is `true`
-
-`onSelect` - **optional** Called when user selects a timezone from the
+* `onSelect` - **optional** Called when user selects a timezone from the
 select. An object parameter is passed to the function which has two
 properties: `label` usually used to show the selected timezone to the user and
 `value` which is the normalized timezone value.

--- a/client/components/timezone/README.md
+++ b/client/components/timezone/README.md
@@ -22,11 +22,7 @@ export default class extends React.Component {
 
 ## Props
 
-* `selectedZone` - **optional** String value to define the selected timezone.
-* `id` - **optional** String value to add an `id=` attribute to the `<select>` element.
-* `includeManualOffsets` - **optional** Boolean value to include/exclude the manual offsets from the
-list of timezones, the default value is `true`
-* `onSelect` - **optional** Called when user selects a timezone from the
-select. An object parameter is passed to the function which has two
-properties: `label` usually used to show the selected timezone to the user and
-`value` which is the normalized timezone value.
+- `id` - _optional_ (string) Value to add an `id=` attribute to the `<select>` element.
+- `includeManualOffsets` - _optional_ (boolean) Whether or not to include the manual offsets from the list of timezones. Default value is `true`
+- `onSelect` - _optional_ (function) Called when user selects a timezone from the select. An object parameter is passed to the function which has two properties: `label` usually used to show the selected timezone to the user and `value` which is the normalized timezone value.
+- `selectedZone` - _optional_ (string) Value to define the selected timezone.

--- a/client/components/timezone/index.jsx
+++ b/client/components/timezone/index.jsx
@@ -54,9 +54,9 @@ class Timezone extends Component {
 	}
 
 	render() {
-		const { selectedZone } = this.props;
+		const { id, selectedZone } = this.props;
 		return (
-			<FormSelect onChange={ this.onSelect } value={ selectedZone || '' }>
+			<FormSelect id={ id } onChange={ this.onSelect } value={ selectedZone || '' }>
 				<QueryTimezones />
 				{ this.renderOptionsByContinent() }
 				<optgroup label="UTC">
@@ -77,6 +77,7 @@ Timezone.propTypes = {
 	selectedZone: PropTypes.string,
 	onSelect: PropTypes.func,
 	includeManualOffsets: PropTypes.bool,
+	id: PropTypes.string,
 };
 
 export default connect( ( state ) => ( {

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -544,6 +544,7 @@ export class SiteSettingsFormGeneral extends Component {
 					selectedZone={ fields.timezone_string }
 					disabled={ isRequestingSettings }
 					onSelect={ this.onTimezoneSelect }
+					id="blogtimezone"
 				/>
 
 				<FormSettingExplanation>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75438

## Proposed Changes

Fixes the "Select element must have an accessible name" warning by associating the `<label>` with the `<select>` element by assigning an `id=` to the latter:

<img width="1469" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/5ffa449f-a413-4cee-9cfb-fb93dc7bf37d">


## Testing Instructions

1. Navigate to 'General Settings'.
2. Verify the `id=` attribute appears as expected.
3. Run the axe DevTools extension and verify the "Select element must have an accessible name" error no longer appears.
