### PR TITLE
Theme Card: Update style variation badge color rendering

### DIFF
--- a/packages/design-picker/src/components/style-variation-badges/utils.ts
+++ b/packages/design-picker/src/components/style-variation-badges/utils.ts
@@ -2,7 +2,6 @@ import { hexToRgb } from '@automattic/onboarding';
 import type {
 	StyleVariation,
 	StyleVariationSettingsColorPalette,
-	StyleVariationPreviewColorPalette,
 	StyleVariationStylesColor,
 } from '../../types';
 
@@ -16,11 +15,9 @@ function getColors( variation: StyleVariation ) {
 	return variation.settings?.color?.palette?.theme || [];
 }
 
-function getColorBaseFromColors( colors: StyleVariationPreviewColorPalette[] ) {
-	const background = colors.find(
-		( item: StyleVariationSettingsColorPalette ) => item.slug === 'background'
-	);
-	const base = colors.find( ( item: StyleVariationSettingsColorPalette ) => item.slug === 'base' );
+function getColorBaseFromColors( colors: StyleVariationSettingsColorPalette[] ) {
+	const background = colors.find( ( item ) => item.slug === 'background' );
+	const base = colors.find( ( item ) => item.slug === 'base' );
 	return base?.color || background?.color || '#ffffff';
 }
 

--- a/packages/design-picker/src/components/style-variation-badges/utils.ts
+++ b/packages/design-picker/src/components/style-variation-badges/utils.ts
@@ -1,4 +1,4 @@
-import { hexToRgb, hasMinContrast } from '@automattic/onboarding';
+import { hexToRgb } from '@automattic/onboarding';
 import type {
 	StyleVariation,
 	StyleVariationSettingsColorPalette,
@@ -6,42 +6,104 @@ import type {
 	StyleVariationStylesColor,
 } from '../../types';
 
-const COLOR_PALETTE_SUPPORTS = [ 'background', 'base', 'contrast', 'foreground', 'primary' ];
-
-function getValueFromVariationSettingColorPalette(
-	variation: StyleVariation,
-	name: string
-): string | undefined {
-	const palette = variation.settings?.color?.palette?.theme || [];
-	return palette.find( ( item: StyleVariationSettingsColorPalette ) => item.slug === name )?.color;
+interface Hsl {
+	h: number;
+	s: number;
+	l: number;
 }
 
-function getColorBackground( color: StyleVariationPreviewColorPalette ) {
-	return color.base || color.background || '#ffffff';
+function getColors( variation: StyleVariation ) {
+	return variation.settings?.color?.palette?.theme || [];
 }
 
-function getColorText( color: StyleVariationPreviewColorPalette ) {
-	const { contrast, foreground, primary } = color;
-	if ( contrast ) {
-		const backgroundRgb = hexToRgb( getColorBackground( color ) );
-		const contrastRgb = hexToRgb( contrast );
-		return hasMinContrast( contrastRgb, backgroundRgb, 0.2 ) ? contrast : foreground || primary;
+function getColorBaseFromColors( colors: StyleVariationPreviewColorPalette[] ) {
+	const background = colors.find(
+		( item: StyleVariationSettingsColorPalette ) => item.slug === 'background'
+	);
+	const base = colors.find( ( item: StyleVariationSettingsColorPalette ) => item.slug === 'base' );
+	return base?.color || background?.color || '#ffffff';
+}
+
+// See: https://en.wikipedia.org/wiki/HSL_and_HSV#From_RGB
+function hexToHsl( hexCode: string ) {
+	const { r, g, b } = hexToRgb( hexCode );
+	const max = Math.max( r, g, b );
+	const min = Math.min( r, g, b );
+	const l = ( max + min ) / 2;
+	let h = 0;
+	let s = 0;
+
+	if ( max !== min ) {
+		const c = max - min;
+		s = l > 0.5 ? c / ( 2 - max - min ) : c / ( max + min );
+
+		switch ( max ) {
+			case r:
+				h = ( g - b ) / c + ( g < b ? 6 : 0 );
+				break;
+
+			case g:
+				h = ( b - r ) / c + 2;
+				break;
+
+			case b:
+				h = ( r - g ) / c + 4;
+				break;
+
+				h /= 6;
+		}
 	}
 
-	return foreground || primary;
+	return { h, s, l };
+}
+
+function getColorAnalogous( { h, s, l }: Hsl ) {
+	const hA = ( h + 1 / 12 ) % 1;
+	const hB = ( h - 1 / 12 + 1 ) % 1;
+	return [
+		{ h: hA, s, l },
+		{ h: hB, s, l },
+	];
+}
+
+function getHslDifference( hslA: Hsl, hslB: Hsl ) {
+	const { h: hA, s: sA, l: lA } = hslA;
+	const { h: hB, s: sB, l: lB } = hslB;
+	return Math.abs( hA - hB ) + Math.abs( sA - sB ) + Math.abs( lA - lB );
+}
+
+function findColorLeastAnalogous( hexCodes: string[], baseHex: string ) {
+	const baseHsl = hexToHsl( baseHex );
+	const analogous = getColorAnalogous( baseHsl );
+
+	let maxHslDifference = -Infinity;
+	let leastAnalogous = '';
+	for ( const hex of hexCodes ) {
+		const hsl = hexToHsl( hex );
+		const hslDifference = Math.max(
+			getHslDifference( analogous[ 0 ], hsl ),
+			getHslDifference( analogous[ 1 ], hsl )
+		);
+
+		if ( hslDifference > maxHslDifference ) {
+			maxHslDifference = hslDifference;
+			leastAnalogous = hex;
+		}
+	}
+
+	return leastAnalogous;
 }
 
 export function getStylesColorFromVariation(
 	variation: StyleVariation
 ): StyleVariationStylesColor {
-	let color: StyleVariationPreviewColorPalette = {};
-	for ( const key of COLOR_PALETTE_SUPPORTS ) {
-		const value = getValueFromVariationSettingColorPalette( variation, key );
-		color = { ...color, ...( value && { [ key ]: value } ) };
-	}
+	const palette = getColors( variation );
+	const colorBase = getColorBaseFromColors( palette );
+	const colorList = palette.map( ( item ) => item.color );
+	const foregroundColor = findColorLeastAnalogous( colorList, colorBase );
 
 	return {
-		background: getColorBackground( color ),
-		text: getColorText( color ),
+		background: colorBase,
+		text: foregroundColor,
 	};
 }

--- a/packages/design-picker/src/components/style-variation-badges/utils.ts
+++ b/packages/design-picker/src/components/style-variation-badges/utils.ts
@@ -105,7 +105,8 @@ function findColorBestAnalogous( hexCodes: string[], baseHex: string ) {
 export function getStylesColorFromVariation(
 	variation: StyleVariation
 ): StyleVariationStylesColor {
-	const colorBase = getColorBaseFromColors( getColors( variation ) );
+	const palette = getColors( variation );
+	const colorBase = getColorBaseFromColors( palette );
 	const colorList = palette.map( ( item ) => item.color );
 
 	return {


### PR DESCRIPTION
## Proposed Changes

This PR proposed a programmatic approach to the color rendering of style variation badges. The implementation extracts the HSL values of the style variation colors, and finds the best HSL contrast. The "best" HSL contrast value is defined by trial-and-error, anchored somewhere around the middle of 255. 

| Before | After |
| --- | --- |
| ![Screenshot 2023-05-25 at 4 27 47 PM](https://github.com/Automattic/wp-calypso/assets/797888/daae13af-7e9e-4f90-8118-ecc417965031) |  ![Screenshot 2023-05-25 at 4 28 09 PM](https://github.com/Automattic/wp-calypso/assets/797888/5fd6ecf6-5555-4df7-9c2b-570e18e47060)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase or the Onboarding Design Picker.
* Ensure that the new style variation badges are not broken because of calculation errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
