### PR TITLE
Site Editor: track page loads

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -10,6 +10,7 @@ import { RedirectOnboardingUserAfterPublishingPost } from './features/redirect-o
 import InserterMenuTrackingEvent from './features/tracking/wpcom-inserter-menu-search-term';
 import './features/site-editor-env-consistency';
 import './editor.scss';
+import './features/tracking/site-editor-load';
 
 registerPlugin( 'track-inserter-menu-events', {
 	render() {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/site-editor-load.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/site-editor-load.js
@@ -9,7 +9,7 @@ registerPlugin( 'wpcom-site-editor-load', {
 			return;
 		}
 		// this is no longer, strictly speaking, a "calypso" page view, but this is for back compat post-un-iframing.
-		tracksRecordEvent( 'caplyso_page_view', { path: '/:post_type/:site' } );
+		tracksRecordEvent( 'calypso_page_view', { path: '/:post_type/:site' } );
 		// @todo handle canvas=edit case: is the nav sidebar open? None of the `select('core/edit-site')` selectors seem to work.
 	},
 } );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/site-editor-load.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/site-editor-load.js
@@ -1,0 +1,15 @@
+import { select } from '@wordpress/data';
+import { registerPlugin } from '@wordpress/plugins';
+import tracksRecordEvent from './track-record-event';
+
+registerPlugin( 'wpcom-site-editor-load', {
+	render: () => {
+		// This also loads in the Post Editor context.
+		if ( ! select( 'core/edit-site' ) ) {
+			return;
+		}
+		// this is no longer, strictly speaking, a "calypso" page view, but this is for back compat post-un-iframing.
+		tracksRecordEvent( 'caplyso_page_view', { path: '/:post_type/:site' } );
+		// @todo handle canvas=edit case: is the nav sidebar open? None of the `select('core/edit-site')` selectors seem to work.
+	},
+} );


### PR DESCRIPTION
After the Site Editor was un-iframed, we stopped tracking `caplyso_page_view` events. This restores them.

Related to #75652 #76244

## Proposed Changes

* Fire the `calypso_page_view` Tracks event on Site Editor load with the `{ path: '/:post_type/:site' }` param.

## Testing Instructions

0. `install-plugin.sh wbe fix/tracks-events-in-site-editor` to install on your wpcom sandbox
1. sandbox `widgets.wp.com`
2. sandbox the site you will be loading the Site Editor within.
3. Load the Site Editor and use Tracks Vigilante or some other method to ensure that the event is fired. Here's the pixel request that gets made:

<img width="516" alt="Screenshot 2023-05-23 at 11 57 14" src="https://github.com/Automattic/wp-calypso/assets/195089/ccd84090-65d2-4645-85a7-381492705e31">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
