### PR TITLE
Jetpack Pro Licensing: Add warning to Prices page when A12s are viewing

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -1,3 +1,4 @@
+import { Card } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
@@ -9,6 +10,7 @@ import LicenseBundleCardDescription from 'calypso/jetpack-cloud/sections/partner
 import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 
 import './style.scss';
@@ -18,6 +20,7 @@ export default function Prices() {
 	const { data: agencyProducts } = useProductsQuery();
 	const userProducts = useSelector( ( state ) => getProductsList( state ) );
 	const currencyFormatOptions = { stripZeros: true };
+	const partner = useSelector( getCurrentPartner );
 
 	const productRows = agencyProducts?.map( ( product ) => {
 		const userYearlyProduct = Object.values( userProducts ).find(
@@ -124,6 +127,14 @@ export default function Prices() {
 					) }
 				</p>
 			</div>
+
+			{ partner.warn_bad_agency_pricing && (
+				<Card highlight="error">
+					<CardHeading size={ 24 }>
+						{ translate( 'WARNING: This pricing may be incorrect for Automatticians.' ) }
+					</CardHeading>
+				</Card>
+			) }
 
 			<table className="prices__table">
 				<thead>

--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -128,7 +128,7 @@ export default function Prices() {
 				</p>
 			</div>
 
-			{ partner.warn_bad_agency_pricing && (
+			{ partner?.warn_bad_agency_pricing && (
 				<Card highlight="error">
 					<CardHeading size={ 24 }>
 						{ translate( 'WARNING: This pricing may be incorrect for Automatticians.' ) }

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -79,6 +79,7 @@ export interface APIPartner {
 	tos: string;
 	partner_type: string;
 	has_valid_payment_method: boolean;
+	warn_bad_agency_pricing: boolean;
 }
 
 // The API-returned license object is not quite consistent right now so we only define the properties we actively rely on.
@@ -191,6 +192,7 @@ export interface Partner {
 	tos: string;
 	partner_type: string;
 	has_valid_payment_method: boolean;
+	warn_bad_agency_pricing: boolean;
 }
 
 export interface PartnerStore {


### PR DESCRIPTION
## Proposed Changes

* Pricing in the Jetpack Pro Dashboard can be incorrect depending on the billing scheme set for the user viewing the portal. For A12s, who are configured in a variety of ways depending on their partner and agency relationships, this means that they're almost always seeing different prices than our actual agency customers. This PR adds a warning based on a new APIPartner property that is introduced in code-D111396.

## Testing Instructions

* Test with code-D111396 and logged in as an A11n you should see the following warning on the prices page:
![Screen Shot 2023-05-19 at 10 30 27 AM](https://github.com/Automattic/wp-calypso/assets/5528445/d73db796-80c7-4af7-891a-541f6441a2f1)
* Please also test under an agency account that is not associated with an A11n account, and ensure that the message does not appear in this context.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
