### PR TITLE
Admin bar: Update My Sites link description

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -236,7 +236,7 @@ class MasterbarLoggedIn extends Component {
 				icon={ icon }
 				onClick={ this.clickMySites }
 				isActive={ this.isActive( 'sites' ) && ! isMenuOpen }
-				tooltip={ translate( 'View a list of your sites and access their dashboards' ) }
+				tooltip={ translate( 'Manage your sites' ) }
 				preloadSection={ this.preloadMySites }
 			>
 				{ hasMoreThanOneSite


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #57292

## Proposed Changes

* Update Calypso's My Sites link description (it's `title` attribute) to "Manage your sites"

The current description is "View a list of your sites and access their dashboards", but this can be misleading. Clicking the My Sites link doesn't pop open a list of sites, it simply navigates the user to their most recently accessed site's dashboard. There might be a site list somewhere in that dashboard, but that's not always the case e.g. clicking My Sites sometimes takes the user to the site's launchpad where there is no site switcher.

This change to the link description doesn't address all of the issues raised in #57292. There is still a difference between how My Sites works in Calypso and wp-admin, and on desktop and mobile layouts. But this wording change at least makes the link description less misleading.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso
* Hover over the My Sites link in the top left: it's tooltip should say "Manage your sites"
* Highlight the My Sites link using a screenreader: after reading the link label (i.e. "My Sites") it should be described as "Manage your sites"
* Clicking the link still takes the user to the last accessed site's dashboard

Note that this PR doesn't change the My Sites link in wp-admin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
