### PR TITLE
Import flow: Site picker step: Support custom filtering

### DIFF
--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -13,8 +13,9 @@ import { SiteExcerptData, SiteExcerptNetworkData } from './site-excerpt-types';
 
 export const USE_SITE_EXCERPTS_QUERY_KEY = 'sites-dashboard-sites-data';
 
-const fetchSites = (): Promise< { sites: SiteExcerptNetworkData[] } > => {
-	const siteFilter = config< string[] >( 'site_filter' );
+const fetchSites = (
+	siteFilter = config< string[] >( 'site_filter' )
+): Promise< { sites: SiteExcerptNetworkData[] } > => {
 	return wpcom.me().sites( {
 		apiVersion: '1.2',
 		site_visibility: 'all',
@@ -26,10 +27,10 @@ const fetchSites = (): Promise< { sites: SiteExcerptNetworkData[] } > => {
 	} );
 };
 
-export const useSiteExcerptsQuery = () => {
+export const useSiteExcerptsQuery = ( siteFilter?: string[] ) => {
 	const store = useStore();
 
-	return useQuery( [ USE_SITE_EXCERPTS_QUERY_KEY ], fetchSites, {
+	return useQuery( [ USE_SITE_EXCERPTS_QUERY_KEY ], () => fetchSites( siteFilter ), {
 		select: ( data ) => data?.sites.map( computeFields( data?.sites ) ),
 		initialData: () => {
 			// Not using `useSelector` (i.e. calling `getSites` directly) because we

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -14,6 +14,7 @@ import { SitesGrid } from 'calypso/sites-dashboard/components/sites-grid';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
 
 const SitesDashboardSitesList = createSitesListComponent();
+const SITE_PICKER_FILTER_CONFIG = [ 'wpcom', 'atomic' ];
 
 interface Props {
 	page: number;
@@ -26,7 +27,7 @@ const SitePicker = function SitePicker( props: Props ) {
 	const { __ } = useI18n();
 	const { page, perPage = 96, search, status, onQueryParamChange } = props;
 	const { sitesSorting, onSitesSortingChange } = useSitesSorting();
-	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
+	const { data: allSites = [], isLoading } = useSiteExcerptsQuery( SITE_PICKER_FILTER_CONFIG );
 
 	return (
 		<div className="site-picker--container">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -65,6 +65,7 @@ const SitePicker = function SitePicker( props: Props ) {
 										isLoading={ isLoading }
 										sites={ paginatedSites }
 										siteSelectorMode={ true }
+										showLinkInBioBanner={ false }
 										onSiteSelectBtnClick={ () => {
 											// console.log( 'onSiteSelectBtnClick', site );
 										} }

--- a/client/sites-dashboard/components/sites-grid.tsx
+++ b/client/sites-dashboard/components/sites-grid.tsx
@@ -28,11 +28,19 @@ interface SitesGridProps {
 	isLoading: boolean;
 	sites: SiteExcerptData[];
 	siteSelectorMode?: boolean;
+	showLinkInBioBanner?: boolean;
 	onSiteSelectBtnClick?: ( site: SiteExcerptData ) => void;
 }
 
 export const SitesGrid = ( props: SitesGridProps ) => {
-	const { sites, isLoading, className, siteSelectorMode = false, onSiteSelectBtnClick } = props;
+	const {
+		sites,
+		isLoading,
+		className,
+		showLinkInBioBanner = true,
+		siteSelectorMode = false,
+		onSiteSelectBtnClick,
+	} = props;
 	const additionalProps = siteSelectorMode
 		? {
 				showLaunchNag: false,
@@ -52,7 +60,7 @@ export const SitesGrid = ( props: SitesGridProps ) => {
 				: sites.map( ( site ) => (
 						<SitesGridItem site={ site } key={ site.ID } { ...additionalProps } />
 				  ) ) }
-			<LinkInBioBanner displayMode="grid" />
+			{ showLinkInBioBanner && <LinkInBioBanner displayMode="grid" /> }
 		</div>
 	);
 };


### PR DESCRIPTION
Related to #76332

## Proposed Changes

* Extend query method to support custom filtering configuration

## Testing Instructions

Site picker custom filter
* Go to `/setup/import-focused/sitePicker?siteSlug={SITE_SLUG}`
* Check if the presented list of sites contains only "wpcom" or "atomic" type of sites.

Sites
* Go to `/sites`
* Check if the filtering works as it did before the change (it should present all types of sites)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
