### PR TITLE
Theme Card: Fix mShots viewport options

### DIFF
--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -106,6 +106,7 @@ $theme-card-info-margin-top: 16px;
 		display: block;
 		height: auto;
 		left: 0;
+		min-height: 100%;
 		padding: 0;
 		position: absolute;
 		right: 0;

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -60,7 +60,7 @@ export const getMShotOptions = ( {
 		// 901 renders well with all the current designs, more details in the links below
 		// https://github.com/Automattic/wp-calypso/issues/71439#issuecomment-1367335609
 		// https://github.com/Automattic/wp-calypso/issues/71439#issuecomment-1369694397
-		vph: scrollable ? 1600 : 901,
+		vph: scrollable ? 1600 : 1040,
 		// When `w` was 1200 it created a visual glitch on one thumbnail. #57261
 		w: highRes ? 1199 : 600,
 		screen_height: 3600,

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -57,9 +57,8 @@ export const getMShotOptions = ( {
 	// Take care changing these values, as the design-picker CSS animations are written for these values (see the *__landscape and *__portrait classes)
 	return {
 		vpw: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
-		// 901 renders well with all the current designs, more details in the links below
-		// https://github.com/Automattic/wp-calypso/issues/71439#issuecomment-1367335609
-		// https://github.com/Automattic/wp-calypso/issues/71439#issuecomment-1369694397
+		// 1040 renders well with all the current designs, more details in the links below.
+		// See: #77052
 		vph: scrollable ? 1600 : 1040,
 		// When `w` was 1200 it created a visual glitch on one thumbnail. #57261
 		w: highRes ? 1199 : 600,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71439 #75858

## Proposed Changes

This PR updates the mShots option `vph` from 901px to 1040px. The 1040px matches with the parameter `viewport_height` set to the block preview API endpoint.

Before this PR, the `vph` of 901px would generate a snapshot of 901px tall, but the page viewport height would be 1040px (`viewport_height`). As a result, blocks using CSS unit `vh` for height will only cover the snapshot viewport of 901px. See screenshot for reference:

![https___public-api wordpress com_wpcom_v2_block-previews_site_stylesheet=pub%2Fblank-canvas-3 pattern_ids=7710-174455321 language=en viewport_height=1040 source_site=patternboilerplates wordpress](https://github.com/Automattic/wp-calypso/assets/797888/a912818e-fa30-4d22-94b8-589accb0a595)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/site-setup?siteSlug=${site_slug}`.
* Continue until you land on the Onboarding Design Picker.
* Ensure that the thumbnail issues reported in #75858 no longer exists.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
