### PR TITLE
Fix missing CSS mixing and variables issue in root storybook

### DIFF
--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -1,6 +1,5 @@
 @import "@automattic/typography/styles/variables";
-// stylelint-disable-next-line scss/at-import-no-partial-leading-underscore
-@import "../../assets/stylesheets/shared/mixins/_breakpoints";
+@import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 
 .card-heading {
 	font-weight: 400;

--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -1,3 +1,6 @@
+@import "@automattic/typography/styles/variables";
+@import "../../assets/stylesheets/shared/mixins/_breakpoints";
+
 .card-heading {
 	font-weight: 400;
 	margin-bottom: 5px;

--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/typography/styles/variables";
+// stylelint-disable-next-line scss/at-import-no-partial-leading-underscore
 @import "../../assets/stylesheets/shared/mixins/_breakpoints";
 
 .card-heading {

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -1,6 +1,4 @@
 @import "@automattic/typography/styles/variables";
-// stylelint-disable-next-line scss/at-import-no-partial-leading-underscore
-@import "client/assets/stylesheets/shared/mixins/_breakpoints";
 
 $theme-card-info-height: 48px;
 $theme-card-info-margin-top: 16px;

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/typography/styles/variables";
+// stylelint-disable-next-line scss/at-import-no-partial-leading-underscore
 @import "client/assets/stylesheets/shared/mixins/_breakpoints";
 
 $theme-card-info-height: 48px;

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -1,3 +1,6 @@
+@import "@automattic/typography/styles/variables";
+@import "client/assets/stylesheets/shared/mixins/_breakpoints";
+
 $theme-card-info-height: 48px;
 $theme-card-info-margin-top: 16px;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1684333670968859-slack-C02DQP0FP

## Proposed Changes

In this PR, I propose to fix the error that pops out when I start the root storybook and prevents me from using it. I fix it by adding an import for files that define breakpoint mixins and typography variables.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run storybook in root:
```
yarn storybook:start
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?