### PR TITLE
Fix bug resizing window with absolute positioned sticky panel

### DIFF
--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -153,7 +153,8 @@ class StickyPanelWithIntersectionObserver extends Component {
 			return this.setState( { isSticky: false } );
 		}
 
-		if ( isSticky !== this.state.isSticky ) {
+		const dimensionUpdates = getDimensionUpdates( this.state._ref.current, this.state );
+		if ( isSticky !== this.state.isSticky || dimensionUpdates ) {
 			this.setState( {
 				isSticky,
 				...getDimensions( this.state._ref.current, isSticky ),

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -191,6 +191,8 @@
 	.sticky-panel {
 		position: absolute;
 		right: -12px;
+		// width must be set for resizing when the panel is already sticky
+		width: 16px;
 	}
 	.sticky-panel__content {
 		padding-top: 24px;


### PR DESCRIPTION
Fixes issue raised here https://github.com/Automattic/wp-calypso/pull/77005#issuecomment-1551369419

Basically if you are in a desktop sized window and have the panel in sticky mode, then resize the window to mobile size, the width of the sticky panel was not adjusted and it took up the full width of the screen.

The sticky panel relied on taking the width of the panel from "un-sticky" mode and then not adjusting it again until sticky mode is toggled.

This diff forces the width to be checked on scroll or resize, it also sets the mobile width in css to make sure it is always available.

https://github.com/Automattic/wp-calypso/assets/22446385/5112ee5a-4464-43e2-ad98-82738b173057

### Testing instructions
Go to /tags in a desktop browser
scroll down until "sticky mode" is engaged
resize the window to mobile size.
The panel should be sized correctly.
