### PR TITLE
Update scan text to mention WAF

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -579,7 +579,7 @@ export const getJetpackProductsShortDescriptions = (): Record< string, Translate
 		'Speed up your site and improve SEO - no developer required.'
 	);
 	const searchShortDescription = translate( 'Help your site visitors find answers instantly.' );
-	const scanShortDescription = translate( 'Automatic malware scanning with one-click fixes.' );
+	const scanShortDescription = translate( '24/7 protection: WAF and automatic malware scanning.' );
 	const videoPressShortDescription = translate(
 		'High-quality, ad-free video built specifically for WordPress.'
 	);
@@ -693,7 +693,7 @@ export const getJetpackProductsLightboxDescription = (): Record< string, Transla
 		'Automatically clear spam from your comments and forms.'
 	);
 	const scanLightboxDescription = translate(
-		'Keep your site or store ahead of security threats with automated malware scanning; including one-click fixes.'
+		'Keep your site or store ahead of security threats with our WAF and automated malware scanning, including one-click fixes.'
 	);
 	const searchLightboxDescription = translate(
 		'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content - right when they need it.'


### PR DESCRIPTION
Update scan text to mention WAF


Related to 1198218726984184-as-1204539846448815/f

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?