### PR TITLE
Enable sharing modal for english speakers

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -17,7 +17,7 @@ import DraftPostModal from './draft-post-modal';
 import FirstPostPublishedModal from './first-post-published-modal';
 import PurchaseNotice from './purchase-notice';
 import SellerCelebrationModal from './seller-celebration-modal';
-// import PostPublishedSharingModal from './sharing-modal';
+import PostPublishedSharingModal from './sharing-modal';
 import { DEFAULT_VARIANT, BLANK_CANVAS_VARIANT } from './store';
 import VideoPressCelebrationModal from './video-celebration-modal';
 import WpcomNux from './welcome-modal/wpcom-nux';
@@ -106,8 +106,7 @@ registerPlugin( 'wpcom-block-editor-nux', {
 				<ShouldShowFirstPostPublishedModalProvider>
 					<WelcomeTour />
 					<FirstPostPublishedModal />
-					{ /* todo: enable once translations are complete */ }
-					{ /* <PostPublishedSharingModal /> */ }
+					<PostPublishedSharingModal />
 					<SellerCelebrationModal />
 					<PurchaseNotice />
 					<VideoPressCelebrationModal />

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useLocale } from '@automattic/i18n-utils';
 import { Modal, Button, ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState, createInterpolateElement } from '@wordpress/element';
@@ -30,6 +31,8 @@ const SharingModal: React.FC = () => {
 	const { launchpadScreenOption } = window?.launchpadOptions || {};
 	const { isDismissed, updateIsDismissed } = useSharingModalDismissed( isDismissedDefault );
 	const { __ } = useI18n();
+	const localeSlug = useLocale();
+	const isEnglish = localeSlug?.startsWith( 'en' );
 
 	const { link, title } = useSelect(
 		( select ) => ( select( 'core/editor' ) as CoreEditorPlaceholder ).getCurrentPost(),
@@ -157,7 +160,7 @@ const SharingModal: React.FC = () => {
 		recordTracksEvent( 'calypso_editor_sharing_view_subscribers' );
 	};
 
-	if ( ! isOpen || isDismissedDefault ) {
+	if ( ! isOpen || isDismissedDefault || ! isEnglish ) {
 		return null;
 	}
 


### PR DESCRIPTION
Enables the sharing modal only for English speakers. see https://github.com/Automattic/wp-calypso/pull/76267

### Testing instructions
Set language to 'en' or 'en-gb'
Publish a new post 
You should see the sharing modal.
