### PR TITLE
Import flow: Site picker: Add recordTracksEvent

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -34,7 +34,11 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 	};
 
 	const selectSite = ( site: SiteExcerptData ) => {
-		recordTracksEvent( 'calypso_import_site_picker_select_site', site );
+		recordTracksEvent( 'calypso_import_site_picker_select_site', {
+			id: site?.ID,
+			slug: site?.slug,
+			title: site?.title,
+		} );
 		navigation.submit?.( { action: 'select-site', site } );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -24,14 +24,17 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 		DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE;
 
 	const onQueryParamChange = ( params: Partial< SitesDashboardQueryParams > ) => {
+		recordTracksEvent( 'calypso_import_site_picker_query_param_change', params );
 		navigation.submit?.( { action: 'update-query', queryParams: params } );
 	};
 
 	const createNewSite = () => {
+		recordTracksEvent( 'calypso_import_site_picker_create_new_site' );
 		navigation.submit?.( { action: 'create-site' } );
 	};
 
 	const selectSite = ( site: SiteExcerptData ) => {
+		recordTracksEvent( 'calypso_import_site_picker_select_site', site );
 		navigation.submit?.( { action: 'select-site', site } );
 	};
 


### PR DESCRIPTION
Related to #76332

## Proposed Changes

* Site picker step: Added recordTracksEvent

## Testing Instructions

* Go to `/setup/import-focused/sitePicker?from={JN_JETPACK_CONNECTED_SITE}`
* Apply filters and check if the event is tracked
* Select a site and check if the event is tracked
* Create a new site and check if the event is tracked

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
