### PR TITLE
Payments: Support Error.prototype.cause in all locations that record errors

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -21,6 +21,7 @@ import {
 	billingHistory,
 } from 'calypso/me/purchases/paths';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
+import { convertErrorToString } from 'calypso/my-sites/checkout/composite-checkout/lib/analytics';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { getVatVendorInfo } from './billing-history/vat-vendor-details';
 import CancelPurchase from './cancel-purchase';
@@ -41,7 +42,7 @@ function useLogPurchasesError( message ) {
 				extra: {
 					env: config( 'env_id' ),
 					type: 'account_level_purchases',
-					message: error.message + '; Stack: ' + error.stack,
+					message: convertErrorToString( error ),
 				},
 			} );
 		},

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -14,6 +14,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutMain from './composite-checkout/components/checkout-main';
 import PrePurchaseNotices from './composite-checkout/components/prepurchase-notices';
+import { convertErrorToString } from './composite-checkout/lib/analytics';
 import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
 
 const logCheckoutError = ( error: Error ) => {
@@ -24,7 +25,7 @@ const logCheckoutError = ( error: Error ) => {
 		extra: {
 			env: config( 'env_id' ),
 			type: 'checkout_system_decider',
-			message: error.message + '; Stack: ' + error.stack,
+			message: convertErrorToString( error ),
 		},
 	} );
 	captureException( error );

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -21,6 +21,7 @@ import { fetchReceipt } from 'calypso/state/receipts/actions';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
 import getOrderTransaction from 'calypso/state/selectors/get-order-transaction';
 import getOrderTransactionError from 'calypso/state/selectors/get-order-transaction-error';
+import { convertErrorToString } from '../../composite-checkout/lib/analytics';
 import type { RedirectInstructions } from 'calypso/my-sites/checkout/composite-checkout/lib/pending-page';
 import type { ReceiptState } from 'calypso/state/receipts/types';
 import type {
@@ -354,7 +355,7 @@ const logCheckoutError = ( error: Error ) => {
 		extra: {
 			env: config( 'env_id' ),
 			type: 'checkout_pending',
-			message: error.message + '; Stack: ' + error.stack,
+			message: convertErrorToString( error ),
 		},
 	} );
 };

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -43,7 +43,7 @@ import useRecordCartLoaded from '../hooks/use-record-cart-loaded';
 import useRecordCheckoutLoaded from '../hooks/use-record-checkout-loaded';
 import useRemoveFromCartAndRedirect from '../hooks/use-remove-from-cart-and-redirect';
 import { useStoredPaymentMethods } from '../hooks/use-stored-payment-methods';
-import { logStashLoadErrorEvent, logStashEvent } from '../lib/analytics';
+import { logStashLoadErrorEvent, logStashEvent, convertErrorToString } from '../lib/analytics';
 import existingCardProcessor from '../lib/existing-card-processor';
 import filterAppropriatePaymentMethods from '../lib/filter-appropriate-payment-methods';
 import freePurchaseProcessor from '../lib/free-purchase-processor';
@@ -556,7 +556,7 @@ export default function CheckoutMain( {
 			}
 			reduxDispatch(
 				recordTracksEvent( errorTypeToTracksEventName( errorType ), {
-					error_message: error.message + '; Stack: ' + error.stack,
+					error_message: convertErrorToString( error ),
 					...errorData,
 				} )
 			);

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -14,10 +14,13 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { useStableCallback } from 'calypso/lib/use-stable-callback';
+import { convertErrorToString } from '../lib/analytics';
 import type { WPCOMProductVariant } from '../components/item-variation-picker';
 import type { ResponseCartProduct, ResponseCartProductVariant } from '@automattic/shopping-cart';
 
 const debug = debugFactory( 'calypso:composite-checkout:product-variants' );
+
+const isError = ( err: unknown ): err is Error => err instanceof Error;
 
 export interface SitePlanData {
 	autoRenew?: boolean;
@@ -109,7 +112,9 @@ export function useGetProductVariants(
 						extra: {
 							env: config( 'env_id' ),
 							variant: JSON.stringify( variant ),
-							message: ( error as Error ).message + '; Stack: ' + ( error as Error ).stack,
+							message: isError( error )
+								? convertErrorToString( error )
+								: `Unknown error: ${ error }`,
 						},
 					} );
 				}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -9,6 +9,7 @@ import { logToLogstash } from 'calypso/lib/logstash';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
 import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
