### PR TITLE
Update sharing modal link to use parent iframe

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -194,7 +194,11 @@ const SharingModal: React.FC = () => {
 						) }
 					</p>
 					<div className="wpcom-block-editor-post-published-buttons">
-						<a href={ link } className="link-button" rel="external">
+						<a
+							href={ link }
+							className="link-button wpcom-block-editor-post-published-sharing-modal__view-post-link"
+							rel="external"
+						>
 							{ ' ' }
 							<Icon icon={ globe } /> { __( 'View Post', 'full-site-editing' ) }
 						</a>

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -530,6 +530,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 		'.components-snackbar-list .components-snackbar__content a', // View Post link in success snackbar, Gutenberg >=5.9
 		'.post-publish-panel__postpublish .components-panel__body.is-opened a', // Post title link in publish panel
 		'.components-panel__body.is-opened .post-publish-panel__postpublish-buttons a.components-button', // View Post button in publish panel
+		'.wpcom-block-editor-post-published-sharing-modal__view-post-link', // View Post button in sharing modal
 	].join( ',' );
 
 	addEditorListener( viewPostLinks, ( e ) => {


### PR DESCRIPTION
Fixes issue raised here p1684871473278599-slack-C03NLNTPZ2T

### Testing instructions
sandbox the ETK
```
cd apps/editing-toolkit
yarn dev --sync
```
Sandbox the wpcom-block-editor
```
cd apps/wpcom-block-editor
yarn dev --sync
```

* On a sandboxed public site on wordpress.com, create a new post with the calypso editor i.e. `https://wordpress.com/$site_slug/post`
* Click publish, the sharing modal should appear 
* Click the **View Post** link
* You should be taken to the correct link on your external site, not the `https://wordpress.com/post/$site_slug/$id` link

