### PR TITLE
Jetpack Pro Dashboard: add tracking events to the monitor notification email configuration changes

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -135,12 +135,12 @@ export default function EmailAddressEditor( {
 			return setValidationError( { email: translate( 'Please enter a valid email address.' ) } );
 		}
 		if ( showCodeVerification ) {
-			handleVerifyEmail();
-		} else if ( verifiedContacts.emails.includes( emailItem.email ) ) {
-			handleAddVerifiedEmail();
-		} else {
-			handleSendVerificationCode();
+			return handleVerifyEmail();
 		}
+		if ( verifiedContacts.emails.includes( emailItem.email ) ) {
+			return handleAddVerifiedEmail();
+		}
+		handleSendVerificationCode();
 	};
 
 	function onSaveLater() {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -19,6 +19,7 @@ interface Props {
 	selectedAction?: AllowedMonitorContactActions;
 	allEmailItems: Array< StateMonitorSettingsEmail >;
 	setAllEmailItems: ( emailAddresses: Array< StateMonitorSettingsEmail > ) => void;
+	recordEvent: ( action: string, params?: object ) => void;
 }
 
 export default function EmailAddressEditor( {
@@ -27,6 +28,7 @@ export default function EmailAddressEditor( {
 	selectedAction = 'add',
 	allEmailItems,
 	setAllEmailItems,
+	recordEvent,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -87,6 +89,7 @@ export default function EmailAddressEditor( {
 	}, [ selectedEmail ] );
 
 	const handleRemove = () => {
+		recordEvent( 'downtime_monitoring_remove_email' );
 		const emailItems = [ ...allEmailItems ];
 		const emailItemIndex = emailItems.findIndex( ( item ) => item.email === emailItem.email );
 		if ( emailItemIndex > -1 ) {
@@ -94,6 +97,22 @@ export default function EmailAddressEditor( {
 		}
 		setAllEmailItems( emailItems );
 		toggleModal();
+	};
+
+	const handleSendVerificationCode = () => {
+		recordEvent( 'downtime_monitoring_request_email_verification_code' );
+		setShowCodeVerification( true );
+		// TODO: implement sending verification code
+	};
+
+	const handleVerifyEmail = () => {
+		recordEvent( 'downtime_monitoring_verify_email' );
+		// TODO: verify email address with code
+	};
+
+	const handleAddVerifiedEmail = () => {
+		recordEvent( 'downtime_monitoring_email_already_verified' );
+		handleSetEmailItems();
 	};
 
 	const onSave = ( event: React.FormEvent< HTMLFormElement > ) => {
@@ -116,16 +135,16 @@ export default function EmailAddressEditor( {
 			return setValidationError( { email: translate( 'Please enter a valid email address.' ) } );
 		}
 		if ( showCodeVerification ) {
-			// TODO: verify email address with code
+			handleVerifyEmail();
 		} else if ( verifiedContacts.emails.includes( emailItem.email ) ) {
-			handleSetEmailItems();
+			handleAddVerifiedEmail();
 		} else {
-			setShowCodeVerification( true );
-			// TODO: implement sending verification code
+			handleSendVerificationCode();
 		}
 	};
 
 	function onSaveLater() {
+		recordEvent( 'downtime_monitoring_verify_email_later' );
 		handleSetEmailItems( false );
 	}
 
@@ -148,6 +167,7 @@ export default function EmailAddressEditor( {
 	}
 
 	const handleResendCode = () => {
+		recordEvent( 'downtime_monitoring_resend_email_verification_code' );
 		// TODO: implement resending verification code
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-item-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-item-content.tsx
@@ -14,9 +14,21 @@ interface Props {
 	item: StateMonitorSettingsEmail;
 	toggleModal?: ( item?: StateMonitorSettingsEmail, action?: AllowedMonitorContactActions ) => void;
 	isRemoveAction?: boolean;
+	recordEvent?: ( action: string, params?: object ) => void;
 }
 
-export default function EmailItemContent( { item, toggleModal, isRemoveAction = false }: Props ) {
+const EVENT_NAMES = {
+	edit: 'downtime_monitoring_email_address_edit_click',
+	remove: 'downtime_monitoring_email_address_remove_click',
+	verify: 'downtime_monitoring_email_address_verify_click',
+};
+
+export default function EmailItemContent( {
+	item,
+	toggleModal,
+	isRemoveAction = false,
+	recordEvent,
+}: Props ) {
 	const translate = useTranslate();
 
 	const [ isOpen, setIsOpen ] = useState( false );
@@ -35,6 +47,10 @@ export default function EmailItemContent( { item, toggleModal, isRemoveAction = 
 
 	const handleToggleModal = ( action: AllowedMonitorContactActions ) => {
 		toggleModal?.( item, action );
+		if ( recordEvent ) {
+			const eventName = EVENT_NAMES?.[ action as keyof typeof EVENT_NAMES ];
+			recordEvent( eventName );
+		}
 	};
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -12,20 +12,35 @@ import './style.scss';
 interface Props {
 	toggleModal: ( item?: StateMonitorSettingsEmail, action?: AllowedMonitorContactActions ) => void;
 	allEmailItems: Array< StateMonitorSettingsEmail >;
+	recordEvent: ( action: string, params?: object ) => void;
 }
 
-export default function ConfigureEmailNotification( { toggleModal, allEmailItems }: Props ) {
+export default function ConfigureEmailNotification( {
+	toggleModal,
+	allEmailItems,
+	recordEvent,
+}: Props ) {
 	const translate = useTranslate();
+
+	const handleAddEmailClick = () => {
+		recordEvent( 'add_email_address_click' );
+		toggleModal();
+	};
 
 	return (
 		<div className="configure-email-address__card-container">
 			{ allEmailItems.map( ( item ) => (
-				<EmailItemContent key={ item.email } item={ item } toggleModal={ toggleModal } />
+				<EmailItemContent
+					key={ item.email }
+					item={ item }
+					toggleModal={ toggleModal }
+					recordEvent={ recordEvent }
+				/>
 			) ) }
 			<Button
 				compact
 				className="configure-email-address__button"
-				onClick={ () => toggleModal() }
+				onClick={ handleAddEmailClick }
 				aria-label={ translate( 'Add email address' ) }
 			>
 				<Icon size={ 18 } icon={ plus } />

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -160,6 +160,7 @@ export default function NotificationSettings( {
 				selectedAction={ selectedAction }
 				allEmailItems={ allEmailItems }
 				setAllEmailItems={ setAllEmailItems }
+				recordEvent={ recordEvent }
 			/>
 		);
 	}
@@ -271,6 +272,7 @@ export default function NotificationSettings( {
 						<ConfigureEmailNotification
 							toggleModal={ toggleAddEmailModal }
 							allEmailItems={ allEmailItems }
+							recordEvent={ recordEvent }
 						/>
 					) }
 				</div>


### PR DESCRIPTION
Related to 1204408201748644-as-1204536887894671

#### Proposed Changes

This PR adds tracking events to the downtime monitor notification email configuration changes

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/monitor-email-tracking-events` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Open the dev tool, go to the network tab, and apply the filters - `jetpack-cloud-development` as search and select `Img` filters.

<img width="739" alt="Screenshot 2023-01-19 at 12 43 57 PM" src="https://user-images.githubusercontent.com/10586875/213378720-624de9b6-dc14-489e-a9a2-d7f04cfa478c.png">

5. Perform the below actions and verify that the API call to track the event is made with the right action names on large and small screen devices

`L: Large screen(>1280px)`
`S: Small Screen(<1280px)`

------

<img width="473" alt="Screenshot 2023-05-22 at 7 02 50 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2652cca4-6f02-4db2-b18c-499166392591">


#### 1) Add email address

Click on `+ Add email address`

Event names

L: calypso_jetpack_agency_dashboard_add_email_address_click_large_screen
S: calypso_jetpack_agency_dashboard_add_email_address_click_small_screen

------

<img width="474" alt="Screenshot 2023-05-22 at 7 03 08 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8bd2ed02-b88f-438a-81f8-7ae39c296922">

#### 2) Request email verification code

Click on `Verify` to request the verification code. 

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_request_email_verification_code_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_request_email_verification_code_small_screen

#### Add a verified email address

Click on `Verify` to add the already verified email address.

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_email_already_verified_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_email_already_verified_small_screen

------

<img width="472" alt="Screenshot 2023-05-22 at 7 03 17 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c3cdfaa1-6776-4667-ab0e-4de82ae46c40">

#### 3) Resend email verification code

Click on `Resend` to request the verification code again. 

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_resend_email_verification_code_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_resend_email_verification_code_small_screen

#### 4) Verify email verification code

Click on `Verify` to verify the verification code. 

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_verify_email_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_verify_email_small_screen

#### 5) Click verify later

Click on `Later` to verify later.

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_verify_email_later_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_verify_email_later_small_screen

------

<img width="472" alt="Screenshot 2023-05-22 at 7 05 21 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f431f726-5559-4ea1-a0e4-f734c4a226cd">

#### 6) Click the `Verify` action

Click on `Verify` from the action menu or the `Pending` badge.

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_email_address_verify_click_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_email_address_verify_click_small_screen

#### 7) Click the `Edit` action

Click on `Edit` from the action menu.

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_email_address_edit_click_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_email_address_edit_click_small_screen

#### 8) Click the `Remove` action

Click on `Remove` from the action menu.

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_email_address_remove_click_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_email_address_remove_click_small_screen


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?