### PR TITLE
Hosting Onboarding: hosting flow only contains signup step, which includes an "I am a dev" checkbox

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { Button, FormInputValidation } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { CheckboxControl } from '@wordpress/components';
 import classNames from 'classnames';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -40,6 +41,7 @@ import TextControl from 'calypso/components/text-control';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
+import { preventWidows } from 'calypso/lib/formatting';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import {
 	isCrowdsignalOAuth2Client,
@@ -95,6 +97,7 @@ class SignupForm extends Component {
 		handleLogin: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
 		isPasswordless: PropTypes.bool,
+		showIsDevAccountCheckbox: PropTypes.bool,
 		isSocialSignupEnabled: PropTypes.bool,
 		locale: PropTypes.string,
 		positionInFlow: PropTypes.number,
@@ -119,6 +122,7 @@ class SignupForm extends Component {
 		displayUsernameInput: true,
 		flowName: '',
 		isPasswordless: false,
+		showIsDevAccountCheckbox: false,
 		isSocialSignupEnabled: false,
 		horizontal: false,
 		shouldDisplayUserExistsError: false,
@@ -150,6 +154,7 @@ class SignupForm extends Component {
 
 		this.state = {
 			submitting: false,
+			isDevAccount: false,
 			isFieldDirty: {
 				email: false,
 				username: false,
@@ -924,6 +929,25 @@ class SignupForm extends Component {
 		return false;
 	}
 
+	isDevAccountCheckbox() {
+		if ( ! this.props.showIsDevAccountCheckbox ) {
+			return null;
+		}
+
+		const { translate } = this.props;
+		return (
+			<CheckboxControl
+				label={ preventWidows(
+					translate(
+						"I'm a developer. Boost my WordPress.com experience and give me early access to developer features"
+					)
+				) }
+				checked={ this.state.isDevAccount }
+				onChange={ ( isDevAccount ) => this.setState( { isDevAccount } ) }
+			/>
+		);
+	}
+
 	emailDisableExplanation() {
 		if ( this.props.disableEmailInput && this.props.disableEmailExplanation ) {
 			return (
@@ -1152,6 +1176,7 @@ class SignupForm extends Component {
 					} ) }
 				>
 					{ this.getNotice() }
+					{ this.isDevAccountCheckbox() }
 					<PasswordlessSignupForm
 						step={ this.props.step }
 						stepName={ this.props.stepName }
@@ -1162,6 +1187,7 @@ class SignupForm extends Component {
 						disabled={ this.props.disabled }
 						disableSubmitButton={ this.props.disableSubmitButton }
 						queryArgs={ this.props.queryArgs }
+						isDevAccount={ this.state.isDevAccount }
 					/>
 
 					{ showSeparator && (

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -513,7 +513,9 @@ class SignupForm extends Component {
 	globalNotice( notice, status ) {
 		return (
 			<Notice
-				className="signup-form__notice"
+				className={ classNames( 'signup-form__notice', {
+					'signup-form__span-columns': this.isHorizontal(),
+				} ) }
 				showDismiss={ false }
 				status={ status }
 				text={ this.getNoticeMessageWithLogin( notice ) }
@@ -937,9 +939,20 @@ class SignupForm extends Component {
 		const { translate } = this.props;
 		return (
 			<CheckboxControl
+				className={ classNames(
+					'signup-form__is-dev-account-checkbox',
+					'signup-form__span-columns',
+					{ 'is-checked': this.state.isDevAccount }
+				) }
+				__nextHasNoMarginBottom
 				label={ preventWidows(
 					translate(
-						"I'm a developer. Boost my WordPress.com experience and give me early access to developer features"
+						"{{strong}}I'm a developer.{{/strong}} Boost my WordPress.com experience and give me early access to developer features",
+						{
+							components: {
+								strong: <span className="signup-form__is-dev-account-strong" />,
+							},
+						}
 					)
 				) }
 				checked={ this.state.isDevAccount }

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -20,10 +20,12 @@ import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/
 class PasswordlessSignupForm extends Component {
 	static propTypes = {
 		locale: PropTypes.string,
+		isDevAccount: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		locale: 'en',
+		isDevAccount: false,
 	};
 
 	state = {
@@ -80,6 +82,7 @@ class PasswordlessSignupForm extends Component {
 				locale: getLocaleSlug(),
 				client_id: config( 'wpcom_signup_id' ),
 				client_secret: config( 'wpcom_signup_key' ),
+				is_dev_account: this.props.isDevAccount,
 			} );
 			this.createAccountCallback( null, response );
 		} catch ( err ) {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -100,6 +100,50 @@
 	}
 }
 
+// Uses the width of the columns to calculate how wide an element that spans all columns needs to be
+// The width variable is set in signup/style.scss and changes according to break points
+.signup-form__span-columns {
+	margin-left: 16px;
+	margin-right: 16px;
+
+	// 32px is the column margins
+	width: calc(var(--signup-form-column-max-width) - 32px);
+
+	@include break-medium {
+		// 2 columns + the 60px wide "or" element
+		width: calc(var(--signup-form-column-max-width) * 2 + 60px - 32px);
+	}
+}
+
+.signup-form__is-dev-account-checkbox {
+	grid-column: span 3;
+	margin-left: 16px;
+	margin-right: 16px;
+	margin-bottom: 48px;
+	padding: 12px;
+	border-radius: 4px;
+	border: 1px solid rgb(220, 220, 222);
+
+	&:has(input:checked) {
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.03);
+		border: 2px solid var(--wp-admin-theme-color);
+		padding: 11px;
+	}
+
+	// Firefox doesn't support :has() yet, so the styling needs to be controlled by JS
+	// :has and .is-checked can't be in the same selector list (separated by a comma)
+	// because if a browser doesn't support the :has selector, the entire list fails.
+	&.is-checked {
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.03);
+		border: 2px solid var(--wp-admin-theme-color);
+		padding: 11px;
+	}
+}
+
+.signup-form__is-dev-account-strong {
+	font-weight: 500;
+}
+
 // Replace recaptcha badge with ToS text and space
 // everything out a little more.
 @media ( max-width: 660px ) {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -21,11 +21,13 @@ export function generateFlows( {
 	const flows = [
 		{
 			name: HOSTING_LP_FLOW,
-			steps: [ 'plans-hosting', 'user-hosting', 'domains' ],
+			steps: isEnabled( 'hosting-onboarding-i2' )
+				? [ 'user-hosting' ]
+				: [ 'plans-hosting', 'user-hosting', 'domains' ],
 			destination: getSitesDestination,
 			description:
 				'Create an account and a blog and give the user the option of adding a domain and plan to the cart.',
-			lastModified: '2023-02-09',
+			lastModified: '2023-05-19',
 			showRecaptcha: true,
 		},
 		{

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -159,6 +159,7 @@ export function generateSteps( {
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 				isPasswordless: true,
+				showIsDevAccountCheckbox: config.isEnabled( 'hosting-onboarding-i2' ),
 			},
 		},
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -26,6 +26,7 @@ import flows from 'calypso/signup/config/flows';
 import P2StepWrapper from 'calypso/signup/p2-step-wrapper';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import {
+	getFlowDestination,
 	getFlowSteps,
 	getNextStepName,
 	getPreviousStepName,
@@ -48,6 +49,9 @@ function getRedirectToAfterLoginUrl( {
 	oauth2Signup,
 	initialContext,
 	flowName,
+	localeSlug,
+	progress,
+	signupDependencies,
 	stepName,
 	userLoggedIn,
 } ) {
@@ -65,6 +69,21 @@ function getRedirectToAfterLoginUrl( {
 	const stepAfterRedirect =
 		getNextStepName( flowName, stepName, userLoggedIn ) ||
 		getPreviousStepName( flowName, stepName, userLoggedIn );
+
+	if ( ! stepAfterRedirect ) {
+		// This is the only step in the flow
+		const goesThroughCheckout = !! progress?.plans?.cartItem;
+		const destination = getFlowDestination(
+			flowName,
+			userLoggedIn,
+			signupDependencies,
+			localeSlug,
+			goesThroughCheckout
+		);
+		if ( destination ) {
+			return destination;
+		}
+	}
 
 	return (
 		window.location.origin +

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -113,10 +113,12 @@ export class UserStep extends Component {
 		subHeaderText: PropTypes.string,
 		isSocialSignupEnabled: PropTypes.bool,
 		initialContext: PropTypes.object,
+		showIsDevAccountCheckbox: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isSocialSignupEnabled: false,
+		showIsDevAccountCheckbox: false,
 	};
 
 	state = {
@@ -482,7 +484,7 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, isReskinned, isPasswordless } = this.props;
+		const { oauth2Client, isReskinned, isPasswordless, showIsDevAccountCheckbox } = this.props;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
@@ -514,6 +516,7 @@ export class UserStep extends Component {
 					suggestedUsername={ this.props.suggestedUsername }
 					handleSocialResponse={ this.handleSocialResponse }
 					isPasswordless={ isMobile() || isPasswordless }
+					showIsDevAccountCheckbox={ showIsDevAccountCheckbox }
 					queryArgs={ this.props.initialContext?.query || {} }
 					isSocialSignupEnabled={ isSocialSignupEnabled }
 					socialService={ socialService }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -626,7 +626,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 			$breakpoint-mobile: 660px;
 			$separator-style: 1px solid #eaeaeb;
 			display: flex;
-			flex-direction: column;
+			flex-direction: row;
 			flex-wrap: wrap;
 			margin-top: 40px;
 			justify-content: center;
@@ -643,26 +643,10 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 			.signup-form__social {
 				background-color: #fdfdfd;
 				width: unset;
-				max-width: 408px;
+				max-width: var(--signup-form-column-max-width);
 				padding: 0 16px;
 				box-shadow: none;
 				margin: 0;
-
-				@include break-mobile {
-					max-width: 600px;
-				}
-
-				@include break-small {
-					max-width: 408px;
-				}
-
-				@include break-medium {
-					max-width: 350px;
-				}
-
-				@include break-large {
-					max-width: 408px;
-				}
 			}
 
 			.logged-out-form {
@@ -953,5 +937,33 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 				transform: translateY(30px);
 			}
 		}
+	}
+}
+
+:root {
+	--signup-form-column-max-width: 408px;
+}
+
+@include break-mobile {
+	:root {
+		--signup-form-column-max-width: 600px;
+	}
+}
+
+@include break-small {
+	:root {
+		--signup-form-column-max-width: 408px;
+	}
+}
+
+@include break-medium {
+	:root {
+		--signup-form-column-max-width: 350px;
+	}
+}
+
+@include break-large {
+	:root {
+		--signup-form-column-max-width: 408px;
 	}
 }

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -91,6 +91,19 @@ export function getFlowPageTitle( flowName, isUserLoggedIn ) {
 	return flow.pageTitle || translate( 'Create a site' );
 }
 
+export function getFlowDestination(
+	flowName,
+	isUserLoggedIn,
+	dependencies,
+	localeSlug,
+	goesThroughCheckout
+) {
+	const flow = flows.getFlow( flowName, isUserLoggedIn );
+	return typeof flow?.destination === 'function'
+		? flow.destination( { flowName, ...dependencies }, localeSlug, goesThroughCheckout )
+		: flow?.destination;
+}
+
 export function getValueFromProgressStore( { signupProgress, stepName, fieldName } ) {
 	const siteStepProgress = find( signupProgress, ( step ) => step.stepName === stepName );
 	return siteStepProgress ? siteStepProgress[ fieldName ] : null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2364

## Proposed Changes

- Removes all steps from `/start/hosting` except signup
- Adds "I am a dev" checkbox to the passwordless signup (only for this flow)
- "Continue as user" version of signup works, even when it's the last step in the flow.

![CleanShot 2023-05-22 at 15 31 35@2x](https://github.com/Automattic/wp-calypso/assets/1500769/ae1fd208-fa33-4a69-bc70-b08f24cfa187)

We should use the state of the "is dev" checkbox for social signup too. But it might be better to leave that for a follow up PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test locally (where `hosting-onboarding-i2` flag is enabled)
   * Test `/start/hosting` when logged out
   * Test `/start/hosting` when logged in (should see the "Continue as user" version of signup)
   * Test the "Have an account? Log in" link
      * I'm not 100% sure what behaviour we want here, but it takes me to the flow destination (i.e. `/sites`) even when that's not my user's preference, so I think that's correct.
   * Confirm the flow only has one step
   * Confirm the user lands on the `/sites` page
   * Confirm the `/start/onboarding` signup behaviour hasn't changed
* Test with `calypso.live` (where `hosting-onboarding-i2` flag is disabled)
   * Test `/start/hosting` should not have changed compared to production
   * Confirm the user lands on the `/sites` page with the `?new-site=` query param
* Apply D111469-code to sandbox and test new users get the correct "is dev" flag

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
