### PR TITLE
Update Woo Express site provisioning loading messages

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -388,14 +388,24 @@ button {
 	}
 	.loading-bar {
 		background-color: var(--studio-woocommerce-purple-5);
-		width: 520px;
+		width: 590px;
 		max-width: 100%;
 		margin-left: auto;
 		margin-right: auto;
+
+		@media screen and (max-width: 640px) {
+			width: 100%;
+		}
+	}
+	.processing-step {
+		width: 100%;
+		max-width: 640px;
+		box-sizing: border-box;
 	}
 	p.processing-step__subtitle {
 		font-family: "SF Pro Text", $sans;
 		font-weight: 400;
+		letter-spacing: initial;
 
 		.woo-inline-purple-heart {
 			width: 18px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -63,8 +63,13 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 	};
 
 	const getSubTitle = () => {
-		return __(
-			'#FunWooFact: Did you know that Woo powers almost 4 million stores worldwide? You’re in good company.'
+		return (
+			<>
+				<strong>{ __( '#FunWooFact: ' ) }</strong>
+				{ __(
+					'Did you know that Woo powers almost 4 million stores worldwide? You’re in good company.'
+				) }
+			</>
 		);
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
@@ -35,9 +35,8 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 						title: __( "Woo! We're creating your store" ),
 						subtitle: (
 							<>
-								<strong>{ __( '#FunWooFact: ' ) }</strong>
 								{ __(
-									"Did you know that Woo powers almost 4 million stores worldwide? You're in good company."
+									'Hang tight! Your free trial is currently being set up and may take a few minutes.'
 								) }
 							</>
 						),
@@ -56,7 +55,19 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 								) }
 							</>
 						),
-						duration: 15000,
+						duration: 8000,
+					},
+					{
+						title: __( 'Organizing the stock room' ),
+						subtitle: (
+							<>
+								<strong>{ __( '#FunWooFact: ' ) }</strong>
+								{ __(
+									"Did you know that Woo powers almost 4 million stores worldwide? You're in good company."
+								) }
+							</>
+						),
+						duration: 6000,
 					},
 					{
 						title: __( 'Organizing the stock room' ),
@@ -66,11 +77,8 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 								{ __( 'Are you Team Cat or Team Dog? The Woo team is split 50/50!' ) }
 							</>
 						),
-						duration: 15000,
+						duration: 6000,
 					},
-				];
-			default:
-				return [
 					{
 						title: __( 'Applying the finishing touches' ),
 						subtitle: (
@@ -81,7 +89,7 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 								) }
 							</>
 						),
-						duration: 10000,
+						duration: 8000,
 					},
 					{
 						title: __( 'Turning on the lights' ),
@@ -93,10 +101,10 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 								) }
 							</>
 						),
-						duration: 15000,
+						duration: 8000,
 					},
 					{
-						title: __( 'Opening the doors' ),
+						title: __( 'Turning on the lights' ),
 						subtitle: (
 							<>
 								<strong>{ __( '#FunWooFact: ' ) }</strong>
@@ -107,6 +115,17 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 									src={ WooPurpleHeart }
 								/>
 							</>
+						),
+						// Set a very long duration to make sure it shows until the step is completed
+						duration: 150000,
+					},
+				];
+			default:
+				return [
+					{
+						title: __( 'Opening the doors' ),
+						subtitle: (
+							<>{ __( "We're almost there! Your free trial will be ready in just a moment." ) }</>
 						),
 						// Set a very long duration to make sure it shows until the step is completed
 						duration: 150000,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
@@ -35,9 +35,8 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 						title: __( "Woo! We're creating your store" ),
 						subtitle: (
 							<>
-								{ __(
-									'Hang tight! Your free trial is currently being set up and may take a few minutes.'
-								) }
+								<strong>{ __( 'Hang tight! ' ) }</strong>
+								{ __( 'Your free trial is currently being set up and may take a few minutes.' ) }
 							</>
 						),
 						duration: 15000,
@@ -125,7 +124,10 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 					{
 						title: __( 'Opening the doors' ),
 						subtitle: (
-							<>{ __( "We're almost there! Your free trial will be ready in just a moment." ) }</>
+							<>
+								<strong>{ __( "We're almost there! " ) }</strong>
+								{ __( 'Your free trial will be ready in just a moment.' ) }
+							</>
 						),
 						// Set a very long duration to make sure it shows until the step is completed
 						duration: 150000,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75273 and [#74691](https://github.com/Automattic/wp-calypso/issues/74691)

## Proposed Changes

Changes to Woo Express site provisioning loading messages:

- Initial message set to `Hang tight! Your free trial is currently being set up and may take a few minutes.`
- Reduced duration of various Woo facts – not all facts are able to be shown (4 out of 6 facts was shown in the video, may vary if loading times are longer/shorter).
- Just before being redirected, the message `We're almost there! Your free trial will be ready in just a moment.` is shown.
- Bold initial words in the tagline
- Fixed letter spacing
- Fixed responsive view

## Testing Instructions

* Go to `http://calypso.localhost:3000/setup/wooexpress`
* Observe the loading messages per highlighted in above changes
* While loading, try to reduce browser width down to 400 - 500px and observe the loading bar does not overflow the screen

<img width="400" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/b8f8f743-4753-443b-b748-8a1d7f20cb08">


https://github.com/Automattic/wp-calypso/assets/3747241/c71b30e1-4481-4896-b70c-4ac75afac17f




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?