### PR TITLE
Agency Dashboard Downtime Monitor Multiple Emails Fix styling for modal

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
@@ -46,28 +46,50 @@
 }
 
 .notification-settings__footer {
-	position: static;
-	justify-content: right;
-	flex-direction: initial;
-	margin-block-start: 32px;
-	margin-block-end: 0;
-	width: auto;
+	margin-block-end: 32px;
+	width: calc(100% - 64px); // reducing the left and right padding
+	display: flex;
+	justify-content: flex-start;
+	flex-direction: column;
+	position: absolute;
+	bottom: 0;
 
 	.notification-settings__footer-buttons {
 		display: flex;
-		flex-direction: row;
-		justify-content: flex-end;
-		align-items: center;
-		gap: 12px;
+		flex-direction: column;
+	}
 
-		button {
-			display: flex;
-			flex-direction: row;
-			align-items: flex-start;
-			padding: 5px 26px;
-			gap: 10px;
+	button {
+		height: 36px;
+		line-height: 18px;
+
+		&:nth-child(2) {
+			margin-block-start: 16px;
 		}
 	}
+
+	@include break-mobile {
+		position: static;
+		justify-content: right;
+		flex-direction: initial;
+		margin-block-start: 32px;
+		margin-block-end: 0;
+		width: auto;
+
+		.notification-settings__footer-buttons {
+			justify-content: end;
+			width: 100%;
+			flex-direction: initial;
+		}
+
+		button {
+			&:nth-child(2) {
+				margin-inline-start: 12px;
+				margin-block-start: 0;
+			}
+		}
+	}
+
 }
 
 .select-dropdown .select-dropdown__container {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
@@ -20,7 +20,6 @@
 	@extend .notification-settings-title-light;
 	position: absolute;
 	inset-block-start: 50px;
-
 }
 
 .notification-settings__content {
@@ -47,50 +46,28 @@
 }
 
 .notification-settings__footer {
-	margin-block-end: 32px;
-	width: calc(100% - 64px); // reducing the left and right padding
-	display: flex;
-	justify-content: flex-start;
-	flex-direction: column;
-	position: absolute;
-	bottom: 0;
+	position: static;
+	justify-content: right;
+	flex-direction: initial;
+	margin-block-start: 32px;
+	margin-block-end: 0;
+	width: auto;
 
 	.notification-settings__footer-buttons {
 		display: flex;
-		flex-direction: column;
-	}
-
-	button {
-		height: 36px;
-		line-height: 18px;
-
-		&:nth-child(2) {
-			margin-block-start: 16px;
-		}
-	}
-
-	@include break-mobile {
-		position: static;
-		justify-content: right;
-		flex-direction: initial;
-		margin-block-start: 32px;
-		margin-block-end: 0;
-		width: auto;
-
-		.notification-settings__footer-buttons {
-			justify-content: end;
-			width: 100%;
-			flex-direction: initial;
-		}
+		flex-direction: row;
+		justify-content: flex-end;
+		align-items: center;
+		gap: 12px;
 
 		button {
-			&:nth-child(2) {
-				margin-inline-start: 12px;
-				margin-block-start: 0;
-			}
+			display: flex;
+			flex-direction: row;
+			align-items: flex-start;
+			padding: 5px 26px;
+			gap: 10px;
 		}
 	}
-
 }
 
 .select-dropdown .select-dropdown__container {
@@ -104,7 +81,6 @@
 	width: 20px;
 }
 
-
 .notification-settings__toggle {
 	width: 15%;
 	display: inline-flex;
@@ -112,10 +88,6 @@
 
 	.components-form-toggle {
 		margin-right: 0 !important;
-	}
-
-	@include break-mobile {
-		justify-content: unset;
 	}
 }
 
@@ -130,11 +102,6 @@
 	width: 480px;
 	animation: components-modal__appear-animation 0.1s ease-out;
 	animation-fill-mode: forwards;
-
-	@include break-mobile {
-		width: 450px;
-		margin: auto;
-	}
 }
 
 .notification-settings__email-container {
@@ -152,10 +119,6 @@
 	.token-field__input-container {
 		cursor: default;
 	}
-
-	@include break-mobile {
-		margin-block-start: 4px;
-	}
 }
 
 .notification-settings__email-condition {
@@ -168,23 +131,19 @@
 	display: inline-flex;
 	flex-direction: row-reverse;
 	width: 100%;
+}
 
-	@include break-mobile {
-		display: block;
-	}
+.notification-settings__toggle-container .components-base-control__field .components-flex {
+	display: inline-flex;
+	flex-direction: row-reverse;
 }
 
 .notification-settings__large-screen {
 	display: none;
-	@include break-mobile {
-		display: inherit;
-	}
 }
 
 .notification-settings__small-screen {
-	@include break-mobile {
-		display: none;
-	}
+	display: inherit;
 }
 
 .notification-settings__footer-validation-error {


### PR DESCRIPTION
This pull request addresses the task of unifying the design and layout of the notification settings modal across both mobile and desktop platforms. The changes implemented are based on the provided designs and aim to ensure a consistent and seamless user experience across all devices.

Related to 1204408201748644-as-1204619196901612/f

## Proposed Changes

* Footer Positioning and Layout: The footer's position has been changed from absolute to static, and the flex-direction has been changed from column to initial. The justify-content property has been updated to align the buttons to the right.

* Footer Buttons Layout: The footer buttons' flex-direction has been changed from column to row, and the buttons are now aligned to the center. The padding has been removed, and a gap has been added between the buttons.

* Button Styling: The button styling has been updated to align the buttons to the flex-start. The padding has been adjusted for better alignment and spacing.

* Toggle Container Layout: The flex-direction of the toggle container has been changed from row-reverse to row.

* Toggle Container Flex Display: The flex display of the toggle container's child elements has been updated to row-reverse.

![Screenshot 2023-05-18 at 9 04 51 AM](https://github.com/Automattic/wp-calypso/assets/12895386/7442c98b-a1e7-4fd5-b998-5e6ab364dc91)
desktop

![Screenshot 2023-05-18 at 9 15 26 AM](https://github.com/Automattic/wp-calypso/assets/12895386/6ba57efc-4f1d-414b-869a-50e714a3e7ab)
mobile

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* use the Jetpack Cloud live link (or roll your own) navigate to /Dashboard
* Click the clock icon in monitoring
* Verify the modal matches the screenshots

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?