### PR TITLE
GF: Update Facebook tracking to supply billing_frequency for yearly or higher plans

### DIFF
--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -289,12 +289,28 @@ function recordOrderInFacebook( cart, orderId, wpcomJetpackCartInfo ) {
 	// WPCom
 	if ( wpcomJetpackCartInfo.containsWpcomProducts ) {
 		if ( null !== wpcomJetpackCartInfo.wpcomCostUSD && wpcomJetpackCartInfo.wpcomCostUSD > 0 ) {
+			// This gives us the billing frequency as a string, and combines yearly and multi-yearly into one bucket.
+			// Due to tracking-constraints in Facebook, this is needed. But we also supply the bill_period separately
+			// as this is used for other tracking purposes in Facebook.
+			const getFrequencyTypeForProduct = ( product ) => {
+				switch ( product.bill_period ) {
+					case '31':
+						return 'monthly';
+					case '365':
+					case '730':
+					case '1095':
+						return 'yearly_or_higher';
+					default:
+						return 'other';
+				}
+			};
 			const cartItemsArray = wpcomJetpackCartInfo.wpcomProducts.map( ( product ) => {
 				return {
 					product_slug: product.product_slug ?? '',
 					id: product.product_id ?? '',
 					product_name: product.product_name ?? '',
 					bill_period: product.bill_period ?? 0,
+					billing_frequency: getFrequencyTypeForProduct( product ),
 					is_sale_coupon_applied: product.is_sale_coupon_applied ?? false,
 					is_bundled: product.is_bundled ?? false,
 					is_domain_registration: product.is_domain_registration ?? false,


### PR DESCRIPTION
Closes Automattic/Martech#1753

## Proposed Changes
We already provide the billing term as a number. Still, due to the limited filtering options for custom conversions in the Facebook Ads Manager, we need to combine 1y, 2y, and 3y billing terms under `yearly_or_higher` in a new prop called `billing_frequency`. 

Doing this will allow us to filter on `is_plan` and `billing_frequency` while still keeping the bill_period intact (for other uses in Facebook).


## Testing Instructions
* Check out this branch locally. Allow for ad-tracking and cookie-banner flags (either via URL, or by toggling them in `development.json`
* Add a `debugger;` statement inside `wpcomJetpackCartInfo.containsWpcomProducts` in `recordOrderInFacebook` at the end of the block. You can start Calypso with source maps (`SOURCEMAP=eval-source-map yarn start`). It's not needed, but makes it easier to read the code around the debugger statement.
* Go through /start, buy a yearly plan (with store sandboxed, credits won't work).
* Once the execution pauses (on the `debugger`) verify that the shape of the object and the values are as expected (see screenshot 1 below).
* Continue in the debugger, and you should see a request to Facebook as shown in screenshot 2. Verify that the object contains the `billing_frequency` and that the value is as expected.

![Screenshot 2023-05-24 at 13 33 56](https://github.com/Automattic/wp-calypso/assets/52675688/7bdbece5-ca22-4520-af24-085f6f8c7808)

![Screenshot 2023-05-24 at 13 34 24](https://github.com/Automattic/wp-calypso/assets/52675688/57997188-9194-40cb-b82f-1e69608860a5)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
