### PR TITLE
i18n: Add error handler for the require chunk translations handler

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -218,6 +218,7 @@ function getIsTranslationChunkPreloaded( chunkId, localeSlug ) {
 	if ( typeof window !== 'undefined' ) {
 		return (
 			window.i18nLanguageManifest?.locale?.[ '' ]?.localeSlug === localeSlug &&
+			window.i18nTranslationChunks &&
 			chunkId in window.i18nTranslationChunks
 		);
 	}
@@ -286,12 +287,15 @@ function addRequireChunkTranslationsHandler( localeSlug = i18n.getLocaleSlug(), 
 			return;
 		}
 
-		const translationChunkPromise = getTranslationChunkFile( chunkId, localeSlug ).then(
-			( translations ) => {
+		const translationChunkPromise = getTranslationChunkFile( chunkId, localeSlug )
+			.then( ( translations ) => {
 				addTranslations( translations, userTranslations );
 				loadedTranslationChunks[ chunkId ] = true;
-			}
-		);
+			} )
+			.catch( ( error ) => {
+				debug( `Encountered an error loading translation chunk ${ chunkId }.` );
+				debug( error );
+			} );
 
 		promises.push( translationChunkPromise );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1684544878901539-slack-C04U5A26MJB

Prior to adding the error handler, if a translation chunk request fails, it would cause the entire Webpack dynamic import to fail which will likely result in crashing the entire app. Adding the error handler for the translation chunk requests would prevent the dynamic import failures and only cause some missing translation, but the rest of the app should remain working as normal.

## Proposed Changes

* Add error handling for the require chunk translations handler.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Boot Calypso locally with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=wpcom-user-bootstrap,use-translation-chunks yarn start`.
* Change UI to a Mag-16 language.
* Delete the language files for the selected language. E.g., for Spanish: `find public/languages/es-* -not -name "*manifest*" -delete`
* Confirm translation chunks fetch requests fail, but the page still loads correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
