### PR TITLE
Import focused flow: Site picker: create and select site implementation

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -1,3 +1,5 @@
 export const WRITE_INTENT_DEFAULT_DESIGN = {
 	theme: 'livro',
 };
+
+export const SITE_PICKER_FILTER_CONFIG = [ 'wpcom', 'atomic' ];

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -168,16 +168,26 @@ const importFlow: Flow = {
 				}
 
 				case 'sitePicker': {
-					const newQueryParams =
-						( providedDependencies?.queryParams as { [ key: string ]: string } ) || {};
+					switch ( providedDependencies?.action ) {
+						case 'update-query': {
+							const newQueryParams =
+								( providedDependencies?.queryParams as { [ key: string ]: string } ) || {};
 
-					Object.keys( newQueryParams ).forEach( ( key ) => {
-						newQueryParams[ key ]
-							? urlQueryParams.set( key, newQueryParams[ key ] )
-							: urlQueryParams.delete( key );
-					} );
+							Object.keys( newQueryParams ).forEach( ( key ) => {
+								newQueryParams[ key ]
+									? urlQueryParams.set( key, newQueryParams[ key ] )
+									: urlQueryParams.delete( key );
+							} );
 
-					return navigate( `sitePicker?${ urlQueryParams.toString() }` );
+							return navigate( `sitePicker?${ urlQueryParams.toString() }` );
+						}
+
+						case 'create-site':
+							return navigate( `migrationHandler` );
+
+						case 'select-site':
+							break;
+					}
 				}
 			}
 		};

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -82,7 +82,7 @@ const importFlow: Flow = {
 
 		const handleMigrationRedirects = ( providedDependencies: ProvidedDependencies = {} ) => {
 			const from = urlQueryParams.get( 'from' );
-			// If there's any errors, we redirct them to the siteCreationStep for a clean start
+			// If there's any errors, we redirect them to the siteCreationStep for a clean start
 			if ( providedDependencies?.hasError ) {
 				return navigate( 'siteCreationStep' );
 			}

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -186,6 +186,7 @@ const importFlow: Flow = {
 							return navigate( `migrationHandler` );
 
 						case 'select-site':
+							// console.log( 'select-site', providedDependencies.site );
 							break;
 					}
 				}

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -61,8 +61,8 @@ const importFlow: Flow = {
 		const { data: sites } = useSiteExcerptsQuery( SITE_PICKER_FILTER_CONFIG );
 		const { addTempSiteToSourceOption } = useAddTempSiteToSourceOptionMutation();
 		const urlQueryParams = useQuery();
-		const from = urlQueryParams.get( 'from' );
-		const { data: sourceSite } = useSiteQuery( from as string );
+		const fromParam = urlQueryParams.get( 'from' );
+		const { data: sourceSite } = useSiteQuery( fromParam as string );
 		const siteSlugParam = useSiteSlugParam();
 		const selectedDesign = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
@@ -107,7 +107,7 @@ const importFlow: Flow = {
 			}
 			// For those who hasn't paid or in the middle of the migration process, we sent them to the importerWordPress step
 			return navigate(
-				`importerWordpress?siteSlug=${ providedDependencies?.targetBlogSlug }&from=${ from }&option=everything`
+				`importerWordpress?siteSlug=${ providedDependencies?.targetBlogSlug }&from=${ fromParam }&option=everything`
 			);
 		};
 
@@ -160,9 +160,11 @@ const importFlow: Flow = {
 
 				case 'processing': {
 					if ( providedDependencies?.siteSlug ) {
-						return ! from
+						return ! fromParam
 							? navigate( `import?siteSlug=${ providedDependencies?.siteSlug }` )
-							: navigate( `import?siteSlug=${ providedDependencies?.siteSlug }&from=${ from }` );
+							: navigate(
+									`import?siteSlug=${ providedDependencies?.siteSlug }&from=${ fromParam }`
+							  );
 					}
 					// End of Pattern Assembler flow
 					if ( isBlankCanvasDesign( selectedDesign ) ) {
@@ -193,7 +195,7 @@ const importFlow: Flow = {
 						case 'select-site': {
 							const selectedSite = providedDependencies.site as SiteExcerptData;
 
-							if ( selectedSite && from ) {
+							if ( selectedSite && sourceSite ) {
 								// Store temporary target blog id to source site option
 								selectedSite &&
 									sourceSite &&

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -25,6 +25,7 @@ import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import SitePickerStep from './internals/steps-repository/site-picker';
 import { Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect } from '@automattic/data-stores';
+import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 const importFlow: Flow = {
 	name: IMPORT_FOCUSED_FLOW,
@@ -182,12 +183,20 @@ const importFlow: Flow = {
 							return navigate( `sitePicker?${ urlQueryParams.toString() }` );
 						}
 
-						case 'create-site':
-							return navigate( `migrationHandler` );
+						case 'select-site': {
+							const selectedSite = providedDependencies.site as SiteExcerptData;
 
-						case 'select-site':
-							// console.log( 'select-site', providedDependencies.site );
-							break;
+							if ( selectedSite ) {
+								urlQueryParams.set( 'siteSlug', selectedSite.slug );
+								urlQueryParams.set( 'option', 'everything' );
+
+								return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
+							}
+						}
+
+						case 'create-site':
+						default:
+							return navigate( `migrationHandler` );
 					}
 				}
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -50,7 +50,7 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 						page={ page }
 						search={ search }
 						status={ status }
-						onCreateSiteClick={ createNewSite }
+						onCreateSite={ createNewSite }
 						onSelectSite={ selectSite }
 						onQueryParamChange={ onQueryParamChange }
 					/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -3,6 +3,7 @@ import {
 	DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE,
 	GroupableSiteLaunchStatuses,
 } from '@automattic/sites';
+import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -14,7 +15,8 @@ import type { Step } from '../../types';
 import './styles.scss';
 
 const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
-	const headerText = 'Pick your destination';
+	const { __ } = useI18n();
+	const headerText = __( 'Pick your destination' );
 	const page = Number( useQuery().get( 'page' ) ) || 1;
 	const search = useQuery().get( 'search' ) || '';
 	const status =
@@ -22,7 +24,11 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 		DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE;
 
 	const onQueryParamChange = ( params: Partial< SitesDashboardQueryParams > ) => {
-		navigation.submit?.( { queryParams: params } );
+		navigation.submit?.( { action: 'update-query', queryParams: params } );
+	};
+
+	const createNewSite = () => {
+		navigation.submit?.( { action: 'create-site' } );
 	};
 
 	return (
@@ -30,13 +36,16 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 			<DocumentHead title={ headerText } />
 			<StepContainer
 				stepName="site-picker"
-				hideSkip={ true }
 				hideBack={ true }
+				hideSkip={ false }
+				skipLabelText={ __( 'Skip and create a new site' ) }
+				goNext={ createNewSite }
 				stepContent={
 					<SitePicker
 						page={ page }
 						search={ search }
 						status={ status }
+						onCreateSiteClick={ createNewSite }
 						onQueryParamChange={ onQueryParamChange }
 					/>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -21,9 +21,6 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 		( useQuery().get( 'status' ) as GroupableSiteLaunchStatuses ) ||
 		DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE;
 
-	const goBack = () => {
-		// Go back logic goes here
-	};
 	const onQueryParamChange = ( params: Partial< SitesDashboardQueryParams > ) => {
 		navigation.submit?.( { queryParams: params } );
 	};
@@ -34,7 +31,7 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 			<StepContainer
 				stepName="site-picker"
 				hideSkip={ true }
-				goBack={ goBack }
+				hideBack={ true }
 				stepContent={
 					<SitePicker
 						page={ page }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -17,7 +17,6 @@ import './styles.scss';
 
 const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 	const { __ } = useI18n();
-	const headerText = __( 'Pick your destination' );
 	const page = Number( useQuery().get( 'page' ) ) || 1;
 	const search = useQuery().get( 'search' ) || '';
 	const status =
@@ -38,7 +37,7 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 
 	return (
 		<>
-			<DocumentHead title={ headerText } />
+			<DocumentHead title={ __( 'Pick your destination' ) } />
 			<StepContainer
 				stepName="site-picker"
 				hideBack={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -11,6 +11,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { SitesDashboardQueryParams } from 'calypso/sites-dashboard/components/sites-content-controls';
 import SitePicker from './site-picker';
 import type { Step } from '../../types';
+import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 import './styles.scss';
 
@@ -31,6 +32,10 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 		navigation.submit?.( { action: 'create-site' } );
 	};
 
+	const selectSite = ( site: SiteExcerptData ) => {
+		navigation.submit?.( { action: 'select-site', site } );
+	};
+
 	return (
 		<>
 			<DocumentHead title={ headerText } />
@@ -46,6 +51,7 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 						search={ search }
 						status={ status }
 						onCreateSiteClick={ createNewSite }
+						onSelectSite={ selectSite }
 						onQueryParamChange={ onQueryParamChange }
 					/>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -14,6 +14,7 @@ import {
 import { PageBodyBottomContainer } from 'calypso/sites-dashboard/components/sites-dashboard';
 import { SitesGrid } from 'calypso/sites-dashboard/components/sites-grid';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
+import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 const SitesDashboardSitesList = createSitesListComponent();
 const SITE_PICKER_FILTER_CONFIG = [ 'wpcom', 'atomic' ];
@@ -24,11 +25,20 @@ interface Props {
 	search: string;
 	status: GroupableSiteLaunchStatuses;
 	onCreateSiteClick: () => void;
+	onSelectSite: ( site: SiteExcerptData ) => void;
 	onQueryParamChange: ( params: Partial< SitesDashboardQueryParams > ) => void;
 }
 const SitePicker = function SitePicker( props: Props ) {
 	const { __ } = useI18n();
-	const { page, perPage = 96, search, status, onCreateSiteClick, onQueryParamChange } = props;
+	const {
+		page,
+		perPage = 96,
+		search,
+		status,
+		onSelectSite,
+		onCreateSiteClick,
+		onQueryParamChange,
+	} = props;
 	const { sitesSorting, onSitesSortingChange } = useSitesSorting();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery( SITE_PICKER_FILTER_CONFIG );
 
@@ -75,9 +85,7 @@ const SitePicker = function SitePicker( props: Props ) {
 										sites={ paginatedSites }
 										siteSelectorMode={ true }
 										showLinkInBioBanner={ false }
-										onSiteSelectBtnClick={ () => {
-											// console.log( 'onSiteSelectBtnClick', site );
-										} }
+										onSiteSelectBtnClick={ onSelectSite }
 									/>
 									{ ( selectedStatus.hiddenCount > 0 || sites.length > perPage ) && (
 										<PageBodyBottomContainer>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import Pagination from 'calypso/components/pagination';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
+import { SITE_PICKER_FILTER_CONFIG } from 'calypso/landing/stepper/constants';
 import { NoSitesMessage } from 'calypso/sites-dashboard/components/no-sites-message';
 import {
 	SitesContentControls,
@@ -17,7 +18,6 @@ import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 const SitesDashboardSitesList = createSitesListComponent();
-const SITE_PICKER_FILTER_CONFIG = [ 'wpcom', 'atomic' ];
 
 interface Props {
 	page: number;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -1,5 +1,7 @@
 import { SubTitle, Title } from '@automattic/onboarding';
 import { createSitesListComponent, GroupableSiteLaunchStatuses } from '@automattic/sites';
+import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import Pagination from 'calypso/components/pagination';
@@ -21,11 +23,12 @@ interface Props {
 	perPage?: number;
 	search: string;
 	status: GroupableSiteLaunchStatuses;
+	onCreateSiteClick: () => void;
 	onQueryParamChange: ( params: Partial< SitesDashboardQueryParams > ) => void;
 }
 const SitePicker = function SitePicker( props: Props ) {
 	const { __ } = useI18n();
-	const { page, perPage = 96, search, status, onQueryParamChange } = props;
+	const { page, perPage = 96, search, status, onCreateSiteClick, onQueryParamChange } = props;
 	const { sitesSorting, onSitesSortingChange } = useSitesSorting();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery( SITE_PICKER_FILTER_CONFIG );
 
@@ -34,8 +37,13 @@ const SitePicker = function SitePicker( props: Props ) {
 			<div className="site-picker--title">
 				<Title>{ __( 'Pick your destination' ) }</Title>
 				<SubTitle>
-					{ __(
-						'Select the WordPress.com site where you’ll move your old site or create a new one'
+					{ createInterpolateElement(
+						__(
+							'Select the WordPress.com site where you’ll move your old site or <button>create a new one</button>'
+						),
+						{
+							button: <Button onClick={ onCreateSiteClick } />,
+						}
 					) }
 				</SubTitle>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -24,7 +24,7 @@ interface Props {
 	perPage?: number;
 	search: string;
 	status: GroupableSiteLaunchStatuses;
-	onCreateSiteClick: () => void;
+	onCreateSite: () => void;
 	onSelectSite: ( site: SiteExcerptData ) => void;
 	onQueryParamChange: ( params: Partial< SitesDashboardQueryParams > ) => void;
 }
@@ -36,7 +36,7 @@ const SitePicker = function SitePicker( props: Props ) {
 		search,
 		status,
 		onSelectSite,
-		onCreateSiteClick,
+		onCreateSite,
 		onQueryParamChange,
 	} = props;
 	const { sitesSorting, onSitesSortingChange } = useSitesSorting();
@@ -52,7 +52,7 @@ const SitePicker = function SitePicker( props: Props ) {
 							'Select the WordPress.com site where you’ll move your old site or <button>create a new one</button>'
 						),
 						{
-							button: <Button onClick={ onCreateSiteClick } />,
+							button: <Button onClick={ onCreateSite } />,
 						}
 					) }
 				</SubTitle>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
@@ -1,5 +1,12 @@
 .site-picker--container {
 	padding-bottom: rem(28px);
+
+	.onboarding-subtitle button {
+		display: inline-block;
+		text-decoration: underline;
+		font-size: 1rem;
+		padding: 0;
+	}
 }
 
 .site-picker--title {


### PR DESCRIPTION
Related to #76332

## Proposed Changes

* Implemented create new site logic
* Implemented select site logic

## Testing Instructions

**Select a site**
* Go to `/setup/migrationHandler?from={JN_JETPACK_CONNECTED_SITE}`
* Check if there is a new SitePicker step
* Pick a site by pressing the button "Select this site"
* Check if the next step is `importerWordpress` with selected `siteSlug` in the URL
* Close the tab
* Go to `/setup/migrationHandler?from={JN_JETPACK_CONNECTED_SITE}`
* Check if there is `importerWordpress` step rendered

**Create a new site**
* Go to `/setup/import-focused/sitePicker?siteSlug={SITE_SLUG}`
* * Click on the navigation's `Skip and create a new site` link
* Check if the flow goes to the next step with new site created
* Repeat prev steps
* * Click on `create a new site` from the subtitle
* Check if the flow goes to the next step with new site created

## Screenshots
<img width="1234" alt="Screenshot 2023-05-22 at 10 18 27" src="https://github.com/Automattic/wp-calypso/assets/1241413/094fa43d-0515-4c1b-9da3-4f4f42f1d48c">
<img width="501" alt="Screenshot 2023-05-22 at 10 18 51" src="https://github.com/Automattic/wp-calypso/assets/1241413/62081a98-274f-4d11-b6c1-af9dbf69fa3b">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
