### PR TITLE
MasterBar: My Sites icon (WordPress logo) - remove link when there are no sites

### DIFF
--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -20,6 +20,7 @@ interface MasterbarItemProps {
 	hasUnseen?: boolean;
 	children?: ReactNode;
 	alwaysShowContent?: boolean;
+	disabled?: boolean;
 }
 
 class MasterbarItem extends Component< MasterbarItemProps > {
@@ -71,6 +72,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			'is-active': this.props.isActive,
 			'has-unseen': this.props.hasUnseen,
 			'masterbar__item--always-show-content': this.props.alwaysShowContent,
+			'masterbar__item-disabled': this.props.disabled,
 		} );
 
 		const attributes = {
@@ -80,6 +82,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			className: itemClasses,
 			onTouchStart: this.preload,
 			onMouseEnter: this.preload,
+			tabIndex: this.props.disabled ? -1 : undefined,
 		};
 
 		if ( this.props.url ) {

--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -72,7 +72,6 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			'is-active': this.props.isActive,
 			'has-unseen': this.props.hasUnseen,
 			'masterbar__item--always-show-content': this.props.alwaysShowContent,
-			'masterbar__item-disabled': this.props.disabled,
 		} );
 
 		const attributes = {
@@ -82,7 +81,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			className: itemClasses,
 			onTouchStart: this.preload,
 			onMouseEnter: this.preload,
-			tabIndex: this.props.disabled ? -1 : undefined,
+			disabled: this.props.disabled,
 		};
 
 		if ( this.props.url ) {

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -224,11 +224,18 @@ class MasterbarLoggedIn extends Component {
 			: getStatsPathForTab( 'day', siteSlug );
 
 		let mySitesUrl = domainOnlySite ? domainManagementList( siteSlug ) : homeUrl;
+
+		const icon =
+			this.state.isMobile && this.props.isInEditor ? 'chevron-left' : this.wordpressIcon();
+
 		if ( 'sites' === section && isResponsiveMenu ) {
 			mySitesUrl = '';
 		}
-		const icon =
-			this.state.isMobile && this.props.isInEditor ? 'chevron-left' : this.wordpressIcon();
+		if ( ! siteSlug && section === 'sites-dashboard' ) {
+			// we are the /sites page but there is no site. Disable the home link
+			return <Item icon={ icon } />;
+		}
+
 		return (
 			<Item
 				url={ mySitesUrl }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -233,7 +233,7 @@ class MasterbarLoggedIn extends Component {
 		}
 		if ( ! siteSlug && section === 'sites-dashboard' ) {
 			// we are the /sites page but there is no site. Disable the home link
-			return <Item icon={ icon } />;
+			return <Item icon={ icon } disabled />;
 		}
 
 		return (

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -315,10 +315,7 @@ $masterbar-color-secondary: #101517;
 		}
 	}
 
-	&.masterbar__item-disabled {
-		&:focus {
-			box-shadow: none;
-		}
+	&:disabled {
 		&:hover {
 			background: initial;
 			color: initial;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -314,6 +314,16 @@ $masterbar-color-secondary: #101517;
 			display: block;
 		}
 	}
+
+	&.masterbar__item-disabled {
+		&:focus {
+			box-shadow: none;
+		}
+		&:hover {
+			background: initial;
+			color: initial;
+		}
+	}
 }
 
 .masterbar__item-logo {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See discussion here https://github.com/Automattic/wp-calypso/pull/76697#issuecomment-1551436023

## Proposed Changes

* When the user is at `/sites` and doesn't have any sites, if they click the WordPress logo, they are taken to `/stats/day`, which shows them a similar UI to the one they saw at `/sites` (See [here](https://github.com/Automattic/wp-calypso/pull/76697#issuecomment-1547490093)). The link and tooltip from this logo icon have been removed, so it now does nothing. Visually nothing changes in the MasterBar. 

 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Thing to test:

* `/sites` page when there are no sites - should do nothing and give no visual feedback
* `/sites` page when there are 1+ sites - should work as before: show the default site's home page
* `/read` page when there are no sites - this still points to `/stats/day`. **Do we want to change this?**
* `/read` page when there are 1+ sites -should work as before: show the default site's home page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
