### PR TITLE
Help Center: move site picker

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -660,8 +660,7 @@ export const HelpCenterContactForm = () => {
 				setSitePickerChoice={ setSitePickerChoice }
 				currentSite={ currentSite }
 				siteId={ sitePickerChoice === 'CURRENT_SITE' ? currentSite?.ID : 0 }
-				showDropDown={ ! userWithNoSites }
-				enabled={
+				sitePickerEnabled={
 					mode === 'FORUM' &&
 					Boolean( supportSite?.plan?.product_slug ) &&
 					isFreePlanProduct( { product_slug: supportSite.plan?.product_slug as string } )

--- a/packages/help-center/src/components/help-center-site-picker.tsx
+++ b/packages/help-center/src/components/help-center-site-picker.tsx
@@ -1,0 +1,59 @@
+import { SitePickerDropDown, SitePickerSite } from '@automattic/site-picker';
+import { TextControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { HELP_CENTER_STORE } from '../stores';
+import { SitePicker } from '../types';
+import { HelpCenterOwnershipNotice } from './help-center-notice';
+import type { HelpCenterSelect } from '@automattic/data-stores';
+
+export const HelpCenterSitePicker: React.FC< SitePicker > = ( {
+	ownershipResult,
+	setSitePickerChoice,
+	currentSite,
+	siteId,
+	enabled,
+	showDropDown,
+} ) => {
+	const { setSite, setUserDeclaredSiteUrl } = useDispatch( HELP_CENTER_STORE );
+	const userDeclaredSiteUrl = useSelect( ( select ) => {
+		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
+		return helpCenterSelect.getUserDeclaredSiteUrl();
+	}, [] );
+
+	const otherSite = {
+		name: __( 'Other site', __i18n_text_domain__ ),
+		ID: 0,
+		logo: { id: '', sizes: [] as never[], url: '' },
+		URL: '',
+	} as const;
+
+	const options: ( SitePickerSite | undefined )[] = [ currentSite, otherSite ];
+
+	return (
+		<section>
+			{ showDropDown ? (
+				<SitePickerDropDown
+					enabled={ enabled }
+					onPickSite={ ( id: string | number ) => {
+						if ( id !== 0 ) {
+							setSite( currentSite );
+						}
+						setSitePickerChoice( id === 0 ? 'OTHER_SITE' : 'CURRENT_SITE' );
+					} }
+					options={ options }
+					siteId={ siteId }
+				/>
+			) : (
+				<>
+					<TextControl
+						label={ __( 'Site address', __i18n_text_domain__ ) }
+						value={ userDeclaredSiteUrl ?? '' }
+						onChange={ setUserDeclaredSiteUrl }
+					/>
+					<HelpCenterOwnershipNotice ownershipResult={ ownershipResult } />
+				</>
+			) }
+		</section>
+	);
+};

--- a/packages/help-center/src/components/help-center-site-picker.tsx
+++ b/packages/help-center/src/components/help-center-site-picker.tsx
@@ -9,11 +9,11 @@ import type { HelpCenterSelect } from '@automattic/data-stores';
 
 export const HelpCenterSitePicker: React.FC< SitePicker > = ( {
 	ownershipResult,
+	sitePickerChoice,
 	setSitePickerChoice,
 	currentSite,
 	siteId,
-	enabled,
-	showDropDown,
+	sitePickerEnabled,
 } ) => {
 	const { setSite, setUserDeclaredSiteUrl } = useDispatch( HELP_CENTER_STORE );
 	const userDeclaredSiteUrl = useSelect( ( select ) => {
@@ -31,29 +31,33 @@ export const HelpCenterSitePicker: React.FC< SitePicker > = ( {
 	const options: ( SitePickerSite | undefined )[] = [ currentSite, otherSite ];
 
 	return (
-		<section>
-			{ showDropDown ? (
-				<SitePickerDropDown
-					enabled={ enabled }
-					onPickSite={ ( id: string | number ) => {
-						if ( id !== 0 ) {
-							setSite( currentSite );
-						}
-						setSitePickerChoice( id === 0 ? 'OTHER_SITE' : 'CURRENT_SITE' );
-					} }
-					options={ options }
-					siteId={ siteId }
-				/>
-			) : (
-				<>
+		<>
+			{ sitePickerEnabled && (
+				<section>
+					<SitePickerDropDown
+						enabled={ true }
+						onPickSite={ ( id: string | number ) => {
+							if ( id !== 0 ) {
+								setSite( currentSite );
+							}
+							setSitePickerChoice( id === 0 ? 'OTHER_SITE' : 'CURRENT_SITE' );
+						} }
+						options={ options }
+						siteId={ siteId }
+					/>
+				</section>
+			) }
+
+			{ sitePickerChoice === 'OTHER_SITE' && (
+				<section>
 					<TextControl
 						label={ __( 'Site address', __i18n_text_domain__ ) }
 						value={ userDeclaredSiteUrl ?? '' }
 						onChange={ setUserDeclaredSiteUrl }
 					/>
 					<HelpCenterOwnershipNotice ownershipResult={ ownershipResult } />
-				</>
+				</section>
 			) }
-		</section>
+		</>
 	);
 };

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -1,4 +1,4 @@
-import type { HelpCenterSite } from '@automattic/data-stores';
+import type { HelpCenterSite, AnalysisReport } from '@automattic/data-stores';
 import type { ReactElement } from 'react';
 
 export interface Container {
@@ -16,10 +16,13 @@ export interface Header {
 }
 
 export interface SitePicker {
+	ownershipResult: AnalysisReport;
+	setSitePickerChoice: any;
+	sitePickerChoice: string;
 	currentSite: HelpCenterSite | undefined;
-	onSelect: ( siteId: number | string ) => void;
 	siteId: string | number | null | undefined;
 	enabled: boolean;
+	showDropDown: boolean;
 }
 
 // ended means the user closed the popup or reloaded the iframe
@@ -70,3 +73,5 @@ export interface MessagingAuth {
 export interface MessagingAvailability {
 	is_available: boolean;
 }
+
+export type Mode = 'CHAT' | 'EMAIL' | 'FORUM';

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -21,12 +21,8 @@ export interface SitePicker {
 	sitePickerChoice: string;
 	currentSite: HelpCenterSite | undefined;
 	siteId: string | number | null | undefined;
-	enabled: boolean;
-	showDropDown: boolean;
+	sitePickerEnabled: boolean;
 }
-
-// ended means the user closed the popup or reloaded the iframe
-export type WindowState = 'open' | 'closed' | 'blurred' | 'ended';
 
 export interface Article {
 	title: string;

--- a/packages/site-picker/src/index.tsx
+++ b/packages/site-picker/src/index.tsx
@@ -158,6 +158,7 @@ export const SitePickerDropDown: FC< Props > = ( {
 								} }
 								selected={ option?.ID === siteId }
 								id={ `site-picker-button-item-${ index }` }
+								key={ index }
 							/>
 						) ) }
 					</div>


### PR DESCRIPTION
## Proposed Changes

This is *part 1* of refactoring the Help Center contact form. I have broken these changes out to make my original PR smaller. Original PR #72699

This moves the site picker / dropdown into its own component allowing the main contact form component to be a little less cluttered. All the logic should be exactly the same just passed over to another file. The component is responsible for the dropdown or the text field. All details are passed in as props.

There was also an error with the `SitePicker` component due to a missing key so I added that as well.

## Testing Instructions

1. Pull branch and `yarn start`
2. Log in and open Help Center.
3. If you have a site available on your user then it should auto-populate the drop down with that site.
4. If you don't then you should see the text field.
5. Check against WordPress.com for regression.

**If you need a test account for a user with no sites I have one you can use. Please ping me.**