### PR TITLE
useStoredPaymentMethods: improve types for query key and the wp.req.get call

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
@@ -9,21 +9,15 @@ export const storedPaymentMethodsQueryKey = 'use-stored-payment-methods';
 
 export type PaymentMethodRequestType = 'card' | 'agreement' | 'all';
 
-const fetchPaymentMethods = ( {
-	type,
-	expired,
-}: {
-	type?: PaymentMethodRequestType;
-	expired?: boolean;
-} ): StoredPaymentMethod[] =>
-	wp.req.get(
-		{
-			path: `/me/payment-methods?type=${ type ?? 'all' }&expired=${
-				expired ? 'include' : 'exclude'
-			}`,
-		},
-		{ apiVersion: '1.2' }
-	);
+const fetchPaymentMethods = (
+	type: PaymentMethodRequestType,
+	expired: boolean
+): StoredPaymentMethod[] =>
+	wp.req.get( '/me/payment-methods', {
+		type,
+		expired: expired ? 'include' : 'exclude',
+		apiVersion: '1.2',
+	} );
 
 const requestPaymentMethodDeletion = ( id: StoredPaymentMethod[ 'stored_details_id' ] ) =>
 	wp.req.post( { path: '/me/stored-cards/' + id + '/delete' } );
@@ -56,9 +50,9 @@ export function withStoredPaymentMethods< P >(
 }
 
 export function useStoredPaymentMethods( {
-	type,
-	expired,
-	isLoggedOut,
+	type = 'all',
+	expired = false,
+	isLoggedOut = false,
 }: {
 	/**
 	 * If there is no logged-in user, we will not try to fetch anything.
@@ -85,7 +79,7 @@ export function useStoredPaymentMethods( {
 
 	const { data, isLoading, error } = useQuery< StoredPaymentMethod[], Error >(
 		queryKey,
-		() => fetchPaymentMethods( { type, expired } ),
+		() => fetchPaymentMethods( type, expired ),
 		{
 			enabled: ! isLoggedOut,
 		}


### PR DESCRIPTION
Looking at the issue with disabled queries and `isLoading` state, I notice the `useStoredPaymentMethods` hook doesn't work very well with the `type` and `expired` default values. They should be defaulted in the `useStoredPaymentMethods` hook, not only in the `fetchPaymentMethods` function. Otherwise we can get different query key values for the same state: the `all` type can be represented as both `"all"` and `undefined` in the key, and `false` expired value as both `false` and `undefined`.

Also I'm improving the `wp.req.get` call by putting the query params to the `query` parameter of `wp.req.get`. If will take care of properly serializing the values and constructing the query string.

@sirbrillig does this look good?
