### PR TITLE
Subscription Management: Add paid label to site subscription list.

### DIFF
--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -42,7 +42,9 @@ export default function SiteRow( {
 	date_subscribed,
 	delivery_methods,
 	is_wpforteams_site,
+	is_paid_subscription,
 }: SiteSubscription ) {
+	const translate = useTranslate();
 	const hostname = useMemo( () => {
 		try {
 			return new URL( url ).hostname;
@@ -82,6 +84,9 @@ export default function SiteRow( {
 						<span className="name">
 							{ name }
 							{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
+							{ !! is_paid_subscription && (
+								<span className="paid-label">{ translate( 'Paid' ) }</span>
+							) }
 						</span>
 						<span className="url">{ hostname }</span>
 					</span>

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -85,7 +85,9 @@ export default function SiteRow( {
 							{ name }
 							{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
 							{ !! is_paid_subscription && (
-								<span className="paid-label">{ translate( 'Paid' ) }</span>
+								<span className="paid-label">
+									{ translate( 'Paid', { context: 'verb: past participle' } ) }
+								</span>
 							) }
 						</span>
 						<span className="url">{ hostname }</span>

--- a/client/landing/subscriptions/styles/styles.scss
+++ b/client/landing/subscriptions/styles/styles.scss
@@ -114,16 +114,27 @@ body {
 		border-top: 1px solid $studio-gray-5;
 	}
 
-	.p2-label {
+	.p2-label,
+	.paid-label {
 		display: inline-block;
 		text-align: center;
-		width: 36px;
 		height: 20px;
-		background: var(--p2-color-link);
 		color: $studio-green-0;
 		font-size: $font-body-extra-small;
 		border-radius: 4px;
 		margin-left: 8px;
 		line-height: 20px;
+	}
+
+	.p2-label {
+		background: var(--p2-color-link);
+		width: 36px;
+	}
+
+	.paid-label {
+		background: $studio-green-50;
+		padding-left: 5px;
+		padding-right: 5px;
+		min-width: 35px;
 	}
 }

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -68,6 +68,7 @@ export type SiteSubscription = {
 	is_owner: boolean;
 	meta: SiteSubscriptionMeta;
 	is_wpforteams_site: boolean;
+	is_paid_subscription: boolean;
 };
 
 export type SiteSubscriptionPage = {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/77219

☢️☢️☢️ Alert: don't merge this PR until this patch is in production: D111591-code ☢️☢️☢️

## Proposed Changes

This PR adds the `Paid` label to the site subscription list in the new Subscription Manager like this:

<img width="1292" alt="Screenshot 2023-05-23 at 19 25 24" src="https://github.com/Automattic/wp-calypso/assets/3832570/25c99ceb-e348-4295-bb69-8a124a7709c5">

## Testing Instructions

Apply this patch in your sandbox: D111591-code.
Sandbox `public-api.wordpress.com`.
Apply this PR.
Add `return next();` right after the line `app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res, next ) {` in the file `client/server/pages/index.js`.
Run Calypso with `yarn start`.
You need to have an internal user with a paid subscription. Follow these instructions to get it: pdDOJh-1SM-p2
With that user, go to `http://calypso.localhost:3000/subscriptions/sites`. You should see the green `Paid` label beside the site name where it corresponds.