### PR TITLE
Social Previews | Update the LinkedIn reading time with a number

### DIFF
--- a/packages/social-previews/src/linkedin-preview/post-preview.tsx
+++ b/packages/social-previews/src/linkedin-preview/post-preview.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { baseDomain, preparePreviewText } from '../helpers';
 import { FEED_TEXT_MAX_LENGTH, FEED_TEXT_MAX_LINES } from './constants';
 import { LinkedInPreviewProps } from './types';
@@ -6,6 +6,7 @@ import { LinkedInPreviewProps } from './types';
 import './style.scss';
 
 export function LinkedInPostPreview( {
+	articleReadTime = 5,
 	image,
 	jobTitle,
 	name,
@@ -98,10 +99,11 @@ export function LinkedInPostPreview( {
 										</span>
 										<span>•</span>
 										<span>
-											{
-												// translators: x is the number of minutes it takes to read the article
-												__( 'x min read', 'social-previews' )
-											}
+											{ sprintf(
+												// translators: %d is the number of minutes it takes to read the article
+												__( '%d min read', 'social-previews' ),
+												articleReadTime
+											) }
 										</span>
 									</div>
 								</div>

--- a/packages/social-previews/src/linkedin-preview/types.ts
+++ b/packages/social-previews/src/linkedin-preview/types.ts
@@ -5,6 +5,7 @@ export type LinkedInPreviewProps = SocialPreviewBaseProps & {
 	name: string;
 	profileImage: string;
 	media?: Array< MediaItem >;
+	articleReadTime?: number;
 };
 
 export type LinkedInPreviewsProps = LinkedInPreviewProps & SocialPreviewsBaseProps;


### PR DESCRIPTION
Completes 1203820933396971-as-1204615220483692/f

## Proposed Changes

* This PR simply replaces `x min read` for LinkedIn preview by `5 min read` by default
* It also allows the consumer component to pass the value.

## Testing Instructions

- Make sure you have a self-hosted site connected to Jetpack, with a subscription that includes Social.
- Spin up Calypso, by running this branch locally or using a live link below.
- Ensure that you have Social Media accounts connected for a self-hosted WP Site
- Go to `/posts/:site` for a self-hosted WP site or a JN site
- Click on the 3 dots for any post and Click "Share"
- Click on "Preview"
- Select LinkedIn
- Confirm that you see "5 min read" instead of "x min read"

| BEFORE | AFTER |
|--------|--------|
|  <img width="534" alt="Screenshot 2023-05-18 at 4 03 44 PM" src="https://github.com/Automattic/wp-calypso/assets/18226415/4ceb611e-e479-495b-bf0f-18120427031b"> | <img width="541" alt="Screenshot 2023-05-18 at 4 02 37 PM" src="https://github.com/Automattic/wp-calypso/assets/18226415/aa48a460-156f-4f08-915a-af9adf34fcf6"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?