### PR TITLE
Blog Onboarding: Remove Move to trash & Schedule for start-writing flow

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/editor.scss
+++ b/apps/wpcom-block-editor/src/wpcom/editor.scss
@@ -1,13 +1,10 @@
 @import "./features/use-classic-block-guide";
 
 .start-writing-hide {
-	.components-external-link {
-		display: none !important;
-	}
-	.edit-post-post-schedule {
-		display: none !important;
-	}
-	.components-panel__row:has(.editor-post-trash) {
+	.components-external-link,
+	.edit-post-post-schedule,
+	.components-panel__row:has(.editor-post-trash),
+	.launchpad__save-modal {
 		display: none !important;
 	}
 }

--- a/apps/wpcom-block-editor/src/wpcom/editor.scss
+++ b/apps/wpcom-block-editor/src/wpcom/editor.scss
@@ -4,4 +4,10 @@
 	.components-external-link {
 		display: none !important;
 	}
+	.edit-post-post-schedule {
+		display: none !important;
+	}
+	.components-panel__row:has(.editor-post-trash) {
+		display: none !important;
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2476
Fixes https://github.com/Automattic/dotcom-forge/issues/2477

## Proposed Changes

Disable/hide `Move to trash` button, the possibility to `Schedule` the post, and the "Great progress" modal when publishing a post.

## Testing Instructions

* Using a new user OR a user without any site, start the flow with [/setup/start-writing](http://calypso.localhost:3000/setup/start-writing).
* In the Site editor, you should not see the `Move to trash` button
* In the Site editor, you should not see the `Publish` row 

## Screenshots
| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/1fb4fd85-6656-480c-ab26-b94678e36ff4) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/421b11de-5449-4cb6-a2a3-c593c3b7f975) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
