### PR TITLE
Google Analytics: fix learn more link

### DIFF
--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -48,9 +48,12 @@ const GoogleAnalyticsJetpackForm = ( {
 	siteId,
 	sitePlugins,
 	translate,
+	isAtomic,
 } ) => {
 	const upsellHref = `/checkout/${ site.slug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_GOOGLE_ANALYTICS ] }`;
-	const analyticsSupportUrl = 'https://jetpack.com/support/google-analytics/';
+	const analyticsSupportUrl = isAtomic
+		? 'https://wordpress.com/support/google-analytics/'
+		: 'https://jetpack.com/support/google-analytics/';
 	const nudgeTitle = translate( 'Connect your site to Google Analytics' );
 	const wooCommercePlugin = find( sitePlugins, { slug: 'woocommerce' } );
 	const wooCommerceActive = wooCommercePlugin ? wooCommercePlugin.active : false;


### PR DESCRIPTION
Related to #63324

## Proposed Changes

Update `GoogleAnalyticsJetpackForm` component to return a WordPress.com support link if the site is Atomic. Otherwise give the Jetpack link.

There are two components for the Google Analytics form one for Simple and another for Jetpack. The Simple form used the WordPress.com link - https://wordpress.com/support/google-analytics/ and the Jetpack version used the Jetpack link. This did not account for Atomic sites. The `isAtomic` already existed in the props.

## Testing Instructions

1. Open the live link below and select an Atomic site from your account.
2. Navigate to Tools ⇢ Marketing ⇢ Traffic
3. Hover over the `Learn more` link for Google Analytics and the link should be - https://wordpress.com/support/google-analytics/