### PR TITLE
React Query in the Help Center: fix infinite loading of chat availability

### DIFF
--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -11,10 +11,10 @@ type Result = {
 
 export function useShouldRenderChatOption(): Result {
 	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
-	const { data, isLoading: isLoadingAvailability } = useMessagingAvailability(
+	const { data, isInitialLoading: isLoadingAvailability } = useMessagingAvailability(
 		Boolean( chatStatus?.is_user_eligible )
 	);
-	const { data: supportActivity, isLoading: isLoadingSupportActivity } = useSupportActivity(
+	const { data: supportActivity, isInitialLoading: isLoadingSupportActivity } = useSupportActivity(
 		Boolean( chatStatus?.is_user_eligible )
 	);
 


### PR DESCRIPTION
React Query returns `isLoading: true` for disabled queries 🤯 , and we disable chat availability query for users who are not eligible. This means the availability query will "load" forever. 

This fixes it by using `isInitialLoading` instead.

Related: https://github.com/TanStack/query/issues/3584
Similar fix: https://github.com/Automattic/wp-calypso/pull/76593

### Testing
1. Using a user who is eligible for email support, but not chat support, 
2. Open the Help Center.
3. Contact options should appear when clicking "Still need help?"