### PR TITLE
PoC of changing the style variation circles

### DIFF
--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -49,6 +49,7 @@ export interface StyleVariationPreviewColorPalette {
 	primary?: string;
 	secondary?: string;
 	tertiary?: string;
+	gradient?: string;
 }
 
 export interface StyleVariationStylesColor {


### PR DESCRIPTION
Tried to get a closer algorithm to the 'style tile' algorithm.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

**Related to https://github.com/Automattic/dotcom-forge/issues/2436 go there for discussion on the output**

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use link below
* Go to wordpress.com/themes
* Look at the style circles, are they more enticing? are they accurate?
* Take a look at any other PoCs linked from https://github.com/Automattic/dotcom-forge/issues/2436 do they give better results?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
