### PR TITLE
Plan Comparison Grid: Update breakpoints in /plans

### DIFF
--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -27,10 +27,10 @@ $planComparisonMinWidthToGridWidthMap: (
 
 // TODO: Replace with use of $plan-features-sidebar-width
 $planComparisonMinWidthToGridWidthWithSidebarMap: (
-	1052px: "630px",
-	1152px: "800px",
-	1296px: "942px",
-	1553px: "1091px",
+	1052px: "686px",
+	1152px: "870px",
+	1296px: "1024px",
+	1553px: "1238px",
 );
 
 
@@ -52,17 +52,6 @@ $planComparisonMinWidthToGridWidthWithSidebarMap: (
 			width: #{$gridWidth};
 		}
 	}
-}
-
-@mixin plan-comparison-grid-breakpoints {
-	width: 100%;
-
-	@each $screenMinWidth, $gridWidth in $planComparisonMinWidthToGridWidthMap {
-		@media ( min-width: #{$screenMinWidth} ) {
-			width: #{$gridWidth};
-		}
-	}
-
 }
 
 /**

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -45,17 +45,6 @@ $planComparisonMinWidthToGridWidthMap: (
 	}
 }
 
-@mixin plan-comparison-grid-breakpoints {
-	width: 100%;
-
-	@each $screenMinWidth, $gridWidth in $planComparisonMinWidthToGridWidthMap {
-		@media ( min-width: #{$screenMinWidth} ) {
-			width: #{$gridWidth};
-		}
-	}
-
-}
-
 /**
  * Media queries for the plans grid on the /plans page.
  * This should stretch to fill it's container.

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -64,6 +64,16 @@ $planComparisonMinWidthToGridWidthMap: (
 	width: 100%;
 }
 
+@mixin plan-comparison-grid-breakpoints-with-sidebar {
+	width: 100%;
+
+	@each $screenMinWidth, $gridWidth in $planComparisonMinWidthToGridWidthMap {
+		@media ( min-width: #{$screenMinWidth} ) {
+			width: #{$gridWidth} + $plan-features-sidebar-width;
+		}
+	}
+}
+
 /**
  * Show/hide desktop/tablet/mobile layouts based on the screen width.
  * Desktop layout: width > $plans-2023-medium-breakpoint

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -45,6 +45,17 @@ $planComparisonMinWidthToGridWidthMap: (
 	}
 }
 
+@mixin plan-comparison-grid-breakpoints {
+	width: 100%;
+
+	@each $screenMinWidth, $gridWidth in $planComparisonMinWidthToGridWidthMap {
+		@media ( min-width: #{$screenMinWidth} ) {
+			width: #{$gridWidth};
+		}
+	}
+
+}
+
 /**
  * Media queries for the plans grid on the /plans page.
  * This should stretch to fill it's container.

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -25,6 +25,15 @@ $planComparisonMinWidthToGridWidthMap: (
 	1281px: "1238px",
 );
 
+// TODO: Replace with use of $plan-features-sidebar-width
+$planComparisonMinWidthToGridWidthWithSidebarMap: (
+	1052px: "630px",
+	1152px: "800px",
+	1296px: "942px",
+	1553px: "1091px",
+);
+
+
 @mixin pricing-grid-breakpoints {
 	width: 100%;
 
@@ -67,9 +76,9 @@ $planComparisonMinWidthToGridWidthMap: (
 @mixin plan-comparison-grid-breakpoints-with-sidebar {
 	width: 100%;
 
-	@each $screenMinWidth, $gridWidth in $planComparisonMinWidthToGridWidthMap {
+	@each $screenMinWidth, $gridWidth in $planComparisonMinWidthToGridWidthWithSidebarMap {
 		@media ( min-width: #{$screenMinWidth} ) {
-			width: #{$gridWidth} + $plan-features-sidebar-width;
+			width: #{$gridWidth};
 		}
 	}
 }

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -803,9 +803,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 
 		visibleLength = isLargeBreakpoint ? 4 : visibleLength;
 		visibleLength = isMediumBreakpoint ? 3 : visibleLength;
-		if ( isInSignup ) {
-			visibleLength = isSmallBreakpoint ? 2 : visibleLength;
-		}
+		visibleLength = isSmallBreakpoint ? 2 : visibleLength;
 
 		if ( newVisiblePlans.length !== visibleLength ) {
 			newVisiblePlans = newVisiblePlans.slice( 0, visibleLength );

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -769,9 +769,9 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		smallBreakpoint = 880;
 	} else {
 		// Breakpoints with admin sidebar
-		largeBreakpoint = 1772; // 1500px + 272px (sidebar)
-		mediumBreakpoint = 1612; // 1340px + 272px (sidebar)
-		smallBreakpoint = 1340; // keeping original breakpoint to match Plan Grid
+		largeBreakpoint = 1553; // 1500px + 272px (sidebar)
+		mediumBreakpoint = 1296; // 1340px + 272px (sidebar)
+		smallBreakpoint = 1152; // keeping original breakpoint to match Plan Grid
 	}
 
 	const isLargeBreakpoint = usePricingBreakpoint( largeBreakpoint );
@@ -818,9 +818,6 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		isSmallBreakpoint,
 		displayedPlansProperties,
 		isInSignup,
-		isSignupLargeBreakpoint,
-		isSignupMediumBreakpoint,
-		isSignupSmallBreakpoint,
 	] );
 
 	const restructuredFootnotes = useMemo( () => {

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -818,6 +818,9 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		isSmallBreakpoint,
 		displayedPlansProperties,
 		isInSignup,
+		isSignupLargeBreakpoint,
+		isSignupMediumBreakpoint,
+		isSignupSmallBreakpoint,
 	] );
 
 	const restructuredFootnotes = useMemo( () => {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -297,32 +297,34 @@ export class PlanFeatures2023Grid extends Component<
 			selectedFeature,
 		} = this.props;
 		return (
-			<div className="plans-wrapper">
-				<QueryActivePromotions />
-				<div className="plan-features">
-					<div className="plan-features-2023-grid__content">
-						<div>
-							<div className="plan-features-2023-grid__desktop-view">
-								{ this.renderTable( planProperties ) }
-							</div>
-							<div className="plan-features-2023-grid__tablet-view">
-								{ this.renderTabletView() }
-							</div>
-							<div className="plan-features-2023-grid__mobile-view">
-								{ this.renderMobileView() }
+			<>
+				<div className="plans-wrapper">
+					<QueryActivePromotions />
+					<div className="plan-features">
+						<div className="plan-features-2023-grid__content">
+							<div>
+								<div className="plan-features-2023-grid__desktop-view">
+									{ this.renderTable( planProperties ) }
+								</div>
+								<div className="plan-features-2023-grid__tablet-view">
+									{ this.renderTabletView() }
+								</div>
+								<div className="plan-features-2023-grid__mobile-view">
+									{ this.renderMobileView() }
+								</div>
 							</div>
 						</div>
 					</div>
+					{ ! hidePlansFeatureComparison && (
+						<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
+							<Button onClick={ this.toggleShowPlansComparisonGrid }>
+								{ this.state.showPlansComparisonGrid
+									? translate( 'Hide comparison' )
+									: translate( 'Compare plans' ) }
+							</Button>
+						</div>
+					) }
 				</div>
-				{ ! hidePlansFeatureComparison && (
-					<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
-						<Button onClick={ this.toggleShowPlansComparisonGrid }>
-							{ this.state.showPlansComparisonGrid
-								? translate( 'Hide comparison' )
-								: translate( 'Compare plans' ) }
-						</Button>
-					</div>
-				) }
 				{ ! hidePlansFeatureComparison && this.state.showPlansComparisonGrid ? (
 					<div
 						ref={ this.plansComparisonGridContainerRef }
@@ -351,7 +353,7 @@ export class PlanFeatures2023Grid extends Component<
 						</div>
 					</div>
 				) : null }
-			</div>
+			</>
 		);
 	}
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -297,34 +297,32 @@ export class PlanFeatures2023Grid extends Component<
 			selectedFeature,
 		} = this.props;
 		return (
-			<>
-				<div className="plans-wrapper">
-					<QueryActivePromotions />
-					<div className="plan-features">
-						<div className="plan-features-2023-grid__content">
-							<div>
-								<div className="plan-features-2023-grid__desktop-view">
-									{ this.renderTable( planProperties ) }
-								</div>
-								<div className="plan-features-2023-grid__tablet-view">
-									{ this.renderTabletView() }
-								</div>
-								<div className="plan-features-2023-grid__mobile-view">
-									{ this.renderMobileView() }
-								</div>
+			<div className="plans-wrapper">
+				<QueryActivePromotions />
+				<div className="plan-features">
+					<div className="plan-features-2023-grid__content">
+						<div>
+							<div className="plan-features-2023-grid__desktop-view">
+								{ this.renderTable( planProperties ) }
+							</div>
+							<div className="plan-features-2023-grid__tablet-view">
+								{ this.renderTabletView() }
+							</div>
+							<div className="plan-features-2023-grid__mobile-view">
+								{ this.renderMobileView() }
 							</div>
 						</div>
 					</div>
-					{ ! hidePlansFeatureComparison && (
-						<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
-							<Button onClick={ this.toggleShowPlansComparisonGrid }>
-								{ this.state.showPlansComparisonGrid
-									? translate( 'Hide comparison' )
-									: translate( 'Compare plans' ) }
-							</Button>
-						</div>
-					) }
 				</div>
+				{ ! hidePlansFeatureComparison && (
+					<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
+						<Button onClick={ this.toggleShowPlansComparisonGrid }>
+							{ this.state.showPlansComparisonGrid
+								? translate( 'Hide comparison' )
+								: translate( 'Compare plans' ) }
+						</Button>
+					</div>
+				) }
 				{ ! hidePlansFeatureComparison && this.state.showPlansComparisonGrid ? (
 					<div
 						ref={ this.plansComparisonGridContainerRef }
@@ -353,7 +351,7 @@ export class PlanFeatures2023Grid extends Component<
 						</div>
 					</div>
 				) : null }
-			</>
+			</div>
 		);
 	}
 

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -377,6 +377,7 @@ $mobile-card-max-width: 440px;
 		background-color: var(--color-surface);
 		position: relative;
 		vertical-align: baseline;
+		max-width: 344px;
 
 		.is-bold {
 			font-weight: 600;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -189,6 +189,12 @@ $mobile-card-max-width: 440px;
 	@include plans-section-break-medium {
 		margin: 0;
 	}
+
+	@media ( min-width: $plans-2023-small-breakpoint ) {
+		.is-section-plans & {
+			margin: 0;
+		}
+	}
 }
 
 .is-2023-pricing-grid {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1014,6 +1014,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 	}
 
 	.plan-comparison-grid__billing-info {
+		flex-basis: 50px;
 		color: var(--studio-gray-50);
 		font-weight: 400;
 		font-size: $font-body-extra-small;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -190,10 +190,12 @@ $mobile-card-max-width: 440px;
 		margin: 0;
 	}
 
-	@media ( min-width: $plans-2023-small-breakpoint ) {
-		.is-section-plans & {
-			margin: 0;
-		}
+	@include plans-2023-break-medium {
+		margin: 0 20px;
+	}
+
+	@include plans-section-break-medium {
+		margin: 0;
 	}
 }
 
@@ -383,7 +385,6 @@ $mobile-card-max-width: 440px;
 		background-color: var(--color-surface);
 		position: relative;
 		vertical-align: baseline;
-		max-width: 344px;
 
 		.is-bold {
 			font-weight: 600;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1093,6 +1093,8 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
  */
 .is-section-plans .plan-features-2023-grid__plan-comparison-grid-container {
 	scroll-margin-top: $plan-features-header-banner-height + 24px;
+	margin: auto;
+	@include plan-comparison-grid-breakpoints-with-sidebar;
 }
 
 .is-section-signup .plan-features-2023-grid__plan-comparison-grid-container {

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -13,6 +13,14 @@
 	@include pricing-grid-breakpoints;
 }
 
