### PR TITLE
A11Y: Improve site setup cards

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -279,7 +279,11 @@ const SiteSetupList = ( {
 						const isCompleted = task.isCompleted;
 
 						return (
-							<li key={ task.id } className={ `site-setup-list__task-${ task.id }` }>
+							<li
+								key={ task.id }
+								className={ `site-setup-list__task-${ task.id }` }
+								role="presentation"
+							>
 								<NavItem
 									key={ task.id }
 									taskId={ task.id }


### PR DESCRIPTION
The site setup cards were being flagged by accessibility linters for having nested focusable elements inside a `tablist`. This change makes the quick but pragmatic approach of making the outer element (li) unfocusable while leaving the inner element (button) focusable.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/75588

## Proposed Changes

*

## Testing Instructions
 1. Open /home page, you should see a site setup list 
   * If you don't see a site setup list then you might need a new site that has completed launchpad 
 2. Run an accessibility checking tool (like axe DevTools Chrome extension) or inspect the site setup list.

Results:
 * Accessibility rule-checking tools shouldn't find any errors related to nested focusable elements on the site setup list
 * The site setup list should allow you to tab through the tabs and use enter/space to activate the tab changing the panel to the left

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
