### PR TITLE
Subscriptions Management: Add "Cancel subscription" button handling

### DIFF
--- a/client/landing/subscriptions/components/notice/style.scss
+++ b/client/landing/subscriptions/components/notice/style.scss
@@ -17,9 +17,10 @@
 		}
 
 		&-content {
-			font-size: $font-body;
+			font-size: $font-body-small;
 			line-height: $font-title-small;
 			letter-spacing: -0.15px;
+			color: $studio-gray-80;
 		}
 
 		&-close {

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -1,5 +1,5 @@
 import { Gridicon } from '@automattic/components';
-import { Reader } from '@automattic/data-stores';
+import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -38,6 +38,9 @@ const SiteSubscriptionPage = () => {
 		deliveryFrequency,
 		subscribers,
 	} = data;
+
+	const { mutate: unsubscribe, isLoading: unsubscribing } =
+		SubscriptionManager.useSiteUnsubscribeMutation();
 
 	if ( ! blogId || isError ) {
 		return <div>Something went wrong.</div>;
@@ -86,7 +89,12 @@ const SiteSubscriptionPage = () => {
 
 					<hr className="subscriptions__separator" />
 
-					<Button className="site-subscription-page__unsubscribe-button" isSecondary>
+					<Button
+						className="site-subscription-page__unsubscribe-button"
+						isSecondary
+						onClick={ () => unsubscribe( { blog_id: blogId, url: data.siteUrl } ) }
+						disabled={ unsubscribing }
+					>
 						{ translate( 'Cancel subscription' ) }
 					</Button>
 				</div>

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -15,7 +15,7 @@ const useSiteSubscription = ( blogId?: string ) => ( {
 	data: {
 		siteName: 'The Atavist Magazine',
 		subscribers: 44109166,
-		siteUrl: 'https://theatavistmagazine.wordpress.com/',
+		siteUrl: 'https://ivanthemetest.wordpress.com/',
 		notifyMeOfNewPosts: true,
 		emailMeNewPosts: true,
 		deliveryFrequency: Reader.EmailDeliveryFrequency.Daily,

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -2,6 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { SiteIcon } from 'calypso/landing/subscriptions/components/site-icon';
@@ -38,6 +39,7 @@ const SiteSubscriptionPage = () => {
 		deliveryFrequency,
 		subscribers,
 	} = data;
+	const [ showSettings, setShowSettings ] = useState( true );
 
 	const { mutate: unsubscribe, isLoading: unsubscribing } =
 		SubscriptionManager.useSiteUnsubscribeMutation();
@@ -50,6 +52,11 @@ const SiteSubscriptionPage = () => {
 		// Full page Wordpress logo loader
 		return <div>Loading...</div>;
 	}
+
+	const handleUnsubscribe: () => void = () => {
+		setShowSettings( false );
+		unsubscribe( { blog_id: blogId, url: data.siteUrl } );
+	};
 
 	const subHeaderText =
 		subscribers > 1
@@ -79,24 +86,28 @@ const SiteSubscriptionPage = () => {
 						<FormattedHeader brandFont headerText={ siteName } subHeaderText={ subHeaderText } />
 					</header>
 
-					<SiteSubscriptionSettings
-						blogId={ blogId }
-						notifyMeOfNewPosts={ notifyMeOfNewPosts }
-						emailMeNewPosts={ emailMeNewPosts }
-						deliveryFrequency={ deliveryFrequency }
-						emailMeNewComments={ emailMeNewComments }
-					/>
+					{ showSettings && (
+						<>
+							<SiteSubscriptionSettings
+								blogId={ blogId }
+								notifyMeOfNewPosts={ notifyMeOfNewPosts }
+								emailMeNewPosts={ emailMeNewPosts }
+								deliveryFrequency={ deliveryFrequency }
+								emailMeNewComments={ emailMeNewComments }
+							/>
 
-					<hr className="subscriptions__separator" />
+							<hr className="subscriptions__separator" />
 
-					<Button
-						className="site-subscription-page__unsubscribe-button"
-						isSecondary
-						onClick={ () => unsubscribe( { blog_id: blogId, url: data.siteUrl } ) }
-						disabled={ unsubscribing }
-					>
-						{ translate( 'Cancel subscription' ) }
-					</Button>
+							<Button
+								className="site-subscription-page__unsubscribe-button"
+								isSecondary
+								onClick={ () => handleUnsubscribe() }
+								disabled={ unsubscribing }
+							>
+								{ translate( 'Cancel subscription' ) }
+							</Button>
+						</>
+					) }
 				</div>
 			</div>
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/76981.

## Proposed Changes

* Attach the `Cancel subscription` button to the `useSiteUnsubscribeMutation` (handles both external and logged-in users).
* Introduce the `showSettings` state that sets to `false` when the unsubscribe mutation is successful. This is planned to be set to `true` on successful resubscribes (that will then make the settings visible again).
* Fix `Notice` component styling to match with the original Figma design (inDLaEQV8jJ21O4WXawIsJ-fi-1195_17698).

ℹ️ Please note the following:
- The PR does not implement the Notice's close `X` button as it didn't make sense to me to have it there. Closing the Notice would result in a page with no action available to the user (apart from navigating to the page with all Subscriptions).
- The subsequent PR will implement the `Resubscribe` button / link.

## Testing Instructions

### Testing as an external user
1. Check out the PR and build the app.
2. Authenticate as an external user (`subkey` "dance" in the incognito browser window).
3. Make sure your external user is subscribed to some sites already.
4. Navigate to `http://calypso.localhost:3000/subscriptions/site/[blog_id]` where `[blog_id]` needs to be replaced with a specific blog ID your user is subscribed to.
5. When the page loads, you should be able to click on the "Cancel subscription" button on the bottom of the page.
6. Once the button is clicked, the user should be unsubscribed from the site (this can be checked at https://wordpress.com/subscriptions/sites), the settings should be hidden and the success notice should display:

![Markup on 2023-05-17 at 13:12:26](https://github.com/Automattic/wp-calypso/assets/25105483/383fe80c-ac9c-4bbb-a9bf-aacc3900c40a)

### Testing as an logged-in user
1. Check out the PR.
2. Navigate to `client/server/pages/index.js` and temporarily add `return next();` to the line `833`:

![Markup on 2023-04-28 at 17:50:44](https://user-images.githubusercontent.com/25105483/235195033-4902bb9d-db57-43a4-b295-2d90feb6731f.png)

3. Navigate to `client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx` and replace the siteAddress with the address of the site you are trying to unsubscribe from:

![Markup on 2023-05-17 at 13:11:00](https://github.com/Automattic/wp-calypso/assets/25105483/2d479438-2229-43c1-bc7b-5fd4b9ade4b9)

4. Build the app.
5. Log in to a test WordPress.com account that has some existing Site subscriptions.
6. Navigate to `http://calypso.localhost:3000/subscriptions/site/[blog_id]` where `[blog_id]` needs to be replaced with a specific blog ID your user is subscribed to.
7. When the page loads, you should be able to click on the "Cancel subscription" button on the bottom of the page.
8. Once the button is clicked, the user should be unsubscribed from the site (this can be checked at https://wordpress.com/subscriptions/sites), the settings should be hidden and the success notice should display:

![Markup on 2023-05-17 at 13:12:26](https://github.com/Automattic/wp-calypso/assets/25105483/383fe80c-ac9c-4bbb-a9bf-aacc3900c40a)

### Testing mutation error state
1. Follow the steps as above, but instead of navigating to `http://calypso.localhost:3000/subscriptions/site/[blog_id]` with correct `[blog_id]` used, replace it with non-existent one, e.g. `http://calypso.localhost:3000/subscriptions/site/hello-folks`.
2. Clicking the "Cancel subscription" button should result in an error message:

![Markup on 2023-05-17 at 13:13:35](https://github.com/Automattic/wp-calypso/assets/25105483/da15b0c2-35db-4138-a117-74a726b4d08a)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?