### PR TITLE
Extend editor iframe click redirection for modals to fix link in the sharing modal

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -29,9 +29,10 @@ let addedListener = false;
 // Replicates basic '$( el ).on( selector, cb )'.
 function addEditorListener( selector, cb ) {
 	clickOverrides[ selector ] = cb;
-
 	if ( ! addedListener ) {
-		document.querySelector( '#editor' )?.addEventListener( 'click', triggerOverrideHandler );
+		document
+			.querySelector( 'body.is-iframed' )
+			?.addEventListener( 'click', triggerOverrideHandler );
 		addedListener = true;
 	}
 }


### PR DESCRIPTION
See slack discussion in p1684871473278599-slack-C03NLNTPZ2T and first attempt https://github.com/Automattic/wp-calypso/pull/77302

## Proposed Changes
When the editor is iframed inside of calypso, the default behavior of clicking links is that they would open in the editor iframe, not in the main browser frame. Therefore, we added code in the wpcom-block-editor that intercepts clicks to links and redirects them to the main browser window.

In https://github.com/Automattic/wp-calypso/pull/77302, I attempted to redirect clicks on a link inside a modal, but it didn't work. This is because the click events are currently attached to the `#editor` element, but modals are outside of that element, directly inside the `body`.

This PR moves the delegated click handler from the `#editor` element up to the `body` of the iframed editor so that all click events can be captured, including in modals.

## Testing Instructions
Sandbox the wpcom-block-editor
```
cd apps/wpcom-block-editor
yarn dev --sync
```
* On a sandboxed public site on wordpress.com, create a new post with the calypso editor i.e. https://wordpress.com/$site_slug/post
* Click publish, the sharing modal should appear
* Click the View Post link
* You should be taken to the correct link on your external site, not the https://wordpress.com/post/$site_slug/$id link

