### PR TITLE
Jetpack Pro Dashboard: save added email addresses to the monitor settings API endpoint

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -200,9 +200,10 @@ export default function EmailAddressEditor( {
 								value={ emailItem.name }
 								disabled={ showCodeVerification }
 								onChange={ handleChange( 'name' ) }
+								aria-describedby={ ! isVerifyAction ? 'name-help-text' : undefined }
 							/>
 							{ ! isVerifyAction && (
-								<div className="configure-email-notification__help-text">
+								<div className="configure-email-notification__help-text" id="name-help-text">
 									{ translate( 'Give this email a nickname for your personal reference' ) }
 								</div>
 							) }
@@ -216,14 +217,15 @@ export default function EmailAddressEditor( {
 								value={ emailItem.email }
 								disabled={ showCodeVerification }
 								onChange={ handleChange( 'email' ) }
+								aria-describedby={ ! isVerifyAction ? 'email-help-text' : undefined }
 							/>
 							{ validationError?.email && (
-								<div className="notification-settings__footer-validation-error">
+								<div className="notification-settings__footer-validation-error" role="alert">
 									{ validationError.email }
 								</div>
 							) }
 							{ ! isVerifyAction && (
-								<div className="configure-email-notification__help-text">
+								<div className="configure-email-notification__help-text" id="email-help-text">
 									{ translate( 'We’ll send a code to verify your email address.' ) }
 								</div>
 							) }
@@ -241,11 +243,11 @@ export default function EmailAddressEditor( {
 									onChange={ handleChange( 'code' ) }
 								/>
 								{ validationError?.code && (
-									<div className="notification-settings__footer-validation-error">
+									<div className="notification-settings__footer-validation-error" role="alert">
 										{ validationError.code }
 									</div>
 								) }
-								<div className="configure-email-notification__help-text">
+								<div className="configure-email-notification__help-text" id="code-help-text">
 									{ translate(
 										'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
 										{

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -97,7 +97,7 @@ export default function NotificationSettings( {
 				emails: extraEmails.map( ( item ) => {
 					return {
 						name: item.name,
-						value: item.email,
+						email_address: item.email,
 						verified: item.verified,
 					};
 				} ),
@@ -128,7 +128,7 @@ export default function NotificationSettings( {
 				let siteEmailItems: Array< MonitorSettingsEmail > = [];
 				if ( settings.monitor_notify_additional_user_emails ) {
 					siteEmailItems = settings.monitor_notify_additional_user_emails.map( ( item ) => ( {
-						email: item.value,
+						email: item.email_address,
 						name: item.name,
 						verified: item.verified,
 					} ) );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -41,6 +41,7 @@ export default function NotificationSettings( {
 	bulkUpdateSettings,
 	isLargeScreen,
 }: Props ) {
+	const isBulkUpdate = !! bulkUpdateSettings;
 	const translate = useTranslate();
 	const { updateMonitorSettings, isLoading, isComplete } = useUpdateMonitorSettings( sites );
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( sites, isLargeScreen );
@@ -128,7 +129,7 @@ export default function NotificationSettings( {
 					verified: true,
 				} ) );
 				let siteEmailItems: Array< MonitorSettingsEmail > = [];
-				if ( settings.monitor_notify_additional_user_emails ) {
+				if ( ! isBulkUpdate && settings.monitor_notify_additional_user_emails ) {
 					siteEmailItems = settings.monitor_notify_additional_user_emails.map( ( item ) => ( {
 						email: item.email_address,
 						name: item.name,
@@ -138,7 +139,7 @@ export default function NotificationSettings( {
 				setAllEmailItems( [ ...userEmailItems, ...siteEmailItems ] );
 			}
 		},
-		[ isMultipleEmailEnabled, translate ]
+		[ isBulkUpdate, isMultipleEmailEnabled, translate ]
 	);
 
 	useEffect( () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -92,7 +92,7 @@ export default function NotificationSettings( {
 			jetmon_defer_status_down_minutes: selectedDuration?.time,
 		} as UpdateMonitorSettingsParams;
 
-		const eventParams = { ...params } as any;
+		const eventParams = { ...params } as any; // Adding eventParams since parameters for tracking events should be flat, not nested.
 
 		if ( isMultipleEmailEnabled ) {
 			const extraEmails = allEmailItems.filter( ( item ) => ! item.isDefault );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -91,6 +91,8 @@ export default function NotificationSettings( {
 			jetmon_defer_status_down_minutes: selectedDuration?.time,
 		} as UpdateMonitorSettingsParams;
 
+		const eventParams = { ...params } as any;
+
 		if ( isMultipleEmailEnabled ) {
 			const extraEmails = allEmailItems.filter( ( item ) => ! item.isDefault );
 			params.contacts = {
@@ -102,9 +104,9 @@ export default function NotificationSettings( {
 					};
 				} ),
 			};
+			eventParams.email_contacts = params.contacts.emails.length;
 		}
-
-		recordEvent( 'notification_save_click', params );
+		recordEvent( 'notification_save_click', eventParams );
 		updateMonitorSettings( params );
 	}
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -123,7 +123,7 @@ export default function NotificationSettings( {
 			if ( isMultipleEmailEnabled ) {
 				const userEmailItems = userEmails.map( ( email ) => ( {
 					email,
-					name: 'Default Email',
+					name: translate( 'Default account email' ),
 					isDefault: true,
 					verified: true,
 				} ) );
@@ -138,7 +138,7 @@ export default function NotificationSettings( {
 				setAllEmailItems( [ ...userEmailItems, ...siteEmailItems ] );
 			}
 		},
-		[ isMultipleEmailEnabled ]
+		[ isMultipleEmailEnabled, translate ]
 	);
 
 	useEffect( () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -226,6 +226,7 @@ export function useUpdateMonitorSettings( sites: Array< { blog_id: number; url: 
 									monitor_deferment_time: data.settings.jetmon_defer_status_down_minutes,
 									monitor_user_email_notifications: data.settings.email_notifications,
 									monitor_user_wp_note_notifications: data.settings.wp_note_notifications,
+									monitor_notify_additional_user_emails: data.settings.contacts?.emails ?? [],
 								},
 							};
 						}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -22,6 +22,15 @@ export type AllowedStatusTypes =
 	| 'disabled'
 	| 'critical';
 
+interface MonitorContactEmail {
+	name: string;
+	value: string;
+	verified: boolean;
+}
+interface MonitorContacts {
+	emails: Array< MonitorContactEmail >;
+}
+
 export interface MonitorSettings {
 	monitor_active: boolean;
 	monitor_site_status: boolean;
@@ -30,6 +39,7 @@ export interface MonitorSettings {
 	monitor_user_emails: Array< string >;
 	monitor_user_email_notifications: boolean;
 	monitor_user_wp_note_notifications: boolean;
+	monitor_notify_additional_user_emails: Array< MonitorContactEmail >;
 }
 
 interface StatsObject {
@@ -227,6 +237,7 @@ export interface UpdateMonitorSettingsAPIResponse {
 		email_notifications: boolean;
 		wp_note_notifications: boolean;
 		jetmon_defer_status_down_minutes: number;
+		contacts?: MonitorContacts;
 	};
 }
 
@@ -234,6 +245,7 @@ export interface UpdateMonitorSettingsParams {
 	wp_note_notifications?: boolean;
 	email_notifications?: boolean;
 	jetmon_defer_status_down_minutes?: number;
+	contacts?: MonitorContacts;
 }
 export interface UpdateMonitorSettingsArgs {
 	siteId: number;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -24,7 +24,7 @@ export type AllowedStatusTypes =
 
 interface MonitorContactEmail {
 	name: string;
-	value: string;
+	email_address: string;
 	verified: boolean;
 }
 interface MonitorContacts {


### PR DESCRIPTION
Related to 1204408201748644-as-1204537108292195

## Proposed Changes

This PR adds the below changes.

- Add the changes which were added here - https://github.com/Automattic/wp-calypso/pull/76977 that got removed 
- Save the added email addresses to the site monitor settings.
- Optimistically update the react-query to have the new values.
- Show the added email addresses to the site from the `sites` API.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Apply this [patch](D110957-code) and sandbox the public API.
2. Run `git checkout add/include-contacts-in-monitor-settings-api` and `yarn start-jetpack-cloud`
3. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
4. Enable monitor if not enabled already.
5. Click on the clock icon next to the monitor toggle.
6. Click the `+ Add email address` button -> Enter the values -> Click `Verify` -> Now click `Later`.
7. Verify the added email address is added to the list.
8. Click `Save` and verify that the added email address is saved to the site and the UI is optimistically updated(you can verify by opening the settings popup again). 
9. Try various scenarios like adding/removing email addresses, removing all the added email addresses, etc, and verify everything works as expected.
10. Perform bulk action(Edit All -> Custom Notification) and verify that the made changes replace the previously set changes to the site.

<img width="454" alt="Screenshot 2023-05-23 at 2 13 20 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/837ff9d6-daac-409a-9c5d-94dc49053f90">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?