### PR TITLE
Subscriptions Management: Create "Resubscribe" button for individual subscription page

### DIFF
--- a/client/landing/subscriptions/components/notice/notice.tsx
+++ b/client/landing/subscriptions/components/notice/notice.tsx
@@ -13,7 +13,9 @@ export enum NoticeType {
 
 export type NoticeState = {
 	type: NoticeType;
-	message: string;
+	message: string | React.ReactNode;
+	onClose?: () => void;
+	action?: React.ReactNode;
 };
 
 type NoticeProps = {

--- a/client/landing/subscriptions/components/notice/style.scss
+++ b/client/landing/subscriptions/components/notice/style.scss
@@ -21,6 +21,7 @@
 			line-height: $font-title-small;
 			letter-spacing: -0.15px;
 			color: $studio-gray-80;
+			margin-right: 16px;
 		}
 
 		&-action {
@@ -29,8 +30,8 @@
 
 		&-close {
 			position: absolute;
-			right: 23px;
-			top: 19px;
+			right: 20px;
+			top: 16px;
 		}
 	}
 }

--- a/client/landing/subscriptions/components/notice/style.scss
+++ b/client/landing/subscriptions/components/notice/style.scss
@@ -23,6 +23,10 @@
 			color: $studio-gray-80;
 		}
 
