### PR TITLE
Add spinner while mastodon connecting

### DIFF
--- a/client/my-sites/marketing/connections/mastodon.tsx
+++ b/client/my-sites/marketing/connections/mastodon.tsx
@@ -1,4 +1,4 @@
-import { FormInputValidation } from '@automattic/components';
+import { FormInputValidation, Spinner } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useState, FormEvent, ChangeEvent, useEffect } from 'react';
@@ -139,6 +139,7 @@ export const Mastodon: React.FC< Props > = ( {
 							isError={ showError }
 							onChange={ handleInstanceChange }
 						/>
+						{ isConnecting && <Spinner /> }
 					</InstanceContainer>
 					{ showError && <FormInputValidation isError text={ error } /> }
 				</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76991 

## Proposed Changes
To add a better visibility on Mastodon connection flow we are presenting a spinner when connection is in progress.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Prerequisites

- Make sure you have a Mastodon account

### Testing

- Spin up Calypso by running this branch locally or by using a live link below
- If you're using a live link, enable the `mastodon` flag by adding the query parameter `?flags=mastodon`
- Navigate to Mastodon in the `/marketing/connections/:site` section
- Make a connection and observe that spinner is shown during all connection process

<img width="656" alt="Screenshot at May 18 11-00-01" src="https://github.com/Automattic/wp-calypso/assets/60262784/c5e53690-fdb2-403e-9e1a-cc10dba73be0">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
