### PR TITLE
Jetpack Pro Dashboard: implement show/hide the "Verified" badge with a 10-sec duration

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -20,6 +20,7 @@ interface Props {
 	allEmailItems: Array< StateMonitorSettingsEmail >;
 	setAllEmailItems: ( emailAddresses: Array< StateMonitorSettingsEmail > ) => void;
 	recordEvent: ( action: string, params?: object ) => void;
+	setVerifiedEmail: ( item: string ) => void;
 }
 
 export default function EmailAddressEditor( {
@@ -29,6 +30,7 @@ export default function EmailAddressEditor( {
 	allEmailItems,
 	setAllEmailItems,
 	recordEvent,
+	setVerifiedEmail,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -113,6 +115,7 @@ export default function EmailAddressEditor( {
 	const handleAddVerifiedEmail = () => {
 		recordEvent( 'downtime_monitoring_email_already_verified' );
 		handleSetEmailItems();
+		setVerifiedEmail( emailItem.email );
 	};
 
 	const onSave = ( event: React.FormEvent< HTMLFormElement > ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-item-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-item-content.tsx
@@ -15,6 +15,7 @@ interface Props {
 	toggleModal?: ( item?: StateMonitorSettingsEmail, action?: AllowedMonitorContactActions ) => void;
 	isRemoveAction?: boolean;
 	recordEvent?: ( action: string, params?: object ) => void;
+	showVerifiedBadge?: boolean;
 }
 
 const EVENT_NAMES = {
@@ -28,6 +29,7 @@ export default function EmailItemContent( {
 	toggleModal,
 	isRemoveAction = false,
 	recordEvent,
+	showVerifiedBadge,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -42,8 +44,6 @@ export default function EmailItemContent( {
 	const closeDropdown = () => {
 		setIsOpen( false );
 	};
-
-	const showVerified = true; // FIXME: This should be dynamic.
 
 	const handleToggleModal = ( action: AllowedMonitorContactActions ) => {
 		toggleModal?.( item, action );
@@ -76,7 +76,7 @@ export default function EmailItemContent( {
 								<Badge type="warning">{ translate( 'Pending' ) }</Badge>
 							</span>
 						) }
-						{ showVerified && item.verified && (
+						{ showVerifiedBadge && item.verified && (
 							<span className="configure-email-address__verification-status">
 								<Badge type="success">{ translate( 'Verified' ) }</Badge>
 							</span>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -13,12 +13,14 @@ interface Props {
 	toggleModal: ( item?: StateMonitorSettingsEmail, action?: AllowedMonitorContactActions ) => void;
 	allEmailItems: Array< StateMonitorSettingsEmail >;
 	recordEvent: ( action: string, params?: object ) => void;
+	verifiedEmail: string | undefined;
 }
 
 export default function ConfigureEmailNotification( {
 	toggleModal,
 	allEmailItems,
 	recordEvent,
+	verifiedEmail,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -35,6 +37,7 @@ export default function ConfigureEmailNotification( {
 					item={ item }
 					toggleModal={ toggleModal }
 					recordEvent={ recordEvent }
+					showVerifiedBadge={ item.email === verifiedEmail }
 				/>
 			) ) }
 			<Button

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 	toggleModal: ( item?: StateMonitorSettingsEmail, action?: AllowedMonitorContactActions ) => void;
 	allEmailItems: Array< StateMonitorSettingsEmail >;
 	recordEvent: ( action: string, params?: object ) => void;
-	verifiedEmail: string | undefined;
+	verifiedEmail?: string;
 }
 
 export default function ConfigureEmailNotification( {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -5,7 +5,11 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
 import SelectDropdown from 'calypso/components/select-dropdown';
-import { useUpdateMonitorSettings, useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
+import {
+	useUpdateMonitorSettings,
+	useJetpackAgencyDashboardRecordTrackEvent,
+	useShowVerifiedBadge,
+} from '../../hooks';
 import {
 	availableNotificationDurations as durations,
 	getSiteCountText,
@@ -45,6 +49,7 @@ export default function NotificationSettings( {
 	const translate = useTranslate();
 	const { updateMonitorSettings, isLoading, isComplete } = useUpdateMonitorSettings( sites );
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( sites, isLargeScreen );
+	const { verifiedItem, handleSetVerifiedItem } = useShowVerifiedBadge();
 
 	const defaultDuration = durations.find( ( duration ) => duration.time === 5 );
 
@@ -186,6 +191,7 @@ export default function NotificationSettings( {
 				allEmailItems={ allEmailItems }
 				setAllEmailItems={ setAllEmailItems }
 				recordEvent={ recordEvent }
+				setVerifiedEmail={ ( item ) => handleSetVerifiedItem( 'email', item ) }
 			/>
 		);
 	}
@@ -298,6 +304,7 @@ export default function NotificationSettings( {
 							toggleModal={ toggleAddEmailModal }
 							allEmailItems={ allEmailItems }
 							recordEvent={ recordEvent }
+							verifiedEmail={ verifiedItem?.email }
 						/>
 					) }
 				</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -1,7 +1,7 @@
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState, useContext, useEffect, RefObject } from 'react';
+import { useCallback, useState, useContext, useEffect, RefObject, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -429,4 +429,27 @@ export const useDashboardAddRemoveLicense = ( siteId: number, type: AllowedTypes
 	};
 
 	return { isLicenseSelected, handleAddLicenseAction };
+};
+
+const TIMEOUT_DURATION = 10000;
+
+export const useShowVerifiedBadge = () => {
+	const [ verifiedItem, setVerifiedItem ] = useState< { [ key: string ]: string } | undefined >();
+
+	const timeoutIdRef = useRef< ReturnType< typeof setTimeout > | undefined >();
+
+	const handleSetVerifiedItem = useCallback(
+		( type: string, item: string ) => {
+			if ( verifiedItem ) {
+				clearTimeout( timeoutIdRef.current );
+			}
+			setVerifiedItem( { [ type ]: item } );
+			timeoutIdRef.current = setTimeout( () => {
+				setVerifiedItem( undefined );
+			}, TIMEOUT_DURATION );
+		},
+		[ verifiedItem ]
+	);
+
+	return { verifiedItem, handleSetVerifiedItem };
 };


### PR DESCRIPTION
Related to 1204408201748644-as-1204610622637448

## Proposed Changes

This PR implements show/hide the "Verified" badge with a 10-sec duration.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/show-email-verified-badge-for-10sec` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Set the below lines to `emails` in the `useFetchMonitorVerfiedContacts` hook - line 16 to see the extra email addresses.

```
emails: [
	{
		verified: true,
		value: 'testemail@email.com',
	},
        {
		verified: true,
		value: 'testemail1@email.com',
	},
]
```

6. Click the `+ Add email address` button -> Enter the name and email `testemail@email.com` -> Click `Verify` and ensure the email is added to the list with a `Verified` badge. The badge should disappear in 10 seconds.

7. Try adding another verified email(testemail1@email.com) within 10 sec, the previously set badge should disappear as soon as the new email is added, and the badge should be shown for the newly added email address.

<img width="447" alt="Screenshot 2023-05-19 at 11 42 10 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/de70ff50-9f35-4241-940d-ab96c9cace50">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?