### PR TITLE
Subscriptions Management: Update subscriptions count when user subscribes / unsubscribes

### DIFF
--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -10,6 +10,7 @@ import { SiteIcon } from 'calypso/landing/subscriptions/components/site-icon';
 import PoweredByWPFooter from 'calypso/layout/powered-by-wp-footer';
 import SiteSubscriptionSettings from './site-subscription-settings';
 import './styles.scss';
+//import type { SingleSiteSubscription } from '@automattic/data-stores/src/reader/types';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const useSiteSubscription = ( blogId?: string ) => ( {
@@ -27,6 +28,38 @@ const useSiteSubscription = ( blogId?: string ) => ( {
 	isError: false,
 } );
 
+const singleData = {
+	ID: '769481850',
+	blog_ID: '214221608',
+	feed_ID: null,
+	URL: 'http://fresh20230112.wordpress.com',
+	date_subscribed: '2023-03-29T14:55:04+00:00',
+	delivery_methods: {
+		email: {
+			send_posts: true,
+			send_comments: false,
+			post_delivery_frequency: 'daily',
+			date_subscribed: '2023-03-29 14:55:04',
+		},
+		notification: {
+			send_posts: false,
+		},
+	},
+	name: 'Site Title',
+	organization_id: 0,
+	unseen_count: 0,
+	last_updated: null,
+	site_icon: null,
+	is_owner: false,
+	meta: {
+		links: {
+			site: 'https://public-api.wordpress.com/rest/v1.2/read/sites/214221608',
+		},
+	},
+	is_wpforteams_site: null,
+	subscribers: 400,
+};
+
 const SiteSubscriptionPage = () => {
 	const translate = useTranslate();
 	const navigate = useNavigate();
@@ -38,7 +71,7 @@ const SiteSubscriptionPage = () => {
 		emailMeNewComments,
 		emailMeNewPosts,
 		deliveryFrequency,
-		subscribers,
+		//subscribers,
 	} = data;
 	const [ notice, setNotice ] = useState< NoticeState | null >( null );
 	const [ siteSubscribed, setSiteSubscribed ] = useState( true );
@@ -128,9 +161,9 @@ const SiteSubscriptionPage = () => {
 	}
 
 	const subHeaderText =
-		subscribers > 1
+		singleData.subscribers > 1
 			? translate( '%d subscribers', {
-					args: [ subscribers ],
+					args: [ singleData.subscribers ],
 					comment: 'Number of subscribers of the subscribed-to site.',
 			  } )
 			: '';

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -1,6 +1,7 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { callApi } from '../helpers';
-import { useIsLoggedIn } from '../hooks';
+import { useCacheKey, useIsLoggedIn } from '../hooks';
+import { SingleSiteSubscription } from '../types';
 
 type SubscribeParams = {
 	blog_id?: number | string;
@@ -19,31 +20,64 @@ type SubscribeResponse = {
 
 const useSiteSubscribeMutation = () => {
 	const { isLoggedIn } = useIsLoggedIn();
+	const queryClient = useQueryClient();
+	const singleSubscriptionCacheKey = useCacheKey( [ 'read', 'single-site-subscriptions', 'dev' ] );
 
-	return useMutation( async ( params: SubscribeParams ) => {
-		if ( ! params.blog_id ) {
-			throw new Error(
-				// reminder: translate this string when we add it to the UI
-				'Something went wrong while subscribing.'
-			);
+	return useMutation(
+		async ( params: SubscribeParams ) => {
+			if ( ! params.blog_id ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while subscribing.'
+				);
+			}
+
+			const response = await callApi< SubscribeResponse >( {
+				path: `/read/site/${ params.blog_id }/post_email_subscriptions/new`,
+				method: 'POST',
+				isLoggedIn,
+				apiVersion: '1.2',
+				body: {},
+			} );
+			if ( ! response.success ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while subscribing.'
+				);
+			}
+
+			return response;
+		},
+		{
+			onMutate: async () => {
+				await queryClient.cancelQueries( singleSubscriptionCacheKey );
+
+				const previousSingleSubscription = queryClient.getQueryData< SingleSiteSubscription >(
+					singleSubscriptionCacheKey
+				);
+				// remove blog from site subscriptions
+				if ( previousSingleSubscription ) {
+					queryClient.setQueryData( singleSubscriptionCacheKey, {
+						...previousSingleSubscription,
+						subscriptions: previousSingleSubscription?.subscriptions + 1,
+					} );
+				}
+
+				return { previousSingleSubscription };
+			},
+			onError: ( error, variables, context ) => {
+				if ( context?.previousSingleSubscription ) {
+					queryClient.setQueryData(
+						singleSubscriptionCacheKey,
+						context.previousSingleSubscription
+					);
+				}
+			},
+			onSettled: () => {
+				queryClient.invalidateQueries( singleSubscriptionCacheKey );
+			},
 		}
-
-		const response = await callApi< SubscribeResponse >( {
-			path: `/read/site/${ params.blog_id }/post_email_subscriptions/new`,
-			method: 'POST',
-			isLoggedIn,
-			apiVersion: '1.2',
-			body: {},
-		} );
-		if ( ! response.success ) {
-			throw new Error(
-				// reminder: translate this string when we add it to the UI
-				'Something went wrong while subscribing.'
-			);
-		}
-
-		return response;
-	} );
+	);
 };
 
 export default useSiteSubscribeMutation;

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -70,6 +70,10 @@ export type SiteSubscription = {
 	is_wpforteams_site: boolean;
 };
 
+export type SingleSiteSubscription = SiteSubscription & {
+	subscriptions: number;
+};
+
 export type SiteSubscriptionPage = {
 	subscriptions: SiteSubscription[];
 	total_subscriptions: number;


### PR DESCRIPTION
🚧 Work in progress. Not ready for review yet. 🚧 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/77093.

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
