### PR TITLE
Add CSS for focus of Buttons on Posts Categories (/settings/taxonomies/category)

### DIFF
--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -97,6 +97,14 @@
 		}
 	}
 
+	span[role="button"],
+	.button {
+		&:focus-visible,
+		&:focus {
+			box-shadow: inset 0 0 0 2px var(--color-primary-light);
+		}
+	}
+
 	.taxonomy-manager__count {
 		margin: auto;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related #76930 #75596

## Proposed Changes

* Add css for focus of buttons

Because the previous PR #76930 didn't add the CSS

|BEFORE|AFTER|
|---|---|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/e2b8713b-3247-4ff0-b78b-932e4d5ff583.mp4" />|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/49874c25-d208-4bf7-8697-7b8559dcba91.mp4" />|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `wordpress.com/settings/taxonomies/category/{ SITE SLUG }`
* Navigate the category list with the keyboard to verify you see a blue border around the cells 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
