### PR TITLE
Category updates - Remove the category featured from all patterns because the editor crashes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -104,18 +104,15 @@ class Block_Patterns_From_API {
 
 			// Register categories (and re-register existing categories).
 			foreach ( (array) $pattern_categories as $slug => &$category_properties ) {
-				// Repurpose categories.
-				if ( 'featured' === $slug ) {
-					$category_properties['label']       = __( 'All', 'full-site-editing' );
-					$category_properties['description'] = __( 'Explore all patterns.', 'full-site-editing' );
-				} elseif ( 'posts' === $slug ) {
+				// Update the Posts category label to Blog Posts.
+				if ( 'posts' === $slug ) {
 					$category_properties['label']       = __( 'Blog Posts', 'full-site-editing' );
 					$category_properties['description'] = __( 'Display your latest posts in lists, grids or other layouts.', 'full-site-editing' );
 				}
 				register_block_pattern_category( $slug, $category_properties );
 			}
 
-			foreach ( (array) $block_patterns as $pattern ) {
+			foreach ( (array) $block_patterns as &$pattern ) {
 				if ( $this->can_register_pattern( $pattern ) ) {
 					$is_premium = isset( $pattern['pattern_meta']['is_premium'] ) ? boolval( $pattern['pattern_meta']['is_premium'] ) : false;
 
@@ -125,6 +122,13 @@ class Block_Patterns_From_API {
 					$viewport_width = $viewport_width < 320 ? 320 : $viewport_width;
 					$pattern_name   = self::PATTERN_NAMESPACE . $pattern['name'];
 					$block_types    = $this->utils->maybe_get_pattern_block_types_from_pattern_meta( $pattern );
+
+					// The API /ptk/patterns/ adds all patterns to the category Featured because it's reused as All.
+					// Here we remove the category from All patterns because the editor crashes
+					// when rendering all patterns in the background.
+					if ( array_key_exists( 'featured', $pattern['categories'] ) ) {
+						unset( $pattern['categories']['featured'] );
+					}
 
 					$results[ $pattern_name ] = register_block_pattern(
 						$pattern_name,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76834 #76580

## Proposed Changes

* Revert changes that updated the label and description of the category `Featured`
* Remove the category `Featured` (`All`) from all patterns only in the editor not in the assembler

These changes avoid a crash in the editor because all patterns in Dotcom patterns are rendered in the background when exploring the category `All`. We don't have this issue in the assembler because we only load the patterns in the view. I'll follow up by opening an [issue](https://github.com/WordPress/gutenberg/issues/50695) in Gutenberg. 

|BEFORE|AFTER|
|----|---|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/24ca7db1-cd84-4644-8e3b-bc26dac33ab4.mp4" />|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/c15961da-7800-4677-a982-643329c7142d.mp4"/>|





## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Install the ETK plugin from this branch

**Test on Simple sites**

* Sandbox your site
* Run `install-plugin.sh etk fix/remove-category-all-from-all-patterns-in-editor`
* Don't forget to revert the ETK after testing with `install-plugin.sh etk --revert`

**Test on Atomic sites**

* Download the ETK plugin zip from Teamcity
* Upload it to an Atomic site and activate it


### Verify the changes
On Simple sites or Atomic sites when the ETK plugin is activated:

- Verify that you don't see the `All` category on the editor
- Verify that you see the `Featured` category if your active theme adds patterns on that category. For instance if your theme is `Storia` you should see three patterns in the `Featured` category but if your theme is `Blank canvas 3` you should not see it at all. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
