### PR TITLE
removing Coupon code for Akismet checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -179,13 +179,15 @@ export default function WPCheckoutOrderReview( {
 				/>
 			</WPOrderReviewSection>
 
-			<CouponFieldArea
-				isCouponFieldVisible={ isCouponFieldVisible }
-				setCouponFieldVisible={ setCouponFieldVisible }
-				isPurchaseFree={ isPurchaseFree }
-				couponStatus={ couponStatus }
-				couponFieldStateProps={ couponFieldStateProps }
-			/>
+			{ ! isAkismetCheckout() && (
+				<CouponFieldArea
+					isCouponFieldVisible={ isCouponFieldVisible }
+					setCouponFieldVisible={ setCouponFieldVisible }
+					isPurchaseFree={ isPurchaseFree }
+					couponStatus={ couponStatus }
+					couponFieldStateProps={ couponFieldStateProps }
+				/>
+			) }
 		</div>
 	);
 }
@@ -227,10 +229,6 @@ function CouponFieldArea( {
 				couponFieldStateProps={ couponFieldStateProps }
 			/>
 		);
-	}
-
-	if ( isAkismetCheckout() ) {
-		return null;
 	}
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -8,7 +8,6 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, joinClasses } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -8,6 +8,8 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, joinClasses } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -225,6 +227,10 @@ function CouponFieldArea( {
 				couponFieldStateProps={ couponFieldStateProps }
 			/>
 		);
+	}
+
+	if ( isAkismetCheckout() ) {
+		return null;
 	}
 
 	return (


### PR DESCRIPTION
Removes the Coupon Code area from Akismet checkout since there are no coupons for that product.

To test:-

- Spin up Calypso locally
- Visit http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_1?checkoutBackUrl=https://akismet.com/pricing/

The coupon code should not show in this branch

- Visit something like http://calypso.localhost:3000/checkout/{site}#step2

The coupon code should show (since won't be Akismet checkout)
