### PR TITLE
Add config event to Akismet GA4 implementation

### DIFF
--- a/client/lib/analytics/ad-tracking/google-analytics-4.ts
+++ b/client/lib/analytics/ad-tracking/google-analytics-4.ts
@@ -39,7 +39,7 @@ export function fireEcommercePurchase( purchase: GaPurchase, ga4PropertyGtag: Ga
 
 export function fireEcommerceAddToCart( item: GaItem, ga4PropertyGtag: Ga4PropertyGtag ) {
 	window.gtag( 'event', 'add_to_cart', {
-		send_to: Ga4PropertyGtag[ ga4PropertyGtag ],
+		send_to: ga4Properties[ ga4PropertyGtag ],
 		value: item.price,
 		currency: 'USD',
 		items: [ item ],

--- a/client/lib/analytics/ad-tracking/google-analytics-4.ts
+++ b/client/lib/analytics/ad-tracking/google-analytics-4.ts
@@ -1,3 +1,4 @@
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { GaPurchase } from '../utils/cart-to-ga-purchase';
 import { GaItem } from '../utils/product-to-ga-item';
@@ -23,6 +24,9 @@ export function setup( params: Gtag.ConfigParams ) {
 
 	if ( isJetpackCloud() ) {
 		window.gtag( 'config', TRACKING_IDS.jetpackGoogleGA4Gtag, params );
+	}
+	if ( isAkismetCheckout() ) {
+		window.gtag( 'config', TRACKING_IDS.akismetGoogleGA4Gtag, params );
 	}
 }
 

--- a/client/lib/analytics/ad-tracking/google-analytics.js
+++ b/client/lib/analytics/ad-tracking/google-analytics.js
@@ -1,4 +1,5 @@
 import { getCurrentUser } from '@automattic/calypso-analytics';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getGaGtag } from '../utils/get-ga-gtag';
 import * as GA4 from './google-analytics-4';
@@ -28,7 +29,10 @@ export function getGoogleAnalyticsDefaultConfig() {
 		custom_map: {
 			dimension3: 'client_id',
 		},
-		linker: isJetpackCloud() ? { domains: [ 'wordpress.com' ] } : { accept_incoming: true },
+		linker:
+			isJetpackCloud() || isAkismetCheckout()
+				? { domains: [ 'wordpress.com' ] }
+				: { accept_incoming: true },
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes

While investigating and fixing broken CPC medium conversions for Akismet checkout, I improve the configuration of GA4 on the site by adding a `config` event, analogically to the implementation of WPCOM/Jetpack.

## Testing Instructions

* Checkout the PR
* Go to `http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_1?flags=ad-tracking,cookie-banner`
* Enable analytics console logs `localStorage.setItem( 'debug', 'calypso:analytics:*' );`, accept cookie banner if in EU/CCPA region, and refresh the page
* See that the config event fired off for the Akismet GA4 property:

```
  {
    "0": "config",
    "1": "G-V8X5PZE9F8",
    "2": {
      "send_page_view": false,
      "user_id": "71d4dd502600d517112c99a044b54e75c77f36281f2aa1982780a6fe0379aea2",
      "anonymize_ip": true,
      "transport_type": "beacon",
      "use_amp_client_id": true,
      "custom_map": {
        "dimension3": "client_id"
      },
      "linker": { 
        "domains": [
          "wordpress.com"
        ],
      },
    }
  },
```
