### PR TITLE
Import focused flow: Site picker: Register new step and integrate Sites Grid component 

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -22,6 +22,7 @@ import MigrationHandler from './internals/steps-repository/migration-handler';
 import PatternAssembler from './internals/steps-repository/pattern-assembler';
 import ProcessingStep from './internals/steps-repository/processing-step';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
+import SitePickerStep from './internals/steps-repository/site-picker';
 import { Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect } from '@automattic/data-stores';
 
@@ -46,6 +47,7 @@ const importFlow: Flow = {
 			{ slug: 'processing', component: ProcessingStep },
 			{ slug: 'siteCreationStep', component: SiteCreationStep },
 			{ slug: 'migrationHandler', component: MigrationHandler },
+			{ slug: 'sitePicker', component: SitePickerStep },
 		];
 	},
 
@@ -163,6 +165,19 @@ const importFlow: Flow = {
 				}
 				case 'migrationHandler': {
 					return handleMigrationRedirects( providedDependencies );
+				}
+
+				case 'sitePicker': {
+					const newQueryParams =
+						( providedDependencies?.queryParams as { [ key: string ]: string } ) || {};
+
+					Object.keys( newQueryParams ).forEach( ( key ) => {
+						newQueryParams[ key ]
+							? urlQueryParams.set( key, newQueryParams[ key ] )
+							: urlQueryParams.delete( key );
+					} );
+
+					return navigate( `sitePicker?${ urlQueryParams.toString() }` );
 				}
 			}
 		};

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -166,6 +166,11 @@ button {
 	}
 }
 
