### PR TITLE
Subscription Management: Temporarily disable comment count on navigation menu.

### DIFF
--- a/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
@@ -43,7 +43,7 @@ const TabsSwitcher = () => {
 
 					<NavItem
 						onClick={ () => navigate( commentsPath ) }
-						count={ counts?.comments || undefined }
+						count={ undefined /* temporarily disable inaccurate comments count */ }
 						selected={ pathname.startsWith( commentsPath ) }
 					>
 						{ translate( 'Comments' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76227

## Proposed Changes

Temporarily disable comment counts on the navigation menu of Subscription Management until it is fixed (which will take awhile as the comment subscriptions table needs to be cleaned up). Context: p1684320981597919-slack-C02TCEHP3HA

## Testing Instructions

1. Apply this PR.
2. In the file `client/server/pages/index.js`, add this in line number 883:
<img width="634" alt="Screenshot 2023-05-16 at 14 40 25" src="https://github.com/Automattic/wp-calypso/assets/3832570/852f5c59-8685-4704-8c4b-9739ea7cd228">
3. Go to `http://calypso.localhost:3000/subscriptions`.
4. The comment count should not appear on the navigation menu.

<img width="765" alt="2023-05-17_16-30-01" src="https://github.com/Automattic/wp-calypso/assets/1287077/ba9bf398-dd27-45e9-8516-e973f6503e71">
<img width="765" alt="2023-05-17_16-30-48" src="https://github.com/Automattic/wp-calypso/assets/1287077/9ec05543-324e-48ff-93e8-4ef47277b8cf">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?