### PR TITLE
Hosting configuration: poll Atomic transfer status when loading the page

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -72,6 +72,15 @@ class Hosting extends Component {
 		this.props.fetchAutomatedTransferStatus( this.props.siteId );
 	}
 
+	componentDidUpdate( prevProps ) {
+		const { COMPLETE } = transferStates;
+		const { transferState, requestSiteById, siteId } = this.props;
+
+		if ( prevProps.transferState !== COMPLETE && transferState === COMPLETE ) {
+			requestSiteById( siteId );
+		}
+	}
+
 	render() {
 		const {
 			teams,
@@ -81,7 +90,6 @@ class Hosting extends Component {
 			isECommerceTrial,
 			isWpcomStagingSite,
 			isTransferring,
-			requestSiteById,
 			siteId,
 			siteSlug,
 			translate,
@@ -112,10 +120,6 @@ class Hosting extends Component {
 				( isTransferring && COMPLETE !== transferState ) ||
 				( isDisabled && COMPLETE === transferState )
 			) {
-				if ( COMPLETE === transferState ) {
-					requestSiteById( siteId );
-				}
-
 				let activationText = translate( 'Please wait while we activate the hosting features.' );
 				if ( this.state.clickOutside ) {
 					activationText = translate( "Don't leave quite yet! Just a bit longer." );

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -113,7 +113,11 @@ class Hosting extends Component {
 		};
 
 		const getAtomicActivationNotice = () => {
-			const { COMPLETE, FAILURE } = transferStates;
+			const { COMPLETE, FAILURE, RELOCATING_REVERT } = transferStates;
+
+			if ( transferState === RELOCATING_REVERT ) {
+				return null;
+			}
 
 			// Transfer in progress
 			if (

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -69,12 +69,7 @@ class Hosting extends Component {
 	}
 
 	componentDidMount() {
-		const { COMPLETE } = transferStates;
-		// Check if a reverted site still has the COMPLETE status
-		if ( this.props.transferState === COMPLETE ) {
-			// Try to refresh the transfer state
-			this.props.fetchAutomatedTransferStatus( this.props.siteId );
-		}
+		this.props.fetchAutomatedTransferStatus( this.props.siteId );
 	}
 
 	render() {

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -135,7 +135,7 @@ const Hosting = ( props ) => {
 			/>
 		);
 
-		if ( ! isTransferring ) {
+		if ( isDisabled && ! isTransferring ) {
 			return (
 				<>
 					{ failureNotice }

--- a/client/state/atomic-transfer/hooks/use-atomic-transfer-query.ts
+++ b/client/state/atomic-transfer/hooks/use-atomic-transfer-query.ts
@@ -1,0 +1,61 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { transferStates, TransferStates } from 'calypso/state/automated-transfer/constants';
+import { SiteSlug } from 'calypso/types';
+
+interface ErrorResponse {
+	code: 'no_transfer_record';
+}
+
+interface SuccessResponse {
+	status: TransferStates;
+}
+
+const fetchLatestAtomicTransfer = (
+	siteSlug: SiteSlug
+): Promise< ErrorResponse | SuccessResponse > =>
+	wpcom.req.get( {
+		path: `/sites/${ siteSlug }/atomic/transfers/latest`,
+		apiNamespace: 'wpcom/v2',
+	} );
+
+interface UseAtomicTransferQueryOptions {
+	refetchInterval?: number;
+}
+
+const endStates = [
+	transferStates.NONE,
+	transferStates.COMPLETE,
+	transferStates.FAILURE,
+	transferStates.ERROR,
+	transferStates.REVERTED,
+] as const;
+
+export const useAtomicTransferQuery = (
+	siteSlug: SiteSlug,
+	{ refetchInterval }: UseAtomicTransferQueryOptions
+) => {
+	const { data } = useQuery( [ 'sites', siteSlug, 'atomic', 'transfers', 'latest' ], {
+		queryFn: () => fetchLatestAtomicTransfer( siteSlug ),
+		refetchInterval,
+	} );
+
+	if ( ! data ) {
+		return {
+			isTransferring: false,
+			transferStatus: transferStates.NONE,
+		};
+	}
+
+	if ( 'code' in data ) {
+		return {
+			transferStatus: transferStates.NONE,
+			isTransferring: false,
+		};
+	}
+
+	return {
+		transferStatus: data.status,
+		isTransferring: ! endStates.includes( data.status as ( typeof endStates )[ number ] ),
+	};
+};

--- a/client/state/atomic-transfer/hooks/use-atomic-transfer-query.ts
+++ b/client/state/atomic-transfer/hooks/use-atomic-transfer-query.ts
@@ -23,13 +23,14 @@ interface UseAtomicTransferQueryOptions {
 	refetchInterval?: number;
 }
 
-const endStates = [
+const endStates: TransferStates[] = [
 	transferStates.NONE,
 	transferStates.COMPLETE,
+	transferStates.COMPLETED,
 	transferStates.FAILURE,
 	transferStates.ERROR,
 	transferStates.REVERTED,
-] as const;
+];
 
 export const useAtomicTransferQuery = (
 	siteSlug: SiteSlug,
@@ -56,6 +57,6 @@ export const useAtomicTransferQuery = (
 
 	return {
 		transferStatus: data.status,
-		isTransferring: ! endStates.includes( data.status as ( typeof endStates )[ number ] ),
+		isTransferring: ! endStates.includes( data.status ),
 	};
 };

--- a/client/state/automated-transfer/constants.ts
+++ b/client/state/automated-transfer/constants.ts
@@ -15,6 +15,7 @@ export const transferStates = {
 	BACKFILLING: 'backfilling',
 	RELOCATING: 'relocating_switcheroo',
 	COMPLETE: 'complete',
+	COMPLETED: 'completed', // there seems to be two spellings for this state
 	/**
 	 * Similar to 'none' there is no existing transfer, but this is when the site has been already reverted from atomic
 	 */

--- a/client/state/automated-transfer/selectors/is-automated-transfer-active.js
+++ b/client/state/automated-transfer/selectors/is-automated-transfer-active.js
@@ -17,6 +17,7 @@ export const isActive = ( status ) =>
 				transferStates.COMPLETE,
 				transferStates.FAILURE,
 				transferStates.ERROR,
+				transferStates.REVERTED,
 		  ].includes( status )
 		: false;
 /**

--- a/client/state/automated-transfer/selectors/is-automated-transfer-active.js
+++ b/client/state/automated-transfer/selectors/is-automated-transfer-active.js
@@ -10,8 +10,15 @@ import 'calypso/state/automated-transfer/init';
  * @param {string} status name of current state in automated transfer
  * @returns {?boolean} is transfer currently active? null if unknown
  */
-export const isActive = ( status ) => ( status ? status === transferStates.START : null );
-
+export const isActive = ( status ) =>
+	status
+		? ! [
+				transferStates.NONE,
+				transferStates.COMPLETE,
+				transferStates.FAILURE,
+				transferStates.ERROR,
+		  ].includes( status )
+		: false;
 /**
  * Indicates whether or not an automated transfer is active for a given site
  *


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/2151. Closes https://github.com/Automattic/wp-calypso/issues/72371. 

## Proposed Changes

This PR tries to fix the problem where the current WPCOM tab doesn't get notified whenever the transfer to Atomic is completed.

It fetches the status on page load and also re-fetches the site whenever the transfer is completed.

The goal is to create an abstraction (i.e. to re-use the transfer status polling logic both in /hosting-configuration and /sites. In the future, as we split HC into multiple pages, this hook and abstraction will be much appreciated since AT transfer is a crucial part of our hosting features activation and management. It also counts as maintenance work.

## Testing Instructions

In both cases, you can follow the progress by opening the dev tools and filtering by `automated-transfers` in the Network tab.

### Without leaving the current tab

1. Pick a Business site;
3. Go to `/hosting-config`;
4. Click "Activate" the Business features;
5. Verify that after a while the site is transferred to Atomic and the page automatically reflects that.

### Refreshing the tab while the transfer is in progress

1. Pick a Business site;
2. Go to `/hosting-config`;
3. Click "Activate" the Business features;
4. Refresh the page;
5. Verify that after a while the site is transferred to Atomic and the page automatically reflects that.

