### PR TITLE
Social Previews | Allow hiding of preview sections

### DIFF
--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.0.0-beta.6",
+	"version": "2.0.0-beta.7",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/src/facebook-preview/previews.tsx
+++ b/packages/social-previews/src/facebook-preview/previews.tsx
@@ -9,47 +9,56 @@ import type { FacebookPreviewProps } from './types';
 
 export type FacebookPreviewsProps = FacebookPreviewProps & SocialPreviewsBaseProps;
 
-export const FacebookPreviews: React.FC< FacebookPreviewsProps > = ( props ) => {
+export const FacebookPreviews: React.FC< FacebookPreviewsProps > = ( {
+	headingLevel,
+	hideLinkPreview,
+	hidePostPreview,
+	...props
+} ) => {
 	const hasMedia = !! props.media?.length;
 	const hasCustomImage = !! props.customImage;
 
 	return (
 		<div className="social-preview facebook-preview">
-			<section className="social-preview__section facebook-preview__section">
-				<SectionHeading level={ props.headingLevel }>
-					{
-						// translators: refers to a social post on Facebook
-						__( 'Your post', 'social-previews' )
-					}
-				</SectionHeading>
-				<p className="social-preview__section-desc">
-					{ __( 'This is what your social post will look like on Facebook:', 'social-previews' ) }
-				</p>
-				{ hasMedia ? <FacebookPostPreview { ...props } /> : <FacebookLinkPreview { ...props } /> }
-			</section>
-			<section className="social-preview__section facebook-preview__section">
-				<SectionHeading level={ props.headingLevel }>
-					{
-						// translators: refers to a link to a Facebook post
-						__( 'Link preview', 'social-previews' )
-					}
-				</SectionHeading>
-				<p className="social-preview__section-desc">
-					{ __(
-						'This is what it will look like when someone shares the link to your WordPress post on Facebook.',
-						'social-previews'
+			{ ! hidePostPreview && (
+				<section className="social-preview__section facebook-preview__section">
+					<SectionHeading level={ headingLevel }>
+						{
+							// translators: refers to a social post on Facebook
+							__( 'Your post', 'social-previews' )
+						}
+					</SectionHeading>
+					<p className="social-preview__section-desc">
+						{ __( 'This is what your social post will look like on Facebook:', 'social-previews' ) }
+					</p>
+					{ hasMedia ? <FacebookPostPreview { ...props } /> : <FacebookLinkPreview { ...props } /> }
+				</section>
+			) }
+			{ ! hideLinkPreview && (
+				<section className="social-preview__section facebook-preview__section">
+					<SectionHeading level={ headingLevel }>
+						{
+							// translators: refers to a link to a Facebook post
+							__( 'Link preview', 'social-previews' )
+						}
+					</SectionHeading>
+					<p className="social-preview__section-desc">
+						{ __(
+							'This is what it will look like when someone shares the link to your WordPress post on Facebook.',
+							'social-previews'
+						) }
+						&nbsp;
+						<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
+							{ __( 'Learn more about links', 'social-previews' ) }
+						</ExternalLink>
+					</p>
+					{ hasCustomImage ? (
+						<LinkPreviewDetails { ...props } />
+					) : (
+						<FacebookLinkPreview { ...props } compactDescription customText="" user={ undefined } />
 					) }
-					&nbsp;
-					<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-						{ __( 'Learn more about links', 'social-previews' ) }
-					</ExternalLink>
-				</p>
-				{ hasCustomImage ? (
-					<LinkPreviewDetails { ...props } />
-				) : (
-					<FacebookLinkPreview { ...props } compactDescription customText="" user={ undefined } />
-				) }
-			</section>
+				</section>
+			) }
 		</div>
 	);
 };

--- a/packages/social-previews/src/linkedin-preview/previews.tsx
+++ b/packages/social-previews/src/linkedin-preview/previews.tsx
@@ -8,41 +8,47 @@ import type { LinkedInPreviewsProps } from './types';
 
 export const LinkedInPreviews: React.FC< LinkedInPreviewsProps > = ( {
 	headingLevel,
+	hideLinkPreview,
+	hidePostPreview,
 	...props
 } ) => {
 	return (
 		<div className="social-preview linkedin-preview">
-			<section className="social-preview__section linkedin-preview__section">
-				<SectionHeading level={ headingLevel }>
-					{
-						// translators: refers to a social post on LinkedIn
-						__( 'Your post', 'social-previews' )
-					}
-				</SectionHeading>
-				<p className="social-preview__section-desc">
-					{ __( 'This is what your social post will look like on LinkedIn:', 'social-previews' ) }
-				</p>
-				<LinkedInPostPreview { ...props } />
-			</section>
-			<section className="social-preview__section linkedin-preview__section">
-				<SectionHeading level={ headingLevel }>
-					{
-						// translators: refers to a link to a LinkedIn post
-						__( 'Link preview', 'social-previews' )
-					}
-				</SectionHeading>
-				<p className="social-preview__section-desc">
-					{ __(
-						'This is what it will look like when someone shares the link to your WordPress post on LinkedIn.',
-						'social-previews'
-					) }
-					&nbsp;
-					<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-						{ __( 'Learn more about links', 'social-previews' ) }
-					</ExternalLink>
-				</p>
-				<LinkedInLinkPreview { ...props } { ...DEFAULT_PROPS } />
-			</section>
+			{ ! hidePostPreview && (
+				<section className="social-preview__section linkedin-preview__section">
+					<SectionHeading level={ headingLevel }>
+						{
+							// translators: refers to a social post on LinkedIn
+							__( 'Your post', 'social-previews' )
+						}
+					</SectionHeading>
+					<p className="social-preview__section-desc">
+						{ __( 'This is what your social post will look like on LinkedIn:', 'social-previews' ) }
+					</p>
+					<LinkedInPostPreview { ...props } />
+				</section>
+			) }
+			{ ! hideLinkPreview && (
+				<section className="social-preview__section linkedin-preview__section">
+					<SectionHeading level={ headingLevel }>
+						{
+							// translators: refers to a link to a LinkedIn post
+							__( 'Link preview', 'social-previews' )
+						}
+					</SectionHeading>
+					<p className="social-preview__section-desc">
+						{ __(
+							'This is what it will look like when someone shares the link to your WordPress post on LinkedIn.',
+							'social-previews'
+						) }
+						&nbsp;
+						<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
+							{ __( 'Learn more about links', 'social-previews' ) }
+						</ExternalLink>
+					</p>
+					<LinkedInLinkPreview { ...props } { ...DEFAULT_PROPS } />
+				</section>
+			) }
 		</div>
 	);
 };

--- a/packages/social-previews/src/tumblr-preview/previews.tsx
+++ b/packages/social-previews/src/tumblr-preview/previews.tsx
@@ -8,40 +8,49 @@ import { TumblrPreviewProps } from './types';
 
 export type TumblrPreviewsProps = TumblrPreviewProps & SocialPreviewsBaseProps;
 
-export const TumblrPreviews: React.FC< TumblrPreviewsProps > = ( props ) => {
+export const TumblrPreviews: React.FC< TumblrPreviewsProps > = ( {
+	headingLevel,
+	hideLinkPreview,
+	hidePostPreview,
+	...props
+} ) => {
 	return (
 		<div className="social-preview tumblr-preview">
-			<section className="social-preview__section tumblr-preview__section">
-				<SectionHeading level={ props.headingLevel }>
-					{
-						// translators: refers to a social post on Tumblr
-						__( 'Your post', 'social-previews' )
-					}
-				</SectionHeading>
-				<p className="social-preview__section-desc">
-					{ __( 'This is what your social post will look like on Tumblr:', 'social-previews' ) }
-				</p>
-				<TumblrPostPreview { ...props } />
-			</section>
-			<section className="social-preview__section tumblr-preview__section">
-				<SectionHeading level={ props.headingLevel }>
-					{
-						// translators: refers to a link on Tumblr
-						__( 'Link preview', 'social-previews' )
-					}
-				</SectionHeading>
-				<p className="social-preview__section-desc">
-					{ __(
-						'This is what it will look like when someone shares the link to your WordPress post on Tumblr.',
-						'social-previews'
-					) }
-					&nbsp;
-					<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-						{ __( 'Learn more about links', 'social-previews' ) }
-					</ExternalLink>
-				</p>
-				<TumblrLinkPreview { ...props } />
-			</section>
+			{ ! hidePostPreview && (
+				<section className="social-preview__section tumblr-preview__section">
+					<SectionHeading level={ headingLevel }>
+						{
+							// translators: refers to a social post on Tumblr
+							__( 'Your post', 'social-previews' )
+						}
+					</SectionHeading>
+					<p className="social-preview__section-desc">
+						{ __( 'This is what your social post will look like on Tumblr:', 'social-previews' ) }
+					</p>
+					<TumblrPostPreview { ...props } />
+				</section>
+			) }
+			{ ! hideLinkPreview && (
+				<section className="social-preview__section tumblr-preview__section">
+					<SectionHeading level={ headingLevel }>
+						{
+							// translators: refers to a link on Tumblr
+							__( 'Link preview', 'social-previews' )
+						}
+					</SectionHeading>
+					<p className="social-preview__section-desc">
+						{ __(
+							'This is what it will look like when someone shares the link to your WordPress post on Tumblr.',
+							'social-previews'
+						) }
+						&nbsp;
+						<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
+							{ __( 'Learn more about links', 'social-previews' ) }
+						</ExternalLink>
+					</p>
+					<TumblrLinkPreview { ...props } />
+				</section>
+			) }
 		</div>
 	);
 };

--- a/packages/social-previews/src/twitter-preview/previews.tsx
+++ b/packages/social-previews/src/twitter-preview/previews.tsx
@@ -5,49 +5,61 @@ import { TwitterLinkPreview } from './link-preview';
 import { TwitterPostPreview } from './post-preview';
 import type { TwitterPreviewsProps } from './types';
 
-export const TwitterPreviews: React.FC< TwitterPreviewsProps > = ( { tweets, headingLevel } ) => {
+export const TwitterPreviews: React.FC< TwitterPreviewsProps > = ( {
+	headingLevel,
+	hideLinkPreview,
+	hidePostPreview,
+	tweets,
+} ) => {
+	if ( ! tweets?.length ) {
+		return null;
+	}
 	return (
 		<div className="social-preview twitter-preview">
-			<section className="social-preview__section twitter-preview__section">
-				<SectionHeading level={ headingLevel }>
-					{
-						// translators: refers to a social post on Twitter
-						__( 'Your post', 'social-previews' )
-					}
-				</SectionHeading>
-				<p className="social-preview__section-desc">
-					{ __( 'This is what your social post will look like on Twitter:', 'social-previews' ) }
-				</p>
-				{ tweets?.map( ( tweet, index ) => {
-					const isLast = index + 1 === tweets.length;
-					return (
-						<TwitterPostPreview
-							key={ `twitter-preview__tweet-${ index }` }
-							{ ...tweet }
-							showThreadConnector={ ! isLast }
-						/>
-					);
-				} ) }
-			</section>
-			<section className="social-preview__section twitter-preview__section">
-				<SectionHeading level={ headingLevel }>
-					{
-						// translators: refers to a link to a Twitter post
-						__( 'Link preview', 'social-previews' )
-					}
-				</SectionHeading>
-				<p className="social-preview__section-desc">
-					{ __(
-						'This is what it will look like when someone shares the link to your WordPress post on Twitter.',
-						'social-previews'
-					) }
-					&nbsp;
-					<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-						{ __( 'Learn more about links', 'social-previews' ) }
-					</ExternalLink>
-				</p>
-				<TwitterLinkPreview { ...tweets[ 0 ] } />
-			</section>
+			{ ! hidePostPreview && (
+				<section className="social-preview__section twitter-preview__section">
+					<SectionHeading level={ headingLevel }>
+						{
+							// translators: refers to a social post on Twitter
+							__( 'Your post', 'social-previews' )
+						}
+					</SectionHeading>
+					<p className="social-preview__section-desc">
+						{ __( 'This is what your social post will look like on Twitter:', 'social-previews' ) }
+					</p>
+					{ tweets.map( ( tweet, index ) => {
+						const isLast = index + 1 === tweets.length;
+						return (
+							<TwitterPostPreview
+								key={ `twitter-preview__tweet-${ index }` }
+								{ ...tweet }
+								showThreadConnector={ ! isLast }
+							/>
+						);
+					} ) }
+				</section>
+			) }
+			{ ! hideLinkPreview && (
+				<section className="social-preview__section twitter-preview__section">
+					<SectionHeading level={ headingLevel }>
+						{
+							// translators: refers to a link to a Twitter post
+							__( 'Link preview', 'social-previews' )
+						}
+					</SectionHeading>
+					<p className="social-preview__section-desc">
+						{ __(
+							'This is what it will look like when someone shares the link to your WordPress post on Twitter.',
+							'social-previews'
+						) }
+						&nbsp;
+						<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
+							{ __( 'Learn more about links', 'social-previews' ) }
+						</ExternalLink>
+					</p>
+					<TwitterLinkPreview { ...tweets[ 0 ] } />
+				</section>
+			) }
 		</div>
 	);
 };

--- a/packages/social-previews/src/types.ts
+++ b/packages/social-previews/src/types.ts
@@ -23,7 +23,20 @@ export interface SocialPreviewBaseProps {
 }
 
 export interface SocialPreviewsBaseProps {
+	/**
+	 * The heading level to use for the preview section title
+	 */
 	headingLevel?: SectionHeadingProps[ 'level' ];
+
+	/**
+	 * Whether to hide the "Your post" section
+	 */
+	hidePostPreview?: boolean;
+
+	/**
+	 * Whether to hide the "Link preview" section
+	 */
+	hideLinkPreview?: boolean;
 }
 
 export type MediaItem = {


### PR DESCRIPTION
Completes 1203820933396971-as-1204619555057255/f

## Proposed Changes

* This PR adds a couple of props to each of the social previews to allow hiding of the sections.

## Testing Instructions

- Make sure you have a self-hosted site connected to Jetpack, with a subscription that includes Social.
- Spin up Calypso, by running this branch locally.
- Ensure that you have Social Media accounts connected for a self-hosted WP Site
- Go to `/posts/:site` for a self-hosted WP site or a JN site
- Click on the 3 dots for any post and Click "Share"
- Click on "Preview"
- Confirm that everything works as before
- Do one of these:
    - Test this with https://github.com/Automattic/jetpack/pull/30812
    - Open `client/components/share/linkedin-share-preview/index.jsx` in your editor and pass `hidePostPreview` boolean prop  to `LinkedInPreviews`
    
```diff
<LinkedInPreviews
	...
	description={ decodeEntities( articleSummary ) }
	url={ articleUrl }
+	hidePostPreview
/>
```
- Open the previews again
- Confirm that LinkedIn preview no longer shows "Your post" preview section

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?