### PR TITLE
Added aria labels to 3 buttons with just icons and no link text

### DIFF
--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -95,6 +95,7 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 		return (
 			<div className="blogging-prompt__prompt-navigation">
 				<Button
+					aria-label={ translate( 'Show previous prompt' ) }
 					borderless={ false }
 					className={ buttonClasses }
 					onClick={ () => navigatePrompts( 'back' ) }
@@ -104,6 +105,7 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 				</Button>
 				<div className="blogging-prompt__prompt-text">{ getPrompt()?.text }</div>
 				<Button
+					aria-label={ translate( 'Show next prompt' ) }
 					borderless={ false }
 					className={ buttonClasses }
 					onClick={ () => navigatePrompts( 'forward' ) }

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -204,7 +204,10 @@ export function RenderDomainUpsell( {
 			<TrackComponentView eventName="calypso_my_home_domain_upsell_impression" />
 			<div>
 				<div className="domain-upsell__card-dismiss">
-					<button onClick={ getDismissClickHandler }>
+					<button
+						aria-label={ translate( 'Dismiss domain name promotion' ) }
+						onClick={ getDismissClickHandler }
+					>
 						<Gridicon icon="cross" width={ 18 } />
 					</button>
 				</div>


### PR DESCRIPTION
## Description

3 My Home buttons were highlighted in #75592 which have icons, but no description text, making them hard to interpret by  folks navigating via a screen reader.

This PR adds aria-label's for all three buttons.

### Before

Here is an example of the next prompt button:

https://github.com/Automattic/wp-calypso/assets/5634774/b32143a5-80eb-4d4b-b24d-981d0d645ca8

Notice that there is no mention of what the button does.

### After

https://github.com/Automattic/wp-calypso/assets/5634774/1776e691-e325-4d0c-ba0d-4ee1ed468cd6

Here's a video recording of what you hear after the change. Notice it calls out "Show next prompt".

## Testing

First step, assuming you're on Mac would be to enable voiceover. Here's a quick walkthrough:

![voiceover-settings](https://github.com/Automattic/wp-calypso/assets/5634774/2b38b3c8-cbdf-4176-8589-55b83ce0a894)

Once you have voiceover enabled, apply this PR and test it locally or via the Calypso Live link.

Related to #75592