### PR TITLE
Update/minor style issues

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -485,6 +485,10 @@
 			.login__form-userdata input:last-of-type {
 				margin-bottom: 10px;
 			}
+
+			input[disabled] {
+				border: 1px solid var(--studio-gray-10);
+			}
 		}
 
 		.card {

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -194,6 +194,7 @@
 		line-height: 1.25;
 		color: var(--studio-gray-50);
 		margin-top: 1.5rem;
+		margin-bottom: 1.5rem;
 
 		a,
 		button {


### PR DESCRIPTION
Related to #76710, #76688

## Proposed Changes

* Add Subscribers form: Added missing margin
* Jetpack login in migration plugin context: add missing input border

## Testing Instructions

Add Subscriber form
* Go to `/people/add-subscribers/{SITE_SLUG}`
* Check if there is "margin"

Jetpack login
* Go to `/log-in/jetpack?from=wpcom-migration`
* Enter your username
* Check if username input has border

## Screenshots
<table>
  <tr>
    <td width="50%">     
      <img width="756" alt="Screenshot 2023-05-18 at 16 09 24" src="https://github.com/Automattic/wp-calypso/assets/1241413/6a6a8785-fb9e-43fa-b78a-58be05b2a32f">
    <td width="50%">
      <img width="781" alt="Screenshot 2023-05-18 at 16 09 31" src="https://github.com/Automattic/wp-calypso/assets/1241413/099b28e2-97c2-4d12-9d8f-29c86f47187b">
  </tr>
  <tr>
    <td width="50%">
      <img width="494" alt="Screenshot 2023-05-18 at 15 54 32" src="https://github.com/Automattic/wp-calypso/assets/1241413/a7f5d73a-1a6d-4042-af4e-49f38e76e02a">
    <td width="50%">
      <img width="474" alt="Screenshot 2023-05-18 at 15 59 29" src="https://github.com/Automattic/wp-calypso/assets/1241413/b680b654-017c-4066-aa65-4d02b46d1310">
  </tr>
</table>


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
