### PR TITLE
Fix issues caused when system time is corrupt

### DIFF
--- a/client/lib/analytics/track-resurrections/index.jsx
+++ b/client/lib/analytics/track-resurrections/index.jsx
@@ -19,7 +19,7 @@ const isResurrected = ( lastSeen ) => {
 
 const TrackResurrections = () => {
 	const userSettings = useSelector( getUserSettings ) || {};
-	const lastSeen = userSettings.last_admin_activity_timestamp || Date.now();
+	const lastSeen = userSettings.last_admin_activity_timestamp || Math.floor( Date.now() / 1000 );
 
 	const isFetching = useSelector( isFetchingUserSettings );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pau2Xa-4GE-p2#comment-13570

## Proposed Changes
In the resurrection event, we see last_seen prop value of -62169984000.
This prop has two notable issues
1) It's in milliseconds. The API sends the timestamp in seconds.
2) The value -62169984000 corresponds to a timestamp often used as a default or uninitialized value when a valid timestamp is unavailable or has an error when retrieving it.

The calculations from the function [isResurrection](https://github.com/Automattic/wp-calypso/blob/1db3b5634e637bab630c2844e90b68a5ec6772ca/client/lib/analytics/track-resurrections/index.jsx#L9) Are thrown off when using the timestamp in milliseconds causing the event to fire with the corrupted system timestamp.

This code converts the milliseconds to seconds, fixing inconsistencies between the WP API timestamp received by the component and the default timestamp we generate from Date.now().
This fix will ensure that if the system time is corrupted, the same corrupted timestamp will be used in  [isResurrection](https://github.com/Automattic/wp-calypso/blob/1db3b5634e637bab630c2844e90b68a5ec6772ca/client/lib/analytics/track-resurrections/index.jsx#L9) and the isResurrection function will return false.

## Testing Instructions
Setup Tracks Vigilante to log events.

Set up calypso locally.

switch to this branch

in [/client/lib/analytics/track-resurrections/index.jsx.](https://github.com/Automattic/wp-calypso/blob/add/calypso_user_resurrected_event/client/lib/analytics/track-resurrections/index.jsx#L17) change this line of code
return lastSeen < oneYearAgoInSeconds;
to
return lastSeen < Math.floor( ( Date.now() - 5 * 60 * 1000 ) / 1000 ); // return true if user was last seen 5mins ego

The change above will ensure that we don't have to wait for one year but 5 minutes to see a resurrection event.

Log out of Calypso.

Wait for 5 minutes or more.

Log back in and immediately visit /home/${ primarySiteSlug }.

You should see a resurrection event logged in Vigilante with a last_seen prop that is a timestamp in seconds.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?