### PR TITLE
Revert "Newsletter onboarding: enable paid newsletter flag"

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -178,8 +178,7 @@
 		"user-management-revamp": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true,
-		"newsletter/paid-subscribers": true
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/test.json
+++ b/config/test.json
@@ -109,7 +109,6 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": false,
-		"newsletter/paid-subscribers": true
+		"wpcom-user-bootstrap": false
 	}
 }


### PR DESCRIPTION
Reverting because this PR still needs a separate PR to be deployed before we update feature flags for paid newsletters.