### PR TITLE
Revert "Checkout: remove annual features from the "what's included" List when picking a monthly plan on tailored flows

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -178,12 +178,7 @@ function CheckoutSummaryFeaturesWrapper( props: {
 	}
 
 	if ( signupFlowName && shouldUseFlowFeatureList ) {
-		return (
-			<CheckoutSummaryFlowFeaturesList
-				flowName={ signupFlowName }
-				nextDomainIsFree={ nextDomainIsFree }
-			/>
-		);
+		return <CheckoutSummaryFlowFeaturesList flowName={ signupFlowName } />;
 	}
 
 	return <CheckoutSummaryFeaturesList siteId={ siteId } nextDomainIsFree={ nextDomainIsFree } />;
@@ -384,39 +379,14 @@ function CheckoutSummaryFeaturesList( props: {
 	);
 }
 
-function CheckoutSummaryFlowFeaturesList( {
-	flowName,
-	nextDomainIsFree,
-}: {
-	flowName: string;
-	nextDomainIsFree: boolean;
-} ) {
+function CheckoutSummaryFlowFeaturesList( { flowName }: { flowName: string } ) {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const planInCart = responseCart.products.find( ( product ) => isPlan( product ) );
-	const hasDomainsInCart = responseCart.products.some(
-		( product ) => isDomainProduct( product ) || isDomainTransfer( product )
-	);
-	const domains = responseCart.products.filter(
-		( product ) => isDomainProduct( product ) || isDomainTransfer( product )
-	);
-	const hasRenewalInCart = responseCart.products.some(
-		( product ) => product.extra.purchaseType === 'renewal'
-	);
-	const planFeatures = getFlowPlanFeatures(
-		flowName,
-		planInCart,
-		hasDomainsInCart,
-		hasRenewalInCart,
-		nextDomainIsFree
-	);
+	const planFeatures = getFlowPlanFeatures( flowName, planInCart );
 
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
-			{ hasDomainsInCart &&
-				domains.map( ( domain ) => {
-					return <CheckoutSummaryFeaturesListDomainItem domain={ domain } key={ domain.uuid } />;
-				} ) }
 			{ planFeatures.map( ( feature ) => {
 				return (
 					<CheckoutSummaryFeaturesListItem key={ `feature-list-${ feature.getSlug() }` }>

--- a/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
@@ -1,8 +1,4 @@
-import {
-	applyTestFiltersToPlansList,
-	getPlan,
-	FEATURE_CUSTOM_DOMAIN,
-} from '@automattic/calypso-products';
+import { getPlan } from '@automattic/calypso-products';
 import { ResponseCartProduct } from '@automattic/shopping-cart';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import {
@@ -12,24 +8,15 @@ import {
 
 export default function getFlowPlanFeatures(
 	flowName: string,
-	product: ResponseCartProduct | undefined,
-	hasDomainsInCart: boolean,
-	hasRenewalInCart: boolean,
-	nextDomainIsFree: boolean
+	plan: ResponseCartProduct | undefined
 ) {
-	const productSlug = product?.product_slug;
+	const productSlug = plan?.product_slug;
 
 	if ( ! productSlug ) {
 		return [];
 	}
 
-	const plan = getPlan( productSlug );
-
-	if ( ! plan ) {
-		return [];
-	}
-
-	const planConstantObj = applyTestFiltersToPlansList( plan, undefined );
+	const planConstantObj = getPlan( productSlug );
 
 	if ( ! planConstantObj ) {
 		return [];
@@ -46,15 +33,10 @@ export default function getFlowPlanFeatures(
 	}
 
 	const highlightedFeatures = getHighlightedFeatures( flowName, planConstantObj );
-	const showFreeDomainFeature = ! hasDomainsInCart && ! hasRenewalInCart && nextDomainIsFree;
-	return getPlanFeaturesObject( ( featureAccessor as () => string[] )() )
-		.filter( ( feature ) => {
-			return showFreeDomainFeature || feature.getSlug() !== FEATURE_CUSTOM_DOMAIN;
-		} )
-		.map( ( feature ) => {
-			return {
-				...feature,
-				isHighlightedFeature: highlightedFeatures.includes( feature.getSlug() ),
-			};
-		} );
+	return getPlanFeaturesObject( featureAccessor() ).map( ( feature ) => {
+		return {
+			...feature,
+			isHighlightedFeature: highlightedFeatures.includes( feature.getSlug() ),
+		};
+	} );
 }

--- a/client/my-sites/plan-features-comparison/util.ts
+++ b/client/my-sites/plan-features-comparison/util.ts
@@ -15,7 +15,7 @@ const linkInBioFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
 };
 
 const hostingFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
-	return isHostingFlow( flowName ) && plan.getHostingSignupFeatures;
+	return isHostingFlow( flowName ) && plan.getHostingSignupFeatures?.( plan.term );
 };
 
 const signupFlowDefaultFeatures = (


### PR DESCRIPTION

This reverts commit 5f382d584a840cabfac394a6522a9d45e5dd37f0.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
