### PR TITLE
Integrate logged in tags page with reader sidebar

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -41,7 +41,7 @@ export const ProviderWrappedLayout = ( {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
 	const layout = userLoggedIn ? (
-		<Layout primary={ primary } secondary={ secondary } headerSection={ headerSection } />
+		<Layout primary={ primary } secondary={ secondary } />
 	) : (
 		<LayoutLoggedOut
 			primary={ primary }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -141,7 +141,6 @@ class Layout extends Component {
 		primary: PropTypes.element,
 		secondary: PropTypes.element,
 		focus: PropTypes.object,
-		headerSection: PropTypes.element,
 		// connected props
 		masterbarIsHidden: PropTypes.bool,
 		isSupportSession: PropTypes.bool,
@@ -250,7 +249,6 @@ class Layout extends Component {
 			'is-support-session': this.props.isSupportSession,
 			'has-no-sidebar': this.props.sidebarIsHidden,
 			'has-docked-chat': this.props.chatIsOpen && this.props.chatIsDocked,
-			'has-header-section': this.props.headerSection,
 			'has-no-masterbar': this.props.masterbarIsHidden,
 			'is-jetpack-login': this.props.isJetpackLogin,
 			'is-jetpack-site': this.props.isJetpack,
@@ -282,7 +280,6 @@ class Layout extends Component {
 			config.isEnabled( 'inline-help' ) &&
 			shouldLoadInlineHelp( this.props.sectionName, this.props.currentRoute ) &&
 			! loadHelpCenter;
-
 		return (
 			<div className={ sectionClass }>
 				<HelpCenterLoader
@@ -310,14 +307,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'layout/guided-tours' ) && (
 					<AsyncLoad require="calypso/layout/guided-tours" placeholder={ null } />
 				) }
-				<div className="layout__header-section">
-					{ this.renderMasterbar( loadHelpCenter ) }
-					{ this.props.headerSection && (
-						<div className="layout__header-section-content logged-in">
-							{ this.props.headerSection }
-						</div>
-					) }
-				</div>
+				<div className="layout__header-section">{ this.renderMasterbar( loadHelpCenter ) }</div>
 				<LayoutLoader />
 				{ isJetpackCloud() && (
 					<AsyncLoad require="calypso/jetpack-cloud/style" placeholder={ null } />

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -27,6 +27,15 @@ body.is-focus-sites {
 	transition: transform 0.15s ease-in-out, opacity 0.15s ease-out;
 }
 
+.layout__header-section-content {
+	box-sizing: border-box;
+	padding: 79px 32px 32px 32px;
+
+	@include breakpoint-deprecated( "<960px" ) {
+		padding: 71px 24px 24px 24px;
+	}
+}
+
 // Setup the content element to adapt to the sidebar,
 // lack of sidebar, or the WebPreview component.
 .layout__content {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -365,7 +365,6 @@
 }
 
 .layout.has-header-section.is-section-reader {
-
 	.layout__header-section {
 		color: var(--studio-white);
 		background-color: #021827;
@@ -385,13 +384,6 @@
 		border-bottom: none;
 		background: transparent;
 		color: var(--studio-white);
-	}
-
-	// logged in master bar
-	header.masterbar {
-		padding: 16px 16px;
-		height: 78px;
-		position: relative;
 	}
 
 	// logged out master bar

--- a/client/reader/tags/controller.tsx
+++ b/client/reader/tags/controller.tsx
@@ -2,7 +2,7 @@ import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import performanceMark, { PartialContext } from 'calypso/server/lib/performance-mark';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { getCurrentUserLocale, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import TagsPage from './main';
 import type { Context as PageJSContext } from 'page';
 
@@ -27,7 +27,9 @@ export interface AlphabeticTagsResult {
 }
 
 export const tagsListing = ( context: PageJSContext, next: () => void ) => {
-	context.headerSection = renderHeaderSection();
+	if ( ! isUserLoggedIn( context.store.getState() ) ) {
+		context.headerSection = renderHeaderSection();
+	}
 	context.primary = (
 		<TagsPage
 			trendingTags={ context.params.trendingTags }

--- a/client/reader/tags/index.web.js
+++ b/client/reader/tags/index.web.js
@@ -1,6 +1,15 @@
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar } from '../controller';
 import { tagsListing, fetchTrendingTags, fetchAlphabeticTags } from './controller';
 
 export default function ( router ) {
-	router( '/tags', fetchTrendingTags, fetchAlphabeticTags, tagsListing, makeLayout, clientRender );
+	router(
+		'/tags',
+		fetchTrendingTags,
+		fetchAlphabeticTags,
+		sidebar,
+		tagsListing,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/tags/main.tsx
+++ b/client/reader/tags/main.tsx
@@ -12,7 +12,7 @@ interface Props {
 export default function TagsPage( { trendingTags, alphabeticTags }: Props ) {
 	const translate = useTranslate();
 	return (
-		<div className="tags">
+		<div className="tags__main">
 			<h4>
 				{
 					// translators: The heading of the reader trending tags section

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -18,7 +18,6 @@
 		padding-left: 0;
 		padding-right: 0;
 	}
-
 	h1 {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 		font-size: 60px; /* stylelint-disable-line declaration-property-unit-allowed-list */
@@ -52,9 +51,25 @@
 	}
 }
 
-.tags h4 {
-	color: var(--studio-gray-50);
-	margin-bottom: 15px;
+// to match other reader pages.
+.layout:not(.has-no-sidebar) .tags__main {
+	padding: 30px 20px;
+	max-width: 600px;
+	margin: 0 auto;
+	@media ( min-width: 660px ) {
+		padding: 30px 0;
+	}
+	@media ( min-width: 782px ) {
+		padding: 60px 0;
+		max-width: 1140px;
+	}
+}
+
+.tags__main {
+	h4 {
+		color: var(--studio-gray-50);
+		margin-bottom: 15px;
+	}
 }
 
 .trending-tags__container {

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -60,7 +60,7 @@
 		padding: 30px 0;
 	}
 	@media ( min-width: 782px ) {
-		padding: 60px 0;
+		padding: 24px 0;
 		max-width: 1140px;
 	}
 }


### PR DESCRIPTION
project thread pe7F0s-Qa-p2

Takes the existing /tags page and updates it to include the logged in sidebar as described in task one of the project thread.
<img width="1728" alt="Screen Shot 2023-05-17 at 5 17 34 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/4bda1507-5529-44f0-828f-c8f203cec109">

<img width="346" alt="Screen Shot 2023-05-17 at 5 18 04 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/9f055775-cfc1-427b-bbc9-888f6adf21fe">


### Testing instructions

Logged out /tags page should remain unchanged

Test logged in tags page in mobile, tablet and desktop. I've attempted to align the left padding with the individual tag pages.
