### PR TITLE
Jetpack Pro Dashboard: Implement remove monitor email address

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
@@ -12,7 +12,7 @@ import {
 	useHandleResetNotification,
 	useHandleShowHideActionBar,
 } from './hooks';
-import type { Site } from '../sites-overview/types';
+import type { Site, MonitorSettings } from '../sites-overview/types';
 
 import './style.scss';
 
@@ -20,13 +20,13 @@ import './style.scss';
 
 interface Props {
 	selectedSites: Array< Site >;
-	monitorUserEmails: Array< string >;
+	bulkUpdateSettings?: MonitorSettings;
 	isLargeScreen?: boolean;
 }
 
 export default function DashboardBulkActions( {
 	selectedSites,
-	monitorUserEmails,
+	bulkUpdateSettings,
 	isLargeScreen,
 }: Props ) {
 	const actionBarRef = createRef< HTMLDivElement >();
@@ -142,7 +142,7 @@ export default function DashboardBulkActions( {
 			{ showNotificationSettingsPopup && (
 				<NotificationSettings
 					sites={ selectedSites }
-					monitorUserEmails={ monitorUserEmails }
+					bulkUpdateSettings={ bulkUpdateSettings }
 					onClose={ toggleNotificationSettingsPopup }
 					isLargeScreen={ isLargeScreen }
 				/>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-item-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-item-content.tsx
@@ -1,5 +1,5 @@
 import { Card, Button } from '@automattic/components';
-import { Icon, pencil, moreHorizontal } from '@wordpress/icons';
+import { Icon, moreHorizontal } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
 import Badge from 'calypso/components/badge';
@@ -12,10 +12,11 @@ import type {
 
 interface Props {
 	item: StateMonitorSettingsEmail;
-	toggleModal: ( item?: StateMonitorSettingsEmail, action?: AllowedMonitorContactActions ) => void;
+	toggleModal?: ( item?: StateMonitorSettingsEmail, action?: AllowedMonitorContactActions ) => void;
+	isRemoveAction?: boolean;
 }
 
-export default function EmailItemContent( { item, toggleModal }: Props ) {
+export default function EmailItemContent( { item, toggleModal, isRemoveAction = false }: Props ) {
 	const translate = useTranslate();
 
 	const [ isOpen, setIsOpen ] = useState( false );
@@ -33,7 +34,7 @@ export default function EmailItemContent( { item, toggleModal }: Props ) {
 	const showVerified = true; // FIXME: This should be dynamic.
 
 	const handleToggleModal = ( action: AllowedMonitorContactActions ) => {
-		toggleModal( item, action );
+		toggleModal?.( item, action );
 	};
 
 	return (
@@ -43,7 +44,10 @@ export default function EmailItemContent( { item, toggleModal }: Props ) {
 					<div className="configure-email-address__card-heading">{ item.email }</div>
 					<div className="configure-email-address__card-sub-heading">{ item.name }</div>
 				</span>
-				{ ! item.isDefault && (
+				{
+					// Show the status and actions only if the action is not remove.
+				 }
+				{ ! item.isDefault && ! isRemoveAction && (
 					<>
 						{ ! item.verified && (
 							<span
@@ -61,44 +65,37 @@ export default function EmailItemContent( { item, toggleModal }: Props ) {
 								<Badge type="success">{ translate( 'Verified' ) }</Badge>
 							</span>
 						) }
-						{ item.verified ? (
+						<>
 							<Button
 								compact
 								borderless
-								className="configure-email-address__edit-icon"
-								onClick={ () => handleToggleModal( 'edit' ) }
-								aria-label={ translate( 'Edit email address' ) }
+								className="configure-email-address__action-icon"
+								onClick={ showActions }
+								aria-label={ translate( 'More actions' ) }
+								ref={ buttonActionRef }
 							>
-								<Icon size={ 18 } icon={ pencil } />
+								<Icon size={ 18 } icon={ moreHorizontal } />
 							</Button>
-						) : (
-							<>
-								<Button
-									compact
-									borderless
-									className="configure-email-address__edit-icon"
-									onClick={ showActions }
-									aria-label={ translate( 'More actions' ) }
-									ref={ buttonActionRef }
-								>
-									<Icon size={ 18 } icon={ moreHorizontal } />
-								</Button>
-								<PopoverMenu
-									className="configure-email-address__popover-menu"
-									context={ buttonActionRef.current }
-									isVisible={ isOpen }
-									onClose={ closeDropdown }
-									position="bottom left"
-								>
+							<PopoverMenu
+								className="configure-email-address__popover-menu"
+								context={ buttonActionRef.current }
+								isVisible={ isOpen }
+								onClose={ closeDropdown }
+								position="bottom left"
+							>
+								{ ! item.verified && (
 									<PopoverMenuItem onClick={ () => handleToggleModal( 'verify' ) }>
 										{ translate( 'Verify' ) }
 									</PopoverMenuItem>
-									<PopoverMenuItem onClick={ () => handleToggleModal( 'edit' ) }>
-										{ translate( 'Edit' ) }
-									</PopoverMenuItem>
-								</PopoverMenu>
-							</>
-						) }
+								) }
+								<PopoverMenuItem onClick={ () => handleToggleModal( 'edit' ) }>
+									{ translate( 'Edit' ) }
+								</PopoverMenuItem>
+								<PopoverMenuItem onClick={ () => handleToggleModal( 'remove' ) }>
+									{ translate( 'Remove' ) }
+								</PopoverMenuItem>
+							</PopoverMenu>
+						</>
 					</>
 				) }
 			</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -1,10 +1,8 @@
 import { Button } from '@automattic/components';
 import { Icon, plus } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
 import EmailItemContent from './email-item-content';
 import type {
-	MonitorSettingsEmail,
 	StateMonitorSettingsEmail,
 	AllowedMonitorContactActions,
 } from '../../sites-overview/types';
@@ -12,34 +10,12 @@ import type {
 import './style.scss';
 
 interface Props {
-	defaultEmailAddresses: Array< string >;
 	toggleModal: ( item?: StateMonitorSettingsEmail, action?: AllowedMonitorContactActions ) => void;
-	addedEmailAddresses?: Array< MonitorSettingsEmail >;
 	allEmailItems: Array< StateMonitorSettingsEmail >;
-	setAllEmailItems: ( emailAddresses: Array< StateMonitorSettingsEmail > ) => void;
 }
 
-export default function ConfigureEmailNotification( {
-	defaultEmailAddresses = [],
-	toggleModal,
-	addedEmailAddresses = [], // FIXME: This value will come from the API.
-	allEmailItems,
-	setAllEmailItems,
-}: Props ) {
+export default function ConfigureEmailNotification( { toggleModal, allEmailItems }: Props ) {
 	const translate = useTranslate();
-
-	useEffect( () => {
-		if ( defaultEmailAddresses ) {
-			const defaultEmailItems = defaultEmailAddresses.map( ( email ) => ( {
-				email,
-				name: 'Default Email', //FIXME: This should be dynamic.
-				isDefault: true,
-				verified: true,
-			} ) );
-			setAllEmailItems( [ ...defaultEmailItems, ...addedEmailAddresses ] );
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
 
 	return (
 		<div className="configure-email-address__card-container">

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
@@ -35,7 +35,7 @@ $help-text-color: #757575;
 	}
 }
 
-button.configure-email-address__edit-icon {
+button.configure-email-address__action-icon {
 	position: absolute;
 	right: 8px;
 	display: flex;

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -97,10 +97,24 @@ export default function NotificationSettings( {
 		'jetpack/pro-dashboard-monitor-multiple-email-recipients'
 	);
 
-	const handleSetEmailItems = useCallback( ( settings: MonitorSettings ) => {
-		const userEmails = settings.monitor_user_emails || [];
-		setDefaultUserEmailAddresses( userEmails );
-	}, [] );
+	const handleSetEmailItems = useCallback(
+		( settings: MonitorSettings ) => {
+			const userEmails = settings.monitor_user_emails || [];
+			setDefaultUserEmailAddresses( userEmails );
+
+			if ( isMultipleEmailEnabled ) {
+				const userEmailItems = userEmails.map( ( email ) => ( {
+					email,
+					name: 'Default Email', //FIXME: This should be dynamic.
+					isDefault: true,
+					verified: true,
+				} ) );
+				// This will also include site's additional email addresses.
+				setAllEmailItems( [ ...userEmailItems ] );
+			}
+		},
+		[ isMultipleEmailEnabled ]
+	);
 
 	useEffect( () => {
 		if ( settings?.monitor_deferment_time ) {
@@ -254,9 +268,7 @@ export default function NotificationSettings( {
 
 					{ enableEmailNotification && isMultipleEmailEnabled && (
 						<ConfigureEmailNotification
-							defaultEmailAddresses={ defaultUserEmailAddresses }
 							toggleModal={ toggleAddEmailModal }
-							setAllEmailItems={ setAllEmailItems }
 							allEmailItems={ allEmailItems }
 						/>
 					) }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -18,6 +18,7 @@ import type {
 	Site,
 	StateMonitorSettingsEmail,
 	AllowedMonitorContactActions,
+	MonitorSettingsEmail,
 } from '../../sites-overview/types';
 
 import './style.scss';
@@ -109,8 +110,8 @@ export default function NotificationSettings( {
 					isDefault: true,
 					verified: true,
 				} ) );
-				// This will also include site's additional email addresses.
-				setAllEmailItems( [ ...userEmailItems ] );
+				const siteEmailItems: Array< MonitorSettingsEmail > = []; // FIXME: This should be dynamic.
+				setAllEmailItems( [ ...userEmailItems, ...siteEmailItems ] );
 			}
 		},
 		[ isMultipleEmailEnabled ]

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -84,7 +84,7 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 			</div>
 			<DashboardBulkActions
 				selectedSites={ selectedSites }
-				monitorUserEmails={ sites?.[ 0 ]?.monitor?.settings?.monitor_user_emails ?? [] }
+				bulkUpdateSettings={ sites?.[ 0 ]?.monitor?.settings }
 				isLargeScreen={ isLargeScreen }
 			/>
 		</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -270,4 +270,4 @@ export interface StateMonitorSettingsEmail extends MonitorSettingsEmail {
 	isDefault?: boolean;
 }
 
-export type AllowedMonitorContactActions = 'add' | 'verify' | 'edit';
+export type AllowedMonitorContactActions = 'add' | 'verify' | 'edit' | 'remove';


### PR DESCRIPTION
Related to 1204408201748644-as-1204484225044568

## Proposed Changes

This PR implements the UI to remove the added email addresses to the monitor notification settings.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-remove-monitor-email-address` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Set the below lines to `siteEmailItems`  in the `NotificationSettings` component - line no 113 to see the extra email addresses. 

```
const siteEmailItems: Array< MonitorSettingsEmail > = [
	{
		email: 'testuser@test.com',
		name: 'Site Email',
		verified: true,
	},
];
```
6. Click the `...` icon and click `Remove`

<img width="445" alt="Screenshot 2023-05-19 at 10 36 48 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/17c9b699-b693-4d5e-8031-4804f6cb0944">

7. Verify that you can see a confirmation popup -> Verify both the actions - `Cancel` and `Remove` work as expected. Clicking on `Remove` should remove the email item from the list.

<img width="443" alt="Screenshot 2023-05-19 at 10 36 55 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6d13af90-bec6-4894-9669-67c2ddc95d81">

8. Verify that the custom notification popup for single and bulk update shows the email address on email notification section as expected

<img width="447" alt="Screenshot 2023-05-19 at 10 48 41 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/06344ab2-d33e-4a15-a263-62291a393db2">

<img width="449" alt="Screenshot 2023-05-19 at 10 49 07 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6402a5a2-0cde-4c5b-8b7d-0d3e5fae53bc">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?