### PR TITLE
Fix color contract issues on /home

### DIFF
--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -52,7 +52,7 @@
 	}
 
 	.go-mobile__link-button.button {
-		color: var(--studio-jetpack-green-40);
+		color: var(--studio-jetpack-green-50);
 		margin-top: 0;
 		text-decoration: underline;
 		text-underline-offset: 3px;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -73,11 +73,11 @@
 		}
 
 		.site-setup-list__nav-item-email {
-			color: var(--studio-gray-40);
+			color: var(--color-text-subtle);
 			display: block;
 			@include break-mobile {
+				color: var(--color-text-subtle);
 				font-weight: 400;
-				color: var(--studio-gray-40);
 			}
 		}
 
@@ -263,8 +263,8 @@
 }
 
 .button.is-primary.is-jetpack-branded {
-	background-color: var(--studio-jetpack-green-40);
-	border-color: var(--studio-jetpack-green-40);
+	background-color: var(--studio-jetpack-green-50);
+	border-color: var(--studio-jetpack-green-50);
 
 	&:hover,
 	&:focus {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75593

## Proposed Changes

This PR fixes some accessibility issues on /home.

**Download mobile app** button
| Before | After |
| --- | --- |
| ![Screenshot 2023-05-22 at 10 54 04 AM](https://github.com/Automattic/wp-calypso/assets/797888/0bb2ba53-1be8-4206-9ce9-519b8f2fe5a0)|![Screenshot 2023-05-22 at 10 54 09 AM](https://github.com/Automattic/wp-calypso/assets/797888/f6cd8b2c-755d-4181-946b-8184a003ff51)|

**Get the Jetpack app** link
| Before | After |
| --- | --- |
| ![Screenshot 2023-05-22 at 10 56 09 AM](https://github.com/Automattic/wp-calypso/assets/797888/0fbed5c4-a78b-4a27-aae8-28d21ae62476) |  ![Screenshot 2023-05-22 at 10 56 15 AM](https://github.com/Automattic/wp-calypso/assets/797888/06fec7dc-00dc-443f-8223-faddf487606b) | 

** User email ** text
| Before | After |
| --- | --- |
| ![Screenshot 2023-05-22 at 10 58 27 AM](https://github.com/Automattic/wp-calypso/assets/797888/d1e6df34-7e06-4a15-ab26-25305e9d9007) | ![Screenshot 2023-05-22 at 10 58 42 AM](https://github.com/Automattic/wp-calypso/assets/797888/0bd0bee1-485c-44e4-8508-e25cb79d847e) |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/home`
* Ensure that the contrast of the adjusted elements satisfy accessibility guidelines.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
