### PR TITLE
happy-blocks: Fix pricing-plans tabs text wrap issue

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/view.scss
+++ b/apps/happy-blocks/block-library/pricing-plans/view.scss
@@ -31,7 +31,6 @@ $brand-display: "SF Pro Display", $sans;
 	background-color: $studio-white;
 	word-break: initial;
 
-
 	&__settings {
 		select {
 			min-height: 30px;
@@ -89,18 +88,17 @@ $brand-display: "SF Pro Display", $sans;
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 6px;
 		padding: 4px;
-		width: min-content;
+		width: fit-content;
 		margin-bottom: 16px;
 
 		&-label {
 			background: $studio-gray-0;
 			padding: 4px 16px;
-			height: 28px;
 			font-family: $brand-display;
 			font-weight: 500;
 			font-size: 0.875rem;
 			line-height: 20px;
-			border: none;
+			border: 0.5px solid $studio-gray-0;
 			/* stylelint-disable-next-line scales/radii */
 			border-radius: 5px;
 			margin: 0;
@@ -249,7 +247,6 @@ $brand-display: "SF Pro Display", $sans;
 		letter-spacing: -0.15px;
 		color: $studio-gray-60;
 	}
-
 
 	&__detail {
 		flex: 1;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 624-gh-Automattic/i18n-issues

## Proposed Changes

* Fix pricing-plans block tabs to prevent text wrapping.

**Before:**
![CleanShot 2023-05-23 at 12 25 03](https://github.com/Automattic/wp-calypso/assets/2722412/a366caf7-11c7-4cf1-a285-b419064a8e9e)
![CleanShot 2023-05-23 at 12 24 48](https://github.com/Automattic/wp-calypso/assets/2722412/93c8f52d-9bec-44c8-8700-b6f5832502a7)

**After:**
![CleanShot 2023-05-23 at 12 20 37](https://github.com/Automattic/wp-calypso/assets/2722412/e1e366a9-4ae0-465d-a356-98703dee3549)
![CleanShot 2023-05-23 at 12 20 05](https://github.com/Automattic/wp-calypso/assets/2722412/a27026b8-e0b5-4a44-8b96-5d3ac6021b30)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow test instructions in D111588-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
