### PR TITLE
Limited Global Styles: Preview post without custom styles

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -148,7 +148,6 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 		array(
 			'assetsUrl'   => plugins_url( 'dist/', __FILE__ ),
 			'upgradeUrl'  => "$calypso_domain/plans/$site_slug?plan=value_bundle&feature=style-customization",
-			'previewUrl'  => add_query_arg( 'hide-global-styles', '', home_url() ),
 			'wpcomBlogId' => wpcom_global_styles_get_wpcom_current_blog_id(),
 		)
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
@@ -6,3 +6,27 @@
 		margin-right: 0;
 	}
 }
+
+.components-notice-list .components-notice__action.components-button.wpcom-global-styles-is-external {
+	display: flex;
+	&::after {
+		content: "";
+		display: inline-block;
+		width: 15px;
+		height: 15px;
+		position: relative;
+		top: 1px;
+		margin-left: 4px;
+		/* stylelint-disable-next-line function-url-quotes */
+		mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='15' height='15' aria-hidden='true' focusable='false'%3E%3Cpath d='M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z'%3E%3C/path%3E%3C/svg%3E");
+		text-decoration: none;
+	}
+
+	&.is-primary::after {
+		background-color: var(--wp-components-color-accent-inverted, #fff);
+	}
+
+	&.is-secondary::after {
+		background-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -83,7 +83,7 @@ function GlobalStylesEditNotice() {
 		} ),
 		[ canvas ]
 	);
-	const { previewCurrentPost } = usePreview();
+	const { previewPostWithoutCustomStyles } = usePreview();
 
 	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
 	const { editEntityRecord } = useDispatch( 'core' );
@@ -94,9 +94,9 @@ function GlobalStylesEditNotice() {
 	}, [ isSiteEditor ] );
 
 	const previewPost = useCallback( () => {
-		previewCurrentPost();
+		previewPostWithoutCustomStyles();
 		trackEvent( 'calypso_global_styles_gating_notice_preview_click', isSiteEditor );
-	}, [ isSiteEditor, previewCurrentPost ] );
+	}, [ isSiteEditor, previewPostWithoutCustomStyles ] );
 
 	const resetGlobalStyles = useCallback( () => {
 		if ( ! globalStylesId ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -83,7 +83,7 @@ function GlobalStylesEditNotice() {
 		} ),
 		[ canvas ]
 	);
-	const { previewPostWithoutCustomStyles } = usePreview();
+	const { previewPostWithoutCustomStyles, canPreviewPost } = usePreview();
 
 	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
 	const { editEntityRecord } = useDispatch( 'core' );
@@ -121,7 +121,7 @@ function GlobalStylesEditNotice() {
 			},
 		];
 
