### PR TITLE
Messaging: Use auth only when necessary

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -37,7 +37,6 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
-import useMessagingAuth from '../hooks/use-messaging-auth';
 import useZendeskConfig from '../hooks/use-zendesk-config';
 import { HELP_CENTER_STORE } from '../stores';
 import { getSupportVariationFromMode } from '../support-variations';
@@ -198,17 +197,6 @@ export const HelpCenterContactForm = () => {
 	} = useDispatch( HELP_CENTER_STORE );
 
 	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
-	const { data: messagingAuth } = useMessagingAuth( Boolean( chatStatus?.is_user_eligible ) );
-	useEffect( () => {
-		const jwt = messagingAuth?.user.jwt;
-		if ( typeof window.zE !== 'function' || ! jwt ) {
-			return;
-		}
-
-		window.zE( 'messenger', 'loginUser', function ( callback ) {
-			callback( jwt );
-		} );
-	}, [ messagingAuth ] );
 	const { status: zendeskStatus } = useZendeskConfig( Boolean( chatStatus?.is_user_eligible ) );
 
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -37,6 +37,7 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
+import useMessagingAuth from '../hooks/use-messaging-auth';
 import useZendeskConfig from '../hooks/use-zendesk-config';
 import { HELP_CENTER_STORE } from '../stores';
 import { getSupportVariationFromMode } from '../support-variations';
@@ -197,6 +198,17 @@ export const HelpCenterContactForm = () => {
 	} = useDispatch( HELP_CENTER_STORE );
 
 	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
+	const { data: messagingAuth } = useMessagingAuth( Boolean( chatStatus?.is_user_eligible ) );
+	useEffect( () => {
+		const jwt = messagingAuth?.user.jwt;
+		if ( typeof window.zE !== 'function' || ! jwt ) {
+			return;
+		}
+
+		window.zE( 'messenger', 'loginUser', function ( callback ) {
+			callback( jwt );
+		} );
+	}, [ messagingAuth ] );
 	const { status: zendeskStatus } = useZendeskConfig( Boolean( chatStatus?.is_user_eligible ) );
 
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -20,6 +20,7 @@ import { getSectionName } from 'calypso/state/ui/selectors';
  * Internal Dependencies
  */
 import { BackButton } from '..';
+import useMessagingAuth from '../hooks/use-messaging-auth';
 import { useShouldRenderChatOption } from '../hooks/use-should-render-chat-option';
 import { useShouldRenderEmailOption } from '../hooks/use-should-render-email-option';
 import { useStillNeedHelpURL } from '../hooks/use-still-need-help-url';
@@ -42,6 +43,20 @@ export const HelpCenterContactPage: FC = () => {
 	const { data: supportActivity, isLoading: isLoadingSupportActivity } = useSupportActivity();
 	const { data: supportAvailability } = useSupportAvailability( 'CHAT' );
 	const isLoading = renderChat.isLoading || renderEmail.isLoading || isLoadingSupportActivity;
+
+	const { data: messagingAuth } = useMessagingAuth(
+		Boolean( supportAvailability?.is_user_eligible )
+	);
+	useEffect( () => {
+		const jwt = messagingAuth?.user.jwt;
+		if ( typeof window.zE !== 'function' || ! jwt ) {
+			return;
+		}
+
+		window.zE( 'messenger', 'loginUser', function ( callback ) {
+			callback( jwt );
+		} );
+	}, [ messagingAuth ] );
 
 	useEffect( () => {
 		if ( isLoading ) {

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -74,7 +74,11 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 		);
 	}, [ setShowMessagingLauncher, setShowMessagingWidget, chatStatus ] );
 
-	const { data: messagingAuth } = useMessagingAuth( Boolean( chatStatus?.is_user_eligible ) );
+	const { data: supportActivity } = useSupportActivity( Boolean( chatStatus?.is_user_eligible ) );
+	const hasActiveChats = supportActivity?.some( ( ticket ) => ticket.channel === 'Messaging' );
+	const { data: messagingAuth } = useMessagingAuth(
+		Boolean( chatStatus?.is_user_eligible ) && Boolean( hasActiveChats )
+	);
 	useEffect( () => {
 		const jwt = messagingAuth?.user.jwt;
 		if ( typeof window.zE !== 'function' || ! jwt || ! isMessagingScriptLoaded ) {
@@ -116,12 +120,11 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 		}
 	}, [ showMessagingWidget, isMessagingScriptLoaded ] );
 
-	const { data: supportActivity } = useSupportActivity( Boolean( chatStatus?.is_user_eligible ) );
 	useEffect( () => {
-		if ( supportActivity?.some( ( ticket ) => ticket.channel === 'Messaging' ) ) {
+		if ( hasActiveChats ) {
 			setShowMessagingLauncher( true );
 		}
-	}, [ setShowMessagingLauncher, supportActivity ] );
+	}, [ setShowMessagingLauncher, hasActiveChats ] );
 
 	useZendeskConfig( Boolean( chatStatus?.is_user_eligible ) ); // Pre-fetch
 


### PR DESCRIPTION
Related to #77024

## Proposed Changes

* Don't proactively auth unless we have active support conversations.
* Only auth once the user shows intent to contact support.

## Testing Instructions

- Verify that we don't call the `authenticate/chat` endpoint when Help Center loads
    - Unless `support-activity` endpoint returns active Messaging conversations
- Otherwise, only when they visit the contact page should we make the auth call.