### PR TITLE
Jetpack Pro Dashboard: Update notification settings to optimize space for email address list.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/select-email-checkbox.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/select-email-checkbox.tsx
@@ -81,7 +81,7 @@ export default function SelectEmailCheckbox( {
 							onClick={ () => handleToggleModal( 'verify' ) }
 							className="configure-email-address__verification-status cursor-pointer"
 						>
-							<Badge type="warning">{ translate( 'Pending Verification' ) }</Badge>
+							<Badge type="warning">{ translate( 'Pending' ) }</Badge>
 						</span>
 					) }
 					{ showVerified && item.verified && (

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
@@ -15,6 +15,7 @@ $help-text-color: #757575;
 .configure-email-address__checkbox-content-container {
 	display: flex;
 	align-items: center;
+	gap: 4px;
 }
 
 .configure-email-address__checkbox-content {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -234,14 +234,6 @@ export default function NotificationSettings( {
 									<div className="notification-settings__content-sub-heading">
 										{ translate( 'Receive email notifications with one or more recipients.' ) }
 									</div>
-									{ enableEmailNotification && (
-										<ConfigureEmailNotification
-											defaultEmailAddresses={ defaultUserEmailAddresses }
-											toggleModal={ toggleAddEmailModal }
-											setAllEmailItems={ setAllEmailItems }
-											allEmailItems={ allEmailItems }
-										/>
-									) }
 								</>
 							) : (
 								<div className="notification-settings__content-sub-heading">
@@ -252,6 +244,15 @@ export default function NotificationSettings( {
 							) }
 						</div>
 					</div>
+
+					{ enableEmailNotification && (
+						<ConfigureEmailNotification
+							defaultEmailAddresses={ defaultUserEmailAddresses }
+							toggleModal={ toggleAddEmailModal }
+							setAllEmailItems={ setAllEmailItems }
+							allEmailItems={ allEmailItems }
+						/>
+					) }
 				</div>
 
 				<div className="notification-settings__footer">


### PR DESCRIPTION
Currently, the Email addresses on the Notification settings modal are getting cut off due to limited spacing.


<img src="https://github.com/Automattic/wp-calypso/assets/56598660/53d4e277-86ac-4ab6-9ee0-c4f50df3f1d4" width="300" />

 This PR updates the modal and improves the use of space to mitigate the issue. **This solution has been consulted with the design team.**

Related to 1204408201748644-as-1204551307515866


## Proposed Changes

* Move the email recipient list outside the toggle container to allow the component to take 100% width space.
* Change the **'Pending verification'** text to just **'Pending'**.

<img width="403" alt="Screen Shot 2023-05-17 at 1 01 22 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b6d29065-1fd4-4829-a054-00324d03604d">


## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

- Run git checkout `fix/truncated-email-address-on-configure-notification-modal` and `yarn start-jetpack-cloud`
- Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the `/dashboard`.
- Enable monitor if not enabled already.
- Click on the clock icon next to the monitor toggle.
- Confirm that the new changes on the modal are applied.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React, or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?