### PR TITLE
AT E2E: fix selector for `Instagram` block in editor and published state.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -51,7 +51,6 @@ export class InstagramBlockFlow implements BlockFlow {
 	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
-		// await context.page.pause();
 		await context.page
 			.getByRole( 'figure' )
 			.filter( {

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -51,11 +51,6 @@ export class InstagramBlockFlow implements BlockFlow {
 	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
-		await context.page
-			.getByRole( 'figure' )
-			.filter( {
-				hasText: 'View this post on Instagram',
-			} )
-			.waitFor();
+		await context.page.getByRole( 'figure' ).getByText( 'View this post on Instagram' ).waitFor();
 	}
 }

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -1,4 +1,3 @@
-import { envVariables } from '../../..';
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
 interface ConfigurationData {
@@ -36,16 +35,12 @@ export class InstagramBlockFlow implements BlockFlow {
 			.getByPlaceholder( 'Enter URL to embed here…' )
 			.fill( this.configurationData.embedUrl );
 
-		if ( envVariables.TEST_ON_ATOMIC ) {
-			await editorCanvas.getByRole( 'button', { name: 'Embed' } ).click();
-		} else {
-			// For some reason, the hierarchy/selector changes for simple sites. Probably
-			// because it's running from within the Gutenframe?
-			await editorCanvas
-				.getByRole( 'document', { name: 'Block: Embed' } )
-				.getByRole( 'button', { name: 'Embed' } )
-				.click();
-		}
+		await editorCanvas
+			.getByRole( 'document', { name: 'Block: Embed' } )
+			.getByRole( 'button', {
+				name: 'Embed',
+			} )
+			.click();
 
 		await editorCanvas.getByTitle( 'Embedded content from instagram.com' ).waitFor();
 	}
@@ -57,6 +52,11 @@ export class InstagramBlockFlow implements BlockFlow {
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		// await context.page.pause();
-		await context.page.locator( '.wp-block-embed-instagram' ).waitFor();
+		await context.page
+			.getByRole( 'figure' )
+			.filter( {
+				hasText: 'View this post on Instagram',
+			} )
+			.waitFor();
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/77190.

## Proposed Changes

This PR updates the selector used for the Instagram block in both editor and published state, to work with Simple and AT sites.

Key changes:
- narrow the selector in the editor canvas.
- narrow the selector in the published state.

## Testing Instructions

Passes on both AT and Simple runs locally.

**AT**
```
➜  ~/workspace/wp-calypso-third git:(trunk) ✗ TEST_ON_ATOMIC=true yarn workspace wp-e2e-tests test -- test/e2e/specs/blocks/blocks__core-jetpack-extended.ts
 PASS  specs/blocks/blocks__core-jetpack-extended.ts (24.217 s)
  Blocks: Jetpack Extended Core Blocks
    ✓ Go to the new post page (13795 ms)
    Add and configure blocks in the editor
      ✓ Instagram: Add the block from the sidebar (3128 ms)
      ✓ Instagram: Configure the block (891 ms)
      ✓ Instagram: There are no block warnings or errors in the editor (3 ms)
      ✓ Twitter: Add the block from the sidebar (1029 ms)
      ✓ Twitter: Configure the block (387 ms)
      ✓ Twitter: There are no block warnings or errors in the editor (3 ms)
    Publishing the post
      ✓ Publish and visit post (1954 ms)
    Validating blocks in published post.
      ✓ Instagram: Expected content is in published post (13 ms)
      ✓ Twitter: Expected content is in published post (212 ms)

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        24.422 s
Ran all test suites matching /test\/e2e\/specs\/blocks\/blocks__core-jetpack-extended.ts/i.
```

**Simple**
```
➜  ~/workspace/wp-calypso-third git:(trunk) ✗ TEST_ON_ATOMIC=false yarn workspace wp-e2e-tests test -- test/e2e/specs/blocks/blocks__core-jetpack-extended.ts
 PASS  specs/blocks/blocks__core-jetpack-extended.ts (20.582 s)
  Blocks: Jetpack Extended Core Blocks
    ✓ Go to the new post page (4927 ms)
    Add and configure blocks in the editor
      ✓ Instagram: Add the block from the sidebar (3549 ms)
      ✓ Instagram: Configure the block (459 ms)
      ✓ Instagram: There are no block warnings or errors in the editor (4 ms)
      ✓ Twitter: Add the block from the sidebar (1930 ms)
      ✓ Twitter: Configure the block (470 ms)
      ✓ Twitter: There are no block warnings or errors in the editor (4 ms)
    Publishing the post
      ✓ Publish and visit post (6072 ms)
    Validating blocks in published post.
      ✓ Instagram: Expected content is in published post (8 ms)
      ✓ Twitter: Expected content is in published post (259 ms)

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        20.78 s, estimated 22 s
Ran all test suites matching /test\/e2e\/specs\/blocks\/blocks__core-jetpack-extended.ts/i.
```

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E Simple production (desktop)
  - [x] Gutenberg E2E Atomic production (desktop)
  - [x] Gutenberg E2E Simple edge (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
