### PR TITLE
Import: update content only link and remove unused functions

### DIFF
--- a/client/blocks/importer/types.ts
+++ b/client/blocks/importer/types.ts
@@ -17,7 +17,6 @@ export type StepNavigator = {
 	goToWpAdminWordPressPluginPage?: () => void;
 	navigate?: ( path: string ) => void;
 	goToAddDomainPage?: () => void;
-	goToImportListStep?: () => void;
 };
 
 export interface ImportError {

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -141,6 +141,7 @@ export class ImportEverything extends SectionMigrate {
 			stepNavigator,
 			showConfirmDialog = true,
 			isMigrateFromWp,
+			onContentOnlySelection,
 		} = this.props;
 
 		if ( sourceSite ) {
@@ -153,7 +154,7 @@ export class ImportEverything extends SectionMigrate {
 						targetSiteSlug={ targetSiteSlug }
 						sourceSite={ sourceSite }
 						sourceSiteUrl={ sourceSite.URL }
-						onContentOnlyClick={ stepNavigator?.goToImportListStep }
+						onContentOnlyClick={ onContentOnlySelection }
 					/>
 				);
 			}

--- a/client/blocks/importer/wordpress/import-everything/migrate-ready.tsx
+++ b/client/blocks/importer/wordpress/import-everything/migrate-ready.tsx
@@ -104,7 +104,7 @@ export const MigrateReady: React.FunctionComponent< Props > = ( props ) => {
 								</NextButton>
 								<Button
 									borderless={ true }
-									className="action-buttons__importer-list"
+									className="action-buttons__content-only"
 									onClick={ onContentOnlyClick }
 								>
 									{ __( 'Use the content-only import option' ) }

--- a/client/blocks/importer/wordpress/import-everything/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/style.scss
@@ -2,7 +2,7 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-// @include onboarding-font-recoleta;
+
 [dir="rtl"] {
 	.import__import-everything {
 		.import_site-mapper-name .site-icon {
@@ -116,7 +116,7 @@
 		margin-bottom: 2.5rem;
 	}
 
-	.action-buttons__importer-list {
+	.action-buttons__content-only {
 		font-weight: 500;
 		text-decoration: underline;
 		color: var(--studio-gray-100);

--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -166,6 +166,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 							stepNavigator={ stepNavigator }
 							isMigrateFromWp={ isMigrateFromWp }
 							showConfirmDialog={ showConfirmDialog }
+							onContentOnlySelection={ switchToContentUploadScreen }
 						/>
 					);
 				} else if ( WPImportOption.CONTENT_ONLY === option ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
@@ -29,10 +29,6 @@ export function useStepNavigator(
 		navigation.goToStep?.( 'import' );
 	}
 
-	function goToImportListStep() {
-		navigation.goToStep?.( `importList?siteSlug=${ siteSlug }` );
-	}
-
 	function goToSiteViewPage() {
 		navigation.submit?.( {
 			type: 'redirect',
@@ -102,7 +98,6 @@ export function useStepNavigator(
 		goToWpAdminImportPage,
 		goToWpAdminWordPressPluginPage,
 		goToAddDomainPage,
-		goToImportListStep,
 		navigate: ( path ) => navigator( path ),
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76964 

## Proposed Changes

* This is a follow up of #76926, to update the content only option link and point it to WordPress importer directly instead of the import list

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `http://calypso.localhost:3000/setup/import-focused/importerWordpress?siteSlug=${target_site}&from=${source_site}&option=everything`

![Screen Shot 2023-05-16 at 3 34 53 PM](https://github.com/Automattic/wp-calypso/assets/4074459/bb7caa30-3544-4605-ab8e-b86f46d213a5)


* Make sure the target site is a simple site
* Make sure the source site is fully connected
* Click on the content-only option and see if it points to the WordPress importer screen
![Screen Shot 2023-05-16 at 3 34 31 PM](https://github.com/Automattic/wp-calypso/assets/4074459/d82ca9d5-211f-4914-82a6-a399bfa1d07b)

Note: This PR also cleans up the unused functions introduced in last PR


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
