### PR TITLE
Add tailored flows to logged out nav menu

### DIFF
--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -167,6 +167,9 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com/start/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		return isLoggedIn ? url : suffixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
 	},
+	'wordpress.com/setup/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
+		return isLoggedIn ? url : suffixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
+	},
 };
 
 function hasTrailingSlash( urlString: string ) {

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -441,6 +441,51 @@ const UniversalNavbarHeader = ( {
 												urlValue={ localizeUrl( '//wordpress.com/professional-email/' ) }
 												type="menu"
 											/>
+											{ isEnglishLocale && (
+												<ClickableItem
+													titleValue={ __( 'Website Design Services', __i18n_text_domain__ ) }
+													content={ __( 'Website Design Services', __i18n_text_domain__ ) }
+													urlValue={ localizeUrl( '//wordpress.com/built-by/?ref=main-menu' ) }
+													type="menu"
+													target="_self"
+												/>
+											) }
+											<ClickableItem
+												titleValue={ __( 'Link in Bio', __i18n_text_domain__ ) }
+												content={ __( 'Link in Bio', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl(
+													'//wordpress.com/setup/link-in-bio/intro?ref=main-menu',
+													locale,
+													isLoggedIn
+												) }
+												type="menu"
+											/>
+											<ClickableItem
+												titleValue={ __( 'Newsletter', __i18n_text_domain__ ) }
+												content={ __( 'Newsletter', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl(
+													'//wordpress.com/setup/newsletter/intro?ref=main-menu',
+													locale,
+													isLoggedIn
+												) }
+												type="menu"
+											/>
+											<ClickableItem
+												titleValue={ __( 'Video', __i18n_text_domain__ ) }
+												content={ __( 'Video', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl(
+													'//wordpress.com/setup/videopress/intro?ref=main-menu',
+													locale,
+													isLoggedIn
+												) }
+												type="menu"
+											/>
+											<ClickableItem
+												titleValue={ __( 'Course', __i18n_text_domain__ ) }
+												content={ __( 'Course', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl( '//wordpress.com/create-a-course/' ) }
+												type="menu"
+											/>
 											<ClickableItem
 												titleValue={ __( 'Enterprise', __i18n_text_domain__ ) }
 												content={ __( 'Enterprise', __i18n_text_domain__ ) }

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -110,6 +110,57 @@ const UniversalNavbarHeader = ( {
 															type="dropdown"
 															target="_self"
 														/>
+														{ isEnglishLocale && (
+															<ClickableItem
+																titleValue={ __( 'Website Design Services', __i18n_text_domain__ ) }
+																content={ __( 'Website Design Services', __i18n_text_domain__ ) }
+																urlValue={ localizeUrl(
+																	'//wordpress.com/built-by/?ref=main-menu'
+																) }
+																type="dropdown"
+																target="_self"
+															/>
+														) }
+														<ClickableItem
+															titleValue={ __( 'Link in Bio', __i18n_text_domain__ ) }
+															content={ __( 'Link in Bio', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl(
+																'//wordpress.com/setup/link-in-bio/intro?ref=main-menu',
+																locale,
+																isLoggedIn
+															) }
+															type="dropdown"
+															target="_self"
+														/>
+														<ClickableItem
+															titleValue={ __( 'Newsletter', __i18n_text_domain__ ) }
+															content={ __( 'Newsletter', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl(
+																'//wordpress.com/setup/newsletter/intro?ref=main-menu',
+																locale,
+																isLoggedIn
+															) }
+															type="dropdown"
+															target="_self"
+														/>
+														<ClickableItem
+															titleValue={ __( 'Video', __i18n_text_domain__ ) }
+															content={ __( 'Video', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl(
+																'//wordpress.com/setup/videopress/intro?ref=main-menu',
+																locale,
+																isLoggedIn
+															) }
+															type="dropdown"
+															target="_self"
+														/>
+														<ClickableItem
+															titleValue={ __( 'Course', __i18n_text_domain__ ) }
+															content={ __( 'Course', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl( '//wordpress.com/create-a-course/' ) }
+															type="dropdown"
+															target="_self"
+														/>
 													</ul>
 													<div className="x-dropdown-content-separator"></div>
 													<ul>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2491

## Proposed Changes

* Add tailored flows to the logged out nav menu
*  Known pages to be reflected: `/themes`, `/plugins,`/tags`

![themes](https://github.com/Automattic/wp-calypso/assets/6586048/cdd7e2e0-8ebc-434c-9e2e-22139faac7a9)
![themes mobile](https://github.com/Automattic/wp-calypso/assets/6586048/c1486125-f487-40cb-a60c-394de823cb0a)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* checkout to this branch
* Check nav menu for `/themes`, `/plugins,`/tags`
* Make sure the items are added for desktop and mobile
* Switch to a different locale e.g., `/plugins?locale=es`
* See if the links are localized

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
