### PR TITLE
[GB 15.8][E2E][Instagram Block] Use a different locator depending on the type of site for clicking the "Embed" button

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -1,3 +1,4 @@
+import { envVariables } from '../../..';
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
 interface ConfigurationData {
@@ -34,7 +35,17 @@ export class InstagramBlockFlow implements BlockFlow {
 		await editorCanvas
 			.getByPlaceholder( 'Enter URL to embed here…' )
 			.fill( this.configurationData.embedUrl );
-		await editorCanvas.getByRole( 'button', { name: 'Embed' } ).click();
+
+		if ( envVariables.TEST_ON_ATOMIC ) {
+			await editorCanvas.getByRole( 'button', { name: 'Embed' } ).click();
+		} else {
+			// For some reason, the hierarchy/selector changes for simple sites. Probably
+			// because it's running from within the Gutenframe?
+			await editorCanvas
+				.getByRole( 'document', { name: 'Block: Embed' } )
+				.getByRole( 'button', { name: 'Embed' } )
+				.click();
+		}
 
 		await editorCanvas.getByTitle( 'Embedded content from instagram.com' ).waitFor();
 	}


### PR DESCRIPTION
## Proposed Changes

See title. The DOM hierarchy seems different on simple sites. I didn't dig deeper into why - I just used the Playwright debugger to confirm the right selector for each case - but it could be due to simple sites running from the Gutenframe.

## Testing Instructions

Tests should pass.


