### PR TITLE
Subscription Management: Fix menu keep shown in Post Subscriptions list after unfollow

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-list.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-list.tsx
@@ -31,7 +31,12 @@ const CommentList = ( { posts }: CommentListProps ) => {
 			{ posts ? (
 				<VirtualizedList items={ posts }>
 					{ ( { item, key, style, registerChild } ) => (
-						<CommentRow key={ key } style={ style } forwardedRef={ registerChild } { ...item } />
+						<CommentRow
+							key={ `${ item.id }-${ key }` }
+							style={ style }
+							forwardedRef={ registerChild }
+							{ ...item }
+						/>
 					) }
 				</VirtualizedList>
 			) : null }

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -125,8 +125,8 @@ const useSiteUnsubscribeMutation = () => {
 			},
 			onSettled: () => {
 				// pass in more minimal keys, everything to the right will be invalidated
-				queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
-				queryClient.invalidateQueries( [ 'read', 'subscriptions-count' ] );
+				queryClient.invalidateQueries( siteSubscriptionsCacheKey );
+				queryClient.invalidateQueries( subscriptionsCountCacheKey );
 			},
 		}
 	);


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76123

## Proposed Changes

**The problem**

In the new Subscription Manager, when the user unfollows a Post, the popup they need to use is shown even when the row is not there anymore. If the user then clicks on "unfollow" in that menu, the actual registry occupying that place in the row is removed. This could lead the user to remove by mistake a subscription to the wrong post.

**Why this is happening**

The comment list is using a virtualized list component to display such a huge amount of rows. Virtualized lists sometimes avoid removing elements from the DOM so they can be reused later, like in the case of removing an element of the list. As the dom element is not removed, and the open menu is nested in the rows themselves, the menu was kept open.

**How was this problem fixed**

The virtualized list was generating its own `key` for the rows in the list. I entangled that `key` with the `post.id`, so the row cannot be reused in case of being removed. The key would change according to its content, forcing a redraw of the row.

## Testing Instructions

1. Apply this PR.
2. In the file `client/server/pages/index.js`, add this in line number 883:
<img width="634" alt="Screenshot 2023-05-16 at 14 40 25" src="https://github.com/Automattic/wp-calypso/assets/3832570/852f5c59-8685-4704-8c4b-9739ea7cd228">
3. Go to `http://calypso.localhost:3000/subscriptions/comments`.
4. Click on the ellipsis menu and click "unfollow". The row and the menu popup should disappear.
