### PR TITLE
ActivityPub: skeleton of the UI for enabling the fediverse

### DIFF
--- a/client/my-sites/site-settings/reading-fediverse-settings/JetpackFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/JetpackFediverseSettingsSection.js
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'react-redux';
 import QueryPlugins from 'calypso/components/data/query-plugins';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 
@@ -16,7 +15,6 @@ export const JetpackFediverseSettingsSection = ( { siteId } ) => {
 	return (
 		<>
 			<QueryPlugins siteId={ siteId } />
-			<SettingsSectionHeader title={ translate( 'Fediverse settings' ) } />
 			<Card className="site-settings__card">
 				<p>
 					{ translate(

--- a/client/my-sites/site-settings/reading-fediverse-settings/JetpackFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/JetpackFediverseSettingsSection.js
@@ -1,0 +1,43 @@
+import { Card, Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useSelector } from 'react-redux';
+import QueryPlugins from 'calypso/components/data/query-plugins';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+
+export const JetpackFediverseSettingsSection = ( { siteId } ) => {
+	const translate = useTranslate();
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+	const plugin = useSelector( ( state ) => getPluginOnSite( state, siteId, 'activitypub' ) );
+	const pluginIsActive = plugin?.active;
+
+	return (
+		<>
+			<QueryPlugins siteId={ siteId } />
+			<SettingsSectionHeader title={ translate( 'Fediverse settings' ) } />
+			<Card className="site-settings__card">
+				<p>
+					{ translate(
+						'The fediverse is a network of social media sites like Mastodon and Pixelfed and Calckey and Peertube and Pleroma, oh my!'
+					) }
+				</p>
+				<p>
+					{ translate(
+						'Your site can publish to the same ActivityPub protocol that powers all of them, just install the ActivityPub plugin!:'
+					) }
+				</p>
+				<p>
+					{ pluginIsActive ? (
+						<strong>{ translate( 'ActivityPub is already enabled for your site!' ) }</strong>
+					) : (
+						<Button primary={ true } onClick={ () => page( `/plugins/activitypub/${ domain }` ) }>
+							{ translate( 'Install ActivityPub' ) }
+						</Button>
+					) }
+				</p>
+			</Card>
+		</>
+	);
+};

--- a/client/my-sites/site-settings/reading-fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/WpcomFediverseSettingsSection.js
@@ -1,0 +1,96 @@
+import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import ClipboardButton from 'calypso/components/forms/clipboard-button';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { getCurrentUserName } from 'calypso/state/current-user/selectors';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { useActivityPubStatus } from './hooks';
+
+const CopyButton = ( { alias } ) => {
+	const translate = useTranslate();
+	const [ isCopied, setIsCopied ] = useState( false );
+	const text = isCopied ? translate( '✅ Copied!' ) : <code>{ alias }</code>;
+	const onCopy = () => {
+		setIsCopied( true );
+		setTimeout( () => setIsCopied( false ), 3333 );
+	};
+
+	return (
+		<ClipboardButton text={ alias } onCopy={ onCopy }>
+			{ text }
+		</ClipboardButton>
+	);
+};
+
+const EnabledSettingsSection = ( { error, siteId } ) => {
+	const translate = useTranslate();
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+	const username = useSelector( getCurrentUserName );
+	const catchallAlias = `${ domain }@${ domain }`;
+	const userAlias = `${ username }@${ domain }`;
+
+	// todo: only show the user alias when the blog has > 1 user, and/or is upgraded.
+	// todo: warnings for non-custom domains
+	return (
+		<Card className="site-settings__card">
+			{ error && (
+				<p>
+					<strong>
+						{ translate(
+							'This section will only appear once the toggle is enabled (not yet working)'
+						) }
+					</strong>
+				</p>
+			) }
+			<p>
+				{ translate(
+					'Lots of cool customizations and bonus features coming soon with WordPress.com Premium and up!'
+				) }
+			</p>
+			<hr />
+			<p>{ translate( 'The fediverse can follow your site with this alias:' ) }</p>
+			<p>
+				<CopyButton alias={ catchallAlias } />
+			</p>
+			<p>Upgraded sites will receive an option for user-based aliases</p>
+			<p>
+				<CopyButton alias={ userAlias } />
+			</p>
+		</Card>
+	);
+};
+
+export const WpcomFediverseSettingsSection = ( { siteId } ) => {
+	const translate = useTranslate();
+	const { isEnabled, setEnabled, isLoading, isError } = useActivityPubStatus( siteId );
+	const disabled = isLoading || isError;
+	return (
+		<>
+			<SettingsSectionHeader title={ translate( 'Fediverse settings' ) } />
+			<Card className="site-settings__card">
+				<p>
+					{ translate(
+						'The fediverse is a network of social media sites like Mastodon and Pixelfed and Calckey and Peertube and Pleroma, oh my!'
+					) }
+				</p>
+				<p>
+					{ translate(
+						'Your site can publish to the same ActivityPub protocol that powers all of them, just enable:'
+					) }
+				</p>
+				<ToggleControl
+					label={ translate( 'Enter the fediverse' ) }
+					disabled={ disabled }
+					checked={ isEnabled }
+					onChange={ () => setEnabled( ! isEnabled ) }
+				/>
+			</Card>
+			{ ( isEnabled /* get rid of isError once the endpoint lands */ || isError ) && (
+				<EnabledSettingsSection error={ isError } siteId={ siteId } />
+			) }
+		</>
+	);
+};

--- a/client/my-sites/site-settings/reading-fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/WpcomFediverseSettingsSection.js
@@ -25,7 +25,7 @@ const CopyButton = ( { alias } ) => {
 	);
 };
 
-const EnabledSettingsSection = ( { error, siteId } ) => {
+const EnabledSettingsSection = ( { siteId } ) => {
 	const translate = useTranslate();
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 	const username = useSelector( getCurrentUserName );
@@ -36,15 +36,6 @@ const EnabledSettingsSection = ( { error, siteId } ) => {
 	// todo: warnings for non-custom domains
 	return (
 		<Card className="site-settings__card">
-			{ error && (
-				<p>
-					<strong>
-						{ translate(
-							'This section will only appear once the toggle is enabled (not yet working)'
-						) }
-					</strong>
-				</p>
-			) }
 			<p>
 				{ translate(
 					'Lots of cool customizations and bonus features coming soon with WordPress.com Premium and up!'
@@ -109,9 +100,7 @@ export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 					onChange={ onChange }
 				/>
 			</Card>
-			{ ( isEnabled /* get rid of isError once the endpoint lands */ || isError ) && (
-				<EnabledSettingsSection error={ isError } siteId={ siteId } />
-			) }
+			{ isEnabled && <EnabledSettingsSection siteId={ siteId } /> }
 		</>
 	);
 };

--- a/client/my-sites/site-settings/reading-fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/WpcomFediverseSettingsSection.js
@@ -4,7 +4,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { useActivityPubStatus } from './hooks';
@@ -69,7 +68,6 @@ export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 	const disabled = isLoading || isError;
 	return (
 		<>
-			<SettingsSectionHeader title={ translate( 'Fediverse settings' ) } />
 			<Card className="site-settings__card">
 				<p>
 					{ translate(

--- a/client/my-sites/site-settings/reading-fediverse-settings/hooks.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/hooks.js
@@ -2,28 +2,20 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
 export const useActivityPubStatus = ( blogId ) => {
-	const key = [ 'activitypub/status', blogId ];
-	const path = `/sites/${ blogId }/activitypub/status`;
+	const queryKey = [ 'activitypub/status', blogId ];
+	const reqArgs = {
+		path: `/sites/${ blogId }/activitypub/status`,
+		apiNamespace: 'wpcom/v2',
+	};
 
 	const { data, isInitialLoading, isError } = useQuery( {
-		queryKey: key,
-		queryFn: () => {
-			return wpcom.req.get( {
-				path,
-				apiNamespace: 'wpcom/v2',
-			} );
-		},
+		queryKey,
+		queryFn: () => wpcom.req.get( reqArgs ),
 	} );
 	const queryClient = useQueryClient();
 	const { mutate, isLoading } = useMutation( {
-		mutationFn: ( enabled ) => {
-			return wpcom.req.post( {
-				path,
-				body: { enabled },
-				apiNamespace: 'wpcom/v2',
-			} );
-		},
-		onSuccess: ( { enabled } ) => queryClient.setQueryData( key, { enabled } ),
+		mutationFn: ( enabled ) => wpcom.req.post( { body: { enabled }, ...reqArgs } ),
+		onSuccess: ( responseData ) => queryClient.setQueryData( queryKey, responseData ),
 	} );
 
 	return {

--- a/client/my-sites/site-settings/reading-fediverse-settings/hooks.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/hooks.js
@@ -1,41 +1,35 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-const queryKey = ( blogId ) => [ 'activitypub/status', blogId ];
-const queryPath = ( blogId ) => `/sites/${ blogId }/activitypub/status`;
+export const useActivityPubStatus = ( blogId ) => {
+	const key = [ 'activitypub/status', blogId ];
+	const path = `/sites/${ blogId }/activitypub/status`;
 
-export const useActivityPubStatusMutation = ( blogId ) => {
+	const { data, isInitialLoading, isError } = useQuery( {
+		queryKey: key,
+		queryFn: () => {
+			return wpcom.req.get( {
+				path,
+				apiNamespace: 'wpcom/v2',
+			} );
+		},
+	} );
 	const queryClient = useQueryClient();
 	const { mutate, isLoading } = useMutation( {
 		mutationFn: ( enabled ) => {
 			return wpcom.req.post( {
-				path: queryPath( blogId ),
+				path,
 				body: { enabled },
 				apiNamespace: 'wpcom/v2',
 			} );
 		},
-		onSuccess: ( { enabled } ) => queryClient.setQueryData( queryKey( blogId ), { enabled } ),
-	} );
-	return {
-		setEnabled: mutate,
-		isMutating: isLoading,
-	};
-};
-
-export const useActivityPubStatus = ( blogId ) => {
-	const { data, isInitialLoading, isError } = useQuery( {
-		queryKey: [ 'activitypub/status', blogId ],
-		queryFn: () => {
-			return wpcom.req.get( {
-				path: queryPath( blogId ),
-				apiNamespace: 'wpcom/v2',
-			} );
-		},
+		onSuccess: ( { enabled } ) => queryClient.setQueryData( key, { enabled } ),
 	} );
 
 	return {
 		isEnabled: !! data?.enabled,
-		isLoading: isInitialLoading,
+		setEnabled: mutate,
+		isLoading: isInitialLoading || isLoading,
 		isError,
 	};
 };

--- a/client/my-sites/site-settings/reading-fediverse-settings/hooks.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/hooks.js
@@ -1,0 +1,41 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+const queryKey = ( blogId ) => [ 'activitypub/status', blogId ];
+const queryPath = ( blogId ) => `/sites/${ blogId }/activitypub/status`;
+
+export const useActivityPubStatusMutation = ( blogId ) => {
+	const queryClient = useQueryClient();
+	const { mutate, isLoading } = useMutation( {
+		mutationFn: ( enabled ) => {
+			return wpcom.req.post( {
+				path: queryPath( blogId ),
+				body: { enabled },
+				apiNamespace: 'wpcom/v2',
+			} );
+		},
+		onSuccess: ( { enabled } ) => queryClient.setQueryData( queryKey( blogId ), { enabled } ),
+	} );
+	return {
+		setEnabled: mutate,
+		isMutating: isLoading,
+	};
+};
+
+export const useActivityPubStatus = ( blogId ) => {
+	const { data, isInitialLoading, isError } = useQuery( {
+		queryKey: [ 'activitypub/status', blogId ],
+		queryFn: () => {
+			return wpcom.req.get( {
+				path: queryPath( blogId ),
+				apiNamespace: 'wpcom/v2',
+			} );
+		},
+	} );
+
+	return {
+		isEnabled: !! data?.enabled,
+		isLoading: isInitialLoading,
+		isError,
+	};
+};

--- a/client/my-sites/site-settings/reading-fediverse-settings/index.jsx
+++ b/client/my-sites/site-settings/reading-fediverse-settings/index.jsx
@@ -1,102 +1,16 @@
-import { Card } from '@automattic/components';
-import { ToggleControl } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import { useSelector } from 'react-redux';
-import ClipboardButton from 'calypso/components/forms/clipboard-button';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import { getCurrentUserName } from 'calypso/state/current-user/selectors';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { useActivityPubStatus } from './hooks';
-
-const CopyButton = ( { alias } ) => {
-	const translate = useTranslate();
-	const [ isCopied, setIsCopied ] = useState( false );
-	const text = isCopied ? translate( '✅ Copied!' ) : <code>{ alias }</code>;
-	const onCopy = () => {
-		setIsCopied( true );
-		setTimeout( () => setIsCopied( false ), 3333 );
-	};
-
-	return (
-		<ClipboardButton text={ alias } onCopy={ onCopy }>
-			{ text }
-		</ClipboardButton>
-	);
-};
-
-const FediverseInnerSettingsSection = ( { error } ) => {
-	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
-	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
-	const username = useSelector( getCurrentUserName );
-	const catchallAlias = `${ domain }@${ domain }`;
-	const userAlias = `${ username }@${ domain }`;
-
-	// todo: only show the user alias when the blog has > 1 user
-	// todo: warnings for non-custom domains
-	return (
-		<Card className="site-settings__card">
-			{ error && (
-				<p>
-					<strong>
-						{ translate(
-							'This section will only appear once the toggle is enabled (not yet working)'
-						) }
-					</strong>
-				</p>
-			) }
-			<p>
-				{ translate(
-					'Lots of cool customizations and bonus features coming soon with WordPress.com Premium and up!'
-				) }
-			</p>
-			<hr />
-			<p>{ translate( 'The fediverse can follow your site with this alias:' ) }</p>
-			<p>
-				<CopyButton alias={ catchallAlias } />
-			</p>
-			<p>Upgraded sites will receive an option for user-based aliases</p>
-			<p>
-				<CopyButton alias={ userAlias } />
-			</p>
-		</Card>
-	);
-};
+import { JetpackFediverseSettingsSection } from './JetpackFediverseSettingsSection';
+import { WpcomFediverseSettingsSection } from './WpcomFediverseSettingsSection';
 
 export const FediverseSettingsSection = () => {
-	const translate = useTranslate();
-	// todo: get/set this from a real endpoint.
-	// todo: make the endpoint.
 	const siteId = useSelector( getSelectedSiteId );
-	const { isEnabled, setEnabled, isLoading, isError } = useActivityPubStatus( siteId );
-	const disabled = isLoading || isError;
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 
-	return (
-		<>
-			<SettingsSectionHeader title={ translate( 'Fediverse settings' ) } />
-			<Card className="site-settings__card">
-				<p>
-					{ translate(
-						'The fediverse is a network of social media sites like Mastodon and Pixelfed and Calckey and Peertube and Pleroma, oh my!'
-					) }
-				</p>
-				<p>
-					{ translate(
-						'Your site can publish to the same ActivityPub protocol that powers all of them, just enable:'
-					) }
-				</p>
-				<ToggleControl
-					label={ translate( 'Enter the fediverse' ) }
-					disabled={ disabled }
-					checked={ isEnabled }
-					onChange={ () => setEnabled( ! isEnabled ) }
-				/>
-			</Card>
-			{ ( isEnabled /* get rid of isError once the endpoint lands */ || isError ) && (
-				<FediverseInnerSettingsSection error={ isError } />
-			) }
-		</>
-	);
+	if ( isJetpack ) {
+		return <JetpackFediverseSettingsSection siteId={ siteId } />;
+	}
+
+	return <WpcomFediverseSettingsSection siteId={ siteId } />;
 };

--- a/client/my-sites/site-settings/reading-fediverse-settings/index.jsx
+++ b/client/my-sites/site-settings/reading-fediverse-settings/index.jsx
@@ -8,7 +8,7 @@ import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-secti
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { useActivityPubStatus, useActivityPubStatusMutation } from './hooks';
+import { useActivityPubStatus } from './hooks';
 
 const ACTIVITYPUB_CATCHALL_PREFIX = 'feed';
 
@@ -73,9 +73,8 @@ export const FediverseSettingsSection = () => {
 	// todo: get/set this from a real endpoint.
 	// todo: make the endpoint.
 	const siteId = useSelector( getSelectedSiteId );
-	const { isEnabled, isLoading, isError } = useActivityPubStatus( siteId );
-	const { setEnabled, isMutating } = useActivityPubStatusMutation( siteId );
-	const disabled = isMutating || isLoading || isError;
+	const { isEnabled, setEnabled, isLoading, isError } = useActivityPubStatus( siteId );
+	const disabled = isLoading || isError;
 
 	return (
 		<>

--- a/client/my-sites/site-settings/reading-fediverse-settings/index.jsx
+++ b/client/my-sites/site-settings/reading-fediverse-settings/index.jsx
@@ -1,0 +1,93 @@
+import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import ClipboardButton from 'calypso/components/forms/clipboard-button';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { getCurrentUserName } from 'calypso/state/current-user/selectors';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const ACTIVITYPUB_CATCHALL_PREFIX = 'feed';
+
+const CopyButton = ( { alias } ) => {
+	const translate = useTranslate();
+	const [ isCopied, setIsCopied ] = useState( false );
+	const text = isCopied ? translate( '✅ Copied!' ) : <code>{ alias }</code>;
+	useEffect( () => {
+		setTimeout( () => {
+			setIsCopied( false );
+		}, 3330 );
+	}, [ isCopied ] );
+
+	return (
+		<ClipboardButton text={ alias } onCopy={ () => setIsCopied( true ) }>
+			{ text }
+		</ClipboardButton>
+	);
+};
+
+const FediverseInnerSettingsSection = () => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+	const username = useSelector( getCurrentUserName );
+	const catchallAlias = `${ ACTIVITYPUB_CATCHALL_PREFIX }@${ domain }`;
+	const userAlias = `${ username }@${ domain }`;
+
+	// todo: only show the user alias when the blog has > 1 user
+	// todo: warnings for non-custom domains
+	return (
+		<Card className="site-settings__card">
+			<p>
+				{ translate(
+					'Lots of cool customizations and bonus features coming soon with WordPress.com Premium and up!'
+				) }
+			</p>
+			<hr />
+			<p>{ translate( 'The fediverse can follow your site with this alias:' ) }</p>
+			<p>
+				<CopyButton alias={ catchallAlias } />
+			</p>
+			<p>{ translate( 'They can also follow just you:' ) }</p>
+			<p>
+				<CopyButton alias={ userAlias } />
+			</p>
+		</Card>
+	);
+};
+
+export const FediverseSettingsSection = () => {
+	const translate = useTranslate();
+	// todo: get/set this from a real endpoint.
+	// todo: make the endpoint.
+	const [ isActivityPubEnabled, setIsActivityPubEnabled ] = useState( false );
+
+	return (
+		<>
+			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
+			<SettingsSectionHeader title={ translate( 'Fediverse settings' ) } />
+			<Card className="site-settings__card">
+				<p>
+					{ translate(
+						'The fediverse is a network of social media sites like Mastodon, Pixelfed, and Peertube!'
+					) }
+				</p>
+				<p>
+					{ translate(
+						'Your site can publish to the same ActivityPub protocol that powers all of them, just enable:'
+					) }
+				</p>
+				<ToggleControl
+					label={ translate( 'Enter the fediverse' ) }
+					checked={ isActivityPubEnabled }
+					onChange={ () => {
+						setIsActivityPubEnabled( ! isActivityPubEnabled );
+					} }
+				/>
+			</Card>
+			{ isActivityPubEnabled && <FediverseInnerSettingsSection /> }
+		</>
+	);
+};

--- a/client/my-sites/site-settings/reading-fediverse-settings/index.jsx
+++ b/client/my-sites/site-settings/reading-fediverse-settings/index.jsx
@@ -1,4 +1,6 @@
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { JetpackFediverseSettingsSection } from './JetpackFediverseSettingsSection';
@@ -7,10 +9,16 @@ import { WpcomFediverseSettingsSection } from './WpcomFediverseSettingsSection';
 export const FediverseSettingsSection = () => {
 	const siteId = useSelector( getSelectedSiteId );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const translate = useTranslate();
 
-	if ( isJetpack ) {
-		return <JetpackFediverseSettingsSection siteId={ siteId } />;
-	}
-
-	return <WpcomFediverseSettingsSection siteId={ siteId } />;
+	return (
+		<>
+			<SettingsSectionHeader title={ translate( 'Fediverse settings' ) } />
+			{ isJetpack ? (
+				<JetpackFediverseSettingsSection siteId={ siteId } />
+			) : (
+				<WpcomFediverseSettingsSection siteId={ siteId } />
+			) }
+		</>
+	);
 };

--- a/client/my-sites/site-settings/reading-fediverse-settings/index.jsx
+++ b/client/my-sites/site-settings/reading-fediverse-settings/index.jsx
@@ -10,8 +10,6 @@ import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useActivityPubStatus } from './hooks';
 
-const ACTIVITYPUB_CATCHALL_PREFIX = 'feed';
-
 const CopyButton = ( { alias } ) => {
 	const translate = useTranslate();
 	const [ isCopied, setIsCopied ] = useState( false );
@@ -33,7 +31,7 @@ const FediverseInnerSettingsSection = ( { error } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 	const username = useSelector( getCurrentUserName );
-	const catchallAlias = `${ ACTIVITYPUB_CATCHALL_PREFIX }@${ domain }`;
+	const catchallAlias = `${ domain }@${ domain }`;
 	const userAlias = `${ username }@${ domain }`;
 
 	// todo: only show the user alias when the blog has > 1 user
@@ -59,7 +57,7 @@ const FediverseInnerSettingsSection = ( { error } ) => {
 			<p>
 				<CopyButton alias={ catchallAlias } />
 			</p>
-			<p>{ translate( 'They can also follow just you:' ) }</p>
+			<p>Upgraded sites will receive an option for user-based aliases</p>
 			<p>
 				<CopyButton alias={ userAlias } />
 			</p>

--- a/client/my-sites/site-settings/reading-fediverse-settings/index.jsx
+++ b/client/my-sites/site-settings/reading-fediverse-settings/index.jsx
@@ -1,7 +1,7 @@
 import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
@@ -16,14 +16,13 @@ const CopyButton = ( { alias } ) => {
 	const translate = useTranslate();
 	const [ isCopied, setIsCopied ] = useState( false );
 	const text = isCopied ? translate( '✅ Copied!' ) : <code>{ alias }</code>;
-	useEffect( () => {
-		setTimeout( () => {
-			setIsCopied( false );
-		}, 3330 );
-	}, [ isCopied ] );
+	const onCopy = () => {
+		setIsCopied( true );
+		setTimeout( () => setIsCopied( false ), 3333 );
+	};
 
 	return (
-		<ClipboardButton text={ alias } onCopy={ () => setIsCopied( true ) }>
+		<ClipboardButton text={ alias } onCopy={ onCopy }>
 			{ text }
 		</ClipboardButton>
 	);

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -10,6 +10,7 @@ import { getSiteUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ReaderSettingsSection from '../reader-settings';
+import { FediverseSettingsSection } from '../reading-fediverse-settings';
 import { NewsletterSettingsSection } from '../reading-newsletter-settings';
 import { RssFeedSettingsSection } from '../reading-rss-feed-settings';
 import { SiteSettingsSection } from '../reading-site-settings';
@@ -139,15 +140,7 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						isSavingSettings={ isSavingSettings }
 						updateFields={ updateFields }
 					/>
-					<RssFeedSettingsSection
-						fields={ fields }
-						onChangeField={ onChangeField }
-						handleSubmitForm={ handleSubmitForm }
-						updateFields={ updateFields }
-						disabled={ disabled }
-						isSavingSettings={ isSavingSettings }
-						siteUrl={ siteUrl }
-					/>
+					{ config.isEnabled( 'fediverse/allow-opt-in' ) && <FediverseSettingsSection /> }
 					<NewsletterSettingsSection
 						fields={ fields }
 						handleToggle={ handleToggle }
@@ -164,6 +157,15 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						isSavingSettings={ isSavingSettings }
 						isAtomic={ isAtomic }
 						siteIsJetpack={ siteIsJetpack }
+					/>
+					<RssFeedSettingsSection
+						fields={ fields }
+						onChangeField={ onChangeField }
+						handleSubmitForm={ handleSubmitForm }
+						updateFields={ updateFields }
+						disabled={ disabled }
+						isSavingSettings={ isSavingSettings }
+						siteUrl={ siteUrl }
 					/>
 				</form>
 			);

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -140,7 +140,6 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						isSavingSettings={ isSavingSettings }
 						updateFields={ updateFields }
 					/>
-					{ config.isEnabled( 'fediverse/allow-opt-in' ) && <FediverseSettingsSection /> }
 					<NewsletterSettingsSection
 						fields={ fields }
 						handleToggle={ handleToggle }
@@ -158,6 +157,7 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						isAtomic={ isAtomic }
 						siteIsJetpack={ siteIsJetpack }
 					/>
+					{ config.isEnabled( 'fediverse/allow-opt-in' ) && <FediverseSettingsSection /> }
 					<RssFeedSettingsSection
 						fields={ fields }
 						onChangeField={ onChangeField }

--- a/config/development.json
+++ b/config/development.json
@@ -64,6 +64,7 @@
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,
 		"external-media/openverse": true,
+		"fediverse/allow-opt-in": true,
 		"full-site-editing/beta-opt-in": true,
 		"cookie-banner": false,
 		"github-integration-i1": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -35,6 +35,7 @@
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,
 		"external-media/openverse": true,
+		"fediverse/allow-opt-in": true,
 		"full-site-editing/beta-opt-in": true,
 		"cookie-banner": true,
 		"google-my-business": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -48,6 +48,7 @@
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,
 		"external-media/openverse": true,
+		"fediverse/allow-opt-in": true,
 		"cookie-banner": true,
 		"github-integration-i1": false,
 		"google-my-business": true,


### PR DESCRIPTION
This provides a rough UI for enabling the ActivityPub plugin on WordPress.com

It works with D111295-code applied to your sandbox

Related to #

## Proposed Changes

* Adds a "Fediverse settings" section to Settings --> Reading

## Testing Instructions

Navigate to Settings --> Reading. You should see a **Fediverse settings** section like:

<img width="742" alt="Screenshot 2023-05-23 at 16 33 24" src="https://github.com/Automattic/wp-calypso/assets/195089/8c795617-68d5-429a-b5dc-69956e15b744">

The calypso.live link (see first comment) should work @pfefferle so you don't have to learn how to compile Calypso first (or do!)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?