### PR TITLE
ESLint: Bulk fix `@tanstack/query/prefer-query-object-syntax` rule violations

### DIFF
--- a/apps/odyssey-stats/src/hooks/use-module-data-query.ts
+++ b/apps/odyssey-stats/src/hooks/use-module-data-query.ts
@@ -38,15 +38,13 @@ function queryModuleData( module: Module ): Promise< ModuleData > {
 }
 
 export default function useModuleDataQuery( module: Module ) {
-	return useQuery< ModuleData, Error >(
-		[ 'stats-widget', 'module-data', module ],
-		() => queryModuleData( module ),
-		{
-			staleTime: 5 * 60 * 1000,
-			// If the module is not active, we don't want to retry the query.
-			retry: false,
-			retryOnMount: false,
-			refetchOnWindowFocus: false,
-		}
-	);
+	return useQuery< ModuleData, Error >( {
+		queryKey: [ 'stats-widget', 'module-data', module ],
+		queryFn: () => queryModuleData( module ),
+		staleTime: 5 * 60 * 1000,
+		// If the module is not active, we don't want to retry the query.
+		retry: false,
+		retryOnMount: false,
+		refetchOnWindowFocus: false,
+	} );
 }

--- a/apps/odyssey-stats/src/hooks/use-referrers-query.ts
+++ b/apps/odyssey-stats/src/hooks/use-referrers-query.ts
@@ -36,33 +36,31 @@ export default function useReferrersQuery(
 	summarize = 1,
 	max = 0
 ) {
-	return useQuery(
-		[ 'stats-widget', 'referrers', siteId, period, num, date, summarize, max ],
-		() => queryReferrers( siteId, { period, num, date, summarize, max } ),
-		{
-			select: ( data ) => {
-				// The groups' views count may not be in descending order
-				// since we use the first result for nest groups.
-				return data?.summary?.groups.map( ( group: GroupWithChildren & GroupWithoutChildren ) => {
-					// Get the first result as the nested group's data.
-					if ( Array.isArray( group.results ) && group.results.length > 0 ) {
-						const subGroup = group.results[ 0 ];
-
-						return {
-							...subGroup,
-							title: subGroup.name,
-							views: subGroup.views,
-						};
-					}
+	return useQuery( {
+		queryKey: [ 'stats-widget', 'referrers', siteId, period, num, date, summarize, max ],
+		queryFn: () => queryReferrers( siteId, { period, num, date, summarize, max } ),
+		select: ( data ) => {
+			// The groups' views count may not be in descending order
+			// since we use the first result for nest groups.
+			return data?.summary?.groups.map( ( group: GroupWithChildren & GroupWithoutChildren ) => {
+				// Get the first result as the nested group's data.
+				if ( Array.isArray( group.results ) && group.results.length > 0 ) {
+					const subGroup = group.results[ 0 ];
 
 					return {
-						...group,
-						title: group.name,
-						views: group.results.views,
+						...subGroup,
+						title: subGroup.name,
+						views: subGroup.views,
 					};
-				} );
-			},
-			staleTime: 5 * 60 * 1000,
-		}
-	);
+				}
+
+				return {
+					...group,
+					title: group.name,
+					views: group.results.views,
+				};
+			} );
+		},
+		staleTime: 5 * 60 * 1000,
+	} );
 }

--- a/apps/odyssey-stats/src/hooks/use-top-posts-query.ts
+++ b/apps/odyssey-stats/src/hooks/use-top-posts-query.ts
@@ -21,12 +21,10 @@ export default function useTopPostsQuery(
 	summarize = 1,
 	max = 0
 ) {
-	return useQuery(
-		[ 'stats-widget', 'top-posts', siteId, period, num, date, summarize, max ],
-		() => queryTopPosts( siteId, { period, num, date, summarize, max } ),
-		{
-			select: ( data ) => data?.summary?.postviews,
-			staleTime: 5 * 60 * 1000,
-		}
-	);
+	return useQuery( {
+		queryKey: [ 'stats-widget', 'top-posts', siteId, period, num, date, summarize, max ],
+		queryFn: () => queryTopPosts( siteId, { period, num, date, summarize, max } ),
+		select: ( data ) => data?.summary?.postviews,
+		staleTime: 5 * 60 * 1000,
+	} );
 }

--- a/apps/odyssey-stats/src/hooks/use-visits-query.ts
+++ b/apps/odyssey-stats/src/hooks/use-visits-query.ts
@@ -21,12 +21,11 @@ export default function useVisitsQuery(
 	date: string,
 	fields = [ 'views', 'visitors' ]
 ) {
-	return useQuery(
-		[ 'stats-widget', 'visits', siteId, unit, quantity, date, fields ],
-		() => queryStatsVisits( siteId, { unit, quantity, date, stat_fields: fields.join( ',' ) } ),
-		{
-			select: parseChartData,
-			staleTime: 5 * 60 * 1000,
-		}
-	);
+	return useQuery( {
+		queryKey: [ 'stats-widget', 'visits', siteId, unit, quantity, date, fields ],
+		queryFn: () =>
+			queryStatsVisits( siteId, { unit, quantity, date, stat_fields: fields.join( ',' ) } ),
+		select: parseChartData,
+		staleTime: 5 * 60 * 1000,
+	} );
 }

