### PR TITLE
Atomic: do not dispatch `transfer_complete` Tracks event on the front-end

### DIFF
--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -145,7 +145,7 @@ export default function WPCOMBusinessAT() {
 	const dispatch = useDispatch();
 	const initiateAT = useCallback( () => {
 		setShowDialog( false );
-		dispatch( initiateThemeTransfer( siteId, null, '' ) );
+		dispatch( initiateThemeTransfer( siteId, null, '', '', 'jetpack_product_activation' ) );
 	}, [ dispatch, siteId ] );
 	const trackInitiateAT = useTrackCallback( initiateAT, 'calypso_jetpack_backup_business_at' );
 

--- a/client/my-sites/hosting/hosting-activate.js
+++ b/client/my-sites/hosting/hosting-activate.js
@@ -5,14 +5,14 @@ import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import HeaderCake from 'calypso/components/header-cake';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { initiateThemeTransfer } from 'calypso/state/themes/actions';
+import { initiateAtomicTransfer } from 'calypso/state/atomic/transfers/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const HostingActivate = ( { initiateTransfer, siteId, siteSlug, translate } ) => {
 	const backUrl = `/hosting-config/${ siteSlug }`;
 
 	const transferInitiate = ( { geo_affinity = '' } ) => {
-		initiateTransfer( siteId, null, null, geo_affinity );
+		initiateTransfer( siteId, { geoAffinity: geo_affinity, context: 'hosting' } );
 		page( backUrl );
 	};
 
@@ -46,7 +46,7 @@ const mapStateToProps = ( state ) => {
 };
 
 const mapDispatchToProps = {
-	initiateTransfer: initiateThemeTransfer,
+	initiateTransfer: initiateAtomicTransfer,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( HostingActivate ) );

--- a/client/my-sites/hosting/hosting-activate.js
+++ b/client/my-sites/hosting/hosting-activate.js
@@ -5,14 +5,14 @@ import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import HeaderCake from 'calypso/components/header-cake';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { initiateAtomicTransfer } from 'calypso/state/atomic/transfers/actions';
+import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const HostingActivate = ( { initiateTransfer, siteId, siteSlug, translate } ) => {
 	const backUrl = `/hosting-config/${ siteSlug }`;
 
 	const transferInitiate = ( { geo_affinity = '' } ) => {
-		initiateTransfer( siteId, { geoAffinity: geo_affinity, context: 'hosting' } );
+		initiateTransfer( siteId, null, null, geo_affinity, 'hosting' );
 		page( backUrl );
 	};
 
@@ -46,7 +46,7 @@ const mapStateToProps = ( state ) => {
 };
 
 const mapDispatchToProps = {
-	initiateTransfer: initiateAtomicTransfer,
+	initiateTransfer: initiateThemeTransfer,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( HostingActivate ) );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -216,7 +216,7 @@ const MarketplaceProductInstall = ( {
 					dispatch( initiateAtomicTransfer( siteId, { themeSlug } ) );
 				} else {
 					setAtomicFlow( true );
-					dispatch( initiateTransfer( siteId, null, pluginSlug ) );
+					dispatch( initiateTransfer( siteId, null, pluginSlug, '', 'plugins' ) );
 				}
 
 				triggerInstallFlow();

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -213,10 +213,10 @@ const MarketplaceProductInstall = ( {
 			} else if ( hasAtomicFeature ) {
 				// initialize atomic flow
 				if ( wpOrgTheme ) {
-					dispatch( initiateAtomicTransfer( siteId, { themeSlug, context: 'themes' } ) );
+					dispatch( initiateAtomicTransfer( siteId, { themeSlug, context: 'theme_install' } ) );
 				} else {
 					setAtomicFlow( true );
-					dispatch( initiateTransfer( siteId, null, pluginSlug, '', 'plugins' ) );
+					dispatch( initiateTransfer( siteId, null, pluginSlug, '', 'plugin_install' ) );
 				}
 
 				triggerInstallFlow();

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -213,7 +213,7 @@ const MarketplaceProductInstall = ( {
 			} else if ( hasAtomicFeature ) {
 				// initialize atomic flow
 				if ( wpOrgTheme ) {
-					dispatch( initiateAtomicTransfer( siteId, { themeSlug } ) );
+					dispatch( initiateAtomicTransfer( siteId, { themeSlug, context: 'themes' } ) );
 				} else {
 					setAtomicFlow( true );
 					dispatch( initiateTransfer( siteId, null, pluginSlug, '', 'plugins' ) );

--- a/client/my-sites/plugins/plugin-eligibility/index.jsx
+++ b/client/my-sites/plugins/plugin-eligibility/index.jsx
@@ -30,7 +30,13 @@ class PluginEligibility extends Component {
 
 	pluginTransferInitiate = () => {
 		// Use theme transfer action until we introduce generic ones that will handle both plugins and themes
-		this.props.initiateTransfer( this.props.siteId, null, this.props.pluginSlug, '', 'plugins' );
+		this.props.initiateTransfer(
+			this.props.siteId,
+			null,
+			this.props.pluginSlug,
+			'',
+			'plugin_install'
+		);
 		this.goBack();
 	};
 

--- a/client/my-sites/plugins/plugin-eligibility/index.jsx
+++ b/client/my-sites/plugins/plugin-eligibility/index.jsx
@@ -30,7 +30,7 @@ class PluginEligibility extends Component {
 
 	pluginTransferInitiate = () => {
 		// Use theme transfer action until we introduce generic ones that will handle both plugins and themes
-		this.props.initiateTransfer( this.props.siteId, null, this.props.pluginSlug );
+		this.props.initiateTransfer( this.props.siteId, null, this.props.pluginSlug, '', 'plugins' );
 		this.goBack();
 	};
 

--- a/client/my-sites/themes/atomic-transfer-dialog.tsx
+++ b/client/my-sites/themes/atomic-transfer-dialog.tsx
@@ -92,7 +92,7 @@ class AtomicTransferDialog extends Component< AtomicTransferDialogProps > {
 		const { requestActiveThemeCount } = this.state;
 		this.setState( { requestActiveThemeCount: requestActiveThemeCount + 1 } );
 
-		dispatchInitiateThemeTransfer( siteId, null, '' );
+		dispatchInitiateThemeTransfer( siteId, null, '', '', 'themes' );
 	}
 
 	getAtomicSitePath = () => {

--- a/client/my-sites/themes/atomic-transfer-dialog.tsx
+++ b/client/my-sites/themes/atomic-transfer-dialog.tsx
@@ -92,7 +92,7 @@ class AtomicTransferDialog extends Component< AtomicTransferDialogProps > {
 		const { requestActiveThemeCount } = this.state;
 		this.setState( { requestActiveThemeCount: requestActiveThemeCount + 1 } );
 
-		dispatchInitiateThemeTransfer( siteId, null, '', '', 'themes' );
+		dispatchInitiateThemeTransfer( siteId, null, '', '', 'theme_install' );
 	}
 
 	getAtomicSitePath = () => {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -277,7 +277,7 @@ class Upload extends Component {
 		const uploadAction = ( siteId, file ) =>
 			isJetpack
 				? this.props.uploadTheme( siteId, file )
-				: this.props.initiateThemeTransfer( siteId, file, '', '', 'themes' );
+				: this.props.initiateThemeTransfer( siteId, file, '', '', 'theme_upload' );
 		const isDisabled =
 			! isStandaloneJetpack && ( ! canUploadThemesOrPlugins || ( ! isAtomic && showEligibility ) );
 

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -274,7 +274,10 @@ class Upload extends Component {
 
 		const { showEligibility } = this.state;
 
-		const uploadAction = isJetpack ? this.props.uploadTheme : this.props.initiateThemeTransfer;
+		const uploadAction = ( siteId, file ) =>
+			isJetpack
+				? this.props.uploadTheme( siteId, file )
+				: this.props.initiateThemeTransfer( siteId, file, '', '', '', 'themes' );
 		const isDisabled =
 			! isStandaloneJetpack && ( ! canUploadThemesOrPlugins || ( ! isAtomic && showEligibility ) );
 

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -277,7 +277,7 @@ class Upload extends Component {
 		const uploadAction = ( siteId, file ) =>
 			isJetpack
 				? this.props.uploadTheme( siteId, file )
-				: this.props.initiateThemeTransfer( siteId, file, '', '', '', 'themes' );
+				: this.props.initiateThemeTransfer( siteId, file, '', '', 'themes' );
 		const isDisabled =
 			! isStandaloneJetpack && ( ! canUploadThemesOrPlugins || ( ! isAtomic && showEligibility ) );
 

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -56,7 +56,9 @@ export default function TransferSite( {
 		if ( ! siteId ) {
 			return;
 		}
-		dispatch( initiateAtomicTransfer( siteId, { softwareSet: 'woo-on-plans' } ) );
+		dispatch(
+			initiateAtomicTransfer( siteId, { softwareSet: 'woo-on-plans', context: 'woo-on-plans' } )
+		);
 	}, [ dispatch, siteId ] );
 
 	// Poll for transfer status

--- a/client/state/atomic/transfers/actions.ts
+++ b/client/state/atomic/transfers/actions.ts
@@ -30,6 +30,8 @@ export interface InitiateTransfer {
 	pluginSlug?: string;
 	pluginFile?: File;
 	themeFile?: File;
+	geoAffinity?: string;
+	context?: string;
 }
 
 /**

--- a/client/state/atomic/transfers/actions.ts
+++ b/client/state/atomic/transfers/actions.ts
@@ -30,7 +30,6 @@ export interface InitiateTransfer {
 	pluginSlug?: string;
 	pluginFile?: File;
 	themeFile?: File;
-	geoAffinity?: string;
 	context?: string;
 }
 

--- a/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
@@ -31,7 +31,9 @@ export const mapToRequestBody = ( action ) => {
 		requestBody.plugin_file = action.pluginFile;
 	}
 
-	requestBody.context = action.context ?? 'plugin_upload';
+	if ( action.context ) {
+		requestBody.context = action.context;
+	}
 
 	return requestBody;
 };

--- a/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
@@ -31,13 +31,7 @@ export const mapToRequestBody = ( action ) => {
 		requestBody.plugin_file = action.pluginFile;
 	}
 
-	if ( action.geoAffinity ) {
-		requestBody.geo_affinity = action.geoAffinity;
-	}
-
-	if ( action.context ) {
-		requestBody.context = action.context;
-	}
+	requestBody.context = action.context ?? 'plugin_upload';
 
 	return requestBody;
 };

--- a/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
@@ -31,6 +31,14 @@ export const mapToRequestBody = ( action ) => {
 		requestBody.plugin_file = action.pluginFile;
 	}
 
+	if ( action.geoAffinity ) {
+		requestBody.geo_affinity = action.geoAffinity;
+	}
+
+	if ( action.context ) {
+		requestBody.context = action.context;
+	}
+
 	return requestBody;
 };
 
@@ -40,11 +48,7 @@ const initiateAtomicTransfer = ( action ) =>
 			apiNamespace: 'wpcom/v2',
 			method: 'POST',
 			path: `/sites/${ action.siteId }/atomic/transfers/`,
-			...( action.softwareSet || action.themeSlug
-				? {
-						body: mapToRequestBody( action ),
-				  }
-				: {} ),
+			body: mapToRequestBody( action ),
 		},
 		action
 	);

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -29,7 +29,10 @@ export const initiateTransferWithPluginZip = ( action ) => {
 				method: 'POST',
 				path: `/sites/${ siteId }/automated-transfers/initiate`,
 				apiVersion: '1',
-				formData: [ [ 'plugin_zip', pluginZip ] ],
+				formData: [
+					[ 'plugin_zip', pluginZip ],
+					[ 'context', 'plugin_upload' ],
+				],
 			},
 			action
 		),

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
@@ -40,7 +40,10 @@ describe( 'initiateTransferWithPluginZip', () => {
 					method: 'POST',
 					path: `/sites/${ siteId }/automated-transfers/initiate`,
 					apiVersion: '1',
-					formData: [ [ 'plugin_zip', 'foo' ] ],
+					formData: [
+						[ 'plugin_zip', 'foo' ],
+						[ 'context', 'plugin_upload' ],
+					],
 				},
 				{ siteId, pluginZip: 'foo' }
 			)

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -1,6 +1,5 @@
 import { delay } from 'lodash';
 import { AUTOMATED_TRANSFER_STATUS_REQUEST } from 'calypso/state/action-types';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	fetchAutomatedTransferStatus,
 	setAutomatedTransferStatus,
@@ -23,7 +22,7 @@ export const requestStatus = ( action ) =>
 	);
 
 export const receiveStatus =
-	( { siteId }, { status, uploaded_plugin_slug, transfer_id } ) =>
+	( { siteId }, { status, uploaded_plugin_slug } ) =>
 	( dispatch ) => {
 		const pluginId = uploaded_plugin_slug;
 
@@ -33,14 +32,6 @@ export const receiveStatus =
 		}
 
 		if ( status === transferStates.COMPLETE ) {
-			dispatch(
-				recordTracksEvent( 'calypso_automated_transfer_complete', {
-					context: 'plugin_upload',
-					transfer_id,
-					uploaded_plugin_slug,
-				} )
-			);
-
 			// Update the now-atomic site to ensure plugin page displays correctly.
 			dispatch( requestSite( siteId ) );
 		}

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -1,4 +1,4 @@
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { SITE_REQUEST } from 'calypso/state/action-types';
 import {
 	fetchAutomatedTransferStatus,
 	setAutomatedTransferStatus,
@@ -44,23 +44,21 @@ describe( 'receiveStatus', () => {
 	test( 'should dispatch set status action', () => {
 		const dispatch = jest.fn();
 		receiveStatus( { siteId }, COMPLETE_RESPONSE )( dispatch );
-		expect( dispatch ).toBeCalledTimes( 3 );
+		expect( dispatch ).toBeCalledTimes( 2 );
 		expect( dispatch ).toBeCalledWith(
 			setAutomatedTransferStatus( siteId, 'complete', 'hello-dolly' )
 		);
 	} );
 
-	test( 'should dispatch tracks event if complete', () => {
-		const dispatch = jest.fn();
+	test( 'should refetch the site if complete', () => {
+		const dispatch = jest.fn( ( thunkDispatch ) => {
+			if ( thunkDispatch instanceof Function ) {
+				thunkDispatch( dispatch );
+			}
+		} );
 		receiveStatus( { siteId }, COMPLETE_RESPONSE )( dispatch );
 		expect( dispatch ).toBeCalledTimes( 3 );
-		expect( dispatch ).toBeCalledWith(
-			recordTracksEvent( 'calypso_automated_transfer_complete', {
-				context: 'plugin_upload',
-				transfer_id: 1,
-				uploaded_plugin_slug: 'hello-dolly',
-			} )
-		);
+		expect( dispatch ).toHaveBeenLastCalledWith( { type: SITE_REQUEST, siteId } );
 	} );
 
 	test( 'should request status again if not complete', () => {

--- a/client/state/themes/actions/theme-transfer.js
+++ b/client/state/themes/actions/theme-transfer.js
@@ -92,7 +92,7 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 						themeInitiateSuccessAction
 					)
 				);
-				dispatch( pollThemeTransferStatus( siteId, transfer_id, context ) );
+				dispatch( pollThemeTransferStatus( siteId, transfer_id ) );
 			} )
 			.catch( ( error ) => {
 				dispatch( transferInitiateFailure( siteId, error, plugin, context ) );
@@ -147,18 +147,11 @@ function transferInitiateFailure( siteId, error, plugin, context ) {
  *
  * @param {number} siteId -- the site being transferred
  * @param {number} transferId -- the specific transfer
- * @param {string} context -- from which the transfer was initiated
  * @param {number} [interval] -- time between poll attempts
  * @param {number} [timeout] -- time to wait for 'complete' status before bailing
  * @returns {Promise} for testing purposes only
  */
-export function pollThemeTransferStatus(
-	siteId,
-	transferId,
-	context,
-	interval = 3000,
-	timeout = 180000
-) {
+export function pollThemeTransferStatus( siteId, transferId, interval = 3000, timeout = 180000 ) {
 	const endTime = Date.now() + timeout;
 	return ( dispatch ) => {
 		const pollStatus = ( resolve, reject ) => {
@@ -173,12 +166,6 @@ export function pollThemeTransferStatus(
 					dispatch( transferStatus( siteId, transferId, status, message, uploaded_theme_slug ) );
 					if ( status === 'complete' ) {
 						// finished, stop polling
-						dispatch(
-							recordTracksEvent( 'calypso_automated_transfer_complete', {
-								transfer_id: transferId,
-								context,
-							} )
-						);
 						return resolve();
 					}
 					// poll again

--- a/client/state/themes/actions/theme-transfer.js
+++ b/client/state/themes/actions/theme-transfer.js
@@ -61,13 +61,7 @@ function initiateTransfer( siteId, plugin, theme, geoAffinity, context, onProgre
  * @param {string} context -- place where this function is being called (e.g. hosting configuration, theme/plugin upload)
  * @returns {Promise} for testing purposes only
  */
-export function initiateThemeTransfer(
-	siteId,
-	file,
-	plugin,
-	geoAffinity = '',
-	context = plugin ? 'plugins' : 'themes'
-) {
+export function initiateThemeTransfer( siteId, file, plugin, geoAffinity = '', context ) {
 	return ( dispatch ) => {
 		const themeInitiateRequest = {
 			type: THEME_TRANSFER_INITIATE_REQUEST,

--- a/client/state/themes/actions/theme-transfer.js
+++ b/client/state/themes/actions/theme-transfer.js
@@ -12,7 +12,7 @@ import {
 
 import 'calypso/state/themes/init';
 
-function initiateTransfer( siteId, plugin, theme, geoAffinity, onProgress ) {
+function initiateTransfer( siteId, plugin, theme, onProgress ) {
 	return new Promise( ( resolve, rejectPromise ) => {
 		const resolver = ( error, data ) => {
 			error ? rejectPromise( error ) : resolve( data );
@@ -32,13 +32,6 @@ function initiateTransfer( siteId, plugin, theme, geoAffinity, onProgress ) {
 			post.formData = [ [ 'theme', theme ] ];
 		}
 
-		if ( geoAffinity ) {
-			post.body = {
-				...post.body,
-				geo_affinity: geoAffinity,
-			};
-		}
-
 		const req = wpcom.req.post( post, resolver );
 		req && ( req.upload.onprogress = onProgress );
 	} );
@@ -50,14 +43,10 @@ function initiateTransfer( siteId, plugin, theme, geoAffinity, onProgress ) {
  * @param {number} siteId -- the site to transfer
  * @param {window.File} file -- theme zip to upload
  * @param {string} plugin -- plugin slug
- * @param {string} geoAffinity -- geographic affinity for the new site
  * @returns {Promise} for testing purposes only
  */
-export function initiateThemeTransfer( siteId, file, plugin, geoAffinity = '' ) {
-	let context = plugin ? 'plugins' : 'themes';
-	if ( ! plugin && ! file ) {
-		context = 'hosting';
-	}
+export function initiateThemeTransfer( siteId, file, plugin ) {
+	const context = plugin ? 'plugins' : 'themes';
 
 	return ( dispatch ) => {
 		const themeInitiateRequest = {
@@ -71,7 +60,7 @@ export function initiateThemeTransfer( siteId, file, plugin, geoAffinity = '' ) 
 				themeInitiateRequest
 			)
 		);
-		return initiateTransfer( siteId, plugin, file, geoAffinity, ( event ) => {
+		return initiateTransfer( siteId, plugin, file, ( event ) => {
 			dispatch( {
 				type: THEME_TRANSFER_INITIATE_PROGRESS,
 				siteId,

--- a/client/state/themes/actions/theme-transfer.js
+++ b/client/state/themes/actions/theme-transfer.js
@@ -12,7 +12,7 @@ import {
 
 import 'calypso/state/themes/init';
 
-function initiateTransfer( siteId, plugin, theme, context, onProgress ) {
+function initiateTransfer( siteId, plugin, theme, geoAffinity, context, onProgress ) {
 	return new Promise( ( resolve, rejectPromise ) => {
 		const resolver = ( error, data ) => {
 			error ? rejectPromise( error ) : resolve( data );
@@ -30,6 +30,13 @@ function initiateTransfer( siteId, plugin, theme, context, onProgress ) {
 		}
 		if ( theme ) {
 			post.formData = [ [ 'theme', theme ] ];
+		}
+
+		if ( geoAffinity ) {
+			post.body = {
+				...post.body,
+				geo_affinity: geoAffinity,
+			};
 		}
 
 		if ( context ) {
@@ -50,11 +57,17 @@ function initiateTransfer( siteId, plugin, theme, context, onProgress ) {
  * @param {number} siteId -- the site to transfer
  * @param {window.File} file -- theme zip to upload
  * @param {string} plugin -- plugin slug
+ * @param {string} geoAffinity -- geographic affinity for the new site
+ * @param {string} context -- place where this function is being called (e.g. hosting configuration, theme/plugin upload)
  * @returns {Promise} for testing purposes only
  */
-export function initiateThemeTransfer( siteId, file, plugin ) {
-	const context = plugin ? 'plugins' : 'themes';
-
+export function initiateThemeTransfer(
+	siteId,
+	file,
+	plugin,
+	geoAffinity = '',
+	context = plugin ? 'plugins' : 'themes'
+) {
 	return ( dispatch ) => {
 		const themeInitiateRequest = {
 			type: THEME_TRANSFER_INITIATE_REQUEST,
@@ -67,7 +80,7 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 				themeInitiateRequest
 			)
 		);
-		return initiateTransfer( siteId, plugin, file, context, ( event ) => {
+		return initiateTransfer( siteId, plugin, file, geoAffinity, context, ( event ) => {
 			dispatch( {
 				type: THEME_TRANSFER_INITIATE_PROGRESS,
 				siteId,

--- a/client/state/themes/actions/theme-transfer.js
+++ b/client/state/themes/actions/theme-transfer.js
@@ -12,7 +12,7 @@ import {
 
 import 'calypso/state/themes/init';
 
-function initiateTransfer( siteId, plugin, theme, onProgress ) {
+function initiateTransfer( siteId, plugin, theme, context, onProgress ) {
 	return new Promise( ( resolve, rejectPromise ) => {
 		const resolver = ( error, data ) => {
 			error ? rejectPromise( error ) : resolve( data );
@@ -30,6 +30,13 @@ function initiateTransfer( siteId, plugin, theme, onProgress ) {
 		}
 		if ( theme ) {
 			post.formData = [ [ 'theme', theme ] ];
+		}
+
+		if ( context ) {
+			post.body = {
+				...post.body,
+				context,
+			};
 		}
 
 		const req = wpcom.req.post( post, resolver );
@@ -60,7 +67,7 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 				themeInitiateRequest
 			)
 		);
-		return initiateTransfer( siteId, plugin, file, ( event ) => {
+		return initiateTransfer( siteId, plugin, file, context, ( event ) => {
 			dispatch( {
 				type: THEME_TRANSFER_INITIATE_PROGRESS,
 				siteId,

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -971,8 +971,7 @@ describe( 'actions', () => {
 		test( 'should dispatch success on status complete', () => {
 			return pollThemeTransferStatus(
 				siteId,
-				1,
-				'themes'
+				1
 			)( spy ).then( () => {
 				expect( spy ).toBeCalledWith( {
 					type: THEME_TRANSFER_STATUS_RECEIVE,
@@ -989,7 +988,6 @@ describe( 'actions', () => {
 			return pollThemeTransferStatus(
 				siteId,
 				2,
-				'themes',
 				10,
 				25
 			)( spy ).then( () => {
@@ -1003,9 +1001,9 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch status update', async () => {
-			await pollThemeTransferStatus( siteId, 3, 'themes', 20 )( spy );
+			await pollThemeTransferStatus( siteId, 3, 20 )( spy );
 			// Two 'progress' then a 'complete'
-			expect( spy ).toBeCalledTimes( 4 );
+			expect( spy ).toBeCalledTimes( 3 );
 			expect( spy ).toBeCalledWith( {
 				type: THEME_TRANSFER_STATUS_RECEIVE,
 				siteId: siteId,
@@ -1025,7 +1023,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch failure on receipt of error', async () => {
-			await pollThemeTransferStatus( siteId, 4, 'themes' )( spy );
+			await pollThemeTransferStatus( siteId, 4 )( spy );
 			expect( spy ).toBeCalledWith(
 				expect.objectContaining( {
 					type: THEME_TRANSFER_STATUS_FAILURE,

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -611,9 +611,14 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 					? {
 							body: {
 								software_set: encodeURIComponent( softwareSet ),
+								context: softwareSet,
 							},
 					  }
-					: {} ),
+					: {
+							body: {
+								context: 'unknown',
+							},
+					  } ),
 			} );
 			yield atomicTransferSuccess( siteId, softwareSet );
 		} catch ( _ ) {

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -210,7 +210,7 @@ describe( 'Site Actions', () => {
 					apiNamespace: 'wpcom/v2',
 					method: 'POST',
 					path: `/sites/${ siteId }/atomic/transfers`,
-					body: { software_set: softwareSet },
+					body: { software_set: softwareSet, context: 'woo-on-plans' },
 				},
 				type: 'WPCOM_REQUEST',
 			};
@@ -242,7 +242,7 @@ describe( 'Site Actions', () => {
 					apiNamespace: 'wpcom/v2',
 					method: 'POST',
 					path: `/sites/${ siteId }/atomic/transfers`,
-					body: { software_set: softwareSet },
+					body: { software_set: softwareSet, context: 'woo-on-plans' },
 				},
 				type: 'WPCOM_REQUEST',
 			};


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/77112.

## Proposed Changes

This PR decouples the Atomic transfer status fetching from the transfer complete event dispatching. The event (`atomic_transfer_complete`) is now going to be dispatched from the back-end after the transfer is completed. Check D111446-code.

Because of that, we now need to provide the `context` (i.e. why this transfer was initiated) to transfer initiate endpoint calls.

## Testing Instructions

1. Apply D111446-code to your sandbox and proxy `public-api.wordpress.com`;
2. Checkout this branch;
3. Open the dev tools and click the Network tab...

### Activation through the /hosting-config page

1. Pick a simple site on the Business plan and browse `/hosting-config/%s`;
2. Activate the Business features and check that the call to `/sites/%s/automated-transfers/initiate` includes `context: 'hosting'` in its payload;
3. Follow the instructions on `D111446-code` to check the `atomic_transfer_complete` event being dispatched with the `context` property correctly set.

### Activation through a plugin installation

1. Pick another simple site on the Business plan and browse `/plugins/%s`;
2. Install a plugin and check that the call to `/sites/%s/automated-transfers/initiate` includes `context: 'plugins'` in its payload;
4. Follow the instructions on `D111446-code` to check the `atomic_transfer_complete` event being dispatched with the `context` property correctly set.

### Activation through a theme installation

1. Pick another simple site on the Business plan and browse `/themes/%s`;
2. Install a theme and check that the call to `/sites/%s/automated-transfers/initiate` includes `context: 'themes'` in its payload;
3. Follow the instructions on `D111446-code` to check the `atomic_transfer_complete` event being dispatched with the `context` property correctly set.

### Activation through installing a theme with a software set

1. Create a Business site;
2. Pick a theme that includes WooCommerce (e.g. "Tazza"). Searching for "woocommerce" will bring you the themes;
3. Activate the theme, and proceed with the installation. You'll be redirected to the `/setup/plugin-bundle` flow;
4. Fill in the information, and in the last step, you'll be asked to transfer to Atomic;
5. Open dev tools > Network tab, and check that the call to `/sites/%s/atomic/transfers/` includes `context: 'woo-on-plans'` in its payload;
6. Follow the instructions on `D111446-code` to check the `atomic_transfer_complete` event being dispatched with the `context` property correctly set.