### PR TITLE
Fix errors on scroll of unmounted sticky component

### DIFF
--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -37,15 +37,15 @@ export function getBlockStyle( state ) {
 	}
 }
 
-export function getDimensions( _ref, isSticky ) {
+export function getDimensions( node, isSticky ) {
 	return {
-		spacerHeight: isSticky ? _ref.current?.clientHeight : 0,
-		blockWidth: isSticky ? _ref.current?.clientWidth : 0,
+		spacerHeight: isSticky ? node.clientHeight : 0,
+		blockWidth: isSticky ? node.clientWidth : 0,
 	};
 }
 
-export function getDimensionUpdates( _ref, previous ) {
-	const newDimensions = getDimensions( _ref, previous.isSticky );
+export function getDimensionUpdates( node, previous ) {
+	const newDimensions = getDimensions( node, previous.isSticky );
 	return previous.spacerHeight !== newDimensions.spacerHeight ||
 		previous.blockWidth !== newDimensions.blockWidth
 		? newDimensions
@@ -101,7 +101,10 @@ class StickyPanelWithIntersectionObserver extends Component {
 	} );
 
 	throttleOnResize = throttle(
-		() => this.setState( ( prevState ) => getDimensions( this.state._ref, prevState.isSticky ) ),
+		() =>
+			this.setState( ( prevState ) =>
+				getDimensions( this.state._ref.current, prevState.isSticky )
+			),
 		RESIZE_RATE_IN_MS
 	);
 
@@ -153,7 +156,7 @@ class StickyPanelWithIntersectionObserver extends Component {
 		if ( isSticky !== this.state.isSticky ) {
 			this.setState( {
 				isSticky,
-				...getDimensions( this.state._ref, isSticky ),
+				...getDimensions( this.state._ref.current, isSticky ),
 			} );
 		}
 	}
@@ -184,7 +187,8 @@ class StickyPanelWithScrollEvent extends Component {
 	} );
 
 	throttleOnResize = throttle(
-		() => this.setState( ( prevState ) => getDimensionUpdates( this.state._ref, prevState ) ),
+		() =>
+			this.setState( ( prevState ) => getDimensionUpdates( this.state._ref.current, prevState ) ),
 		RESIZE_RATE_IN_MS
 	);
 
@@ -209,7 +213,7 @@ class StickyPanelWithScrollEvent extends Component {
 		if ( isSticky !== this.state.isSticky ) {
 			this.setState( {
 				isSticky,
-				...getDimensions( this.state._ref, isSticky ),
+				...getDimensions( this.state._ref.current, isSticky ),
 			} );
 		}
 	}


### PR DESCRIPTION
reported here: p1684284352464299-slack-C04U5A26MJB

I added a backup scroll event to the sticky panel but didn't detatch it on unmount.

There is also an issue with using `ReactDom.findDOMNode( this )`. If the component is unmounted, even checking this will throw a JS error.

Even after I detatched and cancelled the onscroll event, `ReactDom.findDOMNode( this )` was still being called once and throwing an error.

I changed the file to use a reference instead which can safely be checked if the component is unmounted see https://stackoverflow.com/questions/39767482/is-there-a-way-to-check-if-the-react-component-is-unmounted

Related to https://github.com/Automattic/wp-calypso/pull/76747


## Testing Instructions

Go to the /tags page
scroll down until the panel "sticks"
click on a link (if possible, tab to a link, and hit enter while currently scrolling)
on the next page, you should not see an error on scrolling
I was only able to test the "StickyPanelWithScrollEvent" component by hacking the code as follows. It is a fallback for old browsers.

```
export default StickyPanelWithScrollEvent;

// export default hasIntersectionObserver
// 	? StickyPanelWithIntersectionObserver
// 	: StickyPanelWithScrollEvent;
```
