### PR TITLE
Janitorial: add warning to goBack function in Stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -8,7 +8,7 @@ export type NavigationControls = {
 	 * Call this function if you want to go to the previous step.
 	 *
 	 * Please don't change the type of this function to add parameters. Passing data should strictly happen through the `submit` function.
-	 * If you disagree with this, please ping Vertex Team.
+	 * See why here: pdDR7T-KR-p2#steps-should-only-submit
 	 */
 	goBack?: () => void;
 

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -6,6 +6,9 @@ import React from 'react';
 export type NavigationControls = {
 	/**
 	 * Call this function if you want to go to the previous step.
+	 *
+	 * Please don't change the type of this function to add parameters. Passing data should strictly happen through the `submit` function.
+	 * If you disagree with this, please ping Vertex Team.
 	 */
 	goBack?: () => void;
 


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/pull/77072/files#r1198608826