### PR TITLE
Newsletter: Highlight correct Global Styles feature

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -2,7 +2,7 @@ import {
 	FEATURE_VIDEO_UPLOADS,
 	planHasFeature,
 	PLAN_PREMIUM,
-	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
+	FEATURE_STYLE_CUSTOMIZATION,
 } from '@automattic/calypso-products';
 import { isNewsletterFlow, isStartWritingFlow, START_WRITING_FLOW } from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
@@ -141,7 +141,7 @@ export function getEnhancedTasks(
 									plan: PLAN_PREMIUM,
 									feature: isVideoPressFlowWithUnsupportedPlan
 										? FEATURE_VIDEO_UPLOADS
-										: FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
+										: FEATURE_STYLE_CUSTOMIZATION,
 								} ),
 							} );
 							window.location.assign( plansUrl );


### PR DESCRIPTION
## Proposed Changes

Updates the `?feature=` param used in the Newsletter flow with the correct Global Styles feature slug so it can be highlighted in the plans grid.

Before | After
--- | ---
<img width="980" alt="Screenshot 2023-05-16 at 13 45 16" src="https://github.com/Automattic/wp-calypso/assets/1233880/7ecdbe29-fdb0-4def-9309-84e5bfce3063"> | <img width="975" alt="Screenshot 2023-05-16 at 13 45 40" src="https://github.com/Automattic/wp-calypso/assets/1233880/0b0d9f7e-6f19-4113-8551-3abde27b08f9">

## Testing Instructions

- Use the Calypso live link below.
- Go to `/setup/newsletter`.
- Select a custom color and pick a Free plan.
- Proceed with the onboarding until you reach the launchpad.
- Click on the "Choose a plan" task.
- Make sure the "Style customization" feature is highlighted. 
