### PR TITLE
Site Assembler: Switch to use the site-assembler endpoint

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useSyncGlobalStylesUserConfig } from '@automattic/global-styles';
 import { useLocale } from '@automattic/i18n-utils';
-import { StepContainer, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { StepContainer, isSiteAssemblerFlow, isSiteSetupFlow } from '@automattic/onboarding';
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
@@ -81,7 +81,7 @@ const PatternAssembler = ( {
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const locale = useLocale();
-	const isNewSite = !! useQuery().get( 'isNewSite' );
+	const isNewSite = !! useQuery().get( 'isNewSite' ) || isSiteSetupFlow( flow );
 	const isSiteJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 
 	// The categories api triggers the ETK plugin before the PTK api request
@@ -638,7 +638,7 @@ const PatternAssembler = ( {
 		<StepContainer
 			className="pattern-assembler__sidebar-revamp"
 			stepName="pattern-assembler"
-			hideBack={ navigatorPath !== NAVIGATOR_PATHS.MAIN || flow === WITH_THEME_ASSEMBLER_FLOW }
+			hideBack={ navigatorPath !== NAVIGATOR_PATHS.MAIN || isSiteAssemblerFlow( flow ) }
 			goBack={ onBack }
 			goNext={ goNext }
 			isHorizontalLayout={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useSyncGlobalStylesUserConfig } from '@automattic/global-styles';
 import { useLocale } from '@automattic/i18n-utils';
 import { StepContainer, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
@@ -9,11 +10,13 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import classnames from 'classnames';
 import { useState, useRef, useMemo } from 'react';
-import { useDispatch as useReduxDispatch } from 'react-redux';
+import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
-import { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
 import { createRecordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { setActiveTheme } from 'calypso/state/themes/actions';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { activateOrInstallThenActivate, setActiveTheme } from 'calypso/state/themes/actions';
+import { getThemeIdFromStylesheet } from 'calypso/state/themes/utils';
+import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
@@ -46,6 +49,7 @@ import type { StepProps } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { DesignRecipe, Design } from '@automattic/design-picker/src/types';
 import type { GlobalStylesObject } from '@automattic/global-styles';
+import type { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
 import './style.scss';
 
 const PatternAssembler = ( {
@@ -61,7 +65,7 @@ const PatternAssembler = ( {
 	const [ activePosition, setActivePosition ] = useState( -1 );
 	const [ isPatternPanelListOpen, setIsPatternPanelListOpen ] = useState( false );
 	const { goBack, goNext, submit } = navigation;
-	const { applyThemeWithPatterns } = useDispatch( SITE_STORE );
+	const { applyThemeWithPatterns, assembleSite } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const selectedDesign = useSelect(
@@ -77,6 +81,8 @@ const PatternAssembler = ( {
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const locale = useLocale();
+	const isNewSite = !! useQuery().get( 'isNewSite' );
+	const isSiteJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 
 	// The categories api triggers the ETK plugin before the PTK api request
 	const categories = usePatternCategories( site?.ID );
@@ -367,16 +373,38 @@ const PatternAssembler = ( {
 
 	const onSubmit = () => {
 		const design = getDesign();
+		const stylesheet = design?.recipe?.stylesheet ?? '';
+		const themeId = getThemeIdFromStylesheet( stylesheet );
 
-		if ( ! siteSlugOrId ) {
+		if ( ! siteSlugOrId || ! site?.ID || ! themeId ) {
 			return;
 		}
 
-		setPendingAction( () =>
-			applyThemeWithPatterns( siteSlugOrId, design, syncedGlobalStylesUserConfig ).then(
-				( theme: ActiveTheme ) => reduxDispatch( setActiveTheme( site?.ID || -1, theme ) )
-			)
-		);
+		if ( isEnabled( 'pattern-assembler/logged-in-showcase' ) ) {
+			setPendingAction( () =>
+				Promise.resolve()
+					.then( () =>
+						reduxDispatch(
+							activateOrInstallThenActivate( themeId, site?.ID, 'assembler', false, false )
+						)
+					)
+					.then( () =>
+						assembleSite( siteSlugOrId, isSiteJetpack ? themeId : stylesheet, {
+							homeHtml: sections.map( ( pattern ) => pattern.html ).join( '' ),
+							headerHtml: header?.html,
+							footerHtml: footer?.html,
+							globalStyles: syncedGlobalStylesUserConfig,
+							shouldResetContent: isNewSite,
+						} )
+					)
+			);
+		} else {
+			setPendingAction( () =>
+				applyThemeWithPatterns( siteSlugOrId, design, syncedGlobalStylesUserConfig ).then(
+					( theme: ActiveTheme ) => reduxDispatch( setActiveTheme( site?.ID, theme ) )
+				)
+			);
+		}
 
 		recordSelectedDesign( { flow, intent, design } );
 		submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -7,6 +7,7 @@ export type Pattern = {
 	categories: Record< string, Category | undefined >;
 	key?: string;
 	pattern_meta?: Record< string, boolean | undefined >;
+	html?: string;
 };
 
 export interface NavigatorLocation {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -118,6 +118,7 @@ function getChecklistThemeDestination( { flowName, siteSlug, themeParameter } ) 
 				{
 					theme: themeParameter,
 					siteSlug: siteSlug,
+					isNewSite: true,
 				},
 				`/setup/with-theme-assembler`
 			);

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -1,6 +1,6 @@
 export { acceptAtomicTransferDialog } from 'calypso/state/themes/actions/accept-atomic-transfer-dialog';
 export { acceptAutoLoadingHomepageWarning } from 'calypso/state/themes/actions/accept-auto-loading-homepage-warning';
-export { activate } from 'calypso/state/themes/actions/activate';
+export { activate, activateOrInstallThenActivate } from 'calypso/state/themes/actions/activate';
 export { activateTheme } from 'calypso/state/themes/actions/activate-theme';
 export { addExternalManagedThemeToCart } from 'calypso/state/themes/actions/add-external-managed-theme-to-cart';
 export { clearActivated } from 'calypso/state/themes/actions/clear-activated';

--- a/client/state/themes/actions/theme-activated.js
+++ b/client/state/themes/actions/theme-activated.js
@@ -30,12 +30,18 @@ export function themeActivated(
 	purchased = false,
 	styleVariationSlug
 ) {
-	const themeActivatedThunk = ( dispatch, getState ) => {
-		const action = {
-			type: THEME_ACTIVATE_SUCCESS,
-			themeStylesheet,
-			siteId,
-		};
+	const action = {
+		type: THEME_ACTIVATE_SUCCESS,
+		themeStylesheet,
+		siteId,
+	};
+
+	if ( source === 'assembler' ) {
+		return action;
+	}
+
+	// it is named function just for testing purposes
+	return function themeActivatedThunk( dispatch, getState ) {
 		const previousThemeId = getActiveTheme( getState(), siteId );
 		const query = getLastThemeQuery( getState(), siteId );
 		const search_taxonomies = prependThemeFilterKeys( getState(), query.filter );
@@ -58,5 +64,4 @@ export function themeActivated(
 		// Update pages in case the front page was updated on theme switch.
 		dispatch( requestSitePosts( siteId, { type: 'page' } ) );
 	};
-	return themeActivatedThunk; // it is named function just for testing purposes
 }

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -10,7 +10,9 @@ import {
 	AtomicSoftwareStatusError,
 	AtomicSoftwareInstallError,
 	GlobalStyles,
+	AssembleSiteOptions,
 } from './types';
+import { createCustomHomeTemplateContent } from './utils';
 import type {
 	CreateSiteParams,
 	NewSiteErrorResponse,
@@ -32,6 +34,7 @@ import type {
 	CurrentTheme,
 } from './types';
 import type { WpcomClientCredentials } from '../shared-types';
+import type { RequestTemplate } from '../templates';
 
 export function createActions( clientCreds: WpcomClientCredentials ) {
 	const fetchSite = () => ( {
@@ -402,36 +405,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		return activatedTheme;
 	}
 
-	function createCustomHomeTemplateContent(
-		stylesheet: string,
-		hasHeader: boolean,
-		hasFooter: boolean,
-		hasSections: boolean
-	) {
-		const content: string[] = [];
-		if ( hasHeader ) {
-			content.push(
-				`<!-- wp:template-part {"slug":"header","tagName":"header","theme":"${ stylesheet }"} /-->`
-			);
-		}
-
-		if ( hasSections ) {
-			content.push( `
-	<!-- wp:group {"tagName":"main"} -->
-		<main class="wp-block-group">
-		</main>
-	<!-- /wp:group -->` );
-		}
-
-		if ( hasFooter ) {
-			content.push(
-				`<!-- wp:template-part {"slug":"footer","tagName":"footer","theme":"${ stylesheet }","className":"site-footer-container"} /-->`
-			);
-		}
-
-		return content.join( '\n' );
-	}
-
 	function* runThemeSetupOnSite(
 		siteSlug: string,
 		selectedDesign: Design,
@@ -564,6 +537,47 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		} );
 
 		return activatedTheme;
+	}
+
+	function* assembleSite(
+		siteSlug: string,
+		stylesheet = '',
+		{ homeHtml, headerHtml, footerHtml, globalStyles, shouldResetContent }: AssembleSiteOptions = {}
+	) {
+		const templates: RequestTemplate[] = [
+			{
+				type: 'wp_template' as const,
+				slug: 'home',
+				content: createCustomHomeTemplateContent(
+					stylesheet,
+					!! headerHtml,
+					!! footerHtml,
+					!! homeHtml,
+					homeHtml
+				),
+			},
+			{
+				type: 'wp_template_part' as const,
+				slug: 'header',
+				content: headerHtml,
+			},
+			{
+				type: 'wp_template_part' as const,
+				slug: 'footer',
+				content: footerHtml,
+			},
+		].filter( ( template: RequestTemplate ) => !! template.content );
+
+		yield wpcomRequest( {
+			path: `/sites/${ encodeURIComponent( siteSlug ) }/site-assembler`,
+			apiNamespace: 'wpcom/v2',
+			body: {
+				templates,
+				global_styles: globalStyles,
+				should_reset_content: shouldResetContent,
+			},
+			method: 'POST',
+		} );
 	}
 
 	const setSiteSetupError = ( error: string, message: string ) => ( {
@@ -767,6 +781,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		setDesignOnSite,
 		createCustomTemplate,
 		applyThemeWithPatterns,
+		assembleSite,
 		createSite,
 		receiveSite,
 		receiveSiteFailed,

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -510,3 +510,11 @@ export interface SourceSiteMigrationDetails {
 	is_target_blog_upgraded?: boolean;
 	target_blog_slug?: string;
 }
+
+export interface AssembleSiteOptions {
+	homeHtml?: string;
+	headerHtml?: string;
+	footerHtml?: string;
+	globalStyles?: GlobalStyles;
+	shouldResetContent?: boolean;
+}

--- a/packages/data-stores/src/site/utils.ts
+++ b/packages/data-stores/src/site/utils.ts
@@ -1,0 +1,31 @@
+export const createCustomHomeTemplateContent = (
+	stylesheet: string,
+	hasHeader: boolean,
+	hasFooter: boolean,
+	hasSections: boolean,
+	mainHtml = ''
+): string => {
+	const content: string[] = [];
+	if ( hasHeader ) {
+		content.push(
+			`<!-- wp:template-part {"slug":"header","tagName":"header","theme":"${ stylesheet }"} /-->`
+		);
+	}
+
+	if ( hasSections ) {
+		content.push( `
+<!-- wp:group {"tagName":"main"} -->
+	<main class="wp-block-group">
+		${ mainHtml }
+	</main>
+<!-- /wp:group -->` );
+	}
+
+	if ( hasFooter ) {
+		content.push(
+			`<!-- wp:template-part {"slug":"footer","tagName":"footer","theme":"${ stylesheet }","className":"site-footer-container"} /-->`
+		);
+	}
+
+	return content.join( '\n' );
+};

--- a/packages/data-stores/src/templates/index.ts
+++ b/packages/data-stores/src/templates/index.ts
@@ -1,2 +1,2 @@
 export { default as useTemplate } from './use-template';
-export type { Template } from './types';
+export type { Template, RequestTemplate } from './types';

--- a/packages/data-stores/src/templates/types.ts
+++ b/packages/data-stores/src/templates/types.ts
@@ -18,6 +18,11 @@ export type Template = {
 		raw: string;
 		rendered: string;
 	};
-	type: 'wp_template';
+	type: 'wp_template' | 'wp_template_part';
 	wp_id: number;
+};
+
+export type RequestTemplate = Partial< Omit< Template, 'title' | 'content' > > & {
+	title?: string;
+	content?: string;
 };

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -112,6 +112,10 @@ export const isWithThemeFlow = ( flowName: string | null ) => {
 	return !! flowName && WITH_THEME_FLOWS.includes( flowName );
 };
 
+export const isSiteSetupFlow = ( flowName: string | null ) => {
+	return !! flowName && SITE_SETUP_FLOW === flowName;
+};
+
 export const ecommerceFlowRecurTypes = {
 	YEARLY: 'yearly',
 	MONTHLY: 'monthly',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/76933

## Proposed Changes

* Replace the `applyThemeWithPatterns` action with the new one called `assembleSite` to get rid of the headstart process. And it will generate the template/template-parts based on the selected patterns on the PA screen
* Support the `isNewSite` query parameter to decide whether to reset the content of your site
* Use the `activateOrInstallThenActivate` to active or install the theme on your site to support the AT site

https://github.com/Automattic/wp-calypso/assets/13596067/a54b47d2-8357-47fd-8cbe-cbd5402bbf46

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Apply D111641-code to your sandbox before testing

**Logged-in Theme Showcase**
  * Head to `/themes/<your_site>`. Your site can be either a simple site or AT site.
  * Scroll down to select the BCPA CTA, and ensure you land on the PA screen
    ![image](https://github.com/Automattic/wp-calypso/assets/13596067/3b6bd5f5-5c4f-4686-8d1e-c1fb40f15b8c)
  * On the PA screen
    * Select a header
    * Select patterns on your homepage
    * Select a footer
    * Select colors
    * Select fonts
    * Continue
  * When you land on the site editor, ensure your homepage is built with the selected patterns and styles
  * Head to your site and ensure it looks good!
  * Head to `/pages/<your_site>`, and ensure your pages are still there
  * Head to `/posts/<your_site>`, and ensure your posts are still there

**Logged-out Theme Showcase**
  * Head to `/themes`
  * Scroll down to select the BCPA CTA, and ensure you land on the PA screen as above
  * Follow the guidance to create a new site
  * When your site is created, ensure you land on the PA screen
  * On the PA screen, follow the above instructions to select patterns and styles
  * When you land on the site editor, ensure your homepage is built with the selected patterns and styles
  * Head to your site and ensure it looks good!
  * Head to `/pages/<your_site>`, and ensure you don't have any existing page
  * Head to `/posts/<your_site>`, and ensure your have 4 initial posts

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?