### PR TITLE
Agency dashboard multiple emails add beta tag

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -254,7 +254,9 @@ export default function NotificationSettings( {
 								<div className="notification-settings__content-heading">
 									{ translate( 'Email' ) }
 								</div>
-								<div className="notification-settings__beta-tag">{ translate( 'BETA' ) }</div>
+								{ isMultipleEmailEnabled && (
+									<div className="notification-settings__beta-tag">{ translate( 'BETA' ) }</div>
+								) }
 							</div>
 							{ isMultipleEmailEnabled ? (
 								<>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -250,7 +250,12 @@ export default function NotificationSettings( {
 							/>
 						</div>
 						<div className="notification-settings__toggle-content">
-							<div className="notification-settings__content-heading">{ translate( 'Email' ) }</div>
+							<div className="notification-settings__content-heading-with-beta">
+								<div className="notification-settings__content-heading">
+									{ translate( 'Email' ) }
+								</div>
+								<div className="notification-settings__beta-tag">{ translate( 'BETA' ) }</div>
+							</div>
 							{ isMultipleEmailEnabled ? (
 								<>
 									<div className="notification-settings__content-sub-heading">

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
@@ -1,19 +1,20 @@
-@import "@wordpress/base-styles/mixins";
-@import "@wordpress/base-styles/breakpoints";
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
 
 @keyframes components-modal__appear-animation {
 	from {
-		transform: translateY(32px);
+		transform: translateY( 32px );
 	}
+
 	to {
-		transform: translateY(0);
+		transform: translateY( 0 );
 	}
 }
 
 .notification-settings-title-light {
 	font-size: 0.75rem;
 	line-height: 14px;
-	color: var(--studio-gray-50);
+	color: var( --studio-gray-50 );
 }
 
 .notification-settings__sub-title {
@@ -29,18 +30,18 @@
 .notification-settings__content-heading-with-beta {
 	display: flex;
 	align-items: center;
-	gap: 5px;
+	gap: 8px;
 }
 
 .notification-settings__beta-tag {
-	background: #8c8f94;
+	background: var( --studio-gray-30 );
 	border-radius: 4px;
 	font-style: normal;
 	font-weight: 700;
 	font-size: 0.75rem;
 	line-height: 17px;
 	display: flex;
-	color: #fff;
+	color: var( --studio-white );
 	padding: 0 5px;
 	margin-block-end: 8px;
 }
@@ -66,7 +67,7 @@
 
 .notification-settings__footer {
 	margin-block-end: 32px;
-	width: calc(100% - 64px); // reducing the left and right padding
+	width: calc( 100% - 64px ); // reducing the left and right padding
 	display: flex;
 	justify-content: flex-start;
 	flex-direction: column;
@@ -82,7 +83,7 @@
 		height: 36px;
 		line-height: 18px;
 
-		&:nth-child(2) {
+		&:nth-child( 2 ) {
 			margin-block-start: 16px;
 		}
 	}
@@ -102,7 +103,7 @@
 		}
 
 		button {
-			&:nth-child(2) {
+			&:nth-child( 2 ) {
 				margin-inline-start: 12px;
 				margin-block-start: 0;
 			}
@@ -188,13 +189,13 @@
 
 .notification-settings__footer-validation-error {
 	@extend .notification-settings-title-light;
-	color: var(--color-scary-40);
+	color: var( --color-scary-40 );
 	margin-block-end: 16px;
 }
 
 .notification-settings__warning {
 	font-weight: 500;
-	color: var(--color-scary-40);
+	color: var( --color-scary-40 );
 	padding: 10px 0;
 
 	.gridicon {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
@@ -26,6 +26,25 @@
 	margin-block-start: -16px;
 }
 
+.notification-settings__content-heading-with-beta {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+}
+
+.notification-settings__beta-tag {
+	background: #8c8f94;
+	border-radius: 4px;
+	font-style: normal;
+	font-weight: 700;
+	font-size: 0.6rem;
+	line-height: 17px;
+	display: flex;
+	color: #fff;
+	padding: 0 5px;
+	margin-block-end: 8px;
+}
+
 .notification-settings__content-heading {
 	font-size: 0.875rem;
 	line-height: 17px;
@@ -89,7 +108,6 @@
 			}
 		}
 	}
-
 }
 
 .select-dropdown .select-dropdown__container {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
@@ -37,7 +37,7 @@
 	border-radius: 4px;
 	font-style: normal;
 	font-weight: 700;
-	font-size: 0.6rem;
+	font-size: 0.75rem;
 	line-height: 17px;
 	display: flex;
 	color: #fff;

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
@@ -1,20 +1,20 @@
-@import '@wordpress/base-styles/mixins';
-@import '@wordpress/base-styles/breakpoints';
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
 
 @keyframes components-modal__appear-animation {
 	from {
-		transform: translateY( 32px );
+		transform: translateY(32px);
 	}
 
 	to {
-		transform: translateY( 0 );
+		transform: translateY(0);
 	}
 }
 
 .notification-settings-title-light {
 	font-size: 0.75rem;
 	line-height: 14px;
-	color: var( --studio-gray-50 );
+	color: var(--studio-gray-50);
 }
 
 .notification-settings__sub-title {
@@ -34,14 +34,14 @@
 }
 
 .notification-settings__beta-tag {
-	background: var( --studio-gray-30 );
+	background: var(--studio-gray-30);
 	border-radius: 4px;
 	font-style: normal;
 	font-weight: 700;
 	font-size: 0.75rem;
 	line-height: 17px;
 	display: flex;
-	color: var( --studio-white );
+	color: var(--studio-white);
 	padding: 0 5px;
 	margin-block-end: 8px;
 }
@@ -67,7 +67,7 @@
 
 .notification-settings__footer {
 	margin-block-end: 32px;
-	width: calc( 100% - 64px ); // reducing the left and right padding
+	width: calc(100% - 64px); // reducing the left and right padding
 	display: flex;
 	justify-content: flex-start;
 	flex-direction: column;
@@ -83,7 +83,7 @@
 		height: 36px;
 		line-height: 18px;
 
-		&:nth-child( 2 ) {
+		&:nth-child(2) {
 			margin-block-start: 16px;
 		}
 	}
@@ -103,7 +103,7 @@
 		}
 
 		button {
-			&:nth-child( 2 ) {
+			&:nth-child(2) {
 				margin-inline-start: 12px;
 				margin-block-start: 0;
 			}
@@ -189,13 +189,13 @@
 
 .notification-settings__footer-validation-error {
 	@extend .notification-settings-title-light;
-	color: var( --color-scary-40 );
+	color: var(--color-scary-40);
 	margin-block-end: 16px;
 }
 
 .notification-settings__warning {
 	font-weight: 500;
-	color: var( --color-scary-40 );
+	color: var(--color-scary-40);
 	padding: 10px 0;
 
 	.gridicon {


### PR DESCRIPTION
Related to # 1204408201748644-as-1204610622637455/f

## Proposed Changes

* add a beta badge to email settings

![Screenshot 2023-05-19 at 10 09 13 AM](https://github.com/Automattic/wp-calypso/assets/12895386/83f4766a-90f8-4657-8c0f-01d8ab07f311)


## Testing Instructions

* Use Jetpack Cloud live link or spin up this PR locally and visit /dashboard
* Click the clock icon next to notifications to bring up the settings modal
* Ensure there is a beta badge

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?