### PR TITLE
Reader: fix search feed polling request errors

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -164,6 +164,9 @@ const streamApis = {
 				algorithm: 'read:recommendations:sites/es/2',
 				posts_per_site: 1,
 			} ),
+		// Recommended sites can only return a max of 10 sites per request, so we need to override the default number.
+		pollQuery: ( extraFields = [], extraQueryParams = {} ) =>
+			getQueryStringForPoll( extraFields, { ...extraQueryParams, number: 10 } ),
 	},
 	tag: {
 		path: ( { streamKey } ) => `/read/tags/${ streamKeySuffix( streamKey ) }/posts`,


### PR DESCRIPTION
## Proposed Changes

* Limit polling on the Search page of Reader to 10 recommended sites, to prevent an error response and multiple retries when requesting more than 10.

## Testing Instructions

* Visit `/read/search`, open the Network tab, and wait until the client makes a polling request to `v1.2/read/recommendations/sites`.
* Without this change (production/staging), you get an error response with multiple retries: `{ error: "Bad Request", message: "Can only return 10 site results at a time" }`
* With this change, you should see a successful request.
