### PR TITLE
Domains: show error and success notices in domain contact verification card

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
@@ -2,8 +2,10 @@ import { Button } from '@automattic/components';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import FilePicker from 'calypso/components/file-picker';
 import wpcom from 'calypso/lib/wp';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import type { WhoisData } from '../types';
 
 import './style.scss';
@@ -15,6 +17,7 @@ interface Props {
 }
 
 const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const [ selectedFiles, setSelectedFiles ] = useState< FileList | null >( null );
 	const [ submitting, setSubmitting ] = useState( false );
@@ -145,11 +148,13 @@ const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
 
 				if ( error ) {
 					setError( true );
+					dispatch( errorNotice( error.message ) );
 					return;
 				}
 
 				setSubmitted( true );
 				setError( false );
+				dispatch( successNotice( translate( 'Documents submitted succcesfully!' ) ) );
 			}
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
@@ -87,7 +87,7 @@ const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
 				</ul>
 				<p>
 					{ translate(
-						'Click on the button below to upload one or more documents and then click on the "Submit" button. You can upload images and/or PDF files up to 5MB each.'
+						'Click on the button below to upload one or more documents and then click on the "Submit" button. You can upload images (JPEG or PNG) and/or PDF files up to 5MB each.'
 					) }
 				</p>
 			</div>

--- a/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
@@ -95,6 +95,11 @@ const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
 	};
 
 	const handleFilesSelected = ( files: FileList ) => {
+		if ( files.length > 3 ) {
+			dispatch( errorNotice( translate( 'You can only upload up to three documents.' ) ) );
+			return;
+		}
+
 		setSelectedFiles( files );
 		setError( false );
 	};

--- a/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
@@ -87,7 +87,7 @@ const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
 				</ul>
 				<p>
 					{ translate(
-						'Click on the button below to upload one or more documents and then click on the "Submit" button. You can upload images (JPEG or PNG) and/or PDF files up to 5MB each.'
+						'Click on the button below to upload up to three documents and then click on the "Submit" button. You can upload images (JPEG or PNG) and/or PDF files up to 5MB each.'
 					) }
 				</p>
 			</div>
@@ -159,7 +159,9 @@ const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
 
 				setSubmitted( true );
 				setError( false );
-				dispatch( successNotice( translate( 'Documents submitted succcesfully!' ) ) );
+				dispatch(
+					successNotice( translate( 'Documents submitted for verification succcesfully!' ) )
+				);
 			}
 		);
 	};


### PR DESCRIPTION
## Proposed Changes

Note: This depends on D111217-code

This PR
- Updates the Nominet verification card in the domains management page to show the top-right pop-up success or error notices when submitting documents
- Adds a limit of 3 files to be uploaded at once

### Screenshots

- Error notice

<img width="1310" alt="Screenshot 2023-05-17 at 20 16 55" src="https://github.com/Automattic/wp-calypso/assets/5324818/b8c107ac-1841-4051-a605-e58e95fda1ee">

- Success notice

<img width="1304" alt="Screenshot 2023-05-17 at 20 17 19" src="https://github.com/Automattic/wp-calypso/assets/5324818/0de4145b-a59b-48be-a135-11aed57ae5ac">

## Testing Instructions

- Apply D111217-code to your backend if it isn't deployed yet
- Open the live Calypso link or build this branch locally
- Find a .uk domain that needs to have its contact information verified (it's easier to add the Nominet verification requested flag manually to a domain in the backend)
- Go to that domain's management page
- Try to submit a file that's larger than 5MB and ensure an error message shows up
- Try to submit more than 3 files and ensure an error message shows up

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?