### PR TITLE
Move Image generator from coming soon to features list

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -847,6 +847,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Share to Facebook, LinkedIn, and Tumblr' ),
 		translate( 'Engagement Optimizer' ),
 		translate( 'Recycle content' ),
+		translate( 'Image generator' ),
 	];
 
 	return {
@@ -885,7 +886,6 @@ export const getJetpackProductsWhatIsIncludedComingSoon = (): Record<
 > => {
 	const socialAdvancedIncludesInfo = [
 		translate( 'Auto-sharing to Instagram & Mastodon' ),
-		translate( 'Image generator' ),
 		translate( 'Multi-image sharing' ),
 		translate( 'Video sharing' ),
 	];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdrWKz-YO-p2#comment-1293

## Proposed Changes

* Image generator has been released as a feature of Social Advanced. This PR updates the feature list to move it from "Coming soon" to the regular list
<img width="1094" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5714212/48c8971e-08ca-4362-80ff-93e4e6465722">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the /pricing page from the Calypso live link
* Click on "More about Social"
* Make sure "Social Advanced" is selected
* Confirm that "Image generator" is no longer marked as "Coming soon"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?