### PR TITLE
Help Center: Ensure ETK connects to production Zendesk instance

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
@@ -1,12 +1,8 @@
-const isDevelopment = process.env.NODE_ENV === 'development' ? 'development' : 'production';
-
 window.configData = {
-	env_id: isDevelopment ? 'development' : 'production',
+	env_id: 'production',
 	i18n_default_locale_slug: 'en',
 	google_analytics_key: 'UA-10673494-15',
-	zendesk_support_chat_key: isDevelopment
-		? '715f17a8-4a28-4a7f-8447-0ef8f06c70d7'
-		: 'cec07bc9-4da6-4dd2-afa7-c7e01ae73584',
+	zendesk_support_chat_key: 'cec07bc9-4da6-4dd2-afa7-c7e01ae73584',
 	client_slug: 'browser',
 	twemoji_cdn_url: 'https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/',
 	site_filter: [],


### PR DESCRIPTION
Partially reverts #77165
Looks like the "production" ETK build is being built with `development` env set? That needs separate investigation, but for now let's make sure no production user tries to connect to the Zendesk sandbox.

## Proposed Changes

* Revert ETK Help Center's `config.js` to use production values, regardless of env.

## Testing Instructions

- Download the Editing Toolkit build artifact, make sure it's referencing production. The `help-center.min.js` file should contain `env_id: 'production'` and the production Zendesk chat key.