### PR TITLE
Plans 2023: Fix grid responsiveness

### DIFF
--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -6,25 +6,11 @@ $plan-features-header-banner-height: 20px;
 // Breakpoints
 $plans-2023-small-breakpoint: 780px;
 $plans-2023-medium-breakpoint: 1200px;
-
-$minWidthToGridWidthMap: (
-	780px: "668px", // above here - needs padding/margin in signup flow [1]
-	1024px: "860px",
-	1200px: "1134px",
-	1440px: "1320px",
-	1600px: "1480px",
-);
+$plans-2023-large-breakpoint: 1440px;
 
 
 @mixin pricing-grid-breakpoints {
 	width: 100%;
-
-	// @each $screenMinWidth, $gridWidth in $minWidthToGridWidthMap {
-	// 	@media ( min-width: #{$screenMinWidth} ) {
-	// 		width: #{$gridWidth};
-	// 	}
-	// }
-
 }
 
 /**

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -9,22 +9,23 @@ $plans-2023-medium-breakpoint: 1200px;
 $plans-2023-large-breakpoint: 1440px;
 
 $minWidthToGridWidthMap: (
-	780px: "668px", // above here - needs padding/margin in signup flow [1]
+	780px: "668px",
 	1024px: "860px",
-	1200px: "1134px",
-	1440px: "1320px",
-	1600px: "1480px",
+	1200px: "100%",
+	// 1200px: "1134px",
+	// 1440px: "1320px",
+	// 1600px: "1480px",
 );
 
 
 @mixin pricing-grid-breakpoints {
 	width: 100%;
 
-	// @each $screenMinWidth, $gridWidth in $minWidthToGridWidthMap {
-	// 	@media ( min-width: #{$screenMinWidth} ) {
-	// 		width: #{$gridWidth};
-	// 	}
-	// }
+	@each $screenMinWidth, $gridWidth in $minWidthToGridWidthMap {
+		@media ( min-width: #{$screenMinWidth} ) {
+			width: #{$gridWidth};
+		}
+	}
 
 }
 

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -8,22 +8,28 @@ $plans-2023-small-breakpoint: 780px;
 $plans-2023-medium-breakpoint: 1200px;
 
 $minWidthToGridWidthMap: (
-	780px: "668px",
-	1024px: "860px",
-	1200px: "1134px",
-	1440px: "1320px",
+	// 780px: "668px", // above here - needs padding/margin in signup flow [1]
+	// 1024px: "860px",
+	// 1200px: "1134px",
+	// 1440px: "1320px",
 	1600px: "1480px",
 );
+
+// [1]
+// .plans-wrapper -> margin: 0 20px;
+// .plan-features-2023-grid__mobile-plan-card -> margin: 0;
+// 
+// above 1480 - no margin
 
 
 @mixin pricing-grid-breakpoints {
 	width: 100%;
 
-	@each $screenMinWidth, $gridWidth in $minWidthToGridWidthMap {
-		@media ( min-width: #{$screenMinWidth} ) {
-			width: #{$gridWidth};
-		}
-	}
+	// @each $screenMinWidth, $gridWidth in $minWidthToGridWidthMap {
+	// 	@media ( min-width: #{$screenMinWidth} ) {
+	// 		width: #{$gridWidth};
+	// 	}
+	// }
 
 }
 

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -64,7 +64,7 @@ $minWidthToGridWidthMap: (
 	}
 
 	.plan-features-2023-grid__mobile-view {
-		display: block;
+		display: flex;
 
 		@media ( min-width: $plans-2023-small-breakpoint ) {
 			display: none;
@@ -97,7 +97,7 @@ $minWidthToGridWidthMap: (
 	}
 
 	.plan-features-2023-grid__mobile-view {
-		display: block;
+		display: flex;
 
 		@media ( min-width: ( $plans-2023-small-breakpoint + $plan-features-sidebar-width ) ) {
 			display: none;

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -8,18 +8,12 @@ $plans-2023-small-breakpoint: 780px;
 $plans-2023-medium-breakpoint: 1200px;
 
 $minWidthToGridWidthMap: (
-	// 780px: "668px", // above here - needs padding/margin in signup flow [1]
-	// 1024px: "860px",
-	// 1200px: "1134px",
-	// 1440px: "1320px",
+	780px: "668px", // above here - needs padding/margin in signup flow [1]
+	1024px: "860px",
+	1200px: "1134px",
+	1440px: "1320px",
 	1600px: "1480px",
 );
-
-// [1]
-// .plans-wrapper -> margin: 0 20px;
-// .plan-features-2023-grid__mobile-plan-card -> margin: 0;
-// 
-// above 1480 - no margin
 
 
 @mixin pricing-grid-breakpoints {

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -6,7 +6,6 @@ $plan-features-header-banner-height: 20px;
 // Breakpoints
 $plans-2023-small-breakpoint: 780px;
 $plans-2023-medium-breakpoint: 1200px;
-$plans-2023-large-breakpoint: 1440px;
 
 $minWidthToGridWidthMap: (
 	780px: "668px",
@@ -135,6 +134,20 @@ $minWidthToGridWidthMap: (
 		}
 	}
 
+	.is-section-plans:not(.is-sidebar-collapsed) & {
+		@media ( min-width: $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) {
+			@content;
+		}
+	}
+
+	.is-section-plans.is-sidebar-collapsed & {
+		@media ( min-width: $plans-2023-medium-breakpoint ) {
+			@content;
+		}
+	}
+}
+
+@mixin plans-section-break-medium() {
 	.is-section-plans:not(.is-sidebar-collapsed) & {
 		@media ( min-width: $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) {
 			@content;

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -8,9 +8,24 @@ $plans-2023-small-breakpoint: 780px;
 $plans-2023-medium-breakpoint: 1200px;
 $plans-2023-large-breakpoint: 1440px;
 
+$minWidthToGridWidthMap: (
+	780px: "668px", // above here - needs padding/margin in signup flow [1]
+	1024px: "860px",
+	1200px: "1134px",
+	1440px: "1320px",
+	1600px: "1480px",
+);
+
 
 @mixin pricing-grid-breakpoints {
 	width: 100%;
+
+	// @each $screenMinWidth, $gridWidth in $minWidthToGridWidthMap {
+	// 	@media ( min-width: #{$screenMinWidth} ) {
+	// 		width: #{$gridWidth};
+	// 	}
+	// }
+
 }
 
 /**

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -11,9 +11,6 @@ $minWidthToGridWidthMap: (
 	780px: "668px",
 	1024px: "860px",
 	1200px: "100%",
-	// 1200px: "1134px",
-	// 1440px: "1320px",
-	// 1600px: "1480px",
 );
 
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -400,12 +400,12 @@ export class PlanFeatures2023Grid extends Component<
 	renderTabletView() {
 		const { planProperties } = this.props;
 		let plansToShow = [];
-		const numberOfPlansToShowOnTop = 3;
 
 		plansToShow = planProperties
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties ) => properties.planName );
 
+		const numberOfPlansToShowOnTop = 4 === plansToShow.length ? 2 : 3;
 		const topRowPlans = plansToShow.slice( 0, numberOfPlansToShowOnTop );
 		const bottomRowPlans = plansToShow.slice( numberOfPlansToShowOnTop, plansToShow.length );
 		const planPropertiesForTopRow = planProperties.filter( ( properties: PlanProperties ) =>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -373,7 +373,7 @@ export class PlanFeatures2023Grid extends Component<
 		const { translate } = this.props;
 		const tableClasses = classNames(
 			'plan-features-2023-grid__table',
-			`has-${ planPropertiesObj.length }-cols`
+			`has-${ planPropertiesObj.filter( ( { isVisible } ) => isVisible ).length }-cols`
 		);
 
 		return (

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1,6 +1,8 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "calypso/my-sites/plan-features-2023-grid/media-queries";
 
+$table-cell-max-width: 344px;
+
 .plan-features--loading-container {
 	margin-top: 300px;
 }
@@ -317,15 +319,15 @@
 		width: 100%;
 
 		&.has-1-cols {
-			max-width: 344px;
+			max-width: $table-cell-max-width;
 		}
 
 		&.has-2-cols {
-			max-width: 688px;
+			max-width: $table-cell-max-width * 2;
 		}
 
 		&.has-3-cols {
-			max-width: 1032px;
+			max-width: $table-cell-max-width * 3;
 		}
 	}
 

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -170,7 +170,7 @@
 }
 
 .is-2023-pricing-grid .plans-wrapper {
-	margin: 0 auto;
+	margin: 0 20px;
 	padding: 0 0 10px;
 	transform: translateY(-20px);
 	overflow-x: visible;
@@ -208,7 +208,7 @@
 			/* stylelint-disable-next-line */
 			border-radius: 5px;
 			padding: 38px 0 20px 0;
