### PR TITLE
Jetpack Chat: Incorporate Authentication

### DIFF
--- a/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
+++ b/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
@@ -59,30 +59,27 @@ export const ZendeskJetpackChat: React.VFC< { keyType: KeyType } > = ( { keyType
 		if ( ! zendeskChatKey || isLoadingAuth ) {
 			return;
 		}
-
 		const result = loadScript(
 			'https://static.zdassets.com/ekr/snippet.js?key=' + encodeURIComponent( zendeskChatKey ),
 			undefined,
 			{ id: 'ze-snippet' }
 		);
-
 		//pass authentication key to Zendesk
 		Promise.resolve( result ).then( () => {
-			// We need the user's authentication token to log them into chat
-			if ( ! zendeskJwt ) {
-				return;
-			}
-
 			// Chat can't exist if we're not in a browser window
 			if ( typeof window === 'undefined' ) {
 				return;
 			}
-
 			// The `zE` function exposes the required action to authenticate the user
-			if ( typeof window.zE !== 'function' ) {
+			if ( ! ( 'zE' in window ) || typeof window.zE !== 'function' ) {
 				return;
 			}
-
+			// We need the user's authentication token to log them into chat
+			if ( ! zendeskJwt ) {
+				return;
+			}
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore: TypeScript doesn't see the zE property added by the external script.
 			window.zE( 'messenger', 'loginUser', function ( callback: ( jwt: string ) => void ) {
 				callback( zendeskJwt );
 			} );

--- a/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
+++ b/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
@@ -71,6 +71,8 @@ export const ZendeskJetpackChat: React.VFC< { keyType: KeyType } > = ( { keyType
 				return;
 			}
 			// The `zE` function exposes the required action to authenticate the user
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore: TypeScript doesn't see the zE property added by the external script.
 			if ( ! ( 'zE' in window ) || typeof window.zE !== 'function' ) {
 				return;
 			}


### PR DESCRIPTION
Related to [#](1202619025189113-as-1204606912118384/f)

This PR incorporates the newly added useMessagingAuth hook from https://github.com/Automattic/wp-calypso/pull/76777 to get an authentication key (JWT) for the currently logged in user and passes it to Zendesk when a user starts a chat.

On the user side, logged in users will no longer be asked for their name and email, and the current chat will persist across all of jetpack cloud.  (note this still needs to be implemented on Jetpack.com)

He's will now see the user account sidebar in Zendesk more reliably populate the user information.  And a checkmark will appear next to the user's name in the chat window indicating they are authenticated:

![Screenshot 2023-05-18 at 10 23 16 AM](https://github.com/Automattic/wp-calypso/assets/12895386/8735d5d2-1a67-4158-b4a3-3942078fe18a)


## Proposed Changes

* Incorporate the useMessagingAuth hook to collect the JWT for logged in users
* If a JWT is successfully found, use a promise to pass the JWT to the chat window to allow Zendesk to authenticate the user
* Existing conditions to show the chat window (English, there is an HE staffing chat) are still in place

## Testing Instructions

* Use the Jetpack Cloud live link below (or build this PR locally). As always if chat is staffed, you'll see the chat bubble on the lower right
* Make sure you are logged in (you'll see your account icon in the upper right of the page)
* Click the chat bubble to start a chat.  If you are authenticated you will NOT be asked for your name or email.
* You can also ask the HE in the chat if they see the little green check mark next to your name in the chat window

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?