+.is-section-plans:not(.is-sidebar-collapsed) .is-2023-pricing-grid .plan-features-2023-grid__plan-comparison-grid-container {
+	@include plan-comparison-grid-breakpoints-with-sidebar;
+}
+
+.is-section-plans.is-sidebar-collapsed .is-2023-pricing-grid .plan-features-2023-grid__plan-comparison-grid-container {
+	@include plan-comparison-grid-breakpoints;
+}
+
 .plans-step {
 	margin: 0 auto;
 	max-width: 700px;

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -5,11 +5,11 @@
 	@include pricing-grid-breakpoints;
 }
 
-.is-section-plans:not(.is-sidebar-collapsed) .plans-features-main__group.is-2023-pricing-grid {
+.is-section-plans:not(.is-sidebar-collapsed) .is-2023-pricing-grid .plans-wrapper {
 	@include pricing-grid-breakpoints-with-sidebar;
 }
 
-.is-section-plans.is-sidebar-collapsed .plans-features-main__group.is-2023-pricing-grid {
+.is-section-plans.is-sidebar-collapsed .is-2023-pricing-grid .plans-wrapper {
 	@include pricing-grid-breakpoints;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1530


## Proposed Changes

* Previously, the same breakpoints were being applied to both the plan features grid **and** the plan comparison grid
* These changes add new, plan comparison grid specific breakpoints
* Updates the number of plans that we render at each breakpoint

## GIFS
BEFORE
![2023-05-18 14 54 48](https://github.com/Automattic/wp-calypso/assets/5414230/5328324d-ca51-4d91-a26a-de26144ad913)

AFTER
![2023-05-18 14 53 12](https://github.com/Automattic/wp-calypso/assets/5414230/0ee37518-3148-4cfd-96f5-18f017db0267)

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch and run `yarn start`
* Navigate to calypso.localhost:3000
* Navigate to Upgrades > Plans
* Verify that the number of plans shown at each breakpoint is correct
* Verify that the width of each plan column and the gutter space between columns is correct