-			margin: 20px;
+			margin: 0;
 
 			@include plans-section-custom-mobile-breakpoint {
 				margin-left: 0;
@@ -303,9 +303,9 @@
 		border: 1px solid #e0e0e0;
 		border-radius: 5px; /* stylelint-disable-line */
 		background-color: #fff;
-		margin: 0;
+		margin: 0 auto;
 		border-spacing: 0;
-		width: 100%;
+		width: unset;
 	}
 
 	.plan-features-2023-grid__table-bottom .plan-features-2023-grid__table {
@@ -350,6 +350,7 @@
 		background-color: var(--color-surface);
 		position: relative;
 		vertical-align: baseline;
+		max-width: 344px;
 
 		.is-bold {
 			font-weight: 600;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -175,7 +175,6 @@ $mobile-card-max-width: 440px;
 .is-2023-pricing-grid .plans-wrapper {
 	margin: 0 20px;
 	padding: 0 0 10px;
-	// transform: translateY(-20px);
 	overflow-x: visible;
 
 	@include plans-2023-break-small {
@@ -401,7 +400,7 @@ $mobile-card-max-width: 440px;
 	.plan-features-2023-grid__desktop-view,
 	.plan-features-2023-grid__tablet-view {
 		.plan-features-2023-grid__table-item {
-			max-width: 344px;
+			max-width: $table-cell-max-width;
 		}
 	}
 

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -214,8 +214,10 @@ $mobile-card-max-width: 440px;
 
 	.plan-features-2023-grid__mobile-view {
 		flex-direction: column;
-		align-items: center;
+		align-items: stretch;
 		gap: 20px;
+		margin: 0 auto;
+		max-width: $mobile-card-max-width;
 
 		.plan-features-2023-grid__mobile-plan-card {
 			background-color: var(--studio-white);
@@ -223,7 +225,6 @@ $mobile-card-max-width: 440px;
 			/* stylelint-disable-next-line */
 			border-radius: 5px;
 			padding: 38px 0 20px 0;
-			max-width: $mobile-card-max-width;
 
 			@include plans-section-custom-mobile-breakpoint {
 				margin-left: 0;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -312,6 +312,9 @@
 		margin: 0 auto;
 		border-spacing: 0;
 		width: unset;
+		@mixin plans-2023-break-small {
+			width: 100%;
+		}
 	}
 
 	.plan-features-2023-grid__table-bottom .plan-features-2023-grid__table {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -2,6 +2,7 @@
 @import "calypso/my-sites/plan-features-2023-grid/media-queries";
 
 $table-cell-max-width: 344px;
+$mobile-card-max-width: 440px;
 
 .plan-features--loading-container {
 	margin-top: 300px;
@@ -212,6 +213,9 @@ $table-cell-max-width: 344px;
 	}
 
 	.plan-features-2023-grid__mobile-view {
+		flex-direction: column;
+		align-items: center;
+		gap: 20px;
 
 		.plan-features-2023-grid__mobile-plan-card {
 			background-color: var(--studio-white);
@@ -219,7 +223,7 @@ $table-cell-max-width: 344px;
 			/* stylelint-disable-next-line */
 			border-radius: 5px;
 			padding: 38px 0 20px 0;
-			margin: 0;
+			max-width: $mobile-card-max-width;
 
 			@include plans-section-custom-mobile-breakpoint {
 				margin-left: 0;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -178,6 +178,12 @@
 	@include plans-2023-break-small {
 		padding-top: 35px; // enough to cover `plan-features-2023-grid__popular-badge` repositioning (top: -35px)
 	}
+
+	@media ( min-width: $plans-2023-small-breakpoint ) {
+		.is-section-plans & {
+			margin: 0;
+		}
+	}
 }
 
 .is-2023-pricing-grid {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -311,9 +311,22 @@
 		background-color: #fff;
 		margin: 0 auto;
 		border-spacing: 0;
-		width: unset;
-		@mixin plans-2023-break-small {
-			width: 100%;
+		width: 100%;
+
+		&.has-1-cols {
+			width: 344px;
+		}
+
+		&.has-2-cols {
+			width: 688px;
+		}
+
+		&.has-3-cols {
+			max-width: 1032px;
+			// // media query between 780px and 1040px
+			// @media (max-width: 1040px) and (min-width: 780px) {
+			// 	width: 740px;
+			// }
 		}
 	}
 

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -314,19 +314,15 @@
 		width: 100%;
 
 		&.has-1-cols {
-			width: 344px;
+			max-width: 344px;
 		}
 
 		&.has-2-cols {
-			width: 688px;
+			max-width: 688px;
 		}
 
 		&.has-3-cols {
 			max-width: 1032px;
-			// // media query between 780px and 1040px
-			// @media (max-width: 1040px) and (min-width: 780px) {
-			// 	width: 740px;
-			// }
 		}
 	}
 

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -172,17 +172,20 @@
 .is-2023-pricing-grid .plans-wrapper {
 	margin: 0 20px;
 	padding: 0 0 10px;
-	transform: translateY(-20px);
+	// transform: translateY(-20px);
 	overflow-x: visible;
 
 	@include plans-2023-break-small {
 		padding-top: 35px; // enough to cover `plan-features-2023-grid__popular-badge` repositioning (top: -35px)
+		margin: 0;
 	}
 
-	@media ( min-width: $plans-2023-small-breakpoint ) {
-		.is-section-plans & {
-			margin: 0;
-		}
+	@include plans-2023-break-medium {
+		margin: 0 20px;
+	}
+
+	@include plans-section-break-medium {
+		margin: 0;
 	}
 }
 
@@ -368,7 +371,6 @@
 		background-color: var(--color-surface);
 		position: relative;
 		vertical-align: baseline;
-		max-width: 344px;
 
 		.is-bold {
 			font-weight: 600;
@@ -386,6 +388,13 @@
 
 		@include plans-2023-break-small {
 			border-left: solid 1px #e0e0e0;
+		}
+	}
+
+	.plan-features-2023-grid__desktop-view,
+	.plan-features-2023-grid__tablet-view {
+		.plan-features-2023-grid__table-item {
+			max-width: 344px;
 		}
 	}
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -443,10 +443,10 @@ export class PlansFeaturesMain extends Component {
 		const isEnterpriseAvailable = is2023PricingGridVisible && ! hideEnterprisePlan;
 
 		return [
-			TYPE_FREE,
-			isBloggerAvailable && TYPE_BLOGGER,
-			TYPE_PERSONAL,
-			TYPE_PREMIUM,
+			// TYPE_FREE,
+			// isBloggerAvailable && TYPE_BLOGGER,
+			// TYPE_PERSONAL,
+			// TYPE_PREMIUM,
 			TYPE_BUSINESS,
 			TYPE_ECOMMERCE,
 			isEnterpriseAvailable && TYPE_ENTERPRISE_GRID_WPCOM,

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -443,13 +443,13 @@ export class PlansFeaturesMain extends Component {
 		const isEnterpriseAvailable = is2023PricingGridVisible && ! hideEnterprisePlan;
 
 		return [
-			// TYPE_FREE,
-			// isBloggerAvailable && TYPE_BLOGGER,
-			// TYPE_PERSONAL,
-			// TYPE_PREMIUM,
-			TYPE_BUSINESS,
-			TYPE_ECOMMERCE,
-			isEnterpriseAvailable && TYPE_ENTERPRISE_GRID_WPCOM,
+			TYPE_FREE,
+			isBloggerAvailable && TYPE_BLOGGER,
+			TYPE_PERSONAL,
+			TYPE_PREMIUM,
+			// TYPE_BUSINESS,
+			// TYPE_ECOMMERCE,
+			// isEnterpriseAvailable && TYPE_ENTERPRISE_GRID_WPCOM,
 		].filter( ( el ) => el );
 	}
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -447,9 +447,9 @@ export class PlansFeaturesMain extends Component {
 			isBloggerAvailable && TYPE_BLOGGER,
 			TYPE_PERSONAL,
 			TYPE_PREMIUM,
-			// TYPE_BUSINESS,
-			// TYPE_ECOMMERCE,
-			// isEnterpriseAvailable && TYPE_ENTERPRISE_GRID_WPCOM,
+			TYPE_BUSINESS,
+			TYPE_ECOMMERCE,
+			isEnterpriseAvailable && TYPE_ENTERPRISE_GRID_WPCOM,
 		].filter( ( el ) => el );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1584

## Proposed Changes

Fixes grid responsiveness with 3 (or less) plans.

This does not intend to cleanup any of the complexities with these grids and the table structures underneath. It should be an improvement over production, with columns having a max width of `344px` and wrappers with margins (20px) to not touch the edges. 

### Media

**Before** 

| Before    | After |
| -------- | ------- |
| <img width="500" alt="Screenshot 2023-05-19 at 4 30 54 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/d3e4ca48-a56d-40a4-8256-78c6b8db3272"> | <img width="500" alt="Screenshot 2023-05-19 at 4 30 23 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/6a2b7c5f-a02e-45e7-b900-d5f3f130718a"> |
| <img width="500" alt="Screenshot 2023-05-19 at 4 39 16 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/208e3db3-cb01-4c96-abbf-728aaeff7c66"> | <img width="500" alt="Screenshot 2023-05-19 at 4 37 37 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/bd2e4e55-1942-4133-97bd-6dc1c7cecfa4"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to each of `/plans/[PAID]`, `/start/plans`, and `/setup/newsletter`
* Confirm the grids render fine across all resolutions (mobile/tablet/desktop).
    * 344px max width of columns
    * 20px grid margin from the edges
    * when on a paid site with credits available, grid should align with the notice bar (see media). This was different in production - grid would extend beyond that point (which looked broken on a 16 inch).
    * grids with 4 plans/columns should now split at 2x2 when in tablet resolution

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
