### PR TITLE
Support Links: Adding time to read learn more link

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
@@ -97,6 +97,8 @@ const blockLinks: { [ key: string ]: string } = {
 
 	'core/comments': 'https://wordpress.com/support/full-site-editing/theme-blocks/comments-block/',
 
+	'core/post-time-to-read':
+		'https://wordpress.com/support/site-editing/theme-blocks/time-to-read-block',
 	/**
 	 * A8C and CO Blocks
 	 */


### PR DESCRIPTION
## What
Adding a `Learn More` link to the `Time to Read` block in the editor

## Testing
1. Checkout branch and `yarn dev --sync` from `apps/editing-toolkit`
2. Open the editor and insert a Time to Read block.
3. Check that the link is `https://wordpress.com/support/site-editing/theme-blocks/time-to-read-block`

Fixes https://github.com/Automattic/wp-calypso/issues/77308