### PR TITLE
Remove expiry notices from Akismet Business in purchases

### DIFF
--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -5,7 +5,7 @@ import {
 	isPlan,
 	isDomainRegistration,
 	isMonthly,
-	PRODUCT_AKISMET_FREE,
+	isAkismetFreeProduct,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { isEmpty, merge, minBy } from 'lodash';
@@ -266,7 +266,7 @@ class PurchaseNotice extends Component {
 	};
 
 	renderPurchaseExpiringNotice() {
-		const EXCLUDED_PRODUCTS = [ 'ecommerce-trial-bundle-monthly', PRODUCT_AKISMET_FREE ];
+		const EXCLUDED_PRODUCTS = [ 'ecommerce-trial-bundle-monthly' ];
 		const {
 			moment,
 			purchase,
@@ -292,7 +292,8 @@ class PurchaseNotice extends Component {
 
 		if (
 			! isExpiring( currentPurchase ) ||
-			EXCLUDED_PRODUCTS.includes( currentPurchase?.productSlug )
+			EXCLUDED_PRODUCTS.includes( currentPurchase?.productSlug ) ||
+			isAkismetFreeProduct( currentPurchase )
 		) {
 			return null;
 		}

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -1,6 +1,7 @@
 import {
 	isDomainTransfer,
 	isConciergeSession,
+	isAkismetFreeProduct,
 	PLAN_MONTHLY_PERIOD,
 	PLAN_ANNUAL_PERIOD,
 	PLAN_BIENNIAL_PERIOD,
@@ -299,7 +300,7 @@ class PurchaseItem extends Component {
 			} );
 		}
 
-		if ( isExpiring( purchase ) ) {
+		if ( isExpiring( purchase ) && ! isAkismetFreeProduct( purchase ) ) {
 			if ( expiry < moment().add( 30, 'days' ) && ! isRecentMonthlyPurchase( purchase ) ) {
 				const expiryClass =
 					expiry < moment().add( 7, 'days' )
@@ -358,7 +359,10 @@ class PurchaseItem extends Component {
 			return translate( 'Included with Plan' );
 		}
 
-		if ( isOneTimePurchase( purchase ) && ! isDomainTransfer( purchase ) ) {
+		if (
+			( isOneTimePurchase( purchase ) || isAkismetFreeProduct( purchase ) ) &&
+			! isDomainTransfer( purchase )
+		) {
 			return translate( 'Never Expires' );
 		}
 
@@ -445,7 +449,8 @@ class PurchaseItem extends Component {
 		if (
 			purchase.isAutoRenewEnabled &&
 			! hasPaymentMethod( purchase ) &&
-			! isPartnerPurchase( purchase )
+			! isPartnerPurchase( purchase ) &&
+			! isAkismetFreeProduct( purchase )
 		) {
 			return (
 				<div className="purchase-item__no-payment-method">
@@ -456,6 +461,7 @@ class PurchaseItem extends Component {
 		}
 
 		if (
+			! isAkismetFreeProduct( purchase ) &&
 			! isRechargeable( purchase ) &&
 			hasPaymentMethod( purchase ) &&
 			purchase.isAutoRenewEnabled

--- a/packages/calypso-products/src/is-akismet-free-product.ts
+++ b/packages/calypso-products/src/is-akismet-free-product.ts
@@ -1,7 +1,12 @@
 import { camelOrSnakeSlug } from './camel-or-snake-slug';
-import { PRODUCT_AKISMET_FREE } from './constants/akismet';
-import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+import { PRODUCT_AKISMET_FREE, PRODUCT_AKISMET_ENTERPRISE_YEARLY } from './constants/akismet';
+import type { WithSlugAndAmount } from './types';
 
-export function isAkismetFreeProduct( product: WithCamelCaseSlug | WithSnakeCaseSlug ): boolean {
-	return PRODUCT_AKISMET_FREE === camelOrSnakeSlug( product );
+// AKISMET_ENTERPRISE_YEARLY has a $0 plan for nonprofits, so we need to check the amount
+// to determine if it's free or not.
+export function isAkismetFreeProduct( product: WithSlugAndAmount ): boolean {
+	return (
+		PRODUCT_AKISMET_FREE === camelOrSnakeSlug( product ) ||
+		( PRODUCT_AKISMET_ENTERPRISE_YEARLY === camelOrSnakeSlug( product ) && product.amount === 0 )
+	);
 }

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -264,6 +264,10 @@ export type Plan = BillingTerm & {
 export type WithSnakeCaseSlug = { product_slug: string };
 export type WithCamelCaseSlug = { productSlug: string };
 
+export type WithSlugAndAmount = ( WithCamelCaseSlug | WithSnakeCaseSlug ) & {
+	amount: number;
+};
+
 export interface PlanMatchesQuery {
 	term?: string;
 	group?: string;


### PR DESCRIPTION
## Proposed Changes

 * Update `isAkismetFreeProduct` to include the Akismet Business Free plan for nonprofits
 * Use `isAkismetFreeProduct` in several places to remove any expiry notices from the `/me/purchases` page for Akismet Free and Akismet Business for nonprofits

## Testing Instructions

1. Checkout this branch
2. Run `yarn start`
3. Go to the Store Admin under your username and assign yourself an Akismet Free license and an Akismet Business for nonprofits license. The Akismet business for nonprofits will look like this
![image](https://github.com/Automattic/wp-calypso/assets/65001528/890893b6-da6c-452a-bffa-8fe0d39a75e6)
4. Go to http://calypso.localhost:3000/me/purchases. Ensure the purchases you just assigned in the list say "Never Expires"
![image](https://github.com/Automattic/wp-calypso/assets/65001528/6c6bf7cd-e331-4202-a890-edb3fec2dc58)
5. Click on both of them and ensure there is no notice telling the user it will expire without a payment method, and also that there is no "Renew Now" action button
![Screenshot 2023-05-15 at 2 18 40 PM](https://github.com/Automattic/wp-calypso/assets/65001528/40f04f5d-3484-413c-9be5-131b69432ee4)
![Screenshot 2023-05-15 at 2 20 21 PM](https://github.com/Automattic/wp-calypso/assets/65001528/1a520674-cfb3-4cd7-b36e-f5d6ac7b6d6c)


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
