### PR TITLE
Subscription Management: Add subscriber count with formatting.

### DIFF
--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { SubscriptionManager } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -18,8 +18,6 @@ const SiteSubscriptionPage = () => {
 
 	const { data, isLoading, isError } =
 		SubscriptionManager.useSiteSubscriptionDetailsQuery( blogId );
-
-	const subscribers = 1234567; // TODO: API needs to return subscriber count
 
 	const [ notice, setNotice ] = useState< NoticeState | null >( null );
 	const [ siteSubscribed, setSiteSubscribed ] = useState( true );
@@ -118,13 +116,14 @@ const SiteSubscriptionPage = () => {
 		return <div>Loading...</div>;
 	}
 
-	const subHeaderText =
-		subscribers > 1
-			? translate( '%d subscribers', {
-					args: [ subscribers ],
-					comment: 'Number of subscribers of the subscribed-to site.',
-			  } )
-			: '';
+	const subscriberCount = data?.subscriber_count;
+	const subHeaderText = subscriberCount
+		? translate( '%s subscriber', '%s subscribers', {
+				count: subscriberCount,
+				args: [ numberFormat( subscriberCount, 0 ) ],
+				comment: '%s is the number of subscribers. For example: "12,000,000"',
+		  } )
+		: '';
 
 	return (
 		<div className="site-subscription-page">

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -140,6 +140,7 @@ export type SiteSubscriptionDetails = {
 	URL: string;
 	site_icon: string;
 	date_subscribed: Date;
+	subscriber_count: number;
 	delivery_methods: SiteSubscriptionDeliveryMethods;
 };
 
@@ -150,5 +151,6 @@ export type SiteSubscriptionDetailsAPIResponse = {
 	URL: string;
 	site_icon: string;
 	date_subscribed: Date;
+	subscriber_count: number;
 	delivery_methods: SiteSubscriptionDeliveryMethods;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # (no issue created)

## Proposed Changes

* Integrate subscriber count with proper formatting.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test as both logged-in (return next() on client/server/pages/index.js) and external user (subkey).
* Go to `http://calypso.localhost:3000/subscriptions/site/{site_id_here}`.
* It should display formatted subscriber count.

**Test different numbers:**
 * Modify `const subscriberCount = ` to say `0`, `1`, `any number`, `undefined`.
 * If `0` or `undefined`, it should not display the count.
 * If `1`, it should show the singular form.

<img width="756" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/d515a1a8-68c0-4344-a9d4-9bc6367ee4cf">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
