### PR TITLE
Reader: Pass size to receivePosts

### DIFF
--- a/client/state/reader/related-posts/actions.js
+++ b/client/state/reader/related-posts/actions.js
@@ -19,6 +19,7 @@ export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL, size = 2
 				siteId,
 				postId,
 				scope,
+				size,
 			},
 		} );
 
@@ -44,7 +45,7 @@ export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL, size = 2
 			( response ) => {
 				dispatch( {
 					type: READER_RELATED_POSTS_REQUEST_SUCCESS,
-					payload: { siteId, postId, scope },
+					payload: { siteId, postId, scope, size },
 				} );
 
 				// collect posts and dispatch
@@ -55,6 +56,7 @@ export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL, size = 2
 							siteId,
 							postId,
 							scope,
+							size,
 							posts: ( response && response.posts ) || [],
 						},
 					} );
@@ -63,7 +65,7 @@ export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL, size = 2
 			( err ) => {
 				dispatch( {
 					type: READER_RELATED_POSTS_REQUEST_FAILURE,
-					payload: { siteId, postId, scope, error: err },
+					payload: { siteId, postId, scope, size, error: err },
 					error: true,
 				} );
 
@@ -73,6 +75,7 @@ export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL, size = 2
 						siteId,
 						postId,
 						scope,
+						size,
 						posts: [],
 					},
 				} );

--- a/client/state/reader/related-posts/reducer.js
+++ b/client/state/reader/related-posts/reducer.js
@@ -8,10 +8,10 @@ import { combineReducers } from 'calypso/state/utils';
 import { key } from './utils';
 
 function setStateForKey( state, action, val ) {
-	const { siteId, postId, scope } = action.payload;
+	const { siteId, postId, scope, size } = action.payload;
 	return {
 		...state,
-		[ key( siteId, postId, scope ) ]: val,
+		[ key( siteId, postId, scope, size ) ]: val,
 	};
 }
 

--- a/client/state/reader/related-posts/test/actions.js
+++ b/client/state/reader/related-posts/test/actions.js
@@ -46,6 +46,7 @@ describe( 'actions', () => {
 					siteId: 1,
 					postId: 1,
 					scope: 'all',
+					size: 2,
 				},
 			} );
 		} );
@@ -58,6 +59,7 @@ describe( 'actions', () => {
 					siteId: 1,
 					postId: 1,
 					scope: 'all',
+					size: 2,
 					posts: [
 						{
 							ID: 1,
@@ -77,6 +79,7 @@ describe( 'actions', () => {
 					siteId: 1,
 					postId: 1,
 					scope: 'all',
+					size: 2,
 				},
 			} );
 		} );
@@ -106,6 +109,7 @@ describe( 'actions', () => {
 					siteId: 1,
 					postId: 1,
 					scope: 'all',
+					size: 2,
 				},
 			} );
 		} );
@@ -118,6 +122,7 @@ describe( 'actions', () => {
 					siteId: 1,
 					postId: 1,
 					scope: 'all',
+					size: 2,
 					posts: [],
 				},
 			} );
@@ -131,6 +136,7 @@ describe( 'actions', () => {
 					siteId: 1,
 					postId: 1,
 					scope: 'all',
+					size: 2,
 					error: expect.any( Error ),
 				},
 				error: true,

--- a/client/state/reader/related-posts/test/reducer.js
+++ b/client/state/reader/related-posts/test/reducer.js
@@ -83,7 +83,7 @@ describe( 'queuedRequests', () => {
 		expect(
 			queuedRequests(
 				{
-					'1-1-all-2': true,
+					'1-1-all-5': true,
 				},
 				{
 					type: READER_RELATED_POSTS_REQUEST_SUCCESS,

--- a/client/state/reader/related-posts/test/reducer.js
+++ b/client/state/reader/related-posts/test/reducer.js
@@ -16,12 +16,19 @@ describe( 'items', () => {
 					payload: {
 						siteId: 1,
 						postId: 1,
-						posts: [ { global_ID: 2 }, { global_ID: 3 }, { global_ID: 4 } ],
+						size: 5,
+						posts: [
+							{ global_ID: 2 },
+							{ global_ID: 3 },
+							{ global_ID: 4 },
+							{ global_ID: 5 },
+							{ global_ID: 6 },
+						],
 					},
 				}
 			)
 		).toEqual( {
-			'1-1-all-2': [ 2, 3, 4 ],
+			'1-1-all-5': [ 2, 3, 4, 5, 6 ],
 		} );
 	} );
 
@@ -29,19 +36,26 @@ describe( 'items', () => {
 		expect(
 			items(
 				{
-					'1-1-all-2': [ 2, 3, 4 ],
+					'1-1-all-5': [ 2, 3, 4, 5, 6 ],
 				},
 				{
 					type: READER_RELATED_POSTS_RECEIVE,
 					payload: {
 						siteId: 1,
 						postId: 1,
-						posts: [ { global_ID: 3 }, { global_ID: 4 }, { global_ID: 9 } ],
+						size: 5,
+						posts: [
+							{ global_ID: 3 },
+							{ global_ID: 4 },
+							{ global_ID: 9 },
+							{ global_ID: 10 },
+							{ global_ID: 11 },
+						],
 					},
 				}
 			)
 		).toEqual( {
-			'1-1-all-2': [ 3, 4, 9 ],
+			'1-1-all-5': [ 3, 4, 9, 10, 11 ],
 		} );
 	} );
 } );
@@ -56,11 +70,12 @@ describe( 'queuedRequests', () => {
 					payload: {
 						siteId: 1,
 						postId: 1,
+						size: 5,
 					},
 				}
 			)
 		).toEqual( {
-			'1-1-all-2': true,
+			'1-1-all-5': true,
 		} );
 	} );
 
@@ -75,11 +90,12 @@ describe( 'queuedRequests', () => {
 					payload: {
 						siteId: 1,
 						postId: 1,
+						size: 5,
 					},
 				}
 			)
 		).toEqual( {
-			'1-1-all-2': false,
+			'1-1-all-5': false,
 		} );
 	} );
 
@@ -92,11 +108,12 @@ describe( 'queuedRequests', () => {
 					payload: {
 						siteId: 1,
 						postId: 1,
+						size: 5,
 					},
 				}
 			)
 		).toEqual( {
-			'1-1-all-2': false,
+			'1-1-all-5': false,
 		} );
 	} );
 } );


### PR DESCRIPTION
This is a follow up to https://github.com/Automattic/wp-calypso/pull/76891

This passes the size to `receivePosts`. If we pass a size other than the default of 2, the state isn't updated.

This PR updates tests to use non-default size of 5.