+import { convertErrorToString } from '../lib/analytics';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
 import useCountryList from './use-country-list';
 import type {
@@ -123,7 +124,7 @@ function useCachedContactDetailsForCheckoutForm(
 					extra: {
 						env: config( 'env_id' ),
 						type: 'checkout_contact_details_autocomplete',
-						message: error.message + '; Stack: ' + error.stack,
+						message: convertErrorToString( error ),
 					},
 				} );
 			} );

--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -8,7 +8,7 @@ import {
 import type { CheckoutPaymentMethodSlug } from '@automattic/wpcom-checkout';
 import type { CalypsoDispatch } from 'calypso/state/types';
 
-function convertErrorToString( error: Error ): string {
+export function convertErrorToString( error: Error ): string {
 	if ( error.cause ) {
 		return `${ error.message }; Cause: ${ error.cause }; Stack: ${ error.stack }`;
 	}

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -21,6 +21,7 @@ import {
 	ReceiptTitle,
 } from 'calypso/me/purchases/billing-history/receipt';
 import titles from 'calypso/me/purchases/titles';
+import { convertErrorToString } from 'calypso/my-sites/checkout/composite-checkout/lib/analytics';
 import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import getPastBillingTransaction from 'calypso/state/selectors/get-past-billing-transaction';
@@ -42,7 +43,7 @@ function useLogBillingHistoryError( message: string ) {
 				extra: {
 					env: config( 'env_id' ),
 					type: 'site_level_billing_history',
-					message: error.message + '; Stack: ' + error.stack,
+					message: convertErrorToString( error ),
 				},
 			} );
 		},

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -23,6 +23,7 @@ import getAvailableConciergeSessions from 'calypso/state/selectors/get-available
 import getConciergeNextAppointment from 'calypso/state/selectors/get-concierge-next-appointment';
 import getConciergeUserBlocked from 'calypso/state/selectors/get-concierge-user-blocked';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { convertErrorToString } from '../checkout/composite-checkout/lib/analytics';
 import {
 	getPurchaseListUrlFor,
 	getCancelPurchaseUrlFor,
@@ -43,7 +44,7 @@ function useLogPurchasesError( message: string ) {
 				extra: {
 					env: config( 'env_id' ),
 					type: 'site_level_purchases',
-					message: error.message + '; Stack: ' + error.stack,
+					message: convertErrorToString( error ),
 				},
 			} );
 		},

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -28,6 +28,7 @@ import PaymentMethodSelector from 'calypso/me/purchases/manage-purchase/payment-
 import PaymentMethodList from 'calypso/me/purchases/payment-methods/payment-method-list';
 import titles from 'calypso/me/purchases/titles';
 import { useCreateCreditCard } from 'calypso/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods';
+import { convertErrorToString } from 'calypso/my-sites/checkout/composite-checkout/lib/analytics';
 import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -43,7 +44,7 @@ function useLogPaymentMethodsError( message: string ) {
 				extra: {
 					env: config( 'env_id' ),
 					type: 'site_level_payment_methods',
-					message: error.message + '; Stack: ' + error.stack,
+					message: convertErrorToString( error ),
 				},
 			} );
 		},


### PR DESCRIPTION
## Proposed Changes

The `CheckoutErrorBoundary` component is a React error boundary with several features including allowing its parent to provide a logging function for the error message. In https://github.com/Automattic/wp-calypso/pull/75293 we modified the component to record both the original error message inside the `Error.prototype.cause` property and the displayed message in the `Error.prototype.message` property. These are then unraveled using a `convertErrorToString()` function.

However, that PR only updated one of the locations that records error messages from `CheckoutErrorBoundary`, meaning that the other locations no longer recorded their original errors.

This PR modifies all the other places that use `CheckoutErrorBoundary` to use `convertErrorToString()` as well.

Props to @pottedmeat for noticing this issue.

## Testing Instructions

TypeScript should mostly cover this.