### PR TITLE
Staging Sites: Extract new staging site component and add it to storybook

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/card-content-wrapper.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/card-content-wrapper.tsx
@@ -1,0 +1,18 @@
+import { Card, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import CardHeading from 'calypso/components/card-heading';
+
+export const CardContentWrapper: FunctionComponent = ( { children } ) => {
+	const translate = useTranslate();
+	return (
+		<Card className="staging-site-card">
+			{
+				// eslint-disable-next-line wpcalypso/jsx-gridicon-size
+				<Gridicon icon="science" size={ 32 } />
+			}
+			<CardHeading id="staging-site">{ translate( 'Staging site' ) }</CardHeading>
+			{ children }
+		</Card>
+	);
+};

--- a/client/my-sites/hosting/staging-site-card/card-content/exceed-quota-error-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/exceed-quota-error-content.tsx
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+import { useI18n } from '@wordpress/react-i18n';
+import Notice from 'calypso/components/notice';
+
+const ExceedQuotaErrorWrapper = styled.div( {
+	marginTop: '1em',
+} );
+
+export const ExceedQuotaErrorContent = () => {
+	const { __ } = useI18n();
+	return (
+		<ExceedQuotaErrorWrapper data-testid="quota-message">
+			<Notice status="is-warning" showDismiss={ false }>
+				{ __(
+					'Your available storage space is lower than 50%, which is insufficient for creating a staging site.'
+				) }
+			</Notice>
+		</ExceedQuotaErrorWrapper>
+	);
+};

--- a/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -1,0 +1,46 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import { ExceedQuotaErrorContent } from './exceed-quota-error-content';
+
+type CardContentProps = {
+	disabled: boolean;
+	addingStagingSite: boolean;
+	isLoadingQuotaValidation: boolean;
+	hasValidQuota: boolean;
+	onAddClick: () => void;
+};
+
+export const NewStagingSiteCardContent = ( {
+	disabled,
+	addingStagingSite,
+	isLoadingQuotaValidation,
+	hasValidQuota,
+	onAddClick,
+}: CardContentProps ) => {
+	{
+		const translate = useTranslate();
+		return (
+			<>
+				<p>
+					{ translate(
+						'A staging site is a test version of your website you can use to preview and troubleshoot changes before applying them to your production site. {{a}}Learn more{{/a}}.',
+						{
+							components: {
+								a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,
+							},
+						}
+					) }
+				</p>
+				<Button
+					primary
+					disabled={ disabled || addingStagingSite || isLoadingQuotaValidation || ! hasValidQuota }
+					onClick={ onAddClick }
+				>
+					<span>{ translate( 'Add staging site' ) }</span>
+				</Button>
+				{ ! hasValidQuota && ! isLoadingQuotaValidation && <ExceedQuotaErrorContent /> }
+			</>
+		);
+	}
+};

--- a/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -4,19 +4,15 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { ExceedQuotaErrorContent } from './exceed-quota-error-content';
 
 type CardContentProps = {
-	disabled: boolean;
-	addingStagingSite: boolean;
-	isLoadingQuotaValidation: boolean;
-	hasValidQuota: boolean;
 	onAddClick: () => void;
+	isButtonDisabled: boolean;
+	showQuotaError: boolean;
 };
 
 export const NewStagingSiteCardContent = ( {
-	disabled,
-	addingStagingSite,
-	isLoadingQuotaValidation,
-	hasValidQuota,
 	onAddClick,
+	isButtonDisabled,
+	showQuotaError,
 }: CardContentProps ) => {
 	{
 		const translate = useTranslate();
@@ -32,14 +28,10 @@ export const NewStagingSiteCardContent = ( {
 						}
 					) }
 				</p>
-				<Button
-					primary
-					disabled={ disabled || addingStagingSite || isLoadingQuotaValidation || ! hasValidQuota }
-					onClick={ onAddClick }
-				>
+				<Button primary disabled={ isButtonDisabled } onClick={ onAddClick }>
 					<span>{ translate( 'Add staging site' ) }</span>
 				</Button>
-				{ ! hasValidQuota && ! isLoadingQuotaValidation && <ExceedQuotaErrorContent /> }
+				{ showQuotaError && <ExceedQuotaErrorContent /> }
 			</>
 		);
 	}

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -1,4 +1,4 @@
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useQueryClient } from '@tanstack/react-query';
 import { sprintf } from '@wordpress/i18n';
