### PR TITLE
Newsletters: Add subcribe modal setting (behind a feature flag)

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -30,7 +30,7 @@ export const SubscribeModalSetting = ( {
 				checked={ !! value }
 				onChange={ handleToggle( SUBSCRIBE_MODAL_OPTION ) }
 				disabled={ disabled }
-				label={ translate( 'Enable subscriber modal.' ) }
+				label={ translate( 'Enable subscriber modal' ) }
 			/>
 			<FormSettingExplanation>
 				{ translate(

--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -1,0 +1,54 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+
+export const SUBSCRIBE_MODAL_OPTION = 'wpcom_subscribe_modal';
+
+const ToggleControl = OriginalToggleControl as React.ComponentType<
+	OriginalToggleControl.Props & {
+		disabled?: boolean;
+	}
+>;
+
+type SubscribeModalSettingProps = {
+	value?: boolean;
+	handleToggle: ( field: string ) => ( ( isChecked: boolean ) => void ) | undefined;
+	disabled?: boolean;
+};
+
+export const SubscribeModalSetting = ( {
+	value = false,
+	handleToggle,
+	disabled,
+}: SubscribeModalSettingProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<ToggleControl
+				checked={ !! value }
+				onChange={ handleToggle( SUBSCRIBE_MODAL_OPTION ) }
+				disabled={ disabled }
+				label={ translate( 'Enable subscriber modal.' ) }
+			/>
+			<FormSettingExplanation>
+				{ translate(
+					'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll. {{link}}Edit the modal here.{{/link}}.',
+					{
+						components: {
+							link: (
+								<a
+									// TODO: add url to modal template
+									href={ localizeUrl( '#' ) }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+			</FormSettingExplanation>
+		</>
+	);
+};

--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -53,7 +53,7 @@ export const SubscribeModalSetting = ( {
 			/>
 			<FormSettingExplanation>
 				{ translate(
-					'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll. {{link}}Edit the modal here.{{/link}}.',
+					'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll. {{link}}Edit the modal{{/link}}.',
 					{
 						components: {
 							link: (

--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -1,4 +1,3 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -56,14 +55,7 @@ export const SubscribeModalSetting = ( {
 					'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll. {{link}}Edit the modal{{/link}}.',
 					{
 						components: {
-							link: (
-								<a
-									// TODO: add url to modal template
-									href={ localizeUrl( subscribeModalEditorUrl ) }
-									target="_blank"
-									rel="noreferrer"
-								/>
-							),
+							link: <a href={ subscribeModalEditorUrl } target="_blank" rel="noreferrer" />,
 						},
 					}
 				) }

--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -8,7 +8,7 @@ import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-export const SUBSCRIBE_MODAL_OPTION = 'wpcom_subscribe_modal';
+export const SUBSCRIBE_MODAL_OPTION = 'sm_enabled';
 
 const ToggleControl = OriginalToggleControl as React.ComponentType<
 	OriginalToggleControl.Props & {
@@ -29,7 +29,7 @@ export const SubscribeModalSetting = ( {
 }: SubscribeModalSettingProps ) => {
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
-	const siteEditorUrl = useSelector( ( state ) =>
+	const siteEditorUrl = useSelector( ( state: object ) =>
 		getSiteEditorUrl( state, selectedSite?.ID || null )
 	);
 	const themeSlug = useSelector( ( state ) =>

--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -1,7 +1,12 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 export const SUBSCRIBE_MODAL_OPTION = 'wpcom_subscribe_modal';
 
@@ -23,6 +28,20 @@ export const SubscribeModalSetting = ( {
 	disabled,
 }: SubscribeModalSettingProps ) => {
 	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
+	const siteEditorUrl = useSelector( ( state ) =>
+		getSiteEditorUrl( state, selectedSite?.ID || null )
+	);
+	const themeSlug = useSelector( ( state ) =>
+		getSiteOption( state, selectedSite?.ID, 'theme_slug' )
+	);
+	const subscribeModalEditorUrl = themeSlug
+		? addQueryArgs( siteEditorUrl, {
+				postType: 'wp_template_part',
+				postId: `${ themeSlug }//subscribe-modal`,
+				canvas: 'edit',
+		  } )
+		: siteEditorUrl;
 
 	return (
 		<>
@@ -40,7 +59,7 @@ export const SubscribeModalSetting = ( {
 							link: (
 								<a
 									// TODO: add url to modal template
-									href={ localizeUrl( '#' ) }
+									href={ localizeUrl( subscribeModalEditorUrl ) }
 									target="_blank"
 									rel="noreferrer"
 								/>

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -2,6 +2,7 @@ import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { useSiteOption } from 'calypso/state/sites/hooks';
 import { SubscriptionOptions } from '../settings-reading/main';
 import { EmailsTextSetting } from './EmailsTextSetting';
 import { ExcerptSetting } from './ExcerptSetting';
@@ -34,6 +35,8 @@ export const NewsletterSettingsSection = ( {
 	savedSubscriptionOptions,
 	updateFields,
 }: NewsletterSettingsSectionProps ) => {
+	const siteIntent = useSiteOption( 'site_intent' );
+	const isNewsletterSite = siteIntent === 'newsletter';
 	const translate = useTranslate();
 	const {
 		wpcom_featured_image_in_email,
@@ -72,13 +75,15 @@ export const NewsletterSettingsSection = ( {
 					disabled={ disabled }
 				/>
 			</Card>
-			<Card className="site-settings__card">
-				<SubscribeModalSetting
-					value={ wpcom_subscribe_modal }
-					handleToggle={ handleToggle }
-					disabled={ disabled }
-				/>
-			</Card>
+			{ isNewsletterSite && (
+				<Card className="site-settings__card">
+					<SubscribeModalSetting
+						value={ wpcom_subscribe_modal }
+						handleToggle={ handleToggle }
+						disabled={ disabled }
+					/>
+				</Card>
+			) }
 			<Card className="site-settings__card">
 				<ExcerptSetting
 					value={ wpcom_subscription_emails_use_excerpt }

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -6,11 +6,13 @@ import { SubscriptionOptions } from '../settings-reading/main';
 import { EmailsTextSetting } from './EmailsTextSetting';
 import { ExcerptSetting } from './ExcerptSetting';
 import { FeaturedImageEmailSetting } from './FeaturedImageEmailSetting';
+import { SubscribeModalSetting } from './SubscribeModalSetting';
 
 type Fields = {
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 	subscription_options?: SubscriptionOptions;
+	wpcom_subscribe_modal?: boolean;
 };
 
 type NewsletterSettingsSectionProps = {
@@ -37,6 +39,7 @@ export const NewsletterSettingsSection = ( {
 		wpcom_featured_image_in_email,
 		wpcom_subscription_emails_use_excerpt,
 		subscription_options,
+		wpcom_subscribe_modal,
 	} = fields;
 
 	// Update subscription_options form fields when savedSubscriptionOptions changes.
@@ -65,6 +68,13 @@ export const NewsletterSettingsSection = ( {
 			<Card className="site-settings__card">
 				<FeaturedImageEmailSetting
 					value={ wpcom_featured_image_in_email }
+					handleToggle={ handleToggle }
+					disabled={ disabled }
+				/>
+			</Card>
+			<Card className="site-settings__card">
+				<SubscribeModalSetting
+					value={ wpcom_subscribe_modal }
 					handleToggle={ handleToggle }
 					disabled={ disabled }
 				/>

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -13,7 +13,7 @@ type Fields = {
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 	subscription_options?: SubscriptionOptions;
-	wpcom_subscribe_modal?: boolean;
+	sm_enabled?: boolean;
 };
 
 type NewsletterSettingsSectionProps = {
@@ -42,7 +42,7 @@ export const NewsletterSettingsSection = ( {
 		wpcom_featured_image_in_email,
 		wpcom_subscription_emails_use_excerpt,
 		subscription_options,
-		wpcom_subscribe_modal,
+		sm_enabled,
 	} = fields;
 
 	// Update subscription_options form fields when savedSubscriptionOptions changes.
@@ -78,7 +78,7 @@ export const NewsletterSettingsSection = ( {
 			{ isNewsletterSite && (
 				<Card className="site-settings__card">
 					<SubscribeModalSetting
-						value={ wpcom_subscribe_modal }
+						value={ sm_enabled }
 						handleToggle={ handleToggle }
 						disabled={ disabled }
 					/>

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -75,7 +76,7 @@ export const NewsletterSettingsSection = ( {
 					disabled={ disabled }
 				/>
 			</Card>
-			{ isNewsletterSite && (
+			{ isEnabled( 'newsletter/subscribe-modal' ) && isNewsletterSite && (
 				<Card className="site-settings__card">
 					<SubscribeModalSetting
 						value={ sm_enabled }

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -39,7 +39,7 @@ type Fields = {
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_reader_views_enabled?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
-	wpcom_subscribe_modal?: boolean;
+	sm_enabled?: boolean;
 };
 
 const getFormSettings = ( settings: unknown & Fields ) => {
@@ -63,7 +63,7 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 		wpcom_featured_image_in_email,
 		wpcom_reader_views_enabled,
 		wpcom_subscription_emails_use_excerpt,
-		wpcom_subscribe_modal,
+		sm_enabled,
 	} = settings;
 
 	return {
@@ -82,7 +82,7 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 		wpcom_featured_image_in_email: !! wpcom_featured_image_in_email,
 		wpcom_reader_views_enabled: !! wpcom_reader_views_enabled,
 		wpcom_subscription_emails_use_excerpt: !! wpcom_subscription_emails_use_excerpt,
-		wpcom_subscribe_modal: !! wpcom_subscribe_modal,
+		sm_enabled: !! sm_enabled,
 	};
 };
 

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -39,6 +39,7 @@ type Fields = {
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_reader_views_enabled?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
+	wpcom_subscribe_modal?: boolean;
 };
 
 const getFormSettings = ( settings: unknown & Fields ) => {
@@ -62,6 +63,7 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 		wpcom_featured_image_in_email,
 		wpcom_reader_views_enabled,
 		wpcom_subscription_emails_use_excerpt,
+		wpcom_subscribe_modal,
 	} = settings;
 
 	return {
@@ -80,6 +82,7 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 		wpcom_featured_image_in_email: !! wpcom_featured_image_in_email,
 		wpcom_reader_views_enabled: !! wpcom_reader_views_enabled,
 		wpcom_subscription_emails_use_excerpt: !! wpcom_subscription_emails_use_excerpt,
+		wpcom_subscribe_modal: !! wpcom_subscribe_modal,
 	};
 };
 

--- a/client/state/selectors/get-site-editor-url.js
+++ b/client/state/selectors/get-site-editor-url.js
@@ -5,7 +5,7 @@ import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
  * Retrieves url for site editor.
  *
  * @param {Object} state  Global state tree
- * @param {number} siteId Site ID
+ * @param {?number} siteId Site ID
  * @returns {string} Url of site editor instance for calypso or wp-admin.
  */
 export const getSiteEditorUrl = ( state, siteId ) => {

--- a/config/development.json
+++ b/config/development.json
@@ -126,6 +126,7 @@
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"newsletter/stats": true,
+		"newsletter/subscribe-modal": true,
 		"oauth": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -29381,7 +29381,7 @@ __metadata:
 
 "typescript@patch:typescript@^4.5.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.7.4#~builtin<compat/typescript>":
   version: 4.7.4
-  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=7ad353"
+  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver

--- a/yarn.lock
+++ b/yarn.lock
@@ -29381,7 +29381,7 @@ __metadata:
 
 "typescript@patch:typescript@^4.5.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.7.4#~builtin<compat/typescript>":
   version: 4.7.4
-  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=a1c5e5"
+  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to this issue: https://github.com/orgs/Automattic/projects/657/views/1?pane=issue&itemId=26582538

## Proposed Changes

This PR adds a new setting to enable a subscriber modal for Newsletter sites. It is still a draft intended to collect feedback.

Caveats:
   - The subscriber modal itself is not yet implemented. This PR will have no effect without that.
   - The setting is not being persisted a backend option. The settings page is using some non-obvious magic to do that and I still need to figure that part out. As is, if your refresh the page, the value always starts as false / off.
     - Question: Given that we will want to promote the newsletter feature to non-newsletter sites, I wonder if we should expose this to all sites, not just newsletter sites. 
   
<img width="1322" alt="subscribe setting" src="https://github.com/Automattic/wp-calypso/assets/21228350/2ab785ea-d860-410d-9a91-cdfa1ac5f612">

## Testing Instructions

1. Create or use a Newsletter site.  (`/setup/newsletter`)
2. Check out this branch and run yarn and yarn start if needed. 
3. Go to http://calypso.localhost:3000/settings/reading/YOURDOMAIN, scroll down to the Newsletter setting section. 
4. Confirm that the new section and new setting exists, and that the toggle works. 
5. Try loading same page on a non-newsletter site and confirm that setting does NOT show. 

Note that in production you'll have to use the feature flag in the URL: `?flags=newsletter/subscribe-modal`

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
