### PR TITLE
Add feature freeze warning to ETK

### DIFF
--- a/apps/editing-toolkit/README.md
+++ b/apps/editing-toolkit/README.md
@@ -2,7 +2,11 @@
 
 This plugin includes many sub-features which add blocks and new functionality to the Gutenberg editor. The plugin provides a single codebase which can be installed on any platform which requires these features, such as the WordPress.com multisite or other standalone WordPress instances.
 
+New features are currently freezed and switched to use Jetpack packages instead. More info: p58i-dox-p2
+
 This code is developed in the calypso monorepo at <https://github.com/Automattic/wp-calypso/tree/trunk/apps/editing-toolkit>.
+
+
 
 ## Rename Info
 

--- a/apps/editing-toolkit/README.md
+++ b/apps/editing-toolkit/README.md
@@ -2,11 +2,11 @@
 
 This plugin includes many sub-features which add blocks and new functionality to the Gutenberg editor. The plugin provides a single codebase which can be installed on any platform which requires these features, such as the WordPress.com multisite or other standalone WordPress instances.
 
-New features are currently freezed and switched to use Jetpack packages instead. More info: p58i-dox-p2
-
 This code is developed in the calypso monorepo at <https://github.com/Automattic/wp-calypso/tree/trunk/apps/editing-toolkit>.
 
 
+> **Warning**
+> New features are currently frozen to use Jetpacks packages instead. More information: p58i-dox-p2
 
 ## Rename Info
 


### PR DESCRIPTION
## Proposed Changes

As we don't want to add new features to Editing Toolkit in favor of Jetpack packages, we added a warning on the ETK Readme

## Testing Instructions

Check the Warning on top of the [readme file](https://github.com/Automattic/wp-calypso/blob/update/etk-feature-freeze-readme/apps/editing-toolkit/README.md)

![image](https://github.com/Automattic/wp-calypso/assets/402286/505c6ebf-1639-4df7-9e84-11064fb9ee1f)

