### PR TITLE
Update the sale banner text

### DIFF
--- a/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
@@ -66,6 +66,7 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 								'Take %(discount)d%% off new annual Jetpack Security and Complete purchases.',
 								{
 									args: { discount: coupon.final_discount },
+									comment: '%(discount)d%% is discount amount in percentage, e.g. 65%',
 								}
 							) }
 						</div>

--- a/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
@@ -62,9 +62,12 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 						<div>
 							<b>{ saleTitle }</b>
 							&nbsp;
-							{ translate( 'Take %(discount)d%% off all new annual Jetpack purchases.', {
-								args: { discount: coupon.final_discount },
-							} ) }
+							{ translate(
+								'Take %(discount)d%% off new annual Jetpack Security and Complete purchases.',
+								{
+									args: { discount: coupon.final_discount },
+								}
+							) }
 						</div>
 						<span className="sale-banner__countdown-timer">
 							{ translate( 'Sale ends in: %(days)dd %(hours)dh %(minutes)dm %(seconds)ss', {


### PR DESCRIPTION
Updating the sale banner for 2023 spring sale


Related to pbNhbs-6sr-p2#comment-15495 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?