### PR TITLE
Staging sites: remove extra functions

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -232,24 +232,11 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		stagingSite,
 	] );
 
-	const getNewStagingSiteContent = () => {
-		const onAddClick = () => {
-			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' ) );
-			setWasCreating( true );
-			setProgress( 0.1 );
-			addStagingSite();
-		};
-		return (
-			<>
-				<NewStagingSiteCardContent
-					disabled={ disabled }
-					addingStagingSite={ addingStagingSite }
-					isLoadingQuotaValidation={ isLoadingQuotaValidation }
-					hasValidQuota={ hasValidQuota }
-					onAddClick={ onAddClick }
-				/>
-			</>
-		);
+	const onAddClick = () => {
+		dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' ) );
+		setWasCreating( true );
+		setProgress( 0.1 );
+		addStagingSite();
 	};
 
 	const getManageStagingSiteContent = () => {
@@ -374,7 +361,15 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 	} else if ( showManageStagingSite && isStagingSiteTransferComplete ) {
 		stagingSiteCardContent = getManageStagingSiteContent();
 	} else if ( showAddStagingSite && ! addingStagingSite ) {
-		stagingSiteCardContent = getNewStagingSiteContent();
+		stagingSiteCardContent = (
+			<NewStagingSiteCardContent
+				disabled={ disabled }
+				addingStagingSite={ addingStagingSite }
+				isLoadingQuotaValidation={ isLoadingQuotaValidation }
+				hasValidQuota={ hasValidQuota }
+				onAddClick={ onAddClick }
+			/>
+		);
 	} else {
 		stagingSiteCardContent = <LoadingPlaceholder />;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/77081

## Proposed Changes

* remove unnecessary functions

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check https://github.com/Automattic/wp-calypso/pull/77081

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
