### PR TITLE
Blog Onboarding: Avoid W icon & Welcome tour shows on slow connections

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
 import { useEffect, createPortal, useState } from '@wordpress/element';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
+import { getQueryArg } from '@wordpress/url';
 import useSiteIntent from '../../dotcom-fse/lib/site-intent/use-site-intent';
 import WpcomBlockEditorNavSidebar from './components/nav-sidebar';
 import ToggleSidebarButton from './components/toggle-sidebar-button';
@@ -36,7 +37,9 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 			}, [] );
 
 			const { siteIntent: intent } = useSiteIntent();
-			const isStartWritingFlow = intent === START_WRITING_FLOW;
+			const isStartWritingFlow =
+				intent === START_WRITING_FLOW ||
+				getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
 
 			const [ clickGuardRoot ] = useState( () => document.createElement( 'div' ) );
 			useEffect( () => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -37,6 +37,7 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 			}, [] );
 
 			const { siteIntent: intent } = useSiteIntent();
+			// We check the URL param along with site intent because the param loads faster and prevents element flashing.
 			const isStartWritingFlow =
 				intent === START_WRITING_FLOW ||
 				getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -5,6 +5,7 @@ import { WpcomTourKit, usePrefetchTourAssets } from '@automattic/tour-kit';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { useEffect, useMemo } from '@wordpress/element';
+import { getQueryArg } from '@wordpress/url';
 import useSiteIntent from '../../../dotcom-fse/lib/site-intent/use-site-intent';
 import useSitePlan from '../../../dotcom-fse/lib/site-plan/use-site-plan';
 import { selectors as starterPageTemplatesSelectors } from '../../../starter-page-templates/store';
@@ -49,7 +50,9 @@ function LaunchWpcomWelcomeTour() {
 	const localeSlug = useLocale();
 	const editorType = getEditorType();
 	const { siteIntent: intent } = useSiteIntent();
-	const isStartWritingFlow = intent === START_WRITING_FLOW;
+	const isStartWritingFlow =
+		intent === START_WRITING_FLOW ||
+		getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
 
 	// Preload first card image (others preloaded after open state confirmed)
 	usePrefetchTourAssets( [ getTourSteps( localeSlug, false, false, null, siteIntent )[ 0 ] ] );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -50,6 +50,7 @@ function LaunchWpcomWelcomeTour() {
 	const localeSlug = useLocale();
 	const editorType = getEditorType();
 	const { siteIntent: intent } = useSiteIntent();
+	// We check the URL param along with site intent because the param loads faster and prevents element flashing.
 	const isStartWritingFlow =
 		intent === START_WRITING_FLOW ||
 		getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';

--- a/apps/wpcom-block-editor/src/wpcom/editor.scss
+++ b/apps/wpcom-block-editor/src/wpcom/editor.scss
@@ -4,8 +4,7 @@
 	.components-external-link,
 	.edit-post-post-schedule,
 	.components-panel__row:has(.editor-post-trash),
-	.launchpad__save-modal,
-	.edit-post-header > div:has(.wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button) {
+	.launchpad__save-modal {
 		display: none !important;
 	}
 }

--- a/apps/wpcom-block-editor/src/wpcom/editor.scss
+++ b/apps/wpcom-block-editor/src/wpcom/editor.scss
@@ -4,7 +4,8 @@
 	.components-external-link,
 	.edit-post-post-schedule,
 	.components-panel__row:has(.editor-post-trash),
-	.launchpad__save-modal {
+	.launchpad__save-modal,
+	.edit-post-header > div:has(.wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button) {
 		display: none !important;
 	}
 }

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -9,6 +9,7 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 	const { siteIntent: intent } = useSiteIntent();
 
 	useEffect( () => {
+		// We check the URL param along with site intent because the param loads faster and prevents element flashing.
 		const hasStartWritingFlowQueryArg =
 			getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
 

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -9,7 +9,10 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 	const { siteIntent: intent } = useSiteIntent();
 
 	useEffect( () => {
-		if ( intent === START_WRITING_FLOW ) {
+		const hasStartWritingFlowQueryArg =
+			getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
+
+		if ( intent === START_WRITING_FLOW || hasStartWritingFlowQueryArg ) {
 			dispatch( 'core/edit-post' ).closeGeneralSidebar();
 			document.documentElement.classList.add( 'start-writing-hide' );
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2492

## Proposed Changes

W icon and Welcome tour is showing while the Editor is loading on slow connections, we hide them using the `start-writing=true` query argument.

## Testing Instructions

* Using a new user OR a user without any site, start the flow with [/setup/start-writing](http://calypso.localhost:3000/setup/start-writing).
* You have to sandbox the newly created site + widgets.wp.com.
* You have to run `yarn dev --sync` on `/apps/editing-toolkit`
* You also have to run `yarn dev --sync` on `/apps/wpcom-block-editor`
* Throttle the connection to Fast 3G or Slow 3G (using the network tab of your browser development tools)
* Reload the editor and while loading the editor, you should not see the W icon (top left) nor the Welcome tour dialog.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
