### PR TITLE
Virtual themes: Fix preview event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -236,15 +236,23 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	}
 
 	function previewDesign( design: Design, styleVariation?: StyleVariation ) {
-		recordPreviewedDesign( { flow, intent, design, styleVariation } );
-
 		// Virtual designs don't need to be previewed and can go directly to the site assembler.
-		if (
+		const shouldGoToAssembler =
 			design.is_virtual &&
 			design.slug === BLANK_CANVAS_DESIGN.slug &&
 			isDesktop &&
-			isEnabled( 'pattern-assembler/dotcompatterns' )
-		) {
+			isEnabled( 'pattern-assembler/dotcompatterns' );
+
+		if ( shouldGoToAssembler ) {
+			design = {
+				...design,
+				design_type: BLANK_CANVAS_DESIGN.design_type,
+			} as Design;
+		}
+
+		recordPreviewedDesign( { flow, intent, design, styleVariation } );
+
+		if ( shouldGoToAssembler ) {
 			pickDesign( design );
 			return;
 		}
@@ -445,19 +453,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
-		const shouldGoToAssembler =
-			_selectedDesign?.is_virtual &&
-			_selectedDesign?.slug === BLANK_CANVAS_DESIGN.slug &&
-			isDesktop &&
-			isEnabled( 'pattern-assembler/dotcompatterns' );
-
-		if ( shouldGoToAssembler ) {
-			_selectedDesign = {
-				..._selectedDesign,
-				design_type: BLANK_CANVAS_DESIGN.design_type,
-			} as Design;
-		}
-
 		setSelectedDesign( _selectedDesign );
 		if ( siteSlugOrId && _selectedDesign ) {
 			const positionIndex = designs.findIndex(


### PR DESCRIPTION
## Proposed Changes

As of https://github.com/Automattic/wp-calypso/pull/76673, selecting a virtual theme directly leads to the site assembler.

However, as @taipeicoder noted in p1684229789868889-slack-C048CUFRGFQ, we are incorrectly tracking the `calypso_signup_design_preview_select` event with `goes_to_assembler_step: false`.

This PR fixes that by ensuring that the design object passed to `recordPreviewedDesign` has the `assembler` design type.

## Testing Instructions

- Use the Calypso live link below.
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`.
- Open the browser devtools and switch to the Network tab.
- Observe the `t.gif` requests.
- Select a virtual theme.
- Make sure the `calypso_signup_design_preview_select` event is tracked with a  `goes_to_assembler_step: true` property.
- Make sure you land in the site assembler.