### PR TITLE
Checkout: Fix fetching of receipt data for thank-you page

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -32,6 +32,7 @@ import { recordCompositeCheckoutErrorDuringAnalytics } from '../lib/analytics';
 import normalizeTransactionResponse from '../lib/normalize-transaction-response';
 import { absoluteRedirectThroughPending, redirectThroughPending } from '../lib/pending-page';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from '../lib/translate-payment-method-names';
+import type { FailedResponse } from '../lib/normalize-transaction-response';
 import type {
 	PaymentEventCallback,
 	PaymentEventCallbackArguments,
@@ -113,20 +114,21 @@ export default function useCreatePaymentCompleteCallback( {
 			// In the case of a Jetpack product site-less purchase, we need to include the blog ID of the
 			// created site in the Thank You page URL.
 			// TODO: It does not seem like this would be needed for Akismet, but marking to follow up
-			let jetpackTemporarySiteId;
+			let jetpackTemporarySiteId: string | undefined;
 			if (
 				sitelessCheckoutType === 'jetpack' &&
 				! siteSlug &&
-				[ 'no-user', 'no-site' ].includes( String( responseCart.cart_key ) )
+				[ 'no-user', 'no-site' ].includes( String( responseCart.cart_key ) ) &&
+				'purchases' in transactionResult &&
+				transactionResult.purchases
 			) {
-				jetpackTemporarySiteId =
-					transactionResult.purchases && Object.keys( transactionResult.purchases ).pop();
+				jetpackTemporarySiteId = Object.keys( transactionResult.purchases ).pop();
 			}
 
 			const getThankYouPageUrlArguments: PostCheckoutUrlArguments = {
 				siteSlug: siteSlug || undefined,
 				adminUrl,
-				receiptId: transactionResult.receipt_id,
+				receiptId: 'receipt_id' in transactionResult ? transactionResult.receipt_id : undefined,
 				redirectTo,
 				purchaseId,
 				feature,
@@ -168,7 +170,10 @@ export default function useCreatePaymentCompleteCallback( {
 				);
 			}
 
-			const receiptId = transactionResult?.receipt_id;
+			const receiptId =
+				transactionResult && 'receipt_id' in transactionResult
+					? transactionResult.receipt_id
+					: undefined;
 			debug( 'transactionResult was', transactionResult );
 
 			reduxDispatch( clearPurchases() );
@@ -181,7 +186,12 @@ export default function useCreatePaymentCompleteCallback( {
 				clearSignupDestinationCookie();
 			}
 
-			if ( receiptId && transactionResult?.purchases ) {
+			if (
+				receiptId &&
+				transactionResult &&
+				'purchases' in transactionResult &&
+				transactionResult.purchases
+			) {
 				debug( 'fetching receipt' );
 				reduxDispatch( fetchReceiptCompleted( receiptId, transactionResult ) );
 			}
@@ -213,8 +223,8 @@ export default function useCreatePaymentCompleteCallback( {
 				// log-in page which we don't want.
 				absoluteRedirectThroughPending( url, {
 					siteSlug,
-					orderId: transactionResult.order_id,
-					receiptId: transactionResult.receipt_id,
+					orderId: 'order_id' in transactionResult ? transactionResult.order_id : undefined,
+					receiptId: 'receipt_id' in transactionResult ? transactionResult.receipt_id : undefined,
 				} );
 				return;
 			}
@@ -224,8 +234,8 @@ export default function useCreatePaymentCompleteCallback( {
 			if ( isURL( url ) || url.includes( '/setup/' ) ) {
 				absoluteRedirectThroughPending( url, {
 					siteSlug,
-					orderId: transactionResult.order_id,
-					receiptId: transactionResult.receipt_id,
+					orderId: 'order_id' in transactionResult ? transactionResult.order_id : undefined,
+					receiptId: 'receipt_id' in transactionResult ? transactionResult.receipt_id : undefined,
 				} );
 				return;
 			}
@@ -235,11 +245,13 @@ export default function useCreatePaymentCompleteCallback( {
 			} );
 			redirectThroughPending( url, {
 				siteSlug,
-				orderId: transactionResult.order_id,
-				receiptId: transactionResult.receipt_id,
+				orderId: 'order_id' in transactionResult ? transactionResult.order_id : undefined,
+				receiptId: 'receipt_id' in transactionResult ? transactionResult.receipt_id : undefined,
 			} );
 		},
 		[
+			monthlyToAnnualPostPurchaseExperimentUser,
+			purchases,
 			reloadCart,
 			siteSlug,
 			adminUrl,
@@ -274,7 +286,7 @@ function recordPaymentCompleteAnalytics( {
 	sitePlanSlug,
 }: {
 	paymentMethodId: string | null;
-	transactionResult: WPCOMTransactionEndpointResponse | undefined;
+	transactionResult: WPCOMTransactionEndpointResponse | FailedResponse | undefined;
 	redirectUrl: string;
 	responseCart: ResponseCart;
 	checkoutFlow?: string;
@@ -299,7 +311,10 @@ function recordPaymentCompleteAnalytics( {
 	try {
 		recordPurchase( {
 			cart: responseCart,
-			orderId: transactionResult?.receipt_id,
+			orderId:
+				transactionResult && 'receipt_id' in transactionResult
+					? transactionResult.receipt_id
+					: undefined,
 			sitePlanSlug,
 		} );
 	} catch ( err ) {

--- a/client/my-sites/checkout/composite-checkout/lib/normalize-transaction-response.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/normalize-transaction-response.ts
@@ -1,24 +1,26 @@
 import { WPCOMTransactionEndpointResponse } from '@automattic/wpcom-checkout';
 
-const emptyResponse: WPCOMTransactionEndpointResponse = {
+export interface FailedResponse {
+	success: false;
+}
+
+const emptyResponse: FailedResponse = {
 	success: false,
-	error_code: '',
-	error_message: '',
 };
 
 export default function normalizeTransactionResponse(
 	response: unknown
-): WPCOMTransactionEndpointResponse {
+): WPCOMTransactionEndpointResponse | FailedResponse {
 	if ( ! response ) {
 		return emptyResponse;
 	}
 	const transactionResponse = response as WPCOMTransactionEndpointResponse;
 	if (
-		transactionResponse.message ||
+		( 'message' in transactionResponse && transactionResponse.message ) ||
 		transactionResponse.order_id ||
-		transactionResponse.receipt_id ||
-		transactionResponse.purchases ||
-		transactionResponse.failed_purchases ||
+		( 'receipt_id' in transactionResponse && transactionResponse.receipt_id ) ||
+		( 'purchases' in transactionResponse && transactionResponse.purchases ) ||
+		( 'failed_purchases' in transactionResponse && transactionResponse.failed_purchases ) ||
 		transactionResponse.redirect_url
 	) {
 		return transactionResponse;

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -1,8 +1,8 @@
-import type { RawReceiptPurchase } from 'calypso/state/receipts/types';
+import type { Purchase } from '@automattic/wpcom-checkout';
 
 export interface IndividualReceipt {
 	receipt_id: number;
-	purchases: RawReceiptPurchase[];
+	purchases: Purchase[];
 	display_price: string;
 	price_integer: number;
 	price_float: number;

--- a/client/state/receipts/actions.ts
+++ b/client/state/receipts/actions.ts
@@ -6,11 +6,14 @@ import {
 	RECEIPT_FETCH_FAILED,
 } from 'calypso/state/action-types';
 import { createReceiptObject } from './assembler';
+import type { RawReceiptData } from './types';
+import type { CalypsoDispatch } from '../types';
+import type { WPCOMTransactionEndpointResponseSuccess } from '@automattic/wpcom-checkout';
 
 import 'calypso/state/receipts/init';
 
-export function fetchReceipt( receiptId ) {
-	return ( dispatch ) => {
+export function fetchReceipt( receiptId: number ) {
+	return ( dispatch: CalypsoDispatch ) => {
 		dispatch( {
 			type: RECEIPT_FETCH,
 			receiptId,
@@ -18,10 +21,10 @@ export function fetchReceipt( receiptId ) {
 
 		return wpcom.req
 			.get( `/me/billing-history/receipt/${ receiptId }` )
-			.then( ( data ) => {
+			.then( ( data: RawReceiptData ) => {
 				dispatch( fetchReceiptCompleted( receiptId, data ) );
 			} )
-			.catch( ( error ) => {
+			.catch( ( error: Error ) => {
 				const errorMessage =
 					error.message || i18n.translate( 'There was a problem retrieving your receipt.' );
 
@@ -34,7 +37,10 @@ export function fetchReceipt( receiptId ) {
 	};
 }
 
-export function fetchReceiptCompleted( receiptId, data ) {
+export function fetchReceiptCompleted(
+	receiptId: number,
+	data: WPCOMTransactionEndpointResponseSuccess | RawReceiptData
+) {
 	return {
 		type: RECEIPT_FETCH_COMPLETED,
 		receiptId,

--- a/client/state/receipts/assembler.ts
+++ b/client/state/receipts/assembler.ts
@@ -14,7 +14,9 @@ import type {
  * @returns {ReceiptData} The formatted receipt data
  */
 export function createReceiptObject( data: RawReceiptData ): ReceiptData {
-	const purchases = Array.isArray( data.purchases ) ? {} : data.purchases;
+	const purchases = Array.isArray( data.purchases )
+		? data.purchases
+		: flattenPurchases( data.purchases || {} );
 	const failedPurchases = Array.isArray( data.failed_purchases ) ? {} : data.failed_purchases;
 
 	return {
@@ -23,7 +25,7 @@ export function createReceiptObject( data: RawReceiptData ): ReceiptData {
 		currency: data.currency,
 		priceInteger: data.price_integer,
 		priceFloat: data.price_float,
-		purchases: flattenPurchases( purchases || {} ).map( ( purchase ) => {
+		purchases: purchases.map( ( purchase ) => {
 			return {
 				delayedProvisioning: Boolean( purchase.delayed_provisioning ),
 				freeTrial: Boolean( purchase.free_trial ),

--- a/client/state/receipts/assembler.ts
+++ b/client/state/receipts/assembler.ts
@@ -1,11 +1,4 @@
-import type {
-	RawFailedReceiptPurchase,
-	RawFailedReceiptPurchases,
-	RawReceiptData,
-	RawReceiptPurchase,
-	RawReceiptPurchases,
-	ReceiptData,
-} from './types';
+import type { RawReceiptData, ReceiptData } from './types';
 
 /**
  * Converts raw receipt data into receipt data
@@ -14,10 +7,7 @@ import type {
  * @returns {ReceiptData} The formatted receipt data
  */
 export function createReceiptObject( data: RawReceiptData ): ReceiptData {
-	const purchases = Array.isArray( data.purchases )
-		? data.purchases
-		: flattenPurchases( data.purchases || {} );
-	const failedPurchases = Array.isArray( data.failed_purchases ) ? {} : data.failed_purchases;
+	const purchases = Array.isArray( data.purchases ) ? data.purchases : [];
 
 	return {
 		receiptId: data.receipt_id,
@@ -45,40 +35,5 @@ export function createReceiptObject( data: RawReceiptData ): ReceiptData {
 				saasRedirectUrl: purchase.saas_redirect_url ?? '',
 			};
 		} ),
-		failedPurchases: flattenFailedPurchases( failedPurchases || {} ).map( ( purchase ) => {
-			return {
-				meta: purchase.product_meta,
-				productId: purchase.product_id,
-				productCost: purchase.product_cost,
-				productSlug: purchase.product_slug,
-				productName: purchase.product_name,
-			};
-		} ),
 	};
-}
-
-/**
- * Purchases are of the format { [siteId]: [ { productId: ... } ] }
- * so we need to flatten them to get a list of purchases
- */
-function flattenPurchases(
-	purchases: RawReceiptPurchases | Array< void >
-): Array< RawReceiptPurchase > {
-	if ( Array.isArray( purchases ) ) {
-		return [];
-	}
-	return Object.values( purchases ).flat();
-}
-
-/**
- * Purchases are of the format { [siteId]: [ { productId: ... } ] }
- * so we need to flatten them to get a list of purchases
- */
-function flattenFailedPurchases(
-	purchases: RawFailedReceiptPurchases | Array< void >
-): Array< RawFailedReceiptPurchase > {
-	if ( Array.isArray( purchases ) ) {
-		return [];
-	}
-	return Object.values( purchases ).flat();
 }

--- a/client/state/receipts/assembler.ts
+++ b/client/state/receipts/assembler.ts
@@ -1,16 +1,41 @@
 import type { RawReceiptData, ReceiptData } from './types';
+import type {
+	WPCOMTransactionEndpointResponseSuccess,
+	Purchase,
+	FailedPurchase,
+} from '@automattic/wpcom-checkout';
 
 /**
- * Converts raw receipt data into receipt data
- *
- * @param {RawReceiptData} data The raw data returned from the server after a transaction
- * @returns {ReceiptData} The formatted receipt data
+ * Convert raw receipt data into receipt data for the Redux store.
  */
-export function createReceiptObject( data: RawReceiptData ): ReceiptData {
-	const purchases = Array.isArray( data.purchases ) ? data.purchases : [];
+export function createReceiptObject(
+	data: RawReceiptData | WPCOMTransactionEndpointResponseSuccess
+): ReceiptData {
+	// purchases is a key-value store if the data is coming from the transactions
+	// endpoint, but an array if it comes from the receipt endpoint.
+	const purchases = ( (): Purchase[] => {
+		if ( ! data.purchases ) {
+			return [];
+		}
+		if ( Array.isArray( data.purchases ) && data.purchases.length === 0 ) {
+			return [];
+		}
+		if ( Array.isArray( data.purchases ) ) {
+			return data.purchases;
+		}
+		return flattenPurchases( data.purchases );
+	} )();
+
+	// failed_purchases only comes from the transactions endpont and is only an
+	// array if it is empty (PHP converting an empty associative array into an
+	// empty array instead of an object).
+	const failedPurchases =
+		'failed_purchases' in data && ! Array.isArray( data.failed_purchases )
+			? flattenFailedPurchases( data.failed_purchases )
+			: [];
 
 	return {
-		receiptId: data.receipt_id,
+		receiptId: String( data.receipt_id ),
 		displayPrice: data.display_price,
 		currency: data.currency,
 		priceInteger: data.price_integer,
@@ -18,9 +43,9 @@ export function createReceiptObject( data: RawReceiptData ): ReceiptData {
 		purchases: purchases.map( ( purchase ) => {
 			return {
 				delayedProvisioning: Boolean( purchase.delayed_provisioning ),
-				freeTrial: Boolean( purchase.free_trial ),
+				freeTrial: false,
 				isDomainRegistration: Boolean( purchase.is_domain_registration ),
-				meta: purchase.meta,
+				meta: purchase.meta || '',
 				productId: purchase.product_id,
 				productSlug: purchase.product_slug,
 				productType: purchase.product_type,
@@ -35,5 +60,50 @@ export function createReceiptObject( data: RawReceiptData ): ReceiptData {
 				saasRedirectUrl: purchase.saas_redirect_url ?? '',
 			};
 		} ),
+		failedPurchases: failedPurchases.map( ( purchase ) => {
+			return {
+				meta: purchase.product_meta,
+				productId: purchase.product_id,
+				productCost: purchase.product_cost,
+				productSlug: purchase.product_slug,
+				productName: purchase.product_name,
+			};
+		} ),
 	};
+}
+
+/**
+ * Purchases from the transactions endpoint are of the format:
+ *
+ * { [siteId]: [ { productId: ... } ] }
+ *
+ * ...so we need to flatten them to get an array of purchases.
+ */
+function flattenPurchases(
+	purchases: WPCOMTransactionEndpointResponseSuccess[ 'purchases' ]
+): Array< Purchase > {
+	if ( Array.isArray( purchases ) ) {
+		// If the data is an array, it is because PHP converted an empty
+		// associative array into an empty array instead of an empty object.
+		return [];
+	}
+	return Object.values( purchases ).flat();
+}
+
+/**
+ * Failed purchases from the transactions endpoint are of the format:
+ *
+ * { [siteId]: [ { productId: ... } ] }
+ *
+ * ...so we need to flatten them to get an array of purchases.
+ */
+function flattenFailedPurchases(
+	purchases: WPCOMTransactionEndpointResponseSuccess[ 'failed_purchases' ]
+): Array< FailedPurchase > {
+	if ( Array.isArray( purchases ) ) {
+		// If the data is an array, it is because PHP converted an empty
+		// associative array into an empty array instead of an empty object.
+		return [];
+	}
+	return Object.values( purchases ).flat();
 }

--- a/client/state/receipts/test/assembler.ts
+++ b/client/state/receipts/test/assembler.ts
@@ -92,8 +92,13 @@ const standardAssembledReceipt: ReceiptData = {
 };
 
 describe( 'createReceiptObject', () => {
-	it( 'returns an expected object for standard receipt data', () => {
+	it( 'returns an expected object for standard transaction receipt data', () => {
 		const actual = createReceiptObject( rawTransactionReceipt );
+		expect( actual ).toEqual( standardAssembledReceipt );
+	} );
+
+	it( 'returns an expected object for standard receipt endpoint data', () => {
+		const actual = createReceiptObject( rawReceiptEndpointReceipt );
 		expect( actual ).toEqual( standardAssembledReceipt );
 	} );
 

--- a/client/state/receipts/types.ts
+++ b/client/state/receipts/types.ts
@@ -17,14 +17,6 @@ export interface RawReceiptPurchase {
 	saas_redirect_url?: string;
 }
 
-export interface RawFailedReceiptPurchase {
-	product_meta: string;
-	product_id: string | number;
-	product_slug: string;
-	product_cost: string | number;
-	product_name: string;
-}
-
 export interface ReceiptPurchase {
 	delayedProvisioning: boolean;
 	freeTrial: boolean;
@@ -43,38 +35,14 @@ export interface ReceiptPurchase {
 	saasRedirectUrl: string;
 }
 
-export interface FailedReceiptPurchase {
-	meta: string;
-	productId: string | number;
-	productSlug: string;
-	productCost: string | number;
-	productName: string;
-}
-
 export interface RawReceiptData {
 	receipt_id: string;
 	display_price: string;
 	price_float: number;
 	price_integer: number;
 	currency: string;
-
-	/**
-	 * Data returned by the transactions endpoint is a key-value array of blog_id
-	 * to list of purchases. However, data returned by the receipt endpoint is
-	 * just a list of purchases.
-	 */
-	purchases: RawReceiptPurchases | RawReceiptPurchase[] | undefined | false;
-
-	/**
-	 * This is only returned by the transactions endpoint and will only be an
-	 * array if it is empty.
-	 */
-	failed_purchases?: RawFailedReceiptPurchases | Array< void > | undefined | false;
+	purchases: RawReceiptPurchase[] | undefined | false;
 }
-
-export type RawFailedReceiptPurchases = Record< string, RawFailedReceiptPurchase[] >;
-
-export type RawReceiptPurchases = Record< string, RawReceiptPurchase[] >;
 
 export interface ReceiptData {
 	receiptId: string;
@@ -83,7 +51,6 @@ export interface ReceiptData {
 	priceFloat: number;
 	priceInteger: number;
 	purchases: ReceiptPurchase[];
-	failedPurchases: FailedReceiptPurchase[];
 }
 
 export interface ReceiptState {

--- a/client/state/receipts/types.ts
+++ b/client/state/receipts/types.ts
@@ -1,21 +1,4 @@
-export interface RawReceiptPurchase {
-	delayed_provisioning?: boolean;
-	free_trial?: boolean;
-	is_domain_registration?: boolean;
-	meta: string;
-	product_id: string | number;
-	product_slug: string;
-	product_type: string;
-	product_name: string;
-	product_name_short: string;
-	new_quantity: number;
-	registrar_support_url?: string;
-	is_email_verified?: boolean;
-	is_root_domain_with_us?: boolean;
-	is_renewal?: boolean;
-	will_auto_renew?: boolean;
-	saas_redirect_url?: string;
-}
+import type { Purchase } from '@automattic/wpcom-checkout';
 
 export interface ReceiptPurchase {
 	delayedProvisioning: boolean;
@@ -35,13 +18,21 @@ export interface ReceiptPurchase {
 	saasRedirectUrl: string;
 }
 
+export interface FailedReceiptPurchase {
+	meta: string;
+	productId: string | number;
+	productSlug: string;
+	productCost: string | number;
+	productName: string;
+}
+
 export interface RawReceiptData {
 	receipt_id: string;
 	display_price: string;
 	price_float: number;
 	price_integer: number;
 	currency: string;
-	purchases: RawReceiptPurchase[] | undefined | false;
+	purchases: Purchase[] | undefined | false;
 }
 
 export interface ReceiptData {
@@ -51,6 +42,7 @@ export interface ReceiptData {
 	priceFloat: number;
 	priceInteger: number;
 	purchases: ReceiptPurchase[];
+	failedPurchases: FailedReceiptPurchase[];
 }
 
 export interface ReceiptState {

--- a/client/state/receipts/types.ts
+++ b/client/state/receipts/types.ts
@@ -59,14 +59,17 @@ export interface RawReceiptData {
 	currency: string;
 
 	/**
-	 * Will only be an array if it is empty.
+	 * Data returned by the transactions endpoint is a key-value array of blog_id
+	 * to list of purchases. However, data returned by the receipt endpoint is
+	 * just a list of purchases.
 	 */
-	purchases: RawReceiptPurchases | Array< void > | undefined | false;
+	purchases: RawReceiptPurchases | RawReceiptPurchase[] | undefined | false;
 
 	/**
-	 * Will only be an array if it is empty.
+	 * This is only returned by the transactions endpoint and will only be an
+	 * array if it is empty.
 	 */
-	failed_purchases: RawFailedReceiptPurchases | Array< void > | undefined | false;
+	failed_purchases?: RawFailedReceiptPurchases | Array< void > | undefined | false;
 }
 
 export type RawFailedReceiptPurchases = Record< string, RawFailedReceiptPurchase[] >;

--- a/client/state/receipts/types.ts
+++ b/client/state/receipts/types.ts
@@ -16,6 +16,7 @@ export interface ReceiptPurchase {
 	isRenewal: boolean;
 	willAutoRenew: boolean;
 	saasRedirectUrl: string;
+	newQuantity: number | undefined;
 }
 
 export interface FailedReceiptPurchase {

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -4,33 +4,48 @@ import type { TranslateResult } from 'i18n-calypso';
 
 type PurchaseSiteId = number;
 
-export type WPCOMTransactionEndpointResponse = {
-	success: boolean;
-	error_code: string;
-	error_message: string;
-	failed_purchases?: Record< PurchaseSiteId, Purchase[] >;
-	purchases?: Record< PurchaseSiteId, Purchase[] >;
-	receipt_id?: number;
-	order_id?: number;
+export type WPCOMTransactionEndpointResponseSuccess = {
+	success: true;
+	purchases: Record< PurchaseSiteId, Purchase[] > | [];
+	failed_purchases: Record< PurchaseSiteId, FailedPurchase[] > | [];
+	receipt_id: number;
+	order_id: number;
 	redirect_url?: string;
-	message?: { payment_intent_client_secret: string };
+	is_gift_purchase: boolean;
+	display_price: string;
+	price_integer: number;
+	price_float: number;
+	currency: string;
 };
 
+export type WPCOMTransactionEndpointResponseRedirect = {
+	message: { payment_intent_client_secret: string } | '';
+	order_id: number;
+	redirect_url: string;
+};
+
+export type WPCOMTransactionEndpointResponse =
+	| WPCOMTransactionEndpointResponseSuccess
+	| WPCOMTransactionEndpointResponseRedirect;
+
 export interface Purchase {
-	meta: string;
+	delayed_provisioning?: boolean;
+	expiry?: string;
+	is_domain_registration: boolean;
+	is_email_verified?: boolean;
+	is_renewal: boolean;
+	is_root_domain_with_us?: boolean;
+	meta: string | null;
+	new_quantity?: number;
 	product_id: string | number;
-	product_slug: string;
-	product_cost: string | number;
 	product_name: string;
 	product_name_short: string;
-	delayed_provisioning?: boolean;
-	is_domain_registration?: boolean;
+	product_type: string;
+	product_slug: string;
 	registrar_support_url?: string;
-	is_email_verified?: boolean;
-	is_root_domain_with_us?: boolean;
-	will_auto_renew?: boolean;
-	expiry: string;
 	user_email: string;
+	saas_redirect_url?: string;
+	will_auto_renew?: boolean;
 }
 
 export interface TransactionRequest {


### PR DESCRIPTION
We store purchase receipt data in the calypso Redux data store. It gets injected by two different sources: the transactions endpoint response (`/me/transactions`) and the receipt endpoint response (`/me/billing-history/receipt/:receiptId`, but note: the receipt endpoint has two "modes" depending on if `?format=display` is set; in this case we're talking about when that param is _not_ set which only happens on the checkout thank-you page). 

However, the format of those two receipt objects is slightly different. Most notably, in the transactions endpoint, the `purchases` property is a key-value store where the key is the site ID and the value is an array of purchases, but in the receipt endpoint, `purchases` is just an array of purchases.

Because of this difference, the code that processes the receipt data to save it in the Redux store must handle both formats, but it does not do so correctly. Currently it handles only the transactions endpoint response, which means that if the checkout thank-you page fetches its own receipt data, it will fail to find any purchases, leading to a blank page for the user.

In most instances of the checkout flow, this failure is hidden because the transactions endpoint response will have filled in the data just after checkout and before we reach the thank-you page, but that is not the case for redirect transactions like PayPal since their receipt data isn't available before the user leaves checkout.

## Proposed Changes

In this PR, we modify the code that processes receipt data so that it can handle the formats of both the transaction endpoint and the receipts endpoint.

Fixes https://github.com/Automattic/payments-shilling/issues/1673

## Screenshots

Before:

<img width="1504" alt="Screenshot 2023-05-16 at 4 44 17 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/0d12c7f6-76c9-4e1c-a216-010d7d879729">

After:

<img width="1510" alt="Screenshot 2023-05-16 at 4 57 15 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/88f3974a-34ac-4102-934b-7f3b82d7922c">


## Testing Instructions

Automated tests are included, but it's worth testing both versions of the experience to make sure they work as expected with real data.

### Testing transactions endpoint data

- Visit `/domains` and follow the domain-only purchase flow (choose a `.live` domain).
- When you reach checkout, select a credit card (new or existing) as the payment method.
- Complete the purchase.
- If you see an upsell page, click "Skip for now".
- Verify that you see the receipt page.

### Testing receipt endpoint data

- Visit `/domains` and follow the domain-only purchase flow (choose a `.live` domain).
- When you reach checkout, select PayPal as the payment method.
- Complete the flow (you can use a test PayPal account as per these instructions: PCYsg-IA-p2).
- If you see an upsell page, click "Skip for now".
- Verify that you see the receipt page.