--- a/client/blocks/blog-stickers/use-add-blog-sticker-mutation.js
+++ b/client/blocks/blog-stickers/use-add-blog-sticker-mutation.js
@@ -4,8 +4,8 @@ import wp from 'calypso/lib/wp';
 
 export const useAddBlogStickerMutation = ( options = {} ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		async ( { blogId, stickerName } ) => {
+	const mutation = useMutation( {
+		mutationFn: async ( { blogId, stickerName } ) => {
 			const response = await wp.req.post( `/sites/${ blogId }/blog-stickers/add/${ stickerName }` );
 
 			if ( ! response.success ) {
@@ -14,15 +14,13 @@ export const useAddBlogStickerMutation = ( options = {} ) => {
 
 			return response;
 		},
-		{
-			...options,
-			onSuccess( ...args ) {
-				const [ , { blogId } ] = args;
-				queryClient.invalidateQueries( [ `blog-stickers`, blogId ] );
-				options.onSuccess?.( ...args );
-			},
-		}
-	);
+		...options,
+		onSuccess( ...args ) {
+			const [ , { blogId } ] = args;
+			queryClient.invalidateQueries( [ `blog-stickers`, blogId ] );
+			options.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/blocks/blog-stickers/use-blog-stickers-query.js
+++ b/client/blocks/blog-stickers/use-blog-stickers-query.js
@@ -8,13 +8,11 @@ export const useBlogStickersQuery = ( blogId, queryOptions = {} ) => {
 	const teams = useSelector( getReaderTeams );
 	const isAutomattician = isAutomatticTeamMember( teams );
 
-	return useQuery(
-		[ 'blog-stickers', blogId ],
-		() => wp.req.get( `/sites/${ blogId }/blog-stickers` ),
-		{
-			...queryOptions,
-			enabled: !! blogId && isAutomattician,
-			staleTime: 1000 * 60 * 5, // 5 minutes
-		}
-	);
+	return useQuery( {
+		queryKey: [ 'blog-stickers', blogId ],
+		queryFn: () => wp.req.get( `/sites/${ blogId }/blog-stickers` ),
+		...queryOptions,
+		enabled: !! blogId && isAutomattician,
+		staleTime: 1000 * 60 * 5,
+	} );
 };

--- a/client/blocks/blog-stickers/use-remove-blog-sticker-mutation.js
+++ b/client/blocks/blog-stickers/use-remove-blog-sticker-mutation.js
@@ -4,8 +4,8 @@ import wp from 'calypso/lib/wp';
 
 export const useRemoveBlogStickerMutation = ( options = {} ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		async ( { blogId, stickerName } ) => {
+	const mutation = useMutation( {
+		mutationFn: async ( { blogId, stickerName } ) => {
 			const response = await wp.req.post(
 				`/sites/${ blogId }/blog-stickers/remove/${ stickerName }`
 			);
@@ -16,15 +16,13 @@ export const useRemoveBlogStickerMutation = ( options = {} ) => {
 
 			return response;
 		},
-		{
-			...options,
-			onSuccess( ...args ) {
-				const [ , { blogId } ] = args;
-				queryClient.invalidateQueries( [ `blog-stickers`, blogId ] );
-				options.onSuccess?.( ...args );
-			},
-		}
-	);
+		...options,
+		onSuccess( ...args ) {
+			const [ , { blogId } ] = args;
+			queryClient.invalidateQueries( [ `blog-stickers`, blogId ] );
+			options.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/components/advanced-credentials/host-selection/index.tsx
+++ b/client/components/advanced-credentials/host-selection/index.tsx
@@ -18,19 +18,17 @@ interface Guess {
 }
 
 function useHostingProviderGuessQuery( siteId: SiteId ) {
-	return useQuery(
-		[ 'site-hosting-provider-guess', siteId ],
-		(): Promise< Guess > =>
+	return useQuery( {
+		queryKey: [ 'site-hosting-provider-guess', siteId ],
+		queryFn: (): Promise< Guess > =>
 			wpcom.req.get( {
 				path: `/sites/${ siteId }/hosting-provider`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteId,
-			meta: { persist: false },
-			select: ( data ) => data.guess,
-		}
-	);
+		enabled: !! siteId,
+		meta: { persist: false },
+		select: ( data ) => data.guess,
+	} );
 }
 
 const HostSelection: FunctionComponent = () => {

--- a/client/components/language-picker/site-language-picker.jsx
+++ b/client/components/language-picker/site-language-picker.jsx
@@ -34,11 +34,11 @@ const SiteLanguagePicker = ( { languages: origLanguages, ...restProps } ) => {
 		data: wporgTranslations,
 		error,
 		isLoading,
-	} = useQuery(
-		[ 'wporg-translations', wpVersion ],
-		async () => fetchWporgTranslationsList( wpVersion ),
-		{ enabled: !! siteIsJetpack }
-	);
+	} = useQuery( {
+		queryKey: [ 'wporg-translations', wpVersion ],
+		queryFn: async () => fetchWporgTranslationsList( wpVersion ),
+		enabled: !! siteIsJetpack,
+	} );
 
 	// We only need to modify the language list for jetpack or atomic sites
 	if ( siteIsJetpack ) {

--- a/client/components/site-preview-link/use-create-site-preview-link.ts
+++ b/client/components/site-preview-link/use-create-site-preview-link.ts
@@ -17,41 +17,39 @@ export const useCreateSitePreviewLink = ( options: UseCreateSitePreviewLinkOptio
 	const { siteId, onSuccess, onError } = options;
 	const queryKey = [ SITE_PREVIEW_LINKS_QUERY_KEY, siteId ];
 	const queryClient = useQueryClient();
-	const createLinkMutation = useMutation(
-		() =>
+	const createLinkMutation = useMutation( {
+		mutationFn: () =>
 			wpcom.req.post( {
 				path: `/sites/${ siteId }/preview-links`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			onSuccess: () => {
-				onSuccess?.();
-			},
-			onError: ( err, code, context ) => {
-				queryClient.setQueryData( queryKey, context );
-				onError?.();
-			},
-			onMutate: async () => {
-				await queryClient.cancelQueries( queryKey );
-				const cachedData = queryClient.getQueryData( queryKey );
-				queryClient.setQueryData< PreviewLinksResponse >( queryKey, ( old ) => [
-					...( old ?? [] ),
-					{
-						code: '',
-						created_at: '',
-						isCreating: true,
-					},
-				] );
-				return cachedData;
-			},
-			onSettled: ( data: PreviewLink | undefined ) => {
-				if ( data?.code ) {
-					queryClient.setQueryData( queryKey, () => [ data ] );
-				}
-				queryClient.invalidateQueries( queryKey );
-			},
-		}
-	);
+		onSuccess: () => {
+			onSuccess?.();
+		},
+		onError: ( err, code, context ) => {
+			queryClient.setQueryData( queryKey, context );
+			onError?.();
+		},
+		onMutate: async () => {
+			await queryClient.cancelQueries( queryKey );
+			const cachedData = queryClient.getQueryData( queryKey );
+			queryClient.setQueryData< PreviewLinksResponse >( queryKey, ( old ) => [
+				...( old ?? [] ),
+				{
+					code: '',
+					created_at: '',
+					isCreating: true,
+				},
+			] );
+			return cachedData;
+		},
+		onSettled: ( data: PreviewLink | undefined ) => {
+			if ( data?.code ) {
+				queryClient.setQueryData( queryKey, () => [ data ] );
+			}
+			queryClient.invalidateQueries( queryKey );
+		},
+	} );
 
 	const { mutate: createLink, ...restMutation } = createLinkMutation;
 

--- a/client/components/site-preview-link/use-delete-site-preview-link.ts
+++ b/client/components/site-preview-link/use-delete-site-preview-link.ts
@@ -17,49 +17,47 @@ export const useDeleteSitePreviewLink = ( options: UseDeleteSitePreviewLinkOptio
 	const { siteId, onSuccess, onError } = options;
 	const queryKey = [ SITE_PREVIEW_LINKS_QUERY_KEY, siteId ];
 	const queryClient = useQueryClient();
-	const deleteLinkMutation = useMutation(
-		( code: string ) =>
+	const deleteLinkMutation = useMutation( {
+		mutationFn: ( code: string ) =>
 			wpcom.req.post( {
 				method: 'DELETE',
 				path: `/sites/${ siteId }/preview-links/${ code }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			onSuccess: () => {
-				onSuccess?.();
-			},
-			onMutate: async ( code: string ) => {
-				await queryClient.cancelQueries( queryKey );
-				const cachedData = queryClient.getQueryData< PreviewLinksResponse >( queryKey );
-				queryClient.setQueryData< PreviewLinksResponse >( queryKey, ( old ) => {
-					const previewLinks = old ?? [];
-					// Inform the UI the link is being removed
-					const index = previewLinks.findIndex( ( previewLink ) => previewLink.code === code );
-					if ( index >= 0 ) {
-						previewLinks[ index ].isRemoving = true;
-					}
-					return previewLinks;
-				} );
-				return cachedData;
-			},
-			onError: ( err, code, context ) => {
-				queryClient.setQueryData(
-					queryKey,
-					context?.map( ( link ) => ( { ...link, isRemoving: false } ) )
-				);
-				onError?.();
-			},
-			onSettled: ( data: PreviewLink | undefined ) => {
-				if ( data?.code ) {
-					const cachedData = queryClient.getQueryData< PreviewLinksResponse >( queryKey );
-					queryClient.setQueryData( queryKey, () =>
-						cachedData?.filter( ( previewLink ) => ! previewLink.isRemoving )
-					);
+		onSuccess: () => {
+			onSuccess?.();
+		},
+		onMutate: async ( code: string ) => {
+			await queryClient.cancelQueries( queryKey );
+			const cachedData = queryClient.getQueryData< PreviewLinksResponse >( queryKey );
+			queryClient.setQueryData< PreviewLinksResponse >( queryKey, ( old ) => {
+				const previewLinks = old ?? [];
+				// Inform the UI the link is being removed
+				const index = previewLinks.findIndex( ( previewLink ) => previewLink.code === code );
+				if ( index >= 0 ) {
+					previewLinks[ index ].isRemoving = true;
 				}
-				queryClient.invalidateQueries( queryKey );
-			},
-		}
-	);
+				return previewLinks;
+			} );
+			return cachedData;
+		},
+		onError: ( err, code, context ) => {
+			queryClient.setQueryData(
+				queryKey,
+				context?.map( ( link ) => ( { ...link, isRemoving: false } ) )
+			);
+			onError?.();
+		},
+		onSettled: ( data: PreviewLink | undefined ) => {
+			if ( data?.code ) {
+				const cachedData = queryClient.getQueryData< PreviewLinksResponse >( queryKey );
+				queryClient.setQueryData( queryKey, () =>
+					cachedData?.filter( ( previewLink ) => ! previewLink.isRemoving )
+				);
+			}
+			queryClient.invalidateQueries( queryKey );
+		},
+	} );
 
 	const { mutate: deleteLink, ...restMutation } = deleteLinkMutation;
 

--- a/client/components/site-preview-link/use-site-preview-links.ts
+++ b/client/components/site-preview-link/use-site-preview-links.ts
@@ -21,17 +21,15 @@ export const SITE_PREVIEW_LINKS_QUERY_KEY = 'site-preview-links';
 
 export function useSitePreviewLinks( options: UseSitePreviewLinksOptions ) {
 	const { siteId, onSuccess, isEnabled = false } = options;
-	return useQuery< PreviewLinksResponse, unknown, PreviewLink[] >(
-		[ SITE_PREVIEW_LINKS_QUERY_KEY, siteId ],
-		() =>
+	return useQuery< PreviewLinksResponse, unknown, PreviewLink[] >( {
+		queryKey: [ SITE_PREVIEW_LINKS_QUERY_KEY, siteId ],
+		queryFn: () =>
 			wpcom.req.get( {
 				path: `/sites/${ siteId }/preview-links`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: isEnabled && !! siteId,
-			meta: { persist: false },
-			onSuccess,
-		}
-	);
+		enabled: isEnabled && !! siteId,
+		meta: { persist: false },
+		onSuccess,
+	} );
 }

--- a/client/data/activity-log/use-activity-log-query.js
+++ b/client/data/activity-log/use-activity-log-query.js
@@ -5,18 +5,16 @@ import fromActivityLogApi from 'calypso/state/data-layer/wpcom/sites/activity/fr
 import { getFilterKey } from './utils';
 
 export default function useActivityLogQuery( siteId, filter, options ) {
-	return useQuery(
-		[ 'activity-log', siteId, getFilterKey( filter ) ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'activity-log', siteId, getFilterKey( filter ) ],
+		queryFn: () =>
 			wpcom.req
 				.get(
 					{ path: `/sites/${ siteId }/activity`, apiNamespace: 'wpcom/v2' },
 					filterStateToApiQuery( filter )
 				)
 				.then( fromActivityLogApi ),
-		{
-			refetchInterval: 5 * 60 * 1000,
-			...options,
-		}
-	);
+		refetchInterval: 5 * 60 * 1000,
+		...options,
+	} );
 }

--- a/client/data/activity-log/use-rewindable-activity-log-query.js
+++ b/client/data/activity-log/use-rewindable-activity-log-query.js
@@ -5,18 +5,16 @@ import fromActivityLogApi from 'calypso/state/data-layer/wpcom/sites/activity/fr
 import { getFilterKey } from './utils';
 
 export default function useRewindableActivityLogQuery( siteId, filter, options ) {
-	return useQuery(
-		[ 'rewindable-activity-log', siteId, getFilterKey( filter ) ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'rewindable-activity-log', siteId, getFilterKey( filter ) ],
+		queryFn: () =>
 			wpcom.req
 				.get(
 					{ path: `/sites/${ siteId }/activity/rewindable`, apiNamespace: 'wpcom/v2' },
 					filterStateToApiQuery( filter )
 				)
 				.then( fromActivityLogApi ),
-		{
-			refetchInterval: 5 * 60 * 1000,
-			...options,
-		}
-	);
+		refetchInterval: 5 * 60 * 1000,
+		...options,
+	} );
 }

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -39,9 +39,9 @@ const useFetchDashboardSites = (
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
-	return useQuery(
-		[ 'jetpack-agency-dashboard-sites', searchQuery, currentPage, filter, sort ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'jetpack-agency-dashboard-sites', searchQuery, currentPage, filter, sort ],
+		queryFn: () =>
 			wpcomJpl.req.get(
 				{
 					path: '/jetpack-agency/sites',
@@ -54,35 +54,33 @@ const useFetchDashboardSites = (
 					...agencyDashboardSortToQueryObject( sort ),
 				}
 			),
-		{
-			select: ( data ) => {
-				return {
-					sites: data.sites.map( ( site: Site ) => {
-						// Since the "sites" API includes the "is_connected" property in the cache of the query set by
-						// the "useFetchTestConnection" hook, we are setting it here again since the "sites" API gets called
-						// more often than the "/test-connection" API which will flush the cache set by the
-						// "useFetchTestConnection" hook
-						const data: { connected: boolean } | undefined = queryClient.getQueryData( [
-							'jetpack-agency-test-connection',
-							site.blog_id,
-						] );
-						return {
-							...site,
-							is_connected: data?.hasOwnProperty( 'connected' ) ? data.connected : true,
-						};
-					} ),
-					total: data.total,
-					perPage: data.per_page,
-					totalFavorites: data.total_favorites,
-				};
-			},
-			onError: () =>
-				dispatch(
-					errorNotice( translate( 'Failed to retrieve your sites. Please try again later.' ) )
-				),
-			enabled: isPartnerOAuthTokenLoaded,
-		}
-	);
+		select: ( data ) => {
+			return {
+				sites: data.sites.map( ( site: Site ) => {
+					// Since the "sites" API includes the "is_connected" property in the cache of the query set by
+					// the "useFetchTestConnection" hook, we are setting it here again since the "sites" API gets called
+					// more often than the "/test-connection" API which will flush the cache set by the
+					// "useFetchTestConnection" hook
+					const data: { connected: boolean } | undefined = queryClient.getQueryData( [
+						'jetpack-agency-test-connection',
+						site.blog_id,
+					] );
+					return {
+						...site,
+						is_connected: data?.hasOwnProperty( 'connected' ) ? data.connected : true,
+					};
+				} ),
+				total: data.total,
+				perPage: data.per_page,
+				totalFavorites: data.total_favorites,
+			};
+		},
+		onError: () =>
+			dispatch(
+				errorNotice( translate( 'Failed to retrieve your sites. Please try again later.' ) )
+			),
+		enabled: isPartnerOAuthTokenLoaded,
+	} );
 };
 
 export default useFetchDashboardSites;

--- a/client/data/agency-dashboard/use-fetch-monitor-data.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-data.ts
@@ -6,9 +6,9 @@ import {
 import wpcom from 'calypso/lib/wp';
 
 const useFetchMonitorData = ( siteId: number, period: AllowedMonitorPeriods ) => {
-	return useQuery(
-		[ 'jetpack-monitor-uptime', siteId ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'jetpack-monitor-uptime', siteId ],
+		queryFn: () =>
 			wpcom.req.get(
 				{
 					path: `/sites/${ siteId }/jetpack-monitor-uptime`,
@@ -18,21 +18,19 @@ const useFetchMonitorData = ( siteId: number, period: AllowedMonitorPeriods ) =>
 					period,
 				}
 			),
-		{
-			select: ( data: MonitorUptimeAPIResponse ) => {
-				if ( ! data ) {
-					return [];
-				}
-				// Use sort() to ensure the data is always in ascending order
-				// since Object.keys() method does not guarantee the order of the keys.
-				const sortedKeys = Object.keys( data ).sort();
-				return sortedKeys.map( ( date ) => ( {
-					date,
-					...data[ date ],
-				} ) );
-			},
-		}
-	);
+		select: ( data: MonitorUptimeAPIResponse ) => {
+			if ( ! data ) {
+				return [];
+			}
+			// Use sort() to ensure the data is always in ascending order
+			// since Object.keys() method does not guarantee the order of the keys.
+			const sortedKeys = Object.keys( data ).sort();
+			return sortedKeys.map( ( date ) => ( {
+				date,
+				...data[ date ],
+			} ) );
+		},
+	} );
 };
 
 export default useFetchMonitorData;

--- a/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
@@ -4,9 +4,9 @@ import wpcom from 'calypso/lib/wp';
 const isAPIAvailable = false; // FIXME: Remove this line when API is available
 
 const useFetchMonitorVerfiedContacts = () => {
-	return useQuery(
-		[ 'monitor_notification_contacts' ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'monitor_notification_contacts' ],
+		queryFn: () =>
 			isAPIAvailable
 				? wpcom.req.get( {
 						path: '/jetpack-agency/contacts',
@@ -15,16 +15,14 @@ const useFetchMonitorVerfiedContacts = () => {
 				: {
 						emails: [],
 				  }, // FIXME: Remove this line and enable API call when API is available
-		{
-			select: ( contacts: { emails: [ { verified: boolean; value: string } ] } ) => {
-				return {
-					emails: contacts?.emails
-						.filter( ( email ) => email.verified )
-						.map( ( email ) => email.value ),
-				};
-			},
-		}
-	);
+		select: ( contacts: { emails: [ { verified: boolean; value: string } ] } ) => {
+			return {
+				emails: contacts?.emails
+					.filter( ( email ) => email.verified )
+					.map( ( email ) => email.value ),
+			};
+		},
+	} );
 };
 
 export default useFetchMonitorVerfiedContacts;

--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -11,9 +11,9 @@ const useFetchTestConnection = (
 ) => {
 	const queryClient = useQueryClient();
 	const { search, currentPage, filter, sort } = useContext( SitesOverviewContext );
-	return useQuery(
-		[ 'jetpack-agency-test-connection', siteId ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'jetpack-agency-test-connection', siteId ],
+		queryFn: () =>
 			wpcom.req.get(
 				{
 					path: `/jetpack-blogs/${ siteId }/test-connection`,
@@ -24,35 +24,33 @@ const useFetchTestConnection = (
 					is_stale_connection_healthy: Boolean( isConnectionHealthy ),
 				}
 			),
-		{
-			enabled: isPartnerOAuthTokenLoaded,
-			refetchOnWindowFocus: false,
-			// We don't want to trigger another API request to the /test-connection endpoint for a given site
-			// one minute after the first successful one.
-			staleTime: 1000 * 60,
-			onSuccess: ( data ) => {
-				// We are setting the "is_connected" property of the site in the query cache of the "sites"
-				// API to the value returned by the /test-connection endpoint. We are doing this to filter
-				// the site with connection issues easily in the UI and to have a single source of truth for
-				// the connection state of a site to avoid inconsistencies.
-				const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
-				queryClient.setQueryData( queryKey, ( oldSites: any ) => {
-					return {
-						...oldSites,
-						sites: oldSites?.sites.map( ( site: Site ) => {
-							if ( site.blog_id === siteId ) {
-								return {
-									...site,
-									is_connected: data?.hasOwnProperty( 'connected' ) ? data.connected : true,
-								};
-							}
-							return site;
-						} ),
-					};
-				} );
-			},
-		}
-	);
+		enabled: isPartnerOAuthTokenLoaded,
+		refetchOnWindowFocus: false,
+		// We don't want to trigger another API request to the /test-connection endpoint for a given site
+		// one minute after the first successful one.
+		staleTime: 1000 * 60,
+		onSuccess: ( data ) => {
+			// We are setting the "is_connected" property of the site in the query cache of the "sites"
+			// API to the value returned by the /test-connection endpoint. We are doing this to filter
+			// the site with connection issues easily in the UI and to have a single source of truth for
+			// the connection state of a site to avoid inconsistencies.
+			const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
+			queryClient.setQueryData( queryKey, ( oldSites: any ) => {
+				return {
+					...oldSites,
+					sites: oldSites?.sites.map( ( site: Site ) => {
+						if ( site.blog_id === siteId ) {
+							return {
+								...site,
+								is_connected: data?.hasOwnProperty( 'connected' ) ? data.connected : true,
+							};
+						}
+						return site;
+					} ),
+				};
+			} );
+		},
+	} );
 };
 
 export default useFetchTestConnection;

--- a/client/data/akismet/use-akismet-key-query.ts
+++ b/client/data/akismet/use-akismet-key-query.ts
@@ -3,18 +3,16 @@ import wpcom from 'calypso/lib/wp';
 
 const useAkismetKeyQuery = (): UseQueryResult< string > => {
 	const queryKey = [ 'me', 'akismet-key' ];
-	return useQuery(
+	return useQuery( {
 		queryKey,
-		async () =>
+		queryFn: async () =>
 			wpcom.req.get( {
 				path: '/akismet/get-key',
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			refetchIntervalInBackground: false,
-			refetchOnWindowFocus: false,
-		}
-	);
+		refetchIntervalInBackground: false,
+		refetchOnWindowFocus: false,
+	} );
 };
 
 export default useAkismetKeyQuery;

--- a/client/data/application-passwords/use-app-passwords-query.js
+++ b/client/data/application-passwords/use-app-passwords-query.js
@@ -2,7 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 const useAppPasswordsQuery = () =>
-	useQuery( [ 'application-passwords' ], () => wp.req.get( '/me/two-step/application-passwords' ), {
+	useQuery( {
+		queryKey: [ 'application-passwords' ],
+		queryFn: () => wp.req.get( '/me/two-step/application-passwords' ),
 		refetchOnWindowFocus: false,
 		select( data ) {
 			return data.application_passwords;

--- a/client/data/application-passwords/use-create-app-password-mutation.js
+++ b/client/data/application-passwords/use-create-app-password-mutation.js
@@ -4,19 +4,17 @@ import wp from 'calypso/lib/wp';
 
 const useCreateAppPasswordMutation = ( queryOptions = {} ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { appName } ) =>
+	const mutation = useMutation( {
+		mutationFn: ( { appName } ) =>
 			wp.req.post( '/me/two-step/application-passwords/new', {
 				application_name: appName,
 			} ),
-		{
-			...queryOptions,
-			onSuccess( ...args ) {
-				queryClient.invalidateQueries( [ 'application-passwords' ] );
-				queryOptions.onSuccess?.( ...args );
-			},
-		}
-	);
+		...queryOptions,
+		onSuccess( ...args ) {
+			queryClient.invalidateQueries( [ 'application-passwords' ] );
+			queryOptions.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/data/application-passwords/use-delete-app-password-mutation.js
+++ b/client/data/application-passwords/use-delete-app-password-mutation.js
@@ -4,17 +4,15 @@ import wp from 'calypso/lib/wp';
 
 const useDeleteAppPasswordMutation = ( queryOptions = {} ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { appPasswordId } ) =>
+	const mutation = useMutation( {
+		mutationFn: ( { appPasswordId } ) =>
 			wp.req.post( `/me/two-step/application-passwords/${ appPasswordId }/delete` ),
-		{
-			...queryOptions,
-			onSuccess( ...args ) {
-				queryClient.invalidateQueries( [ 'application-passwords' ] );
-				queryOptions.onSuccess?.( ...args );
-			},
-		}
-	);
+		...queryOptions,
+		onSuccess( ...args ) {
+			queryClient.invalidateQueries( [ 'application-passwords' ] );
+			queryOptions.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/data/block-editor/use-block-editor-nux-status-query.ts
+++ b/client/data/block-editor/use-block-editor-nux-status-query.ts
@@ -13,14 +13,14 @@ export const useBlockEditorNuxStatusQuery = (
 	const queryKey = [ 'blockEditorNuxStatus', siteId ];
 	const siteIsJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 
-	return useQuery< BlockEditorNuxStatus >(
+	return useQuery< BlockEditorNuxStatus >( {
 		queryKey,
-		() => {
+		queryFn: () => {
 			return wpcom.req.get( {
 				path: `/sites/${ siteId }/block-editor/nux`,
 				apiNamespace: 'wpcom/v2',
 			} );
 		},
-		{ enabled: !! siteId && ! siteIsJetpack }
-	);
+		enabled: !! siteId && ! siteIsJetpack,
+	} );
 };

--- a/client/data/block-editor/use-block-editor-settings-query.ts
+++ b/client/data/block-editor/use-block-editor-settings-query.ts
@@ -22,14 +22,14 @@ export const useBlockEditorSettingsQuery = (
 
 	const queryKey = [ 'blockEditorSettings', siteId, themeId ];
 
-	return useQuery< BlockEditorSettings >(
+	return useQuery< BlockEditorSettings >( {
 		queryKey,
-		() => {
+		queryFn: () => {
 			return wpcom.req.get( {
 				path: `/sites/${ siteId }/block-editor`,
 				apiNamespace: 'wpcom/v2',
 			} );
 		},
-		{ enabled: isEnabled && !! siteId }
-	);
+		enabled: isEnabled && !! siteId,
+	} );
 };

--- a/client/data/blogging-prompt/use-blogging-prompts.ts
+++ b/client/data/blogging-prompt/use-blogging-prompts.ts
@@ -28,18 +28,15 @@ export const useBloggingPrompts = (
 ): UseQueryResult< BloggingPrompt[] | null > => {
 	const today = moment().format( 'YYYY-MM-DD' );
 
-	return useQuery(
-		// Blogging prompts are the same for all sites, so can be cached only by date.
-		[ 'blogging-prompts', today + '-' + page ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'blogging-prompts', today + '-' + page ],
+		queryFn: () =>
 			wp.req.get( {
 				path: `/sites/${ siteId }/blogging-prompts?number=${ page }&from=${ today }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteId,
-			staleTime: 86400000, // 1 day
-			select: selectPrompts,
-		}
-	);
+		enabled: !! siteId,
+		staleTime: 86400000,
+		select: selectPrompts,
+	} );
 };

--- a/client/data/courses/use-course-query.js
+++ b/client/data/courses/use-course-query.js
@@ -2,18 +2,17 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
 const useCourseQuery = ( courseSlug, queryOptions = {} ) => {
-	return useQuery(
-		[ 'courses', courseSlug ],
-		() => wpcom.req.get( '/courses', { course_slug: courseSlug, apiNamespace: 'wpcom/v2' } ),
-		{
-			refetchOnReconnect: true,
-			refetchOnWindowFocus: false,
-			...queryOptions,
-			meta: {
-				...queryOptions.meta,
-			},
-		}
-	);
+	return useQuery( {
+		queryKey: [ 'courses', courseSlug ],
+		queryFn: () =>
+			wpcom.req.get( '/courses', { course_slug: courseSlug, apiNamespace: 'wpcom/v2' } ),
+		refetchOnReconnect: true,
+		refetchOnWindowFocus: false,
+		...queryOptions,
+		meta: {
+			...queryOptions.meta,
+		},
+	} );
 };
 
 export default useCourseQuery;

--- a/client/data/courses/use-update-user-course-progression-mutation.js
+++ b/client/data/courses/use-update-user-course-progression-mutation.js
@@ -4,8 +4,8 @@ import wpcom from 'calypso/lib/wp';
 
 function useUpdateUserCourseProgressionMutation( queryOptions = {} ) {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { courseSlug, videoSlug } ) =>
+	const mutation = useMutation( {
+		mutationFn: ( { courseSlug, videoSlug } ) =>
 			wpcom.req.post(
 				'/courses/videos',
 				{
@@ -16,14 +16,12 @@ function useUpdateUserCourseProgressionMutation( queryOptions = {} ) {
 					video_slug: videoSlug,
 				}
 			),
-		{
-			...queryOptions,
-			onSuccess( data, variables, context ) {
-				queryClient.invalidateQueries( [ 'courses', variables.courseSlug ] );
-				queryOptions.onSuccess?.( data, variables, context );
-			},
-		}
-	);
+		...queryOptions,
+		onSuccess( data, variables, context ) {
+			queryClient.invalidateQueries( [ 'courses', variables.courseSlug ] );
+			queryOptions.onSuccess?.( data, variables, context );
+		},
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/data/domains/nameservers/use-domain-nameservers-query.js
+++ b/client/data/domains/nameservers/use-domain-nameservers-query.js
@@ -2,10 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 const useDomainNameserversQuery = ( domainName ) =>
-	useQuery(
-		[ 'domain-nameservers', domainName ],
-		() => wp.req.get( `/domains/${ domainName }/nameservers/` ),
-		{ refetchOnWindowFocus: false }
-	);
+	useQuery( {
+		queryKey: [ 'domain-nameservers', domainName ],
+		queryFn: () => wp.req.get( `/domains/${ domainName }/nameservers/` ),
+		refetchOnWindowFocus: false,
+	} );
 
 export default useDomainNameserversQuery;

--- a/client/data/domains/nameservers/use-update-nameservers-mutation.js
+++ b/client/data/domains/nameservers/use-update-nameservers-mutation.js
@@ -4,19 +4,17 @@ import wp from 'calypso/lib/wp';
 
 function useUpdateNameserversMutation( domainName, queryOptions = {} ) {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { nameservers } ) =>
+	const mutation = useMutation( {
+		mutationFn: ( { nameservers } ) =>
 			wp.req.post( `/domains/${ domainName }/nameservers`, {
 				nameservers: nameservers.map( ( nameserver ) => ( { nameserver } ) ),
 			} ),
-		{
-			...queryOptions,
-			onSuccess( ...args ) {
-				queryClient.invalidateQueries( [ 'domain-nameservers', domainName ] );
-				queryOptions.onSuccess?.( ...args );
-			},
-		}
-	);
+		...queryOptions,
+		onSuccess( ...args ) {
+			queryClient.invalidateQueries( [ 'domain-nameservers', domainName ] );
+			queryOptions.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/data/domains/use-get-domains-query.ts
+++ b/client/data/domains/use-get-domains-query.ts
@@ -13,19 +13,17 @@ export const useGetDomainsQuery = (
 ) => {
 	const enabled = queryOptions?.enabled ?? true;
 
-	return useQuery< any, unknown, UseGetDomainsQueryData >(
-		getCacheKey( siteId ),
-		() =>
+	return useQuery< any, unknown, UseGetDomainsQueryData >( {
+		queryKey: getCacheKey( siteId ),
+		queryFn: () =>
 			wpcom.req.get(
 				{
 					path: `/sites/${ siteId }/domains`,
 				},
 				{ apiVersion: '1.2' }
 			),
-		{
-			select: ( data ) => data.domains,
-			...queryOptions,
-			enabled: !! siteId && enabled,
-		}
-	);
+		select: ( data ) => data.domains,
+		...queryOptions,
+		enabled: !! siteId && enabled,
+	} );
 };

--- a/client/data/dropdown-pages/use-dropdown-pages.ts
+++ b/client/data/dropdown-pages/use-dropdown-pages.ts
@@ -16,14 +16,13 @@ const useDropdownPagesQuery = < TData = DropdownPagesResponse >(
 	siteId?: number,
 	queryOptions = {}
 ) => {
-	return useQuery< DropdownPagesResponse, unknown, TData >(
-		[ 'sites', siteId, 'dropdown-pages' ],
-		(): Promise< DropdownPagesResponse > => wpcom.req.get( `/sites/${ siteId }/dropdown-pages` ),
-		{
-			enabled: !! siteId,
-			...queryOptions,
-		}
-	);
+	return useQuery< DropdownPagesResponse, unknown, TData >( {
+		queryKey: [ 'sites', siteId, 'dropdown-pages' ],
+		queryFn: (): Promise< DropdownPagesResponse > =>
+			wpcom.req.get( `/sites/${ siteId }/dropdown-pages` ),
+		enabled: !! siteId,
+		...queryOptions,
+	} );
 };
 
 export default useDropdownPagesQuery;

--- a/client/data/emails/use-create-titan-mailbox-mutation.ts
+++ b/client/data/emails/use-create-titan-mailbox-mutation.ts
@@ -8,8 +8,8 @@ import type { TitanMailboxFields } from 'calypso/my-sites/email/form/mailboxes/c
  * @returns Returns the result of the `useMutation` call
  */
 export const useCreateTitanMailboxMutation = () => {
-	return useMutation< unknown, unknown, TitanMailboxFields >(
-		( { domain, isAdmin, mailbox, name, password, passwordResetEmail } ) => {
+	return useMutation< unknown, unknown, TitanMailboxFields >( {
+		mutationFn: ( { domain, isAdmin, mailbox, name, password, passwordResetEmail } ) => {
 			return wpcom.req.post( {
 				path: `/emails/titan/${ encodeURIComponent( domain ) }/mailbox/create`,
 				apiNamespace: 'wpcom/v2',
@@ -21,6 +21,6 @@ export const useCreateTitanMailboxMutation = () => {
 					is_admin: isAdmin,
 				},
 			} );
-		}
-	);
+		},
+	} );
 };

--- a/client/data/emails/use-get-email-accounts-query.ts
+++ b/client/data/emails/use-get-email-accounts-query.ts
@@ -27,16 +27,14 @@ export const useGetEmailAccountsQuery = (
 	domain: string,
 	queryOptions?: UseQueryOptions< any, unknown, UseGetEmailAccountsQueryData >
 ) => {
-	return useQuery< any, unknown, UseGetEmailAccountsQueryData >(
-		getCacheKey( siteId, domain ),
-		() =>
+	return useQuery< any, unknown, UseGetEmailAccountsQueryData >( {
+		queryKey: getCacheKey( siteId, domain ),
+		queryFn: () =>
 			wpcom.req.get( {
 				path: `/sites/${ siteId }/emails/accounts/${ encodeURIComponent( domain ) }/mailboxes`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			select: ( data ) => data.accounts,
-			...queryOptions,
-		}
-	);
+		select: ( data ) => data.accounts,
+		...queryOptions,
+	} );
 };

--- a/client/data/emails/use-get-mailboxes.ts
+++ b/client/data/emails/use-get-mailboxes.ts
@@ -18,16 +18,14 @@ export const useGetMailboxes = (
 	siteId: number,
 	queryOptions?: UseQueryOptions< any, unknown, UseGetMailboxesQueryData >
 ) => {
-	return useQuery< any, unknown, UseGetMailboxesQueryData >(
-		getCacheKey( siteId ),
-		() =>
+	return useQuery< any, unknown, UseGetMailboxesQueryData >( {
+		queryKey: getCacheKey( siteId ),
+		queryFn: () =>
 			wpcom.req.get( {
 				path: `/sites/${ siteId }/emails/mailboxes`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			select: ( data ) => data.mailboxes,
-			...queryOptions,
-		}
-	);
+		select: ( data ) => data.mailboxes,
+		...queryOptions,
+	} );
 };

--- a/client/data/emails/use-get-titan-mailbox-availability.ts
+++ b/client/data/emails/use-get-titan-mailbox-availability.ts
@@ -26,18 +26,16 @@ export const useGetTitanMailboxAvailability = (
 	mailboxName: string,
 	queryOptions: UseQueryOptions< any, any > = {}
 ) => {
-	return useQuery< any, any >(
-		getCacheKey( domainName, mailboxName ),
-		() =>
+	return useQuery< any, any >( {
+		queryKey: getCacheKey( domainName, mailboxName ),
+		queryFn: () =>
 			wpcom.req.get( {
 				path: `/emails/titan/${ encodeURIComponent(
 					domainName
 				) }/check-mailbox-availability/${ encodeURIComponent( mailboxName ) }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			...queryOptions,
-			retry: ( count, { message: status } ) => finalErrorStatuses.includes( status ),
-		}
-	);
+		...queryOptions,
+		retry: ( count, { message: status } ) => finalErrorStatuses.includes( status ),
+	} );
 };

--- a/client/data/external-contributors/use-add-external-contributor-mutation.js
+++ b/client/data/external-contributors/use-add-external-contributor-mutation.js
@@ -4,8 +4,8 @@ import wp from 'calypso/lib/wp';
 
 function useAddExternalContributorMutation() {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { siteId, userId } ) =>
+	const mutation = useMutation( {
+		mutationFn: ( { siteId, userId } ) =>
 			wp.req.post(
 				`/sites/${ siteId }/external-contributors/add`,
 				{
@@ -13,12 +13,10 @@ function useAddExternalContributorMutation() {
 				},
 				{ user_id: userId }
 			),
-		{
-			onSuccess( data, { siteId } ) {
-				queryClient.setQueryData( [ 'external-contributors', siteId ], data );
-			},
-		}
-	);
+		onSuccess( data, { siteId } ) {
+			queryClient.setQueryData( [ 'external-contributors', siteId ], data );
+		},
+	} );
 
 	const { mutate } = mutation;
 	const addExternalContributor = useCallback(

--- a/client/data/external-contributors/use-external-contributors.js
+++ b/client/data/external-contributors/use-external-contributors.js
@@ -2,22 +2,20 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
 const useExternalContributorsQuery = ( siteId, queryOptions = {} ) => {
-	return useQuery(
-		[ 'external-contributors', siteId ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'external-contributors', siteId ],
+		queryFn: () =>
 			wpcom.req.get( {
 				path: `/sites/${ siteId }/external-contributors`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteId,
-			// The external contributors endpoint can be a little slow, so don't
-			// retry too soon if it is taking a while.
-			retryDelay: 2000,
-			staleTime: 1000 * 60 * 3, // 3 minutes
-			...queryOptions,
-		}
-	);
+		enabled: !! siteId,
+		// The external contributors endpoint can be a little slow, so don't
+		// retry too soon if it is taking a while.
+		retryDelay: 2000,
+		staleTime: 1000 * 60 * 3, // 3 minutes
+		...queryOptions,
+	} );
 };
 
 export default useExternalContributorsQuery;

--- a/client/data/external-contributors/use-remove-external-contributor-mutation.js
+++ b/client/data/external-contributors/use-remove-external-contributor-mutation.js
@@ -4,8 +4,8 @@ import wp from 'calypso/lib/wp';
 
 function useRemoveExternalContributorMutation() {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { siteId, userId } ) =>
+	const mutation = useMutation( {
+		mutationFn: ( { siteId, userId } ) =>
 			wp.req.post(
 				`/sites/${ siteId }/external-contributors/remove`,
 				{
@@ -13,12 +13,10 @@ function useRemoveExternalContributorMutation() {
 				},
 				{ user_id: userId }
 			),
-		{
-			onSuccess( data, { siteId } ) {
-				queryClient.setQueryData( [ 'external-contributors', siteId ], data );
-			},
-		}
-	);
+		onSuccess( data, { siteId } ) {
+			queryClient.setQueryData( [ 'external-contributors', siteId ], data );
+		},
+	} );
 
 	const { mutate } = mutation;
 	const removeExternalContributor = useCallback(

--- a/client/data/followers/use-follower-query.js
+++ b/client/data/followers/use-follower-query.js
@@ -15,15 +15,15 @@ const useFollowerQuery = ( siteId, subscriberId, type ) => {
 		};
 	}
 
-	return useQuery(
-		[ 'subscriber', subscriberId, type ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'subscriber', subscriberId, type ],
+		queryFn: () =>
 			wpcom.req.get( {
 				path: `/sites/${ siteId }/followers/${ subscriberId }?type=${ type }&http_envelope=1`,
 				apiNamespace: 'rest/v1.1',
 			} ),
-		{ select: normalizeFollower }
-	);
+		select: normalizeFollower,
+	} );
 };
 
 export default useFollowerQuery;

--- a/client/data/followers/use-remove-follower-mutation.js
+++ b/client/data/followers/use-remove-follower-mutation.js
@@ -4,18 +4,16 @@ import wp from 'calypso/lib/wp';
 
 function useRemoveFollowerMutation() {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { siteId, type, followerId } ) => {
+	const mutation = useMutation( {
+		mutationFn: ( { siteId, type, followerId } ) => {
 			const typeSlug = type === 'email' ? 'email-followers' : 'followers';
 			return wp.req.post( `/sites/${ siteId }/${ typeSlug }/${ followerId }/delete` );
 		},
-		{
-			onSuccess( data, variables ) {
-				const { siteId, type } = variables;
-				queryClient.invalidateQueries( [ 'followers', siteId, type ] );
-			},
-		}
-	);
+		onSuccess( data, variables ) {
+			const { siteId, type } = variables;
+			queryClient.invalidateQueries( [ 'followers', siteId, type ] );
+		},
+	} );
 	const { mutate } = mutation;
 	const removeFollower = useCallback(
 		( siteId, type, followerId ) => mutate( { siteId, type, followerId } ),

--- a/client/data/geo/use-geolocation-query.ts
+++ b/client/data/geo/use-geolocation-query.ts
@@ -10,8 +10,10 @@ export interface GeoLocationData {
 }
 
 export const useGeoLocationQuery = () =>
-	useQuery< GeoLocationData >( [ 'geo' ], () =>
-		globalThis
-			.fetch( 'https://public-api.wordpress.com/geo/' )
-			.then( ( response ) => response.json() )
-	);
+	useQuery< GeoLocationData >( {
+		queryKey: [ 'geo' ],
+		queryFn: () =>
+			globalThis
+				.fetch( 'https://public-api.wordpress.com/geo/' )
+				.then( ( response ) => response.json() ),
+	} );

--- a/client/data/help/use-active-support-tickets-query.js
+++ b/client/data/help/use-active-support-tickets-query.js
@@ -4,18 +4,16 @@ import wpcom from 'calypso/lib/wp';
 const ACTIVE_STATUSES = [ 'New', 'Open', 'Hold' ];
 
 export const useActiveSupportTicketsQuery = ( email, queryOptions = {} ) =>
-	useQuery(
-		[ 'activeSupportTickets', email ],
-		() => wpcom.req.get( '/support-history', { email, apiNamespace: 'wpcom/v2' } ),
-		{
-			enabled: !! email,
-			select: ( { data } ) =>
-				data.filter(
-					( item ) => item.type === 'Zendesk_History' && ACTIVE_STATUSES.includes( item.status )
-				),
-			meta: {
-				persist: false,
-			},
-			...queryOptions,
-		}
-	);
+	useQuery( {
+		queryKey: [ 'activeSupportTickets', email ],
+		queryFn: () => wpcom.req.get( '/support-history', { email, apiNamespace: 'wpcom/v2' } ),
+		enabled: !! email,
+		select: ( { data } ) =>
+			data.filter(
+				( item ) => item.type === 'Zendesk_History' && ACTIVE_STATUSES.includes( item.status )
+			),
+		meta: {
+			persist: false,
+		},
+		...queryOptions,
+	} );

--- a/client/data/help/use-help-search-query.ts
+++ b/client/data/help/use-help-search-query.ts
@@ -16,12 +16,11 @@ export const useHelpSearchQuery = (
 		params.append( 'query', search );
 	}
 
-	return useQuery< { wordpress_support_links: LinksForSection[] } >(
-		[ 'help', search ],
-		() => wpcomRequest( { path: '/help/search', query: params.toString(), apiVersion: '1.1' } ),
-		{
-			enabled: !! search,
-			...queryOptions,
-		}
-	);
+	return useQuery< { wordpress_support_links: LinksForSection[] } >( {
+		queryKey: [ 'help', search ],
+		queryFn: () =>
+			wpcomRequest( { path: '/help/search', query: params.toString(), apiVersion: '1.1' } ),
+		enabled: !! search,
+		...queryOptions,
+	} );
 };

--- a/client/data/home/use-home-layout-query.ts
+++ b/client/data/home/use-home-layout-query.ts
@@ -12,7 +12,9 @@ const useHomeLayoutQuery = (
 ): UseQueryResult => {
 	const query = useHomeLayoutQueryParams();
 
-	return useQuery( getCacheKey( siteId ), () => fetchHomeLayout( siteId, query ), {
+	return useQuery( {
+		queryKey: getCacheKey( siteId ),
+		queryFn: () => fetchHomeLayout( siteId, query ),
 		enabled: !! siteId && enabled,
 
 		// The `/layout` endpoint can return a random view. Disable implicit refetches

--- a/client/data/home/use-skip-current-view-mutation.ts
+++ b/client/data/home/use-skip-current-view-mutation.ts
@@ -20,8 +20,8 @@ function useSkipCurrentViewMutation< TData, TError >( siteId: number ): Result< 
 	const queryClient = useQueryClient();
 	const query = useHomeLayoutQueryParams();
 
-	const mutation = useMutation< TData, TError, Variables >(
-		async ( { reminder, card } ) => {
+	const mutation = useMutation< TData, TError, Variables >( {
+		mutationFn: async ( { reminder, card } ) => {
 			const data = await queryClient.fetchQuery(
 				getCacheKey( siteId ),
 				() => fetchHomeLayout( siteId, query ),
@@ -42,12 +42,10 @@ function useSkipCurrentViewMutation< TData, TError >( siteId: number ): Result< 
 				}
 			);
 		},
-		{
-			onSuccess( data ) {
-				queryClient.setQueryData( getCacheKey( siteId ), data );
-			},
-		}
-	);
+		onSuccess( data ) {
+			queryClient.setQueryData( getCacheKey( siteId ), data );
+		},
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -53,9 +53,9 @@ export function useSiteLogsQuery(
 		setScrollId( undefined );
 	}
 
-	const queryResult = useQuery< SiteLogsAPIResponse, unknown, SiteLogsData >(
-		buildQueryKey( siteId, params ),
-		() => {
+	const queryResult = useQuery< SiteLogsAPIResponse, unknown, SiteLogsData >( {
+		queryKey: buildQueryKey( siteId, params ),
+		queryFn: () => {
 			const logTypeFragment = params.logType === 'php' ? 'error-logs' : 'logs';
 			const path = `/sites/${ siteId }/hosting/${ logTypeFragment }`;
 			return wpcom.req.post(
@@ -69,33 +69,31 @@ export function useSiteLogsQuery(
 				}
 			);
 		},
-		{
-			enabled: !! siteId && params.start <= params.end,
-			staleTime: Infinity, // The logs within a specified time range never change.
-			select( { data } ) {
-				return {
-					...data,
-					total_results:
-						typeof data.total_results === 'number' ? data.total_results : data.total_results.value,
-				};
-			},
-			onSuccess( data ) {
-				if ( data.scroll_id ) {
-					setScrollId( data.scroll_id );
-				} else {
-					setIsFinishedPaging( true );
-				}
+		enabled: !! siteId && params.start <= params.end,
+		staleTime: Infinity, // The logs within a specified time range never change.
+		select( { data } ) {
+			return {
+				...data,
+				total_results:
+					typeof data.total_results === 'number' ? data.total_results : data.total_results.value,
+			};
+		},
+		onSuccess( data ) {
+			if ( data.scroll_id ) {
+				setScrollId( data.scroll_id );
+			} else {
+				setIsFinishedPaging( true );
+			}
 
-				if ( queryOptions.onSuccess ) {
-					return queryOptions.onSuccess( data );
-				}
-			},
-			meta: {
-				persist: false,
-			},
-			...queryOptions,
-		}
-	);
+			if ( queryOptions.onSuccess ) {
+				return queryOptions.onSuccess( data );
+			}
+		},
+		meta: {
+			persist: false,
+		},
+		...queryOptions,
+	} );
 
 	// The state represented by scroll ID will have already advanced to the next page, so we
 	// can't allow `refetch` to be used. Remember, the logs are fetched with a POST and the

--- a/client/data/invites/use-get-invites-query.ts
+++ b/client/data/invites/use-get-invites-query.ts
@@ -9,11 +9,14 @@ const useGetInvitesQuery = ( siteId: number ) => {
 		isRequestingInvitesForSite( state, siteId )
 	);
 
-	return useQuery( [ 'invites', siteId ], () => {
-		if ( siteId && ! requestingInProgress ) {
-			dispatch( requestSiteInvites( siteId ) );
-		}
-		return null;
+	return useQuery( {
+		queryKey: [ 'invites', siteId ],
+		queryFn: () => {
+			if ( siteId && ! requestingInProgress ) {
+				dispatch( requestSiteInvites( siteId ) );
+			}
+			return null;
+		},
 	} );
 };
 

--- a/client/data/jetpack-licensing/use-user-license-by-receipt-query.ts
+++ b/client/data/jetpack-licensing/use-user-license-by-receipt-query.ts
@@ -5,19 +5,17 @@ import type { UserLicenseApi, UserLicense } from './types';
 
 const useUserLicenseByReceiptQuery = ( receiptId: number ): UseQueryResult< UserLicense[] > => {
 	const queryKey = [ 'user-license', receiptId ];
-	return useQuery< UserLicenseApi[], unknown, UserLicense[] >(
+	return useQuery< UserLicenseApi[], unknown, UserLicense[] >( {
 		queryKey,
-		async () =>
+		queryFn: async () =>
 			wpcom.req.get( {
 				path: `/jetpack-licensing/user/receipt/${ receiptId }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			select: mapManyLicenseApiToLicense,
-			refetchIntervalInBackground: false,
-			refetchOnWindowFocus: false,
-		}
-	);
+		select: mapManyLicenseApiToLicense,
+		refetchIntervalInBackground: false,
+		refetchOnWindowFocus: false,
+	} );
 };
 
 export default useUserLicenseByReceiptQuery;

--- a/client/data/jetpack-licensing/use-user-license-by-subscription-query.ts
+++ b/client/data/jetpack-licensing/use-user-license-by-subscription-query.ts
@@ -7,19 +7,17 @@ const useUserLicenseBySubscriptionQuery = (
 	subscriptionId: number
 ): UseQueryResult< UserLicense > => {
 	const queryKey = [ 'user-license', subscriptionId ];
-	return useQuery< UserLicenseApi, unknown, UserLicense >(
+	return useQuery< UserLicenseApi, unknown, UserLicense >( {
 		queryKey,
-		async () =>
+		queryFn: async () =>
 			wpcom.req.get( {
 				path: `/jetpack-licensing/user/subscription/${ subscriptionId }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			select: mapSingleLicenseApiToLicense,
-			refetchIntervalInBackground: false,
-			refetchOnWindowFocus: false,
-		}
-	);
+		select: mapSingleLicenseApiToLicense,
+		refetchIntervalInBackground: false,
+		refetchOnWindowFocus: false,
+	} );
 };
 
 export default useUserLicenseBySubscriptionQuery;

--- a/client/data/media-storage/use-media-storage-query.js
+++ b/client/data/media-storage/use-media-storage-query.js
@@ -2,14 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 function useMediaStorageQuery( siteId, queryOptions = {} ) {
-	return useQuery(
-		[ 'media-storage', siteId ],
-		() => wp.req.get( `/sites/${ siteId }/media-storage` ),
-		{
-			...queryOptions,
-			enabled: !! siteId,
-		}
-	);
+	return useQuery( {
+		queryKey: [ 'media-storage', siteId ],
+		queryFn: () => wp.req.get( `/sites/${ siteId }/media-storage` ),
+		...queryOptions,
+		enabled: !! siteId,
+	} );
 }
 
 export default useMediaStorageQuery;

--- a/client/data/media/use-upload-media-mutation.js
+++ b/client/data/media/use-upload-media-mutation.js
@@ -12,26 +12,24 @@ import { isFileList } from 'calypso/state/media/utils/is-file-list';
 export const useUploadMediaMutation = ( queryOptions = {} ) => {
 	const queryClient = useQueryClient();
 	const dispatch = useDispatch();
-	const mutation = useMutation(
-		( { file, siteId, postId, uploader } ) => uploader( file, siteId, postId ),
-		{
-			onSuccess( { media: [ uploadedMedia ], found }, { siteId, transientMedia } ) {
-				const uploadedMediaWithTransientId = {
-					...uploadedMedia,
-					transientId: transientMedia.ID,
-				};
+	const mutation = useMutation( {
+		mutationFn: ( { file, siteId, postId, uploader } ) => uploader( file, siteId, postId ),
+		onSuccess( { media: [ uploadedMedia ], found }, { siteId, transientMedia } ) {
+			const uploadedMediaWithTransientId = {
+				...uploadedMedia,
+				transientId: transientMedia.ID,
+			};
 
-				dispatch( successMediaItemRequest( siteId, transientMedia.ID ) );
-				dispatch( receiveMedia( siteId, uploadedMediaWithTransientId, found ) );
+			dispatch( successMediaItemRequest( siteId, transientMedia.ID ) );
+			dispatch( receiveMedia( siteId, uploadedMediaWithTransientId, found ) );
 
-				queryClient.invalidateQueries( [ 'media-storage', siteId ] );
-			},
-			onError( error, { siteId, transientMedia } ) {
-				dispatch( failMediaItemRequest( siteId, transientMedia.ID, error ) );
-			},
-			...queryOptions,
-		}
-	);
+			queryClient.invalidateQueries( [ 'media-storage', siteId ] );
+		},
+		onError( error, { siteId, transientMedia } ) {
+			dispatch( failMediaItemRequest( siteId, transientMedia.ID, error ) );
+		},
+		...queryOptions,
+	} );
 
 	const { mutateAsync } = mutation;
 

--- a/client/data/notification-devices/use-notification-devices-query.js
+++ b/client/data/notification-devices/use-notification-devices-query.js
@@ -2,7 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 export const useNotificationDevicesQuery = () =>
-	useQuery( [ 'notification-devices' ], () => wp.req.get( `/notifications/devices` ), {
+	useQuery( {
+		queryKey: [ 'notification-devices' ],
+		queryFn: () => wp.req.get( `/notifications/devices` ),
 		select( data ) {
 			return data.map( ( { device_id: id, device_name: name } ) => ( { id, name } ) );
 		},

--- a/client/data/p2/use-p2-guests-query.js
+++ b/client/data/p2/use-p2-guests-query.js
@@ -10,9 +10,9 @@ const useP2GuestsQuery = ( siteId, queryOptions = {} ) => {
 	// For sites that can't have P2 guests, don't even make the request.
 	const requestUnnecessary = ! isWPForTeamsSite || isP2Hub;
 
-	return useQuery(
-		[ 'p2-guest-users', siteId ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'p2-guest-users', siteId ],
+		queryFn: () =>
 			wpcom.req.get(
 				{
 					path: `/p2/users/guests/`,
@@ -22,12 +22,10 @@ const useP2GuestsQuery = ( siteId, queryOptions = {} ) => {
 					blog_id: siteId,
 				}
 			),
-		{
-			...queryOptions,
-			enabled: !! siteId && ! requestUnnecessary,
-			retryDelay: 3000,
-		}
-	);
+		...queryOptions,
+		enabled: !! siteId && ! requestUnnecessary,
+		retryDelay: 3000,
+	} );
 };
 
 export default useP2GuestsQuery;

--- a/client/data/p2/use-p2-hub-p2s-query.js
+++ b/client/data/p2/use-p2-hub-p2s-query.js
@@ -10,9 +10,9 @@ const useP2HubP2sQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
 	// For sites that are not P2 Hubs, we don't need to make the query.
 	const requestUnnecessary = ! isWPForTeamsSite || ! isP2Hub;
 
-	return useQuery(
-		[ 'p2-hub-p2s', siteId, fetchOptions ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'p2-hub-p2s', siteId, fetchOptions ],
+		queryFn: () =>
 			wpcom.req.get(
 				{
 					path: `/p2/workspace/sites/all`,
@@ -23,12 +23,10 @@ const useP2HubP2sQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
 					...fetchOptions,
 				}
 			),
-		{
-			...queryOptions,
-			enabled: !! siteId && ! requestUnnecessary,
-			retryDelay: 3000,
-		}
-	);
+		...queryOptions,
+		enabled: !! siteId && ! requestUnnecessary,
+		retryDelay: 3000,
+	} );
 };
 
 export default useP2HubP2sQuery;

--- a/client/data/plans/use-plans-comparison-meta.ts
+++ b/client/data/plans/use-plans-comparison-meta.ts
@@ -8,14 +8,14 @@ export type PlansComparisonMetaData = {
 };
 
 export default function usePlansComparisonMeta( currency: string ) {
-	return useQuery< unknown, unknown, PlansComparisonMetaData >(
-		[ 'plans-comparison-meta', currency ],
-		() =>
+	return useQuery< unknown, unknown, PlansComparisonMetaData >( {
+		queryKey: [ 'plans-comparison-meta', currency ],
+		queryFn: () =>
 			wpcom.req.get(
 				{
 					path: '/plans-comparison-meta',
 				},
 				{ apiVersion: '1.2' }
-			)
-	);
+			),
+	} );
 }

--- a/client/data/post-formats/use-post-formats-query.js
+++ b/client/data/post-formats/use-post-formats-query.js
@@ -2,6 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
 const usePostFormatsQuery = ( siteId ) =>
-	useQuery( [ 'postFormats', siteId ], () => wpcom.req.get( `/sites/${ siteId }/post-formats` ) );
+	useQuery( {
+		queryKey: [ 'postFormats', siteId ],
+		queryFn: () => wpcom.req.get( `/sites/${ siteId }/post-formats` ),
+	} );
 
 export default usePostFormatsQuery;

--- a/client/data/posts/use-posts-query.ts
+++ b/client/data/posts/use-posts-query.ts
@@ -44,14 +44,12 @@ type Response = {
 };
 
 const usePostsQuery = ( siteId?: number, params: PostsRequestParams = {}, queryOptions = {} ) => {
-	return useQuery(
-		[ 'sites', siteId, 'posts', params ],
-		(): Promise< Response > => wpcom.req.get( `/sites/${ siteId }/posts`, params ),
-		{
-			enabled: !! siteId,
-			...queryOptions,
-		}
-	);
+	return useQuery( {
+		queryKey: [ 'sites', siteId, 'posts', params ],
+		queryFn: (): Promise< Response > => wpcom.req.get( `/sites/${ siteId }/posts`, params ),
+		enabled: !! siteId,
+		...queryOptions,
+	} );
 };
 
 export default usePostsQuery;

--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -66,24 +66,22 @@ export type CampaignStats = {
 };
 
 const useCampaignsQuery = ( siteId: number, queryOptions = {} ) => {
-	return useQuery(
-		[ 'promote-post-campaigns', siteId ],
-		async () => {
+	return useQuery( {
+		queryKey: [ 'promote-post-campaigns', siteId ],
+		queryFn: async () => {
 			const { results: campaigns } = await requestDSP< { results: Campaign[] } >(
 				siteId,
 				`/campaigns/site/${ siteId }/summary`
 			);
 			return campaigns;
 		},
-		{
-			...queryOptions,
-			enabled: !! siteId,
-			retryDelay: 3000,
-			meta: {
-				persist: false,
-			},
-		}
-	);
+		...queryOptions,
+		enabled: !! siteId,
+		retryDelay: 3000,
+		meta: {
+			persist: false,
+		},
+	} );
 };
 
 export default useCampaignsQuery;

--- a/client/data/promote-post/use-promote-post-campaigns-stats-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-stats-query.ts
@@ -3,24 +3,22 @@ import { CampaignStats } from 'calypso/data/promote-post/use-promote-post-campai
 import { requestDSP } from 'calypso/lib/promote-post';
 
 const useCampaignsStatsQuery = ( siteId: number, queryOptions = {} ) => {
-	return useQuery(
-		[ 'promote-post-campaigns-stats', siteId ],
-		async () => {
+	return useQuery( {
+		queryKey: [ 'promote-post-campaigns-stats', siteId ],
+		queryFn: async () => {
 			const { results: campaigns } = await requestDSP< { results: CampaignStats[] } >(
 				siteId,
 				`/campaigns/site/${ siteId }/stats`
 			);
 			return campaigns;
 		},
-		{
-			...queryOptions,
-			enabled: !! siteId,
-			retryDelay: 3000,
-			meta: {
-				persist: false,
-			},
-		}
-	);
+		...queryOptions,
+		enabled: !! siteId,
+		retryDelay: 3000,
+		meta: {
+			persist: false,
+		},
+	} );
 };
 
 export default useCampaignsStatsQuery;

--- a/client/data/promote-post/use-promote-post-cancel-campaign-mutation.ts
+++ b/client/data/promote-post/use-promote-post-cancel-campaign-mutation.ts
@@ -5,16 +5,14 @@ import { requestDSP } from 'calypso/lib/promote-post';
 
 export const useCancelCampaignMutation = ( onError: () => void ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		async ( { siteId, campaignId }: { siteId: number; campaignId: number } ) =>
+	const mutation = useMutation( {
+		mutationFn: async ( { siteId, campaignId }: { siteId: number; campaignId: number } ) =>
 			await requestDSP< { results: Campaign[] } >( siteId, `/campaigns/${ campaignId }/stop` ),
-		{
-			onSuccess( data, { siteId } ) {
-				queryClient.invalidateQueries( [ 'promote-post-campaigns', siteId ] );
-			},
-			onError,
-		}
-	);
+		onSuccess( data, { siteId } ) {
+			queryClient.invalidateQueries( [ 'promote-post-campaigns', siteId ] );
+		},
+		onError,
+	} );
 
 	const { mutate } = mutation;
 	const cancelCampaign = useCallback(

--- a/client/data/reader/use-related-meta-by-tag.ts
+++ b/client/data/reader/use-related-meta-by-tag.ts
@@ -107,18 +107,16 @@ const selectFromCards = ( response: {
 export const useRelatedMetaByTag = ( tag: string ): UseQueryResult< RelatedMetaByTag | null > => {
 	const tag_recs_per_card = 10;
 	const site_recs_per_card = 5;
-	return useQuery(
-		[ 'related-meta-by-tag-' + tag_recs_per_card + '-' + site_recs_per_card, tag ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'related-meta-by-tag-' + tag_recs_per_card + '-' + site_recs_per_card, tag ],
+		queryFn: () =>
 			wp.req.get( {
 				path: `/read/tags/${ encodeURIComponent(
 					tag
 				) }/cards?tag_recs_per_card=${ tag_recs_per_card }&site_recs_per_card=${ site_recs_per_card }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			staleTime: 3600000, // 1 hour
-			select: selectFromCards,
-		}
-	);
+		staleTime: 3600000,
+		select: selectFromCards,
+	} );
 };

--- a/client/data/reader/use-tag-stats.ts
+++ b/client/data/reader/use-tag-stats.ts
@@ -9,14 +9,12 @@ export interface TagStats {
 }
 
 export const useTagStats = ( tag: string ): UseQueryResult< TagStats | null > =>
-	useQuery(
-		[ 'tag-stats', tag ],
-		() =>
+	useQuery( {
+		queryKey: [ 'tag-stats', tag ],
+		queryFn: () =>
 			wp.req.get( `/read/topics/${ encodeURIComponent( tag ) }/stats`, {
 				apiVersion: '1.3',
 			} ),
-		{
-			staleTime: 86400000, // 1 day
-			refetchOnMount: 'always',
-		}
-	);
+		staleTime: 86400000, // 1 day
+		refetchOnMount: 'always',
+	} );

--- a/client/data/site-migration/use-add-temp-site-mutation.ts
+++ b/client/data/site-migration/use-add-temp-site-mutation.ts
@@ -9,8 +9,8 @@ interface TempSiteToSourceOption {
 
 function useAddTempSiteToSourceOptionMutation() {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { targetBlogId, sourceBlogId }: TempSiteToSourceOption ) =>
+	const mutation = useMutation( {
+		mutationFn: ( { targetBlogId, sourceBlogId }: TempSiteToSourceOption ) =>
 			wp.req.post(
 				`/migrations/from-source/${ sourceBlogId }`,
 				{
@@ -18,12 +18,10 @@ function useAddTempSiteToSourceOptionMutation() {
 				},
 				{ target_blog_id: targetBlogId }
 			),
-		{
-			onSuccess( data, { sourceBlogId } ) {
-				queryClient.setQueryData( [ 'temp-target-site', sourceBlogId ], data );
-			},
-		}
-	);
+		onSuccess( data, { sourceBlogId } ) {
+			queryClient.setQueryData( [ 'temp-target-site', sourceBlogId ], data );
+		},
+	} );
 
 	const { mutate } = mutation;
 	const addTempSiteToSourceOption = useCallback(

--- a/client/data/site-migration/use-source-migration-status-query.ts
+++ b/client/data/site-migration/use-source-migration-status-query.ts
@@ -4,18 +4,16 @@ import wp from 'calypso/lib/wp';
 import type { SiteId } from 'calypso/types';
 
 export const useSourceMigrationStatusQuery = ( sourceId: SiteId | undefined ) => {
-	return useQuery(
-		[ 'source-migration-status', sourceId ],
-		(): Promise< SourceSiteMigrationDetails > =>
+	return useQuery( {
+		queryKey: [ 'source-migration-status', sourceId ],
+		queryFn: (): Promise< SourceSiteMigrationDetails > =>
 			wp.req.get( {
 				path: '/migrations/from-source/' + encodeURIComponent( sourceId as number ),
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			meta: {
-				persist: false,
-			},
-			enabled: !! sourceId,
-		}
-	);
+		meta: {
+			persist: false,
+		},
+		enabled: !! sourceId,
+	} );
 };

--- a/client/data/site-monitor/use-site-monitor-settings-query.js
+++ b/client/data/site-monitor/use-site-monitor-settings-query.js
@@ -2,7 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 const useSiteMonitorSettingsQuery = ( siteId ) =>
-	useQuery( [ 'site-monitor-settings', siteId ], () => wp.req.get( `/jetpack-blogs/${ siteId }` ), {
+	useQuery( {
+		queryKey: [ 'site-monitor-settings', siteId ],
+		queryFn: () => wp.req.get( `/jetpack-blogs/${ siteId }` ),
 		refetchOnWindowFocus: false,
 		enabled: !! siteId,
 		meta: {

--- a/client/data/site-monitor/use-update-site-monitor-settings-mutation.js
+++ b/client/data/site-monitor/use-update-site-monitor-settings-mutation.js
@@ -4,16 +4,14 @@ import wp from 'calypso/lib/wp';
 
 function useUpdateSiteMonitorSettingsMutation( siteId, queryOptions = {} ) {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { settings } ) => wp.req.post( `/jetpack-blogs/${ siteId }`, settings ),
-		{
-			...queryOptions,
-			onSuccess( ...args ) {
-				queryClient.invalidateQueries( [ 'site-monitor-settings', siteId ] );
-				queryOptions.onSuccess?.( ...args );
-			},
-		}
-	);
+	const mutation = useMutation( {
+		mutationFn: ( { settings } ) => wp.req.post( `/jetpack-blogs/${ siteId }`, settings ),
+		...queryOptions,
+		onSuccess( ...args ) {
+			queryClient.invalidateQueries( [ 'site-monitor-settings', siteId ] );
+			queryOptions.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/data/site-roles/use-site-roles-query.js
+++ b/client/data/site-roles/use-site-roles-query.js
@@ -2,7 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 function useSiteRolesQuery( siteId, queryOptions = {} ) {
-	return useQuery( [ 'site-roles', siteId ], () => wp.req.get( `/sites/${ siteId }/roles` ), {
+	return useQuery( {
+		queryKey: [ 'site-roles', siteId ],
+		queryFn: () => wp.req.get( `/sites/${ siteId }/roles` ),
 		...queryOptions,
 		select: ( { roles } ) => {
 			return roles.map( ( role ) =>

--- a/client/data/site-verticals/use-site-vertical-query-by-id.ts
+++ b/client/data/site-verticals/use-site-vertical-query-by-id.ts
@@ -3,7 +3,9 @@ import wpcom from 'calypso/lib/wp';
 import type { SiteVerticalsResponse, SiteVerticalQueryByIdParams } from './types';
 
 const useSiteVerticalQueryById = ( id: string ): UseQueryResult< SiteVerticalsResponse > => {
-	return useQuery( getCacheKey( id ), () => fetchSiteVertical( { id } ), {
+	return useQuery( {
+		queryKey: getCacheKey( id ),
+		queryFn: () => fetchSiteVertical( { id } ),
 		enabled: typeof id === 'string' && id !== '',
 		staleTime: Infinity,
 		refetchInterval: false,

--- a/client/data/site-verticals/use-site-verticals-featured.ts
+++ b/client/data/site-verticals/use-site-verticals-featured.ts
@@ -3,7 +3,9 @@ import wpcom from 'calypso/lib/wp';
 import type { SiteVerticalsResponse } from './types';
 
 const useSiteVerticalsFeatured = (): UseQueryResult< SiteVerticalsResponse[] > => {
-	return useQuery( getCacheKey(), () => fetchSiteVerticalsFeatured(), {
+	return useQuery( {
+		queryKey: getCacheKey(),
+		queryFn: () => fetchSiteVerticalsFeatured(),
 		enabled: true,
 		staleTime: Infinity,
 		refetchInterval: false,

--- a/client/data/site-verticals/use-site-verticals-query.ts
+++ b/client/data/site-verticals/use-site-verticals-query.ts
@@ -14,16 +14,14 @@ const useSiteVerticalsQuery = (
 ): UseQueryResult< SiteVerticalsResponse[] > => {
 	const { term } = fetchOptions;
 
-	return useQuery(
-		getCacheKey( term || '' ),
-		() => fetchSiteVerticals( { ...defaults, ...fetchOptions } ),
-		{
-			enabled: typeof term === 'string' && term !== '',
-			staleTime: Infinity,
-			refetchInterval: false,
-			refetchOnMount: 'always',
-		}
-	);
+	return useQuery( {
+		queryKey: getCacheKey( term || '' ),
+		queryFn: () => fetchSiteVerticals( { ...defaults, ...fetchOptions } ),
+		enabled: typeof term === 'string' && term !== '',
+		staleTime: Infinity,
+		refetchInterval: false,
+		refetchOnMount: 'always',
+	} );
 };
 
 export function fetchSiteVerticals(

--- a/client/data/sites/use-launchpad.ts
+++ b/client/data/sites/use-launchpad.ts
@@ -33,7 +33,9 @@ export const updateLaunchpadSettings = (
 
 export const useLaunchpad = ( siteSlug: string | null ) => {
 	const key = [ 'launchpad', siteSlug ];
-	return useQuery( key, () => fetchLaunchpad( siteSlug ), {
+	return useQuery( {
+		queryKey: key,
+		queryFn: () => fetchLaunchpad( siteSlug ),
 		refetchOnMount: true,
 		staleTime: 0,
 		retry: 3,

--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -30,7 +30,9 @@ const fetchSites = (
 export const useSiteExcerptsQuery = ( siteFilter?: string[] ) => {
 	const store = useStore();
 
-	return useQuery( [ USE_SITE_EXCERPTS_QUERY_KEY ], () => fetchSites( siteFilter ), {
+	return useQuery( {
+		queryKey: [ USE_SITE_EXCERPTS_QUERY_KEY ],
+		queryFn: () => fetchSites( siteFilter ),
 		select: ( data ) => data?.sites.map( computeFields( data?.sites ) ),
 		initialData: () => {
 			// Not using `useSelector` (i.e. calling `getSites` directly) because we

--- a/client/data/sites/use-site-query.ts
+++ b/client/data/sites/use-site-query.ts
@@ -3,17 +3,15 @@ import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 export const useSiteQuery = ( sourceSiteSlug: string, enabled = true ) => {
-	return useQuery(
-		[ 'site-details', sourceSiteSlug ],
-		(): Promise< SiteDetails > =>
+	return useQuery( {
+		queryKey: [ 'site-details', sourceSiteSlug ],
+		queryFn: (): Promise< SiteDetails > =>
 			wp.req.get( {
 				path: '/sites/' + encodeURIComponent( sourceSiteSlug as string ),
 			} ),
-		{
-			meta: {
-				persist: false,
-			},
-			enabled,
-		}
-	);
+		meta: {
+			persist: false,
+		},
+		enabled,
+	} );
 };

--- a/client/data/stats/use-has-never-published-post.ts
+++ b/client/data/stats/use-has-never-published-post.ts
@@ -17,14 +17,12 @@ export const useHasNeverPublishedPost = (
 	queryOptions: Options
 ): UseQueryResult< boolean > => {
 	const { enabled = true } = queryOptions;
-	return useQuery(
-		useHasNeverPublishedPostCacheKey( siteId, includePages ),
-		() => fetchHasNeverPublishedPost( siteId, includePages ),
-		{
-			...queryOptions,
-			enabled: !! siteId && enabled,
-		}
-	);
+	return useQuery( {
+		queryKey: useHasNeverPublishedPostCacheKey( siteId, includePages ),
+		queryFn: () => fetchHasNeverPublishedPost( siteId, includePages ),
+		...queryOptions,
+		enabled: !! siteId && enabled,
+	} );
 };
 
 function fetchHasNeverPublishedPost(

--- a/client/data/support-article-alternates/use-support-article-alternates-query.js
+++ b/client/data/support-article-alternates/use-support-article-alternates-query.js
@@ -7,19 +7,17 @@ import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slu
 function useSupportArticleAlternatesQuery( blogId, postId, queryOptions = {} ) {
 	const locale = useSelector( getCurrentLocaleSlug );
 
-	return useQuery(
-		[ 'support-article-alternates', blogId, postId ],
-		() => wp.req.get( `/support/alternates/${ blogId }/posts/${ postId }` ),
-		{
-			...queryOptions,
-			enabled: ! isDefaultLocale( locale ) && !! ( blogId && postId ),
-			refetchOnMount: false,
-			refetchOnWindowFocus: false,
-			select: ( data ) => {
-				return data[ locale ];
-			},
-		}
-	);
+	return useQuery( {
+		queryKey: [ 'support-article-alternates', blogId, postId ],
+		queryFn: () => wp.req.get( `/support/alternates/${ blogId }/posts/${ postId }` ),
+		...queryOptions,
+		enabled: ! isDefaultLocale( locale ) && !! ( blogId && postId ),
+		refetchOnMount: false,
+		refetchOnWindowFocus: false,
+		select: ( data ) => {
+			return data[ locale ];
+		},
+	} );
 }
 
 export default useSupportArticleAlternatesQuery;

--- a/client/data/themes/use-active-theme-query.ts
+++ b/client/data/themes/use-active-theme-query.ts
@@ -19,14 +19,14 @@ export const useActiveThemeQuery = (
 	const themeSlug = useSelector( ( state ) => getSiteOption( state, siteId, 'theme_slug' ) );
 	const queryKey = [ 'activeTheme', siteId, themeSlug ];
 
-	return useQuery< ActiveTheme[] >(
+	return useQuery< ActiveTheme[] >( {
 		queryKey,
-		() => {
+		queryFn: () => {
 			return wpcom.req.get( {
 				path: `/sites/${ siteId }/themes?status=active`,
 				apiNamespace: 'wp/v2',
 			} );
 		},
-		{ enabled: isEnabled && !! siteId }
-	);
+		enabled: isEnabled && !! siteId,
+	} );
 };

--- a/client/data/users/use-delete-user-mutation.js
+++ b/client/data/users/use-delete-user-mutation.js
@@ -4,17 +4,15 @@ import wp from 'calypso/lib/wp';
 
 function useDeleteUserMutation( siteId, queryOptions = {} ) {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { userId, variables } ) =>
+	const mutation = useMutation( {
+		mutationFn: ( { userId, variables } ) =>
 			wp.req.post( `/sites/${ siteId }/users/${ userId }/delete`, variables ),
-		{
-			...queryOptions,
-			onSuccess( ...args ) {
-				queryClient.invalidateQueries( [ 'users', siteId ] );
-				queryOptions.onSuccess?.( ...args );
-			},
-		}
-	);
+		...queryOptions,
+		onSuccess( ...args ) {
+			queryClient.invalidateQueries( [ 'users', siteId ] );
+			queryOptions.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/data/users/use-update-user-mutation.js
+++ b/client/data/users/use-update-user-mutation.js
@@ -5,16 +5,15 @@ import { getCacheKey } from './use-user-query';
 
 function useUpdateUserMutation( siteId, queryOptions = {} ) {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { userId, variables } ) => wp.req.post( `/sites/${ siteId }/users/${ userId }`, variables ),
-		{
-			...queryOptions,
-			onSuccess( data, ...rest ) {
-				queryClient.setQueryData( getCacheKey( siteId, data.login ), data );
-				queryOptions.onSuccess?.( data, ...rest );
-			},
-		}
-	);
+	const mutation = useMutation( {
+		mutationFn: ( { userId, variables } ) =>
+			wp.req.post( `/sites/${ siteId }/users/${ userId }`, variables ),
+		...queryOptions,
+		onSuccess( data, ...rest ) {
+			queryClient.setQueryData( getCacheKey( siteId, data.login ), data );
+			queryOptions.onSuccess?.( data, ...rest );
+		},
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/data/users/use-user-query.js
+++ b/client/data/users/use-user-query.js
@@ -4,11 +4,11 @@ import wpcom from 'calypso/lib/wp';
 export const getCacheKey = ( siteId, login ) => [ 'user', siteId, login ];
 
 const useUserQuery = ( siteId, login, queryOptions = {} ) => {
-	return useQuery(
-		getCacheKey( siteId, login ),
-		() => wpcom.req.get( `/sites/${ siteId }/users/login:${ login }` ),
-		queryOptions
-	);
+	return useQuery( {
+		queryKey: getCacheKey( siteId, login ),
+		queryFn: () => wpcom.req.get( `/sites/${ siteId }/users/login:${ login }` ),
+		...queryOptions,
+	} );
 };
 
 export default useUserQuery;

--- a/client/data/viewers/use-remove-viewer-mutation.js
+++ b/client/data/viewers/use-remove-viewer-mutation.js
@@ -4,17 +4,15 @@ import wp from 'calypso/lib/wp';
 
 function useRemoveViewer() {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { siteId, viewerId } ) => {
+	const mutation = useMutation( {
+		mutationFn: ( { siteId, viewerId } ) => {
 			return wp.req.post( `/sites/${ siteId }/viewers/${ viewerId }/delete` );
 		},
-		{
-			onSuccess( data, variables ) {
-				const { siteId } = variables;
-				queryClient.invalidateQueries( [ 'viewers', siteId ] );
-			},
-		}
-	);
+		onSuccess( data, variables ) {
+			const { siteId } = variables;
+			queryClient.invalidateQueries( [ 'viewers', siteId ] );
+		},
+	} );
 
 	const { mutate } = mutation;
 	const removeViewer = useCallback(

--- a/client/data/viewers/use-viewer-query.js
+++ b/client/data/viewers/use-viewer-query.js
@@ -2,12 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
 const useViewerQuery = ( siteId, userId ) => {
-	return useQuery( [ 'viewer', userId ], () =>
-		wpcom.req.get( {
-			path: `/sites/${ siteId }/viewer/${ userId }?http_envelope=1`,
-			apiNamespace: 'rest/v1.1',
-		} )
-	);
+	return useQuery( {
+		queryKey: [ 'viewer', userId ],
+		queryFn: () =>
+			wpcom.req.get( {
+				path: `/sites/${ siteId }/viewer/${ userId }?http_envelope=1`,
+				apiNamespace: 'rest/v1.1',
+			} ),
+	} );
 };
 
 export default useViewerQuery;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -13,6 +13,8 @@ import { useDashboardAddRemoveLicense } from '../../hooks';
 import { DASHBOARD_LICENSE_TYPES, getExtractedBackupTitle } from '../utils';
 import ExpandedCard from './expanded-card';
 import type { Site, Backup } from '../types';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { Moment } from 'moment';
 
 interface Props {
 	site: Site;
@@ -47,11 +49,14 @@ const BackupStorageContent = ( {
 			select: ( backups: Backup[] ) =>
 				backups.filter( ( backup ) => isSuccessfulRealtimeBackup( backup ) ),
 		}
-	);
+	) as UseQueryResult< Backup[] >;
 
 	const backup = data?.[ 0 ] ?? null;
 
-	const lastBackupDate = useDateOffsetForSite( backup?.activityTs, siteId );
+	const lastBackupDate = useDateOffsetForSite(
+		backup?.activityTs as Moment | undefined | null,
+		siteId
+	);
 	// Ignore type checking because TypeScript is incorrectly inferring the prop type due to .js usage in use-get-display-date
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -256,6 +256,8 @@ export interface ToggleActivateMonitorArgs {
 export interface Backup {
 	activityTitle: string;
 	activityDescription: { children: { text: string }[] }[];
+	activityName: string;
+	activityTs: number;
 }
 
 export type AllowedMonitorPeriods = 'day' | 'week' | '30 days' | '90 days';

--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -49,17 +49,15 @@ export function useReturnUrl( redirect: boolean ): void {
  *
  */
 export function useRecentPaymentMethodsQuery( { enabled = true }: UseQueryOptions = {} ) {
-	return useQuery(
-		[ 'jetpack-cloud', 'partner-portal', 'recent-cards' ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'jetpack-cloud', 'partner-portal', 'recent-cards' ],
+		queryFn: () =>
 			wpcomJpl.req.get( {
 				apiNamespace: 'wpcom/v2',
 				path: '/jetpack-licensing/stripe/payment-methods',
 			} ),
-		{
-			enabled: enabled,
-		}
-	);
+		enabled: enabled,
+	} );
 }
 
 /**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
@@ -6,9 +6,9 @@ const useDotcomPatterns = (
 	lang?: string,
 	queryOptions: UseQueryOptions< any, unknown, Pattern[] > = {}
 ): Pattern[] => {
-	const { data } = useQuery< any, unknown, Pattern[] >(
-		[ lang, 'patterns' ],
-		() => {
+	const { data } = useQuery< any, unknown, Pattern[] >( {
+		queryKey: [ lang, 'patterns' ],
+		queryFn: () => {
 			return wpcomRequest( {
 				path: `/ptk/patterns/${ lang }`,
 				method: 'GET',
@@ -19,16 +19,14 @@ const useDotcomPatterns = (
 				} ).toString(),
 			} );
 		},
-		{
-			...queryOptions,
-			staleTime: Infinity,
-			enabled: !! lang,
-			meta: {
-				persist: false,
-				...queryOptions.meta,
-			},
-		}
-	);
+		...queryOptions,
+		staleTime: Infinity,
+		enabled: !! lang,
+		meta: {
+			persist: false,
+			...queryOptions.meta,
+		},
+	} );
 
 	return data ?? [];
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-categories.ts
@@ -9,39 +9,37 @@ const usePatternCategories = (
 	queryOptions: UseQueryOptions< any, unknown, Category[] > = {}
 ): Category[] => {
 	const translate = useTranslate();
-	const { data } = useQuery< any, unknown, Category[] >(
-		[ siteId, 'block-patterns', 'categories' ],
-		() => {
+	const { data } = useQuery< any, unknown, Category[] >( {
+		queryKey: [ siteId, 'block-patterns', 'categories' ],
+		queryFn: () => {
 			return wpcom.req.get( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/block-patterns/categories`,
 				apiNamespace: 'wp/v2',
 			} );
 		},
-		{
-			...queryOptions,
-			staleTime: Infinity,
-			enabled: !! siteId,
-			meta: {
-				persist: false,
-				...queryOptions.meta,
-			},
-			select: ( data: Category[] ) => {
-				if ( ! isEnabled( 'pattern-assembler/all-patterns-category' ) ) {
-					return data;
+		...queryOptions,
+		staleTime: Infinity,
+		enabled: !! siteId,
+		meta: {
+			persist: false,
+			...queryOptions.meta,
+		},
+		select: ( data: Category[] ) => {
+			if ( ! isEnabled( 'pattern-assembler/all-patterns-category' ) ) {
+				return data;
+			}
+			return data.map( ( category ) => {
+				if ( 'featured' === category.name ) {
+					return {
+						...category,
+						label: translate( 'All' ),
+						description: translate( 'Browse through all the patterns.' ),
+					};
 				}
-				return data.map( ( category ) => {
-					if ( 'featured' === category.name ) {
-						return {
-							...category,
-							label: translate( 'All' ),
-							description: translate( 'Browse through all the patterns.' ),
-						};
-					}
-					return category;
-				} );
-			},
-		}
-	);
+				return category;
+			} );
+		},
+	} );
 	return data ?? [];
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -53,7 +53,9 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 	const [ formTouched, setFormTouched ] = React.useState( false );
 	const translate = useTranslate();
 
-	useQuery( [ 'site-suggestions' ], getSiteSuggestions, {
+	useQuery( {
+		queryKey: [ 'site-suggestions' ],
+		queryFn: getSiteSuggestions,
 		enabled: ! currentSiteTitle,
 		onSuccess: ( response ) => {
 			if ( ! siteTitle && response.success === true ) {

--- a/client/landing/stepper/hooks/use-countries.ts
+++ b/client/landing/stepper/hooks/use-countries.ts
@@ -6,17 +6,15 @@ type WooCountries = Record< string, string >;
 export function useCountries(
 	queryOptions: UseQueryOptions< any, unknown, WooCountries > = {}
 ): UseQueryResult< WooCountries > {
-	return useQuery< any, unknown, WooCountries >(
-		[ 'countries' ],
-		() => wpcom.req.get( '/woocommerce/countries/regions/', { apiNamespace: 'wpcom/v2' } ),
-		{
-			staleTime: Infinity,
-			refetchOnWindowFocus: false,
-			refetchOnReconnect: false,
-			...queryOptions,
-			meta: {
-				...queryOptions.meta,
-			},
-		}
-	);
+	return useQuery< any, unknown, WooCountries >( {
+		queryKey: [ 'countries' ],
+		queryFn: () => wpcom.req.get( '/woocommerce/countries/regions/', { apiNamespace: 'wpcom/v2' } ),
+		staleTime: Infinity,
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
+		...queryOptions,
+		meta: {
+			...queryOptions.meta,
+		},
+	} );
 }

--- a/client/landing/stepper/hooks/use-theme-details.ts
+++ b/client/landing/stepper/hooks/use-theme-details.ts
@@ -14,14 +14,12 @@ type Theme = {
 };
 
 export function useThemeDetails( slug = '' ): UseQueryResult< Theme > {
-	return useQuery< Theme >(
-		[ 'theme-details', slug ],
-		() => wpcom.req.get( `/themes/${ slug }`, { apiVersion: '1.2' } ),
-		{
-			staleTime: 60 * 5 * 1000, // 5 minutes
-			refetchOnWindowFocus: false,
-			refetchOnReconnect: false,
-			enabled: !! slug,
-		}
-	);
+	return useQuery< Theme >( {
+		queryKey: [ 'theme-details', slug ],
+		queryFn: () => wpcom.req.get( `/themes/${ slug }`, { apiVersion: '1.2' } ),
+		staleTime: 60 * 5 * 1000,
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
+		enabled: !! slug,
+	} );
 }

--- a/client/lib/jetpack/use-jp-presales-availability-query.ts
+++ b/client/lib/jetpack/use-jp-presales-availability-query.ts
@@ -37,9 +37,9 @@ export function useJpPresalesAvailabilityQuery(
 ) {
 	//adding a safeguard to ensure if there's an unkown error with the widget it won't crash the whole app
 	try {
-		return useQuery< boolean, Error >(
-			[ 'presales-availability' ],
-			async () => {
+		return useQuery< boolean, Error >( {
+			queryKey: [ 'presales-availability' ],
+			queryFn: async () => {
 				const url = 'https://public-api.wordpress.com/wpcom/v2/presales/chat';
 				const queryObject = {
 					group: 'jp_presales',
@@ -60,11 +60,9 @@ export function useJpPresalesAvailabilityQuery(
 				const data: PresalesChatResponse = await response.json();
 				return data.is_available;
 			},
-			{
-				enabled,
-				meta: { persist: false },
-			}
-		);
+			enabled,
+			meta: { persist: false },
+		} );
 	} catch ( error ) {
 		setError && setError( true );
 		return { data: false };

--- a/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
+++ b/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
@@ -27,14 +27,13 @@ export default function PaymentMethodBackupToggle( { card }: { card: StoredPayme
 	const storedDetailsId = card.stored_details_id;
 	const initialIsBackup = !! card.is_backup;
 	const queryClient = useQueryClient();
-	const { isLoading, isError, data } = useQuery< { is_backup: boolean }, Error >(
-		[ 'payment-method-backup-toggle', storedDetailsId ],
-		() => fetchIsBackup( storedDetailsId ),
-		{
-			initialData: { is_backup: initialIsBackup },
-		}
-	);
-	const mutation = useMutation( ( isBackup: boolean ) => setIsBackup( storedDetailsId, isBackup ), {
+	const { isLoading, isError, data } = useQuery< { is_backup: boolean }, Error >( {
+		queryKey: [ 'payment-method-backup-toggle', storedDetailsId ],
+		queryFn: () => fetchIsBackup( storedDetailsId ),
+		initialData: { is_backup: initialIsBackup },
+	} );
+	const mutation = useMutation( {
+		mutationFn: ( isBackup: boolean ) => setIsBackup( storedDetailsId, isBackup ),
 		onMutate: ( isBackup ) => {
 			// Optimistically update the toggle
 			queryClient.setQueryData( [ 'payment-method-backup-toggle', storedDetailsId ], {

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -59,7 +59,8 @@ const emptyVatDetails = {};
 export default function useVatDetails(): VatDetailsManager {
 	const queryClient = useQueryClient();
 	const query = useQuery< VatDetails, FetchError >( [ 'vat-details' ], fetchVatDetails );
-	const mutation = useMutation< VatDetails, UpdateError, VatDetails >( setVatDetails, {
+	const mutation = useMutation< VatDetails, UpdateError, VatDetails >( {
+		mutationFn: setVatDetails,
 		onSuccess: ( data ) => {
 			queryClient.setQueryData( [ 'vat-details' ], data );
 		},

--- a/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
@@ -21,8 +21,8 @@ export const useAddSSHKeyMutation = (
 	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		async ( { name, key }: MutationVariables ) =>
+	const mutation = useMutation( {
+		mutationFn: async ( { name, key }: MutationVariables ) =>
 			wp.req.post(
 				{ path: '/me/ssh-keys', apiNamespace: 'wpcom/v2' },
 				{
@@ -30,14 +30,12 @@ export const useAddSSHKeyMutation = (
 					key,
 				}
 			),
-		{
-			...options,
-			onSuccess: async ( ...args ) => {
-				await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
-				options.onSuccess?.( ...args );
-			},
-		}
-	);
+		...options,
+		onSuccess: async ( ...args ) => {
+			await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+			options.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate, isLoading } = mutation;
 

--- a/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
@@ -20,21 +20,19 @@ export const useDeleteSSHKeyMutation = (
 	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		async ( { sshKeyName }: MutationVariables ) =>
+	const mutation = useMutation( {
+		mutationFn: async ( { sshKeyName }: MutationVariables ) =>
 			wp.req.get( {
 				path: `/me/ssh-keys/${ sshKeyName }`,
 				apiNamespace: 'wpcom/v2',
 				method: 'DELETE',
 			} ),
-		{
-			...options,
-			onSuccess: async ( ...args ) => {
-				await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
-				options.onSuccess?.( ...args );
-			},
-		}
-	);
+		...options,
+		onSuccess: async ( ...args ) => {
+			await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+			options.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/me/security-ssh-key/use-ssh-key-query.ts
+++ b/client/me/security-ssh-key/use-ssh-key-query.ts
@@ -25,15 +25,13 @@ export interface SSHKeyData {
 export const SSH_KEY_QUERY_KEY = [ 'me', 'ssh-keys' ];
 
 export const useSSHKeyQuery = () =>
-	useQuery(
-		SSH_KEY_QUERY_KEY,
-		(): SSHKeyData[] =>
+	useQuery( {
+		queryKey: SSH_KEY_QUERY_KEY,
+		queryFn: (): SSHKeyData[] =>
 			wp.req.get( '/me/ssh-keys', {
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			meta: {
-				persist: false,
-			},
-		}
-	);
+		meta: {
+			persist: false,
+		},
+	} );

--- a/client/me/security-ssh-key/use-update-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-update-ssh-key-mutation.ts
@@ -22,8 +22,8 @@ export const useUpdateSSHKeyMutation = (
 	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		async ( { name, key }: MutationVariables ) =>
+	const mutation = useMutation( {
+		mutationFn: async ( { name, key }: MutationVariables ) =>
 			wp.req.put(
 				{
 					path: `/me/ssh-keys/${ name }`,
@@ -35,15 +35,13 @@ export const useUpdateSSHKeyMutation = (
 					key,
 				}
 			),
-		{
-			...options,
-			onSuccess: async ( ...args ) => {
-				await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
-				await queryClient.invalidateQueries( [ USE_ATOMIC_SSH_KEYS_QUERY_KEY ] );
-				options.onSuccess?.( ...args );
-			},
-		}
-	);
+		...options,
+		onSuccess: async ( ...args ) => {
+			await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+			await queryClient.invalidateQueries( [ USE_ATOMIC_SSH_KEYS_QUERY_KEY ] );
+			options.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate, isLoading } = mutation;
 

--- a/client/my-sites/activity/activity-log-tasklist/to-update.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/to-update.jsx
@@ -31,15 +31,14 @@ export default function ( WrappedComponent ) {
 				: pluginsWithUpdates;
 		plugins.current = { siteId, mergedPlugins };
 
-		const siteAlertsQuery = useQuery(
-			[ 'site-alerts', siteId ],
-			() => wpcom.req.get( { path: `/sites/${ siteId }/alerts`, apiNamespace: 'wpcom/v2' } ),
-			{
-				staleTime: Infinity,
-				refetchOnMount: 'always',
-				refetchInterval: 5 * 60 * 1000,
-			}
-		);
+		const siteAlertsQuery = useQuery( {
+			queryKey: [ 'site-alerts', siteId ],
+			queryFn: () =>
+				wpcom.req.get( { path: `/sites/${ siteId }/alerts`, apiNamespace: 'wpcom/v2' } ),
+			staleTime: Infinity,
+			refetchOnMount: 'always',
+			refetchInterval: 5 * 60 * 1000,
+		} );
 
 		const themes = siteAlertsQuery.data?.updates?.themes ?? EMPTY_LIST;
 		const core = siteAlertsQuery.data?.updates?.core ?? EMPTY_LIST;

--- a/client/my-sites/activity/filterbar/type-selector/activity-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/activity-type-selector.jsx
@@ -24,20 +24,18 @@ const activityCountsQueryKey = ( siteId, filter ) => [
 ];
 const withActivityTypes = ( WrappedComponent ) => ( props ) => {
 	const { siteId, filter } = props;
-	const { data } = useQuery(
-		activityCountsQueryKey( siteId, filter ),
-		() =>
+	const { data } = useQuery( {
+		queryKey: activityCountsQueryKey( siteId, filter ),
+		queryFn: () =>
 			wpcom.req
 				.get(
 					{ path: `/sites/${ siteId }/activity/count/group`, apiNamespace: 'wpcom/v2' },
 					filterStateToApiQuery( filter, false )
 				)
 				.then( fromActivityTypeApi ),
-		{
-			enabled: !! siteId,
-			staleTime: 10 * 1000,
-		}
-	);
+		enabled: !! siteId,
+		staleTime: 10 * 1000,
+	} );
 	return <WrappedComponent { ...props } types={ data ?? [] } />;
 };
 

--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -44,6 +44,7 @@ import RewindFlowNotice, { RewindFlowNoticeLevel } from '../rewind-flow/rewind-f
 import { defaultRewindConfig, RewindConfig } from '../rewind-flow/types';
 import CloneFlowStepProgress from './step-progress';
 import CloneFlowSuggestionSearch from './suggestion-search';
+import type { UseQueryResult } from '@tanstack/react-query';
 import type { RestoreProgress } from 'calypso/state/data-layer/wpcom/activity-log/rewind/restore-status/type';
 import type { RewindState } from 'calypso/state/data-layer/wpcom/sites/rewind/type';
 import './style.scss';
@@ -51,6 +52,10 @@ import './style.scss';
 interface Props {
 	siteId: number;
 }
+
+type ActivityLogEntry = {
+	activityDate: string;
+};
 
 const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 	const dispatch = useDispatch();
@@ -233,7 +238,11 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 
 	const disableClone = false;
 
-	const { data: logs } = useRewindableActivityLogQuery( siteId, {}, { enabled: !! siteId } );
+	const { data: logs } = useRewindableActivityLogQuery(
+		siteId,
+		{},
+		{ enabled: !! siteId }
+	) as UseQueryResult< ActivityLogEntry[] >;
 	const lastBackup = logs && logs.length > 0 ? logs[ 0 ] : undefined;
 
 	// Screen that allows user to add credentials for an alternate restore / clone
@@ -291,7 +300,7 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 					</Card>
 				) }
 				<ActivityCardList
-					logs={ logs.slice( 1 ) }
+					logs={ logs?.slice( 1 ) ?? [] }
 					pageSize={ 10 }
 					showFilter={ false }
 					availableActions={ [ 'clone' ] }

--- a/client/my-sites/backup/rewind-flow/index.tsx
+++ b/client/my-sites/backup/rewind-flow/index.tsx
@@ -43,17 +43,17 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 	const siteId = useSelector( getSelectedSiteId );
 	const siteUrl = useSelector( ( state ) => ( siteId && getSiteUrl( state, siteId ) ) || '' );
 
-	const activityQuery = useQuery< Activity, ActivityError >(
-		[ 'activity', siteId, rewindId ],
-		() =>
+	const activityQuery = useQuery< Activity, ActivityError >( {
+		queryKey: [ 'activity', siteId, rewindId ],
+		queryFn: () =>
 			wpcom.req
 				.get( {
 					apiNamespace: 'wpcom/v2',
 					path: `/sites/${ siteId }/activity/${ rewindId }`,
 				} )
 				.then( fromActivityApi ),
-		{ retry: false }
-	);
+		retry: false,
+	} );
 
 	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ?? 0 ) );
 	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ?? 0 ) );

--- a/client/my-sites/checkout/checkout-thank-you/gift/gift-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/gift/gift-thank-you.tsx
@@ -18,11 +18,11 @@ interface Site {
 }
 
 function useSiteQuery( siteId: string | number ) {
-	return useQuery< Site >(
-		[ 'unauthorized-site', siteId ],
-		() => wpcom.req.get( { path: `/sites/${ siteId }`, apiVersion: '1.2' } ),
-		{ meta: { persist: false } }
-	);
+	return useQuery< Site >( {
+		queryKey: [ 'unauthorized-site', siteId ],
+		queryFn: () => wpcom.req.get( { path: `/sites/${ siteId }`, apiVersion: '1.2' } ),
+		meta: { persist: false },
+	} );
 }
 
 export default function GiftThankYou( { site }: { site: number | string } ) {

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-thank-you.tsx
@@ -22,11 +22,11 @@ interface Site {
 }
 
 function useSiteQuery( siteId: string | number ) {
-	return useQuery< Site >(
-		[ 'unauthorized-site', siteId ],
-		() => wpcom.req.get( { path: `/sites/${ siteId }`, apiVersion: '1.2' } ),
-		{ meta: { persist: false } }
-	);
+	return useQuery< Site >( {
+		queryKey: [ 'unauthorized-site', siteId ],
+		queryFn: () => wpcom.req.get( { path: `/sites/${ siteId }`, apiVersion: '1.2' } ),
+		meta: { persist: false },
+	} );
 }
 
 const JetpackCheckoutThankYou: FunctionComponent< Props > = ( {

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/use-payment-method-tax-info.ts
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/use-payment-method-tax-info.ts
@@ -32,17 +32,16 @@ export function usePaymentMethodTaxInfo(
 		enabled: ! doNotFetch,
 	} );
 
-	const mutation = useMutation(
-		( mutationInputValues: TaxInfo ) => setTaxInfoOnServer( storedDetailsId, mutationInputValues ),
-		{
-			onSuccess: ( onSuccessInputValues: TaxInfo ) => {
-				queryClient.setQueryData( queryKey, {
-					...onSuccessInputValues,
-					is_tax_info_set: true,
-				} );
-			},
-		}
-	);
+	const mutation = useMutation( {
+		mutationFn: ( mutationInputValues: TaxInfo ) =>
+			setTaxInfoOnServer( storedDetailsId, mutationInputValues ),
+		onSuccess: ( onSuccessInputValues: TaxInfo ) => {
+			queryClient.setQueryData( queryKey, {
+				...onSuccessInputValues,
+				is_tax_info_set: true,
+			} );
+		},
+	} );
 
 	const setTaxInfo = useCallback(
 		( newInfo: TaxInfo ): Promise< void > => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
@@ -77,13 +77,11 @@ export function useStoredPaymentMethods( {
 
 	const queryKey = [ storedPaymentMethodsQueryKey, type, expired ];
 
-	const { data, isLoading, error } = useQuery< StoredPaymentMethod[], Error >(
+	const { data, isLoading, error } = useQuery< StoredPaymentMethod[], Error >( {
 		queryKey,
-		() => fetchPaymentMethods( type, expired ),
-		{
-			enabled: ! isLoggedOut,
-		}
-	);
+		queryFn: () => fetchPaymentMethods( type, expired ),
+		enabled: ! isLoggedOut,
+	} );
 
 	const translate = useTranslate();
 	const isDataValid = Array.isArray( data );
@@ -93,7 +91,8 @@ export function useStoredPaymentMethods( {
 		StoredPaymentMethod[ 'stored_details_id' ],
 		Error,
 		StoredPaymentMethod[ 'stored_details_id' ]
-	>( ( id ) => requestPaymentMethodDeletion( id ), {
+	>( {
+		mutationFn: ( id ) => requestPaymentMethodDeletion( id ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( [ storedPaymentMethodsQueryKey ] );
 		},

--- a/client/my-sites/hosting/github/deployment-card/use-deployment-logs-url.ts
+++ b/client/my-sites/hosting/github/deployment-card/use-deployment-logs-url.ts
@@ -20,17 +20,21 @@ export const useDeploymentLogsURL = ( {
 }: UseDeploymentLogsURLArguments ) => {
 	const siteId = useSelector( getSelectedSiteId );
 
-	const { data } = useQuery< DeploymentLogsData >(
-		[ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId, 'deployment-logs', deploymentTimestamp ],
-		() =>
+	const { data } = useQuery< DeploymentLogsData >( {
+		queryKey: [
+			GITHUB_INTEGRATION_QUERY_KEY,
+			siteId,
+			connectionId,
+			'deployment-logs',
+			deploymentTimestamp,
+		],
+		queryFn: () =>
 			wp.req.get( {
 				path: `/sites/${ siteId }/hosting/github/deployment-logs`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteId,
-		}
-	);
+		enabled: !! siteId,
+	} );
 
 	const logsBlobUrl = useMemo( () => {
 		if ( ! data ) {

--- a/client/my-sites/hosting/github/deployment-card/use-deployment-status-query.ts
+++ b/client/my-sites/hosting/github/deployment-card/use-deployment-status-query.ts
@@ -17,20 +17,18 @@ export const useDeploymentStatusQuery = (
 	connectionId: number,
 	options?: UseQueryOptions< DeploymentData >
 ) => {
-	return useQuery< DeploymentData >(
-		[ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId, 'deployment-status' ],
-		(): DeploymentData =>
+	return useQuery< DeploymentData >( {
+		queryKey: [ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId, 'deployment-status' ],
+		queryFn: (): DeploymentData =>
 			wp.req.get( {
 				path: `/sites/${ siteId }/hosting/github/deployment-status`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteId,
-			meta: {
-				persist: false,
-			},
-			...options,
-			refetchInterval: 5000,
-		}
-	);
+		enabled: !! siteId,
+		meta: {
+			persist: false,
+		},
+		...options,
+		refetchInterval: 5000,
+	} );
 };

--- a/client/my-sites/hosting/github/deployment-card/use-disconnect-repo.ts
+++ b/client/my-sites/hosting/github/deployment-card/use-disconnect-repo.ts
@@ -15,28 +15,26 @@ export const useGithubDisconnectRepoMutation = (
 	options: UseMutationOptions< unknown, MutationError, unknown > = {}
 ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		async () =>
+	const mutation = useMutation( {
+		mutationFn: async () =>
 			wp.req.post( {
 				method: 'DELETE',
 				path: `/sites/${ siteId }/hosting/github/connection`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			...options,
-			onSuccess: async ( ...args ) => {
-				await Promise.all( [
-					queryClient.invalidateQueries( [ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId ] ),
-					queryClient.invalidateQueries( [
-						GITHUB_INTEGRATION_QUERY_KEY,
-						siteId,
-						GITHUB_CONNECTION_QUERY_KEY,
-					] ),
-				] );
-				options.onSuccess?.( ...args );
-			},
-		}
-	);
+		...options,
+		onSuccess: async ( ...args ) => {
+			await Promise.all( [
+				queryClient.invalidateQueries( [ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId ] ),
+				queryClient.invalidateQueries( [
+					GITHUB_INTEGRATION_QUERY_KEY,
+					siteId,
+					GITHUB_CONNECTION_QUERY_KEY,
+				] ),
+			] );
+			options.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate, isLoading } = mutation;
 

--- a/client/my-sites/hosting/github/disconnect-github-button/index.tsx
+++ b/client/my-sites/hosting/github/disconnect-github-button/index.tsx
@@ -21,14 +21,16 @@ export function DisconnectGitHubButton( { connection }: DisconnectGitHubButtonPr
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	// Using ReactQuery to manage `isDisconnecting` state because it's not exposed from the Redux store.
-	const mutation = useMutation< unknown, unknown, Connection >( async ( c ) => {
-		dispatch( recordTracksEvent( 'calypso_hosting_github_unauthorize_click' ) );
-		await dispatch( deleteStoredKeyringConnection( c ) );
-		await queryClient.invalidateQueries( [
-			GITHUB_INTEGRATION_QUERY_KEY,
-			siteId,
-			GITHUB_CONNECTION_QUERY_KEY,
-		] );
+	const mutation = useMutation< unknown, unknown, Connection >( {
+		mutationFn: async ( c ) => {
+			dispatch( recordTracksEvent( 'calypso_hosting_github_unauthorize_click' ) );
+			await dispatch( deleteStoredKeyringConnection( c ) );
+			await queryClient.invalidateQueries( [
+				GITHUB_INTEGRATION_QUERY_KEY,
+				siteId,
+				GITHUB_CONNECTION_QUERY_KEY,
+			] );
+		},
 	} );
 	const { mutate: disconnect, isLoading: isDisconnecting } = mutation;
 

--- a/client/my-sites/hosting/github/github-authorize-card/index.tsx
+++ b/client/my-sites/hosting/github/github-authorize-card/index.tsx
@@ -24,25 +24,21 @@ export const GithubAuthorizeCard = () => {
 		getKeyringServiceByName( state, 'github-deploy' )
 	) as Service;
 
-	const { mutate: authorize, isLoading: isAuthorizing } = useMutation< void, unknown, string >(
-		async ( connectURL ) => {
+	const { mutate: authorize, isLoading: isAuthorizing } = useMutation< void, unknown, string >( {
+		mutationFn: async ( connectURL ) => {
 			dispatch( recordTracksEvent( 'calypso_hosting_github_authorize_click' ) );
 			await new Promise( ( resolve ) => requestExternalAccess( connectURL, resolve ) );
 			await dispatch( requestKeyringConnections() );
 		},
-		{
-			onSuccess: async () => {
-				const connectionKey = [ GITHUB_INTEGRATION_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ];
-				await queryClient.invalidateQueries( connectionKey );
+		onSuccess: async () => {
+			const connectionKey = [ GITHUB_INTEGRATION_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ];
+			await queryClient.invalidateQueries( connectionKey );
 
-				const authorized =
-					queryClient.getQueryData< GithubConnectionData >( connectionKey )?.connected;
-				dispatch(
-					recordTracksEvent( 'calypso_hosting_github_authorize_complete', { authorized } )
-				);
-			},
-		}
-	);
+			const authorized =
+				queryClient.getQueryData< GithubConnectionData >( connectionKey )?.connected;
+			dispatch( recordTracksEvent( 'calypso_hosting_github_authorize_complete', { authorized } ) );
+		},
+	} );
 
 	return (
 		<Card className="github-hosting-card">

--- a/client/my-sites/hosting/github/github-connect-card/use-github-branches-query.ts
+++ b/client/my-sites/hosting/github/github-connect-card/use-github-branches-query.ts
@@ -19,21 +19,19 @@ export const useGithubBranchesQuery = (
 	connectionId: number,
 	options?: UseQueryOptions< string[] >
 ) => {
-	return useQuery< string[] >(
-		[ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId, 'branches', repoName ],
-		(): string[] =>
+	return useQuery< string[] >( {
+		queryKey: [ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId, 'branches', repoName ],
+		queryFn: (): string[] =>
 			wp.req.get( {
 				path: `/sites/${ siteId }/hosting/github/branches?repo=${ repoName }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteId && !! repoName,
-			select: ( data ) => data.sort( sortBranches ),
-			meta: {
-				persist: false,
-			},
-			...options,
-			cacheTime: CACHE_TIME,
-		}
-	);
+		enabled: !! siteId && !! repoName,
+		select: ( data ) => data.sort( sortBranches ),
+		meta: {
+			persist: false,
+		},
+		...options,
+		cacheTime: CACHE_TIME,
+	} );
 };

--- a/client/my-sites/hosting/github/github-connect-card/use-github-connect-mutation.ts
+++ b/client/my-sites/hosting/github/github-connect-card/use-github-connect-mutation.ts
@@ -24,9 +24,9 @@ export const useGithubConnectMutation = (
 	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
+	const mutation = useMutation( {
 		//todo sent basePath
-		async ( { repoName, branchName, basePath }: MutationVariables ) =>
+		mutationFn: async ( { repoName, branchName, basePath }: MutationVariables ) =>
 			wp.req.post(
 				{
 					path: `/sites/${ siteId }/hosting/github/connection`,
@@ -34,18 +34,16 @@ export const useGithubConnectMutation = (
 				},
 				{ repo: repoName, branch: branchName, base_path: basePath }
 			),
-		{
-			...options,
-			onSuccess: async ( ...args ) => {
-				await queryClient.invalidateQueries( [
-					GITHUB_INTEGRATION_QUERY_KEY,
-					siteId,
-					GITHUB_CONNECTION_QUERY_KEY,
-				] );
-				options.onSuccess?.( ...args );
-			},
-		}
-	);
+		...options,
+		onSuccess: async ( ...args ) => {
+			await queryClient.invalidateQueries( [
+				GITHUB_INTEGRATION_QUERY_KEY,
+				siteId,
+				GITHUB_CONNECTION_QUERY_KEY,
+			] );
+			options.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate, isLoading } = mutation;
 

--- a/client/my-sites/hosting/github/github-connect-card/use-github-repos-query.ts
+++ b/client/my-sites/hosting/github/github-connect-card/use-github-repos-query.ts
@@ -9,20 +9,18 @@ export const useGithubReposQuery = (
 	connectionId: number,
 	options?: UseQueryOptions< string[] >
 ) => {
-	return useQuery< string[] >(
-		[ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId, 'repos', query ],
-		(): string[] =>
+	return useQuery< string[] >( {
+		queryKey: [ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId, 'repos', query ],
+		queryFn: (): string[] =>
 			wp.req.get( {
 				path: addQueryArgs( { query }, `/sites/${ siteId }/hosting/github/repos` ),
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteId && !! query,
-			meta: {
-				persist: false,
-			},
-			refetchOnWindowFocus: false,
-			...options,
-		}
-	);
+		enabled: !! siteId && !! query,
+		meta: {
+			persist: false,
+		},
+		refetchOnWindowFocus: false,
+		...options,
+	} );
 };

--- a/client/my-sites/hosting/github/use-github-connection-query.ts
+++ b/client/my-sites/hosting/github/use-github-connection-query.ts
@@ -19,19 +19,17 @@ export const useGithubConnectionQuery = (
 	siteId: number | null,
 	options?: UseQueryOptions< GithubConnectionData >
 ) => {
-	return useQuery< GithubConnectionData >(
-		[ GITHUB_INTEGRATION_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ],
-		(): GithubConnectionData =>
+	return useQuery< GithubConnectionData >( {
+		queryKey: [ GITHUB_INTEGRATION_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ],
+		queryFn: (): GithubConnectionData =>
 			wp.req.get( {
 				path: `/sites/${ siteId }/hosting/github/connection`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteId,
-			meta: {
-				persist: false,
-			},
-			...options,
-		}
-	);
+		enabled: !! siteId,
+		meta: {
+			persist: false,
+		},
+		...options,
+	} );
 };

--- a/client/my-sites/hosting/sftp-card/use-atomic-ssh-keys.ts
+++ b/client/my-sites/hosting/sftp-card/use-atomic-ssh-keys.ts
@@ -11,21 +11,19 @@ export interface AtomicKey {
 }
 
 export const useAtomicSshKeys = ( siteId: number, options: UseQueryOptions ) => {
-	return useQuery< { ssh_keys: Array< AtomicKey > }, unknown, Array< AtomicKey > >(
-		[ USE_ATOMIC_SSH_KEYS_QUERY_KEY, siteId ],
-		() =>
+	return useQuery< { ssh_keys: Array< AtomicKey > }, unknown, Array< AtomicKey > >( {
+		queryKey: [ USE_ATOMIC_SSH_KEYS_QUERY_KEY, siteId ],
+		queryFn: () =>
 			wp.req.get( {
 				path: `/sites/${ siteId }/hosting/ssh-keys`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteId && ( options.enabled ?? true ),
-			select: ( data ) => {
-				return data.ssh_keys;
-			},
-			meta: {
-				persist: false,
-			},
-		}
-	);
+		enabled: !! siteId && ( options.enabled ?? true ),
+		select: ( data ) => {
+			return data.ssh_keys;
+		},
+		meta: {
+			persist: false,
+		},
+	} );
 };

--- a/client/my-sites/hosting/sftp-card/use-attach-ssh-key.ts
+++ b/client/my-sites/hosting/sftp-card/use-attach-ssh-key.ts
@@ -21,21 +21,19 @@ export const useAttachSshKeyMutation = (
 	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		async ( { name }: MutationVariables ) =>
+	const mutation = useMutation( {
+		mutationFn: async ( { name }: MutationVariables ) =>
 			wp.req.post( {
 				path: `/sites/${ siteId }/hosting/ssh-keys`,
 				apiNamespace: 'wpcom/v2',
 				body: { name },
 			} ),
-		{
-			...options,
-			onSuccess: async ( ...args ) => {
-				await queryClient.invalidateQueries( [ USE_ATOMIC_SSH_KEYS_QUERY_KEY, siteId ] );
-				options.onSuccess?.( ...args );
-			},
-		}
-	);
+		...options,
+		onSuccess: async ( ...args ) => {
+			await queryClient.invalidateQueries( [ USE_ATOMIC_SSH_KEYS_QUERY_KEY, siteId ] );
+			options.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate, isLoading } = mutation;
 

--- a/client/my-sites/hosting/sftp-card/use-detach-ssh-key.ts
+++ b/client/my-sites/hosting/sftp-card/use-detach-ssh-key.ts
@@ -22,22 +22,20 @@ export const useDetachSshKeyMutation = (
 	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		async ( { user_login, name }: MutationVariables ) => {
+	const mutation = useMutation( {
+		mutationFn: async ( { user_login, name }: MutationVariables ) => {
 			return wp.req.post( {
 				path: `/sites/${ siteId }/hosting/ssh-keys/${ user_login }/${ name }`,
 				apiNamespace: 'wpcom/v2',
 				method: 'DELETE',
 			} );
 		},
-		{
-			...options,
-			onSuccess: async ( ...args ) => {
-				await queryClient.invalidateQueries( [ USE_ATOMIC_SSH_KEYS_QUERY_KEY, siteId ] );
-				options.onSuccess?.( ...args );
-			},
-		}
-	);
+		...options,
+		onSuccess: async ( ...args ) => {
+			await queryClient.invalidateQueries( [ USE_ATOMIC_SSH_KEYS_QUERY_KEY, siteId ] );
+			options.onSuccess?.( ...args );
+		},
+	} );
 	const { mutate, isLoading } = mutation;
 
 	const detachSshKey = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );

--- a/client/my-sites/hosting/staging-site-card/use-add-staging-site.ts
+++ b/client/my-sites/hosting/staging-site-card/use-add-staging-site.ts
@@ -28,21 +28,19 @@ export const useAddStagingSiteMutation = (
 	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		async () =>
+	const mutation = useMutation( {
+		mutationFn: async () =>
 			wp.req.post( {
 				path: `/sites/${ siteId }/staging-site`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			...options,
-			mutationKey: [ ADD_STAGING_SITE_MUTATION_KEY, siteId ],
-			onSuccess: async ( ...args ) => {
-				await queryClient.invalidateQueries( [ USE_STAGING_SITE_QUERY_KEY, siteId ] );
-				options.onSuccess?.( ...args );
-			},
-		}
-	);
+		...options,
+		mutationKey: [ ADD_STAGING_SITE_MUTATION_KEY, siteId ],
+		onSuccess: async ( ...args ) => {
+			await queryClient.invalidateQueries( [ USE_STAGING_SITE_QUERY_KEY, siteId ] );
+			options.onSuccess?.( ...args );
+		},
+	} );
 
 	const { mutate } = mutation;
 	// isMutating is returning a number. Greater than 0 means we have some pending mutations for

--- a/client/my-sites/hosting/staging-site-card/use-delete-staging-site.ts
+++ b/client/my-sites/hosting/staging-site-card/use-delete-staging-site.ts
@@ -53,31 +53,29 @@ export const useDeleteStagingSite = ( options: UseDeleteStagingSiteOptions ) => 
 		};
 	}, [ isDeletingInitiated, onReverted, queryClient, stagingSiteId ] );
 
-	const mutation = useMutation(
-		() => {
+	const mutation = useMutation( {
+		mutationFn: () => {
 			return wpcom.req.post( {
 				method: 'DELETE',
 				path: `/sites/${ siteId }/staging-site/${ stagingSiteId }`,
 				apiNamespace: 'wpcom/v2',
 			} );
 		},
-		{
-			mutationKey: [ DELETE_STAGING_SITE_MUTATION_KEY, siteId ],
-			onMutate: () => {
-				onMutate?.();
-			},
-			onSuccess: async () => {
-				// Wait for the staging site async job to start
-				setTimeout( () => {
-					dispatch( fetchAutomatedTransferStatus( stagingSiteId ) );
-				}, 3000 );
-			},
-			onError: ( error: MutationError ) => {
-				setIsDeletingInitiated( false );
-				onError?.( error );
-			},
-		}
-	);
+		mutationKey: [ DELETE_STAGING_SITE_MUTATION_KEY, siteId ],
+		onMutate: () => {
+			onMutate?.();
+		},
+		onSuccess: async () => {
+			// Wait for the staging site async job to start
+			setTimeout( () => {
+				dispatch( fetchAutomatedTransferStatus( stagingSiteId ) );
+			}, 3000 );
+		},
+		onError: ( error: MutationError ) => {
+			setIsDeletingInitiated( false );
+			onError?.( error );
+		},
+	} );
 
 	// isMutating is returning a number. Greater than 0 means we have some pending mutations for
 	// the provided key. This is preserved across different pages, while isLoading it's not.

--- a/client/my-sites/hosting/staging-site-card/use-has-valid-quota.ts
+++ b/client/my-sites/hosting/staging-site-card/use-has-valid-quota.ts
@@ -4,23 +4,21 @@ import wp from 'calypso/lib/wp';
 export const USE_VALID_QUOTA_QUERY_KEY = 'valid-quota';
 
 export const useHasValidQuotaQuery = ( siteId: number, options: UseQueryOptions ) => {
-	return useQuery< boolean, unknown, boolean >(
-		[ USE_VALID_QUOTA_QUERY_KEY, siteId ],
-		() =>
+	return useQuery< boolean, unknown, boolean >( {
+		queryKey: [ USE_VALID_QUOTA_QUERY_KEY, siteId ],
+		queryFn: () =>
 			wp.req.post( {
 				path: `/sites/${ siteId }/staging-site/validate-quota`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteId && ( options?.enabled ?? true ),
-			select: ( data ) => {
-				return data;
-			},
-			meta: {
-				persist: false,
-			},
-			staleTime: 10 * 1000,
-			onError: options?.onError,
-		}
-	);
+		enabled: !! siteId && ( options?.enabled ?? true ),
+		select: ( data ) => {
+			return data;
+		},
+		meta: {
+			persist: false,
+		},
+		staleTime: 10 * 1000,
+		onError: options?.onError,
+	} );
 };

--- a/client/my-sites/hosting/staging-site-card/use-production-site-detail.ts
+++ b/client/my-sites/hosting/staging-site-card/use-production-site-detail.ts
@@ -10,23 +10,21 @@ export interface ProductionSite {
 }
 
 export const useProductionSiteDetail = ( siteId: number, options: UseQueryOptions ) => {
-	return useQuery< ProductionSite, unknown, ProductionSite >(
-		[ USE_PRODUCTION_SITE_DETAIL_QUERY_KEY, siteId ],
-		() =>
+	return useQuery< ProductionSite, unknown, ProductionSite >( {
+		queryKey: [ USE_PRODUCTION_SITE_DETAIL_QUERY_KEY, siteId ],
+		queryFn: () =>
 			wp.req.get( {
 				path: `/sites/${ siteId }/staging-site/production-site-details`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteId && ( options.enabled ?? true ),
-			select: ( data ) => {
-				return data;
-			},
-			meta: {
-				persist: false,
-			},
-			staleTime: 10 * 1000,
-			onError: options.onError,
-		}
-	);
+		enabled: !! siteId && ( options.enabled ?? true ),
+		select: ( data ) => {
+			return data;
+		},
+		meta: {
+			persist: false,
+		},
+		staleTime: 10 * 1000,
+		onError: options.onError,
+	} );
 };

--- a/client/my-sites/hosting/staging-site-card/use-staging-site.ts
+++ b/client/my-sites/hosting/staging-site-card/use-staging-site.ts
@@ -11,23 +11,21 @@ export interface StagingSite {
 }
 
 export const useStagingSite = ( siteId: number, options: UseQueryOptions ) => {
-	return useQuery< Array< StagingSite >, unknown, Array< StagingSite > >(
-		[ USE_STAGING_SITE_QUERY_KEY, siteId ],
-		() =>
+	return useQuery< Array< StagingSite >, unknown, Array< StagingSite > >( {
+		queryKey: [ USE_STAGING_SITE_QUERY_KEY, siteId ],
+		queryFn: () =>
 			wp.req.get( {
 				path: `/sites/${ siteId }/staging-site`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteId && ( options.enabled ?? true ),
-			select: ( data ) => {
-				return data;
-			},
-			meta: {
-				persist: false,
-			},
-			staleTime: 10 * 1000,
-			onError: options.onError,
-		}
-	);
+		enabled: !! siteId && ( options.enabled ?? true ),
+		select: ( data ) => {
+			return data;
+		},
+		meta: {
+			persist: false,
+		},
+		staleTime: 10 * 1000,
+		onError: options.onError,
+	} );
 };

--- a/client/my-sites/marketing/buttons/use-sharing-buttons-query.js
+++ b/client/my-sites/marketing/buttons/use-sharing-buttons-query.js
@@ -3,30 +3,25 @@ import { useCallback } from 'react';
 import wpcom from 'calypso/lib/wp';
 
 export function useSharingButtonsQuery( siteId ) {
-	return useQuery(
-		[ 'sharing-buttons', siteId ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'sharing-buttons', siteId ],
+		queryFn: () =>
 			wpcom.req
 				.get( `/sites/${ siteId }/sharing-buttons` )
 				.then( ( data ) => data.sharing_buttons ),
-
-		{
-			enabled: !! siteId,
-		}
-	);
+		enabled: !! siteId,
+	} );
 }
 
 export function useSaveSharingButtonsMutation( siteId ) {
 	const queryClient = useQueryClient();
-	const mutation = useMutation(
-		( { buttons } ) =>
+	const mutation = useMutation( {
+		mutationFn: ( { buttons } ) =>
 			wpcom.req.post( `/sites/${ siteId }/sharing-buttons`, { sharing_buttons: buttons } ),
-		{
-			onSuccess( data ) {
-				queryClient.setQueryData( [ 'sharing-buttons', siteId ], data.updated );
-			},
-		}
-	);
+		onSuccess( data ) {
+			queryClient.setQueryData( [ 'sharing-buttons', siteId ], data.updated );
+		},
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/my-sites/stats/hooks/use-subscribers-query.js
+++ b/client/my-sites/stats/hooks/use-subscribers-query.js
@@ -41,12 +41,10 @@ function selectSubscribers( payload ) {
 
 export default function useSubscribersQuery( siteId, period, quantity, date ) {
 	// TODO: Account for other query parameters before release.
-	return useQuery(
-		[ 'stats', 'subscribers', siteId, period, quantity, date ],
-		() => querySubscribers( siteId, period, quantity, date ),
-		{
-			select: selectSubscribers,
-			staleTime: 1000 * 60 * 5, // 5 minutes
-		}
-	);
+	return useQuery( {
+		queryKey: [ 'stats', 'subscribers', siteId, period, quantity, date ],
+		queryFn: () => querySubscribers( siteId, period, quantity, date ),
+		select: selectSubscribers,
+		staleTime: 1000 * 60 * 5, // 5 minutes
+	} );
 }

--- a/client/my-sites/themes/fse-themes.jsx
+++ b/client/my-sites/themes/fse-themes.jsx
@@ -5,17 +5,16 @@ import wpcom from 'calypso/lib/wp';
 import { ConnectedThemesSelection } from './themes-selection';
 
 const FseThemes = localize( ( { translate, ...restProps } ) => {
-	const { data, error, isLoading } = useQuery(
-		[ 'fse-themes' ],
-		() =>
+	const { data, error, isLoading } = useQuery( {
+		queryKey: [ 'fse-themes' ],
+		queryFn: () =>
 			wpcom.req.get( '/themes', {
 				filter: 'full-site-editing',
 				number: 50,
 				tier: '',
 				apiVersion: '1.2',
 			} ),
-		{}
-	);
+	} );
 	if ( error ) {
 		return <EmptyContent title={ translate( 'Sorry, no themes found.' ) } />;
 	}

--- a/client/state/partner-portal/invoices/hooks/use-invoices-query.ts
+++ b/client/state/partner-portal/invoices/hooks/use-invoices-query.ts
@@ -53,20 +53,18 @@ export default function useInvoicesQuery(
 	const dispatch = useDispatch();
 	const activeKeyId = useSelector( getActivePartnerKeyId );
 
-	return useQuery< APIInvoices, QueryError, Invoices >(
-		[ 'partner-portal', 'invoices', activeKeyId, pagination ],
-		queryInvoices,
-		{
-			refetchOnWindowFocus: false,
-			select: selectInvoices,
-			onError: () => {
-				dispatch(
-					errorNotice( translate( 'We were unable to retrieve your invoices.' ), {
-						id: 'partner-portal-invoices-failure',
-					} )
-				);
-			},
-			...options,
-		}
-	);
+	return useQuery< APIInvoices, QueryError, Invoices >( {
+		queryKey: [ 'partner-portal', 'invoices', activeKeyId, pagination ],
+		queryFn: queryInvoices,
+		refetchOnWindowFocus: false,
+		select: selectInvoices,
+		onError: () => {
+			dispatch(
+				errorNotice( translate( 'We were unable to retrieve your invoices.' ), {
+					id: 'partner-portal-invoices-failure',
+				} )
+			);
+		},
+		...options,
+	} );
 }

--- a/client/state/partner-portal/licenses/hooks/use-products-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-products-query.ts
@@ -49,7 +49,9 @@ export default function useProductsQuery(): UseQueryResult< APIProductFamilyProd
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	return useQuery( [ 'partner-portal', 'licenses', 'products' ], queryProducts, {
+	return useQuery( {
+		queryKey: [ 'partner-portal', 'licenses', 'products' ],
+		queryFn: queryProducts,
 		select: selectAlphabeticallySortedProductOptions,
 		onError: () => {
 			dispatch(

--- a/client/state/signup/steps/website-content/hooks/use-get-website-content-query.ts
+++ b/client/state/signup/steps/website-content/hooks/use-get-website-content-query.ts
@@ -5,30 +5,28 @@ import type { WebsiteContentResponseDTO, WebsiteContentServerState } from '../ty
 import type { SiteSlug } from 'calypso/types';
 
 export function useGetWebsiteContentQuery( siteSlug: SiteSlug | undefined ) {
-	return useQuery< WebsiteContentResponseDTO, unknown, WebsiteContentServerState >(
-		[ 'bbe-website-content', siteSlug ],
-		(): Promise< WebsiteContentResponseDTO > =>
+	return useQuery< WebsiteContentResponseDTO, unknown, WebsiteContentServerState >( {
+		queryKey: [ 'bbe-website-content', siteSlug ],
+		queryFn: (): Promise< WebsiteContentResponseDTO > =>
 			wpcom.req.get( {
 				path: `/sites/${ siteSlug }/do-it-for-me/website-content`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			enabled: !! siteSlug,
-			meta: { persist: false },
-			select: ( data: WebsiteContentResponseDTO ) => ( {
-				selectedPageTitles: data.selected_page_titles,
-				isWebsiteContentSubmitted: data.is_website_content_submitted,
-				isStoreFlow: data.is_store_flow,
-				pages: data.pages?.length
-					? data.pages.map( ( page: Record< string, unknown > ) =>
-							mapRecordKeysRecursively( page, snakeToCamelCase )
-					  )
-					: [],
-				siteLogoUrl: data.site_logo_url,
-				genericFeedback: data.generic_feedback,
-				searchTerms: data.search_terms,
-			} ),
-			staleTime: Infinity,
-		}
-	);
+		enabled: !! siteSlug,
+		meta: { persist: false },
+		select: ( data: WebsiteContentResponseDTO ) => ( {
+			selectedPageTitles: data.selected_page_titles,
+			isWebsiteContentSubmitted: data.is_website_content_submitted,
+			isStoreFlow: data.is_store_flow,
+			pages: data.pages?.length
+				? data.pages.map( ( page: Record< string, unknown > ) =>
+						mapRecordKeysRecursively( page, snakeToCamelCase )
+				  )
+				: [],
+			siteLogoUrl: data.site_logo_url,
+			genericFeedback: data.generic_feedback,
+			searchTerms: data.search_terms,
+		} ),
+		staleTime: Infinity,
+	} );
 }

--- a/client/state/sites/hooks/use-premium-global-styles.ts
+++ b/client/state/sites/hooks/use-premium-global-styles.ts
@@ -24,14 +24,12 @@ export function usePremiumGlobalStyles(
 		return site?.ID ?? null;
 	} );
 
-	const { data } = useQuery(
-		[ 'globalStylesInfo', siteId ],
-		() => getGlobalStylesInfoForSite( siteId ),
-		{
-			placeholderData: DEFAULT_GLOBAL_STYLES_INFO,
-			refetchOnWindowFocus: false,
-		}
-	);
+	const { data } = useQuery( {
+		queryKey: [ 'globalStylesInfo', siteId ],
+		queryFn: () => getGlobalStylesInfoForSite( siteId ),
+		placeholderData: DEFAULT_GLOBAL_STYLES_INFO,
+		refetchOnWindowFocus: false,
+	} );
 
 	return data ?? DEFAULT_GLOBAL_STYLES_INFO;
 }

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -37,14 +37,12 @@ export const getGlobalStylesInfoForSite = ( siteId: number | null ): GlobalStyle
 };
 
 export function useSiteGlobalStylesStatus( siteId: number ): GlobalStylesStatus {
-	const { data } = useQuery(
-		[ 'globalStylesInfo', siteId ],
-		() => getGlobalStylesInfoForSite( siteId ),
-		{
-			placeholderData: DEFAULT_GLOBAL_STYLES_INFO,
-			refetchOnWindowFocus: false,
-		}
-	);
+	const { data } = useQuery( {
+		queryKey: [ 'globalStylesInfo', siteId ],
+		queryFn: () => getGlobalStylesInfoForSite( siteId ),
+		placeholderData: DEFAULT_GLOBAL_STYLES_INFO,
+		refetchOnWindowFocus: false,
+	} );
 
 	return data ?? DEFAULT_GLOBAL_STYLES_INFO;
 }

--- a/client/state/test/data-fetching-persistence.tsx
+++ b/client/state/test/data-fetching-persistence.tsx
@@ -76,7 +76,9 @@ const DataFetchingComponent = < T, >( {
 	queryFn,
 	persistencePredicate,
 }: DataFetchingComponentProps< T > ) => {
-	const { status } = useQuery( [ queryKey ], queryFn, {
+	const { status } = useQuery( {
+		queryKey: [ queryKey ],
+		queryFn,
 		retry: false,
 		meta: {
 			persist: persistencePredicate != null ? persistencePredicate : undefined,

--- a/packages/block-renderer/src/hooks/use-block-renderer-settings.ts
+++ b/packages/block-renderer/src/hooks/use-block-renderer-settings.ts
@@ -13,24 +13,22 @@ const useBlockRendererSettings = (
 		use_inline_styles: useInlineStyles.toString(),
 	} );
 
-	return useQuery< any, unknown, BlockRendererSettings >(
-		[ siteId, 'block-renderer', stylesheet, useInlineStyles ],
-		() =>
+	return useQuery< any, unknown, BlockRendererSettings >( {
+		queryKey: [ siteId, 'block-renderer', stylesheet, useInlineStyles ],
+		queryFn: () =>
 			wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/block-renderer/settings`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
 				query: params.toString(),
 			} ),
-		{
-			...queryOptions,
-			staleTime: Infinity,
-			meta: {
-				persist: false,
-				...queryOptions.meta,
-			},
-		}
-	);
+		...queryOptions,
+		staleTime: Infinity,
+		meta: {
+			persist: false,
+			...queryOptions.meta,
+		},
+	} );
 };
 
 export default useBlockRendererSettings;

--- a/packages/data-stores/src/queries/use-happiness-engineers-query.ts
+++ b/packages/data-stores/src/queries/use-happiness-engineers-query.ts
@@ -8,11 +8,10 @@ export const useHappinessEngineersQuery = () =>
 			name: string;
 			avatar_URL: string;
 		}[]
-	>(
-		[ 'happinessEngineers' ],
-		async () => await wpcomRequest( { path: '/meta/happiness-engineers/', apiVersion: '1.1' } ),
-		{
-			refetchOnWindowFocus: false,
-			staleTime: Infinity,
-		}
-	);
+	>( {
+		queryKey: [ 'happinessEngineers' ],
+		queryFn: async () =>
+			await wpcomRequest( { path: '/meta/happiness-engineers/', apiVersion: '1.1' } ),
+		refetchOnWindowFocus: false,
+		staleTime: Infinity,
+	} );

--- a/packages/data-stores/src/queries/use-is-wporg-site.ts
+++ b/packages/data-stores/src/queries/use-is-wporg-site.ts
@@ -12,9 +12,9 @@ type Analysis = {
 };
 
 export function useIsWpOrgSite( siteUrl: string | undefined, enabled = true ) {
-	return useQuery(
-		[ 'is-site-wporg-', siteUrl ],
-		async () => {
+	return useQuery( {
+		queryKey: [ 'is-site-wporg-', siteUrl ],
+		queryFn: async () => {
 			const analysis = await wpcomRequest< Analysis >( {
 				path: `/imports/analyze-url?site_url=${ encodeURIComponent( siteUrl as string ) }`,
 				apiNamespace: 'wpcom/v2',
@@ -24,10 +24,8 @@ export function useIsWpOrgSite( siteUrl: string | undefined, enabled = true ) {
 			}
 			return false;
 		},
-		{
-			refetchOnWindowFocus: false,
-			staleTime: Infinity,
-			enabled: !! siteUrl && enabled,
-		}
-	);
+		refetchOnWindowFocus: false,
+		staleTime: Infinity,
+		enabled: !! siteUrl && enabled,
+	} );
 }

--- a/packages/data-stores/src/queries/use-jetpack-search-ai.ts
+++ b/packages/data-stores/src/queries/use-jetpack-search-ai.ts
@@ -27,9 +27,9 @@ export type JetpackSearchAIResult = {
 };
 
 export function useJetpackSearchAIQuery( config: JetpackSearchAIConfig ) {
-	return useQuery< JetpackSearchAIResult >(
-		[ 'aiQuery', config.query, config.stopAt ],
-		() =>
+	return useQuery< JetpackSearchAIResult >( {
+		queryKey: [ 'aiQuery', config.query, config.stopAt ],
+		queryFn: () =>
 			canAccessWpcomApis()
 				? wpcomRequest( {
 						path: `sites/${ config.siteId }/jetpack-search/ai/search`,
@@ -43,11 +43,9 @@ export function useJetpackSearchAIQuery( config: JetpackSearchAIConfig ) {
 							config.siteId
 						}&query=${ encodeURIComponent( config.query ) }&stop_at=${ config.stopAt }`,
 				  } as APIFetchOptions ),
-		{
-			refetchOnWindowFocus: false,
-			keepPreviousData: false,
-			enabled: config.enabled && !! config.query,
-			retry: false,
-		}
-	);
+		refetchOnWindowFocus: false,
+		keepPreviousData: false,
+		enabled: config.enabled && !! config.query,
+		retry: false,
+	} );
 }

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -67,7 +67,9 @@ export const useLaunchpad = (
 	checklist_slug?: string | 0 | null | undefined
 ) => {
 	const key = [ 'launchpad', siteSlug, checklist_slug ];
-	return useQuery( key, () => fetchLaunchpad( siteSlug, checklist_slug ), {
+	return useQuery( {
+		queryKey: key,
+		queryFn: () => fetchLaunchpad( siteSlug, checklist_slug ),
 		retry: 3,
 		initialData: {
 			site_intent: '',

--- a/packages/data-stores/src/queries/use-site-intent.ts
+++ b/packages/data-stores/src/queries/use-site-intent.ts
@@ -4,17 +4,15 @@ import wpcomRequest from 'wpcom-proxy-request';
 export function useSiteIntent( siteId: string | number | undefined ) {
 	return useQuery< {
 		site_intent: '';
-	} >(
-		[ 'site-intent', siteId ],
-		async () =>
+	} >( {
+		queryKey: [ 'site-intent', siteId ],
+		queryFn: async () =>
 			await wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId as string ) }/site-intent`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			refetchOnWindowFocus: false,
-			staleTime: Infinity,
-			enabled: !! siteId,
-		}
-	);
+		refetchOnWindowFocus: false,
+		staleTime: Infinity,
+		enabled: !! siteId,
+	} );
 }

--- a/packages/data-stores/src/queries/use-user-sites.ts
+++ b/packages/data-stores/src/queries/use-user-sites.ts
@@ -3,17 +3,15 @@ import wpcomRequest from 'wpcom-proxy-request';
 import type { SiteDetails } from '../site';
 
 export function useUserSites( userId: number | string, enabled = true ) {
-	return useQuery(
-		[ 'user-sites', userId ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'user-sites', userId ],
+		queryFn: () =>
 			wpcomRequest< { sites: SiteDetails[] } >( {
 				path: '/me/sites/',
 				apiVersion: '1.1',
 			} ),
-		{
-			refetchOnWindowFocus: false,
-			staleTime: 5 * 60 * 1000,
-			enabled,
-		}
-	);
+		refetchOnWindowFocus: false,
+		staleTime: 5 * 60 * 1000,
+		enabled,
+	} );
 }

--- a/packages/data-stores/src/queries/use-wpcom-site.ts
+++ b/packages/data-stores/src/queries/use-wpcom-site.ts
@@ -3,17 +3,15 @@ import wpcomRequest from 'wpcom-proxy-request';
 import type { SiteDetails } from '../site';
 
 export function useWpcomSite( siteId: number | string | undefined, enabled = true ) {
-	return useQuery(
-		[ 'wpcom-site', siteId ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'wpcom-site', siteId ],
+		queryFn: () =>
 			wpcomRequest< SiteDetails >( {
 				path: '/sites/' + encodeURIComponent( siteId as string ),
 				apiVersion: '1.1',
 			} ),
-		{
-			refetchOnWindowFocus: false,
-			staleTime: Infinity,
-			enabled: !! siteId && enabled,
-		}
-	);
+		refetchOnWindowFocus: false,
+		staleTime: Infinity,
+		enabled: !! siteId && enabled,
+	} );
 }

--- a/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
@@ -15,8 +15,8 @@ const usePendingPostConfirmMutation = () => {
 	const isLoggedIn = useIsLoggedIn();
 	const queryClient = useQueryClient();
 	const countCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
-	return useMutation(
-		async ( { id }: PendingPostConfirmParams ) => {
+	return useMutation( {
+		mutationFn: async ( { id }: PendingPostConfirmParams ) => {
 			if ( ! id ) {
 				throw new Error(
 					// reminder: translate this string when we add it to the UI
@@ -38,69 +38,67 @@ const usePendingPostConfirmMutation = () => {
 
 			return response;
 		},
-		{
-			onMutate: async ( { id } ) => {
-				await queryClient.cancelQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
-				await queryClient.cancelQueries( countCacheKey );
+		onMutate: async ( { id } ) => {
+			await queryClient.cancelQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+			await queryClient.cancelQueries( countCacheKey );
 
-				const previousPendingPostSubscriptions =
-					queryClient.getQueryData< PendingPostSubscriptionsResult >( [
-						'read',
-						'pending-post-subscriptions',
-						isLoggedIn,
-					] );
+			const previousPendingPostSubscriptions =
+				queryClient.getQueryData< PendingPostSubscriptionsResult >( [
+					'read',
+					'pending-post-subscriptions',
+					isLoggedIn,
+				] );
 
-				// remove post comment from pending post subscriptions
-				if ( previousPendingPostSubscriptions?.pendingPosts ) {
-					queryClient.setQueryData< PendingPostSubscriptionsResult >(
-						[ [ 'read', 'pending-post-subscriptions', isLoggedIn ] ],
-						{
-							pendingPosts: previousPendingPostSubscriptions.pendingPosts.filter(
-								( pendingPost ) => pendingPost.id !== id
-							),
-							totalCount: previousPendingPostSubscriptions.totalCount - 1,
-						}
-					);
-				}
+			// remove post comment from pending post subscriptions
+			if ( previousPendingPostSubscriptions?.pendingPosts ) {
+				queryClient.setQueryData< PendingPostSubscriptionsResult >(
+					[ [ 'read', 'pending-post-subscriptions', isLoggedIn ] ],
+					{
+						pendingPosts: previousPendingPostSubscriptions.pendingPosts.filter(
+							( pendingPost ) => pendingPost.id !== id
+						),
+						totalCount: previousPendingPostSubscriptions.totalCount - 1,
+					}
+				);
+			}
 
-				const previousSubscriptionsCount =
-					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey );
+			const previousSubscriptionsCount =
+				queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey );
 
-				// decrement the post comment count
-				if ( previousSubscriptionsCount ) {
-					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey, {
-						...previousSubscriptionsCount,
-						comments: previousSubscriptionsCount?.comments
-							? previousSubscriptionsCount?.comments + 1
-							: 1,
-						pending: previousSubscriptionsCount?.pending
-							? previousSubscriptionsCount?.pending - 1
-							: null,
-					} );
-				}
+			// decrement the post comment count
+			if ( previousSubscriptionsCount ) {
+				queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey, {
+					...previousSubscriptionsCount,
+					comments: previousSubscriptionsCount?.comments
+						? previousSubscriptionsCount?.comments + 1
+						: 1,
+					pending: previousSubscriptionsCount?.pending
+						? previousSubscriptionsCount?.pending - 1
+						: null,
+				} );
+			}
 
-				return { previousPendingPostSubscriptions, previousSubscriptionsCount };
-			},
-			onError: ( error, variables, context ) => {
-				if ( context?.previousPendingPostSubscriptions ) {
-					queryClient.setQueryData< PendingPostSubscriptionsResult >(
-						[ 'read', 'pending-post-subscriptions', isLoggedIn ],
-						context.previousPendingPostSubscriptions
-					);
-				}
-				if ( context?.previousSubscriptionsCount ) {
-					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
-						countCacheKey,
-						context.previousSubscriptionsCount
-					);
-				}
-			},
-			onSettled: () => {
-				queryClient.invalidateQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
-				queryClient.invalidateQueries( countCacheKey );
-			},
-		}
-	);
+			return { previousPendingPostSubscriptions, previousSubscriptionsCount };
+		},
+		onError: ( error, variables, context ) => {
+			if ( context?.previousPendingPostSubscriptions ) {
+				queryClient.setQueryData< PendingPostSubscriptionsResult >(
+					[ 'read', 'pending-post-subscriptions', isLoggedIn ],
+					context.previousPendingPostSubscriptions
+				);
+			}
+			if ( context?.previousSubscriptionsCount ) {
+				queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+					countCacheKey,
+					context.previousSubscriptionsCount
+				);
+			}
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+			queryClient.invalidateQueries( countCacheKey );
+		},
+	} );
 };
 
 export default usePendingPostConfirmMutation;

--- a/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
@@ -15,8 +15,8 @@ const usePendingPostDeleteMutation = () => {
 	const isLoggedIn = useIsLoggedIn();
 	const queryClient = useQueryClient();
 	const countCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
-	return useMutation(
-		async ( params: PendingPostDeleteParams ) => {
+	return useMutation( {
+		mutationFn: async ( params: PendingPostDeleteParams ) => {
 			if ( ! params.id ) {
 				throw new Error(
 					// reminder: translate this string when we add it to the UI
@@ -38,66 +38,64 @@ const usePendingPostDeleteMutation = () => {
 
 			return response;
 		},
-		{
-			onMutate: async ( params ) => {
-				await queryClient.cancelQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
-				await queryClient.cancelQueries( countCacheKey );
+		onMutate: async ( params ) => {
+			await queryClient.cancelQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+			await queryClient.cancelQueries( countCacheKey );
 
-				const previousPendingPostSubscriptions =
-					queryClient.getQueryData< PendingPostSubscriptionsResult >( [
-						'read',
-						'pending-post-subscriptions',
-						isLoggedIn,
-					] );
+			const previousPendingPostSubscriptions =
+				queryClient.getQueryData< PendingPostSubscriptionsResult >( [
+					'read',
+					'pending-post-subscriptions',
+					isLoggedIn,
+				] );
 
-				// remove post comment from pending post subscriptions
-				if ( previousPendingPostSubscriptions?.pendingPosts ) {
-					queryClient.setQueryData< PendingPostSubscriptionsResult >(
-						[ [ 'read', 'pending-post-subscriptions', isLoggedIn ] ],
-						{
-							pendingPosts: previousPendingPostSubscriptions.pendingPosts.filter(
-								( pendingPostSubscription ) => pendingPostSubscription.id !== params.id
-							),
-							totalCount: previousPendingPostSubscriptions.totalCount - 1,
-						}
-					);
-				}
+			// remove post comment from pending post subscriptions
+			if ( previousPendingPostSubscriptions?.pendingPosts ) {
+				queryClient.setQueryData< PendingPostSubscriptionsResult >(
+					[ [ 'read', 'pending-post-subscriptions', isLoggedIn ] ],
+					{
+						pendingPosts: previousPendingPostSubscriptions.pendingPosts.filter(
+							( pendingPostSubscription ) => pendingPostSubscription.id !== params.id
+						),
+						totalCount: previousPendingPostSubscriptions.totalCount - 1,
+					}
+				);
+			}
 
-				const previousSubscriptionsCount =
-					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey );
+			const previousSubscriptionsCount =
+				queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey );
 
-				// decrement the post comment count
-				if ( previousSubscriptionsCount ) {
-					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey, {
-						...previousSubscriptionsCount,
-						pending: previousSubscriptionsCount?.pending
-							? previousSubscriptionsCount?.pending - 1
-							: null,
-					} );
-				}
+			// decrement the post comment count
+			if ( previousSubscriptionsCount ) {
+				queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey, {
+					...previousSubscriptionsCount,
+					pending: previousSubscriptionsCount?.pending
+						? previousSubscriptionsCount?.pending - 1
+						: null,
+				} );
+			}
 
-				return { previousPendingPostSubscriptions, previousSubscriptionsCount };
-			},
-			onError: ( error, variables, context ) => {
-				if ( context?.previousPendingPostSubscriptions ) {
-					queryClient.setQueryData< PendingPostSubscriptionsResult >(
-						[ 'read', 'pending-post-subscriptions', isLoggedIn ],
-						context.previousPendingPostSubscriptions
-					);
-				}
-				if ( context?.previousSubscriptionsCount ) {
-					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
-						countCacheKey,
-						context.previousSubscriptionsCount
-					);
-				}
-			},
-			onSettled: () => {
-				queryClient.invalidateQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
-				queryClient.invalidateQueries( countCacheKey );
-			},
-		}
-	);
+			return { previousPendingPostSubscriptions, previousSubscriptionsCount };
+		},
+		onError: ( error, variables, context ) => {
+			if ( context?.previousPendingPostSubscriptions ) {
+				queryClient.setQueryData< PendingPostSubscriptionsResult >(
+					[ 'read', 'pending-post-subscriptions', isLoggedIn ],
+					context.previousPendingPostSubscriptions
+				);
+			}
+			if ( context?.previousSubscriptionsCount ) {
+				queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+					countCacheKey,
+					context.previousSubscriptionsCount
+				);
+			}
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+			queryClient.invalidateQueries( countCacheKey );
+		},
+	} );
 };
 
 export default usePendingPostDeleteMutation;

--- a/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
@@ -15,8 +15,8 @@ const usePendingSiteDeleteMutation = () => {
 	const isLoggedIn = useIsLoggedIn();
 	const queryClient = useQueryClient();
 	const countCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
-	return useMutation(
-		async ( params: PendingSiteDeleteParams ) => {
+	return useMutation( {
+		mutationFn: async ( params: PendingSiteDeleteParams ) => {
 			if ( ! params.id ) {
 				throw new Error(
 					// reminder: translate this string when we add it to the UI
@@ -38,66 +38,64 @@ const usePendingSiteDeleteMutation = () => {
 
 			return response;
 		},
-		{
-			onMutate: async ( params ) => {
-				await queryClient.cancelQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
-				await queryClient.cancelQueries( countCacheKey );
+		onMutate: async ( params ) => {
+			await queryClient.cancelQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+			await queryClient.cancelQueries( countCacheKey );
 
-				const previousPendingSiteSubscriptions =
-					queryClient.getQueryData< PendingSiteSubscriptionsResult >( [
-						'read',
-						'pending-site-subscriptions',
-						isLoggedIn,
-					] );
+			const previousPendingSiteSubscriptions =
+				queryClient.getQueryData< PendingSiteSubscriptionsResult >( [
+					'read',
+					'pending-site-subscriptions',
+					isLoggedIn,
+				] );
 
-				// remove blog from pending site subscriptions
-				if ( previousPendingSiteSubscriptions?.pendingSites ) {
-					queryClient.setQueryData< PendingSiteSubscriptionsResult >(
-						[ [ 'read', 'pending-site-subscriptions', isLoggedIn ] ],
-						{
-							pendingSites: previousPendingSiteSubscriptions.pendingSites.filter(
-								( pendingSiteSubscription ) => pendingSiteSubscription.id !== params.id
-							),
-							totalCount: previousPendingSiteSubscriptions.totalCount - 1,
-						}
-					);
-				}
+			// remove blog from pending site subscriptions
+			if ( previousPendingSiteSubscriptions?.pendingSites ) {
+				queryClient.setQueryData< PendingSiteSubscriptionsResult >(
+					[ [ 'read', 'pending-site-subscriptions', isLoggedIn ] ],
+					{
+						pendingSites: previousPendingSiteSubscriptions.pendingSites.filter(
+							( pendingSiteSubscription ) => pendingSiteSubscription.id !== params.id
+						),
+						totalCount: previousPendingSiteSubscriptions.totalCount - 1,
+					}
+				);
+			}
 
-				const previousSubscriptionsCount =
-					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey );
+			const previousSubscriptionsCount =
+				queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey );
 
-				// decrement the blog count
-				if ( previousSubscriptionsCount ) {
-					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey, {
-						...previousSubscriptionsCount,
-						pending: previousSubscriptionsCount?.pending
-							? previousSubscriptionsCount?.pending - 1
-							: null,
-					} );
-				}
+			// decrement the blog count
+			if ( previousSubscriptionsCount ) {
+				queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey, {
+					...previousSubscriptionsCount,
+					pending: previousSubscriptionsCount?.pending
+						? previousSubscriptionsCount?.pending - 1
+						: null,
+				} );
+			}
 
-				return { previousPendingSiteSubscriptions, previousSubscriptionsCount };
-			},
-			onError: ( error, variables, context ) => {
-				if ( context?.previousPendingSiteSubscriptions ) {
-					queryClient.setQueryData< PendingSiteSubscriptionsResult >(
-						[ 'read', 'pending-site-subscriptions', isLoggedIn ],
-						context.previousPendingSiteSubscriptions
-					);
-				}
-				if ( context?.previousSubscriptionsCount ) {
-					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
-						countCacheKey,
-						context.previousSubscriptionsCount
-					);
-				}
-			},
-			onSettled: () => {
-				queryClient.invalidateQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
-				queryClient.invalidateQueries( countCacheKey );
-			},
-		}
-	);
+			return { previousPendingSiteSubscriptions, previousSubscriptionsCount };
+		},
+		onError: ( error, variables, context ) => {
+			if ( context?.previousPendingSiteSubscriptions ) {
+				queryClient.setQueryData< PendingSiteSubscriptionsResult >(
+					[ 'read', 'pending-site-subscriptions', isLoggedIn ],
+					context.previousPendingSiteSubscriptions
+				);
+			}
+			if ( context?.previousSubscriptionsCount ) {
+				queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+					countCacheKey,
+					context.previousSubscriptionsCount
+				);
+			}
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+			queryClient.invalidateQueries( countCacheKey );
+		},
+	} );
 };
 
 export default usePendingSiteDeleteMutation;

--- a/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
@@ -31,8 +31,8 @@ const usePostUnsubscribeMutation = () => {
 	const postSubscriptionsCacheKey = useCacheKey( [ 'read', 'post-subscriptions' ] );
 	const subscriptionsCountCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
 
-	return useMutation(
-		async ( params: UnsubscribeParams ) => {
+	return useMutation( {
+		mutationFn: async ( params: UnsubscribeParams ) => {
 			if ( ! params.blog_id ) {
 				throw new Error(
 					// reminder: translate this string when we add it to the UI
@@ -56,68 +56,66 @@ const usePostUnsubscribeMutation = () => {
 
 			return response;
 		},
-		{
-			onMutate: async ( params ) => {
-				await queryClient.cancelQueries( postSubscriptionsCacheKey );
-				await queryClient.cancelQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+		onMutate: async ( params ) => {
+			await queryClient.cancelQueries( postSubscriptionsCacheKey );
+			await queryClient.cancelQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
 
-				const previousPostSubscriptions =
-					queryClient.getQueryData< PostSubscriptionsPages >( postSubscriptionsCacheKey );
+			const previousPostSubscriptions =
+				queryClient.getQueryData< PostSubscriptionsPages >( postSubscriptionsCacheKey );
 
-				// remove post from comment subscriptions
-				if ( previousPostSubscriptions ) {
-					queryClient.setQueryData< PostSubscriptionsPages >( postSubscriptionsCacheKey, {
-						...previousPostSubscriptions,
-						pages: previousPostSubscriptions.pages.map( ( page ) => ( {
-							...page,
-							comment_subscriptions: page.comment_subscriptions.filter(
-								( subscription ) => subscription.id !== params.id
-							),
-							total_comment_subscriptions_count: page.total_comment_subscriptions_count - 1,
-						} ) ),
-					} );
-				}
+			// remove post from comment subscriptions
+			if ( previousPostSubscriptions ) {
+				queryClient.setQueryData< PostSubscriptionsPages >( postSubscriptionsCacheKey, {
+					...previousPostSubscriptions,
+					pages: previousPostSubscriptions.pages.map( ( page ) => ( {
+						...page,
+						comment_subscriptions: page.comment_subscriptions.filter(
+							( subscription ) => subscription.id !== params.id
+						),
+						total_comment_subscriptions_count: page.total_comment_subscriptions_count - 1,
+					} ) ),
+				} );
+			}
 
-				const previousSubscriptionsCount =
-					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >(
-						subscriptionsCountCacheKey
-					);
+			const previousSubscriptionsCount =
+				queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >(
+					subscriptionsCountCacheKey
+				);
 
-				// decrement the comments count
-				if ( previousSubscriptionsCount ) {
-					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
-						subscriptionsCountCacheKey,
-						{
-							...previousSubscriptionsCount,
-							comments: previousSubscriptionsCount?.comments
-								? previousSubscriptionsCount?.comments - 1
-								: null,
-						}
-					);
-				}
+			// decrement the comments count
+			if ( previousSubscriptionsCount ) {
+				queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+					subscriptionsCountCacheKey,
+					{
+						...previousSubscriptionsCount,
+						comments: previousSubscriptionsCount?.comments
+							? previousSubscriptionsCount?.comments - 1
+							: null,
+					}
+				);
+			}
 
-				return { previousPostSubscriptions, previousSubscriptionsCount };
-			},
-			onError: ( error, variables, context ) => {
-				if ( context?.previousPostSubscriptions ) {
-					queryClient.setQueryData< PostSubscriptionsPages >(
-						postSubscriptionsCacheKey,
-						context.previousPostSubscriptions
-					);
-				}
-				if ( context?.previousSubscriptionsCount ) {
-					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
-						subscriptionsCountCacheKey,
-						context.previousSubscriptionsCount
-					);
-				}
-			},
-			onSettled: () => {
-				queryClient.invalidateQueries( postSubscriptionsCacheKey );
-				queryClient.invalidateQueries( subscriptionsCountCacheKey );
-			},
-		}
-	);
+			return { previousPostSubscriptions, previousSubscriptionsCount };
+		},
+		onError: ( error, variables, context ) => {
+			if ( context?.previousPostSubscriptions ) {
+				queryClient.setQueryData< PostSubscriptionsPages >(
+					postSubscriptionsCacheKey,
+					context.previousPostSubscriptions
+				);
+			}
+			if ( context?.previousSubscriptionsCount ) {
+				queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+					subscriptionsCountCacheKey,
+					context.previousSubscriptionsCount
+				);
+			}
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries( postSubscriptionsCacheKey );
+			queryClient.invalidateQueries( subscriptionsCountCacheKey );
+		},
+	} );
 };
 
 export default usePostUnsubscribeMutation;

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
@@ -24,8 +24,8 @@ const useSiteEmailMeNewCommentsMutation = ( blog_id?: string ) => {
 		...( blog_id ? [ blog_id ] : [] ),
 	] );
 
-	return useMutation(
-		async ( params: SiteSubscriptionEmailMeNewCommentsParams ) => {
+	return useMutation( {
+		mutationFn: async ( params: SiteSubscriptionEmailMeNewCommentsParams ) => {
 			if ( ! params.blog_id || typeof params.send_comments !== 'boolean' ) {
 				throw new Error(
 					// reminder: translate this string when we add it to the UI
@@ -51,74 +51,71 @@ const useSiteEmailMeNewCommentsMutation = ( blog_id?: string ) => {
 
 			return response;
 		},
-		{
-			onMutate: async ( params ) => {
-				await queryClient.cancelQueries( siteSubscriptionsCacheKey );
-				await queryClient.cancelQueries( siteSubscriptionDetailsCacheKey );
+		onMutate: async ( params ) => {
+			await queryClient.cancelQueries( siteSubscriptionsCacheKey );
+			await queryClient.cancelQueries( siteSubscriptionDetailsCacheKey );
 
-				const previousSiteSubscriptions =
-					queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
-				const previousSiteSubscriptionDetails = queryClient.getQueryData< SiteSubscriptionDetails >(
-					siteSubscriptionDetailsCacheKey
-				);
+			const previousSiteSubscriptions =
+				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
+			const previousSiteSubscriptionDetails = queryClient.getQueryData< SiteSubscriptionDetails >(
+				siteSubscriptionDetailsCacheKey
+			);
 
-				if ( previousSiteSubscriptions ) {
-					queryClient.setQueryData( siteSubscriptionsCacheKey, {
-						...previousSiteSubscriptions,
-						pages: previousSiteSubscriptions.pages.map( ( page ) => {
-							return {
-								...page,
-								subscriptions: page.subscriptions.map( ( siteSubscription ) => {
-									if ( siteSubscription.blog_ID === params.blog_id ) {
-										return {
-											...siteSubscription,
-											delivery_methods: {
-												...siteSubscription.delivery_methods,
-												email: {
-													...siteSubscription.delivery_methods?.email,
-													send_comments: params.send_comments,
-												},
+			if ( previousSiteSubscriptions ) {
+				queryClient.setQueryData( siteSubscriptionsCacheKey, {
+					...previousSiteSubscriptions,
+					pages: previousSiteSubscriptions.pages.map( ( page ) => {
+						return {
+							...page,
+							subscriptions: page.subscriptions.map( ( siteSubscription ) => {
+								if ( siteSubscription.blog_ID === params.blog_id ) {
+									return {
+										...siteSubscription,
+										delivery_methods: {
+											...siteSubscription.delivery_methods,
+											email: {
+												...siteSubscription.delivery_methods?.email,
+												send_comments: params.send_comments,
 											},
-										};
-									}
-									return siteSubscription;
-								} ),
-							};
-						} ),
-					} );
-				}
-				if ( previousSiteSubscriptionDetails ) {
-					queryClient.setQueryData( siteSubscriptionDetailsCacheKey, {
-						...previousSiteSubscriptionDetails,
-						delivery_methods: {
-							...previousSiteSubscriptionDetails.delivery_methods,
-							email: {
-								...previousSiteSubscriptionDetails.delivery_methods?.email,
-								send_comments: params.send_comments,
-							},
+										},
+									};
+								}
+								return siteSubscription;
+							} ),
+						};
+					} ),
+				} );
+			}
+			if ( previousSiteSubscriptionDetails ) {
+				queryClient.setQueryData( siteSubscriptionDetailsCacheKey, {
+					...previousSiteSubscriptionDetails,
+					delivery_methods: {
+						...previousSiteSubscriptionDetails.delivery_methods,
+						email: {
+							...previousSiteSubscriptionDetails.delivery_methods?.email,
+							send_comments: params.send_comments,
 						},
-					} );
-				}
-				return { previousSiteSubscriptions, previousSiteSubscriptionDetails };
-			},
-
-			onError: ( err, params, context ) => {
-				if ( context?.previousSiteSubscriptions ) {
-					queryClient.setQueryData( siteSubscriptionsCacheKey, context.previousSiteSubscriptions );
-				}
-				if ( context?.previousSiteSubscriptionDetails ) {
-					queryClient.setQueryData(
-						siteSubscriptionDetailsCacheKey,
-						context.previousSiteSubscriptionDetails
-					);
-				}
-			},
-			onSettled: () => {
-				queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
-				queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey );
-			},
-		}
-	);
+					},
+				} );
+			}
+			return { previousSiteSubscriptions, previousSiteSubscriptionDetails };
+		},
+		onError: ( err, params, context ) => {
+			if ( context?.previousSiteSubscriptions ) {
+				queryClient.setQueryData( siteSubscriptionsCacheKey, context.previousSiteSubscriptions );
+			}
+			if ( context?.previousSiteSubscriptionDetails ) {
+				queryClient.setQueryData(
+					siteSubscriptionDetailsCacheKey,
+					context.previousSiteSubscriptionDetails
+				);
+			}
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
+			queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey );
+		},
+	} );
 };
 
 export default useSiteEmailMeNewCommentsMutation;

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
@@ -24,8 +24,8 @@ const useSiteEmailMeNewPostsMutation = ( blog_id?: string ) => {
 		...( blog_id ? [ blog_id ] : [] ),
 	] );
 
-	return useMutation(
-		async ( params: SiteSubscriptionEmailMeNewPostsParams ) => {
+	return useMutation( {
+		mutationFn: async ( params: SiteSubscriptionEmailMeNewPostsParams ) => {
 			if ( ! params.blog_id || typeof params.send_posts !== 'boolean' ) {
 				throw new Error(
 					// reminder: translate this string when we add it to the UI
@@ -51,75 +51,72 @@ const useSiteEmailMeNewPostsMutation = ( blog_id?: string ) => {
 
 			return response;
 		},
-		{
-			onMutate: async ( params ) => {
-				await queryClient.cancelQueries( siteSubscriptionsCacheKey );
-				await queryClient.cancelQueries( siteSubscriptionDetailsCacheKey );
+		onMutate: async ( params ) => {
+			await queryClient.cancelQueries( siteSubscriptionsCacheKey );
+			await queryClient.cancelQueries( siteSubscriptionDetailsCacheKey );
 
-				const previousSiteSubscriptions =
-					queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
-				const previousSiteSubscriptionDetails = queryClient.getQueryData< SiteSubscriptionDetails >(
-					siteSubscriptionDetailsCacheKey
-				);
+			const previousSiteSubscriptions =
+				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
+			const previousSiteSubscriptionDetails = queryClient.getQueryData< SiteSubscriptionDetails >(
+				siteSubscriptionDetailsCacheKey
+			);
 
-				if ( previousSiteSubscriptions ) {
-					queryClient.setQueryData( siteSubscriptionsCacheKey, {
-						...previousSiteSubscriptions,
-						pages: previousSiteSubscriptions.pages.map( ( page ) => {
-							return {
-								...page,
-								subscriptions: page.subscriptions.map( ( siteSubscription ) => {
-									if ( siteSubscription.blog_ID === params.blog_id ) {
-										return {
-											...siteSubscription,
-											delivery_methods: {
-												...siteSubscription.delivery_methods,
-												email: {
-													...siteSubscription.delivery_methods?.email,
-													send_posts: params.send_posts,
-												},
+			if ( previousSiteSubscriptions ) {
+				queryClient.setQueryData( siteSubscriptionsCacheKey, {
+					...previousSiteSubscriptions,
+					pages: previousSiteSubscriptions.pages.map( ( page ) => {
+						return {
+							...page,
+							subscriptions: page.subscriptions.map( ( siteSubscription ) => {
+								if ( siteSubscription.blog_ID === params.blog_id ) {
+									return {
+										...siteSubscription,
+										delivery_methods: {
+											...siteSubscription.delivery_methods,
+											email: {
+												...siteSubscription.delivery_methods?.email,
+												send_posts: params.send_posts,
 											},
-										};
-									}
-									return siteSubscription;
-								} ),
-							};
-						} ),
-					} );
-				}
-				if ( previousSiteSubscriptionDetails ) {
-					queryClient.setQueryData( siteSubscriptionDetailsCacheKey, {
-						...previousSiteSubscriptionDetails,
-						delivery_methods: {
-							...previousSiteSubscriptionDetails.delivery_methods,
-							email: {
-								...previousSiteSubscriptionDetails.delivery_methods?.email,
-								send_posts: params.send_posts,
-							},
+										},
+									};
+								}
+								return siteSubscription;
+							} ),
+						};
+					} ),
+				} );
+			}
+			if ( previousSiteSubscriptionDetails ) {
+				queryClient.setQueryData( siteSubscriptionDetailsCacheKey, {
+					...previousSiteSubscriptionDetails,
+					delivery_methods: {
+						...previousSiteSubscriptionDetails.delivery_methods,
+						email: {
+							...previousSiteSubscriptionDetails.delivery_methods?.email,
+							send_posts: params.send_posts,
 						},
-					} );
-				}
+					},
+				} );
+			}
 
-				return { previousSiteSubscriptions, previousSiteSubscriptionDetails };
-			},
-
-			onError: ( err, params, context ) => {
-				if ( context?.previousSiteSubscriptions ) {
-					queryClient.setQueryData( siteSubscriptionsCacheKey, context.previousSiteSubscriptions );
-				}
-				if ( context?.previousSiteSubscriptionDetails ) {
-					queryClient.setQueryData(
-						siteSubscriptionDetailsCacheKey,
-						context.previousSiteSubscriptionDetails
-					);
-				}
-			},
-			onSettled: () => {
-				queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
-				queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey );
-			},
-		}
-	);
+			return { previousSiteSubscriptions, previousSiteSubscriptionDetails };
+		},
+		onError: ( err, params, context ) => {
+			if ( context?.previousSiteSubscriptions ) {
+				queryClient.setQueryData( siteSubscriptionsCacheKey, context.previousSiteSubscriptions );
+			}
+			if ( context?.previousSiteSubscriptionDetails ) {
+				queryClient.setQueryData(
+					siteSubscriptionDetailsCacheKey,
+					context.previousSiteSubscriptionDetails
+				);
+			}
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
+			queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey );
+		},
+	} );
 };
 
 export default useSiteEmailMeNewPostsMutation;

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -21,36 +21,38 @@ type SubscribeResponse = {
 const useSiteSubscribeMutation = () => {
 	const { isLoggedIn } = useIsLoggedIn();
 
-	return useMutation( async ( params: SubscribeParams ) => {
-		if ( ! params.blog_id ) {
-			throw new Error(
-				// reminder: translate this string when we add it to the UI
-				'Something went wrong while subscribing.'
+	return useMutation( {
+		mutationFn: async ( params: SubscribeParams ) => {
+			if ( ! params.blog_id ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while subscribing.'
+				);
+			}
+
+			const { path, apiVersion, body } = getSubscriptionMutationParams(
+				'new',
+				isLoggedIn,
+				params.blog_id,
+				params.url
 			);
-		}
 
-		const { path, apiVersion, body } = getSubscriptionMutationParams(
-			'new',
-			isLoggedIn,
-			params.blog_id,
-			params.url
-		);
+			const response = await callApi< SubscribeResponse >( {
+				path,
+				method: 'POST',
+				isLoggedIn,
+				apiVersion,
+				body,
+			} );
+			if ( ! response.subscribed ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while subscribing.'
+				);
+			}
 
-		const response = await callApi< SubscribeResponse >( {
-			path,
-			method: 'POST',
-			isLoggedIn,
-			apiVersion,
-			body,
-		} );
-		if ( ! response.subscribed ) {
-			throw new Error(
-				// reminder: translate this string when we add it to the UI
-				'Something went wrong while subscribing.'
-			);
-		}
-
-		return response;
+			return response;
+		},
 	} );
 };
 

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -20,8 +20,8 @@ const useSiteUnsubscribeMutation = () => {
 	const siteSubscriptionsCacheKey = useCacheKey( [ 'read', 'site-subscriptions' ] );
 	const subscriptionsCountCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
 
-	return useMutation(
-		async ( params: UnsubscribeParams ) => {
+	return useMutation( {
+		mutationFn: async ( params: UnsubscribeParams ) => {
 			if ( ! params.blog_id ) {
 				throw new Error(
 					// reminder: translate this string when we add it to the UI
@@ -57,67 +57,63 @@ const useSiteUnsubscribeMutation = () => {
 
 			return response;
 		},
-		{
-			onMutate: async ( params ) => {
-				await queryClient.cancelQueries( siteSubscriptionsCacheKey );
-				await queryClient.cancelQueries( subscriptionsCountCacheKey );
+		onMutate: async ( params ) => {
+			await queryClient.cancelQueries( siteSubscriptionsCacheKey );
+			await queryClient.cancelQueries( subscriptionsCountCacheKey );
 
-				const previousSiteSubscriptions =
-					queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
-				// remove blog from site subscriptions
-				if ( previousSiteSubscriptions ) {
-					queryClient.setQueryData( siteSubscriptionsCacheKey, {
-						...previousSiteSubscriptions,
-						pages: previousSiteSubscriptions.pages.map( ( page ) => {
-							return {
-								...page,
-								subscriptions: page.subscriptions.filter(
-									( siteSubscription ) => siteSubscription.blog_ID !== params.blog_id
-								),
-								total_subscriptions: page.total_subscriptions - 1,
-							};
-						} ),
-					} );
-				}
+			const previousSiteSubscriptions =
+				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
+			// remove blog from site subscriptions
+			if ( previousSiteSubscriptions ) {
+				queryClient.setQueryData( siteSubscriptionsCacheKey, {
+					...previousSiteSubscriptions,
+					pages: previousSiteSubscriptions.pages.map( ( page ) => {
+						return {
+							...page,
+							subscriptions: page.subscriptions.filter(
+								( siteSubscription ) => siteSubscription.blog_ID !== params.blog_id
+							),
+							total_subscriptions: page.total_subscriptions - 1,
+						};
+					} ),
+				} );
+			}
 
-				const previousSubscriptionsCount =
-					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >(
-						subscriptionsCountCacheKey
-					);
+			const previousSubscriptionsCount =
+				queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >(
+					subscriptionsCountCacheKey
+				);
 
-				// decrement the blog count
-				if ( previousSubscriptionsCount ) {
-					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
-						subscriptionsCountCacheKey,
-						{
-							...previousSubscriptionsCount,
-							blogs: previousSubscriptionsCount?.blogs
-								? previousSubscriptionsCount?.blogs - 1
-								: null,
-						}
-					);
-				}
+			// decrement the blog count
+			if ( previousSubscriptionsCount ) {
+				queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+					subscriptionsCountCacheKey,
+					{
+						...previousSubscriptionsCount,
+						blogs: previousSubscriptionsCount?.blogs ? previousSubscriptionsCount?.blogs - 1 : null,
+					}
+				);
+			}
 
-				return { previousSiteSubscriptions, previousSubscriptionsCount };
-			},
-			onError: ( error, variables, context ) => {
-				if ( context?.previousSiteSubscriptions ) {
-					queryClient.setQueryData( siteSubscriptionsCacheKey, context.previousSiteSubscriptions );
-				}
-				if ( context?.previousSubscriptionsCount ) {
-					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
-						subscriptionsCountCacheKey,
-						context.previousSubscriptionsCount
-					);
-				}
-			},
-			onSettled: () => {
-				// pass in more minimal keys, everything to the right will be invalidated
-				queryClient.invalidateQueries( siteSubscriptionsCacheKey );
-				queryClient.invalidateQueries( subscriptionsCountCacheKey );
-			},
-		}
-	);
+			return { previousSiteSubscriptions, previousSubscriptionsCount };
+		},
+		onError: ( error, variables, context ) => {
+			if ( context?.previousSiteSubscriptions ) {
+				queryClient.setQueryData( siteSubscriptionsCacheKey, context.previousSiteSubscriptions );
+			}
+			if ( context?.previousSubscriptionsCount ) {
+				queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+					subscriptionsCountCacheKey,
+					context.previousSubscriptionsCount
+				);
+			}
+		},
+		onSettled: () => {
+			// pass in more minimal keys, everything to the right will be invalidated
+			queryClient.invalidateQueries( siteSubscriptionsCacheKey );
+			queryClient.invalidateQueries( subscriptionsCountCacheKey );
+		},
+	} );
 };
 
 export default useSiteUnsubscribeMutation;

--- a/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
@@ -12,8 +12,8 @@ const useUserSettingsMutation = () => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
 	const emailSettingsCacheKey = useCacheKey( [ 'read', 'email-settings' ] );
-	return useMutation< SubscriptionManagerUserSettings, Error, SubscriptionManagerUserSettings >(
-		async ( data: SubscriptionManagerUserSettings ) => {
+	return useMutation< SubscriptionManagerUserSettings, Error, SubscriptionManagerUserSettings >( {
+		mutationFn: async ( data: SubscriptionManagerUserSettings ) => {
 			const { settings } = await callApi< EmailSettingsAPIResponse >( {
 				path: '/read/email-settings',
 				method: 'POST',
@@ -33,34 +33,32 @@ const useUserSettingsMutation = () => {
 			}
 			return settings;
 		},
-		{
-			onMutate: async ( data ) => {
-				await queryClient.cancelQueries( emailSettingsCacheKey );
-				const previousSettings =
-					queryClient.getQueryData< SubscriptionManagerUserSettings >( emailSettingsCacheKey );
+		onMutate: async ( data ) => {
+			await queryClient.cancelQueries( emailSettingsCacheKey );
+			const previousSettings =
+				queryClient.getQueryData< SubscriptionManagerUserSettings >( emailSettingsCacheKey );
 
-				queryClient.setQueryData< SubscriptionManagerUserSettings >( emailSettingsCacheKey, {
-					...previousSettings,
-					...data,
-				} );
-				return { previousSettings: previousSettings };
-			},
-			onError: ( error, variables, context ) => {
-				// For some reason the TypeScript compiler doesn't like the `context` parameter in this mutation
-				// That's why we're using the `as MutationContext` cast here
-				if ( ( context as MutationContext )?.previousSettings ) {
-					queryClient.setQueryData< SubscriptionManagerUserSettings >(
-						emailSettingsCacheKey,
-						( context as MutationContext ).previousSettings
-					);
-				}
-			},
-			onSettled: () => {
-				// pass in a more minimal key, everything to the right will be invalidated
-				queryClient.invalidateQueries( [ 'read', 'email-settings' ] );
-			},
-		}
-	);
+			queryClient.setQueryData< SubscriptionManagerUserSettings >( emailSettingsCacheKey, {
+				...previousSettings,
+				...data,
+			} );
+			return { previousSettings: previousSettings };
+		},
+		onError: ( error, variables, context ) => {
+			// For some reason the TypeScript compiler doesn't like the `context` parameter in this mutation
+			// That's why we're using the `as MutationContext` cast here
+			if ( ( context as MutationContext )?.previousSettings ) {
+				queryClient.setQueryData< SubscriptionManagerUserSettings >(
+					emailSettingsCacheKey,
+					( context as MutationContext ).previousSettings
+				);
+			}
+		},
+		onSettled: () => {
+			// pass in a more minimal key, everything to the right will be invalidated
+			queryClient.invalidateQueries( [ 'read', 'email-settings' ] );
+		},
+	} );
 };
 
 export default useUserSettingsMutation;

--- a/packages/data-stores/src/reader/queries/use-pending-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-pending-post-subscriptions-query.ts
@@ -51,16 +51,14 @@ const usePendingPostSubscriptionsQuery = ( {
 	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 
-	const { data, ...rest } = useQuery< PendingPostSubscriptionsResult >(
-		[ 'read', 'pending-post-subscriptions', isLoggedIn ],
-		async () => {
+	const { data, ...rest } = useQuery< PendingPostSubscriptionsResult >( {
+		queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
+		queryFn: async () => {
 			return await callPendingBlogSubscriptionsEndpoint( isLoggedIn );
 		},
-		{
-			enabled,
-			refetchOnWindowFocus: false,
-		}
-	);
+		enabled,
+		refetchOnWindowFocus: false,
+	} );
 
 	return {
 		data: {

--- a/packages/data-stores/src/reader/queries/use-pending-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-pending-site-subscriptions-query.ts
@@ -51,16 +51,14 @@ const usePendingSiteSubscriptionsQuery = ( {
 	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 
-	const { data, ...rest } = useQuery< PendingSiteSubscriptionsResult >(
-		[ 'read', 'pending-site-subscriptions', isLoggedIn ],
-		async () => {
+	const { data, ...rest } = useQuery< PendingSiteSubscriptionsResult >( {
+		queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
+		queryFn: async () => {
 			return await callPendingSiteSubscriptionsEndpoint( isLoggedIn );
 		},
-		{
-			enabled,
-			refetchOnWindowFocus: false,
-		}
-	);
+		enabled,
+		refetchOnWindowFocus: false,
+	} );
 
 	return {
 		data: {

--- a/packages/data-stores/src/reader/queries/use-site-subscription-details-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscription-details-query.ts
@@ -7,9 +7,9 @@ const useSiteSubscriptionDetailsQuery = ( siteId: string ) => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 	const cacheKey = useCacheKey( [ 'read', 'site-subscription-details', siteId ] );
-	return useQuery< SiteSubscriptionDetails >(
-		cacheKey,
-		async () => {
+	return useQuery< SiteSubscriptionDetails >( {
+		queryKey: cacheKey,
+		queryFn: async () => {
 			const subscriptionDetails = await callApi< SiteSubscriptionDetailsAPIResponse >( {
 				path: '/read/sites/' + siteId + '/subscription-details',
 				isLoggedIn,
@@ -18,11 +18,9 @@ const useSiteSubscriptionDetailsQuery = ( siteId: string ) => {
 			} );
 			return subscriptionDetails;
 		},
-		{
-			enabled,
-			refetchOnWindowFocus: false,
-		}
-	);
+		enabled,
+		refetchOnWindowFocus: false,
+	} );
 };
 
 export default useSiteSubscriptionDetailsQuery;

--- a/packages/data-stores/src/reader/queries/use-subscriptions-count-query.ts
+++ b/packages/data-stores/src/reader/queries/use-subscriptions-count-query.ts
@@ -8,19 +8,17 @@ const useSubscriptionsCountQuery = () => {
 	const enabled = useIsQueryEnabled();
 	const cacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
 
-	return useQuery< SubscriptionManagerSubscriptionsCount >(
-		cacheKey,
-		async () => {
+	return useQuery< SubscriptionManagerSubscriptionsCount >( {
+		queryKey: cacheKey,
+		queryFn: async () => {
 			return await callApi< SubscriptionManagerSubscriptionsCount >( {
 				path: '/read/subscriptions-count',
 				isLoggedIn,
 			} );
 		},
-		{
-			enabled,
-			refetchOnWindowFocus: false,
-		}
-	);
+		enabled,
+		refetchOnWindowFocus: false,
+	} );
 };
 
 export default useSubscriptionsCountQuery;

--- a/packages/data-stores/src/reader/queries/use-user-settings-query.ts
+++ b/packages/data-stores/src/reader/queries/use-user-settings-query.ts
@@ -7,20 +7,18 @@ const useUserSettingsQuery = () => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 	const cacheKey = useCacheKey( [ 'read', 'email-settings' ] );
-	return useQuery< SubscriptionManagerUserSettings >(
-		cacheKey,
-		async () => {
+	return useQuery< SubscriptionManagerUserSettings >( {
+		queryKey: cacheKey,
+		queryFn: async () => {
 			const { settings } = await callApi< EmailSettingsAPIResponse >( {
 				path: '/read/email-settings',
 				isLoggedIn,
 			} );
 			return settings;
 		},
-		{
-			enabled,
-			refetchOnWindowFocus: false,
-		}
-	);
+		enabled,
+		refetchOnWindowFocus: false,
+	} );
 };
 
 export default useUserSettingsQuery;

--- a/packages/data-stores/src/starter-designs-queries/use-starter-design-by-slug.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-design-by-slug.ts
@@ -10,7 +10,9 @@ export function useStarterDesignBySlug(
 	slug: string,
 	queryOptions: Options = {}
 ): UseQueryResult< Design > {
-	return useQuery( [ 'starter-designs-get', slug ], () => fetchStarterDesignBySlug( slug ), {
+	return useQuery( {
+		queryKey: [ 'starter-designs-get', slug ],
+		queryFn: () => fetchStarterDesignBySlug( slug ),
 		refetchOnMount: 'always',
 		staleTime: Infinity,
 		...queryOptions,

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -43,7 +43,9 @@ export function useStarterDesignsQuery(
 	queryParams: StarterDesignsQueryParams,
 	{ select, ...queryOptions }: Options = {}
 ): UseQueryResult< StarterDesigns > {
-	return useQuery( [ 'starter-designs', queryParams ], () => fetchStarterDesigns( queryParams ), {
+	return useQuery( {
+		queryKey: [ 'starter-designs', queryParams ],
+		queryFn: () => fetchStarterDesigns( queryParams ),
 		select: ( response: StarterDesignsResponse ) => {
 			const allDesigns = {
 				filters: {

--- a/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
+++ b/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
@@ -21,8 +21,8 @@ export type ForumResponse = {
 };
 
 export function useSubmitForumsMutation() {
-	return useMutation(
-		( {
+	return useMutation( {
+		mutationFn: ( {
 			ownershipResult,
 			message,
 			subject,
@@ -70,6 +70,6 @@ export function useSubmitForumsMutation() {
 						method: 'POST',
 						data: requestData,
 				  } as APIFetchOptions );
-		}
-	);
+		},
+	} );
 }

--- a/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
+++ b/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
@@ -13,20 +13,21 @@ type Ticket = {
 };
 
 export function useSubmitTicketMutation() {
-	return useMutation( ( newTicket: Ticket ) =>
-		canAccessWpcomApis()
-			? wpcomRequest( {
-					path: 'help/ticket/new',
-					apiNamespace: 'wpcom/v2/',
-					apiVersion: '2',
-					method: 'POST',
-					body: newTicket,
-			  } )
-			: apiFetch( {
-					global: true,
-					path: '/help-center/ticket/new',
-					method: 'POST',
-					data: newTicket,
-			  } as APIFetchOptions )
-	);
+	return useMutation( {
+		mutationFn: ( newTicket: Ticket ) =>
+			canAccessWpcomApis()
+				? wpcomRequest( {
+						path: 'help/ticket/new',
+						apiNamespace: 'wpcom/v2/',
+						apiVersion: '2',
+						method: 'POST',
+						body: newTicket,
+				  } )
+				: apiFetch( {
+						global: true,
+						path: '/help-center/ticket/new',
+						method: 'POST',
+						data: newTicket,
+				  } as APIFetchOptions ),
+	} );
 }

--- a/packages/data-stores/src/support-queries/use-support-activity.ts
+++ b/packages/data-stores/src/support-queries/use-support-activity.ts
@@ -6,9 +6,9 @@ import type { SupportActivity } from './types';
 const ACTIVE_STATUSES = [ 'New', 'Open', 'Hold' ];
 
 export function useSupportActivity( enabled = true ) {
-	return useQuery(
-		[ 'help-support-activity' ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'help-support-activity' ],
+		queryFn: () =>
 			canAccessWpcomApis()
 				? wpcomRequest< SupportActivity[] >( {
 						path: 'support-activity',
@@ -19,18 +19,16 @@ export function useSupportActivity( enabled = true ) {
 						path: 'help-center/support-activity',
 						global: true,
 				  } as APIFetchOptions ),
-		{
-			refetchOnWindowFocus: false,
-			keepPreviousData: false,
-			refetchOnMount: true,
-			enabled,
-			select: ( activities ) => {
-				return activities.filter( ( activity ) => ACTIVE_STATUSES.includes( activity.status ) );
-			},
-			staleTime: 30 * 60 * 1000,
-			meta: {
-				persist: false,
-			},
-		}
-	);
+		refetchOnWindowFocus: false,
+		keepPreviousData: false,
+		refetchOnMount: true,
+		enabled,
+		select: ( activities ) => {
+			return activities.filter( ( activity ) => ACTIVE_STATUSES.includes( activity.status ) );
+		},
+		staleTime: 30 * 60 * 1000,
+		meta: {
+			persist: false,
+		},
+	} );
 }

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -16,9 +16,9 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	supportType: SUPPORT_TYPE,
 	enabled = true
 ) {
-	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >(
-		[ supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability' ],
-		async () =>
+	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >( {
+		queryKey: [ supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability' ],
+		queryFn: async () =>
 			canAccessWpcomApis()
 				? await wpcomRequest( {
 						path: `help/eligibility/${ supportType === 'OTHER' ? 'all' : 'chat' }/mine`,
@@ -29,11 +29,9 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 						path: `help-center/support-availability/${ supportType === 'OTHER' ? 'all' : 'chat' }`,
 						global: true,
 				  } as APIFetchOptions ),
-		{
-			enabled,
-			refetchOnWindowFocus: false,
-			keepPreviousData: true,
-			staleTime: 6 * 60 * 60 * 1000, // 6 hours
-		}
-	);
+		enabled,
+		refetchOnWindowFocus: false,
+		keepPreviousData: true,
+		staleTime: 6 * 60 * 60 * 1000, // 6 hours
+	} );
 }

--- a/packages/data-stores/src/support-queries/use-update-zendesk-user-fields.ts
+++ b/packages/data-stores/src/support-queries/use-update-zendesk-user-fields.ts
@@ -10,20 +10,22 @@ type ZendeskUserFields = {
 };
 
 export function useUpdateZendeskUserFieldsMutation() {
-	return useMutation( ( userFields: ZendeskUserFields ) => {
-		return canAccessWpcomApis()
-			? wpcomRequest( {
-					path: 'help/zendesk/update-user-fields',
-					apiNamespace: 'wpcom/v2/',
-					apiVersion: '2',
-					method: 'POST',
-					body: { fields: userFields },
-			  } )
-			: apiFetch( {
-					global: true,
-					path: '/help-center/zendesk/user-fields',
-					method: 'POST',
-					data: { fields: userFields },
-			  } as APIFetchOptions );
+	return useMutation( {
+		mutationFn: ( userFields: ZendeskUserFields ) => {
+			return canAccessWpcomApis()
+				? wpcomRequest( {
+						path: 'help/zendesk/update-user-fields',
+						apiNamespace: 'wpcom/v2/',
+						apiVersion: '2',
+						method: 'POST',
+						body: { fields: userFields },
+				  } )
+				: apiFetch( {
+						global: true,
+						path: '/help-center/zendesk/user-fields',
+						method: 'POST',
+						data: { fields: userFields },
+				  } as APIFetchOptions );
+		},
 	} );
 }

--- a/packages/data-stores/src/templates/use-template.ts
+++ b/packages/data-stores/src/templates/use-template.ts
@@ -11,19 +11,17 @@ const useTemplate = (
 	templateId: string,
 	queryOptions: Options = {}
 ): UseQueryResult< Template > => {
-	return useQuery< Template >(
-		[ siteId, 'templates', templateId ],
-		() =>
+	return useQuery< Template >( {
+		queryKey: [ siteId, 'templates', templateId ],
+		queryFn: () =>
 			wpcomRequest( {
 				path: `/sites/${ siteId }/templates/${ templateId }`,
 				apiNamespace: 'wp/v2',
 			} ),
-		{
-			refetchOnMount: 'always',
-			staleTime: Infinity,
-			...queryOptions,
-		}
-	);
+		refetchOnMount: 'always',
+		staleTime: Infinity,
+		...queryOptions,
+	} );
 };
 
 export default useTemplate;

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -24,9 +24,9 @@ export function useThemeDesignsQuery(
 	{ filter = 'auto-loading-homepage', tier = 'all' }: UseThemeDesignsQueryOptions = {},
 	queryOptions: UseQueryOptions< unknown, unknown, Design[] > = {}
 ): UseQueryResult< Design[] > {
-	return useQuery< any, unknown, Design[] >(
-		[ 'themes', filter, tier ],
-		() =>
+	return useQuery< any, unknown, Design[] >( {
+		queryKey: [ 'themes', filter, tier ],
+		queryFn: () =>
 			wpcom.req.get( '/themes', {
 				search: '',
 				number: 50,
@@ -34,22 +34,17 @@ export function useThemeDesignsQuery(
 				filter,
 				apiVersion: '1.2',
 			} ),
-		{
-			// Our theme offering doesn't change that often, we don't need to
-			// re-fetch until the next page refresh.
-			staleTime: Infinity,
-
-			select: ( response ) => response.themes.map( apiThemeToDesign ),
-
-			...queryOptions,
-
-			meta: {
-				// Asks Calypso not to persist the data
-				persist: false,
-				...queryOptions.meta,
-			},
-		}
-	);
+		// Our theme offering doesn't change that often, we don't need to
+		// re-fetch until the next page refresh.
+		staleTime: Infinity,
+		select: ( response ) => response.themes.map( apiThemeToDesign ),
+		...queryOptions,
+		meta: {
+			// Asks Calypso not to persist the data
+			persist: false,
+			...queryOptions.meta,
+		},
+	} );
 }
 
 function apiThemeToDesign( { id, name, taxonomies, stylesheet, price }: any ): Design {

--- a/packages/global-styles/src/hooks/use-color-palette-variations.ts
+++ b/packages/global-styles/src/hooks/use-color-palette-variations.ts
@@ -3,21 +3,19 @@ import wpcomRequest from 'wpcom-proxy-request';
 import type { GlobalStylesObject } from '../types';
 
 const useColorPaletteVariations = ( siteId: number | string, stylesheet: string ) => {
-	const { data } = useQuery< any, unknown, GlobalStylesObject[] >(
-		[ 'global-styles-color-palette', siteId, stylesheet ],
-		async () =>
+	const { data } = useQuery< any, unknown, GlobalStylesObject[] >( {
+		queryKey: [ 'global-styles-color-palette', siteId, stylesheet ],
+		queryFn: async () =>
 			wpcomRequest< GlobalStylesObject[] >( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/global-styles-variation/color-palettes`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
 				query: new URLSearchParams( { stylesheet } ).toString(),
 			} ),
-		{
-			refetchOnMount: 'always',
-			staleTime: Infinity,
-			enabled: !! ( siteId && stylesheet ),
-		}
-	);
+		refetchOnMount: 'always',
+		staleTime: Infinity,
+		enabled: !! ( siteId && stylesheet ),
+	} );
 
 	return data;
 };

--- a/packages/global-styles/src/hooks/use-font-pairing-variations.ts
+++ b/packages/global-styles/src/hooks/use-font-pairing-variations.ts
@@ -3,21 +3,19 @@ import wpcomRequest from 'wpcom-proxy-request';
 import type { GlobalStylesObject } from '../types';
 
 const useFontPairingVariations = ( siteId: number | string, stylesheet: string ) => {
-	const { data } = useQuery< any, unknown, GlobalStylesObject[] >(
-		[ 'global-styles-font-pairings', siteId, stylesheet ],
-		async () =>
+	const { data } = useQuery< any, unknown, GlobalStylesObject[] >( {
+		queryKey: [ 'global-styles-font-pairings', siteId, stylesheet ],
+		queryFn: async () =>
 			wpcomRequest< GlobalStylesObject[] >( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/global-styles-variation/font-pairings`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
 				query: new URLSearchParams( { stylesheet } ).toString(),
 			} ),
-		{
-			refetchOnMount: 'always',
-			staleTime: Infinity,
-			enabled: !! ( siteId && stylesheet ),
-		}
-	);
+		refetchOnMount: 'always',
+		staleTime: Infinity,
+		enabled: !! ( siteId && stylesheet ),
+	} );
 
 	return data;
 };

--- a/packages/global-styles/src/hooks/use-get-global-styles-base-config.ts
+++ b/packages/global-styles/src/hooks/use-get-global-styles-base-config.ts
@@ -3,9 +3,9 @@ import wpcomRequest from 'wpcom-proxy-request';
 import type { GlobalStylesObject } from '../types';
 
 const useGetGlobalStylesBaseConfig = ( siteId: number | string, stylesheet: string ) => {
-	return useQuery< any, unknown, unknown >(
-		[ 'global-styles-base-config', siteId, stylesheet ],
-		async () =>
+	return useQuery< any, unknown, unknown >( {
+		queryKey: [ 'global-styles-base-config', siteId, stylesheet ],
+		queryFn: async () =>
 			wpcomRequest< GlobalStylesObject >( {
 				// We have to fetch the base config from wpcom as the core endpoint only supports
 				// active theme
@@ -14,12 +14,10 @@ const useGetGlobalStylesBaseConfig = ( siteId: number | string, stylesheet: stri
 				apiNamespace: 'wpcom/v2',
 				query: new URLSearchParams( { stylesheet } ).toString(),
 			} ),
-		{
-			refetchOnMount: 'always',
-			staleTime: Infinity,
-			enabled: !! ( siteId && stylesheet ),
-		}
-	);
+		refetchOnMount: 'always',
+		staleTime: Infinity,
+		enabled: !! ( siteId && stylesheet ),
+	} );
 };
 
 export default useGetGlobalStylesBaseConfig;

--- a/packages/happychat-connection/src/use-happychat-auth.ts
+++ b/packages/happychat-connection/src/use-happychat-auth.ts
@@ -26,7 +26,9 @@ export async function requestHappyChatAuth() {
 }
 
 export default function useHappychatAuth( enabled = true ) {
-	return useQuery< HappychatAuth >( happychatAuthQueryKey, requestHappyChatAuth, {
+	return useQuery< HappychatAuth >( {
+		queryKey: happychatAuthQueryKey,
+		queryFn: requestHappyChatAuth,
 		staleTime: 10 * 60 * 1000, // 10 minutes
 		enabled,
 		meta: {

--- a/packages/happychat-connection/src/use-happychat-available.ts
+++ b/packages/happychat-connection/src/use-happychat-available.ts
@@ -55,17 +55,15 @@ function getHCAvailabilityAndStatus( dataAuth: HappychatAuth ) {
 export function useHappychatAvailable( enabled = true, staleTime = 10 * 60 * 1000 ) {
 	const { data: dataAuth, isLoading: isLoadingAuth } = useHappychatAuth();
 
-	return useQuery(
-		[ 'happychat-available' ],
-		() => getHCAvailabilityAndStatus( dataAuth as HappychatAuth ),
-		{
-			enabled: ! isLoadingAuth && !! dataAuth && enabled,
-			staleTime,
-			meta: {
-				persist: false,
-			},
-		}
-	);
+	return useQuery( {
+		queryKey: [ 'happychat-available' ],
+		queryFn: () => getHCAvailabilityAndStatus( dataAuth as HappychatAuth ),
+		enabled: ! isLoadingAuth && !! dataAuth && enabled,
+		staleTime,
+		meta: {
+			persist: false,
+		},
+	} );
 }
 
 export default useHappychatAvailable;

--- a/packages/help-center/src/hooks/use-launchpad-checklist.tsx
+++ b/packages/help-center/src/hooks/use-launchpad-checklist.tsx
@@ -46,7 +46,9 @@ export const useLaunchpadChecklist = (
 	siteIntent: string | null = null
 ) => {
 	const key = [ 'launchpad-checklist', siteSlug ];
-	const queryResult = useQuery( key, () => fetchLaunchpadChecklist( siteSlug, siteIntent ), {
+	const queryResult = useQuery( {
+		queryKey: key,
+		queryFn: () => fetchLaunchpadChecklist( siteSlug, siteIntent ),
 		retry: 3,
 		placeholderData: { checklist: [] },
 		enabled: !! siteSlug && !! siteIntent,

--- a/packages/help-center/src/hooks/use-messaging-auth.ts
+++ b/packages/help-center/src/hooks/use-messaging-auth.ts
@@ -30,7 +30,9 @@ function requestMessagingAuth() {
 }
 
 export default function useMessagingAuth( zendeskKey: string | false, enabled: boolean ) {
-	return useQuery< MessagingAuth >( [ 'getMessagingAuth', zendeskKey ], requestMessagingAuth, {
+	return useQuery< MessagingAuth >( {
+		queryKey: [ 'getMessagingAuth', zendeskKey ],
+		queryFn: requestMessagingAuth,
 		staleTime: 7 * 24 * 60 * 60 * 1000, // 1 week (JWT is actually 2 weeks, but lets be on the safe side)
 		enabled,
 	} );

--- a/packages/help-center/src/hooks/use-messaging-availability.ts
+++ b/packages/help-center/src/hooks/use-messaging-availability.ts
@@ -33,15 +33,13 @@ function requestMessagingAvailability() {
 }
 
 export default function useMessagingAvailability( enabled = true ) {
-	return useQuery< MessagingAvailability >(
-		[ 'getMessagingAvailability' ],
-		requestMessagingAvailability,
-		{
-			staleTime: 60 * 1000, // 1 minute
-			meta: {
-				persist: false,
-			},
-			enabled,
-		}
-	);
+	return useQuery< MessagingAvailability >( {
+		queryKey: [ 'getMessagingAvailability' ],
+		queryFn: requestMessagingAvailability,
+		staleTime: 60 * 1000, // 1 minute
+		meta: {
+			persist: false,
+		},
+		enabled,
+	} );
 }

--- a/packages/help-center/src/hooks/use-zendesk-config.ts
+++ b/packages/help-center/src/hooks/use-zendesk-config.ts
@@ -5,7 +5,9 @@ function requestZendeskConfig() {
 }
 
 export default function useZendeskConfig( enabled: boolean ) {
-	return useQuery( [ 'getZendeskConfig' ], requestZendeskConfig, {
+	return useQuery( {
+		queryKey: [ 'getZendeskConfig' ],
+		queryFn: requestZendeskConfig,
 		staleTime: Infinity,
 		retry: false,
 		refetchOnMount: false,

--- a/packages/pattern-picker/src/use-link-in-bio-designs.ts
+++ b/packages/pattern-picker/src/use-link-in-bio-designs.ts
@@ -10,19 +10,17 @@ import type { Design } from '@automattic/design-picker';
  * @returns an array of numbers in a random order
  */
 function useOrder( length: number ) {
-	return useQuery(
-		[ 'ptk/order', length ],
-		async () => {
+	return useQuery( {
+		queryKey: [ 'ptk/order', length ],
+		queryFn: async () => {
 			const indices = Array.from( { length }, ( _, i ) => i );
 			const firstFour = indices.slice( 0, 4 ).sort( () => Math.random() - 0.5 );
 			const theRest = indices.slice( 4 );
 			return [ ...firstFour, ...theRest ];
 		},
-		{
-			staleTime: Infinity,
-			enabled: length > 0,
-		}
-	);
+		staleTime: Infinity,
+		enabled: length > 0,
+	} );
 }
 
 export const useLinkInBioDesigns = (): Design[] => {

--- a/packages/whats-new/src/index.tsx
+++ b/packages/whats-new/src/index.tsx
@@ -29,9 +29,9 @@ interface APIFetchOptions {
 const WhatsNewGuide: React.FC< Props > = ( { onClose } ) => {
 	const locale = useLocale();
 
-	const { data, isLoading } = useQuery< WhatsNewAnnouncement[] >(
-		[ 'WhatsNewAnnouncements' ],
-		async () =>
+	const { data, isLoading } = useQuery< WhatsNewAnnouncement[] >( {
+		queryKey: [ 'WhatsNewAnnouncements' ],
+		queryFn: async () =>
 			canAccessWpcomApis()
 				? await wpcomRequest( {
 						path: `/whats-new/list?_locale=${ locale }`,
@@ -41,10 +41,8 @@ const WhatsNewGuide: React.FC< Props > = ( { onClose } ) => {
 						global: true,
 						path: `/wpcom/v2/block-editor/whats-new-list?_locale=${ locale }`,
 				  } as APIFetchOptions ),
-		{
-			refetchOnWindowFocus: false,
-		}
-	);
+		refetchOnWindowFocus: false,
+	} );
 
 	if ( ! data || isLoading ) {
 		return null;


### PR DESCRIPTION
## Proposed Changes

This PR performs a bulk update to all React Query usages in Calypso to use the query object syntax. It's worth noting that the object syntax will also be the only available option in a future major version (see [docs](https://tanstack.com/query/v4/docs/react/eslint/prefer-query-object-syntax)).

Fixes most of the existing [`@tanstack/query/prefer-query-object-syntax`](https://tanstack.com/query/v4/docs/react/eslint/prefer-query-object-syntax) ESLint errors, which aren't enabled yet, but will be once we merge #77214. This PR is a pre-requisite of #77214. Our end goal is to enable the recommended ESLint rules for TanStack Query and make sure we're following the recommended best practices.

There are a few more violations to fix, but I'd like to keep this PR "smaller", and those other ones will require bigger refactors. Okay, I agree, the PR is not that small, but at least the changes are quite straightforward.

Would be great if I can get a quick review because the PR can get stale quickly as it touches many files.

## Testing Instructions

* Smoke test everything you can in Calypso.
* Verify all checks are green.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
