### PR TITLE
Messaging: Improve handling of Zendesk key for auth

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
@@ -1,8 +1,12 @@
+const isDevelopment = process.env.NODE_ENV === 'development' ? 'development' : 'production';
+
 window.configData = {
-	env_id: 'production',
+	env_id: isDevelopment ? 'development' : 'production',
 	i18n_default_locale_slug: 'en',
 	google_analytics_key: 'UA-10673494-15',
-	zendesk_support_chat_key: 'cec07bc9-4da6-4dd2-afa7-c7e01ae73584',
+	zendesk_support_chat_key: isDevelopment
+		? '715f17a8-4a28-4a7f-8447-0ef8f06c70d7'
+		: 'cec07bc9-4da6-4dd2-afa7-c7e01ae73584',
 	client_slug: 'browser',
 	twemoji_cdn_url: 'https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/',
 	site_filter: [],

--- a/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
+++ b/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
@@ -36,7 +36,7 @@ export const ZendeskJetpackChat: React.VFC< { keyType: KeyType } > = ( { keyType
 	}, [ keyType ] );
 
 	//get user's authentication key
-	const { data: dataAuth, isLoading: isLoadingAuth } = useMessagingAuth( true );
+	const { data: dataAuth, isLoading: isLoadingAuth } = useMessagingAuth( zendeskChatKey, true );
 
 	const zendeskJwt = dataAuth?.user?.jwt;
 	const isLoggedIn = useSelector( isUserLoggedIn );

--- a/config/development.json
+++ b/config/development.json
@@ -27,7 +27,7 @@
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
-	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
+	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -44,7 +44,9 @@ export const HelpCenterContactPage: FC = () => {
 	const { data: supportAvailability } = useSupportAvailability( 'CHAT' );
 	const isLoading = renderChat.isLoading || renderEmail.isLoading || isLoadingSupportActivity;
 
+	const zendeskKey: string = config( 'zendesk_support_chat_key' );
 	const { data: messagingAuth } = useMessagingAuth(
+		zendeskKey,
 		Boolean( supportAvailability?.is_user_eligible )
 	);
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -32,13 +32,9 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const { setShowMessagingWidget } = useDispatch( HELP_CENTER_STORE );
 	const [ isMessagingScriptLoaded, setMessagingScriptLoaded ] = useState( false );
 
+	const zendeskKey: string = config( 'zendesk_support_chat_key' );
 	useEffect( () => {
 		if ( ! chatStatus?.is_user_eligible ) {
-			return;
-		}
-
-		const zendeskKey: string | false = config( 'zendesk_support_chat_key' );
-		if ( ! zendeskKey ) {
 			return;
 		}
 
@@ -72,11 +68,12 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 			setUpMessagingEventHandlers,
 			{ id: ZENDESK_SCRIPT_ID }
 		);
-	}, [ setShowMessagingLauncher, setShowMessagingWidget, chatStatus ] );
+	}, [ setShowMessagingLauncher, setShowMessagingWidget, chatStatus, zendeskKey ] );
 
 	const { data: supportActivity } = useSupportActivity( Boolean( chatStatus?.is_user_eligible ) );
 	const hasActiveChats = supportActivity?.some( ( ticket ) => ticket.channel === 'Messaging' );
 	const { data: messagingAuth } = useMessagingAuth(
+		zendeskKey,
 		Boolean( chatStatus?.is_user_eligible ) && Boolean( hasActiveChats )
 	);
 	useEffect( () => {

--- a/packages/help-center/src/hooks/use-messaging-auth.ts
+++ b/packages/help-center/src/hooks/use-messaging-auth.ts
@@ -29,8 +29,8 @@ function requestMessagingAuth() {
 		  } as APIFetchOptions );
 }
 
-export default function useMessagingAuth( enabled: boolean ) {
-	return useQuery< MessagingAuth >( [ 'getMessagingAuth' ], requestMessagingAuth, {
+export default function useMessagingAuth( zendeskKey: string, enabled: boolean ) {
+	return useQuery< MessagingAuth >( [ 'getMessagingAuth', zendeskKey ], requestMessagingAuth, {
 		staleTime: 7 * 24 * 60 * 60 * 1000, // 1 week (JWT is actually 2 weeks, but lets be on the safe side)
 		enabled,
 	} );

--- a/packages/help-center/src/hooks/use-messaging-auth.ts
+++ b/packages/help-center/src/hooks/use-messaging-auth.ts
@@ -29,7 +29,7 @@ function requestMessagingAuth() {
 		  } as APIFetchOptions );
 }
 
-export default function useMessagingAuth( zendeskKey: string, enabled: boolean ) {
+export default function useMessagingAuth( zendeskKey: string | false, enabled: boolean ) {
 	return useQuery< MessagingAuth >( [ 'getMessagingAuth', zendeskKey ], requestMessagingAuth, {
 		staleTime: 7 * 24 * 60 * 60 * 1000, // 1 week (JWT is actually 2 weeks, but lets be on the safe side)
 		enabled,


### PR DESCRIPTION
## Proposed Changes

* Switches to sandbox key for development env.
* Ensures we refetch the JWT once the key changes, so that we don't get 403 responses from Zendesk.

## Testing Instructions
Good to start by cleaning your state, so that the previous JWT keys are removed: just add `?flags=force-sympathy` to the URL.

- Open Help Center -> Still need help.
- In the Network tab, you should have a request to `https://public-api.wordpress.com/wpcom/v2/help/authenticate/chat?_envelope=1&type=zendesk&test_mode=true`.
- There should also be a successful POST request to `https://woothemes1654197491support.zendesk.com/sc/sdk/v2/apps/633dcb21690c2c00f4ca2eb8/login`.
- Refresh Calypso, redo the steps. However, now there should be _no_ request to `/wpcom/v2/help/authenticate/chat` (the JWT returned there can and should be cached for a week). But there should still be a successful POST to Zendesk's `login`.

Now, stop Calypso, switch the key back to production one (`cec07bc9-4da6-4dd2-afa7-c7e01ae73584`), restart Calypso. You'll also need to hardcode `test_mode: 'false'` here: https://github.com/Automattic/wp-calypso/blob/bdff6b74ae544e736e33e620f12225a3ffa453e0/packages/help-center/src/hooks/use-messaging-auth.ts#L15.

- Redo the steps. Now there should be again a request to `/wpcom/v2/help/authenticate/chat` (to fetch the correct JWT for production). And there should still be a successful POST to Zendesk's `login`, but on the `wpcomsupport.zendesk.com` host.