@@ -7,12 +7,12 @@ import { localize } from 'i18n-calypso';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
-import CardHeading from 'calypso/components/card-heading';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import Notice from 'calypso/components/notice';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { urlToSlug } from 'calypso/lib/url';
+import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
 import { NewStagingSiteCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content';
 import { LoadingPlaceholder } from 'calypso/my-sites/hosting/staging-site-card/loading-placeholder';
 import { useAddStagingSiteMutation } from 'calypso/my-sites/hosting/staging-site-card/use-add-staging-site';
@@ -374,16 +374,7 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		stagingSiteCardContent = <LoadingPlaceholder />;
 	}
 
-	return (
-		<Card className="staging-site-card">
-			{
-				// eslint-disable-next-line wpcalypso/jsx-gridicon-size
-				<Gridicon icon="science" size={ 32 } />
-			}
-			<CardHeading id="staging-site">{ translate( 'Staging site' ) }</CardHeading>
-			{ stagingSiteCardContent }
-		</Card>
-	);
+	return <CardContentWrapper>{ stagingSiteCardContent }</CardContentWrapper>;
 };
 
 export default connect( ( state ) => {

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -242,11 +242,11 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		return (
 			<>
 				<NewStagingSiteCardContent
-					disabled={ disabled }
-					addingStagingSite={ addingStagingSite }
-					isLoadingQuotaValidation={ isLoadingQuotaValidation }
-					hasValidQuota={ hasValidQuota }
 					onAddClick={ onAddClick }
+					isButtonDisabled={
+						disabled || addingStagingSite || isLoadingQuotaValidation || ! hasValidQuota
+					}
+					showQuotaError={ ! hasValidQuota && ! isLoadingQuotaValidation }
 				/>
 			</>
 		);

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -13,6 +13,7 @@ import { LoadingBar } from 'calypso/components/loading-bar';
 import Notice from 'calypso/components/notice';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { urlToSlug } from 'calypso/lib/url';
+import { NewStagingSiteCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content';
 import { LoadingPlaceholder } from 'calypso/my-sites/hosting/staging-site-card/loading-placeholder';
 import { useAddStagingSiteMutation } from 'calypso/my-sites/hosting/staging-site-card/use-add-staging-site';
 import { useCheckStagingSiteStatus } from 'calypso/my-sites/hosting/staging-site-card/use-check-staging-site-status';
@@ -39,10 +40,6 @@ const StyledLoadingBar = styled( LoadingBar )( {
 const ActionButtons = styled.div( {
 	display: 'flex',
 	gap: '1em',
-} );
-
-const ExceedQuotaErrorWrapper = styled.div( {
-	marginTop: '1em',
 } );
 
 const SiteRow = styled.div( {
@@ -235,44 +232,22 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		stagingSite,
 	] );
 
-	const getExceedQuotaErrorContent = () => {
-		return (
-			<ExceedQuotaErrorWrapper data-testid="quota-message">
-				<Notice status="is-warning" showDismiss={ false }>
-					{ __(
-						'Your available storage space is lower than 50%, which is insufficient for creating a staging site.'
-					) }
-				</Notice>
-			</ExceedQuotaErrorWrapper>
-		);
-	};
-
 	const getNewStagingSiteContent = () => {
+		const onAddClick = () => {
+			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' ) );
+			setWasCreating( true );
+			setProgress( 0.1 );
+			addStagingSite();
+		};
 		return (
 			<>
-				<p>
-					{ translate(
-						'A staging site is a test version of your website you can use to preview and troubleshoot changes before applying them to your production site. {{a}}Learn more{{/a}}.',
-						{
-							components: {
-								a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,
-							},
-						}
-					) }
-				</p>
-				<Button
-					primary
-					disabled={ disabled || addingStagingSite || isLoadingQuotaValidation || ! hasValidQuota }
-					onClick={ () => {
-						dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' ) );
-						setWasCreating( true );
-						setProgress( 0.1 );
-						addStagingSite();
-					} }
-				>
-					<span>{ translate( 'Add staging site' ) }</span>
-				</Button>
-				{ ! hasValidQuota && ! isLoadingQuotaValidation && getExceedQuotaErrorContent() }
+				<NewStagingSiteCardContent
+					disabled={ disabled }
+					addingStagingSite={ addingStagingSite }
+					isLoadingQuotaValidation={ isLoadingQuotaValidation }
+					hasValidQuota={ hasValidQuota }
+					onAddClick={ onAddClick }
+				/>
 			</>
 		);
 	};

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -232,24 +232,11 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		stagingSite,
 	] );
 
-	const getNewStagingSiteContent = () => {
-		const onAddClick = () => {
-			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' ) );
-			setWasCreating( true );
-			setProgress( 0.1 );
-			addStagingSite();
-		};
-		return (
-			<>
-				<NewStagingSiteCardContent
-					onAddClick={ onAddClick }
-					isButtonDisabled={
-						disabled || addingStagingSite || isLoadingQuotaValidation || ! hasValidQuota
-					}
-					showQuotaError={ ! hasValidQuota && ! isLoadingQuotaValidation }
-				/>
-			</>
-		);
+	const onAddClick = () => {
+		dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' ) );
+		setWasCreating( true );
+		setProgress( 0.1 );
+		addStagingSite();
 	};
 
 	const getManageStagingSiteContent = () => {
@@ -374,7 +361,15 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 	} else if ( showManageStagingSite && isStagingSiteTransferComplete ) {
 		stagingSiteCardContent = getManageStagingSiteContent();
 	} else if ( showAddStagingSite && ! addingStagingSite ) {
-		stagingSiteCardContent = getNewStagingSiteContent();
+		stagingSiteCardContent = (
+			<NewStagingSiteCardContent
+				onAddClick={ onAddClick }
+				isButtonDisabled={
+					disabled || addingStagingSite || isLoadingQuotaValidation || ! hasValidQuota
+				}
+				showQuotaError={ ! hasValidQuota && ! isLoadingQuotaValidation }
+			/>
+		);
 	} else {
 		stagingSiteCardContent = <LoadingPlaceholder />;
 	}

--- a/client/my-sites/hosting/staging-site-card/staging-site-card.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-card.stories.tsx
@@ -1,0 +1,53 @@
+import { Card, Gridicon } from '@automattic/components';
+import { action } from '@storybook/addon-actions';
+import { Story, Meta } from '@storybook/react';
+import { useTranslate } from 'i18n-calypso';
+import { ComponentProps } from 'react';
+import { documentHeadStoreMock, ReduxDecorator } from 'calypso/__mocks__/storybook/redux';
+import CardHeading from 'calypso/components/card-heading';
+import { NewStagingSiteCardContent } from './card-content/new-staging-site-card-content';
+
+export default {
+	title: 'client/components/StagingSite',
+	component: NewStagingSiteCardContent,
+	decorators: [
+		( Story ) => {
+			return (
+				<ReduxDecorator store={ { ...documentHeadStoreMock } }>
+					<Story></Story>
+				</ReduxDecorator>
+			);
+		},
+		( Story ) => {
+			const translate = useTranslate();
+			return (
+				<Card className="staging-site-card">
+					{
+						// eslint-disable-next-line wpcalypso/jsx-gridicon-size
+						<Gridicon icon="science" size={ 32 } />
+					}
+					<CardHeading id="staging-site">{ translate( 'Staging site' ) }</CardHeading>
+					<Story></Story>
+				</Card>
+			);
+		},
+	],
+} as Meta;
+
+type NewStagingSiteCardContentStory = Story< ComponentProps< typeof NewStagingSiteCardContent > >;
+const Template: NewStagingSiteCardContentStory = ( args ) => {
+	return <NewStagingSiteCardContent { ...args } />;
+};
+
+const defaultArgs = {
+	disabled: false,
+	addingStagingSite: false,
+	isLoadingQuotaValidation: false,
+	hasValidQuota: true,
+	onAddClick: action( 'onClick' ),
+};
+
+export const NewStagingSiteCard = Template.bind( {} );
+NewStagingSiteCard.args = {
+	...defaultArgs,
+};

--- a/client/my-sites/hosting/staging-site-card/staging-site-card.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-card.stories.tsx
@@ -7,6 +7,12 @@ import { documentHeadStoreMock, ReduxDecorator } from 'calypso/__mocks__/storybo
 import CardHeading from 'calypso/components/card-heading';
 import { NewStagingSiteCardContent } from './card-content/new-staging-site-card-content';
 
+/**
+ * Ideally, this component should depend only on local `./style.scss`. However, currently, some card styles are defined
+ * in hosting page CSS file, so we need to include it here.
+ */
+import '../style.scss';
+
 export default {
 	title: 'client/components/StagingSite',
 	component: NewStagingSiteCardContent,
@@ -33,7 +39,7 @@ export default {
 		},
 		( Story ) => {
 			return (
-				<div style={ { padding: '20px', backgroundColor: '#f6f7f7' } }>
+				<div className="hosting" style={ { padding: '20px', backgroundColor: '#f6f7f7' } }>
 					<Story></Story>
 				</div>
 			);

--- a/client/my-sites/hosting/staging-site-card/staging-site-card.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-card.stories.tsx
@@ -40,11 +40,9 @@ const Template: NewStagingSiteCardContentStory = ( args ) => {
 };
 
 const defaultArgs = {
-	disabled: false,
-	addingStagingSite: false,
-	isLoadingQuotaValidation: false,
-	hasValidQuota: true,
 	onAddClick: action( 'onClick' ),
+	isButtonDisabled: false,
+	showQuotaError: false,
 };
 
 export const NewStagingSiteCard = Template.bind( {} );

--- a/client/my-sites/hosting/staging-site-card/staging-site-card.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-card.stories.tsx
@@ -1,10 +1,8 @@
-import { Card, Gridicon } from '@automattic/components';
 import { action } from '@storybook/addon-actions';
 import { Story, Meta } from '@storybook/react';
-import { useTranslate } from 'i18n-calypso';
 import { ComponentProps } from 'react';
 import { documentHeadStoreMock, ReduxDecorator } from 'calypso/__mocks__/storybook/redux';
-import CardHeading from 'calypso/components/card-heading';
+import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
 import { NewStagingSiteCardContent } from './card-content/new-staging-site-card-content';
 
 /**
@@ -25,16 +23,10 @@ export default {
 			);
 		},
 		( Story ) => {
-			const translate = useTranslate();
 			return (
-				<Card className="staging-site-card">
-					{
-						// eslint-disable-next-line wpcalypso/jsx-gridicon-size
-						<Gridicon icon="science" size={ 32 } />
-					}
-					<CardHeading id="staging-site">{ translate( 'Staging site' ) }</CardHeading>
+				<CardContentWrapper>
 					<Story></Story>
-				</Card>
+				</CardContentWrapper>
 			);
 		},
 		( Story ) => {

--- a/client/my-sites/hosting/staging-site-card/staging-site-card.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-card.stories.tsx
@@ -31,6 +31,13 @@ export default {
 				</Card>
 			);
 		},
+		( Story ) => {
+			return (
+				<div style={ { padding: '20px', backgroundColor: '#f6f7f7' } }>
+					<Story></Story>
+				</div>
+			);
+		},
 	],
 } as Meta;
 
@@ -48,4 +55,11 @@ const defaultArgs = {
 export const NewStagingSiteCard = Template.bind( {} );
 NewStagingSiteCard.args = {
 	...defaultArgs,
+};
+
+export const NewStagingSiteCardWithQuotaError = Template.bind( {} );
+NewStagingSiteCardWithQuotaError.args = {
+	...defaultArgs,
+	isButtonDisabled: true,
+	showQuotaError: true,
 };

--- a/client/my-sites/hosting/staging-site-card/test/index.js
+++ b/client/my-sites/hosting/staging-site-card/test/index.js
@@ -112,7 +112,11 @@ describe( 'StagingSiteCard component', () => {
 	it( 'shows a loading state when we still loading.', () => {
 		useStagingSite.mockReturnValue( { data: null, isLoading: true } );
 
-		render( <StagingSiteCard { ...defaultProps } /> );
+		render(
+			<Provider store={ store }>
+				<StagingSiteCard { ...defaultProps } />
+			</Provider>
+		);
 		expect( useStagingSite ).toHaveBeenCalledWith( defaultProps.siteId, {
 			enabled: true,
 			onError: expect.any( Function ),
@@ -124,7 +128,11 @@ describe( 'StagingSiteCard component', () => {
 	it( 'shows the add staging buttons, if we dont have any staging sites', () => {
 		useStagingSite.mockReturnValue( { data: [], isLoading: false } );
 
-		render( <StagingSiteCard { ...defaultProps } /> );
+		render(
+			<Provider store={ store }>
+				<StagingSiteCard { ...defaultProps } />
+			</Provider>
+		);
 
 		expect( screen.getByText( addStagingSiteBtnName ) ).toBeVisible();
 	} );
@@ -175,12 +183,20 @@ describe( 'StagingSiteCard component', () => {
 	it( 'shows quota exceeded error message', async () => {
 		useStagingSite.mockReturnValue( { data: [], isLoading: false } );
 
-		const { rerender } = render( <StagingSiteCard { ...defaultProps } /> );
+		const { rerender } = render(
+			<Provider store={ store }>
+				<StagingSiteCard { ...defaultProps } />
+			</Provider>
+		);
 
 		expect( screen.queryByTestId( 'quota-message' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( addStagingSiteBtnName ) ).not.toBeDisabled();
 		useHasValidQuotaQuery.mockReturnValueOnce( { data: false } );
-		rerender( <StagingSiteCard { ...defaultProps } /> );
+		rerender(
+			<Provider store={ store }>
+				<StagingSiteCard { ...defaultProps } />
+			</Provider>
+		);
 
 		expect( screen.getByTestId( 'quota-message' ) ).toBeVisible();
 	} );
@@ -192,7 +208,11 @@ describe( 'StagingSiteCard component', () => {
 			isLoading: false,
 		} );
 
-		render( <StagingSiteCard { ...defaultProps } /> );
+		render(
+			<Provider store={ store }>
+				<StagingSiteCard { ...defaultProps } />
+			</Provider>
+		);
 
 		fireEvent.click( screen.getByText( addStagingSiteBtnName ) );
 		expect( useAddStagingSiteMutation().addStagingSite ).toHaveBeenCalled();
@@ -205,7 +225,11 @@ describe( 'StagingSiteCard component', () => {
 			data: [ { id: 2, url: 'https://staging.example.com', user_has_permission: false } ],
 			isLoading: false,
 		} );
-		render( <StagingSiteCard { ...defaultProps } /> );
+		render(
+			<Provider store={ store }>
+				<StagingSiteCard { ...defaultProps } />
+			</Provider>
+		);
 		expect( screen.queryByTestId( 'staging-sites-access-message' ) ).toBeVisible();
 		expect( screen.queryByText( addStagingSiteBtnName ) ).not.toBeInTheDocument();
 	} );

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -1,3 +1,5 @@
+@import "calypso/assets/stylesheets/shared/mixins/breakpoints";
+
 .hosting {
 	.card > .material-icon,
 	.card > .gridicon {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2212

## Proposed Changes

Our staging sites cards component has grown a bit, it consists of business logic mixed with the presentation layer.

In this PR, I propose to refactor it and extract each variation ([each version of stagingSiteCardContent variable](https://github.com/Automattic/wp-calypso/blob/f74d8966dcc1e641efe3a34b9105282377f636f4/client/my-sites/hosting/staging-site-card/index.js#L381)) to the separate component, and add them to the storybook.

### Screenshots:

Staging site card:
<img width="1278" alt="Screenshot 2023-05-19 at 09 16 36" src="https://github.com/Automattic/wp-calypso/assets/779993/b8eb3c1e-707c-46be-ab8b-b9e59cbd17f6">

Quota error:
<img width="1259" alt="Screenshot 2023-05-19 at 09 06 13" src="https://github.com/Automattic/wp-calypso/assets/779993/aeec19af-729b-4f97-b317-3cf6d80163fc">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run the storybook

```
yarn storybook:start
```

2. Test different component states
3. Test staging sites UI in Calypso to ensure nothing is broken

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
