### PR TITLE
Purchases: Convert PurchaseNotice to TypeScript

### DIFF
--- a/client/components/notice/notice-action.tsx
+++ b/client/components/notice/notice-action.tsx
@@ -6,7 +6,7 @@ import './style.scss';
 
 interface NoticeActionProps {
 	'aria-label'?: string;
-	href?: string;
+	href?: string | null;
 	onClick?: () => void;
 	external?: boolean;
 	icon?: string;
@@ -33,10 +33,11 @@ export default class NoticeAction extends Component< NoticeActionProps > {
 			target?: string;
 			rel?: string;
 			tabIndex?: number;
+			href?: string;
 		} = {
 			'aria-label': this.props[ 'aria-label' ],
 			className: 'notice__action',
-			href: this.props.href,
+			href: this.props.href ?? undefined,
 			onClick: this.props.onClick,
 			tabIndex: 0,
 		};

--- a/client/components/notice/notice-action.tsx
+++ b/client/components/notice/notice-action.tsx
@@ -4,7 +4,15 @@ import { Component } from 'react';
 
 import './style.scss';
 
-export default class extends Component {
+interface NoticeActionProps {
+	'aria-label'?: string;
+	href?: string;
+	onClick?: () => void;
+	external?: boolean;
+	icon?: string;
+}
+
+export default class NoticeAction extends Component< NoticeActionProps > {
 	static displayName = 'NoticeAction';
 
 	static propTypes = {
@@ -20,7 +28,12 @@ export default class extends Component {
 	};
 
 	render() {
-		const attributes = {
+		const attributes: NoticeActionProps & {
+			className?: string;
+			target?: string;
+			rel?: string;
+			tabIndex?: number;
+		} = {
 			'aria-label': this.props[ 'aria-label' ],
 			className: 'notice__action',
 			href: this.props.href,


### PR DESCRIPTION
## Proposed Changes

This diff converts the `PurchaseNotice` component to TypeScript with as few functional changes as possible.

<img width="813" alt="Screenshot 2023-05-29 at 12 42 28 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/c074308f-cd5b-4c5d-9a53-12025cae49bd">

<img width="982" alt="Screenshot 2023-05-29 at 2 31 09 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/790bb674-ad15-4017-b2b4-92ccd56e5c75">

<img width="976" alt="Screenshot 2023-05-29 at 2 31 28 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/d90a11d7-3a25-44bf-94d8-0831db8d8fc7">


## Testing Instructions

You can view this component by visiting `/me/purchases` and selecting a product which has expired, is expiring soon, or has a credit card which is expiring soon.

Click on the purchase, then you'll see the notice displayed as a box at the top of the page.