### PR TITLE
Implment the GA promo banner in /stats

### DIFF
--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -82,6 +82,7 @@ export const DotPager = ( {
 	className = '',
 	onPageSelected = null,
 	isClickEnabled = false,
+	rotateTime = 0,
 	...props
 } ) => {
 	// Filter out the empty children
@@ -96,6 +97,16 @@ export const DotPager = ( {
 			setCurrentPage( numPages - 1 );
 		}
 	}, [ numPages, currentPage ] );
+
+	useEffect( () => {
+		if ( rotateTime > 0 ) {
+			const timerId = setTimeout( () => {
+				setCurrentPage( ( currentPage + 1 ) % numPages );
+			}, rotateTime );
+
+			return () => clearTimeout( timerId );
+		}
+	}, [ currentPage ] );
 
 	const handleSelectPage = ( index ) => {
 		setCurrentPage( index );

--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -99,14 +99,14 @@ export const DotPager = ( {
 	}, [ numPages, currentPage ] );
 
 	useEffect( () => {
-		if ( rotateTime > 0 ) {
+		if ( rotateTime > 0 && numPages > 1 ) {
 			const timerId = setTimeout( () => {
 				setCurrentPage( ( currentPage + 1 ) % numPages );
 			}, rotateTime );
 
 			return () => clearTimeout( timerId );
 		}
-	}, [ currentPage ] );
+	}, [ currentPage, numPages, rotateTime ] );
 
 	const handleSelectPage = ( index ) => {
 		setCurrentPage( index );

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -1,15 +1,18 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isFreePlan, isPersonalPlan } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import rocketImage from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 import YoastLogo from 'calypso/assets/images/icons/yoast-logo.svg';
+import GoogleAnalyticsLogo from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
 import writePost from 'calypso/assets/images/onboarding/site-options.svg';
 import BlazeLogo from 'calypso/components/blaze-logo';
 import DotPager from 'calypso/components/dot-pager';
 import { useHasNeverPublishedPost } from 'calypso/data/stats/use-has-never-published-post';
 import { PromoteWidgetStatus, usePromoteWidget } from 'calypso/lib/promote-post';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MiniCarouselBlock from './mini-carousel-block';
@@ -29,6 +32,9 @@ const EVENT_PRIVATE_SITE_BANNER_DISMISS = 'calypso_stats_private_site_banner_dis
 const EVENT_NO_CONTENT_BANNER_VIEW = 'calypso_stats_no_content_banner_view';
 const EVENT_NO_CONTENT_BANNER_CLICK = 'calypso_stats_no_content_banner_click';
 const EVENT_NO_CONTENT_BANNER_DISMISS = 'calypso_stats_no_content_banner_dismiss';
+const EVENT_GOOGLE_ANALYTICS_BANNER_VIEW = 'calypso_stats_google_analytics_banner_view';
+const EVENT_GOOGLE_ANALYTICS_BANNER_CLICK = 'calypso_stats_google_analytics_banner_click';
+const EVENT_GOOGLE_ANALYTICS_BANNER_DISMISS = 'calypso_stats_google_analytics_banner_dismiss';
 
 const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -41,6 +47,10 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	const jetpackNonAtomic = useSelector(
 		( state ) => isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId )
 	);
+
+	const currentPlanSlug = useSelector( ( state ) =>
+		getCurrentPlan( state, selectedSiteId )
+	)?.productSlug;
 
 	// Keep a replica of the pager index state.
 	// TODO: Figure out an approach that doesn't require replicating state value from DotPager.
@@ -68,14 +78,25 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	const showYoastPromo =
 		! useSelector( isBlockDismissed( EVENT_YOAST_PROMO_DISMISS ) ) && ! jetpackNonAtomic;
 
+	const showGoogleAnalyticsPromo =
+		! useSelector( isBlockDismissed( EVENT_GOOGLE_ANALYTICS_BANNER_DISMISS ) ) &&
+		( isFreePlan( currentPlanSlug ) || isPersonalPlan( currentPlanSlug ) );
+
 	const viewEvents = useMemo( () => {
 		const events = [];
 		isSitePrivate && events.push( EVENT_PRIVATE_SITE_BANNER_VIEW );
 		showWriteAPostBanner && events.push( EVENT_NO_CONTENT_BANNER_VIEW );
 		showBlazePromo && events.push( EVENT_TRAFFIC_BLAZE_PROMO_VIEW );
 		showYoastPromo && events.push( EVENT_YOAST_PROMO_VIEW );
+		showGoogleAnalyticsPromo && events.push( EVENT_GOOGLE_ANALYTICS_BANNER_VIEW );
 		return events;
-	}, [ isSitePrivate, showWriteAPostBanner, showBlazePromo, showYoastPromo ] );
+	}, [
+		isSitePrivate,
+		showWriteAPostBanner,
+		showBlazePromo,
+		showYoastPromo,
+		showGoogleAnalyticsPromo,
+	] );
 
 	// Handle view events upon initial mount and upon paging DotPager.
 	useEffect( () => {
@@ -157,6 +178,23 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 				ctaText={ translate( 'Get Yoast' ) }
 				href={ `/plugins/wordpress-seo-premium/${ slug || '' }` }
 				key="yoast"
+			/>
+		);
+	}
+
+	if ( showGoogleAnalyticsPromo ) {
+		blocks.push(
+			<MiniCarouselBlock
+				clickEvent={ EVENT_GOOGLE_ANALYTICS_BANNER_CLICK }
+				dismissEvent={ EVENT_GOOGLE_ANALYTICS_BANNER_DISMISS }
+				image={ <img src={ GoogleAnalyticsLogo } alt="" width={ 45 } height={ 45 } /> }
+				headerText={ translate( 'Connect your site to Google Analytics' ) }
+				contentText={ translate(
+					'Linking Google Analytics to your account is effortless with our Premium plan – no coding required. Gain valuable insights in seconds.'
+				) }
+				ctaText={ translate( 'Get Premium' ) }
+				href={ `/checkout/premium/${ slug || '' }` }
+				key="google-analytics"
 			/>
 		);
 	}

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -204,7 +204,12 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	}
 
 	return (
-		<DotPager className="mini-carousel" hasDynamicHeight onPageSelected={ pagerDidSelectPage }>
+		<DotPager
+			className="mini-carousel"
+			hasDynamicHeight
+			onPageSelected={ pagerDidSelectPage }
+			rotateTime={ 5000 }
+		>
 			{ blocks }
 		</DotPager>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes to Automattic/martech#1718

## Proposed Changes

This PR implements the requested changes in the linked issue above regarding the banner carousell in `/stats`:

1. Show the GA promo banner for sites on the Free plan and the Personal plan.
2. Automatically rotate the banner by the given period. Currently I've anecdotally set it as 5 secs.

The automatical rotation mechanism is lifted into the underlying `<DotPager>` component, since it's a general functionality that the rest of the codebase can be benefited from as well.

Screencast:

https://github.com/Automattic/wp-calypso/assets/1842898/06d8a32e-b36c-400a-bbf1-5c62013ea336

# Testing Instructions

1. Logging into a Free site, visit `/stats` and confirm that the GA promo banner exists.
2. Logging into a Personal site, visit `/stats` and confirm that the GA promo banner exists.
3. Dismissing the GA promo banner by clickgin "hide this" should make the banner disappear even after refreshing.
4. Confirm that the carousell rotates automatically. After manually navigating back-and-forth the banners, it should still advance automatically.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
