### PR TITLE
Atomic transfer: do not dispatch `calypso_atomic_transfer_complete` event when polling status

### DIFF
--- a/client/state/data-layer/wpcom/sites/transfers/latest.js
+++ b/client/state/data-layer/wpcom/sites/transfers/latest.js
@@ -1,6 +1,5 @@
 import { delay } from 'lodash';
 import { ATOMIC_TRANSFER_REQUEST } from 'calypso/state/action-types';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchAtomicTransfer, setAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
 import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
@@ -29,12 +28,6 @@ export const receiveTransfer =
 		}
 
 		if ( status === transferStates.COMPLETED ) {
-			dispatch(
-				recordTracksEvent( 'calypso_atomic_transfer_complete', {
-					transfer_id: transfer.atomic_transfer_id,
-				} )
-			);
-
 			// Update the now-atomic site to ensure plugin page displays correctly.
 			dispatch( requestSite( siteId ) );
 		}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/77186

## Proposed Changes

I missed this spot in https://github.com/Automattic/wp-calypso/pull/77186. We should not dispatch the transfer complete Tracks event when polling the transfer status. This tracking is done on the back-end (D111446-code).

## Testing Instructions

Pick any Atomic site, browse `/checkout/thank-you/%s`, and...

### On `trunk`

Verify that the `calypso_atomic_transfer_complete` event was dispatched.

### With this patch

Verify that the `calypso_atomic_transfer_complete` event was **NOT** dispatched.