### PR TITLE
Stepper Framework: Un-deprecate the `goBack()` navigation function

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/domain-upsell.ts
@@ -46,6 +46,12 @@ const domainUpsell: Flow = {
 			window.location.assign( location );
 		};
 
+		function goBack() {
+			if ( currentStep === 'plans' ) {
+				navigate( 'domains' );
+			}
+		}
+
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
 				case 'domains':
@@ -62,9 +68,6 @@ const domainUpsell: Flow = {
 					navigate( 'plans' );
 
 				case 'plans':
-					if ( providedDependencies?.goBack ) {
-						return navigate( 'domains' );
-					}
 					if ( providedDependencies?.goToCheckout ) {
 						const planCartItem = getPlanCartItem();
 						const domainCartItem = getDomainCartItem();
@@ -85,7 +88,7 @@ const domainUpsell: Flow = {
 			}
 		}
 
-		return { submit, exitFlow };
+		return { submit, exitFlow, goBack };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
@@ -42,6 +42,12 @@ const hosting: Flow = {
 
 		const flowName = this.name;
 
+		const goBack = () => {
+			if ( _currentStepSlug === 'plans' ) {
+				navigate( 'options' );
+			}
+		};
+
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
 
@@ -52,10 +58,6 @@ const hosting: Flow = {
 					return navigate( 'plans' );
 				}
 				case 'plans':
-					if ( providedDependencies?.goBack ) {
-						return navigate( 'options' );
-					}
-
 					setPlanCartItem( {
 						product_slug: ( providedDependencies?.plan as MinimalRequestCartProduct | null )
 							?.product_slug,
@@ -88,7 +90,7 @@ const hosting: Flow = {
 			return providedDependencies;
 		};
 
-		return { submit };
+		return { goBack, submit };
 	},
 	useSideEffect( currentStepSlug ) {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -11,7 +11,7 @@ import type { ProvidedDependencies, Step } from '../../types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const plans: Step = function Plans( { navigation, flow } ) {
-	const { submit } = navigation;
+	const { goBack, submit } = navigation;
 
 	const handleSubmit = ( plan: MinimalRequestCartProduct | null ) => {
 		const providedDependencies: ProvidedDependencies = {
@@ -31,7 +31,7 @@ const plans: Step = function Plans( { navigation, flow } ) {
 	return (
 		<StepContainer
 			stepName="plans"
-			goBack={ () => submit?.( { goBack: true } ) }
+			goBack={ goBack }
 			isHorizontalLayout={ false }
 			isWideLayout={ ! is2023PricingGridVisible }
 			isFullLayout={ is2023PricingGridVisible }

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -6,11 +6,6 @@ import React from 'react';
 export type NavigationControls = {
 	/**
 	 * Call this function if you want to go to the previous step.
-	 *
-	 * @deprecated Avoid this method. Use submit() instead.
-	 * If you need to navigate back and forth between
-	 * stepper screens, consider adding screen(s) to a new
-	 * stepper flow and linking directly between flows/screens.
 	 */
 	goBack?: () => void;
 
@@ -32,6 +27,7 @@ export type NavigationControls = {
 	 * between flows/screens.
 	 */
 	goToStep?: ( step: string ) => void;
+
 	/**
 	 * Submits the answers provided in the flow
 	 */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Originally discussed in https://github.com/Automattic/wp-calypso/pull/76854#issuecomment-1549382116, this PR un-deprecates the `goBack()` navigation function.

`goBack()` is really just a special version of `submit()` i.e. it can be achieved by calling `submit( { goBack: true } )`. But as was brought up in the above PR, it'd be nice for all the flows to use a consistent flag name for step submissions that represent going backwards. And if they all have a consistent flag name, isn't that the same thing as having an explicit `goBack()` function?

Another reason to favour a `goBack()` function is that it's more type safe. The `ProvidedDependencies` parameter passed to `submit()` isn't strongly typed, so you have to check the value of the `goBack` flag without knowing whether it'll be there. Whereas you know the `goBack()` function is always being called by someone who wanted to go back.
It doesn't solve it for all the other cases where `ProvidedDependencies` has to be accessed, but it's something.

CC @Automattic/vertex and @edanzer who did the work to deprecate this method in the first place.

I'm open to discussion. There's definitely something appealing about the idea of only having one function for moving the state-machine to another state.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I've tested the `/setup/new-hosted-site` flow but I'm not sure how to test the domain upsell flow. I think it's liked to from one of the launch pads?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
