### PR TITLE
Update SiteDashboard components in order to be customizable

### DIFF
--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -124,6 +124,7 @@ import WpcomColophon from 'calypso/components/wpcom-colophon/docs/example';
 import Collection from 'calypso/devdocs/design/search-collection';
 import { slugToCamelCase } from 'calypso/devdocs/docs-example/util';
 import SitesGridItemExample from 'calypso/sites-dashboard/components/sites-grid-item/docs/example';
+import SitesGridItemSelectExample from 'calypso/sites-dashboard/components/sites-grid-item-select/docs/example';
 import SitesTableRowExample from 'calypso/sites-dashboard/components/sites-table-row/docs/example';
 
 export default class DesignAssets extends Component {
@@ -273,6 +274,7 @@ export default class DesignAssets extends Component {
 					<Spotlight />
 					<SiteThumbnail readmeFilePath="/packages/components/src/site-thumbnail" />
 					<SitesGridItemExample readmeFilePath="/client/sites-dashboard/components/sites-grid-item" />
+					<SitesGridItemSelectExample readmeFilePath="/client/sites-dashboard/components/sites-grid-item-select" />
 					<SitesTableRowExample readmeFilePath="/client/sites-dashboard/components/sites-table-row" />
 					<StepProgress readmeFilePath="step-progress" />
 					<Suggestions readmeFilePath="/packages/components/src/suggestions" />

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -83,6 +83,7 @@ type Statuses = ReturnType< typeof useSitesListGrouping >[ 'statuses' ];
 
 type SitesContentControlsProps = {
 	initialSearch?: string;
+	onQueryParamChange?: ( params: Partial< SitesDashboardQueryParams > ) => void;
 	statuses: Statuses;
 	selectedStatus: Statuses[ number ];
 } & ComponentPropsWithoutRef< typeof SitesDisplayModeSwitcher > &
@@ -111,6 +112,7 @@ export function handleQueryParamChange( queryParams: SitesDashboardQueryParams )
 
 export const SitesContentControls = ( {
 	initialSearch,
+	onQueryParamChange = handleQueryParamChange,
 	statuses,
 	selectedStatus,
 	displayMode,
@@ -130,7 +132,7 @@ export const SitesContentControls = ( {
 		<FilterBar>
 			<SitesSearch
 				searchIcon={ <SitesSearchIcon /> }
-				onSearch={ ( term ) => handleQueryParamChange( { search: term?.trim(), page: undefined } ) }
+				onSearch={ ( term ) => onQueryParamChange( { search: term?.trim(), page: undefined } ) }
 				isReskinned
 				placeholder={ __( 'Search by name or domain…' ) }
 				disableAutocorrect={ true }
@@ -166,7 +168,7 @@ export const SitesContentControls = ( {
 								count,
 							} ) }
 							onClick={ () =>
-								handleQueryParamChange( {
+								onQueryParamChange( {
 									status: 'all' !== name ? name : undefined,
 									page: undefined,
 								} )
@@ -182,10 +184,12 @@ export const SitesContentControls = ( {
 						sitesSorting={ sitesSorting }
 						onSitesSortingChange={ onSitesSortingChange }
 					/>
-					<SitesDisplayModeSwitcher
-						displayMode={ displayMode }
-						onDisplayModeChange={ onDisplayModeChange }
-					/>
+					{ onDisplayModeChange && (
+						<SitesDisplayModeSwitcher
+							displayMode={ displayMode }
+							onDisplayModeChange={ onDisplayModeChange }
+						/>
+					) }
 				</VisibilityControls>
 			</DisplayControls>
 		</FilterBar>

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -96,7 +96,7 @@ const sitesMargin = css( {
 	marginBlockEnd: '1.5em',
 } );
 
-const PageBodyBottomContainer = styled.div( {
+export const PageBodyBottomContainer = styled.div( {
 	color: 'var( --color-text-subtle )',
 	paddingBlockStart: '16px',
 	paddingBlockEnd: '24px',

--- a/client/sites-dashboard/components/sites-grid-item-select/README.md
+++ b/client/sites-dashboard/components/sites-grid-item-select/README.md
@@ -1,10 +1,11 @@
 # SitesGridItem
 
-Renders a SitesGridItem component.
+Renders a SitesGridItem component with site selection option.
 
 ## How to use
 
 ```jsx
+import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 import SitesGridItem from 'calypso/sites-dashboard/components/sites-grid-item';
 
 function render() {
@@ -14,6 +15,11 @@ function render() {
 			<SitesGridItem
 				site={ site }
 				key={ site.ID }
+				showLaunchNag={ false } // optional
+				showBadgeSection={ false } // optional
+				showThumbnailLink={ false } // optional
+				showSiteRenewLink={ false } // optional
+				onSiteSelectBtnClick={ ( s: SiteExcerptData ) => {} } // optional
 			></SitesGridItem>
 		</div>
 	);

--- a/client/sites-dashboard/components/sites-grid-item-select/docs/example.jsx
+++ b/client/sites-dashboard/components/sites-grid-item-select/docs/example.jsx
@@ -29,18 +29,28 @@ const itemClassName = css( {
 	minWidth: 0,
 } );
 
-const SitesGridItemExample = () => {
+const SitesGridItemSelectExample = () => {
 	return (
 		<div className={ classnames( container, className ) }>
 			{ sampleSiteData.map( ( site ) => (
 				<div className={ itemClassName } key={ site.ID }>
-					<SitesGridItem site={ site } key={ site.ID } />
+					<SitesGridItem
+						site={ site }
+						key={ site.ID }
+						showLaunchNag={ false }
+						showBadgeSection={ false }
+						showThumbnailLink={ false }
+						showSiteRenewLink={ false }
+						onSiteSelectBtnClick={ () => {
+							// console.log( _site );
+						} }
+					/>
 				</div>
 			) ) }
 		</div>
 	);
 };
 
-SitesGridItemExample.displayName = 'SitesGridItem';
+SitesGridItemSelectExample.displayName = 'SitesGridItemSelect';
 
-export default SitesGridItemExample;
+export default SitesGridItemSelectExample;

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -1,9 +1,10 @@
 import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
 import { useSiteLaunchStatusLabel, getSiteLaunchStatus } from '@automattic/sites';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { AnchorHTMLAttributes, memo } from 'react';
+import { memo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 import { displaySiteUrl, getDashboardUrl, isStagingSite } from '../utils';
@@ -41,6 +42,16 @@ const badges = css( {
 	marginInlineStart: 'auto',
 } );
 
+const selectAction = css( {
+	display: 'flex',
+	gap: '8px',
+	alignItems: 'center',
+	marginInlineStart: 'auto',
+	button: {
+		whiteSpace: 'nowrap',
+	},
+} );
+
 export const siteThumbnail = css( {
 	aspectRatio: '16 / 11',
 	width: '100%',
@@ -72,10 +83,23 @@ const ellipsis = css( {
 
 interface SitesGridItemProps {
 	site: SiteExcerptData;
+	showLaunchNag?: boolean;
+	showBadgeSection?: boolean;
+	showThumbnailLink?: boolean;
+	showSiteRenewLink?: boolean;
+	onSiteSelectBtnClick?: ( site: SiteExcerptData ) => void;
 }
 
-export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
+export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 	const { __ } = useI18n();
+	const {
+		site,
+		showLaunchNag = true,
+		showBadgeSection = true,
+		showThumbnailLink = true,
+		showSiteRenewLink = true,
+		onSiteSelectBtnClick,
+	} = props;
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );
@@ -84,10 +108,14 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 
 	const { ref, inView } = useInView( { triggerOnce: true } );
 
-	const siteDashboardUrlProps: AnchorHTMLAttributes< HTMLAnchorElement > = {
-		href: getDashboardUrl( site.slug ),
-		title: __( 'Visit Dashboard' ),
-	};
+	const ThumbnailWrapper = showThumbnailLink ? ThumbnailLink : 'div';
+
+	const siteDashboardUrlProps = showThumbnailLink
+		? {
+				href: getDashboardUrl( site.slug ),
+				title: __( 'Visit Dashboard' ),
+		  }
+		: {};
 
 	let siteUrl = site.URL;
 	if ( site.options?.is_redirect && site.options?.unmapped_url ) {
@@ -99,7 +127,7 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 			ref={ ref }
 			leading={
 				<>
-					<ThumbnailLink { ...siteDashboardUrlProps }>
+					<ThumbnailWrapper { ...siteDashboardUrlProps }>
 						<SiteItemThumbnail
 							displayMode="tile"
 							className={ siteThumbnail }
@@ -109,8 +137,8 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 							height={ THUMBNAIL_DIMENSION.height }
 							sizesAttr={ SIZES_ATTR }
 						/>
-					</ThumbnailLink>
-					{ site.plan?.expired && (
+					</ThumbnailWrapper>
+					{ showSiteRenewLink && site.plan?.expired && (
 						<SitesGridActionRenew site={ site } hideRenewLink={ isECommerceTrialSite } />
 					) }
 				</>
@@ -121,16 +149,29 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 						{ site.title }
 					</SiteName>
 
-					<div className={ badges }>
-						{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
-						{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
-						{ getSiteLaunchStatus( site ) !== 'public' && (
-							<SitesLaunchStatusBadge>{ translatedStatus }</SitesLaunchStatusBadge>
-						) }
-						<EllipsisMenuContainer>
-							{ inView && <SitesEllipsisMenu className={ ellipsis } site={ site } /> }
-						</EllipsisMenuContainer>
-					</div>
+					{ showBadgeSection && (
+						<div className={ badges }>
+							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
+							{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
+							{ getSiteLaunchStatus( site ) !== 'public' && (
+								<SitesLaunchStatusBadge>{ translatedStatus }</SitesLaunchStatusBadge>
+							) }
+							<EllipsisMenuContainer>
+								{ inView && <SitesEllipsisMenu className={ ellipsis } site={ site } /> }
+							</EllipsisMenuContainer>
+						</div>
+					) }
+					{ onSiteSelectBtnClick && (
+						<div className={ selectAction }>
+							<Button
+								compact={ true }
+								primary={ true }
+								onClick={ () => onSiteSelectBtnClick( site ) }
+							>
+								{ __( 'Select this site' ) }
+							</Button>
+						</div>
+					) }
 				</>
 			}
 			secondary={
@@ -138,7 +179,7 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 					<SiteUrl href={ siteUrl } title={ siteUrl }>
 						<Truncated>{ displaySiteUrl( siteUrl ) }</Truncated>
 					</SiteUrl>
-					<SiteLaunchNag site={ site } />
+					{ showLaunchNag && <SiteLaunchNag site={ site } /> }
 				</SitesGridItemSecondary>
 			}
 		/>

--- a/client/sites-dashboard/components/sites-grid-item/README.md
+++ b/client/sites-dashboard/components/sites-grid-item/README.md
@@ -11,7 +11,15 @@ function render() {
 	const site = {};
 	return (
 		<div>
-			<SitesGridItem site={ site } key={ site.ID }></SitesGridItem>
+			<SitesGridItem
+				site={ site }
+				key={ site.ID }
+				showLaunchNag={ false } // optional
+				showBadgeSection={ false } // optional
+				showThumbnailLink={ false } // optional
+				showSiteRenewLink={ false } // optional
+				onSiteSelectBtnClick={ ( site: SiteExcerptData ) => {} } // optional
+			></SitesGridItem>
 		</div>
 	);
 }
@@ -21,3 +29,8 @@ function render() {
 
 - `site`: a site data e.g. SiteExcerptData object.
 - `key`: unique key eg. Site ID.
+- `showLaunchNag`: boolean, optional, default: true.
+- `showBadgeSection`: boolean, optional, default: true.
+- `showThumbnailLink`: boolean, optional, default: true.
+- `showSiteRenewLink`: boolean, optional, default: true.
+- `onSiteSelectBtnClick`: function, optional, default: undefined.

--- a/client/sites-dashboard/components/sites-grid-item/README.md
+++ b/client/sites-dashboard/components/sites-grid-item/README.md
@@ -5,6 +5,7 @@ Renders a SitesGridItem component.
 ## How to use
 
 ```jsx
+import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 import SitesGridItem from 'calypso/sites-dashboard/components/sites-grid-item';
 
 function render() {
@@ -18,7 +19,7 @@ function render() {
 				showBadgeSection={ false } // optional
 				showThumbnailLink={ false } // optional
 				showSiteRenewLink={ false } // optional
-				onSiteSelectBtnClick={ ( site: SiteExcerptData ) => {} } // optional
+				onSiteSelectBtnClick={ ( s: SiteExcerptData ) => {} } // optional
 			></SitesGridItem>
 		</div>
 	);

--- a/client/sites-dashboard/components/sites-grid-item/docs/example.jsx
+++ b/client/sites-dashboard/components/sites-grid-item/docs/example.jsx
@@ -41,8 +41,8 @@ const SitesGridItemExample = () => {
 						showBadgeSection={ false }
 						showThumbnailLink={ false }
 						showSiteRenewLink={ false }
-						onSiteSelectBtnClick={ ( _site ) => {
-							console.log( _site );
+						onSiteSelectBtnClick={ () => {
+							// console.log( _site );
 						} }
 					/>
 				</div>

--- a/client/sites-dashboard/components/sites-grid-item/docs/example.jsx
+++ b/client/sites-dashboard/components/sites-grid-item/docs/example.jsx
@@ -34,7 +34,17 @@ const SitesGridItemExample = () => {
 		<div className={ classnames( container, className ) }>
 			{ sampleSiteData.map( ( site ) => (
 				<div className={ itemClassName } key={ site.ID }>
-					<SitesGridItem site={ site } />
+					<SitesGridItem
+						site={ site }
+						key={ site.ID }
+						showLaunchNag={ false }
+						showBadgeSection={ false }
+						showThumbnailLink={ false }
+						showSiteRenewLink={ false }
+						onSiteSelectBtnClick={ ( _site ) => {
+							console.log( _site );
+						} }
+					/>
 				</div>
 			) ) }
 		</div>

--- a/client/sites-dashboard/components/sites-grid.tsx
+++ b/client/sites-dashboard/components/sites-grid.tsx
@@ -27,16 +27,31 @@ interface SitesGridProps {
 	className?: string;
 	isLoading: boolean;
 	sites: SiteExcerptData[];
+	siteSelectorMode?: boolean;
+	onSiteSelectBtnClick?: ( site: SiteExcerptData ) => void;
 }
 
-export const SitesGrid = ( { sites, isLoading, className }: SitesGridProps ) => {
+export const SitesGrid = ( props: SitesGridProps ) => {
+	const { sites, isLoading, className, siteSelectorMode = false, onSiteSelectBtnClick } = props;
+	const additionalProps = siteSelectorMode
+		? {
+				showLaunchNag: false,
+				showBadgeSection: false,
+				showThumbnailLink: false,
+				showSiteRenewLink: false,
+				onSiteSelectBtnClick,
+		  }
+		: {};
+
 	return (
 		<div className={ classnames( container, className ) }>
 			{ isLoading
 				? Array( N_LOADING_ROWS )
 						.fill( null )
 						.map( ( _, i ) => <SitesGridItemLoading key={ i } delayMS={ i * 150 } /> )
-				: sites.map( ( site ) => <SitesGridItem site={ site } key={ site.ID } /> ) }
+				: sites.map( ( site ) => (
+						<SitesGridItem site={ site } key={ site.ID } { ...additionalProps } />
+				  ) ) }
 			<LinkInBioBanner displayMode="grid" />
 		</div>
 	);

--- a/client/sites-dashboard/components/test/__snapshots__/sites-grid-item.tsx.snap
+++ b/client/sites-dashboard/components/test/__snapshots__/sites-grid-item.tsx.snap
@@ -1,5 +1,203 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<SitesGridItem> Custom render 1`] = `
+<div
+  className="css-lvc9r-container"
+>
+  <a
+    className="css-1ctre4x-ThumbnailLink e19s2eol0"
+    href="/home/test_slug"
+    title="Visit Dashboard"
+  >
+    <div
+      className="site-thumbnail site-thumbnail-loading css-ut2tya-DEFAULT_CLASSNAME css-1mwzofc-siteThumbnail css-1uizeh6-disallowSelection"
+      style={
+        Object {
+          "backgroundColor": undefined,
+          "color": undefined,
+        }
+      }
+    >
+      <div
+        className="site-thumbnail-icon"
+      >
+        <div
+          aria-label="Site Icon"
+          className="css-k8j3dg-NoIcon e1y9o06l0"
+          role="img"
+        >
+          T
+        </div>
+      </div>
+      
+    </div>
+  </a>
+  <div>
+    <div
+      className="css-1xtz7v6-primaryContainer"
+    >
+      <a
+        className="css-6u0p2y-SiteName esmj6c50"
+        fontSize={16}
+        href="/home/test_slug"
+        title="Visit Dashboard"
+      >
+        The example site
+      </a>
+    </div>
+    <div
+      className="css-12bwudn-SitesGridItemSecondary eke2d2q1"
+    >
+      <a
+        className="components-external-link css-d9p5eo-SiteUrl ejzgyku1"
+        href=""
+        onClick={[Function]}
+        rel="external noreferrer noopener"
+        target="_blank"
+        title=""
+      >
+        <span
+          className="css-1i2o39r-Truncated ejzgyku0"
+        >
+          
+        </span>
+        <span
+          className="components-visually-hidden css-1mm2cvy-View e19lxcc00"
+          data-wp-c16t={true}
+          data-wp-component="VisuallyHidden"
+          style={
+            Object {
+              "WebkitClipPath": "inset( 50% )",
+              "border": 0,
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "clipPath": "inset( 50% )",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "width": "1px",
+              "wordWrap": "normal",
+            }
+          }
+        >
+          (opens in a new tab)
+        </span>
+        <svg
+          aria-hidden={true}
+          className="components-external-link__icon css-16iaek2-StyledIcon esh4a730"
+          focusable={false}
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+          />
+        </svg>
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<SitesGridItem> Custom render 2 1`] = `
+<div
+  className="css-lvc9r-container"
+>
+  <div>
+    <div
+      className="site-thumbnail site-thumbnail-loading css-ut2tya-DEFAULT_CLASSNAME css-1mwzofc-siteThumbnail css-1uizeh6-disallowSelection"
+      style={
+        Object {
+          "backgroundColor": undefined,
+          "color": undefined,
+        }
+      }
+    >
+      <div
+        className="site-thumbnail-icon"
+      >
+        <div
+          aria-label="Site Icon"
+          className="css-k8j3dg-NoIcon e1y9o06l0"
+          role="img"
+        >
+          T
+        </div>
+      </div>
+      
+    </div>
+  </div>
+  <div>
+    <div
+      className="css-1xtz7v6-primaryContainer"
+    >
+      <a
+        className="css-6u0p2y-SiteName esmj6c50"
+        fontSize={16}
+      >
+        The example site
+      </a>
+    </div>
+    <div
+      className="css-12bwudn-SitesGridItemSecondary eke2d2q1"
+    >
+      <a
+        className="components-external-link css-d9p5eo-SiteUrl ejzgyku1"
+        href=""
+        onClick={[Function]}
+        rel="external noreferrer noopener"
+        target="_blank"
+        title=""
+      >
+        <span
+          className="css-1i2o39r-Truncated ejzgyku0"
+        >
+          
+        </span>
+        <span
+          className="components-visually-hidden css-1mm2cvy-View e19lxcc00"
+          data-wp-c16t={true}
+          data-wp-component="VisuallyHidden"
+          style={
+            Object {
+              "WebkitClipPath": "inset( 50% )",
+              "border": 0,
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "clipPath": "inset( 50% )",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "width": "1px",
+              "wordWrap": "normal",
+            }
+          }
+        >
+          (opens in a new tab)
+        </span>
+        <svg
+          aria-hidden={true}
+          className="components-external-link__icon css-16iaek2-StyledIcon esh4a730"
+          focusable={false}
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+          />
+        </svg>
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<SitesGridItem> Default render 1`] = `
 <div
   className="css-lvc9r-container"

--- a/client/sites-dashboard/components/test/__snapshots__/sites-grid-item.tsx.snap
+++ b/client/sites-dashboard/components/test/__snapshots__/sites-grid-item.tsx.snap
@@ -1,0 +1,110 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SitesGridItem> Default render 1`] = `
+<div
+  className="css-lvc9r-container"
+>
+  <a
+    className="css-1ctre4x-ThumbnailLink e19s2eol0"
+    href="/home/test_slug"
+    title="Visit Dashboard"
+  >
+    <div
+      className="site-thumbnail site-thumbnail-loading css-ut2tya-DEFAULT_CLASSNAME css-1mwzofc-siteThumbnail css-1uizeh6-disallowSelection"
+      style={
+        Object {
+          "backgroundColor": undefined,
+          "color": undefined,
+        }
+      }
+    >
+      <div
+        className="site-thumbnail-icon"
+      >
+        <div
+          aria-label="Site Icon"
+          className="css-k8j3dg-NoIcon e1y9o06l0"
+          role="img"
+        >
+          T
+        </div>
+      </div>
+      
+    </div>
+  </a>
+  <div>
+    <div
+      className="css-1xtz7v6-primaryContainer"
+    >
+      <a
+        className="css-6u0p2y-SiteName esmj6c50"
+        fontSize={16}
+        href="/home/test_slug"
+        title="Visit Dashboard"
+      >
+        The example site
+      </a>
+      <div
+        className="css-lnphaf-badges"
+      >
+        <div
+          className="css-1j6mrwp-EllipsisMenuContainer eke2d2q0"
+        />
+      </div>
+    </div>
+    <div
+      className="css-12bwudn-SitesGridItemSecondary eke2d2q1"
+    >
+      <a
+        className="components-external-link css-d9p5eo-SiteUrl ejzgyku1"
+        href=""
+        onClick={[Function]}
+        rel="external noreferrer noopener"
+        target="_blank"
+        title=""
+      >
+        <span
+          className="css-1i2o39r-Truncated ejzgyku0"
+        >
+          
+        </span>
+        <span
+          className="components-visually-hidden css-1mm2cvy-View e19lxcc00"
+          data-wp-c16t={true}
+          data-wp-component="VisuallyHidden"
+          style={
+            Object {
+              "WebkitClipPath": "inset( 50% )",
+              "border": 0,
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "clipPath": "inset( 50% )",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "width": "1px",
+              "wordWrap": "normal",
+            }
+          }
+        >
+          (opens in a new tab)
+        </span>
+        <svg
+          aria-hidden={true}
+          className="components-external-link__icon css-16iaek2-StyledIcon esh4a730"
+          focusable={false}
+          height={24}
+          viewBox="0 0 24 24"
+          width={24}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+          />
+        </svg>
+      </a>
+    </div>
+  </div>
+</div>
+`;

--- a/client/sites-dashboard/components/test/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/test/sites-grid-item.tsx
@@ -29,4 +29,34 @@ describe( '<SitesGridItem>', () => {
 			.toJSON();
 		expect( tree ).toMatchSnapshot();
 	} );
+
+	test( 'Custom render', () => {
+		const tree = renderer
+			.create(
+				<SitesGridItem
+					site={ makeTestSite( { title: 'The example site' } ) as SiteExcerptData }
+					showLaunchNag={ false }
+					showBadgeSection={ false }
+					showThumbnailLink={ true }
+					showSiteRenewLink={ false }
+				/>
+			)
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	test( 'Custom render 2', () => {
+		const tree = renderer
+			.create(
+				<SitesGridItem
+					site={ makeTestSite( { title: 'The example site' } ) as SiteExcerptData }
+					showLaunchNag={ false }
+					showBadgeSection={ false }
+					showThumbnailLink={ false }
+					showSiteRenewLink={ false }
+				/>
+			)
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
 } );

--- a/client/sites-dashboard/components/test/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/test/sites-grid-item.tsx
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+import { SitesGridItem } from 'calypso/sites-dashboard/components/sites-grid-item';
+
+function makeTestSite( { title = 'test', is_coming_soon = false, lang = 'en' } = {} ) {
+	return {
+		ID: 1,
+		title,
+		slug: 'test_slug',
+		URL: '',
+		launch_status: 'launched',
+		options: {},
+		jetpack: false,
+		is_coming_soon,
+		lang,
+	};
+}
+
+describe( '<SitesGridItem>', () => {
+	test( 'Default render', () => {
+		const tree = renderer
+			.create(
+				<SitesGridItem site={ makeTestSite( { title: 'The example site' } ) as SiteExcerptData } />
+			)
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Related to #76332

## Proposed Changes

* Update SiteGridItem component supporting additional customization, such as:
  * show/hide launch nag
  * show/hide badge section
  * show/hide thumbnail link
  * show/hide site renew link
  * created site selection action "Select this site" button
  * provide select site callback method
* Update content controls component supporting customization, such as:
  * provide custom onQueryParamChange callback handler
  * show/hide mode switcher if there is no callback method
* Sites grid
  * introduce `siteSelectorMode` boolean property predefining set of properties
  * provide `onSiteSelectBtnClick` callback handler

![Markup on 2023-05-16 at 11:44:04](https://github.com/Automattic/wp-calypso/assets/1241413/ec9a63ef-b58f-467d-9f4c-ca6ab79d8699)

## Testing Instructions

* Go to `/sites`
* Check does everything look the same as before this chunk of changes

* The usage of this customization could be tested in the next PR related to [the Migration Plugin i2](https://github.com/orgs/Automattic/projects/331/views/25) project.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
