### PR TITLE
Blog onboarding: Hide Masterbar on mobile, "Move to trash" button, and schedule post date/time picker

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/editor.scss
+++ b/apps/wpcom-block-editor/src/wpcom/editor.scss
@@ -6,8 +6,7 @@
 	.launchpad__save-modal, // "Great progress" modal popup after publishing a post. Used in other flows.
 	.edit-post-post-schedule, // Schedule post in sidebar.
 	.block-editor-publish-date-time-picker, // Schedule post date/time picker panel in publish confirmation panel.
-	#wpadminbar // Masterbar on mobile.
-	{
+	#wpadminbar { // Masterbar on mobile.
 		display: none !important;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/editor.scss
+++ b/apps/wpcom-block-editor/src/wpcom/editor.scss
@@ -1,10 +1,19 @@
 @import "./features/use-classic-block-guide";
 
 .start-writing-hide {
-	.components-external-link,
-	.edit-post-post-schedule,
-	.components-panel__row:has(.editor-post-trash),
-	.launchpad__save-modal {
+	.components-external-link, // "Connect an account" link in Jetpack sidebar
+	.editor-post-trash, // "Move to trash" button in sidebar.
+	.launchpad__save-modal, // "Great progress" modal popup after publishing a post. Used in other flows.
+	.edit-post-post-schedule, // Schedule post in sidebar.
+	.block-editor-publish-date-time-picker, // Schedule post date/time picker panel in publish confirmation panel.
+	#wpadminbar // Masterbar on mobile.
+	{
 		display: none !important;
+	}
+
+	// Adjusts elements up after hiding the Masterbar.
+	.interface-interface-skeleton,
+	.edit-post-layout .editor-post-publish-panel {
+		top: 0;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2203

## Proposed Changes

* This PR hides the Masterbar (top navigation bar) on mobile for the start-writing flow and adjust other element up to fill the missing space left by the Masterbar.
* It hides "Move to trash" button in the sidebar
* It hides the date/time picker panel in the publish confirmation panel.
* It also adds descriptive comment to all the elements we're hiding.

Before | After
--|--
![masterbar-before](https://github.com/Automattic/wp-calypso/assets/140841/5b95678a-1ff7-47db-babe-106331d7bf43)  |  ![masterbar-after](https://github.com/Automattic/wp-calypso/assets/140841/203f3c62-5bb1-42f5-b102-4a734075d403)

Before | After
--|--
![trash-before](https://github.com/Automattic/wp-calypso/assets/140841/e0e521d6-0019-4749-ade7-596ac22030d9)   | ![trash-after](https://github.com/Automattic/wp-calypso/assets/140841/7f732527-0890-4755-869a-878877030188)


Before | After
--|--
![publish-before](https://github.com/Automattic/wp-calypso/assets/140841/6c80240e-9098-4907-a7d0-21c4b4610aa1)  | ![publish-after](https://github.com/Automattic/wp-calypso/assets/140841/cdf7a36d-49b1-4f9f-bf2b-01115185245a)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using a new user OR a user without any site, start the flow with [/setup/start-writing](http://calypso.localhost:3000/setup/start-writing).
* You have to sandbox the newly created site + widgets.wp.com.
* You also have to run `yarn dev --sync` on `/apps/wpcom-block-editor`
* Confirm that all the changes above work on mobile
* Confirm that the changes look ok on desktop view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
