### PR TITLE
Social previews | Add media support to "Your post" sections

### DIFF
--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.0.0-beta.4",
+	"version": "2.0.0-beta.5",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/src/facebook-preview/post-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/post-preview.tsx
@@ -11,10 +11,10 @@ export const FacebookPostPreview: React.FC< FacebookPreviewProps > = ( {
 	url,
 	user,
 	customText,
-	customImage,
+	media,
 	imageMode,
 } ) => {
-	const [ mode, isLoadingImage, imgProps ] = useImage( { mode: imageMode } );
+	const [ mode ] = useImage( { mode: imageMode } );
 	const modeClass = `is-${ mode === PORTRAIT_MODE ? 'portrait' : 'landscape' }`;
 
 	return (
@@ -22,11 +22,26 @@ export const FacebookPostPreview: React.FC< FacebookPreviewProps > = ( {
 			<FacebookPostHeader user={ user } />
 			<div className="facebook-preview__content">
 				{ customText && <CustomText text={ customText } url={ url } forceUrlDisplay /> }
-				<div className={ `facebook-preview__body ${ isLoadingImage ? 'is-loading' : '' }` }>
-					<div className={ `facebook-preview__custom-image ${ modeClass }` }>
-						{ /* eslint-disable jsx-a11y/alt-text */ }
-						<img src={ customImage } { ...imgProps } />
-					</div>
+				<div className="facebook-preview__body">
+					{ media ? (
+						<div className={ `facebook-preview__media ${ modeClass }` }>
+							{ media.map( ( mediaItem, index ) => (
+								<div
+									key={ `facebook-preview__media-item-${ index }` }
+									className={ `facebook-preview__media-item ${ modeClass }` }
+								>
+									{ mediaItem.type.startsWith( 'video/' ) ? (
+										// eslint-disable-next-line jsx-a11y/media-has-caption
+										<video controls>
+											<source src={ mediaItem.url } type={ mediaItem.type } />
+										</video>
+									) : (
+										<img alt={ mediaItem.alt || '' } src={ mediaItem.url } />
+									) }
+								</div>
+							) ) }
+						</div>
+					) : null }
 				</div>
 			</div>
 			<FacebookPostActions />

--- a/packages/social-previews/src/facebook-preview/previews.tsx
+++ b/packages/social-previews/src/facebook-preview/previews.tsx
@@ -10,8 +10,8 @@ import type { FacebookPreviewProps } from './types';
 export type FacebookPreviewsProps = FacebookPreviewProps & SocialPreviewsBaseProps;
 
 export const FacebookPreviews: React.FC< FacebookPreviewsProps > = ( props ) => {
-	const { customImage } = props;
-	const hasCustomImage = !! customImage;
+	const hasMedia = !! props.media?.length;
+	const hasCustomImage = !! props.customImage;
 
 	return (
 		<div className="social-preview facebook-preview">
@@ -25,11 +25,7 @@ export const FacebookPreviews: React.FC< FacebookPreviewsProps > = ( props ) => 
 				<p className="social-preview__section-desc">
 					{ __( 'This is what your social post will look like on Facebook:', 'social-previews' ) }
 				</p>
-				{ hasCustomImage ? (
-					<FacebookPostPreview { ...props } />
-				) : (
-					<FacebookLinkPreview { ...props } />
-				) }
+				{ hasMedia ? <FacebookPostPreview { ...props } /> : <FacebookLinkPreview { ...props } /> }
 			</section>
 			<section className="social-preview__section facebook-preview__section">
 				<SectionHeading level={ props.headingLevel }>

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -114,11 +114,13 @@
 }
 
 .facebook-preview__image,
-.facebook-preview__custom-image {
-	img {
+.facebook-preview__custom-image,
+.facebook-preview__media-item {
+	img,
+	video {
 		display: block;
-
 		object-fit: cover;
+		width: 100%;
 	}
 }
 
@@ -148,7 +150,8 @@
 	}
 }
 
-.facebook-preview__custom-image {
+.facebook-preview__custom-image,
+.facebook-preview__media-item {
 	display: flex;
 	justify-content: center;
 

--- a/packages/social-previews/src/facebook-preview/types.ts
+++ b/packages/social-previews/src/facebook-preview/types.ts
@@ -1,5 +1,5 @@
 import { TYPE_WEBSITE, TYPE_ARTICLE, LANDSCAPE_MODE, PORTRAIT_MODE } from '../constants';
-import type { SocialPreviewBaseProps } from '../types';
+import type { MediaItem, SocialPreviewBaseProps } from '../types';
 
 export type ImageMode = typeof LANDSCAPE_MODE | typeof PORTRAIT_MODE;
 
@@ -14,4 +14,5 @@ export type FacebookPreviewProps = SocialPreviewBaseProps & {
 	customText?: string;
 	customImage?: string;
 	imageMode?: ImageMode;
+	media?: Array< MediaItem >;
 };

--- a/packages/social-previews/src/linkedin-preview/link-preview.tsx
+++ b/packages/social-previews/src/linkedin-preview/link-preview.tsx
@@ -8,5 +8,13 @@ export type LinkedInLinkPreviewProps = Omit< LinkedInPreviewProps, keyof Optiona
 	OptionalProps;
 
 export function LinkedInLinkPreview( props: LinkedInLinkPreviewProps ) {
-	return <LinkedInPostPreview { ...DEFAULT_PROPS } { ...props } />;
+	return (
+		<LinkedInPostPreview
+			{ ...DEFAULT_PROPS }
+			{ ...props }
+			// Override the props that are irrelevant to link preview
+			description=""
+			media={ undefined }
+		/>
+	);
 }

--- a/packages/social-previews/src/linkedin-preview/post-preview.tsx
+++ b/packages/social-previews/src/linkedin-preview/post-preview.tsx
@@ -11,12 +11,15 @@ export function LinkedInPostPreview( {
 	name,
 	profileImage,
 	description,
+	media,
 	title,
 	url,
 }: LinkedInPreviewProps ) {
+	const hasMedia = !! media?.length;
+
 	return (
 		<div className="linkedin-preview__wrapper">
-			<section className="linkedin-preview__container">
+			<section className={ `linkedin-preview__container ${ hasMedia ? 'has-media' : '' }` }>
 				<div className="linkedin-preview__header">
 					<div className="linkedin-preview__header--avatar">
 						<img src={ profileImage } alt="" />
@@ -65,24 +68,46 @@ export function LinkedInPostPreview( {
 							} }
 						/>
 					) : null }
-					<article>
-						{ image ? <img className="linkedin-preview__image" src={ image } alt="" /> : null }
-						{ url ? (
-							<div className="linkedin-preview__description">
-								<h2 className="linkedin-preview__description--title">{ title }</h2>
-								<div className="linkedin-preview__description--meta">
-									<span className="linkedin-preview__description--url">{ baseDomain( url ) }</span>
-									<span>•</span>
-									<span>
-										{
-											// translators: x is the number of minutes it takes to read the article
-											__( 'x min read', 'social-previews' )
-										}
-									</span>
+					{ hasMedia ? (
+						<div className="linkedin-preview__media">
+							{ media.map( ( mediaItem, index ) => (
+								<div
+									key={ `linkedin-preview__media-item-${ index }` }
+									className="linkedin-preview__media-item"
+								>
+									{ mediaItem.type.startsWith( 'video/' ) ? (
+										// eslint-disable-next-line jsx-a11y/media-has-caption
+										<video controls>
+											<source src={ mediaItem.url } type={ mediaItem.type } />
+										</video>
+									) : (
+										<img alt={ mediaItem.alt || '' } src={ mediaItem.url } />
+									) }
 								</div>
-							</div>
-						) : null }
-					</article>
+							) ) }
+						</div>
+					) : (
+						<article>
+							{ image ? <img className="linkedin-preview__image" src={ image } alt="" /> : null }
+							{ url ? (
+								<div className="linkedin-preview__description">
+									<h2 className="linkedin-preview__description--title">{ title }</h2>
+									<div className="linkedin-preview__description--meta">
+										<span className="linkedin-preview__description--url">
+											{ baseDomain( url ) }
+										</span>
+										<span>•</span>
+										<span>
+											{
+												// translators: x is the number of minutes it takes to read the article
+												__( 'x min read', 'social-previews' )
+											}
+										</span>
+									</div>
+								</div>
+							) : null }
+						</article>
+					) }
 				</div>
 			</section>
 		</div>

--- a/packages/social-previews/src/linkedin-preview/style.scss
+++ b/packages/social-previews/src/linkedin-preview/style.scss
@@ -27,6 +27,12 @@
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 8px;
 		overflow: hidden;
+
+		&.has-media {
+			// When the preview has media, we want to hide the border radius on the bottom
+			border-end-end-radius: 0;
+			border-end-start-radius: 0;
+		}
 	}
 
 	&__header {
@@ -73,11 +79,22 @@
 		font-weight: 400;
 	}
 
-	&__content article {
+	&__content article,
+	&__media {
 		margin-top: 0.5rem;
 		background-color: #eef3f8;
 		display: flex;
 		flex-direction: column;
+	}
+
+	&__media-item {
+		display: flex;
+
+		img,
+		video {
+			width: 100%;
+			object-fit: cover;
+		}
 	}
 
 	&__description {

--- a/packages/social-previews/src/linkedin-preview/types.ts
+++ b/packages/social-previews/src/linkedin-preview/types.ts
@@ -1,9 +1,10 @@
-import { SocialPreviewBaseProps, SocialPreviewsBaseProps } from '../types';
+import { MediaItem, SocialPreviewBaseProps, SocialPreviewsBaseProps } from '../types';
 
 export type LinkedInPreviewProps = SocialPreviewBaseProps & {
 	jobTitle?: string;
 	name: string;
 	profileImage: string;
+	media?: Array< MediaItem >;
 };
 
 export type LinkedInPreviewsProps = LinkedInPreviewProps & SocialPreviewsBaseProps;

--- a/packages/social-previews/src/twitter-preview/card.tsx
+++ b/packages/social-previews/src/twitter-preview/card.tsx
@@ -16,9 +16,6 @@ export const Card: React.FC< TwitterCardProps > = ( {
 	cardType,
 	url,
 } ) => {
-	if ( ! title && ! description && ! image && ! url ) {
-		return null;
-	}
 	const cardClassNames = classnames( `twitter-preview__card-${ cardType }`, {
 		'twitter-preview__card-has-image': !! image,
 	} );

--- a/packages/social-previews/src/twitter-preview/link-preview.tsx
+++ b/packages/social-previews/src/twitter-preview/link-preview.tsx
@@ -8,5 +8,13 @@ export type TwitterLinkPreviewProps = Omit< TwitterPreviewProps, keyof OptionalP
 	OptionalProps;
 
 export const TwitterLinkPreview: React.FC< TwitterLinkPreviewProps > = ( props ) => {
-	return <TwitterPostPreview { ...DEFAULT_PROPS } { ...props } text="" />;
+	return (
+		<TwitterPostPreview
+			{ ...DEFAULT_PROPS }
+			{ ...props }
+			// Override the props that are irrelevant to link preview
+			text=""
+			media={ undefined }
+		/>
+	);
 };

--- a/packages/social-previews/src/twitter-preview/media.tsx
+++ b/packages/social-previews/src/twitter-preview/media.tsx
@@ -1,11 +1,8 @@
 import classnames from 'classnames';
+import { Fragment } from 'react';
 import { MediaProps } from './types';
 
 export const Media: React.FC< MediaProps > = ( { media } ) => {
-	if ( ! media ) {
-		return null;
-	}
-
 	// Ensure we're only trying to show valid media, and the correct quantity.
 	const filteredMedia = media
 		// Only image/ and video/ mime types are supported.
@@ -34,34 +31,31 @@ export const Media: React.FC< MediaProps > = ( { media } ) => {
 		// We only want the first four items of the array, at most.
 		.slice( 0, 4 );
 
-	const isVideo = filteredMedia.length > 0 && filteredMedia[ 0 ].type.startsWith( 'video/' );
+	if ( 0 === filteredMedia.length ) {
+		return null;
+	}
+
+	const isVideo = filteredMedia[ 0 ].type.startsWith( 'video/' );
 
 	const mediaClasses = classnames( [
 		'twitter-preview__media',
 		'twitter-preview__media-children-' + filteredMedia.length,
 	] );
 
-	if ( 0 === filteredMedia.length ) {
-		return null;
-	}
-
 	return (
 		<div className={ mediaClasses }>
-			{ isVideo &&
-				filteredMedia.map( ( mediaItem, index ) => (
-					// eslint-disable-next-line jsx-a11y/media-has-caption
-					<video key={ `twitter-preview__media-item-${ index }` } controls>
-						<source src={ mediaItem.url } type={ mediaItem.type } />{ ' ' }
-					</video>
-				) ) }
-			{ ! isVideo &&
-				filteredMedia.map( ( mediaItem, index ) => (
-					<img
-						key={ `twitter-preview__media-item-${ index }` }
-						alt={ mediaItem.alt }
-						src={ mediaItem.url }
-					/>
-				) ) }
+			{ filteredMedia.map( ( mediaItem, index ) => (
+				<Fragment key={ `twitter-preview__media-item-${ index }` }>
+					{ isVideo ? (
+						// eslint-disable-next-line jsx-a11y/media-has-caption
+						<video controls>
+							<source src={ mediaItem.url } type={ mediaItem.type } />
+						</video>
+					) : (
+						<img alt={ mediaItem.alt || '' } src={ mediaItem.url } />
+					) }
+				</Fragment>
+			) ) }
 		</div>
 	);
 };

--- a/packages/social-previews/src/twitter-preview/post-preview.tsx
+++ b/packages/social-previews/src/twitter-preview/post-preview.tsx
@@ -24,6 +24,8 @@ export const TwitterPostPreview: React.FC< TwitterPreviewProps > = ( {
 	cardType,
 	url,
 } ) => {
+	const hasMedia = !! media?.length;
+
 	return (
 		<div className="twitter-preview__wrapper">
 			<div className="twitter-preview__container">
@@ -31,16 +33,18 @@ export const TwitterPostPreview: React.FC< TwitterPreviewProps > = ( {
 				<div className="twitter-preview__main">
 					<Header name={ name } screenName={ screenName } date={ date } />
 					<div className="twitter-preview__content">
-						<Text text={ text } url={ url || '' } />
-						<Media media={ media } />
-						<QuoteTweet tweet={ tweet } />
-						<Card
-							description={ description }
-							image={ image }
-							title={ title }
-							cardType={ cardType }
-							url={ url }
-						/>
+						{ text ? <Text text={ text } url={ url || '' } retainUrl={ hasMedia } /> : null }
+						{ hasMedia ? <Media media={ media } /> : null }
+						{ tweet ? <QuoteTweet tweet={ tweet } /> : null }
+						{ ! hasMedia && title && description && image && url && (
+							<Card
+								description={ description }
+								image={ image }
+								title={ title }
+								cardType={ cardType || '' }
+								url={ url }
+							/>
+						) }
 					</div>
 					<Footer />
 				</div>

--- a/packages/social-previews/src/twitter-preview/text.tsx
+++ b/packages/social-previews/src/twitter-preview/text.tsx
@@ -1,14 +1,17 @@
 import { preparePreviewText } from '../helpers';
 import { TextProps } from './types';
 
-export const Text: React.FC< TextProps > = ( { text, url } ) => {
+export const Text: React.FC< TextProps > = ( { text, url, retainUrl } ) => {
 	if ( ! text ) {
 		return null;
 	}
 	// If the text ends with the card URL, remove it.
-	const deCardedText = text.endsWith( url ) ? text.substring( 0, text.lastIndexOf( url ) ) : text;
+	const tweetText =
+		url && ! retainUrl && text.endsWith( url )
+			? text.substring( 0, text.lastIndexOf( url ) )
+			: text;
 
-	const __html = preparePreviewText( deCardedText, { platform: 'twitter' } );
+	const __html = preparePreviewText( tweetText, { platform: 'twitter' } );
 
 	return (
 		<div

--- a/packages/social-previews/src/twitter-preview/types.ts
+++ b/packages/social-previews/src/twitter-preview/types.ts
@@ -1,13 +1,7 @@
-import { SocialPreviewBaseProps, SocialPreviewsBaseProps } from '../types';
+import { MediaItem, SocialPreviewBaseProps, SocialPreviewsBaseProps } from '../types';
 
 export type TwitterPreviewsProps = SocialPreviewsBaseProps & {
 	tweets: Array< TwitterPreviewProps >;
-};
-
-export type TwitterMedia = {
-	alt: string;
-	type: string;
-	url: string;
 };
 
 export type TwitterCardProps = SocialPreviewBaseProps & {
@@ -26,21 +20,19 @@ export type HeaderProps = {
 };
 
 export type MediaProps = {
-	media?: Array< TwitterMedia >;
+	media: Array< MediaItem >;
 };
 
 export type QuoteTweetProps = {
-	tweet?: TwitterPreviewProps;
+	tweet: TwitterPreviewProps;
 };
 
 export type TextProps = {
 	text: string;
 	url: string;
+	retainUrl?: boolean;
 };
 
 export type TwitterPreviewProps = SidebarProps &
 	HeaderProps &
-	MediaProps &
-	QuoteTweetProps &
-	TwitterCardProps &
-	Pick< TextProps, 'text' >;
+	Partial< MediaProps & QuoteTweetProps & TwitterCardProps & Pick< TextProps, 'text' > >;

--- a/packages/social-previews/src/types.ts
+++ b/packages/social-previews/src/types.ts
@@ -25,3 +25,20 @@ export interface SocialPreviewBaseProps {
 export interface SocialPreviewsBaseProps {
 	headingLevel?: SectionHeadingProps[ 'level' ];
 }
+
+export type MediaItem = {
+	/**
+	 * The alt text for the image.
+	 */
+	alt?: string;
+
+	/**
+	 * The mime type of the media
+	 */
+	type: string;
+
+	/**
+	 * The URL of the media.
+	 */
+	url: string;
+};

--- a/packages/social-previews/test/index.js
+++ b/packages/social-previews/test/index.js
@@ -129,9 +129,19 @@ describe( 'Twitter previews', () => {
 		urls: [],
 	};
 
+	const dummyProps = {
+		title: 'test',
+		description: 'test',
+		image: 'https://s1.wp.com/wp-content/themes/h4/i/automattic-2x.png',
+		url: 'https://wordpress.com/',
+	};
+
 	it( 'should display an untruncated title', () => {
 		const { container } = render(
-			<Twitter title="I am the very model of a modern Major-General, I've information vegetable, animal, and mineral." />
+			<Twitter
+				{ ...dummyProps }
+				title="I am the very model of a modern Major-General, I've information vegetable, animal, and mineral."
+			/>
 		);
 
 		const tweetWrapper = container.querySelector( '.twitter-preview__container' );
@@ -145,7 +155,10 @@ describe( 'Twitter previews', () => {
 
 	it( 'should display a truncated description', () => {
 		const { container } = render(
-			<Twitter description="I know the kings of England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, both the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse." />
+			<Twitter
+				{ ...dummyProps }
+				description="I know the kings of England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, both the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse."
+			/>
 		);
 
 		const tweetWrapper = container.querySelector( '.twitter-preview__container' );
@@ -160,7 +173,10 @@ describe( 'Twitter previews', () => {
 
 	it( 'should strip html tags from the description', () => {
 		const { container } = render(
-			<Twitter description="<p style='color:red'>I know the kings of <span>England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, <span>both</span> the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse." />
+			<Twitter
+				{ ...dummyProps }
+				description="<p style='color:red'>I know the kings of <span>England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, <span>both</span> the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse."
+			/>
 		);
 
 		const tweetWrapper = container.querySelector( '.twitter-preview__container' );
@@ -175,8 +191,8 @@ describe( 'Twitter previews', () => {
 	it( 'should display image only when provided', () => {
 		const { container } = render(
 			<>
-				<Twitter />
-				<Twitter image={ IMAGE_SRC_FIXTURE } />
+				<Twitter { ...dummyProps } image="" />
+				<Twitter { ...dummyProps } image={ IMAGE_SRC_FIXTURE } />
 			</>
 		);
 
@@ -197,7 +213,7 @@ describe( 'Twitter previews', () => {
 	} );
 
 	it( 'should display a protocol-less url only (with no separator) when author is not provided', () => {
-		const { container } = render( <Twitter url="https://wordpress.com" /> );
+		const { container } = render( <Twitter { ...dummyProps } url="https://wordpress.com" /> );
 
 		const tweetWrapper = container.querySelector( '.twitter-preview__container' );
 
@@ -209,7 +225,7 @@ describe( 'Twitter previews', () => {
 
 	describe( 'Styling hooks', () => {
 		it( 'should append a classname with the correct "type" to the root element when provided', () => {
-			const { container } = render( <Twitter cardType="article" title="test" /> );
+			const { container } = render( <Twitter { ...dummyProps } cardType="article" title="test" /> );
 
 			const tweetWrapper = container.querySelector( '.twitter-preview__container' );
 			const innerEl = tweetWrapper.querySelector( '.twitter-preview__card > div' );


### PR DESCRIPTION
Right now the "Your post" section in Social Previews is pretty much the same as link preview which is not always the case. The users can add custom media or an image generated by Social Image Generator and choose to share that media as a social post instead of the default post.

Completes 1203820933396971-as-1204615220483680/f

## Proposed Changes

* Add media support for Facebook, Twitter and LinkedIn previews

## Testing Instructions

See https://github.com/Automattic/jetpack/pull/30787


BEFORE

https://github.com/Automattic/wp-calypso/assets/18226415/b758a1cf-5d0e-4772-a2e1-88bb8a59dae2

AFTER

https://github.com/Automattic/wp-calypso/assets/18226415/4dbcc482-cb35-4eef-a5cf-82132dc520f5



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1204615220483680