### PR TITLE
Plugin Management: Fix issue with auto managed plugin tooltip appearing on self-hosted sites.

### DIFF
--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -10,6 +10,7 @@ import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/ac
 import { togglePluginAutoUpdate } from 'calypso/state/plugins/installed/actions';
 import { isPluginActionInProgress } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { AUTOMOMANAGED_PLUGINS, PREINSTALLED_PLUGINS } from '../constants';
 
 const autoUpdateActions = [ ENABLE_AUTOUPDATE_PLUGIN, DISABLE_AUTOUPDATE_PLUGIN ];
@@ -59,10 +60,10 @@ export class PluginAutoUpdateToggle extends Component {
 	};
 
 	isAutoManaged = () =>
-		( this.props.isMarketplaceProduct && this.props.productPurchase ) ||
-		( this.props.site?.is_wpcom_atomic &&
-			PREINSTALLED_PLUGINS.includes( this.props.plugin.slug ) ) ||
-		AUTOMOMANAGED_PLUGINS.includes( this.props.plugin.slug );
+		this.props.siteAutomatedTransfer &&
+		( ( this.props.isMarketplaceProduct && this.props.productPurchase ) ||
+			PREINSTALLED_PLUGINS.includes( this.props.plugin.slug ) ||
+			AUTOMOMANAGED_PLUGINS.includes( this.props.plugin.slug ) );
 
 	getDisabledInfo() {
 		const { site, wporg, translate } = this.props;
@@ -193,6 +194,7 @@ PluginAutoUpdateToggle.defaultProps = {
 export default connect(
 	( state, { site, plugin } ) => ( {
 		inProgress: plugin && isPluginActionInProgress( state, site.ID, plugin.id, autoUpdateActions ),
+		siteAutomatedTransfer: isSiteAutomatedTransfer( state, site.ID ),
 	} ),
 	{
 		recordGoogleEvent,

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -59,11 +59,18 @@ export class PluginAutoUpdateToggle extends Component {
 		}
 	};
 
-	isAutoManaged = () =>
-		this.props.siteAutomatedTransfer &&
-		( ( this.props.isMarketplaceProduct && this.props.productPurchase ) ||
-			PREINSTALLED_PLUGINS.includes( this.props.plugin.slug ) ||
-			AUTOMOMANAGED_PLUGINS.includes( this.props.plugin.slug ) );
+	isAutoManaged = () => {
+		const isPurchasedMarketplaceProduct =
+			this.props.isMarketplaceProduct && this.props.productPurchase;
+		const isPreinstalledPlugin = PREINSTALLED_PLUGINS.includes( this.props.plugin.slug );
+		const isAutomanagedPlugin = AUTOMOMANAGED_PLUGINS.includes( this.props.plugin.slug );
+
+		// Auto-managed are only applicable to sites that are part of an automated transfer.
+		return (
+			this.props.siteAutomatedTransfer &&
+			( isPurchasedMarketplaceProduct || isPreinstalledPlugin || isAutomanagedPlugin )
+		);
+	};
 
 	getDisabledInfo() {
 		const { site, wporg, translate } = this.props;

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -60,7 +60,8 @@ export class PluginAutoUpdateToggle extends Component {
 
 	isAutoManaged = () =>
 		( this.props.isMarketplaceProduct && this.props.productPurchase ) ||
-		PREINSTALLED_PLUGINS.includes( this.props.plugin.slug ) ||
+		( this.props.site?.is_wpcom_atomic &&
+			PREINSTALLED_PLUGINS.includes( this.props.plugin.slug ) ) ||
 		AUTOMOMANAGED_PLUGINS.includes( this.props.plugin.slug );
 
 	getDisabledInfo() {


### PR DESCRIPTION
Currently, in the Plugin Management UI, preinstalled plugins in the Atomic sites and not on the self-hosted site appear to be **auto-managed**. 

![219199741-63130ee1-55ae-4773-a8a6-1843d79ef278](https://github.com/Automattic/wp-calypso/assets/56598660/8d6fdb44-5cf0-46bf-91c2-de78fba351eb)


Related to https://github.com/Automattic/wp-calypso/issues/73403

## Proposed Changes

* Update `isAutoManaged` to only consider preinstalled plugins for Atomic sites.

## Testing Instructions

**Self-hosted sites**
* Spin up a JN site and connect it to the Jetpack cloud. Make sure there is Jetpack or any plugins that are preinstalled on Atomic sites (e.g., Akismet, Gutenberg, etc. )
* Use the Jetpack Cloud or Calypso live link and goto `/plugins/manage/<JN site>.`
* Confirm that the Jetpack or any preinstalled plugins on Atomic sites do not appear as **auto-managed** in the JN site.
<img width="1395" alt="Screen Shot 2023-05-24 at 3 02 35 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a3cb75b5-7e23-4703-95e2-1ccab06cce28">

**Atomic sites**
* Spin up an Atomic site by creating a new WordPress site in WPCOM with a Business plan. This should convert your site to an Atomic site
* Use the Calypso live link and goto `/plugins/manage/<JN site>.`
* Confirm that the Jetpack or any preinstalled plugins on Atomic sites are auto-managed.
<img width="1401" alt="Screen Shot 2023-05-24 at 3 05 36 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/801d7a03-1329-4ded-b409-e08cc6626e38">


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React, or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
