### PR TITLE
Jetpack Pro Dashboard: Remove the email checkbox from downtime monitoring notification settings

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -7,17 +7,13 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import type {
-	MonitorSettingsEmail,
 	AllowedMonitorContactActions,
+	StateMonitorSettingsEmail,
 } from '../../sites-overview/types';
-interface StateEmailItem extends MonitorSettingsEmail {
-	checked: boolean;
-	isDefault?: boolean;
-}
 
 interface Props {
 	toggleModal: () => void;
-	selectedEmail?: StateEmailItem;
+	selectedEmail?: StateMonitorSettingsEmail;
 	selectedAction?: AllowedMonitorContactActions;
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-item-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-item-content.tsx
@@ -15,7 +15,7 @@ interface Props {
 	toggleModal: ( item?: StateMonitorSettingsEmail, action?: AllowedMonitorContactActions ) => void;
 }
 
-export default function SelectEmailCheckbox( { item, toggleModal }: Props ) {
+export default function EmailItemContent( { item, toggleModal }: Props ) {
 	const translate = useTranslate();
 
 	const [ isOpen, setIsOpen ] = useState( false );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { Icon, plus } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import SelectEmailCheckbox from './select-email-checkbox';
+import EmailItemContent from './email-item-content';
 import type {
 	MonitorSettingsEmail,
 	StateMonitorSettingsEmail,
@@ -44,7 +44,7 @@ export default function ConfigureEmailNotification( {
 	return (
 		<div className="configure-email-address__card-container">
 			{ allEmailItems.map( ( item ) => (
-				<SelectEmailCheckbox key={ item.email } item={ item } toggleModal={ toggleModal } />
+				<EmailItemContent key={ item.email } item={ item } toggleModal={ toggleModal } />
 			) ) }
 			<Button
 				compact

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -33,15 +33,10 @@ export default function ConfigureEmailNotification( {
 			const defaultEmailItems = defaultEmailAddresses.map( ( email ) => ( {
 				email,
 				name: 'Default Email', //FIXME: This should be dynamic.
-				checked: true,
 				isDefault: true,
 				verified: true,
 			} ) );
-			const addedEmailItems = addedEmailAddresses.map( ( email ) => ( {
-				...email,
-				checked: email.verified, // Checked only if the email is verified.
-			} ) );
-			setAllEmailItems( [ ...defaultEmailItems, ...addedEmailItems ] );
+			setAllEmailItems( [ ...defaultEmailItems, ...addedEmailAddresses ] );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -49,13 +49,7 @@ export default function ConfigureEmailNotification( {
 	return (
 		<div className="configure-email-address__card-container">
 			{ allEmailItems.map( ( item ) => (
-				<SelectEmailCheckbox
-					key={ item.email }
-					item={ item }
-					toggleModal={ toggleModal }
-					allEmailItems={ allEmailItems }
-					setAllEmailItems={ setAllEmailItems }
-				/>
+				<SelectEmailCheckbox key={ item.email } item={ item } toggleModal={ toggleModal } />
 			) ) }
 			<Button
 				compact

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/select-email-checkbox.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/select-email-checkbox.tsx
@@ -1,5 +1,4 @@
 import { Card, Button } from '@automattic/components';
-import { CheckboxControl } from '@wordpress/components';
 import { Icon, pencil, moreHorizontal } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
@@ -14,16 +13,9 @@ import type {
 interface Props {
 	item: StateMonitorSettingsEmail;
 	toggleModal: ( item?: StateMonitorSettingsEmail, action?: AllowedMonitorContactActions ) => void;
-	allEmailItems: Array< StateMonitorSettingsEmail >;
-	setAllEmailItems: ( emailAddresses: Array< StateMonitorSettingsEmail > ) => void;
 }
 
-export default function SelectEmailCheckbox( {
-	item,
-	toggleModal,
-	allEmailItems,
-	setAllEmailItems,
-}: Props ) {
+export default function SelectEmailCheckbox( { item, toggleModal }: Props ) {
 	const translate = useTranslate();
 
 	const [ isOpen, setIsOpen ] = useState( false );
@@ -40,106 +32,76 @@ export default function SelectEmailCheckbox( {
 
 	const showVerified = true; // FIXME: This should be dynamic.
 
-	const handleOnChange = ( checked: boolean ) => {
-		if ( item.isDefault ) {
-			return;
-			// FIXME: We need to show a custom error message here or a tooltip.
-		}
-		if ( ! item.verified ) {
-			return;
-			// FIXME: We can open the verification modal here.
-		}
-		const updatedEmailItems = allEmailItems.map( ( emailItem ) => {
-			if ( emailItem.email === item.email ) {
-				return {
-					...emailItem,
-					checked,
-				};
-			}
-			return emailItem;
-		} );
-		setAllEmailItems( updatedEmailItems );
-	};
-
 	const handleToggleModal = ( action: AllowedMonitorContactActions ) => {
 		toggleModal( item, action );
 	};
 
-	const checkboxContent = (
-		<div className="configure-email-address__checkbox-content-container">
-			<span className="configure-email-address__checkbox-content">
-				<div className="configure-email-address__checkbox-heading">{ item.email }</div>
-				<div className="configure-email-address__checkbox-sub-heading">{ item.name }</div>
-			</span>
-			{ ! item.isDefault && (
-				<>
-					{ ! item.verified && (
-						<span
-							role="button"
-							tabIndex={ 0 }
-							onKeyPress={ () => handleToggleModal( 'verify' ) }
-							onClick={ () => handleToggleModal( 'verify' ) }
-							className="configure-email-address__verification-status cursor-pointer"
-						>
-							<Badge type="warning">{ translate( 'Pending' ) }</Badge>
-						</span>
-					) }
-					{ showVerified && item.verified && (
-						<span className="configure-email-address__verification-status">
-							<Badge type="success">{ translate( 'Verified' ) }</Badge>
-						</span>
-					) }
-					{ item.verified ? (
-						<Button
-							compact
-							borderless
-							className="configure-email-address__edit-icon"
-							onClick={ () => handleToggleModal( 'edit' ) }
-							aria-label={ translate( 'Edit email address' ) }
-						>
-							<Icon size={ 18 } icon={ pencil } />
-						</Button>
-					) : (
-						<>
+	return (
+		<Card className="configure-email-address__card" key={ item.email } compact>
+			<div className="configure-email-address__card-content-container">
+				<span className="configure-email-address__card-content">
+					<div className="configure-email-address__card-heading">{ item.email }</div>
+					<div className="configure-email-address__card-sub-heading">{ item.name }</div>
+				</span>
+				{ ! item.isDefault && (
+					<>
+						{ ! item.verified && (
+							<span
+								role="button"
+								tabIndex={ 0 }
+								onKeyPress={ () => handleToggleModal( 'verify' ) }
+								onClick={ () => handleToggleModal( 'verify' ) }
+								className="configure-email-address__verification-status cursor-pointer"
+							>
+								<Badge type="warning">{ translate( 'Pending' ) }</Badge>
+							</span>
+						) }
+						{ showVerified && item.verified && (
+							<span className="configure-email-address__verification-status">
+								<Badge type="success">{ translate( 'Verified' ) }</Badge>
+							</span>
+						) }
+						{ item.verified ? (
 							<Button
 								compact
 								borderless
 								className="configure-email-address__edit-icon"
-								onClick={ showActions }
-								aria-label={ translate( 'More actions' ) }
-								ref={ buttonActionRef }
+								onClick={ () => handleToggleModal( 'edit' ) }
+								aria-label={ translate( 'Edit email address' ) }
 							>
-								<Icon size={ 18 } icon={ moreHorizontal } />
+								<Icon size={ 18 } icon={ pencil } />
 							</Button>
-							<PopoverMenu
-								className="configure-email-address__popover-menu"
-								context={ buttonActionRef.current }
-								isVisible={ isOpen }
-								onClose={ closeDropdown }
-								position="bottom left"
-							>
-								<PopoverMenuItem onClick={ () => handleToggleModal( 'verify' ) }>
-									{ translate( 'Verify' ) }
-								</PopoverMenuItem>
-								<PopoverMenuItem onClick={ () => handleToggleModal( 'edit' ) }>
-									{ translate( 'Edit' ) }
-								</PopoverMenuItem>
-							</PopoverMenu>
-						</>
-					) }
-				</>
-			) }
-		</div>
-	);
-
-	return (
-		<Card className="configure-email-address__card" key={ item.email } compact>
-			<CheckboxControl
-				className="configure-email-address__checkbox"
-				checked={ item.checked }
-				onChange={ handleOnChange }
-				label={ checkboxContent }
-			/>
+						) : (
+							<>
+								<Button
+									compact
+									borderless
+									className="configure-email-address__edit-icon"
+									onClick={ showActions }
+									aria-label={ translate( 'More actions' ) }
+									ref={ buttonActionRef }
+								>
+									<Icon size={ 18 } icon={ moreHorizontal } />
+								</Button>
+								<PopoverMenu
+									className="configure-email-address__popover-menu"
+									context={ buttonActionRef.current }
+									isVisible={ isOpen }
+									onClose={ closeDropdown }
+									position="bottom left"
+								>
+									<PopoverMenuItem onClick={ () => handleToggleModal( 'verify' ) }>
+										{ translate( 'Verify' ) }
+									</PopoverMenuItem>
+									<PopoverMenuItem onClick={ () => handleToggleModal( 'edit' ) }>
+										{ translate( 'Edit' ) }
+									</PopoverMenuItem>
+								</PopoverMenu>
+							</>
+						) }
+					</>
+				) }
+			</div>
 		</Card>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
@@ -12,13 +12,14 @@ $help-text-color: #757575;
 	padding: 16px !important;
 }
 
-.configure-email-address__checkbox-content-container {
+.configure-email-address__card-content-container {
 	display: flex;
 	align-items: center;
 	gap: 4px;
+	width: 100%;
 }
 
-.configure-email-address__checkbox-content {
+.configure-email-address__card-content {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -27,10 +28,9 @@ $help-text-color: #757575;
 }
 
 .configure-email-address__verification-status {
-	margin-right: 42px;
+	margin-right: 24px;
 
 	.badge {
-		line-height: 14px;
 		font-size: 0.75rem;
 	}
 }
@@ -45,25 +45,6 @@ button.configure-email-address__edit-icon {
 	padding: 4px !important;
 }
 
-.configure-email-address__checkbox {
-	width: 100%;
-
-	.components-checkbox-control__input:checked {
-		background: var(--studio-gray-80);
-		border-color: var(--studio-gray-80);
-	}
-
-	.components-checkbox-control__label {
-		font-weight: 500;
-		min-width: 95%;
-	}
-
-	.components-base-control__field {
-		margin-bottom: 0;
-		display: flex;
-		align-items: center;
-	}
-}
 
 .handle-overflow {
 	white-space: nowrap;
@@ -71,7 +52,7 @@ button.configure-email-address__edit-icon {
 	text-overflow: ellipsis;
 }
 
-.configure-email-address__checkbox-heading {
+.configure-email-address__card-heading {
 	@extend .handle-overflow;
 	font-weight: 500;
 	font-size: 0.875rem;
@@ -79,7 +60,7 @@ button.configure-email-address__edit-icon {
 	color: var(--studio-gray-100);
 }
 
-.configure-email-address__checkbox-sub-heading {
+.configure-email-address__card-sub-heading {
 	@extend .handle-overflow;
 	font-weight: 400;
 	font-size: 0.75rem;

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
@@ -28,7 +28,7 @@ $help-text-color: #757575;
 }
 
 .configure-email-address__verification-status {
-	margin-right: 24px;
+	margin-inline-end: 24px;
 
 	.badge {
 		font-size: 0.75rem;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -267,7 +267,6 @@ export interface MonitorSettingsEmail {
 }
 
 export interface StateMonitorSettingsEmail extends MonitorSettingsEmail {
-	checked: boolean;
 	isDefault?: boolean;
 }
 


### PR DESCRIPTION
Related to 1204408201748644-as-1204610622637468

## Proposed Changes

This PR removes the checkbox for email selection from the downtime monitoring notification settings popup.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/add-email-validation-ui` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Verify that the default email is shown and no checkbox appears on the card.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

<img width="443" alt="Screenshot 2023-05-17 at 12 49 46 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6a979d96-db8d-415a-86f2-77408de9fd23">

</td>
<td>

<img width="443" alt="Screenshot 2023-05-17 at 12 41 15 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/13b8f781-1929-46a9-bb4d-1201fe8a4f02">

</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?