### PR TITLE
Messaging: Make sure to pass the userfields to correct endpoint

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-user-fields.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-user-fields.php
@@ -56,7 +56,7 @@ class WP_REST_Help_Center_User_Fields extends \WP_REST_Controller {
 			array(
 				'method' => 'POST',
 			),
-			$request['fields']
+			array( 'fields' => $request['fields'] )
 		);
 
 		if ( is_wp_error( $body ) ) {

--- a/packages/data-stores/src/support-queries/use-update-zendesk-user-fields.ts
+++ b/packages/data-stores/src/support-queries/use-update-zendesk-user-fields.ts
@@ -21,7 +21,7 @@ export function useUpdateZendeskUserFieldsMutation() {
 			  } )
 			: apiFetch( {
 					global: true,
-					path: '/help-center/ticket/new',
+					path: '/help-center/zendesk/user-fields',
 					method: 'POST',
 					data: { fields: userFields },
 			  } as APIFetchOptions );


### PR DESCRIPTION
Related to #77024
While working on #77024, I forgot to update the endpoint in ETK when we're not in the WPCOM env.

## Proposed Changes

* Make sure to pass the userfields to correct endpoint

## Testing Instructions

Get the ETK artifact and install on your Atomic site. Make sure that when the Zendesk widget appears, the `/help-center/zendesk/user-fields` endpoint is successfully called.