### PR TITLE
Subscription Management: Add subscription info on individual subscription page.

### DIFF
--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -5,6 +5,7 @@ import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import FormattedHeader from 'calypso/components/formatted-header';
+import TimeSince from 'calypso/components/time-since';
 import { Notice, NoticeState, NoticeType } from 'calypso/landing/subscriptions/components/notice';
 import { SiteIcon } from 'calypso/landing/subscriptions/components/site-icon';
 import PoweredByWPFooter from 'calypso/layout/powered-by-wp-footer';
@@ -125,6 +126,8 @@ const SiteSubscriptionPage = () => {
 		  } )
 		: '';
 
+	const date_subscribed = data?.date_subscribed;
+
 	return (
 		<div className="site-subscription-page">
 			<Button
@@ -162,6 +165,24 @@ const SiteSubscriptionPage = () => {
 							/>
 
 							<hr className="subscriptions__separator" />
+
+							{ /* TODO: Move to SiteSubscriptionInfo component when payment details are in. */ }
+							<div className="site-subscription-info">
+								<h2 className="site-subscription-info__heading">{ translate( 'Subscription' ) }</h2>
+								<dl className="site-subscription-info__list">
+									<dt>{ translate( 'Date' ) }</dt>
+									<dd>
+										<TimeSince
+											date={
+												( date_subscribed.valueOf()
+													? date_subscribed
+													: new Date( 0 )
+												).toISOString?.() ?? date_subscribed
+											}
+										/>
+									</dd>
+								</dl>
+							</div>
 
 							<Button
 								className="site-subscription-page__unsubscribe-button"

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-settings.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-settings.tsx
@@ -30,7 +30,7 @@ const SiteSubscriptionSettings = ( {
 
 	return (
 		<div className="site-subscription-settings">
-			<h2 className="site-subscription-settings__heading">{ translate( 'Settings ' ) }</h2>
+			<h2 className="site-subscription-settings__heading">{ translate( 'Settings' ) }</h2>
 			<SiteSettings
 				// NotifyMeOfNewPosts
 				notifyMeOfNewPosts={ notifyMeOfNewPosts }

--- a/client/landing/subscriptions/components/site-subscription-page/styles.scss
+++ b/client/landing/subscriptions/components/site-subscription-page/styles.scss
@@ -51,6 +51,10 @@
 		}
 	}
 
+	.powered-by-wp-footer {
+		position: relative;
+	}
+
 	.site-subscription-settings {
 		width: 100%;
 		@extend .settings;
@@ -80,6 +84,47 @@
 			font-size: $font-body;
 			line-height: rem(22px);
 			font-weight: 600;
+		}
+	}
+
+	.site-subscription-info {
+		width: 100%;
+		@extend .settings;
+
+		&__heading {
+			margin: 40px 0 24px;
+			color: $studio-gray-100;
+			font-family: "SF Pro Text", $sans;
+			font-size: $font-body;
+			line-height: rem(22px);
+			font-weight: 600;
+		}
+
+		&__list {
+			margin: 0;
+
+			dt,
+			dd {
+				font-family: "SF Pro Text", $sans;
+				font-size: rem(14px);
+				line-height: rem(20px);
+				letter-spacing: -0.15px;
+				color: $studio-gray-100;
+			}
+
+			dt {
+				font-weight: 500;
+				margin-bottom: 8px;
+			}
+
+			dd {
+				font-weight: 400;
+				margin: 0;
+
+				+ dt {
+					margin-top: 24px;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/77249

## Proposed Changes

* Add subscription info (currently just subscription date) on subscription page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test as both logged-in (return next() on client/server/pages/index.js) and external user (subkey).
* Go to `http://calypso.localhost:3000/subscriptions/site/{site_id_here}`.
* You should see the subscription date.

<img width="746" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/9a851dc5-8b52-41d2-939e-549b978b8213">

**Below is how it might look like with multiple items (stylesheet is built for it now):**

<img width="863" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/95a57559-e12f-4f0e-85d2-de7972cfbce6">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
