### PR TITLE
JP Pro Dashboard: fix multiple recipient list showing when not enabled.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -245,7 +245,7 @@ export default function NotificationSettings( {
 						</div>
 					</div>
 
-					{ enableEmailNotification && (
+					{ enableEmailNotification && isMultipleEmailEnabled && (
 						<ConfigureEmailNotification
 							defaultEmailAddresses={ defaultUserEmailAddresses }
 							toggleModal={ toggleAddEmailModal }


### PR DESCRIPTION
This is a follow-up PR to #76979, which has a minor bug. The multiple email recipient list should only show up when it is enabled.

<img width="471" alt="Screen Shot 2023-05-17 at 3 03 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/869a2769-2ebb-49fc-aa73-30ccb89188eb">


Related to 1204408201748644-as-1204551307515866

## Proposed Changes

* Add correct flag to render the email recipient list component.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

- Run git checkout `fix/jp-pro-dashboard-appearing-multi-email-list` and `yarn start-jetpack-cloud`
- Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the `/dashboard`.
- Enable monitor if not enabled already.
- Click on the clock icon next to the monitor toggle.
- Confirm that the multiple email recipient list is not visible.

<img width="477" alt="Screen Shot 2023-05-17 at 3 06 44 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a25bfa5f-77ac-47d8-8ec3-da28ed11b1e0">


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React, or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
