### PR TITLE
E2E: Fix failing specs for the Gutenberg v15.8.0 release

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -37,15 +37,15 @@ export class InstagramBlockFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		const editorParent = await context.editorPage.getEditorParent();
-		const embedUrlLocator = editorParent.locator( selectors.embedUrlInput );
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const embedUrlLocator = editorCanvas.locator( selectors.embedUrlInput );
 		await embedUrlLocator.fill( this.configurationData.embedUrl );
 
-		const embedButtonLocator = editorParent.locator( selectors.embedButton );
+		const embedButtonLocator = editorCanvas.locator( selectors.embedButton );
 		await embedButtonLocator.click();
 
 		// We should make sure the actual Iframe loads, because it takes a second.
-		const instagramIframeLocator = editorParent
+		const instagramIframeLocator = editorCanvas
 			.frameLocator( selectors.editorInstagramIframe )
 			.locator( 'body' );
 		await instagramIframeLocator.waitFor();

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -45,7 +45,9 @@ export class InstagramBlockFlow implements BlockFlow {
 		await embedButtonLocator.click();
 
 		// We should make sure the actual Iframe loads, because it takes a second.
-		const instagramIframeLocator = editorParent.locator( selectors.editorInstagramIframe );
+		const instagramIframeLocator = editorParent
+			.frameLocator( selectors.editorInstagramIframe )
+			.locator( 'body' );
 		await instagramIframeLocator.waitFor();
 	}
 

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/layout-grid.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/layout-grid.ts
@@ -46,8 +46,8 @@ export class LayoutGridBlockFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution.
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		const editorParent = await context.editorPage.getEditorParent();
-		const twoColumnButtonLocator = editorParent.locator( selectors.twoColumnButton );
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const twoColumnButtonLocator = editorCanvas.locator( selectors.twoColumnButton );
 		await twoColumnButtonLocator.click();
 
 		/**
@@ -103,8 +103,8 @@ export class LayoutGridBlockFlow implements BlockFlow {
 			openInlineInserter
 		);
 
-		const editorParent = await context.editorPage.getEditorParent();
-		const addedParagraphLocator = editorParent.locator(
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const addedParagraphLocator = editorCanvas.locator(
 			selectors.paragraphBlock( columnDetails.columnNumber )
 		);
 		await addedParagraphLocator.fill( columnDetails.textToAdd );

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
@@ -37,16 +37,16 @@ export class TwitterBlockFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		const editorParent = await context.editorPage.getEditorParent();
+		const editorCanvas = await context.editorPage.getEditorCanvas();
 
-		const urlInputLocator = editorParent.locator( selectors.embedUrlInput );
+		const urlInputLocator = editorCanvas.locator( selectors.embedUrlInput );
 		await urlInputLocator.fill( this.configurationData.embedUrl );
 
-		const embedButtonLocator = editorParent.locator( selectors.embedButton );
+		const embedButtonLocator = editorCanvas.locator( selectors.embedButton );
 		await embedButtonLocator.click();
 
 		// We should make sure the actual Iframe loads, because it takes a second.
-		const twitterIframeLocator = editorParent.locator( selectors.editorTwitterIframe );
+		const twitterIframeLocator = editorCanvas.locator( selectors.editorTwitterIframe );
 		await twitterIframeLocator.waitFor();
 	}
 

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
@@ -37,16 +37,16 @@ export class YouTubeBlockFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution.
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		const editorParent = await context.editorPage.getEditorParent();
+		const editorCanvas = await context.editorPage.getEditorCanvas();
 
-		const urlInputLocator = editorParent.locator( selectors.embedUrlInput );
+		const urlInputLocator = editorCanvas.locator( selectors.embedUrlInput );
 		await urlInputLocator.fill( this.configurationData.embedUrl );
 
-		const embedButtonLocator = editorParent.locator( selectors.embedButton );
+		const embedButtonLocator = editorCanvas.locator( selectors.embedButton );
 		await embedButtonLocator.click();
 
 		// We should make sure the actual Iframe loads, because it takes a second.
-		const youTubeIframeLocator = editorParent.locator( selectors.editorYouTubeIframe );
+		const youTubeIframeLocator = editorCanvas.locator( selectors.editorYouTubeIframe );
 		await youTubeIframeLocator.waitFor();
 	}
 

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -11,9 +11,6 @@ import type {
 const panel = '[aria-label="Editor settings"]';
 
 const selectors = {
-	// Close button for mobile
-	mobileCloseSidebarButton: `${ panel } [aria-label="Close settings"]:visible`,
-
 	// Tab
 	tabButton: ( tabName: EditorSidebarTab ) => `${ panel } button[data-label="${ tabName }"]`,
 	activeTabButton: ( tabName: EditorSidebarTab ) =>
@@ -71,8 +68,8 @@ export class EditorSettingsSidebarComponent {
 			return;
 		}
 		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.mobileCloseSidebarButton );
-		await locator.click();
+		const closeButton = editorParent.getByRole( 'button', { name: 'Close Settings' } );
+		await closeButton.click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -127,6 +127,10 @@ export class EditorPage {
 
 	/**
 	 * Resolves with the Editor canvas element locator.
+	 *
+	 * You *must* use this method if you want to select an element inside the canvas
+	 * iframe. This already takes into account the parent wrapper element, so
+	 * there's *no* need to to chain `getEditorParent()` before calling it.
 	 */
 	async getEditorCanvas() {
 		return await this.editor.canvas();

--- a/packages/calypso-e2e/src/lib/pages/revisions-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/revisions-page.ts
@@ -24,6 +24,7 @@ export class RevisionsPage {
 	 */
 	async selectRevision( index: number ): Promise< void > {
 		const sliderTickmarks = this.page.locator( '.revisions-tickmarks > div' );
+		await sliderTickmarks.nth( 0 ).waitFor( { state: 'attached' } );
 		const revisionCount = ( await sliderTickmarks.count() ) + 1;
 
 		if ( index > revisionCount ) {
@@ -32,7 +33,7 @@ export class RevisionsPage {
 			);
 		}
 
-		const slider = this.page.locator( '.revisions-controls > .wp-slider' );
+		const slider = this.page.locator( '.wp-slider' );
 		const sliderWidth = ( await slider.boundingBox() )?.width as number;
 		// Calculate click position on the horizontal slider. For example, if
 		// there are 4 revisions, the second one should be at 25% of the total

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -63,8 +63,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Template content loads into editor', async function () {
-		const editorParent = await editorPage.getEditorParent();
-		await editorParent.locator( `h1:text-is("About Me")` ).waitFor();
+		const editorCanvas = await editorPage.getEditorCanvas();
+		await editorCanvas.locator( `h1:text-is("About Me")` ).waitFor();
 	} );
 
 	it( 'Open setting sidebar', async function () {

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -56,14 +56,7 @@ describe( `Editor: Revisions`, function () {
 
 	it( 'View revisions', async function () {
 		await editorPage.openSettings();
-
-		if ( envVariables.TEST_ON_ATOMIC ) {
-			// Revisions are opened on a dedicated page on Atomic sites, e.g.
-			// https://yourblog.wpcomstaging.com/wp-admin/revision.php?revision=123
-			await Promise.all( [ page.waitForNavigation(), editorPage.viewRevisions() ] );
-		} else {
-			await editorPage.viewRevisions();
-		}
+		await editorPage.viewRevisions();
 	} );
 
 	it( 'Select first revision', async function () {

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -97,10 +97,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 			const tmpPage = await browser.newPage(); // Calling from browser opens new incognito window
 
 			await tmpPage.goto( postURL.href );
-			await new PublishedPostPage( tmpPage ).validateTextInPost(
-				'It looks like nothing was found at this location. Maybe try a search?'
-			);
-
+			await tmpPage.locator( 'body.error404' ).waitFor();
 			await tmpPage.close();
 		} );
 	} );


### PR DESCRIPTION
#### Fix Gutenberg atomic E2E tests edge (mobile):
- specs/editor/editor__schedule.ts: Editor: Schedule: Schedule: future
- specs/editor/editor__post-advanced-flow.ts: Editor: Advanced Post Flow: Revert post to draft
- specs/editor/editor__privacy-private.ts: Editor: Privacy (Private): Create a Private page
- specs/editor/editor__privacy-password.ts: Editor: Privacy (Password): Create a Password page
- specs/editor/editor__privacy-public.ts: Editor: Privacy (Public): Create a Public page
- specs/editor/editor__revisions.ts: Editor: Revisions
- specs/blocks/blocks__core-jetpack-extended.ts: Blocks: Jetpack Extended Core Blocks: Validating blocks in published post.: Instagram
- specs/editor/editor__page-basic-flow.ts: Editor: Basic Post Flow
- specs/editor/editor__post-basic-flow.ts: Editor: Basic Post Flow: Preview