### PR TITLE
 Assembler: Update the large preview placeholder UI

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -114,20 +114,35 @@
 	background: #f8f8f8;
 
 	.pattern-large-preview__placeholder-icon {
-		margin-bottom: 28px;
-		fill: #c9c9c9;
+		margin-bottom: 24px;
+		fill: var(--studio-gray-10);
 	}
 
 	h2 {
-		color: var(--studio-gray-100);
-		margin-bottom: 5px;
+		color: #000;
+		margin-bottom: 4px;
 		font-size: $font-title-small;
 		font-weight: 500;
 	}
 
 	span {
-		max-width: 600px;
+		color: #000;
 		font-size: $font-body;
+		max-width: 600px;
 		text-align: center;
+	}
+
+	button {
+		border: 1px solid var(--studio-gray-10);
+		border-radius: 4px;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+		background-color: #fff;
+		color: var(--studio-gray-100);
+		font-size: $font-body-small;
+		font-weight: 500;
+		letter-spacing: -0.15px;
+		line-height: 20px;
+		margin-top: 24px;
+		padding: 10px 24px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -1,5 +1,5 @@
 import { PatternRenderer } from '@automattic/block-renderer';
-import { DeviceSwitcher } from '@automattic/components';
+import { Button, DeviceSwitcher } from '@automattic/components';
 import { useStyle } from '@automattic/global-styles';
 import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
 import { Icon, layout } from '@wordpress/icons';
@@ -81,22 +81,15 @@ const PatternLargePreview = ( {
 			return translate( "It's time to get creative. Add your first pattern to get started." );
 		}
 
-		return translate(
-			'You can view your color and font selections after you select a pattern. Get started by {{link}}adding a header pattern{{/link}}.',
-			{
-				components: {
-					link: (
-						// eslint-disable-next-line jsx-a11y/anchor-is-valid
-						<a
-							href="#"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ handleAddHeaderClick }
-						/>
-					),
-				},
-			}
-		);
+		return translate( 'You can view your color and font selections after you select a pattern.' );
+	};
+
+	const getAction = () => {
+		if ( ! shouldShowSelectPatternHint ) {
+			return null;
+		}
+
+		return <Button onClick={ handleAddHeaderClick }>{ translate( 'Add header' ) }</Button>;
 	};
 
 	const renderPattern = ( type: string, pattern: Pattern, position = -1 ) => {
@@ -219,9 +212,10 @@ const PatternLargePreview = ( {
 				</ul>
 			) : (
 				<div className="pattern-large-preview__placeholder">
-					<Icon className="pattern-large-preview__placeholder-icon" icon={ layout } size={ 72 } />
+					<Icon className="pattern-large-preview__placeholder-icon" icon={ layout } size={ 56 } />
 					<h2>{ getTitle() }</h2>
 					<span>{ getDescription() }</span>
+					{ getAction() }
 				</div>
 			) }
 		</DeviceSwitcher>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76918

## Proposed Changes

As discussed in #76918, this PR updates the large preview placeholder UI as per design spec Tv3pYqA3EcRfiXC31IxrXE-fi-538_21593.

| Before | After |
| --- | --- |
| ![Screenshot 2023-05-19 at 6 06 14 PM](https://github.com/Automattic/wp-calypso/assets/797888/f4c8d900-9fdd-41bd-bb82-9cf1e04100e7) | ![Screenshot 2023-05-19 at 6 05 25 PM](https://github.com/Automattic/wp-calypso/assets/797888/82cff18f-776d-4b9d-b11e-7782c85ddf49)| 

| Before | After |
| --- | --- |
| ![Screenshot 2023-05-19 at 6 06 22 PM](https://github.com/Automattic/wp-calypso/assets/797888/32c3c581-d1bb-4aa0-ba81-35da891cd745) | ![Screenshot 2023-05-19 at 6 05 33 PM](https://github.com/Automattic/wp-calypso/assets/797888/c3f37e33-9499-4705-a608-352d53e60ddb) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /setup/site-setup?siteSlug=${site_slug}.
* Continue until you land on the Design Picker, and select the Pattern Assembler CTA.
* Once in the Pattern Assembler, ensure that the large preview placeholder is as described above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?