### PR TITLE
Limited Global Styles: Toggle preview with switch

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -422,10 +422,8 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 	$upgrade_url = 'https://wordpress.com/plans/' . $site_slug . '?plan=value_bundle&feature=style-customization';
 
 	if ( wpcom_is_previewing_global_styles() ) {
-		$preview_text     = __( 'Turn off preview', 'full-site-editing' );
 		$preview_location = remove_query_arg( 'preview-global-styles' );
 	} else {
-		$preview_text     = __( 'Turn on preview', 'full-site-editing' );
 		$preview_location = add_query_arg( 'preview-global-styles', '' );
 	}
 
@@ -480,10 +478,11 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 					class="launch-bar-global-styles-upgrade"
 					href="<?php echo esc_url( $upgrade_url ); ?>"
 				>
-					<?php echo esc_html__( 'Upgrade your plan', 'full-site-editing' ); ?>
+					<?php echo esc_html__( 'Upgrade now', 'full-site-editing' ); ?>
 				</a>
 				<a class="launch-bar-global-styles-preview" href="<?php echo esc_url( $preview_location ); ?>">
-					<?php echo esc_html( $preview_text ); ?>
+					<label><input type="checkbox" <?php echo wpcom_is_previewing_global_styles() ? 'checked' : ''; ?>><span></span></label>
+					<?php echo esc_html__( 'Preview custom styles', 'full-site-editing' ); ?>
 				</a>
 			</div>
 			<a class="launch-bar-global-styles-toggle" href="#">

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.js
@@ -58,7 +58,13 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	previewButton?.addEventListener( 'click', ( event ) => {
 		event.preventDefault();
-		recordEvent( 'wpcom_global_styles_gating_notice_preview' );
+		const checkbox = previewButton.querySelector( 'input[type="checkbox"]' );
+		if ( checkbox ) {
+			checkbox.checked = ! checkbox.checked;
+		}
+		recordEvent( 'wpcom_global_styles_gating_notice_preview', {
+			action: checkbox.checked ? 'show' : 'hide',
+		} );
 		window.location = previewButton.href;
 	} );
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -12,7 +12,7 @@
 	left: 50%;
 	transform: translateX(-50%);
 	background-color: #fff;
-	padding: 24px;
+	padding: 24px 24px 0;
 	line-height: 20px;
 	color: #2c3338;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
@@ -35,33 +35,85 @@
 		transform: translateX(-50%);
 	}
 
-	.launch-bar-global-styles-upgrade,
-	.launch-bar-global-styles-preview {
+	.launch-bar-global-styles-upgrade {
 		min-height: 28px;
 		box-sizing: border-box;
 		border-radius: 2px;
 		width: 100%;
 		justify-content: center;
 		height: auto;
-		border: 1px solid;
-	}
-
-	.launch-bar-global-styles-upgrade {
+		border: 1px solid #0675c4;
 		background: #0675c4;
-		border-color: #0675c4;
 		color: #fff;
 
 		&:hover {
 			background: #006ba1;
 		}
 	}
+}
 
-	.launch-bar-global-styles-preview {
-		border-color: #c3c4c7;
-		color: #3c434a;
+.launch-banner-content .launch-bar-global-styles-preview {
+	border-top: 1px solid #c3c4c7;
+	width: calc(100% + 48px);
+	margin: 12px -24px 0;
+	box-sizing: border-box;
+	padding: 12px 24px;
+	font-size: 13px;
+	line-height: 17px;
+	color: inherit;
 
-		&:hover {
-			background: #f6f7f7;
+	&:hover {
+		background: none;
+	}
+
+	label {
+		position: relative;
+		display: inline-block;
+		width: 36px;
+		height: 18px;
+		margin-right: 8px;
+
+		span {
+			position: absolute;
+			cursor: pointer;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			background-color: #ccc;
+			transition: 0.4s;
+			/* stylelint-disable-next-line scales/radii */
+			border-radius: 18px;
+
+			&::before {
+				position: absolute;
+				content: "";
+				height: 12px;
+				width: 12px;
+				left: 3px;
+				bottom: 3px;
+				background-color: #fff;
+				transition: 0.4s;
+				border-radius: 50%;
+			}
+		}
+
+		input {
+			opacity: 0;
+			width: 0;
+			height: 0;
+
+			&:checked + span {
+				background-color: #0675c4;
+
+				&::before {
+					transform: translateX(18px);
+				}
+			}
+
+			&:focus + span {
+				box-shadow: 0 0 1px #2196f3;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Adds a toggle switch to the limited Global Styles launchbar notice so it's clear what users can preview.

Before | After
--- | ---
<img width="347" alt="Screenshot 2023-05-16 at 10 30 49" src="https://github.com/Automattic/wp-calypso/assets/1233880/94e67158-0714-42dc-9299-e3fcfd8c90e3"> | <img width="362" alt="Screenshot 2023-05-16 at 10 31 18" src="https://github.com/Automattic/wp-calypso/assets/1233880/c6979331-011f-48ce-849a-42cb1ccba594">

More context: pekYwv-1qM-p2#comment-1164

## Testing Instructions

- Apply these changes to your sandbox.
- Sandbox a site with limited Global Styles.
- Visit the frontend.
- Make sure the launchbar notices includes a toggle switcher.
- Make sure you can use it to toggle the preview of custom styles.