### PR TITLE
Flaky E2E: intercept Instagram embed request.

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -138,7 +138,7 @@ open class E2EBuildType(
 					mkdir temp
 
 					# Run suite.
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup
+					for i in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup; done
 				"""
 				dockerImage = "%docker_image_e2e%"
 				dockerRunParameters = "-u %env.UID% --shm-size=4g"

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -76,7 +76,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 		buildUuid = buildUuid,
 		buildName = "Gutenberg $siteType E2E tests $edgeType ($targetDevice)",
 		buildDescription = "Runs Gutenberg $siteType E2E tests on $targetDevice size",
-		testGroup = "gutenberg",
+		testGroup = "gutenberg-loop",
 		buildParams = {
 			text(
 				name = "env.CALYPSO_BASE_URL",

--- a/test/e2e/specs/blocks/blocks__core-jetpack-extended.ts
+++ b/test/e2e/specs/blocks/blocks__core-jetpack-extended.ts
@@ -1,5 +1,5 @@
 /**
- * @group gutenberg
+ * @group gutenberg-loop
  * @group jetpack-wpcom-integration
  */
 
@@ -11,10 +11,10 @@ const blockFlows: BlockFlow[] = [
 		embedUrl: 'https://www.instagram.com/p/BlDOZMil933/',
 		expectedPostText: 'woocommerce',
 	} ),
-	new TwitterBlockFlow( {
-		embedUrl: 'https://twitter.com/automattic/status/1360312228415700993',
-		expectedTweetText: '@automattic',
-	} ),
+	// new TwitterBlockFlow( {
+	// 	embedUrl: 'https://twitter.com/automattic/status/1360312228415700993',
+	// 	expectedTweetText: '@automattic',
+	// } ),
 ];
 
 createBlockTests( 'Blocks: Jetpack Extended Core Blocks', blockFlows );


### PR DESCRIPTION

Fixes https://github.com/Automattic/wp-calypso/issues/77190.

## Proposed Changes

This PR intercepts the Instagram block's request to their servers when testing in E2E, and replaces it with just enough dummy data to render the block.

Key changes
- add a `page.route` to intercept and fulfill the request out to Instagram servers.
- change the expected selectors to merely check the presence of Instagram embed block.

## Testing Instructions


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
