### PR TITLE
Subscription Management: Fix mutation updates related to `useSiteSubscribeMutation` and `useSiteUnsubscribeMutation`

### DIFF
--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -28,14 +28,14 @@ const SiteSubscriptionPage = () => {
 		isLoading: subscribing,
 		isSuccess: subscribed,
 		error: subscribeError,
-	} = SubscriptionManager.useSiteSubscribeMutation();
+	} = SubscriptionManager.useSiteSubscribeMutation( blogId );
 
 	const {
 		mutate: unsubscribe,
 		isLoading: unsubscribing,
 		isSuccess: unsubscribed,
 		error: unsubscribeError,
-	} = SubscriptionManager.useSiteUnsubscribeMutation();
+	} = SubscriptionManager.useSiteUnsubscribeMutation( blogId );
 
 	useEffect( () => {
 		if ( subscribed ) {
@@ -174,7 +174,7 @@ const SiteSubscriptionPage = () => {
 									<dd>
 										<TimeSince
 											date={
-												( date_subscribed.valueOf()
+												( date_subscribed?.valueOf()
 													? date_subscribed
 													: new Date( 0 )
 												).toISOString?.() ?? date_subscribed

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -22,6 +22,8 @@ type SubscribeResponse = {
 const useSiteSubscribeMutation = ( blog_id?: string ) => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
+	const siteSubscriptionsCacheKey = useCacheKey( [ 'read', 'site-subscriptions' ] );
+	const subscriptionsCountCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
 	const siteSubscriptionDetailsCacheKey = useCacheKey( [
 		'read',
 		'site-subscription-details',
@@ -85,6 +87,8 @@ const useSiteSubscribeMutation = ( blog_id?: string ) => {
 			}
 		},
 		onSettled: () => {
+			queryClient.invalidateQueries( siteSubscriptionsCacheKey );
+			queryClient.invalidateQueries( subscriptionsCountCacheKey );
 			queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey );
 		},
 	} );

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -140,11 +140,9 @@ const useSiteUnsubscribeMutation = ( blog_id?: string ) => {
 			}
 		},
 		onSettled: () => {
-			// We are not invalidating the `siteSubscriptionDetailsCacheKey` on purpose here,
-			// because we need the related values in place (Site title, Site icon and
-			// Subscriber count are still displayed in the UI even after unsubscribing).
 			queryClient.invalidateQueries( siteSubscriptionsCacheKey );
 			queryClient.invalidateQueries( subscriptionsCountCacheKey );
+			queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey, { refetchType: 'none' } );
 		},
 	} );
 };


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/77093.

TODO:
- [x] rebase this PR and resolve conflicts after https://github.com/Automattic/wp-calypso/pull/77266#pullrequestreview-1441130804 is merged.

## Proposed Changes

* add `onMutate` (including optimistic update for `subscriber_count`), `onError` and `onSettled` (invalidating queries after successful resubscribe) to `useSiteSubscribeMutation` 
* add optimistic update for `subscriber_count` to `useSiteUnsubscribeMutation`
* fix "`date_subscribed` undefined" error that manifested on resubscribe

### External user

https://github.com/Automattic/wp-calypso/assets/25105483/d2b4329e-2ac1-440f-99d1-91b95088c883

### Logged-in user

https://github.com/Automattic/wp-calypso/assets/25105483/e7846cb8-5ade-49b5-8649-284ed2421be0

## Testing Instructions

### Testing as an external user
1. Check out the PR and build the app.
2. Authenticate as an external user (`subkey` "dance" in the incognito browser window).
3. Make sure your external user is subscribed to some sites already.
4. Navigate to `http://calypso.localhost:3000/subscriptions/site/[blog_id]` where `[blog_id]` needs to be replaced with a specific blog ID your user is subscribed to.
5. When the page loads, make sure the "Email me new posts" is set to something else than "Immediately". 
6. Click on the "Cancel subscription" button on the bottom of the page.
7. The user should be unsubscribed from the site (this can be checked at https://wordpress.com/subscriptions/sites), the settings should be hidden, success notice should display and the `subscriber_count` should be decremented.
8. Click on the "Resubscribe" button. You should be resubscribed to the site, the settings should display again, `subscriber_count` should increment, "Email me new posts" setting should switch to "Immediately" (the default value)  and the "Date" to "just now".

Feel free to compare the behavior with the screen recording above.

### Testing as a logged-in user
1. Check out the PR.
2. Navigate to `client/server/pages/index.js` and temporarily add `return next();` to the line `833`:

![Markup on 2023-04-28 at 17:50:44](https://user-images.githubusercontent.com/25105483/235195033-4902bb9d-db57-43a4-b295-2d90feb6731f.png)

3. Build the app.
4. Log in to a test WordPress.com account that has some existing Site subscriptions.
5. Navigate to `http://calypso.localhost:3000/subscriptions/site/[blog_id]` where `[blog_id]` needs to be replaced with a specific blog ID your user is subscribed to.
6. When the page loads, change the settings randomly.
7. Click on the "Cancel subscription" button on the bottom of the page.
8. The user should be unsubscribed from the site (this can be checked at https://wordpress.com/subscriptions/sites), the settings should be hidden, the success notice should display and `subscriber_count` should decrement (similarly as when testing with the external user).
9. Click on the "Resubscribe" button. You should be resubscribed to the site, `subscriber_count` should increment and the settings should display again while switching to their default values.

Feel free to compare the behavior with the screen recording above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
