### PR TITLE
2023 Pricing Grid: Update breakpoints for pricing grid

### DIFF
--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -4,15 +4,14 @@ $plan-features-sidebar-width: 272px;
 $plan-features-header-banner-height: 20px;
 
 // Breakpoints
-$plans-2023-small-breakpoint: 780px;
-$plans-2023-medium-breakpoint: 1200px;
+$plans-2023-small-breakpoint: 880px;
+$plans-2023-medium-breakpoint: 1024px;
+$plans-2023-large-breakpoint: 1281px;
 
 $minWidthToGridWidthMap: (
-	780px: "668px",
-	1024px: "860px",
-	1200px: "1134px",
-	1440px: "1320px",
-	1600px: "1480px",
+	880px: "524px",
+	1024px: "708px",
+	1281px: "1076px",
 );
 
 
@@ -45,8 +44,20 @@ $minWidthToGridWidthMap: (
 	.plan-features-2023-grid__desktop-view {
 		display: none;
 
+		@media ( min-width: $plans-2023-large-breakpoint ) {
+			display: block;
+		}
+	}
+
+	.plan-features-2023-grid__large-tablet-view {
+		display: none;
+
 		@media ( min-width: $plans-2023-medium-breakpoint ) {
 			display: block;
+		}
+
+		@media ( min-width: $plans-2023-large-breakpoint ) {
+			display: none;
 		}
 	}
 
@@ -78,8 +89,20 @@ $minWidthToGridWidthMap: (
 	.plan-features-2023-grid__desktop-view {
 		display: none;
 
+		@media ( min-width: ( $plans-2023-large-breakpoint + $plan-features-sidebar-width ) ) {
+			display: block;
+		}
+	}
+
+	.plan-features-2023-grid__large-tablet-view {
+		display: none;
+
 		@media ( min-width: ( $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) ) {
 			display: block;
+		}
+
+		@media ( min-width: ($plans-2023-large-breakpoint + $plan-features-sidebar-width ) ) {
+			display: none;
 		}
 	}
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -319,6 +319,9 @@ export class PlanFeatures2023Grid extends Component<
 							<div className="plan-features-2023-grid__desktop-view">
 								{ this.renderTable( planProperties ) }
 							</div>
+							<div className="plan-features-2023-grid__large-tablet-view">
+								{ this.renderLargeTabletView() }
+							</div>
 							<div className="plan-features-2023-grid__tablet-view">
 								{ this.renderTabletView() }
 							</div>
@@ -394,6 +397,29 @@ export class PlanFeatures2023Grid extends Component<
 					<tr>{ this.renderPlanStorageOptions( planPropertiesObj ) }</tr>
 				</tbody>
 			</table>
+		);
+	}
+
+	renderLargeTabletView() {
+		const { planProperties } = this.props;
+		let plansToShow = [];
+		const numberOfPlansToShow = 4;
+
+		plansToShow = planProperties
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( properties ) => properties.planName );
+
+		const plans = plansToShow.slice( 0, numberOfPlansToShow );
+		const planPropertiesForTopRow = planProperties.filter( ( properties: PlanProperties ) =>
+			plans.includes( properties.planName )
+		);
+
+		return (
+			<>
+				<div className="plan-features-2023-grid__table-top">
+					{ this.renderTable( planPropertiesForTopRow ) }
+				</div>
+			</>
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1530

## Proposed Changes

* Adds a new, "large" breakpoint to accommodate new designs
* Updates the number of plans that we render at each breakpoint

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch and run `yarn start`
* Navigate to calypso.localhost:3000/start
* Choose some free domain and land on the plans page
* Verify that the number of plans shown at each breakpoint is correct
* Verify that the width of each plan column and the gutter space between columns is correct
* Navigate to the `/plans` page
* Repeat verification of behavior

## Design Requirements
- Each plan column should be a fixed 156px
- Each plan column should have gutter spacing of 28px

**ONBOARDING FLOW**
- From 1600px to 1281px, show all plans. 
- From 1280px to 1024px, show 4 plans. 
- From 1023px to 880px, show 3 plans
- From 880px to mobile, we show 2 plans. 

**/PLANS PAGE**
- We can follow the same rationale but now we need to consider the lateral menu width 272px. For example, with the width of 1440px. We have only 1168px of space (1440px - [272px lateral menu](![Jg0zg2.png](https://github.com/Automattic/martech/assets/5414230/2984e807-bde6-4457-a750-0359d000f231))), so we will show 4 plans.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
