### PR TITLE
Update Mastodon connection flow with better input handling

### DIFF
--- a/client/my-sites/marketing/connections/mastodon.tsx
+++ b/client/my-sites/marketing/connections/mastodon.tsx
@@ -1,7 +1,7 @@
 import { FormInputValidation } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useState, FormEvent, ChangeEvent } from 'react';
+import { useState, FormEvent, ChangeEvent, useEffect } from 'react';
 import FormsButton from 'calypso/components/forms/form-button';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -65,6 +65,13 @@ const InstanceContainer = styled.div( {
 export const isValidUsername = ( username: string ) =>
 	/@?\b([A-Z0-9_]+)@([A-Z0-9.-]+\.[A-Z]{2,})\b/gi.test( username );
 
+const isAlreadyConnected = ( connections: Connection[], instance: string ) => {
+	return connections.some( ( connection ) => {
+		const { external_display } = connection;
+		return external_display === instance;
+	} );
+};
+
 export const Mastodon: React.FC< Props > = ( {
 	service,
 	action,
@@ -76,10 +83,21 @@ export const Mastodon: React.FC< Props > = ( {
 	const [ instance, setInstance ] = useState( '' );
 	const [ error, setError ] = useState( '' );
 
+	// After sucessfully connecting an account, reset the instance.
+	// Disabled react-hooks/exhaustive-deps because we don't want to run this on instance change
+	useEffect( () => {
+		if ( ! isConnecting && isAlreadyConnected( connections, instance ) ) {
+			setInstance( '' );
+		}
+	}, [ isConnecting, connections ] ); // eslint-disable-line react-hooks/exhaustive-deps
+
 	const handleInstanceChange = ( e: ChangeEvent< HTMLInputElement > ) => {
 		const instance = e.target.value.trim();
 		setInstance( instance );
-		if ( isValidUsername( instance ) || ! instance ) {
+
+		if ( isAlreadyConnected( connections, instance ) ) {
+			setError( translate( 'This account is already connected.' ) );
+		} else if ( isValidUsername( instance ) || ! instance ) {
 			setError( '' );
 		} else {
 			setError( translate( 'This username is not valid.' ) );

--- a/client/my-sites/marketing/connections/test/mastodon.jsx
+++ b/client/my-sites/marketing/connections/test/mastodon.jsx
@@ -5,16 +5,20 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Mastodon, isValidUsername } from '../mastodon';
 
-const props = {
-	service: {
-		ID: 'mastodon',
-		connect_URL: 'https://testurl.test/?param1=1&param2=2',
-	},
-	connectAnother: () => {},
-	connections: [],
-	action: () => {},
-	isConnecting: false,
-};
+let props = {};
+
+beforeEach( () => {
+	props = {
+		service: {
+			ID: 'mastodon',
+			connect_URL: 'https://testurl.test/?param1=1&param2=2',
+		},
+		connectAnother: () => {},
+		connections: [],
+		action: () => {},
+		isConnecting: false,
+	};
+} );
 
 describe( 'Mastodon', () => {
 	test( 'it displays the input form without errors', () => {
@@ -40,6 +44,22 @@ describe( 'Mastodon', () => {
 		expect( screen.getByRole( 'alert' ) ).toBeInTheDocument();
 
 		const btn = screen.getByRole( 'button', { name: /Connect account/i } );
+		expect( btn ).toBeDisabled();
+	} );
+
+	test( 'displays an error message when instance is already connected', async () => {
+		props.connections = [ { external_display: '@user@example.com' } ];
+		render( <Mastodon { ...props } /> );
+
+		await userEvent.type(
+			screen.getByLabelText( 'Enter your Mastodon username' ),
+			'@user@example.com'
+		);
+
+		// error message is displayed
+		expect( screen.getByRole( 'alert' ) ).toBeInTheDocument();
+
+		const btn = screen.getByRole( 'button', { name: /Connect one more account/i } );
 		expect( btn ).toBeDisabled();
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76991

## Proposed Changes

On Marketing connection page some improvements to Mastodon flow. We are clearing out the `input` after a successful connection. We are also checking if the connection is already present to show an error.

## Testing Instructions

### Prerequisites

- Make sure you have a Mastodon account
- 

### Testing

- Spin up Calypso by running this branch locally or by using a live link below
- If you're using a live link, enable the `mastodon` flag by adding the query parameter `?flags=mastodon`
- Navigate to Mastodon in the `/marketing/connections/:site` section
- Make a connection and observe that after Success the text field is cleared
- Try to enter same account again, you should see an error:

<img width="555" alt="Screenshot at May 16 12-12-53" src="https://github.com/Automattic/wp-calypso/assets/60262784/8595d7c0-6434-420c-badc-5bed153cb1da">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
