### PR TITLE
Pro Dashboard: Highlight the agency pricing column in the Prices section of the licensing portal

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -128,7 +128,7 @@ export default function Prices() {
 
 			<table className="prices__table">
 				<thead>
-					<tr style={ { backgroundColor: 'transparent' } }>
+					<tr className="prices__head-row" style={ { backgroundColor: 'transparent' } }>
 						<th colSpan={ 3 }></th>
 						<th className="prices__column-highlight">
 							<div className="prices__column-highlight-content">
@@ -139,7 +139,7 @@ export default function Prices() {
 							</div>
 						</th>
 					</tr>
-					<tr>
+					<tr className="prices__head-row">
 						<th></th>
 						<th>
 							<div>{ translate( 'Jetpack.com Pricing' ) }</div>

--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
@@ -127,6 +128,17 @@ export default function Prices() {
 
 			<table className="prices__table">
 				<thead>
+					<tr style={ { backgroundColor: 'transparent' } }>
+						<th colSpan={ 3 }></th>
+						<th className="prices__column-highlight">
+							<div className="prices__column-highlight-content">
+								<Gridicon icon="star" size={ 18 } className="prices__column-highlight-icon" />
+								<span className="prices__column-highlight-label">
+									{ translate( 'Your Price' ) }
+								</span>
+							</div>
+						</th>
+					</tr>
 					<tr>
 						<th></th>
 						<th>

--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/style.scss
@@ -99,12 +99,20 @@ tr:nth-child(odd) {
 	.prices__table th {
 		display: block;
 		width: 100%;
-		padding: 0.5rem 0;
+		padding: 0.5rem;
 	}
 }
 
+.prices__table thead {
+	display: none;
+}
+
 /* "Your Price" column highlight */
-@include break-xlarge {
+@include break-large {
+	.prices__table thead {
+		display: table-header-group;
+	}
+
 	.prices__table td:last-child,
 	.prices__table th:last-child {
 		border: 2px solid #c9356e;
@@ -116,6 +124,7 @@ tr:nth-child(odd) {
 	}
 
 	th.prices__column-highlight {
+		visibility: visible;
 		padding: 8px;
 		line-height: 24px;
 		font-size: 0.75rem;

--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .prices__header {
 	display: flex;
 	align-items: center;
@@ -97,5 +100,40 @@ tr:nth-child(odd) {
 		display: block;
 		width: 100%;
 		padding: 0.5rem 0;
+	}
+}
+
+/* "Your Price" column highlight */
+@include break-xlarge {
+	.prices__table td:last-child,
+	.prices__table th:last-child {
+		border: 2px solid #c9356e;
+		border-top-width: 0;
+		border-bottom-width: 0;
+	}
+	.prices__table tr:last-child td:last-child {
+		border-bottom-width: 2px;
+	}
+
+	th.prices__column-highlight {
+		padding: 8px;
+		line-height: 24px;
+		font-size: 0.75rem;
+		font-weight: 700;
+		color: #fff;
+		background: #c9356e;
+		/* stylelint-disable-next-line scales/radii */
+		border-top-left-radius: 8px;
+		/* stylelint-disable-next-line scales/radii */
+		border-top-right-radius: 8px;
+	}
+
+	.prices__column-highlight-content {
+		display: flex;
+		align-items: center;
+	}
+
+	.prices__column-highlight-icon {
+		margin-right: 4px;
 	}
 }


### PR DESCRIPTION
Related to p1683878378146449-slack-C0CMN0V97
Reviewed in p1684828989677749-slack-C053ZV01C3V

## Proposed Changes

* Highlight the agency pricing in the Prices section of the Pro Dashboard in order to reduce confusion. The design was borrowed from https://jetpack.com/.

## Testing Instructions

* Checkout the PR and run Jetpack Cloud
* Open up http://jetpack.cloud.localhost:3000/partner-portal/prices and check out the high column highlight.

![Screen Shot 2023-05-23 at 10 52 30](https://github.com/Automattic/wp-calypso/assets/22746396/360469c9-33ec-4d00-b48a-532c0bb9891e)
Note: The prices in the screenshot are not real.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?