### PR TITLE
Limited Global Styles: Add link to reset styles support doc

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -484,6 +484,7 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 						<path d="M5.8125 5.6875C5.8125 4.75552 6.56802 4 7.5 4C8.43198 4 9.1875 4.75552 9.1875 5.6875C9.1875 6.55621 8.53108 7.2716 7.6872 7.36473C7.58427 7.37609 7.5 7.45895 7.5 7.5625V8.5M7.5 9.25V10.375M13.5 7C13.5 10.3137 10.8137 13 7.5 13C4.18629 13 1.5 10.3137 1.5 7C1.5 3.68629 4.18629 1 7.5 1C10.8137 1 13.5 3.68629 13.5 7Z" stroke="#1E1E1E" stroke-width="1.5"/>
 					</svg>
 					<?php echo esc_html__( 'Remove custom styles', 'full-site-editing' ); ?>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg>
 				</a>
 				<a class="launch-bar-global-styles-preview" href="<?php echo esc_url( $preview_location ); ?>">
 					<label><input type="checkbox" <?php echo wpcom_is_previewing_global_styles() ? 'checked' : ''; ?>><span></span></label>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -475,6 +475,16 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 				>
 					<?php echo esc_html__( 'Upgrade now', 'full-site-editing' ); ?>
 				</a>
+				<a
+					class="launch-bar-global-styles-reset"
+					href="https://wordpress.com/support/using-styles/#reset-all-styles"
+					target="_blank"
+				>
+					<svg width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+						<path d="M5.8125 5.6875C5.8125 4.75552 6.56802 4 7.5 4C8.43198 4 9.1875 4.75552 9.1875 5.6875C9.1875 6.55621 8.53108 7.2716 7.6872 7.36473C7.58427 7.37609 7.5 7.45895 7.5 7.5625V8.5M7.5 9.25V10.375M13.5 7C13.5 10.3137 10.8137 13 7.5 13C4.18629 13 1.5 10.3137 1.5 7C1.5 3.68629 4.18629 1 7.5 1C10.8137 1 13.5 3.68629 13.5 7Z" stroke="#1E1E1E" stroke-width="1.5"/>
+					</svg>
+					<?php echo esc_html__( 'Remove custom styles', 'full-site-editing' ); ?>
+				</a>
 				<a class="launch-bar-global-styles-preview" href="<?php echo esc_url( $preview_location ); ?>">
 					<label><input type="checkbox" <?php echo wpcom_is_previewing_global_styles() ? 'checked' : ''; ?>><span></span></label>
 					<?php echo esc_html__( 'Preview custom styles', 'full-site-editing' ); ?>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
@@ -7,43 +7,45 @@
 	}
 }
 
