### PR TITLE
Subscription Management: Fix align popover inner contents to the left

### DIFF
--- a/client/landing/subscriptions/components/settings/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings/settings-popover/styles.scss
@@ -4,11 +4,13 @@
 	outline: none;
 	min-width: 305px;
 
-	.popover__inner {
-		border: none;
-		box-shadow: 0 3px 8px rgba($studio-black, 0.12), 0 3px 1px rgba($studio-black, 0.04);
-		padding: 21px;
-		text-align: left;
+	.popover {
+		&__inner {
+			border: none;
+			box-shadow: 0 3px 8px rgba($studio-black, 0.12), 0 3px 1px rgba($studio-black, 0.04);
+			padding: 21px;
+			text-align: left;
+		}
 	}
 
 	.delivery-frequency-input__control,


### PR DESCRIPTION
| Before | After |
|:---:|:---:|
| <img src="https://github.com/Automattic/wp-calypso/assets/2019970/f5a722ec-f1d1-48d3-a4b0-b501b04a9f22" width="400"> | <img src="https://github.com/Automattic/wp-calypso/assets/2019970/7d69930b-fed8-41b4-b597-1c8df632de9c" width="400"> |



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/77242

## Proposed Changes

* Make the `.popover .popover__inner` style override selector more precise, so that it takes precedence of the predefined one

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/subscriptions/sites
* See if the "Unsubscribe" from a site button, inside the site subscription settings popover, is left aligned

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