+		&-action {
+			align-self: center;
+		}
+
 		&-close {
 			position: absolute;
 			right: 23px;

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -5,7 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { Notice, NoticeType } from 'calypso/landing/subscriptions/components/notice';
+import { Notice, NoticeState, NoticeType } from 'calypso/landing/subscriptions/components/notice';
 import { SiteIcon } from 'calypso/landing/subscriptions/components/site-icon';
 import PoweredByWPFooter from 'calypso/layout/powered-by-wp-footer';
 import SiteSubscriptionSettings from './site-subscription-settings';
@@ -40,14 +40,15 @@ const SiteSubscriptionPage = () => {
 		deliveryFrequency,
 		subscribers,
 	} = data;
+	const [ notice, setNotice ] = useState< NoticeState | null >( null );
 	const [ siteSubscribed, setSiteSubscribed ] = useState( true );
 
 	const {
 		mutate: subscribe,
 		isLoading: subscribing,
 		isSuccess: subscribed,
+		error: subscribeError,
 	} = SubscriptionManager.useSiteSubscribeMutation();
-	// todo: handle error
 
 	const {
 		mutate: unsubscribe,
@@ -55,6 +56,16 @@ const SiteSubscriptionPage = () => {
 		isSuccess: unsubscribed,
 		error: unsubscribeError,
 	} = SubscriptionManager.useSiteUnsubscribeMutation();
+
+	// todo: style the button (underline, color?, etc.)
+	const Resubscribe = () => (
+		<Button
+			onClick={ () => subscribe( { blog_id: blogId } ) }
+			disabled={ subscribing || unsubscribing }
+		>
+			{ translate( 'Resubscribe' ) }
+		</Button>
+	);
 
 	useEffect( () => {
 		if ( subscribed ) {
@@ -68,16 +79,48 @@ const SiteSubscriptionPage = () => {
 		}
 	}, [ unsubscribed ] );
 
+	useEffect( () => {
+		if ( siteSubscribed ) {
+			setNotice( null );
+		}
+		if ( ! siteSubscribed && ! subscribeError ) {
+			setNotice( {
+				type: NoticeType.Success,
+				action: <Resubscribe />,
+				message: translate(
+					'You have successfully unsubscribed and will no longer receive emails from %s.',
+					{
+						args: [ data.siteName ],
+						comment: 'Name of the site that the user has unsubscribed from.',
+					}
+				),
+			} );
+		}
+		if ( unsubscribeError ) {
+			setNotice( {
+				type: NoticeType.Error,
+				onClose: () => setNotice( null ),
+				message: translate( 'There was an error when trying to unsubscribe from %s.', {
+					args: [ data.siteName ],
+					comment: 'Name of the site that the user tried to unsubscribe from.',
+				} ),
+			} );
+		}
+		if ( subscribeError ) {
+			setNotice( {
+				type: NoticeType.Error,
+				action: <Resubscribe />,
+				message: translate( 'There was an error when trying to resubscribe to %s.', {
+					args: [ data.siteName ],
+					comment: 'Name of the site that the user tried to resubscribe to.',
+				} ),
+			} );
+		}
+	}, [ siteSubscribed, unsubscribeError, subscribeError, subscribing, unsubscribing ] );
+
 	if ( ! blogId || isError ) {
 		return <div>Something went wrong.</div>;
 	}
-
-	// todo: style the button (underline, color?, etc.)
-	const Resubscribe = () => (
-		<Button onClick={ () => subscribe( { blog_id: blogId } ) } disabled={ subscribing }>
-			{ translate( 'Resubscribe' ) }
-		</Button>
-	);
 
 	if ( isLoading ) {
 		// Full page Wordpress logo loader
@@ -112,26 +155,14 @@ const SiteSubscriptionPage = () => {
 						<FormattedHeader brandFont headerText={ siteName } subHeaderText={ subHeaderText } />
 					</header>
 
-					{ ! siteSubscribed && (
-						<Notice type={ NoticeType.Success } action={ <Resubscribe /> }>
-							{ translate(
-								'You have successfully unsubscribed and will no longer receive emails from %s.',
-								{
-									args: [ data.siteName ],
-									comment: 'Name of the site that the user has unsubscribed from.',
-								}
-							) }
-						</Notice>
-					) }
-
-					{ unsubscribeError && (
-						<Notice type={ NoticeType.Error }>
-							{ translate( 'There was an error when trying to unsubscribe from %s.', {
-								args: [ data.siteName ],
-								comment: 'Name of the site that the user tried to unsubscribe from.',
-							} ) }
-						</Notice>
-					) }
+					<Notice
+						onClose={ notice?.onClose }
+						visible={ !! notice }
+						type={ notice?.type }
+						action={ notice?.action }
+					>
+						{ notice?.message }
+					</Notice>
 
 					{ siteSubscribed && (
 						<>

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -40,9 +40,14 @@ const SiteSubscriptionPage = () => {
 		deliveryFrequency,
 		subscribers,
 	} = data;
-	const [ showSettings, setShowSettings ] = useState( true );
+	const [ siteSubscribed, setSiteSubscribed ] = useState( true );
 
-	const { mutate: subscribe } = SubscriptionManager.useSiteSubscribeMutation();
+	const {
+		mutate: subscribe,
+		isLoading: subscribing,
+		isSuccess: subscribed,
+	} = SubscriptionManager.useSiteSubscribeMutation();
+	// todo: handle error
 
 	const {
 		mutate: unsubscribe,
@@ -52,8 +57,14 @@ const SiteSubscriptionPage = () => {
 	} = SubscriptionManager.useSiteUnsubscribeMutation();
 
 	useEffect( () => {
+		if ( subscribed ) {
+			setSiteSubscribed( true );
+		}
+	}, [ subscribed ] );
+
+	useEffect( () => {
 		if ( unsubscribed ) {
-			setShowSettings( false );
+			setSiteSubscribed( false );
 		}
 	}, [ unsubscribed ] );
 
@@ -61,8 +72,9 @@ const SiteSubscriptionPage = () => {
 		return <div>Something went wrong.</div>;
 	}
 
+	// todo: style the button (underline, color?, etc.)
 	const Resubscribe = () => (
-		<Button onClick={ () => subscribe( { blog_id: blogId } ) }>
+		<Button onClick={ () => subscribe( { blog_id: blogId } ) } disabled={ subscribing }>
 			{ translate( 'Resubscribe' ) }
 		</Button>
 	);
@@ -100,7 +112,7 @@ const SiteSubscriptionPage = () => {
 						<FormattedHeader brandFont headerText={ siteName } subHeaderText={ subHeaderText } />
 					</header>
 
-					{ unsubscribed && (
+					{ ! siteSubscribed && (
 						<Notice type={ NoticeType.Success } action={ <Resubscribe /> }>
 							{ translate(
 								'You have successfully unsubscribed and will no longer receive emails from %s.',
@@ -121,7 +133,7 @@ const SiteSubscriptionPage = () => {
 						</Notice>
 					) }
 
-					{ showSettings && (
+					{ siteSubscribed && (
 						<>
 							<SiteSubscriptionSettings
 								blogId={ blogId }

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -41,7 +41,8 @@ const SiteSubscriptionPage = () => {
 		subscribers,
 	} = data;
 	const [ showSettings, setShowSettings ] = useState( true );
-	const Resubscribe = () => <Button onClick={ () => null }>{ translate( 'Resubscribe' ) }</Button>;
+
+	const { mutate: subscribe } = SubscriptionManager.useSiteSubscribeMutation();
 
 	const {
 		mutate: unsubscribe,
@@ -59,6 +60,12 @@ const SiteSubscriptionPage = () => {
 	if ( ! blogId || isError ) {
 		return <div>Something went wrong.</div>;
 	}
+
+	const Resubscribe = () => (
+		<Button onClick={ () => subscribe( { blog_id: blogId } ) }>
+			{ translate( 'Resubscribe' ) }
+		</Button>
+	);
 
 	if ( isLoading ) {
 		// Full page Wordpress logo loader
@@ -94,7 +101,7 @@ const SiteSubscriptionPage = () => {
 					</header>
 
 					{ unsubscribed && (
-						<Notice type={ NoticeType.Success }>
+						<Notice type={ NoticeType.Success } action={ <Resubscribe /> }>
 							{ translate(
 								'You have successfully unsubscribed and will no longer receive emails from %s.',
 								{
@@ -106,7 +113,7 @@ const SiteSubscriptionPage = () => {
 					) }
 
 					{ unsubscribeError && (
-						<Notice type={ NoticeType.Error } action={ <Resubscribe /> }>
+						<Notice type={ NoticeType.Error }>
 							{ translate( 'There was an error when trying to unsubscribe from %s.', {
 								args: [ data.siteName ],
 								comment: 'Name of the site that the user tried to unsubscribe from.',

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -41,6 +41,7 @@ const SiteSubscriptionPage = () => {
 		subscribers,
 	} = data;
 	const [ showSettings, setShowSettings ] = useState( true );
+	const Resubscribe = () => <Button onClick={ () => null }>{ translate( 'Resubscribe' ) }</Button>;
 
 	const {
 		mutate: unsubscribe,
@@ -105,7 +106,7 @@ const SiteSubscriptionPage = () => {
 					) }
 
 					{ unsubscribeError && (
-						<Notice type={ NoticeType.Error }>
+						<Notice type={ NoticeType.Error } action={ <Resubscribe /> }>
 							{ translate( 'There was an error when trying to unsubscribe from %s.', {
 								args: [ data.siteName ],
 								comment: 'Name of the site that the user tried to unsubscribe from.',

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -2,6 +2,7 @@ import { useSubscriberEmailAddress, useIsLoggedIn } from './hooks';
 import {
 	usePostUnsubscribeMutation,
 	useSiteDeliveryFrequencyMutation,
+	useSiteSubscribeMutation,
 	useSiteUnsubscribeMutation,
 	useUserSettingsMutation,
 	usePendingSiteConfirmMutation,
@@ -30,6 +31,7 @@ export const SubscriptionManager = {
 	useSiteDeliveryFrequencyMutation,
 	useSiteSubscriptionsQuery,
 	usePostSubscriptionsQuery,
+	useSiteSubscribeMutation,
 	useSiteUnsubscribeMutation,
 	useSubscriptionsCountQuery,
 	useSubscriberEmailAddress,

--- a/packages/data-stores/src/reader/mutations/index.ts
+++ b/packages/data-stores/src/reader/mutations/index.ts
@@ -1,5 +1,6 @@
 export { default as usePostUnsubscribeMutation } from './use-post-unsubscribe-mutation';
 export { default as useSiteDeliveryFrequencyMutation } from './use-site-delivery-frequency-mutation';
+export { default as useSiteSubscribeMutation } from './use-site-subscribe-mutation';
 export { default as useSiteUnsubscribeMutation } from './use-site-unsubscribe-mutation';
 export { default as useUserSettingsMutation } from './use-user-settings-mutation';
 export { default as usePendingSiteConfirmMutation } from './use-pending-site-confirm-mutation';

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -3,7 +3,7 @@ import { callApi } from '../helpers';
 import { useIsLoggedIn } from '../hooks';
 
 type SubscribeParams = {
-	blog_id: number | string;
+	blog_id?: number | string;
 };
 
 type SubscribeResponse = {

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -1,0 +1,49 @@
+import { useMutation } from '@tanstack/react-query';
+import { callApi } from '../helpers';
+import { useIsLoggedIn } from '../hooks';
+
+type SubscribeParams = {
+	blog_id: number | string;
+};
+
+type SubscribeResponse = {
+	success?: boolean;
+	subscribed?: boolean;
+	subscription?: {
+		blog_ID: string;
+		delivery_frequency: string;
+		status: string;
+		ts: string;
+	};
+};
+
+const useSiteSubscribeMutation = () => {
+	const { isLoggedIn } = useIsLoggedIn();
+
+	return useMutation( async ( params: SubscribeParams ) => {
+		if ( ! params.blog_id ) {
+			throw new Error(
+				// reminder: translate this string when we add it to the UI
+				'Something went wrong while subscribing.'
+			);
+		}
+
+		const response = await callApi< SubscribeResponse >( {
+			path: `/read/site/${ params.blog_id }/post_email_subscriptions/new`,
+			method: 'POST',
+			isLoggedIn,
+			apiVersion: '1.2',
+			body: {},
+		} );
+		if ( ! response.success ) {
+			throw new Error(
+				// reminder: translate this string when we add it to the UI
+				'Something went wrong while subscribing.'
+			);
+		}
+
+		return response;
+	} );
+};
+
+export default useSiteSubscribeMutation;


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/77034.

## Proposed Changes

* introduce the `useSiteSubscribeMutation` mutation and attach it with the new "Resubscribe" button 
* handle error states (when "Cancel subscription" or "Resubscribe" actions fail)
* fix styling of `X` on the Notice component to match with the Figma design (inDLaEQV8jJ21O4WXawIsJ-fi-1195_17698) 

https://github.com/Automattic/wp-calypso/assets/25105483/ad628676-ad72-4bae-8777-bcf36c1b2d1b

ℹ️ Please note that:

- the "Resubscribe" button doesn't match the styles provided in Figma. The reason for this is the ongoing discussion on component we want use (inDLaEQV8jJ21O4WXawIsJ-fi-712:30977).
- the number of subscriptions isn't being updated (we will address this in a separate PR once we the API for fetching subscription details is ready)

## Testing Instructions

### Testing as an external user
1. Check out the PR and build the app.
2. Authenticate as an external user (`subkey` "dance" in the incognito browser window).
3. Make sure your external user is subscribed to some sites already.
4. Navigate to `http://calypso.localhost:3000/subscriptions/site/[blog_id]` where `[blog_id]` needs to be replaced with a specific blog ID your user is subscribed to.
5. When the page loads, you should be able to click on the "Cancel subscription" button on the bottom of the page.
6. Once the button is clicked, the user should be unsubscribed from the site (this can be checked at https://wordpress.com/subscriptions/sites), the settings should be hidden and the success notice should display:

![Markup on 2023-05-18 at 14:47:40](https://github.com/Automattic/wp-calypso/assets/25105483/cb27d85f-866e-4257-94fc-c1b25a3a3c1d)

7. Click on the "Resubscribe" button. You should be resubscribed to the site and the settings should display again:

![Markup on 2023-05-18 at 14:47:58](https://github.com/Automattic/wp-calypso/assets/25105483/de24bbe0-3347-4d84-8320-74b86c62b4b5)

### Testing as an logged-in user
1. Check out the PR.
2. Navigate to `client/server/pages/index.js` and temporarily add `return next();` to the line `833`:

![Markup on 2023-04-28 at 17:50:44](https://user-images.githubusercontent.com/25105483/235195033-4902bb9d-db57-43a4-b295-2d90feb6731f.png)

3. Navigate to `client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx` and replace the `siteAddress` with the address of the site you are trying to unsubscribe from:

![Markup on 2023-05-17 at 13:11:00](https://github.com/Automattic/wp-calypso/assets/25105483/2d479438-2229-43c1-bc7b-5fd4b9ade4b9)

4. Build the app.
5. Log in to a test WordPress.com account that has some existing Site subscriptions.
6. Navigate to `http://calypso.localhost:3000/subscriptions/site/[blog_id]` where `[blog_id]` needs to be replaced with a specific blog ID your user is subscribed to.
7. When the page loads, you should be able to click on the "Cancel subscription" button on the bottom of the page.
9. Once the button is clicked, the user should be unsubscribed from the site (this can be checked at https://wordpress.com/subscriptions/sites), the settings should be hidden and the success notice should display (similarly as when testing the external user).
10. Click on the "Resubscribe" button. You should be resubscribed to the site and the settings should display again (similarly as when testing the external user).

### Testing **unsubscribe** mutation error state
1. Follow the steps as above, but instead of navigating to `http://calypso.localhost:3000/subscriptions/site/[blog_id]` with correct `[blog_id]` used, replace it with non-existent one, e.g. `http://calypso.localhost:3000/subscriptions/site/hello-folks`.
2. Clicking the "Cancel subscription" button should result in an error message:

![Markup on 2023-05-18 at 14:57:26](https://github.com/Automattic/wp-calypso/assets/25105483/300b1a43-c388-4d47-a295-b6a4fdc4e503)

3. Clicking the `X` button should close the error notice.

### Testing **subscribe** mutation error state
1. Follow the steps as with the external or logged-in user, but break the query in some way, e.g. by navigating to `packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts` and changing the request `path`:

![Markup on 2023-05-18 at 15:01:34](https://github.com/Automattic/wp-calypso/assets/25105483/b4ddc279-21b4-4a23-af50-31ab9e925cc6)

2. When you try to resubscribe, an error message should display:

![Markup on 2023-05-18 at 15:02:59](https://github.com/Automattic/wp-calypso/assets/25105483/740d34a4-0091-4524-bf79-8478e3797ef3)

3. Clicking the "Resubscribe" button should try to subscribe the user again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?