### PR TITLE
Settings: add Reader post views setting

### DIFF
--- a/client/my-sites/site-settings/reader-settings/index.tsx
+++ b/client/my-sites/site-settings/reader-settings/index.tsx
@@ -1,0 +1,56 @@
+import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import FormLegend from 'calypso/components/forms/form-legend';
+import SupportInfo from 'calypso/components/support-info';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+
+type Fields = {
+	wpcom_reader_views_enabled?: boolean;
+};
+
+type ReaderSettingsSectionProps = {
+	fields: Fields;
+	handleAutosavingToggle: ( field: string ) => () => void;
+	isAtomic: boolean | null;
+	isRequestingSettings: boolean;
+	isSavingSettings: boolean;
+	siteIsJetpack: boolean | null;
+};
+
+const ReaderSettingsSection = ( {
+	fields,
+	handleAutosavingToggle,
+	isRequestingSettings,
+	isSavingSettings,
+	isAtomic,
+	siteIsJetpack,
+}: ReaderSettingsSectionProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
+			<SettingsSectionHeader title={ translate( 'Reader settings' ) } />
+			<Card className="site-settings__card">
+				{ /* @ts-expect-error FormLegend is not typed and has a className error */ }
+				<FormLegend>{ translate( 'Reader content' ) }</FormLegend>
+				<SupportInfo
+					text={ translate(
+						"Settings that control how the site's content is displayed in the Reader."
+					) }
+					link="https://wordpress.com/support/reader/"
+					privacyLink={ siteIsJetpack && ! isAtomic }
+				/>
+				<ToggleControl
+					checked={ !! fields.wpcom_reader_views_enabled }
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'wpcom_reader_views_enabled' ) }
+					label={ translate( 'Show post views in Reader' ) }
+				/>
+			</Card>
+		</>
+	);
+};
+
+export default ReaderSettingsSection;

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -5,8 +5,10 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
-import { getSiteUrl } from 'calypso/state/sites/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { getSiteUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import ReaderSettingsSection from '../reader-settings';
 import { NewsletterSettingsSection } from '../reading-newsletter-settings';
 import { RssFeedSettingsSection } from '../reading-rss-feed-settings';
 import { SiteSettingsSection } from '../reading-site-settings';
@@ -33,6 +35,7 @@ type Fields = {
 	show_on_front?: 'posts' | 'page';
 	subscription_options?: SubscriptionOptions;
 	wpcom_featured_image_in_email?: boolean;
+	wpcom_reader_views_enabled?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 };
 
@@ -55,6 +58,7 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 		show_on_front,
 		subscription_options,
 		wpcom_featured_image_in_email,
+		wpcom_reader_views_enabled,
 		wpcom_subscription_emails_use_excerpt,
 	} = settings;
 
@@ -72,6 +76,7 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 		...( show_on_front && { show_on_front } ),
 		...( subscription_options && { subscription_options } ),
 		wpcom_featured_image_in_email: !! wpcom_featured_image_in_email,
+		wpcom_reader_views_enabled: !! wpcom_reader_views_enabled,
 		wpcom_subscription_emails_use_excerpt: !! wpcom_subscription_emails_use_excerpt,
 	};
 };
@@ -79,19 +84,26 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteUrl = siteId && getSiteUrl( state, siteId );
+	const siteIsJetpack = isJetpackSite( state, siteId );
+	const isAtomic = isSiteAutomatedTransfer( state, siteId );
 	return {
 		...( siteUrl && { siteUrl } ),
+		siteIsJetpack,
+		isAtomic,
 	};
 } );
 
 type ReadingSettingsFormProps = {
 	fields: Fields;
 	onChangeField: ( field: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => void;
+	handleAutosavingToggle: ( field: string ) => () => void;
 	handleToggle: ( field: string ) => ( ( isChecked: boolean ) => void ) | undefined;
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
+	isAtomic: boolean | null;
 	isRequestingSettings: boolean;
 	isSavingSettings: boolean;
 	settings: { subscription_options?: SubscriptionOptions };
+	siteIsJetpack: boolean | null;
 	siteUrl?: string;
 	updateFields: ( fields: Fields ) => void;
 };
@@ -101,11 +113,14 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 		( {
 			fields,
 			onChangeField,
+			handleAutosavingToggle,
 			handleSubmitForm,
 			handleToggle,
+			isAtomic,
 			isRequestingSettings,
 			isSavingSettings,
 			settings,
+			siteIsJetpack,
 			siteUrl,
 			updateFields,
 		}: ReadingSettingsFormProps ) => {
@@ -140,6 +155,14 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						isSavingSettings={ isSavingSettings }
 						savedSubscriptionOptions={ savedSubscriptionOptions }
 						updateFields={ updateFields }
+					/>
+					<ReaderSettingsSection
+						fields={ fields }
+						handleAutosavingToggle={ handleAutosavingToggle }
+						isRequestingSettings={ isRequestingSettings }
+						isSavingSettings={ isSavingSettings }
+						isAtomic={ isAtomic }
+						siteIsJetpack={ siteIsJetpack }
 					/>
 				</form>
 			);


### PR DESCRIPTION
## Proposed Changes

* Adds a new section for Reader related settings in Settings > Reading
* Adds a toggle for the `wpcom_reader_views_enabled` blog option to control if [post views](https://github.com/Automattic/wp-calypso/pull/76803) show in Reader for the site

<img width="779" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1699996/189d6e03-816f-404d-ab42-e17b3e3f08b6">


## Testing Instructions

* Apply [this Jetpack PR](https://github.com/Automattic/jetpack/pull/30800) to a wpcom sandbox and sandbox public-api.wordpress.com
* Go to `/settings/reading/{site}` to see the new Reader section at the bottom
* Toggle the setting and verify the option is updated on the site
