### PR TITLE
Quarentined e2e tests because of wpcom etk bug

### DIFF
--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -1,7 +1,5 @@
 /**
- * @group calypso-pr
- * @group gutenberg
- * @group jetpack-wpcom-integration
+ * @group quarantined
  */
 
 import {

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -1,6 +1,5 @@
 /**
- * @group gutenberg
- * @group calypso-pr
+ * @group quarantined
  */
 
 import {


### PR DESCRIPTION
## Proposed Changes

As ETK works on wpcom and tests runs for it, if ETK has an error, all tests are failing.
We quarentined 2 tests that are failing and we will bring it back after the ETK bugs were fixed.

