### PR TITLE
Added launchpad feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -102,6 +102,7 @@
 		"jetpack-social/multiple-connections": true,
 		"jitms": true,
 		"lasagna": true,
+		"launchpad-updates": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -64,6 +64,7 @@
 		"jetpack-social/multiple-connections": false,
 		"jitms": true,
 		"lasagna": true,
+		"launchpad-updates": false,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/production.json
+++ b/config/production.json
@@ -76,6 +76,7 @@
 		"jetpack-social/multiple-connections": false,
 		"jitms": true,
 		"lasagna": true,
+		"launchpad-updates": false,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -71,6 +71,7 @@
 		"jetpack-social/multiple-connections": false,
 		"jitms": true,
 		"lasagna": true,
+		"launchpad-updates": false,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/test.json
+++ b/config/test.json
@@ -59,6 +59,7 @@
 		"jetpack-social/multiple-connections": false,
 		"jitms": true,
 		"lasagna": false,
+		"launchpad-updates": false,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -79,6 +79,7 @@
 		"jetpack-social/multiple-connections": false,
 		"jitms": true,
 		"lasagna": true,
+		"launchpad-updates": false,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,


### PR DESCRIPTION
Closes [#74123](https://github.com/Automattic/wp-calypso/issues/77282)

## Proposed Changes

Add a `launchpad-updates` flag that's only enabled on dev.

## Testing Instructions

After switching to this branch, run `yarn feature-search launchpad`.

The output should look like this:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/fec3b3f7-6ec8-4f31-b2f8-c24b9661938f)
