### PR TITLE
Add tailored flows to happy-blocks navigation

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -7,6 +7,12 @@
  * @package happy-blocks
  */
 
+/**
+ * Load functions from the h4 theme, we're using localized_tailored_flow_url here.
+ */
+require_once WP_CONTENT_DIR . '/themes/h4/landing/marketing/pages/_common/lib/functions.php';
+use function \WPCOM\Themes\H4\Landing\Marketing\localized_tailored_flow_url;
+
 if ( ! isset( $args ) ) {
 	$args = array();
 }
@@ -131,6 +137,26 @@ $happy_blocks_tabs = array(
 							<li>
 								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/professional-email/' ) ); ?>" title="<?php echo esc_attr( fixme__( 'Professional Email', __( 'Email', 'happy-blocks' ) ) ); ?>" tabindex="-1">
 									<?php echo esc_html( fixme__( 'Professional Email', __( 'Email', 'happy-blocks' ) ) ); ?>
+								</a>
+							</li>
+							<li>
+								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_tailored_flow_url( '//wordpress.com/setup/link-in-bio/intro?ref=main-menu' ) ); ?>" title="<?php echo esc_attr( fixme__( 'Link in Bio', 'happy-blocks' ) ); ?>" tabindex="-1">
+									<?php echo esc_html( fixme__( 'Link in Bio', 'happy-blocks' ) ); ?>
+								</a>
+							</li>
+							<li>
+								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_tailored_flow_url( '//wordpress.com/setup/newsletter/intro?ref=main-menu' ) ); ?>" title="<?php echo esc_attr( fixme__( 'Newsletter', 'happy-blocks' ) ); ?>" tabindex="-1">
+									<?php echo esc_html( fixme__( 'Newsletter', 'happy-blocks' ) ); ?>
+								</a>
+							</li>
+							<li>
+								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_tailored_flow_url( '//wordpress.com/setup/videopress/intro?ref=main-menu' ) ); ?>" title="<?php echo esc_attr( fixme__( 'Video', 'happy-blocks' ) ); ?>" tabindex="-1">
+									<?php echo esc_html( fixme__( 'Video', 'happy-blocks' ) ); ?>
+								</a>
+							</li>
+							<li>
+								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/create-a-course' ) ); ?>" title="<?php echo esc_attr( fixme__( 'Course', 'happy-blocks' ) ); ?>" tabindex="-1">
+									<?php echo esc_html( fixme__( 'Course', 'happy-blocks' ) ); ?>
 								</a>
 							</li>
 						</ul>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2491

## Proposed Changes

* Add tailored flows landing pages (link in bio, newsletter, video, course) to /support's Product's menu, it's using happy-blocks

![menu](https://github.com/Automattic/wp-calypso/assets/6586048/a3a6e79f-c3fd-46b5-a304-249965b65eb6)


## Testing Instructions

* Checkout to this branch
* Sync to your sandbox by `yarn dev --sync`
* sandbox wordpress.com
* Go to wordpress.com/support
* Check if the links are present
* Switch to a different locale
* Check to see if the locale is being added to tailored flows (link in bio, newsletter, video) like screenshot below

![link](https://github.com/Automattic/wp-calypso/assets/6586048/55ec759d-82ba-4591-bb86-c2e29ecdd31a)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
