### PR TITLE
Add WooExpress `Upgrades > Plans` track

### DIFF
--- a/client/my-sites/sidebar/item.jsx
+++ b/client/my-sites/sidebar/item.jsx
@@ -69,6 +69,7 @@ MySitesSidebarUnifiedItem.propTypes = {
 	url: PropTypes.string,
 	shouldOpenExternalLinksInCurrentTab: PropTypes.bool.isRequired,
 	canNavigate: PropTypes.func.isRequired,
+	trackClickEvent: PropTypes.func,
 };
 
 export default memo( MySitesSidebarUnifiedItem );

--- a/client/my-sites/sidebar/item.jsx
+++ b/client/my-sites/sidebar/item.jsx
@@ -42,6 +42,7 @@ export const MySitesSidebarUnifiedItem = ( {
 		}
 
 		if ( url.startsWith( '/plans/' ) ) {
+			// Note that we also track this event in WooCommerce Screen via wc-calypso-bridge. If you change this event, please update it there as well. See: https://github.com/Automattic/wc-calypso-bridge/pull/1156.
 			reduxDispatch(
 				recordTracksEvent( 'calypso_sidebar_item_click', {
 					path: '/plans',

--- a/client/my-sites/sidebar/item.jsx
+++ b/client/my-sites/sidebar/item.jsx
@@ -6,16 +6,12 @@
  * These two cases might be to be split up?
  */
 
-import { isWooExpressPlan, PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import PropTypes from 'prop-types';
 import { memo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import SidebarItem from 'calypso/layout/sidebar/item';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { collapseAllMySitesSidebarSections } from 'calypso/state/my-sites/sidebar/actions';
-import { getSitePlanSlug } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MySitesSidebarUnifiedStatsSparkline from './sparkline';
 
 export const MySitesSidebarUnifiedItem = ( {
@@ -29,35 +25,19 @@ export const MySitesSidebarUnifiedItem = ( {
 	url,
 	shouldOpenExternalLinksInCurrentTab,
 	canNavigate,
+	trackClickEvent,
 } ) => {
 	const reduxDispatch = useDispatch();
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const sitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, selectedSiteId ) );
-
-	const trackItemClick = () => {
-		// For now, we only track clicks on the Plans menu item for WooExpress sites.
-		const isEcommerceTrial = sitePlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
-		if ( ! isEcommerceTrial && ! isWooExpressPlan( sitePlanSlug ) ) {
-			return;
-		}
-
-		if ( url.startsWith( '/plans/' ) ) {
-			// Note that we also track this event in WooCommerce Screen via wc-calypso-bridge. If you change this event, please update it there as well. See: https://github.com/Automattic/wc-calypso-bridge/pull/1156.
-			reduxDispatch(
-				recordTracksEvent( 'calypso_sidebar_item_click', {
-					path: '/plans',
-				} )
-			);
-		}
-	};
 
 	const onNavigate = ( event ) => {
 		if ( ! canNavigate( url ) ) {
 			event?.preventDefault();
 			return;
 		}
+		if ( typeof trackClickEvent === 'function' ) {
+			trackClickEvent( url );
+		}
 
-		trackItemClick();
 		reduxDispatch( collapseAllMySitesSidebarSections() );
 		window.scrollTo( 0, 0 );
 	};

--- a/client/my-sites/sidebar/menu.jsx
+++ b/client/my-sites/sidebar/menu.jsx
@@ -5,14 +5,18 @@
  * This item can be expanded and collapsed by clicking.
  */
 
+import { isWooExpressPlan, PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import { PromoteWidgetStatus, usePromoteWidget } from 'calypso/lib/promote-post';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { toggleMySitesSidebarSection as toggleSection } from 'calypso/state/my-sites/sidebar/actions';
 import { isSidebarSectionOpen } from 'calypso/state/my-sites/sidebar/selectors';
+import { getSitePlanSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MySitesSidebarUnifiedItem from './item';
 import { itemLinkMatches } from './utils';
 
@@ -33,6 +37,8 @@ export const MySitesSidebarUnifiedMenu = ( {
 	const reduxDispatch = useDispatch();
 	const sectionId = 'SIDEBAR_SECTION_' + slug;
 	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const sitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, selectedSiteId ) );
 	const selectedMenuItem =
 		Array.isArray( children ) &&
 		children.find( ( menuItem ) => menuItem?.url && itemLinkMatches( menuItem.url, path ) );
@@ -44,6 +50,32 @@ export const MySitesSidebarUnifiedMenu = ( {
 		( isDesktop && childIsSelected && ! sidebarCollapsed ); // For desktop breakpoints, a child should be selected and the sidebar being expanded.
 
 	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
+
+	const trackClickEvent = ( _link ) => {
+		// For now, we only track clicks on the Plans menu item for WooExpress sites.
+		const isEcommerceTrial = sitePlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+		if ( ! isEcommerceTrial && ! isWooExpressPlan( sitePlanSlug ) ) {
+			return;
+		}
+
+		if ( typeof _link !== 'string' || ! _link.startsWith( '/plans/' ) ) {
+			return;
+		}
+
+		// Check if we're navigating to /plans/:siteSlug or some deeper path below /plans/[something]/siteSlug
+		// The implementation can be changed to be simpler or different, but the check is needed.
+		const hasDeeperPath = _link.replace( '/plans/', '' ).includes( '/' );
+		if ( hasDeeperPath ) {
+			return;
+		}
+
+		// Note that we also track this event in WooCommerce Screen via wc-calypso-bridge. If you change this event, please update it there as well. See: https://github.com/Automattic/wc-calypso-bridge/pull/1156.
+		reduxDispatch(
+			recordTracksEvent( 'calypso_sidebar_item_click', {
+				path: '/plans',
+			} )
+		);
+	};
 
 	const onClick = ( event ) => {
 		// Block the navigation on mobile viewports and just toggle the section,
@@ -60,6 +92,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 			return;
 		}
 
+		trackClickEvent( link );
 		window.scrollTo( 0, 0 );
 		reduxDispatch( toggleSection( sectionId ) );
 	};
@@ -88,6 +121,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 							key={ item.title }
 							{ ...item }
 							selected={ isSelected }
+							trackClickEvent={ trackClickEvent }
 							isSubItem={ true }
 							shouldOpenExternalLinksInCurrentTab={ shouldOpenExternalLinksInCurrentTab }
 							canNavigate={ canNavigate }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76877 https://github.com/Automattic/wc-calypso-bridge/pull/1156

## Proposed Changes

This PR adds `calypso_sidebar_item_click` track which is fired when a user clicks on `Upgrades > Plans`  menu item in a WooExpress/WooTrial site.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a WooExpress free trial site 
* Go to `/settings/general/{site_slug}`
* Open the dev tool console and enable debugging via `window.localStorage.setItem( 'debug', 'calypso:analytics' )`
* Click on `Upgrades > Plans`
* Observe that `calypso_sidebar_item_click` event is recorded with prop `path = '/plans'`.

![Screenshot 2023-05-24 at 10 27 39](https://github.com/Automattic/wp-calypso/assets/4344253/fd7ef433-2f04-4ff1-8420-0f25e5a6c03c)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
