### PR TITLE
Subscription Management: Add and integrate useSiteSubscriptionDetailsQuery.

### DIFF
--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -22,6 +22,7 @@ import {
 	useUserSettingsQuery,
 	usePendingSiteSubscriptionsQuery,
 	usePendingPostSubscriptionsQuery,
+	useSiteSubscriptionDetailsQuery,
 } from './queries';
 
 export const SubscriptionManager = {
@@ -47,6 +48,7 @@ export const SubscriptionManager = {
 	useSiteEmailMeNewPostsMutation,
 	useSiteEmailMeNewCommentsMutation,
 	useIsLoggedIn,
+	useSiteSubscriptionDetailsQuery,
 };
 
 export { EmailDeliveryFrequency } from './constants';

--- a/packages/data-stores/src/reader/queries/index.ts
+++ b/packages/data-stores/src/reader/queries/index.ts
@@ -10,3 +10,4 @@ export {
 } from './use-post-subscriptions-query';
 export { default as usePendingSiteSubscriptionsQuery } from './use-pending-site-subscriptions-query';
 export { default as usePendingPostSubscriptionsQuery } from './use-pending-post-subscriptions-query';
+export { default as useSiteSubscriptionDetailsQuery } from './use-site-subscription-details-query';

--- a/packages/data-stores/src/reader/queries/use-site-subscription-details-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscription-details-query.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { callApi } from '../helpers';
+import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
+import type { SiteSubscriptionDetails, SiteSubscriptionDetailsAPIResponse } from '../types';
+
+const useSiteSubscriptionDetailsQuery = ( siteId: string ) => {
+	const { isLoggedIn } = useIsLoggedIn();
+	const enabled = useIsQueryEnabled();
+	const cacheKey = useCacheKey( [ 'read', 'site-subscription-details', siteId ] );
+	return useQuery< SiteSubscriptionDetails >(
+		cacheKey,
+		async () => {
+			const subscriptionDetails = await callApi< SiteSubscriptionDetailsAPIResponse >( {
+				path: '/read/sites/' + siteId + '/subscription-details',
+				isLoggedIn,
+				apiNamespace: 'wpcom/v2',
+				apiVersion: '2',
+			} );
+			return subscriptionDetails;
+		},
+		{
+			enabled,
+			refetchOnWindowFocus: false,
+		}
+	);
+};
+
+export default useSiteSubscriptionDetailsQuery;

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -131,3 +131,23 @@ export type PendingPostSubscriptionsResult = {
 	pendingPosts: PendingPostSubscription[];
 	totalCount: number;
 };
+
+export type SiteSubscriptionDetails = {
+	ID: string;
+	blog_ID: string;
+	name: string;
+	URL: string;
+	site_icon: string;
+	date_subscribed: Date;
+	delivery_methods: SiteSubscriptionDeliveryMethods;
+};
+
+export type SiteSubscriptionDetailsAPIResponse = {
+	ID: string;
+	blog_ID: string;
+	name: string;
+	URL: string;
+	site_icon: string;
+	date_subscribed: Date;
+	delivery_methods: SiteSubscriptionDeliveryMethods;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # (don't have an issue created for this yet)

## Proposed Changes

* Add useSiteSubscriptionDetailsQuery.
* Integrate it to the existing individual subscription management page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test as both logged-in (return next() on client/server/pages/index.js) and external user (subkey).
* Go to `http://calypso.localhost:3000/subscriptions/site/{site_id_here}`.
* It should display with actual data (except for subscriber count).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