+.import-focused .step-container.site-picker {
+	max-width: 1280px;
+	padding: 1.5rem;
+}
+
 .is-section-stepper {
 	.search-filters__popover {
 		--color-accent: #117ac9 !important;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -53,7 +53,8 @@ button {
 }
 
 .accessible-focus {
-	.site-setup {
+	.site-setup,
+	.import-focused {
 		.button.is-primary:focus {
 			box-shadow: 0 0 0 2px var(--color-primary-light);
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -1,0 +1,52 @@
+import { StepContainer } from '@automattic/onboarding';
+import {
+	DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE,
+	GroupableSiteLaunchStatuses,
+} from '@automattic/sites';
+import React from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { SitesDashboardQueryParams } from 'calypso/sites-dashboard/components/sites-content-controls';
+import SitePicker from './site-picker';
+import type { Step } from '../../types';
+
+import './styles.scss';
+
+const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
+	const headerText = 'Pick your destination';
+	const page = Number( useQuery().get( 'page' ) ) || 1;
+	const search = useQuery().get( 'search' ) || '';
+	const status =
+		( useQuery().get( 'status' ) as GroupableSiteLaunchStatuses ) ||
+		DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE;
+
+	const goBack = () => {
+		// Go back logic goes here
+	};
+	const onQueryParamChange = ( params: Partial< SitesDashboardQueryParams > ) => {
+		navigation.submit?.( { queryParams: params } );
+	};
+
+	return (
+		<>
+			<DocumentHead title={ headerText } />
+			<StepContainer
+				stepName="site-picker"
+				hideSkip={ true }
+				goBack={ goBack }
+				stepContent={
+					<SitePicker
+						page={ page }
+						search={ search }
+						status={ status }
+						onQueryParamChange={ onQueryParamChange }
+					/>
+				}
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
+	);
+};
+
+export default SitePickerStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -1,0 +1,99 @@
+import { SubTitle, Title } from '@automattic/onboarding';
+import { createSitesListComponent, GroupableSiteLaunchStatuses } from '@automattic/sites';
+import { useI18n } from '@wordpress/react-i18n';
+import React from 'react';
+import Pagination from 'calypso/components/pagination';
+import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
+import { NoSitesMessage } from 'calypso/sites-dashboard/components/no-sites-message';
+import {
+	SitesContentControls,
+	SitesDashboardQueryParams,
+} from 'calypso/sites-dashboard/components/sites-content-controls';
+import { PageBodyBottomContainer } from 'calypso/sites-dashboard/components/sites-dashboard';
+import { SitesGrid } from 'calypso/sites-dashboard/components/sites-grid';
+import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
+
+const SitesDashboardSitesList = createSitesListComponent();
+
+interface Props {
+	page: number;
+	perPage?: number;
+	search: string;
+	status: GroupableSiteLaunchStatuses;
+	onQueryParamChange: ( params: Partial< SitesDashboardQueryParams > ) => void;
+}
+const SitePicker = function SitePicker( props: Props ) {
+	const { __ } = useI18n();
+	const { page, perPage = 96, search, status, onQueryParamChange } = props;
+	const { sitesSorting, onSitesSortingChange } = useSitesSorting();
+	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
+
+	return (
+		<div className="site-picker--container">
+			<div className="site-picker--title">
+				<Title>{ __( 'Pick your destination' ) }</Title>
+				<SubTitle>
+					{ __(
+						'Select the WordPress.com site where you’ll move your old site or create a new one'
+					) }
+				</SubTitle>
+			</div>
+			<SitesDashboardSitesList
+				sites={ allSites }
+				filtering={ { search } }
+				sorting={ sitesSorting }
+				grouping={ { status, showHidden: true } }
+			>
+				{ ( { sites, statuses } ) => {
+					const paginatedSites = sites.slice( ( page - 1 ) * perPage, page * perPage );
+					const selectedStatus = statuses.find( ( { name } ) => name === status ) || statuses[ 0 ];
+
+					return (
+						<>
+							<SitesContentControls
+								initialSearch={ search }
+								onQueryParamChange={ onQueryParamChange }
+								sitesSorting={ sitesSorting }
+								onSitesSortingChange={ onSitesSortingChange }
+								statuses={ statuses }
+								selectedStatus={ selectedStatus }
+								hasSitesSortingPreferenceLoaded={ true }
+							/>
+							{ paginatedSites.length > 0 || isLoading ? (
+								<>
+									<SitesGrid
+										isLoading={ isLoading }
+										sites={ paginatedSites }
+										siteSelectorMode={ true }
+										onSiteSelectBtnClick={ () => {
+											// console.log( 'onSiteSelectBtnClick', site );
+										} }
+									/>
+									{ ( selectedStatus.hiddenCount > 0 || sites.length > perPage ) && (
+										<PageBodyBottomContainer>
+											<Pagination
+												page={ page }
+												perPage={ perPage }
+												total={ sites.length }
+												pageClick={ ( page: number ) => {
+													onQueryParamChange( { page } );
+												} }
+											/>
+										</PageBodyBottomContainer>
+									) }
+								</>
+							) : (
+								<NoSitesMessage
+									status={ selectedStatus.name }
+									statusSiteCount={ selectedStatus.count }
+								/>
+							) }
+						</>
+					);
+				} }
+			</SitesDashboardSitesList>
+		</div>
+	);
+};
+
+export default SitePicker;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
@@ -1,0 +1,8 @@
+.site-picker--container {
+	padding-bottom: rem(28px);
+}
+
+.site-picker--title {
+	text-align: center;
+	margin-bottom: rem(68px);
+}

--- a/client/sites-dashboard/components/sites-display-mode-switcher.tsx
+++ b/client/sites-dashboard/components/sites-display-mode-switcher.tsx
@@ -23,8 +23,8 @@ export const useSitesDisplayMode = () => {
 };
 
 interface SitesDisplayModeSwitcherProps {
-	onDisplayModeChange( newValue: SitesDisplayMode ): void;
-	displayMode: ReturnType< typeof useSitesDisplayMode >[ 0 ];
+	onDisplayModeChange?( newValue: SitesDisplayMode ): void;
+	displayMode?: ReturnType< typeof useSitesDisplayMode >[ 0 ];
 }
 
 export const SitesDisplayModeSwitcher = ( {
@@ -56,7 +56,7 @@ export const SitesDisplayModeSwitcher = ( {
 				} else {
 					listRef.current?.focus();
 				}
-				onDisplayModeChange( newMode );
+				onDisplayModeChange?.( newMode );
 			}
 		},
 		[ onDisplayModeChange ]
@@ -68,7 +68,7 @@ export const SitesDisplayModeSwitcher = ( {
 				role="radio"
 				aria-label={ __( 'Tile view' ) }
 				title={ __( 'Switch to tile view' ) }
-				onClick={ () => onDisplayModeChange( 'tile' ) }
+				onClick={ () => onDisplayModeChange?.( 'tile' ) }
 				icon={ <Gridicon icon="grid" /> }
 				ref={ tileRef }
 				onKeyDown={ ( event: React.KeyboardEvent ) => handleKeyDown( event, 'tile' ) }
@@ -82,7 +82,7 @@ export const SitesDisplayModeSwitcher = ( {
 				role="radio"
 				aria-label={ __( 'List view' ) }
 				title={ __( 'Switch to list view' ) }
-				onClick={ () => onDisplayModeChange( 'list' ) }
+				onClick={ () => onDisplayModeChange?.( 'list' ) }
 				icon={ <Gridicon icon="list-unordered" /> }
 				ref={ listRef }
 				onKeyDown={ ( event: React.KeyboardEvent ) => handleKeyDown( event, 'list' ) }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/76332

## Proposed Changes

* Import-focused flow: register a new `sitePicker` step
* sitePicker step: Sites Grid Component integration

## Screenshot
<img width="1372" alt="Screenshot 2023-05-16 at 22 38 29" src="https://github.com/Automattic/wp-calypso/assets/1241413/bb3e3cac-b701-493f-a8db-27a408432557">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused/sitePicker?siteSlug={SITE_SLUG}`
* Check how filtering works
* Check responsive design

**NOTE:** This PR doesn't contain logic for `Select this site` CTA

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
