### PR TITLE
Fixed pending tab not loading for logged in users in Subscription Manager

### DIFF
--- a/packages/data-stores/src/reader/queries/use-pending-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-pending-site-subscriptions-query.ts
@@ -13,30 +13,33 @@ type SubscriptionManagerPendingSiteSubscriptionsQueryProps = {
 	sort?: ( a?: PendingSiteSubscription, b?: PendingSiteSubscription ) => number;
 };
 
-const callPendingSiteSubscriptionsEndpoint =
-	async (): Promise< PendingSiteSubscriptionsResult > => {
-		const pendingSites = [];
-		const perPage = 1000; // TODO: This is a temporary workaround to get all pending subscriptions. We should remove this once we decide how to handle pagination.
+const callPendingSiteSubscriptionsEndpoint = async (
+	isLoggedIn: boolean
+): Promise< PendingSiteSubscriptionsResult > => {
+	const pendingSites = [];
+	const perPage = 1000; // TODO: This is a temporary workaround to get all pending subscriptions. We should remove this once we decide how to handle pagination.
 
-		const incoming = await callApi< SubscriptionManagerPendingSiteSubscriptions >( {
-			path: `/pending-blog-subscriptions?per_page=${ perPage }`,
-			apiVersion: '2',
-		} );
+	const incoming = await callApi< SubscriptionManagerPendingSiteSubscriptions >( {
+		path: `/pending-blog-subscriptions?per_page=${ perPage }`,
+		apiNamespace: 'wpcom/v2',
+		apiVersion: '2',
+		isLoggedIn,
+	} );
 
-		if ( incoming && incoming.pending_blog_subscriptions ) {
-			pendingSites.push(
-				...incoming.pending_blog_subscriptions.map( ( pendingSubscription ) => ( {
-					...pendingSubscription,
-					date_subscribed: new Date( pendingSubscription.date_subscribed ),
-				} ) )
-			);
-		}
+	if ( incoming && incoming.pending_blog_subscriptions ) {
+		pendingSites.push(
+			...incoming.pending_blog_subscriptions.map( ( pendingSubscription ) => ( {
+				...pendingSubscription,
+				date_subscribed: new Date( pendingSubscription.date_subscribed ),
+			} ) )
+		);
+	}
 
-		return {
-			pendingSites,
-			totalCount: parseInt( incoming?.total_pending_blog_subscriptions_count ?? 0 ),
-		};
+	return {
+		pendingSites,
+		totalCount: parseInt( incoming?.total_pending_blog_subscriptions_count ?? 0 ),
 	};
+};
 
 const defaultFilter = () => true;
 const defaultSort = () => 0;
@@ -45,13 +48,13 @@ const usePendingSiteSubscriptionsQuery = ( {
 	filter = defaultFilter,
 	sort = defaultSort,
 }: SubscriptionManagerPendingSiteSubscriptionsQueryProps = {} ) => {
-	const isLoggedIn = useIsLoggedIn();
+	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 
 	const { data, ...rest } = useQuery< PendingSiteSubscriptionsResult >(
 		[ 'read', 'pending-site-subscriptions', isLoggedIn ],
 		async () => {
-			return await callPendingSiteSubscriptionsEndpoint();
+			return await callPendingSiteSubscriptionsEndpoint( isLoggedIn );
 		},
 		{
 			enabled,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/77079

## Proposed Changes

**The problem**

When a logged-in user goes to the `pending` tab in Subscription Manager, they will find this in the console sometimes:

<img width="935" alt="Screenshot 2023-05-18 at 12 04 43" src="https://github.com/Automattic/wp-calypso/assets/3832570/9d619895-0d72-4245-aab1-083df759eaec">

**The solution**

Turns out the problem was the queries to retrieve the pending site and comment subscriptions ignoring the logged status of the user:
<img width="604" alt="Screenshot 2023-05-18 at 18 40 26" src="https://github.com/Automattic/wp-calypso/assets/3832570/885b3bdf-607a-4501-b3c1-49cc436c74ad">

As you can see, the variable `isLoggedIn` wasn't being passed to the `callApi` method. Additionally, the nameSpace was required too, because being a logged-in user, the method called to make the request inside `callApi` is `wpcomRequest`. Internally, if the namespace is not passed, the URL of the request is formed like this:

fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Qcebkl%2Swdhrel%2Qcebivqre.wf%3Se%3Qq5r14q9q%23144-og

Our endpoint doesn't live there, but in `wpcom/v2` namespace, that's why we have to pass this parameter too:

<img width="634" alt="Screenshot 2023-05-18 at 18 47 12" src="https://github.com/Automattic/wp-calypso/assets/3832570/0cb89834-67f8-42d2-a467-522c71e5db64">

## Testing Instructions

Apply this PR.
As an external user, go to `https://wordpress.com/subscriptions/pending` with the browser console open.
Check that it works and that there is no error message in the console.
Change to other tabs and check the same.
As an internal user, go to `https://wordpress.com/subscriptions/pending` with the browser console open.
Check that it works and that there is no error message in the console.
Change to other tabs and check the same.
