### PR TITLE
Added P2 label to the list of comments in Subscription Manager

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -24,6 +24,7 @@ const CommentRow = ( {
 	date_subscribed,
 	forwardedRef,
 	style,
+	is_wpforteams_site,
 }: CommentRowProps ) => {
 	const translate = useTranslate();
 	const hostname = useMemo( () => new URL( site_url ).hostname, [ site_url ] );
@@ -50,7 +51,10 @@ const CommentRow = ( {
 					<span className="title-box" role="cell">
 						{ siteIcon }
 						<span className="title-column">
-							<span className="name">{ site_title }</span>
+							<span className="name">
+								{ site_title }
+								{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
+							</span>
 							<span className="url">{ hostname }</span>
 						</span>
 					</span>

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -94,6 +94,7 @@ export type PostSubscription = {
 	post_title: string;
 	post_excerpt: string;
 	post_url: string;
+	is_wpforteams_site: boolean;
 };
 
 export type PendingSiteSubscription = {


### PR DESCRIPTION
## Proposed Changes

This PR adds the P2 label to the list of comments in the new Subscription Manager, as seen in the Figma file: inDLaEQV8jJ21O4WXawIsJ-fi-712_18319

## Testing Instructions

1. Apply this PR.
2. Go to this file `client/server/pages/index.js` and change the call back in `app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res, next ) {` to it ends up like this:
```js
	app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res, next ) {
		return next();
	} );
```
3. Log in to your Calypso local and go to `http://calypso.localhost:3000/subscriptions/comments`.
4. If your user has P2 and non-P2 site subscriptions, you should see the P2 tag beside the site's name accordingly.
