### PR TITLE
Staging Sites: Add staging site card wrapper

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/card-content-wrapper.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/card-content-wrapper.tsx
@@ -1,0 +1,18 @@
+import { Card, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import CardHeading from 'calypso/components/card-heading';
+
+export const CardContentWrapper: FunctionComponent = ( { children } ) => {
+	const translate = useTranslate();
+	return (
+		<Card className="staging-site-card">
+			{
+				// eslint-disable-next-line wpcalypso/jsx-gridicon-size
+				<Gridicon icon="science" size={ 32 } />
+			}
+			<CardHeading id="staging-site">{ translate( 'Staging site' ) }</CardHeading>
+			{ children }
+		</Card>
+	);
+};

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -1,4 +1,4 @@
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useQueryClient } from '@tanstack/react-query';
 import { sprintf } from '@wordpress/i18n';
@@ -7,12 +7,12 @@ import { localize } from 'i18n-calypso';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
-import CardHeading from 'calypso/components/card-heading';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import Notice from 'calypso/components/notice';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { urlToSlug } from 'calypso/lib/url';
+import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
 import { NewStagingSiteCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content';
 import { LoadingPlaceholder } from 'calypso/my-sites/hosting/staging-site-card/loading-placeholder';
 import { useAddStagingSiteMutation } from 'calypso/my-sites/hosting/staging-site-card/use-add-staging-site';
@@ -374,16 +374,7 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		stagingSiteCardContent = <LoadingPlaceholder />;
 	}
 
-	return (
-		<Card className="staging-site-card">
-			{
-				// eslint-disable-next-line wpcalypso/jsx-gridicon-size
-				<Gridicon icon="science" size={ 32 } />
-			}
-			<CardHeading id="staging-site">{ translate( 'Staging site' ) }</CardHeading>
-			{ stagingSiteCardContent }
-		</Card>
-	);
+	return <CardContentWrapper>{ stagingSiteCardContent }</CardContentWrapper>;
 };
 
 export default connect( ( state ) => {

--- a/client/my-sites/hosting/staging-site-card/staging-site-card.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-card.stories.tsx
@@ -1,10 +1,8 @@
-import { Card, Gridicon } from '@automattic/components';
 import { action } from '@storybook/addon-actions';
 import { Story, Meta } from '@storybook/react';
-import { useTranslate } from 'i18n-calypso';
 import { ComponentProps } from 'react';
 import { documentHeadStoreMock, ReduxDecorator } from 'calypso/__mocks__/storybook/redux';
-import CardHeading from 'calypso/components/card-heading';
+import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
 import { NewStagingSiteCardContent } from './card-content/new-staging-site-card-content';
 
 /**
@@ -25,16 +23,10 @@ export default {
 			);
 		},
 		( Story ) => {
-			const translate = useTranslate();
 			return (
-				<Card className="staging-site-card">
-					{
-						// eslint-disable-next-line wpcalypso/jsx-gridicon-size
-						<Gridicon icon="science" size={ 32 } />
-					}
-					<CardHeading id="staging-site">{ translate( 'Staging site' ) }</CardHeading>
+				<CardContentWrapper>
 					<Story></Story>
-				</Card>
+				</CardContentWrapper>
 			);
 		},
 		( Story ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/77081

## Proposed Changes

In this PR, I would like to add the staging site card wrapper to its component to avoid repetition.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
