### PR TITLE
Subscriptions Management: Use correct endpoint for subscribing of logged-in users

### DIFF
--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -156,9 +156,9 @@ const SiteSubscriptionPage = () => {
 							<SiteSubscriptionSettings
 								blogId={ blogId }
 								notifyMeOfNewPosts={ data.delivery_methods?.notification?.send_posts }
-								emailMeNewPosts={ data.delivery_methods?.email.send_posts }
-								deliveryFrequency={ data.delivery_methods?.email.post_delivery_frequency }
-								emailMeNewComments={ data.delivery_methods?.email.send_comments }
+								emailMeNewPosts={ data.delivery_methods?.email?.send_posts }
+								deliveryFrequency={ data.delivery_methods?.email?.post_delivery_frequency }
+								emailMeNewComments={ data.delivery_methods?.email?.send_comments }
 							/>
 
 							<hr className="subscriptions__separator" />

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -52,7 +52,7 @@ const SiteSubscriptionPage = () => {
 		// todo: style the button (underline, color?, etc.)
 		const Resubscribe = () => (
 			<Button
-				onClick={ () => subscribe( { blog_id: blogId } ) }
+				onClick={ () => subscribe( { blog_id: blogId, url: data?.URL } ) }
 				disabled={ subscribing || unsubscribing }
 			>
 				{ translate( 'Resubscribe' ) }

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -82,4 +82,26 @@ const applyCallbackToPages = < K extends string, T >(
 	};
 };
 
-export { callApi, applyCallbackToPages, getSubkey };
+// Helper function to determine which API endpoint to call based on whether the user is logged in or not.
+const getApiParams = (
+	action: 'new' | 'delete',
+	isLoggedIn: boolean,
+	blogId: number | string,
+	url?: string
+) => {
+	if ( isLoggedIn ) {
+		return {
+			path: `/read/following/mine/${ action }`,
+			apiVersion: '1.1',
+			body: { source: 'calypso', url: url },
+		};
+	}
+
+	return {
+		path: `/read/site/${ blogId }/post_email_subscriptions/${ action }`,
+		apiVersion: '1.2',
+		body: {},
+	};
+};
+
+export { callApi, applyCallbackToPages, getSubkey, getApiParams };

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -82,8 +82,8 @@ const applyCallbackToPages = < K extends string, T >(
 	};
 };
 
-// Helper function to determine which API endpoint to call based on whether the user is logged in or not.
-const getApiParams = (
+// Subscriptions Management helper function to determine which API endpoint to call based on whether the user is logged in or not.
+const getSubscriptionMutationParams = (
 	action: 'new' | 'delete',
 	isLoggedIn: boolean,
 	blogId: number | string,
@@ -104,4 +104,4 @@ const getApiParams = (
 	};
 };
 
-export { callApi, applyCallbackToPages, getSubkey, getApiParams };
+export { callApi, applyCallbackToPages, getSubkey, getSubscriptionMutationParams };

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -1,9 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
-import { callApi } from '../helpers';
+import { callApi, getApiParams } from '../helpers';
 import { useIsLoggedIn } from '../hooks';
 
 type SubscribeParams = {
 	blog_id?: number | string;
+	url?: string;
 };
 
 type SubscribeResponse = {
@@ -28,12 +29,19 @@ const useSiteSubscribeMutation = () => {
 			);
 		}
 
+		const { path, apiVersion, body } = getApiParams(
+			'new',
+			isLoggedIn,
+			params.blog_id,
+			params.url
+		);
+
 		const response = await callApi< SubscribeResponse >( {
-			path: `/read/site/${ params.blog_id }/post_email_subscriptions/new`,
+			path,
 			method: 'POST',
 			isLoggedIn,
-			apiVersion: '1.2',
-			body: {},
+			apiVersion,
+			body,
 		} );
 		if ( ! response.success ) {
 			throw new Error(

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -43,7 +43,7 @@ const useSiteSubscribeMutation = () => {
 			apiVersion,
 			body,
 		} );
-		if ( ! response.success ) {
+		if ( ! response.subscribed ) {
 			throw new Error(
 				// reminder: translate this string when we add it to the UI
 				'Something went wrong while subscribing.'

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { callApi, getApiParams } from '../helpers';
+import { callApi, getSubscriptionMutationParams } from '../helpers';
 import { useIsLoggedIn } from '../hooks';
 
 type SubscribeParams = {
@@ -29,7 +29,7 @@ const useSiteSubscribeMutation = () => {
 			);
 		}
 
-		const { path, apiVersion, body } = getApiParams(
+		const { path, apiVersion, body } = getSubscriptionMutationParams(
 			'new',
 			isLoggedIn,
 			params.blog_id,

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { callApi, getApiParams } from '../helpers';
+import { callApi, getSubscriptionMutationParams } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
 import { SiteSubscriptionsPages, SubscriptionManagerSubscriptionsCount } from '../types';
 
@@ -29,7 +29,7 @@ const useSiteUnsubscribeMutation = () => {
 				);
 			}
 
-			const { path, apiVersion, body } = getApiParams(
+			const { path, apiVersion, body } = getSubscriptionMutationParams(
 				'delete',
 				isLoggedIn,
 				params.blog_id,

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { callApi } from '../helpers';
+import { callApi, getApiParams } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
 import { SiteSubscriptionsPages, SubscriptionManagerSubscriptionsCount } from '../types';
 
@@ -12,23 +12,6 @@ type UnsubscribeResponse = {
 	success?: boolean;
 	subscribed?: boolean;
 	subscription?: null;
-};
-
-// Helper function to determine which API endpoint to call based on whether the user is logged in or not.
-const getApiParams = ( isLoggedIn: boolean, blogId: number | string, url?: string ) => {
-	if ( isLoggedIn ) {
-		return {
-			path: '/read/following/mine/delete',
-			apiVersion: '1.1',
-			body: { source: 'calypso', url: url },
-		};
-	}
-
-	return {
-		path: `/read/site/${ blogId }/post_email_subscriptions/delete`,
-		apiVersion: '1.2',
-		body: {},
-	};
 };
 
 const useSiteUnsubscribeMutation = () => {
@@ -46,7 +29,12 @@ const useSiteUnsubscribeMutation = () => {
 				);
 			}
 
-			const { path, apiVersion, body } = getApiParams( isLoggedIn, params.blog_id, params.url );
+			const { path, apiVersion, body } = getApiParams(
+				'delete',
+				isLoggedIn,
+				params.blog_id,
+				params.url
+			);
 
 			const response = await callApi< UnsubscribeResponse >( {
 				path,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/77241.

## Proposed Changes

* update `getApiParams` to accept endpoint "action type" and extract the function out to the `helpers` directory
* make use of `/read/following/mine/${ action }` endpoint for logged-in users - allowing them to resubscribe:

```js
{
	path: `/read/following/mine/${ action }`,
	apiVersion: '1.1',
	body: { source: 'calypso', url: url },
}
```
* fix "`send_posts` undefined" and potential similar errors related to `SiteSubscriptionSettings` props


## Testing Instructions

### Testing as an external user
1. Check out the PR and build the app.
2. Authenticate as an external user (`subkey` "dance" in the incognito browser window).
3. Make sure your external user is subscribed to some sites already.
4. Navigate to `http://calypso.localhost:3000/subscriptions/site/[blog_id]` where `[blog_id]` needs to be replaced with a specific blog ID your user is subscribed to.
5. When the page loads, you should be able to click on the "Cancel subscription" button on the bottom of the page.
6. Once the button is clicked, the user should be unsubscribed from the site (this can be checked at https://wordpress.com/subscriptions/sites), the settings should be hidden and the success notice should display:

![Markup on 2023-05-18 at 14:47:40](https://github.com/Automattic/wp-calypso/assets/25105483/cb27d85f-866e-4257-94fc-c1b25a3a3c1d)

7. Click on the "Resubscribe" button. You should be resubscribed to the site and the settings should display again:

![Markup on 2023-05-18 at 14:47:58](https://github.com/Automattic/wp-calypso/assets/25105483/de24bbe0-3347-4d84-8320-74b86c62b4b5)

ℹ️ Please note that the optimistic updates for unsubscribe / resubscribe haven't been implemented yet. This means that when you resubscribe, the "Delivery Frequency" setting won't switch itself to "Immediately" (as it should). 

### Testing as a logged-in user
1. Check out the PR.
2. Navigate to `client/server/pages/index.js` and temporarily add `return next();` to the line `833`:

![Markup on 2023-04-28 at 17:50:44](https://user-images.githubusercontent.com/25105483/235195033-4902bb9d-db57-43a4-b295-2d90feb6731f.png)

3. Build the app.
4. Log in to a test WordPress.com account that has some existing Site subscriptions.
5. Navigate to `http://calypso.localhost:3000/subscriptions/site/[blog_id]` where `[blog_id]` needs to be replaced with a specific blog ID your user is subscribed to.
6. When the page loads, you should be able to click on the "Cancel subscription" button on the bottom of the page.
7. Once the button is clicked, the user should be unsubscribed from the site (this can be checked at https://wordpress.com/subscriptions/sites), the settings should be hidden and the success notice should display (similarly as when testing the external user).
8. Click on the "Resubscribe" button. You should be resubscribed to the site and the settings should display again (similarly as when testing the external user).

### Testing unsubscribe and subscribe mutation error states
1. Follow the steps as with the external or logged-in user, but break the queries in some way, e.g. by navigating to `packages/data-stores/src/reader/helpers/index.ts` and changing the request `path`s inside `getApiParams()` (e.g. by adding an extra space).
2. Depending on which path is broken: 
  * Clicking the "Cancel subscription" button should result in an error message.
  * When you try to resubscribe, an error message should display as well.
  * Clicking the "Resubscribe" button should try to subscribe the user again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
