### PR TITLE
Blog onboarding: Don't use pink on domains filter

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -166,6 +166,13 @@ button {
 	}
 }
 
+.is-section-stepper:has(div.domains) {
+	.search-filters__popover {
+		--color-accent: #117ac9 !important;
+		--color-accent-60: #0e64a5 !important;
+	}
+}
+
 .intro {
 	.signup-header {
 		z-index: 0 !important; /* set to 0 to prevent it from covering top of intro modal */

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -166,7 +166,7 @@ button {
 	}
 }
 
-.is-section-stepper:has(div.domains) {
+.is-section-stepper {
 	.search-filters__popover {
 		--color-accent: #117ac9 !important;
 		--color-accent-60: #0e64a5 !important;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2485

## Proposed Changes

We don't want to use different colors for filters than buttons on domain selection while on start-writing flow.

## Testing Instructions

* Using a new user OR a user without any site, start the flow with [/setup/start-writing](http://calypso.localhost:3000/setup/start-writing).
* When select a domain, open the filters and check the colors are the same as the rest of the flow (not pink)

## Screenshot
| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/8f2ced6d-2113-4af6-b69a-d28db9d4b2ed) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/40c4a690-822f-41f8-ac36-fbfc3cad2b20) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
