### PR TITLE
Newsletter: remove paid newsletter flag after release

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { hexToRgb, StepContainer, base64ImageToBlob } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -155,23 +154,21 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 							setAccentColor={ setAccentColor }
 							labelText={ newsletterFormText?.colorLabel }
 						/>
-						{ isEnabled( 'newsletter/paid-subscribers' ) && (
-							<FormFieldset className="newsletter-setup__paid-subscribers">
-								<FormLabel>
-									<FormInputCheckbox
-										name="paid_newsletters"
-										checked={ paidSubscribers }
-										onChange={ onPaidSubscribersChanged }
-									/>
-									<span>{ translate( 'I want to start a paid newsletter' ) }</span>
-								</FormLabel>
-								<InfoPopover position="bottom right">
-									{ translate(
-										'Let your audience support your work. Add paid subscriptions and gated content to your newsletter.'
-									) }
-								</InfoPopover>
-							</FormFieldset>
-						) }
+						<FormFieldset className="newsletter-setup__paid-subscribers">
+							<FormLabel>
+								<FormInputCheckbox
+									name="paid_newsletters"
+									checked={ paidSubscribers }
+									onChange={ onPaidSubscribersChanged }
+								/>
+								<span>{ translate( 'I want to start a paid newsletter' ) }</span>
+							</FormLabel>
+							<InfoPopover position="bottom right">
+								{ translate(
+									'Let your audience support your work. Add paid subscriptions and gated content to your newsletter.'
+								) }
+							</InfoPopover>
+						</FormFieldset>
 					</>
 				</SetupForm>
 			}

--- a/config/development.json
+++ b/config/development.json
@@ -126,7 +126,6 @@
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
-		"newsletter/paid-subscribers": true,
 		"newsletter/stats": true,
 		"oauth": false,
 		"onboarding/import": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,7 +83,6 @@
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
-		"newsletter/paid-subscribers": true,
 		"newsletter/stats": true,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/2023-pricing-grid": true,

--- a/config/production.json
+++ b/config/production.json
@@ -179,8 +179,7 @@
 		"user-management-revamp": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true,
-		"newsletter/paid-subscribers": true
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -92,7 +92,6 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
-		"newsletter/paid-subscribers": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/test.json
+++ b/config/test.json
@@ -109,7 +109,6 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": false,
-		"newsletter/paid-subscribers": true
+		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -101,7 +101,6 @@
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
-		"newsletter/paid-subscribers": true,
 		"newsletter/stats": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/77009 and https://github.com/Automattic/wp-calypso/pull/76839 where we released the feature.

## Proposed Changes

* Remove `newsletter/paid-subscribers` feature flag and check

## Testing Instructions

* Test /setup/newsletter and see the setup step
* Paid newsletter Checkbox should be visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