-.components-notice-list .components-notice__action.components-button.wpcom-global-styles-is-external {
+.components-notice-list .components-notice__action.components-button.wpcom-global-styles-action-has-icon {
 	display: flex;
-	&::after {
-		content: "";
+	&::after,
+	&::before {
 		display: inline-block;
 		width: 15px;
 		height: 15px;
 		position: relative;
 		top: 1px;
+	}
+
+	&.is-primary {
+		&::after,
+		&::before {
+			background-color: var(--wp-components-color-accent-inverted, #fff);
+		}
+	}
+
+	&.is-secondary,
+	&.is-link {
+		&::after,
+		&::before {
+			background-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+		}
+	}
+
+	&.wpcom-global-styles-action-is-external::after {
+		content: "";
 		margin-left: 4px;
 		/* stylelint-disable-next-line function-url-quotes */
 		mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='15' height='15' aria-hidden='true' focusable='false'%3E%3Cpath d='M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z'%3E%3C/path%3E%3C/svg%3E");
-		text-decoration: none;
 	}
 
-	&.is-primary::after {
-		background-color: var(--wp-components-color-accent-inverted, #fff);
-	}
-
-	&.is-secondary::after {
-		background-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
-	}
-}
-
-.components-notice-list .components-notice__action.components-button.wpcom-global-styles-reset-support {
-	display: flex;
-	&::before {
+	&.wpcom-global-styles-action-is-support::before {
 		content: "";
-		display: inline-block;
 		width: 15px;
 		height: 14px;
-		position: relative;
-		top: 1px;
 		margin-right: 4px;
-		background-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 		/* stylelint-disable-next-line function-url-quotes */
 		mask-image: url('data:image/svg+xml,%3Csvg width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M5.8125 5.6875C5.8125 4.75552 6.56802 4 7.5 4C8.43198 4 9.1875 4.75552 9.1875 5.6875C9.1875 6.55621 8.53108 7.2716 7.6872 7.36473C7.58427 7.37609 7.5 7.45895 7.5 7.5625V8.5M7.5 9.25V10.375M13.5 7C13.5 10.3137 10.8137 13 7.5 13C4.18629 13 1.5 10.3137 1.5 7C1.5 3.68629 4.18629 1 7.5 1C10.8137 1 13.5 3.68629 13.5 7Z" style="stroke: %231E1E1E;" stroke-width="1.5"/%3E%3C/svg%3E%0A');
-		text-decoration: none;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
@@ -30,3 +30,20 @@
 		background-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 	}
 }
+
+.components-notice-list .components-notice__action.components-button.wpcom-global-styles-reset-support {
+	display: flex;
+	&::before {
+		content: "";
+		display: inline-block;
+		width: 15px;
+		height: 14px;
+		position: relative;
+		top: 1px;
+		margin-right: 4px;
+		background-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+		/* stylelint-disable-next-line function-url-quotes */
+		mask-image: url('data:image/svg+xml,%3Csvg width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M5.8125 5.6875C5.8125 4.75552 6.56802 4 7.5 4C8.43198 4 9.1875 4.75552 9.1875 5.6875C9.1875 6.55621 8.53108 7.2716 7.6872 7.36473C7.58427 7.37609 7.5 7.45895 7.5 7.5625V8.5M7.5 9.25V10.375M13.5 7C13.5 10.3137 10.8137 13 7.5 13C4.18629 13 1.5 10.3137 1.5 7C1.5 3.68629 4.18629 1 7.5 1C10.8137 1 13.5 3.68629 13.5 7Z" style="stroke: %231E1E1E;" stroke-width="1.5"/%3E%3C/svg%3E%0A');
+		text-decoration: none;
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -111,6 +111,11 @@ function GlobalStylesEditNotice() {
 		trackEvent( 'calypso_global_styles_gating_notice_reset_click', isSiteEditor );
 	}, [ editEntityRecord, globalStylesId, isSiteEditor ] );
 
+	const openResetGlobalStylesSupport = useCallback( () => {
+		window.open( 'https://wordpress.com/support/using-styles/#reset-all-styles', '_blank' ).focus();
+		trackEvent( 'calypso_global_styles_gating_notice_reset_support_click', isSiteEditor );
+	}, [ isSiteEditor ] );
+
 	const showNotice = useCallback( () => {
 		const actions = [
 			{
@@ -132,14 +137,13 @@ function GlobalStylesEditNotice() {
 			} );
 		}
 
-		if ( isSiteEditor ) {
-			actions.push( {
-				label: __( 'Remove custom styles', 'full-site-editing' ),
-				onClick: resetGlobalStyles,
-				variant: 'secondary',
-				noDefaultClasses: true,
-			} );
-		}
+		actions.push( {
+			label: __( 'Remove custom styles', 'full-site-editing' ),
+			onClick: isSiteEditor ? resetGlobalStyles : openResetGlobalStylesSupport,
+			variant: isSiteEditor ? 'secondary' : 'link',
+			noDefaultClasses: true,
+			className: isSiteEditor ? '' : 'wpcom-global-styles-reset-support',
+		} );
 
 		createWarningNotice(
 			__(
@@ -158,6 +162,7 @@ function GlobalStylesEditNotice() {
 		createWarningNotice,
 		isPostEditor,
 		isSiteEditor,
+		openResetGlobalStylesSupport,
 		previewPost,
 		resetGlobalStyles,
 		upgradePlan,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -123,7 +123,7 @@ function GlobalStylesEditNotice() {
 				onClick: upgradePlan,
 				variant: 'primary',
 				noDefaultClasses: true,
-				className: 'wpcom-global-styles-is-external',
+				className: 'wpcom-global-styles-action-has-icon wpcom-global-styles-action-is-external',
 			},
 		];
 
@@ -133,7 +133,7 @@ function GlobalStylesEditNotice() {
 				onClick: previewPost,
 				variant: 'secondary',
 				noDefaultClasses: true,
-				className: 'wpcom-global-styles-is-external',
+				className: 'wpcom-global-styles-action-has-icon wpcom-global-styles-action-is-external',
 			} );
 		}
 
@@ -142,7 +142,9 @@ function GlobalStylesEditNotice() {
 			onClick: isSiteEditor ? resetGlobalStyles : openResetGlobalStylesSupport,
 			variant: isSiteEditor ? 'secondary' : 'link',
 			noDefaultClasses: true,
-			className: isSiteEditor ? '' : 'wpcom-global-styles-reset-support',
+			className: isSiteEditor
+				? ''
+				: 'wpcom-global-styles-action-has-icon wpcom-global-styles-action-is-external wpcom-global-styles-action-is-support',
 		} );
 
 		createWarningNotice(

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.js
@@ -27,6 +27,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const upgradeButton = container.querySelector( '.launch-bar-global-styles-upgrade' );
 	const previewButton = container.querySelector( '.launch-bar-global-styles-preview' );
 	const closeButton = container.querySelector( '.launch-bar-global-styles-close' );
+	const resetButton = container.querySelector( '.launch-bar-global-styles-reset' );
 
 	const limitedGlobalStylesNoticeAction =
 		localStorage.getItem( 'limitedGlobalStylesNoticeAction' ) ?? 'show';
@@ -66,5 +67,11 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			action: checkbox.checked ? 'show' : 'hide',
 		} );
 		window.location = previewButton.href;
+	} );
+
+	resetButton?.addEventListener( 'click', ( event ) => {
+		event.preventDefault();
+		recordEvent( 'wpcom_global_styles_gating_notice_reset' );
+		window.open( resetButton.href, '_blank' ).focus();
 	} );
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.js
@@ -71,7 +71,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	resetButton?.addEventListener( 'click', ( event ) => {
 		event.preventDefault();
-		recordEvent( 'wpcom_global_styles_gating_notice_reset' );
+		recordEvent( 'wpcom_global_styles_gating_notice_reset_support' );
 		window.open( resetButton.href, '_blank' ).focus();
 	} );
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -35,19 +35,37 @@
 		transform: translateX(-50%);
 	}
 
-	.launch-bar-global-styles-upgrade {
+	.launch-bar-global-styles-upgrade,
+	.launch-bar-global-styles-reset {
 		min-height: 28px;
 		box-sizing: border-box;
-		border-radius: 2px;
 		width: 100%;
 		justify-content: center;
 		height: auto;
+	}
+
+	.launch-bar-global-styles-upgrade {
 		border: 1px solid #0675c4;
 		background: #0675c4;
 		color: #fff;
+		border-radius: 2px;
 
 		&:hover {
 			background: #006ba1;
+		}
+	}
+
+	.launch-bar-global-styles-reset {
+		color: inherit;
+		font-weight: normal !important;
+
+		svg {
+			margin-right: 4px;
+		}
+
+		&:hover {
+			background: transparent;
+			color: #676767;
 		}
 	}
 }
@@ -55,7 +73,7 @@
 .launch-banner-content .launch-bar-global-styles-preview {
 	border-top: 1px solid #c3c4c7;
 	width: calc(100% + 48px);
-	margin: 12px -24px 0;
+	margin: 0 -24px;
 	box-sizing: border-box;
 	padding: 12px 24px;
 	font-size: 13px;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -59,8 +59,14 @@
 		color: inherit;
 		font-weight: normal !important;
 
-		svg {
+		svg:first-child {
 			margin-right: 4px;
+		}
+
+		svg:last-child {
+			margin-left: 4px;
+			position: relative;
+			top: 1px;
 		}
 
 		&:hover {


### PR DESCRIPTION
## Proposed Changes

Adds a link to the limited Global Styles notice in the post editor and in the launchbar that opens the support doc explaining how to reset styles.

Launchbar | Post editor
--- | ---
<img width="415" alt="Screenshot 2023-05-18 at 16 35 58" src="https://github.com/Automattic/wp-calypso/assets/1233880/e5b900e8-bfde-4549-aeaf-f7c1695e6fb8"> | <img width="1277" alt="Screenshot 2023-05-18 at 16 16 24" src="https://github.com/Automattic/wp-calypso/assets/1233880/2bd576b9-2594-487c-ace9-af31c892e422">

## Testing Instructions

- Apply these ETK changes to your sandbox
- Sandbox a site with limited Global Styles
- Visit the frontend
- Make sure the launchbar notice contains a "Reset custom styles" link
- Click on it
- Make sure it opens the expected support doc
- Visit the open editor
- Make sure the post editor global notice contains a "Reset custom styles" link
- Click on it
- Make sure it opens the expected support doc