### PR TITLE
Blog onboarding: Applying selected free domain after user selection

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -88,7 +88,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 			setDomainCartItem( domainCartItem );
 		}
 
-		submit?.( { freeDomain: suggestion?.is_free } );
+		submit?.( { freeDomain: suggestion?.is_free, domainName: suggestion?.domain_name } );
 	};
 
 	const getStartWritingFlowStepContent = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -52,6 +52,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	const onSkip = async () => {
 		if ( isStartWritingFlow ) {
 			setDomain( null );
+			setDomainCartItem( undefined );
 			setHideFreePlan( false );
 			submit?.( { freeDomain: true } );
 		} else {

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -12,6 +12,7 @@ import {
 	Flow,
 	ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { freeSiteAddressType } from 'calypso/lib/domains/constants';
@@ -71,6 +72,7 @@ const startWriting: Flow = {
 			( select ) => select( ONBOARD_STORE ) as OnboardSelect,
 			[]
 		).getState();
+		const site = useSite();
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );
@@ -128,7 +130,7 @@ const startWriting: Flow = {
 
 						if ( providedDependencies?.domainName ) {
 							await requestSiteAddressChange(
-								state.selectedSite,
+								site?.ID,
 								newDomainName,
 								'wordpress.com',
 								siteSlug,

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -117,12 +117,6 @@ const startWriting: Flow = {
 					return navigate( 'launchpad' );
 				}
 				case 'domains':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, {
-							checklist_statuses: { domain_upsell_deferred: true },
-						} );
-					}
-
 					if ( providedDependencies?.freeDomain ) {
 						const freeDomainSuffix = '.wordpress.com';
 						const newDomainName = String( providedDependencies?.domainName ).replace(
@@ -130,25 +124,31 @@ const startWriting: Flow = {
 							''
 						);
 
-						requestSiteAddressChange(
-							selectedSiteId,
-							newDomainName,
-							'wordpress.com',
-							siteSlug,
-							freeSiteAddressType.BLOG,
-							true,
-							false
-						)( dispatch, state );
+						if ( providedDependencies?.domainName ) {
+							await requestSiteAddressChange(
+								selectedSiteId,
+								newDomainName,
+								'wordpress.com',
+								siteSlug,
+								freeSiteAddressType.BLOG,
+								true,
+								false
+							)( dispatch, state );
+						}
+
+						const currentSiteSlug = String( providedDependencies?.domainName ?? siteSlug );
 
 						await replaceProductsInCart(
-							siteSlug as string,
+							currentSiteSlug as string,
 							[ getPlanCartItem() ].filter( Boolean ) as MinimalRequestCartProduct[]
 						);
 
+						await updateLaunchpadSettings( currentSiteSlug, {
+							checklist_statuses: { domain_upsell_deferred: true },
+						} );
+
 						return window.location.assign(
-							`/setup/start-writing/launchpad?siteSlug=${ encodeURIComponent(
-								newDomainName + freeDomainSuffix
-							) }`
+							`/setup/start-writing/launchpad?siteSlug=${ currentSiteSlug }`
 						);
 					}
 

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -117,6 +117,12 @@ const startWriting: Flow = {
 					return navigate( 'launchpad' );
 				}
 				case 'domains':
+					if ( siteSlug ) {
+						await updateLaunchpadSettings( siteSlug, {
+							checklist_statuses: { domain_upsell_deferred: true },
+						} );
+					}
+
 					if ( providedDependencies?.freeDomain ) {
 						const freeDomainSuffix = '.wordpress.com';
 						const newDomainName = String( providedDependencies?.domainName ).replace(
@@ -142,10 +148,6 @@ const startWriting: Flow = {
 							currentSiteSlug as string,
 							[ getPlanCartItem() ].filter( Boolean ) as MinimalRequestCartProduct[]
 						);
-
-						await updateLaunchpadSettings( currentSiteSlug, {
-							checklist_statuses: { domain_upsell_deferred: true },
-						} );
 
 						return window.location.assign(
 							`/setup/start-writing/launchpad?siteSlug=${ currentSiteSlug }`

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -67,10 +67,6 @@ const startWriting: Flow = {
 		);
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
 		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
-		const selectedSiteId = useSelect(
-			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSite(),
-			[]
-		);
 		const state = useSelect(
 			( select ) => select( ONBOARD_STORE ) as OnboardSelect,
 			[]
@@ -132,7 +128,7 @@ const startWriting: Flow = {
 
 						if ( providedDependencies?.domainName ) {
 							await requestSiteAddressChange(
-								selectedSiteId,
+								state.selectedSite,
 								newDomainName,
 								'wordpress.com',
 								siteSlug,

--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -101,7 +101,15 @@ export const clearValidationError = ( siteId ) => ( dispatch ) => {
 };
 
 export const requestSiteAddressChange =
-	( siteId, newBlogName, domain, oldDomain, siteType, discard = true, requireValidEmail = true ) =>
+	(
+		siteId,
+		newBlogName,
+		domain,
+		oldDomain,
+		siteType,
+		discard = true,
+		requireVerifiedEmail = true
+	) =>
 	async ( dispatch, getState ) => {
 		dispatch( {
 			type: SITE_ADDRESS_CHANGE_REQUEST,
@@ -115,7 +123,7 @@ export const requestSiteAddressChange =
 			old_domain: oldDomain,
 			site_type: siteType,
 			discard,
-			require_valid_email: requireValidEmail,
+			require_verified_email: requireVerifiedEmail,
 		};
 
 		dispatch( recordTracksEvent( 'calypso_siteaddresschange_request', eventProperties ) );
@@ -134,7 +142,7 @@ export const requestSiteAddressChange =
 					type: siteType,
 					discard,
 					nonce,
-					require_valid_email: requireValidEmail,
+					require_verified_email: requireVerifiedEmail,
 				}
 			);
 

--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -101,7 +101,7 @@ export const clearValidationError = ( siteId ) => ( dispatch ) => {
 };
 
 export const requestSiteAddressChange =
-	( siteId, newBlogName, domain, oldDomain, siteType, discard = true ) =>
+	( siteId, newBlogName, domain, oldDomain, siteType, discard = true, requireValidEmail = true ) =>
 	async ( dispatch, getState ) => {
 		dispatch( {
 			type: SITE_ADDRESS_CHANGE_REQUEST,
@@ -115,6 +115,7 @@ export const requestSiteAddressChange =
 			old_domain: oldDomain,
 			site_type: siteType,
 			discard,
+			require_valid_email: requireValidEmail,
 		};
 
 		dispatch( recordTracksEvent( 'calypso_siteaddresschange_request', eventProperties ) );
@@ -126,7 +127,15 @@ export const requestSiteAddressChange =
 					path: `/sites/${ siteId }/site-address-change`,
 					apiNamespace: 'wpcom/v2',
 				},
-				{ blogname: newBlogName, domain, old_domain: oldDomain, type: siteType, discard, nonce }
+				{
+					blogname: newBlogName,
+					domain,
+					old_domain: oldDomain,
+					type: siteType,
+					discard,
+					nonce,
+					require_valid_email: requireValidEmail,
+				}
 			);
 
 			const newSlug = get( data, 'new_slug' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2441-gh-Automattic/dotcom-forge

## Proposed Changes

* When the user selects a free domain, instantly renames it

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff in your sandbox: D111167-code
* From a new user OR a user without a site, start the flow at http://calypso.localhost:3000/setup/start-writing/
* Name the blog
* Select a free domain and ensure that the new domain name will be the main site domain
* Ensure skipping a domain selection will not try to rename a site
* Buy a pid site and ensure it also works as expected (it won't apply instantly but it will be at the user's cart and after paying, in our Upgrades > Domains)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?