### PR TITLE
a11y: add empty alt text to all icons under `/marketing/business-tools`.

### DIFF
--- a/client/my-sites/marketing/business-tools/index.tsx
+++ b/client/my-sites/marketing/business-tools/index.tsx
@@ -80,6 +80,7 @@ export const MarketingBusinessTools: FunctionComponent< Props > = ( { recordTrac
 						"Create and track invoices, track expenses, generate profit & loss statements, and make tax time for your business a breeze with the world's #1 accounting software for small businesses!"
 					) }
 					imagePath={ quickbooksLogo }
+					imageAlt=""
 				>
 					<Button
 						onClick={ handleQuickBooksClick }
@@ -97,6 +98,7 @@ export const MarketingBusinessTools: FunctionComponent< Props > = ( { recordTrac
 						'Evernote is the place to organize your work, declutter your life, and remember everything. Maintaining the important information you need to manage your work or your personal life has never been easier.'
 					) }
 					imagePath={ evernoteLogo }
+					imageAlt=""
 				>
 					<Button
 						onClick={ handleEvernoteClick }
@@ -114,6 +116,7 @@ export const MarketingBusinessTools: FunctionComponent< Props > = ( { recordTrac
 						'monday.com is a centralized platform for teams to manage every detail of their work, from high-level roadmap planning to specifics tasks.'
 					) }
 					imagePath={ mondayLogo }
+					imageAlt=""
 				>
 					<Button
 						onClick={ handleMondayClick }
@@ -131,6 +134,7 @@ export const MarketingBusinessTools: FunctionComponent< Props > = ( { recordTrac
 						'The to-do list to organize work & life. ✅ Trusted by over 20 million people, Todoist is an incredibly powerful and flexible task management app that can turn your to-do list into a got-it-done list.'
 					) }
 					imagePath={ todoistLogo }
+					imageAlt=""
 				>
 					<Button
 						onClick={ handleTodoistClick }
@@ -148,6 +152,7 @@ export const MarketingBusinessTools: FunctionComponent< Props > = ( { recordTrac
 						'Bench gives you a professional bookkeeper at a price you can afford, and powerful financial reporting software with zero learning curve.'
 					) }
 					imagePath={ benchLogo }
+					imageAlt=""
 				>
 					<Button
 						onClick={ handleBenchClick }
@@ -165,6 +170,7 @@ export const MarketingBusinessTools: FunctionComponent< Props > = ( { recordTrac
 						'Track everything and always have context, directly in your Gmail account. Keep your leads and sales pipeline moving with Streak.com.'
 					) }
 					imagePath={ streakLogo }
+					imageAlt=""
 				>
 					<Button
 						onClick={ handleStreakClick }
@@ -182,6 +188,7 @@ export const MarketingBusinessTools: FunctionComponent< Props > = ( { recordTrac
 						'Bill.com is the intelligent way to create and pay bills, send invoices, and get paid.'
 					) }
 					imagePath={ billcomLogo }
+					imageAlt=""
 				>
 					<Button
 						onClick={ handleBillcomClick }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75602.

## Proposed Changes

This PR adds alt text to all icons in the `/marketing/business-tools` page.

## Testing Instructions

Confirm in the calypso.live build that all icons in the aforementioned endpoint have an empty alt text.

<img width="1428" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6549265/3b5b94a2-504f-4cdf-a5e9-d02886a98bf7">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