-		if ( isPostEditor ) {
+		if ( isPostEditor && canPreviewPost ) {
 			actions.push( {
 				label: __( 'Preview without custom styles', 'full-site-editing' ),
 				onClick: previewPost,
@@ -152,6 +152,7 @@ function GlobalStylesEditNotice() {
 
 		trackEvent( 'calypso_global_styles_gating_notice_show', isSiteEditor );
 	}, [
+		canPreviewPost,
 		createWarningNotice,
 		isPostEditor,
 		isSiteEditor,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -118,6 +118,7 @@ function GlobalStylesEditNotice() {
 				onClick: upgradePlan,
 				variant: 'primary',
 				noDefaultClasses: true,
+				className: 'wpcom-global-styles-is-external',
 			},
 		];
 
@@ -127,6 +128,7 @@ function GlobalStylesEditNotice() {
 				onClick: previewPost,
 				variant: 'secondary',
 				noDefaultClasses: true,
+				className: 'wpcom-global-styles-is-external',
 			} );
 		}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/use-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/use-preview.js
@@ -1,0 +1,155 @@
+import { Path, SVG } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback, useRef, renderToString, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+function writeInterstitialMessage( targetDocument ) {
+	let markup = renderToString(
+		<div className="editor-post-preview-button__interstitial-message">
+			<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+				<Path
+					className="outer"
+					d="M48 12c19.9 0 36 16.1 36 36S67.9 84 48 84 12 67.9 12 48s16.1-36 36-36"
+					fill="none"
+				/>
+				<Path
+					className="inner"
+					d="M69.5 46.4c0-3.9-1.4-6.7-2.6-8.8-1.6-2.6-3.1-4.9-3.1-7.5 0-2.9 2.2-5.7 5.4-5.7h.4C63.9 19.2 56.4 16 48 16c-11.2 0-21 5.7-26.7 14.4h2.1c3.3 0 8.5-.4 8.5-.4 1.7-.1 1.9 2.4.2 2.6 0 0-1.7.2-3.7.3L40 67.5l7-20.9L42 33c-1.7-.1-3.3-.3-3.3-.3-1.7-.1-1.5-2.7.2-2.6 0 0 5.3.4 8.4.4 3.3 0 8.5-.4 8.5-.4 1.7-.1 1.9 2.4.2 2.6 0 0-1.7.2-3.7.3l11.5 34.3 3.3-10.4c1.6-4.5 2.4-7.8 2.4-10.5zM16.1 48c0 12.6 7.3 23.5 18 28.7L18.8 35c-1.7 4-2.7 8.4-2.7 13zm32.5 2.8L39 78.6c2.9.8 5.9 1.3 9 1.3 3.7 0 7.3-.6 10.6-1.8-.1-.1-.2-.3-.2-.4l-9.8-26.9zM76.2 36c0 3.2-.6 6.9-2.4 11.4L64 75.6c9.5-5.5 15.9-15.8 15.9-27.6 0-5.5-1.4-10.8-3.9-15.3.1 1 .2 2.1.2 3.3z"
+					fill="none"
+				/>
+			</SVG>
+			<p>{ __( 'Generating preview…', 'full-site-editing' ) }</p>
+		</div>
+	);
+
+	markup += `
+		<style>
+			body {
+				margin: 0;
+			}
+			.editor-post-preview-button__interstitial-message {
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				height: 100vh;
+				width: 100vw;
+			}
+			@-webkit-keyframes paint {
+				0% {
+					stroke-dashoffset: 0;
+				}
+			}
+			@-moz-keyframes paint {
+				0% {
+					stroke-dashoffset: 0;
+				}
+			}
+			@-o-keyframes paint {
+				0% {
+					stroke-dashoffset: 0;
+				}
+			}
+			@keyframes paint {
+				0% {
+					stroke-dashoffset: 0;
+				}
+			}
+			.editor-post-preview-button__interstitial-message svg {
+				width: 192px;
+				height: 192px;
+				stroke: #555d66;
+				stroke-width: 0.75;
+			}
+			.editor-post-preview-button__interstitial-message svg .outer,
+			.editor-post-preview-button__interstitial-message svg .inner {
+				stroke-dasharray: 280;
+				stroke-dashoffset: 280;
+				-webkit-animation: paint 1.5s ease infinite alternate;
+				-moz-animation: paint 1.5s ease infinite alternate;
+				-o-animation: paint 1.5s ease infinite alternate;
+				animation: paint 1.5s ease infinite alternate;
+			}
+			p {
+				text-align: center;
+				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			}
+		</style>
+	`;
+
+	targetDocument.write( markup );
+	targetDocument.title = __( 'Generating preview…', 'full-site-editing' );
+	targetDocument.close();
+}
+
+export function usePreview() {
+	const { currentPostLink, isAutosaveable, isDraft, isPostEditor, isLocked, previewLink } =
+		useSelect( ( select ) => {
+			const {
+				getCurrentPostId,
+				getCurrentPostAttribute,
+				getEditedPostPreviewLink,
+				isEditedPostAutosaveable,
+				isPostLocked,
+				getEditedPostAttribute,
+			} = select( 'core/editor' );
+			return {
+				currentPostLink: getCurrentPostAttribute( 'link' ),
+				isAutosaveable: isEditedPostAutosaveable(),
+				isDraft: [ 'draft', 'auto-draft' ].indexOf( getEditedPostAttribute( 'status' ) ) !== -1,
+				isLocked: isPostLocked(),
+				isPostEditor: ! select( 'core/edit-site' ) && !! getCurrentPostId(),
+				previewLink: getEditedPostPreviewLink(),
+			};
+		} );
+	const previewWindow = useRef( null );
+
+	const { autosave, savePost } = useDispatch( 'core/editor' );
+
+	const previewCurrentPost = useCallback( () => {
+		if ( ! isPostEditor ) {
+			return;
+		}
+
+		if ( ! previewWindow.current || previewWindow.current.closed ) {
+			previewWindow.current = window.open( '', '_blank' );
+		}
+		previewWindow.current.focus();
+
+		if ( ! isAutosaveable || isLocked ) {
+			if ( previewWindow && ! previewWindow.closed ) {
+				previewWindow.current.location = previewLink || currentPostLink;
+			}
+			return;
+		}
+
+		if ( isDraft ) {
+			savePost( { isPreview: true } );
+		} else {
+			autosave( { isPreview: true } );
+		}
+
+		writeInterstitialMessage( previewWindow.current.document );
+	}, [
+		autosave,
+		currentPostLink,
+		isAutosaveable,
+		isDraft,
+		isLocked,
+		isPostEditor,
+		previewLink,
+		savePost,
+	] );
+
+	useEffect( () => {
+		if ( ! isPostEditor ) {
+			return;
+		}
+
+		if ( previewWindow.current && previewLink && ! previewWindow.current.closed ) {
+			previewWindow.current.location = previewLink;
+		}
+	}, [ isPostEditor, previewLink ] );
+
+	return { previewCurrentPost };
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/use-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/use-preview.js
@@ -159,7 +159,7 @@ export function usePreview() {
 		}
 
 		if ( previewWindow.current && previewLink && ! previewWindow.current.closed ) {
-			previewWindow.current.location = addQueryArgs( previewLink, { 'hide-global-styles': '' } );
+			previewWindow.current.location = addQueryArgs( previewLink, { 'hide-global-styles': true } );
 		}
 	}, [ isPostEditor, previewLink ] );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/use-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/use-preview.js
@@ -2,6 +2,7 @@ import { Path, SVG } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useRef, renderToString, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 function writeInterstitialMessage( targetDocument ) {
 	let markup = renderToString(
@@ -106,7 +107,7 @@ export function usePreview() {
 
 	const { autosave, savePost } = useDispatch( 'core/editor' );
 
-	const previewCurrentPost = useCallback( () => {
+	const previewPostWithoutCustomStyles = useCallback( () => {
 		if ( ! isPostEditor ) {
 			return;
 		}
@@ -117,8 +118,10 @@ export function usePreview() {
 		previewWindow.current.focus();
 
 		if ( ! isAutosaveable || isLocked ) {
-			if ( previewWindow && ! previewWindow.closed ) {
-				previewWindow.current.location = previewLink || currentPostLink;
+			if ( previewWindow.current && ! previewWindow.current.closed ) {
+				previewWindow.current.location = addQueryArgs( previewLink || currentPostLink, {
+					'hide-global-styles': '',
+				} );
 			}
 			return;
 		}
@@ -147,9 +150,9 @@ export function usePreview() {
 		}
 
 		if ( previewWindow.current && previewLink && ! previewWindow.current.closed ) {
-			previewWindow.current.location = previewLink;
+			previewWindow.current.location = addQueryArgs( previewLink, { 'hide-global-styles': '' } );
 		}
 	}, [ isPostEditor, previewLink ] );
 
-	return { previewCurrentPost };
+	return { previewPostWithoutCustomStyles };
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/use-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/use-preview.js
@@ -84,25 +84,34 @@ function writeInterstitialMessage( targetDocument ) {
 }
 
 export function usePreview() {
-	const { currentPostLink, isAutosaveable, isDraft, isPostEditor, isLocked, previewLink } =
-		useSelect( ( select ) => {
-			const {
-				getCurrentPostId,
-				getCurrentPostAttribute,
-				getEditedPostPreviewLink,
-				isEditedPostAutosaveable,
-				isPostLocked,
-				getEditedPostAttribute,
-			} = select( 'core/editor' );
-			return {
-				currentPostLink: getCurrentPostAttribute( 'link' ),
-				isAutosaveable: isEditedPostAutosaveable(),
-				isDraft: [ 'draft', 'auto-draft' ].indexOf( getEditedPostAttribute( 'status' ) ) !== -1,
-				isLocked: isPostLocked(),
-				isPostEditor: ! select( 'core/edit-site' ) && !! getCurrentPostId(),
-				previewLink: getEditedPostPreviewLink(),
-			};
-		} );
+	const {
+		currentPostLink,
+		isAutosaveable,
+		isDraft,
+		isPostEditor,
+		isLocked,
+		isSaveable,
+		previewLink,
+	} = useSelect( ( select ) => {
+		const {
+			getCurrentPostId,
+			getCurrentPostAttribute,
+			getEditedPostPreviewLink,
+			isEditedPostAutosaveable,
+			isEditedPostSaveable,
+			isPostLocked,
+			getEditedPostAttribute,
+		} = select( 'core/editor' );
+		return {
+			currentPostLink: getCurrentPostAttribute( 'link' ),
+			isAutosaveable: isEditedPostAutosaveable(),
+			isDraft: [ 'draft', 'auto-draft' ].indexOf( getEditedPostAttribute( 'status' ) ) !== -1,
+			isLocked: isPostLocked(),
+			isPostEditor: ! select( 'core/edit-site' ) && !! getCurrentPostId(),
+			isSaveable: isEditedPostSaveable(),
+			previewLink: getEditedPostPreviewLink(),
+		};
+	} );
 	const previewWindow = useRef( null );
 
 	const { autosave, savePost } = useDispatch( 'core/editor' );
@@ -154,5 +163,5 @@ export function usePreview() {
 		}
 	}, [ isPostEditor, previewLink ] );
 
-	return { previewPostWithoutCustomStyles };
+	return { previewPostWithoutCustomStyles, canPreviewPost: isSaveable };
 }


### PR DESCRIPTION
## Proposed Changes

Adds a button to the limited Global Styles notice displayed in the post editor so users can preview the post without custom styles being visible.

<img width="1278" alt="Screenshot 2023-05-18 at 13 34 40" src="https://github.com/Automattic/wp-calypso/assets/1233880/262ccba1-4c32-42a5-8fca-6e81792dc157">

This is highly inspired by how Gutenberg previews a post in the post editor: https://github.com/WordPress/gutenberg/blob/83a33e7c24ee1db8fe426052ac73137f51289234/packages/editor/src/components/post-preview-button/index.js#L149

## Testing Instructions

- Apply these ETK changes to your sandbox.
- Sandbox a site with limited Global styles.
- Open the post editor.
- Make sure the limited Global Styles notice contains a preview button.
- Click on it.
- Make sure the current post is previewed without custom styles.
