### PR TITLE
AT E2E: update the `Likes: Posts` spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -39,7 +39,7 @@ export class PublishedPostPage {
 	async likePost(): Promise< void > {
 		const locator = this.page
 			.frameLocator( 'iframe[title="Like or Reblog"]' )
-			.getByRole( 'link', { name: 'Like' } );
+			.getByRole( 'link', { name: 'Like', exact: true } );
 
 		// On AT sites Playwright is not able to scroll directly to the iframe
 		// containing the Like/Unlike button (similar to Post Comments).
@@ -74,7 +74,7 @@ export class PublishedPostPage {
 		// The button should now read "Like".
 		await this.page
 			.frameLocator( 'iframe[title="Like or Reblog"]' )
-			.getByRole( 'link', { name: 'Like' } )
+			.getByRole( 'link', { name: 'Like', exact: true } )
 			.waitFor();
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -50,7 +50,7 @@ export class PublishedPostPage {
 		// The button should now read "Liked".
 		await this.page
 			.frameLocator( 'iframe[title="Like or Reblog"]' )
-			.getByRole( 'link', { name: 'Liked' } )
+			.getByRole( 'link', { name: 'Liked', exact: true } )
 			.waitFor();
 	}
 
@@ -63,7 +63,7 @@ export class PublishedPostPage {
 	async unlikePost(): Promise< void > {
 		const locator = this.page
 			.frameLocator( 'iframe[title="Like or Reblog"]' )
-			.getByRole( 'link', { name: 'Liked' } );
+			.getByRole( 'link', { name: 'Liked', exact: true } );
 
 		// On AT sites Playwright is not able to scroll directly to the iframe
 		// containing the Like/Unlike button (similar to Post Comments).

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -2,16 +2,7 @@ import { Page } from 'playwright';
 
 const selectors = {
 	// Post body
-	postBody: '.entry-content',
 	postPasswordInput: 'input[name="post_password"]',
-	submitPasswordButton: 'input[name="Submit"]',
-
-	// Like Widget
-	likeWidget: 'iframe[title="Like or Reblog"]',
-	likeButton: 'a.like',
-	unlikeButton: 'a.liked',
-	likedText: 'text=Liked',
-	notLikedText: 'text=Like',
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -1,4 +1,4 @@
-import { Frame, Page } from 'playwright';
+import { Page } from 'playwright';
 
 const selectors = {
 	// Post body
@@ -40,36 +40,27 @@ export class PublishedPostPage {
 	}
 
 	/**
-	 * Returns the frame which holds the Like widget.
-	 *
-	 * @returns {Promise<Frame>} Frame holding the like widget on page.
-	 */
-	private async getLikeFrame(): Promise< Frame > {
-		// Obtain the ElementHandle for the widget containing the like/unlike button.
-		const elementHandle = await this.page.waitForSelector( selectors.likeWidget );
-		// Without the next line, headless viewports fail to locate the Like widget.
-		await elementHandle.scrollIntoViewIfNeeded();
-		// Obtain the Frame object from the elementHandleHandle. This represents the widget iframe.
-		const frame = ( await elementHandle.contentFrame() ) as Frame;
-		// Wait until the widget element is stable in the DOM.
-		await elementHandle.waitForElementState( 'stable' );
-
-		return frame;
-	}
-
-	/**
 	 * Clicks the Like button on the post.
 	 *
 	 * This method will also confirm that click action on the Like button
 	 * had the intended effect.
-	 *
-	 * @returns {Promise<void>} No return value.
 	 */
 	async likePost(): Promise< void > {
-		await this.page.evaluate( () => window.scrollTo( 0, document.body.scrollHeight ) );
-		const frame = await this.getLikeFrame();
-		await frame.click( selectors.likeButton );
-		await frame.waitForSelector( selectors.likedText, { state: 'visible' } );
+		const locator = this.page
+			.frameLocator( 'iframe[title="Like or Reblog"]' )
+			.getByRole( 'link', { name: 'Like' } );
+
+		// On AT sites Playwright is not able to scroll directly to the iframe
+		// containing the Like/Unlike button (similar to Post Comments).
+		await locator.evaluate( ( element ) => element.scrollIntoView() );
+
+		await locator.click();
+
+		// The button should now read "Liked".
+		await this.page
+			.frameLocator( 'iframe[title="Like or Reblog"]' )
+			.getByRole( 'link', { name: 'Liked' } )
+			.waitFor();
 	}
 
 	/**
@@ -77,13 +68,23 @@ export class PublishedPostPage {
 	 *
 	 * This method will also confirm that click action on the Like button
 	 * had the intended effect.
-	 *
-	 * @returns {Promise<void>} No return value.
 	 */
 	async unlikePost(): Promise< void > {
-		const frame = await this.getLikeFrame();
-		await frame.click( selectors.unlikeButton );
-		await frame.waitForSelector( selectors.notLikedText, { state: 'visible' } );
+		const locator = this.page
+			.frameLocator( 'iframe[title="Like or Reblog"]' )
+			.getByRole( 'link', { name: 'Liked' } );
+
+		// On AT sites Playwright is not able to scroll directly to the iframe
+		// containing the Like/Unlike button (similar to Post Comments).
+		await locator.evaluate( ( element ) => element.scrollIntoView() );
+
+		await locator.click();
+
+		// The button should now read "Like".
+		await this.page
+			.frameLocator( 'iframe[title="Like or Reblog"]' )
+			.getByRole( 'link', { name: 'Like' } )
+			.waitFor();
 	}
 
 	/**

--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -81,7 +81,6 @@ describe( 'Likes: Post', function () {
 
 		beforeAll( async () => {
 			newPage = await browser.newPage();
-			await otherUser.authenticate( newPage );
 		} );
 
 		it( 'Go to the published post page', async () => {
@@ -90,7 +89,11 @@ describe( 'Likes: Post', function () {
 			} );
 		} );
 
-		it( 'Like post', async function () {
+		it( 'Login via popup to like the post', async function () {
+			newPage.on( 'popup', async ( popup ) => {
+				await otherUser.logInViaPopupPage( popup );
+			} );
+
 			await ElementHelper.reloadAndRetry( newPage, async () => {
 				publishedPostPage = new PublishedPostPage( newPage );
 				await publishedPostPage.likePost();

--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -83,7 +83,7 @@ describe( 'Likes: Post', function () {
 		} );
 
 		it( 'Go to the published post page', async () => {
-			await newPage.goto( newPost.URL );
+			await newPage.goto( newPost.URL, { timeout: 20 * 1000 } );
 		} );
 
 		it( 'Like post', async function () {

--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -55,7 +55,9 @@ describe( 'Likes: Post', function () {
 		let publishedPostPage: PublishedPostPage;
 
 		it( 'View post', async function () {
-			await page.goto( newPost.URL, { timeout: 20 * 1000 } );
+			await ElementHelper.reloadAndRetry( page, async () => {
+				await page.goto( newPost.URL, { timeout: 20 * 1000 } );
+			} );
 		} );
 
 		it( 'Like post', async function () {
@@ -83,7 +85,9 @@ describe( 'Likes: Post', function () {
 		} );
 
 		it( 'Go to the published post page', async () => {
-			await newPage.goto( newPost.URL, { timeout: 20 * 1000 } );
+			await ElementHelper.reloadAndRetry( newPage, async () => {
+				await newPage.goto( newPost.URL, { timeout: 20 * 1000 } );
+			} );
 		} );
 
 		it( 'Like post', async function () {

--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -5,24 +5,19 @@
 import {
 	DataHelper,
 	ElementHelper,
-	EditorPage,
 	PublishedPostPage,
 	TestAccount,
 	envVariables,
 	getTestAccountByFeature,
 	envToFeatureKey,
+	RestAPIClient,
+	PostResponse,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-/**
- * Constants
- */
-const quote =
-	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
-
-describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
+describe( 'Likes: Post', function () {
 	const features = envToFeatureKey( envVariables );
 	// @todo Does it make sense to create a `simpleSitePersonalPlanUserEdge` with GB edge?
 	// for now, it will pick up the default `gutenbergAtomicSiteEdgeUser` if edge is set.
@@ -35,35 +30,32 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 	] );
 
 	const postingUser = new TestAccount( accountName );
-	const likeUser = new TestAccount( 'defaultUser' );
+	const otherUser = new TestAccount( 'defaultUser' );
 	let page: Page;
-	let publishedURL: URL;
-	let publishedPostPage: PublishedPostPage;
+	let restAPIClient: RestAPIClient;
+
+	let newPost: PostResponse;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		await postingUser.authenticate( page );
+	} );
+
+	it( 'Setup the test', async function () {
+		restAPIClient = new RestAPIClient( postingUser.credentials );
+		newPost = await restAPIClient.createPost(
+			postingUser.credentials.testSites?.primary.id as number,
+			{
+				title: DataHelper.getRandomPhrase(),
+			}
+		);
+	} );
 
 	describe( 'As the posting user', function () {
-		let editorPage: EditorPage;
+		let publishedPostPage: PublishedPostPage;
 
-		beforeAll( async () => {
-			page = await browser.newPage();
-			editorPage = new EditorPage( page );
-			await postingUser.authenticate( page );
-		} );
-
-		it( 'Go to the new post page', async function () {
-			await editorPage.visit( 'post' );
-		} );
-
-		it( 'Enter post title', async function () {
-			const title = DataHelper.getRandomPhrase();
-			await editorPage.enterTitle( title );
-		} );
-
-		it( 'Enter post text', async function () {
-			await editorPage.enterText( quote );
-		} );
-
-		it( 'Publish and visit post', async function () {
-			publishedURL = await editorPage.publish( { visit: true } );
+		it( 'View post', async function () {
+			await page.goto( newPost.URL, { timeout: 20 * 1000 } );
 		} );
 
 		it( 'Like post', async function () {
@@ -81,24 +73,35 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 		} );
 	} );
 
-	describe( 'As the liking user', function () {
+	describe( 'As an unrelated user', function () {
+		let newPage: Page;
+		let publishedPostPage: PublishedPostPage;
+
 		beforeAll( async () => {
-			page = await browser.newPage();
+			newPage = await browser.newPage();
+			await otherUser.authenticate( newPage );
 		} );
 
 		it( 'Go to the published post page', async () => {
-			await page.goto( publishedURL.href );
+			await newPage.goto( newPost.URL );
 		} );
 
-		it( 'Login via popup to like the post', async function () {
-			page.on( 'popup', async ( popup ) => {
-				await likeUser.logInViaPopupPage( popup );
-			} );
-
-			await ElementHelper.reloadAndRetry( page, async () => {
-				publishedPostPage = new PublishedPostPage( page );
+		it( 'Like post', async function () {
+			await ElementHelper.reloadAndRetry( newPage, async () => {
+				publishedPostPage = new PublishedPostPage( newPage );
 				await publishedPostPage.likePost();
 			} );
 		} );
+	} );
+
+	afterAll( async function () {
+		if ( ! newPost ) {
+			return;
+		}
+
+		await restAPIClient.deletePost(
+			postingUser.credentials.testSites?.primary.id as number,
+			newPost.ID
+		);
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/77194.

## Proposed Changes

This PR updates the Likes: Posts spec to modern standards, including the use of role-based selectors where possible.

Key changes:
- update the Likes widget portion of the `PublishedPostPage` to use locators.

## Testing Instructions

While not perfect, the best performance seen is to pass 86 iterations successfully.

<img width="914" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6549265/63ee02a7-e43c-45fe-974d-aa53ac1876d0">

Ensure the following build configurations are passing:
  - [ ] Gutenberg E2E Simple production (desktop)
  - [ ] Gutenberg E2E Atomic production (desktop)
  - [ ] Gutenberg E2E Simple edge (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
