### PR TITLE
Blog Onboarding: SiteIntent saving & post-publish fix for start-writing flow

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -41,7 +41,7 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 		if (
 			! isSavingPost &&
 			( isCurrentPostPublished || isCurrentPostScheduled ) &&
-			getCurrentPostRevisionsCount === 1
+			getCurrentPostRevisionsCount >= 1
 		) {
 			unsubscribe();
 

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -1,0 +1,233 @@
+import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
+import { DESIGN_FIRST_FLOW, replaceProductsInCart } from '@automattic/onboarding';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { useSelect, useDispatch, dispatch } from '@wordpress/data';
+import { useSelector } from 'react-redux';
+import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
+import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
+import {
+	AssertConditionResult,
+	AssertConditionState,
+	Flow,
+	ProvidedDependencies,
+} from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
+import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { freeSiteAddressType } from 'calypso/lib/domains/constants';
+import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { requestSiteAddressChange } from 'calypso/state/site-address-change/actions';
+
+const designFirst: Flow = {
+	name: DESIGN_FIRST_FLOW,
+	title: 'Blog',
+	useSteps() {
+		return [
+			{
+				slug: 'site-creation-step',
+				asyncComponent: () => import( './internals/steps-repository/site-creation-step' ),
+			},
+			{
+				slug: 'processing',
+				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
+			},
+			{
+				slug: 'domains',
+				asyncComponent: () => import( './internals/steps-repository/choose-a-domain' ),
+			},
+			{
+				slug: 'use-my-domain',
+				asyncComponent: () => import( './internals/steps-repository/use-my-domain' ),
+			},
+			{ slug: 'plans', asyncComponent: () => import( './internals/steps-repository/plans' ) },
+			{
+				slug: 'setup-blog',
+				asyncComponent: () => import( './internals/steps-repository/setup-blog' ),
+			},
+			{
+				slug: 'launchpad',
+				asyncComponent: () => import( './internals/steps-repository/launchpad' ),
+			},
+			{
+				slug: 'design-first-done',
+				asyncComponent: () => import( './internals/steps-repository/start-writing-done' ),
+			},
+		];
+	},
+
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
+		const siteSlug = useSiteSlug();
+		const { getDomainCartItem, getPlanCartItem } = useSelect(
+			( select ) => ( {
+				getDomainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem,
+				getPlanCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem,
+			} ),
+			[]
+		);
+		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
+		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
+		const state = useSelect(
+			( select ) => select( ONBOARD_STORE ) as OnboardSelect,
+			[]
+		).getState();
+		const site = useSite();
+
+		async function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, '', flowName, currentStep );
+			const returnUrl = `/setup/design-first/design-first-done?siteSlug=${ siteSlug }`;
+
+			switch ( currentStep ) {
+				case 'site-creation-step':
+					return navigate( 'processing' );
+				case 'processing': {
+					// If we just created a new site.
+					if ( ! providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
+						setSelectedSite( providedDependencies?.siteId );
+						setIntentOnSite( providedDependencies?.siteSlug, DESIGN_FIRST_FLOW );
+						saveSiteSettings( providedDependencies?.siteId, {
+							launchpad_screen: 'full',
+						} );
+
+						const siteOrigin = window.location.origin;
+
+						return redirect(
+							`https://${ providedDependencies?.siteSlug }/wp-admin/post-new.php?${ DESIGN_FIRST_FLOW }=true&origin=${ siteOrigin }`
+						);
+					}
+
+					// If the user's site has just been launched.
+					if ( providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
+						// Remove the site_intent.
+						setIntentOnSite( providedDependencies?.siteSlug, '' );
+
+						// If the user launched their site with a plan or domain in their cart, redirect them to
+						// checkout before sending them home.
+						if ( getPlanCartItem() || getDomainCartItem() ) {
+							const encodedReturnUrl = encodeURIComponent( returnUrl );
+
+							return window.location.assign(
+								`/checkout/${ encodeURIComponent(
+									( siteSlug as string ) ?? ''
+								) }?redirect_to=${ encodedReturnUrl }`
+							);
+						}
+						return window.location.replace( returnUrl );
+					}
+					return navigate( 'launchpad' );
+				}
+				case 'domains':
+					if ( siteSlug ) {
+						await updateLaunchpadSettings( siteSlug, {
+							checklist_statuses: { domain_upsell_deferred: true },
+						} );
+					}
+
+					if ( providedDependencies?.freeDomain ) {
+						const freeDomainSuffix = '.wordpress.com';
+						const newDomainName = String( providedDependencies?.domainName ).replace(
+							freeDomainSuffix,
+							''
+						);
+
+						if ( providedDependencies?.domainName ) {
+							await requestSiteAddressChange(
+								site?.ID,
+								newDomainName,
+								'wordpress.com',
+								siteSlug,
+								freeSiteAddressType.BLOG,
+								true,
+								false
+							)( dispatch, state );
+						}
+
+						const currentSiteSlug = String( providedDependencies?.domainName ?? siteSlug );
+
+						await replaceProductsInCart(
+							currentSiteSlug as string,
+							[ getPlanCartItem() ].filter( Boolean ) as MinimalRequestCartProduct[]
+						);
+
+						return window.location.assign(
+							`/setup/design-first/launchpad?siteSlug=${ currentSiteSlug }`
+						);
+					}
+
+					return navigate( 'plans' );
+				case 'use-my-domain':
+					if ( siteSlug ) {
+						await updateLaunchpadSettings( siteSlug, {
+							checklist_statuses: { domain_upsell_deferred: true },
+						} );
+					}
+					return navigate( 'plans' );
+				case 'plans':
+					if ( siteSlug ) {
+						await updateLaunchpadSettings( siteSlug, {
+							checklist_statuses: { plan_completed: true },
+						} );
+					}
+					if ( providedDependencies?.goToCheckout ) {
+						const items = [ getPlanCartItem(), getDomainCartItem() ].filter(
+							Boolean
+						) as MinimalRequestCartProduct[];
+
+						// Always replace items in the cart so we can remove old plan/domain items.
+						await replaceProductsInCart( siteSlug as string, items );
+					}
+					return navigate( 'launchpad' );
+				case 'setup-blog':
+					if ( siteSlug ) {
+						await updateLaunchpadSettings( siteSlug, {
+							checklist_statuses: { setup_blog: true },
+						} );
+					}
+					return navigate( 'launchpad' );
+				case 'launchpad':
+					return navigate( 'processing' );
+			}
+		}
+		return { submit };
+	},
+
+	useAssertConditions(): AssertConditionResult {
+		const flowName = this.name;
+		const isLoggedIn = useSelector( isUserLoggedIn );
+		const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
+		const locale = useLocale();
+		const currentPath = window.location.pathname;
+		const isSiteCreationStep =
+			currentPath.endsWith( 'setup/design-first/' ) ||
+			currentPath.includes( 'setup/design-first/site-creation-step' );
+		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
+
+		const logInUrl =
+			locale && locale !== 'en'
+				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Pick%20a%20design&redirect_to=/setup/${ flowName }`
+				: `/start/account/user?variationName=${ flowName }&pageTitle=Pick%20a%20design&redirect_to=/setup/${ flowName }`;
+
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+
+		if ( ! isLoggedIn ) {
+			redirect( logInUrl );
+			result = {
+				state: AssertConditionState.CHECKING,
+				message: `${ flowName } requires a logged in user`,
+			};
+		} else if ( userAlreadyHasSites && isSiteCreationStep ) {
+			// Redirect users with existing sites out of the flow as we create a new site as the first step in this flow.
+			// This prevents a bunch of sites being created accidentally.
+			redirect( `/post?${ DESIGN_FIRST_FLOW }=true` );
+			result = {
+				state: AssertConditionState.CHECKING,
+				message: `${ flowName } requires no preexisting sites`,
+			};
+		}
+
+		return result;
+	},
+};
+
+export default designFirst;

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -3,6 +3,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { DESIGN_FIRST_FLOW, replaceProductsInCart } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { useSelector } from 'react-redux';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
@@ -83,24 +84,27 @@ const designFirst: Flow = {
 					return navigate( 'processing' );
 				case 'processing': {
 					// If we just created a new site.
-					if ( ! providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
-						setSelectedSite( providedDependencies?.siteId );
-						setIntentOnSite( providedDependencies?.siteSlug, DESIGN_FIRST_FLOW );
-						saveSiteSettings( providedDependencies?.siteId, {
+					const siteSlug = providedDependencies?.siteSlug;
+					if ( ! providedDependencies?.blogLaunched && siteSlug ) {
+						const siteId = providedDependencies?.siteId;
+						setSelectedSite( siteId );
+						setIntentOnSite( siteSlug, DESIGN_FIRST_FLOW );
+						saveSiteSettings( siteId, {
 							launchpad_screen: 'full',
 						} );
 
-						const siteOrigin = window.location.origin;
-
-						return redirect(
-							`https://${ providedDependencies?.siteSlug }/wp-admin/post-new.php?${ DESIGN_FIRST_FLOW }=true&origin=${ siteOrigin }`
+						return window.location.assign(
+							addQueryArgs( `/setup/update-design/designSetup`, {
+								siteSlug: siteSlug,
+								flowToReturnTo: flowName,
+							} )
 						);
 					}
 
 					// If the user's site has just been launched.
-					if ( providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
+					if ( providedDependencies?.blogLaunched && siteSlug ) {
 						// Remove the site_intent.
-						setIntentOnSite( providedDependencies?.siteSlug, '' );
+						setIntentOnSite( siteSlug, '' );
 
 						// If the user launched their site with a plan or domain in their cart, redirect them to
 						// checkout before sending them home.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { ProductsList } from '@automattic/data-stores';
-import { START_WRITING_FLOW } from '@automattic/onboarding';
+import {
+	DESIGN_FIRST_FLOW,
+	START_WRITING_FLOW,
+	isDesignFirstFlow,
+	isStartWritingFlow,
+} from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
@@ -23,7 +28,6 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	const { goNext, goBack, submit } = navigation;
 	const { __ } = useI18n();
 	const isVideoPressFlow = 'videopress' === flow;
-	const isStartWritingFlow = 'start-writing' === flow;
 	const { siteTitle, domain, productsList } = useSelect(
 		( select ) => ( {
 			siteTitle: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteTitle(),
@@ -50,7 +54,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	};
 
 	const onSkip = async () => {
-		if ( isStartWritingFlow ) {
+		if ( isStartWritingFlow( flow ) || isDesignFirstFlow( flow ) ) {
 			setDomain( null );
 			setDomainCartItem( undefined );
 			setHideFreePlan( false );
@@ -64,11 +68,11 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		recordUseYourDomainButtonClick( flow );
 		const siteSlug = getQueryArg( window.location.search, 'siteSlug' );
 		window.location.assign(
-			addQueryArgs( `/setup/${ START_WRITING_FLOW }/use-my-domain`, {
+			addQueryArgs( `/setup/${ flow }/use-my-domain`, {
 				siteSlug,
 				flowToReturnTo: flow,
 				domainAndPlanPackage: true,
-				[ START_WRITING_FLOW ]: true,
+				[ flow ]: true,
 			} )
 		);
 	};
@@ -172,7 +176,8 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		switch ( flow ) {
 			case 'videopress':
 				return getVideoPressFlowStepContent();
-			case 'start-writing':
+			case START_WRITING_FLOW:
+			case DESIGN_FIRST_FLOW:
 				return getStartWritingFlowStepContent();
 			default:
 				return getDefaultStepContent();
@@ -201,7 +206,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 			);
 		}
 
-		if ( isStartWritingFlow ) {
+		if ( isStartWritingFlow( flow ) || isDesignFirstFlow( flow ) ) {
 			return (
 				<FormattedHeader
 					id="choose-a-domain-writer-header"
@@ -228,7 +233,9 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 			<QueryProductsList />
 			<StepContainer
 				stepName="chooseADomain"
-				shouldHideNavButtons={ isVideoPressFlow || isStartWritingFlow }
+				shouldHideNavButtons={
+					isVideoPressFlow || isStartWritingFlow( flow ) || isDesignFirstFlow( flow )
+				}
 				goBack={ goBack }
 				goNext={ goNext }
 				isHorizontalLayout={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -6,6 +6,7 @@ import {
 	BUILD_FLOW,
 	WRITE_FLOW,
 	START_WRITING_FLOW,
+	DESIGN_FIRST_FLOW,
 } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -77,14 +78,11 @@ const LaunchpadSitePreview = ( {
 	function getSitePreviewDefaultDevice( flow: string | null ) {
 		switch ( flow ) {
 			case NEWSLETTER_FLOW:
-				return DEVICE_TYPES.COMPUTER;
 			case FREE_FLOW:
-				return DEVICE_TYPES.COMPUTER;
 			case BUILD_FLOW:
-				return DEVICE_TYPES.COMPUTER;
 			case WRITE_FLOW:
-				return DEVICE_TYPES.COMPUTER;
 			case START_WRITING_FLOW:
+			case DESIGN_FIRST_FLOW:
 				return DEVICE_TYPES.COMPUTER;
 			default:
 				return DEVICE_TYPES.PHONE;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,6 +1,6 @@
 import { Gridicon, CircularProgressBar } from '@automattic/components';
 import { OnboardSelect, useLaunchpad } from '@automattic/data-stores';
-import { isStartWritingFlow } from '@automattic/onboarding';
+import { isDesignFirstFlow, isStartWritingFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useRef, useState } from '@wordpress/element';
 import { Icon, copy } from '@wordpress/icons';
@@ -66,7 +66,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	);
 
 	const showDomain =
-		! isStartWritingFlow( flow ) ||
+		! ( isStartWritingFlow( flow ) || isDesignFirstFlow( flow ) ) ||
 		( checklistStatuses?.domain_upsell_deferred === true && selectedDomain );
 
 	const isEmailVerified = useSelector( isCurrentUserEmailVerified );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -142,6 +142,7 @@
 
 // Launchpad - Sidebar heading text
 .start-writing,
+.design-first,
 .newsletter,
 .link-in-bio.launchpad,
 .link-in-bio-tld:not(.domains),
@@ -262,7 +263,8 @@
 
 }
 
-.start-writing .launchpad__sidebar-admin-link {
+.start-writing .launchpad__sidebar-admin-link,
+.design-first .launchpad__sidebar-admin-link {
 	display: none;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -42,6 +42,14 @@ export function getEnhancedTasks(
 		return [];
 	}
 
+	/**
+	 * Remove the first_post_published task from the task list if the flow is design-first.
+	 * This is temporary until we proper implement the editor flow.
+	 */
+	if ( isDesignFirstFlow( flow ) ) {
+		tasks = tasks.filter( ( task ) => task.id !== 'first_post_published' );
+	}
+
 	const enhancedTaskList: Task[] = [];
 
 	const productSlug =

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -45,7 +45,8 @@ export function getEnhancedTasks(
 	const enhancedTaskList: Task[] = [];
 
 	const productSlug =
-		( isStartWritingFlow( flow ) ? planCartProductSlug : null ) ?? site?.plan?.product_slug;
+		( isStartWritingFlow( flow ) || isDesignFirstFlow( flow ) ? planCartProductSlug : null ) ??
+		site?.plan?.product_slug;
 
 	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
 
@@ -53,7 +54,7 @@ export function getEnhancedTasks(
 
 	const planCompleted =
 		Boolean( tasks?.find( ( task ) => task.id === 'plan_completed' )?.completed ) ||
-		! isStartWritingFlow( flow );
+		! ( isStartWritingFlow( flow ) || isDesignFirstFlow( flow ) );
 
 	const videoPressUploadCompleted = Boolean(
 		tasks?.find( ( task ) => task.id === 'video_uploaded' )?.completed
@@ -276,7 +277,8 @@ export function getEnhancedTasks(
 					break;
 				case 'blog_launched':
 					taskData = {
-						disabled: isStartWritingFlow( flow ) && ! planCompleted,
+						disabled:
+							( isStartWritingFlow( flow ) || isDesignFirstFlow( flow ) ) && ! planCompleted,
 						actionDispatch: () => {
 							if ( site?.ID ) {
 								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -4,7 +4,7 @@ import {
 	PLAN_PREMIUM,
 	FEATURE_STYLE_CUSTOMIZATION,
 } from '@automattic/calypso-products';
-import { isNewsletterFlow, isStartWritingFlow, START_WRITING_FLOW } from '@automattic/onboarding';
+import { isDesignFirstFlow, isNewsletterFlow, isStartWritingFlow } from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -95,8 +95,8 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								addQueryArgs( `/setup/${ START_WRITING_FLOW }/setup-blog`, {
-									...{ siteSlug: siteSlug, 'start-writing': true },
+								addQueryArgs( `/setup/${ flow }/setup-blog`, {
+									...{ siteSlug: siteSlug },
 								} )
 							);
 						},
@@ -155,8 +155,8 @@ export function getEnhancedTasks(
 					taskData = {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							const plansUrl = addQueryArgs( `/setup/${ START_WRITING_FLOW }/plans`, {
-								...{ siteSlug: siteSlug, 'start-writing': true },
+							const plansUrl = addQueryArgs( `/setup/${ flow }/plans`, {
+								...{ siteSlug: siteSlug },
 							} );
 
 							window.location.assign( plansUrl );
@@ -338,14 +338,13 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id );
 
-							if ( isStartWritingFlow( flow || null ) ) {
+							if ( isStartWritingFlow( flow ) || isDesignFirstFlow( flow ) ) {
 								window.location.assign(
-									addQueryArgs( `/setup/${ START_WRITING_FLOW }/domains`, {
+									addQueryArgs( `/setup/${ flow }/domains`, {
 										siteSlug,
 										flowToReturnTo: flow,
 										new: site?.name,
 										domainAndPlanPackage: true,
-										[ START_WRITING_FLOW ]: true,
 									} )
 								);
 
@@ -362,7 +361,9 @@ export function getEnhancedTasks(
 							window.location.assign( destinationUrl );
 						},
 						badge_text:
-							domainUpsellCompleted || isStartWritingFlow( flow || null )
+							domainUpsellCompleted ||
+							isStartWritingFlow( flow || null ) ||
+							isDesignFirstFlow( flow || null )
 								? ''
 								: translate( 'Upgrade plan' ),
 					};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -184,6 +184,18 @@ describe( 'Sidebar', () => {
 		expect( renderedDomain ).toBeNull();
 	} );
 
+	it( 'design-first flow does not display the current site url', () => {
+		renderSidebar( {
+			...props,
+			flow: 'design-first',
+		} );
+
+		const renderedDomain = screen.queryByText( ( content ) =>
+			content.includes( secondAndTopLevelDomain )
+		);
+		expect( renderedDomain ).toBeNull();
+	} );
+
 	it( 'displays customize badge for wpcom domains (free)', () => {
 		renderSidebar( props );
 		expect( screen.getByRole( 'link', { name: upgradeDomainBadgeText } ) ).toHaveAttribute(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { NEWSLETTER_FLOW, START_WRITING_FLOW } from '@automattic/onboarding';
+import { DESIGN_FIRST_FLOW, NEWSLETTER_FLOW, START_WRITING_FLOW } from '@automattic/onboarding';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import nock from 'nock';
@@ -93,6 +93,32 @@ jest.mock( '@automattic/data-stores', () => ( {
 						completed: false,
 						disabled: false,
 						title: 'Choose a plan',
+					},
+					{
+						id: 'blog_launched',
+						completed: false,
+						disabled: false,
+						title: 'Launch your blog',
+					},
+				];
+				break;
+
+			case 'design-first':
+				checklist = [
+					{ id: 'select_design', completed: false, disabled: false, title: 'Select a design' },
+					{ id: 'setup_blog', completed: false, disabled: false, title: 'Name your blog' },
+					{ id: 'domain_upsell', completed: false, disabled: false, title: 'Choose a domain' },
+					{
+						id: 'plan_completed',
+						completed: false,
+						disabled: false,
+						title: 'Choose a plan',
+					},
+					{
+						id: 'first_post_published',
+						completed: false,
+						disabled: false,
+						title: 'Write your first post',
 					},
 					{
 						id: 'blog_launched',
@@ -254,6 +280,47 @@ describe( 'StepContent', () => {
 
 		it( 'renders web preview section', () => {
 			renderStepContent( false, START_WRITING_FLOW );
+
+			expect( screen.getByTitle( 'Preview' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'when flow is Design first', () => {
+		beforeEach( () => {
+			mockSite.options.site_intent = DESIGN_FIRST_FLOW;
+		} );
+		it( 'renders correct sidebar header content', () => {
+			renderStepContent( false, DESIGN_FIRST_FLOW );
+
+			expect( screen.getByText( "Your blog's almost ready!" ) ).toBeInTheDocument();
+			expect(
+				screen.getByText( 'Keep up the momentum with these final steps.' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'renders correct sidebar tasks', () => {
+			renderStepContent( false, START_WRITING_FLOW );
+
+			expect( screen.getByText( 'Select a design' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Name your blog' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Choose a domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Choose a plan' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Write your first post' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Launch your blog' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders correct status for each task', () => {
+			renderStepContent( false, DESIGN_FIRST_FLOW );
+
+			const setupBlogListItem = screen.getByText( 'Name your blog' ).closest( 'li' );
+			expect( setupBlogListItem ).toHaveClass( 'pending' );
+
+			const choosePlanListItem = screen.getByText( 'Choose a plan' ).closest( 'li' );
+			expect( choosePlanListItem ).toHaveClass( 'pending' );
+		} );
+
+		it( 'renders web preview section', () => {
+			renderStepContent( false, DESIGN_FIRST_FLOW );
 
 			expect( screen.getByTitle( 'Preview' ) ).toBeInTheDocument();
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -7,6 +7,7 @@ import {
 	WRITE_FLOW,
 	BUILD_FLOW,
 	START_WRITING_FLOW,
+	DESIGN_FIRST_FLOW,
 } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 import { TranslatedLaunchpadStrings } from './types';
@@ -45,6 +46,7 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 			translatedStrings.launchTitle = translate( 'Your site is almost ready!' );
 			break;
 		case START_WRITING_FLOW:
+		case DESIGN_FIRST_FLOW:
 			translatedStrings.flowName = translate( 'Blog' );
 			translatedStrings.title = translate( "Your blog's almost ready!" );
 			translatedStrings.launchTitle = translate( "Your blog's almost ready!" );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -1,8 +1,9 @@
 import { is2023PricingGridActivePage } from '@automattic/calypso-products';
 import {
-	DOMAIN_UPSELL_FLOW,
+	isDesignFirstFlow,
+	isDomainUpsellFlow,
 	isHostingSiteCreationFlow,
-	START_WRITING_FLOW,
+	isStartWritingFlow,
 	StepContainer,
 } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -18,7 +19,7 @@ const plans: Step = function Plans( { navigation, flow } ) {
 			plan,
 		};
 
-		if ( flow === DOMAIN_UPSELL_FLOW || flow === START_WRITING_FLOW ) {
+		if ( isDomainUpsellFlow( flow ) || isStartWritingFlow( flow ) || isDesignFirstFlow( flow ) ) {
 			providedDependencies.goToCheckout = true;
 		}
 
@@ -26,7 +27,7 @@ const plans: Step = function Plans( { navigation, flow } ) {
 	};
 	const is2023PricingGridVisible = is2023PricingGridActivePage( window );
 
-	const isAllowedToGoBack = flow === DOMAIN_UPSELL_FLOW || isHostingSiteCreationFlow( flow );
+	const isAllowedToGoBack = isDomainUpsellFlow( flow ) || isHostingSiteCreationFlow( flow );
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -21,6 +21,8 @@ import {
 	LINK_IN_BIO_FLOW,
 	HOSTING_SITE_CREATION_FLOW,
 	isHostingSiteCreationFlow,
+	isDesignFirstFlow,
+	isDomainUpsellFlow,
 } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
@@ -189,6 +191,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		if (
 			isNewsletterFlow( flowName ) ||
 			isStartWritingFlow( flowName ) ||
+			isDesignFirstFlow( flowName ) ||
 			isLinkInBioFlow( flowName )
 		) {
 			return __( `There's a plan for you.` );
@@ -208,19 +211,13 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			<Button onClick={ handleFreePlanButtonClick } className="is-borderless" />
 		);
 
-		if ( isStartWritingFlow( flowName ) ) {
-			return;
-		}
-
-		if ( isNewsletterFlow( flowName ) ) {
-			return;
-		}
-
-		if ( isLinkInBioFlow( flowName ) ) {
-			return;
-		}
-
-		if ( flowName === DOMAIN_UPSELL_FLOW ) {
+		if (
+			isStartWritingFlow( flowName ) ||
+			isDesignFirstFlow( flowName ) ||
+			isNewsletterFlow( flowName ) ||
+			isLinkInBioFlow( flowName ) ||
+			isDomainUpsellFlow( flowName )
+		) {
 			return;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -23,6 +23,7 @@ import {
 	isHostingSiteCreationFlow,
 	isDesignFirstFlow,
 	isDomainUpsellFlow,
+	DESIGN_FIRST_FLOW,
 } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
@@ -54,6 +55,7 @@ interface Props {
 function getPlanTypes( flowName: string | null, hideFreePlan: boolean ) {
 	switch ( flowName ) {
 		case START_WRITING_FLOW:
+		case DESIGN_FIRST_FLOW:
 			return hideFreePlan
 				? [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS ]
 				: [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-blog/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-blog/index.tsx
@@ -1,4 +1,4 @@
-import { StepContainer, isStartWritingFlow } from '@automattic/onboarding';
+import { StepContainer } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
@@ -37,7 +37,7 @@ const SetupBlog: Step = ( { navigation, flow } ) => {
 
 	useEffect( () => {
 		// Clear site title and show placeholder for the flows below
-		if ( isStartWritingFlow( flow ) && siteTitle === 'Site Title' ) {
+		if ( siteTitle === 'Site Title' ) {
 			setComponentSiteTitle( '' );
 		}
 	}, [ flow, setComponentSiteTitle, siteTitle ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -13,6 +13,7 @@ import {
 	isStartWritingFlow,
 	isWooExpressFlow,
 	isHostingSiteCreationFlow,
+	isDesignFirstFlow,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -103,6 +104,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		isLinkInBioFlow( flow ) ||
 		isMigrationFlow( flow ) ||
 		isStartWritingFlow( flow ) ||
+		isDesignFirstFlow( flow ) ||
 		isHostingSiteCreationFlow( flow ) ||
 		wooFlows.includes( flow || '' )
 	) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { useDispatch } from '@wordpress/data';
 import { getQueryArg } from '@wordpress/url';
-import { StepContainer } from 'calypso/../packages/onboarding/src';
+import {
+	DESIGN_FIRST_FLOW,
+	START_WRITING_FLOW,
+	StepContainer,
+	isStartWritingFlow,
+} from 'calypso/../packages/onboarding/src';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { useMyDomainInputMode as inputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import UseMyDomainComponent from 'calypso/components/domains/use-my-domain';
@@ -16,7 +21,6 @@ import './style.scss';
 const UseMyDomain: Step = function UseMyDomain( { navigation, flow } ) {
 	const { setHideFreePlan, setDomainCartItem } = useDispatch( ONBOARD_STORE );
 	const { goNext, goBack, submit } = navigation;
-	const isStartWritingFlow = 'start-writing' === flow;
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
 
 	const handleOnTransfer = async ( domain: string, authCode: string ) => {
@@ -64,7 +68,8 @@ const UseMyDomain: Step = function UseMyDomain( { navigation, flow } ) {
 
 	const getStepContent = () => {
 		switch ( flow ) {
-			case 'start-writing':
+			case START_WRITING_FLOW:
+			case DESIGN_FIRST_FLOW:
 				return getStartWritingFlowStepContent();
 			default:
 				return getDefaultStepContent();
@@ -76,7 +81,7 @@ const UseMyDomain: Step = function UseMyDomain( { navigation, flow } ) {
 			<QueryProductsList />
 			<StepContainer
 				stepName="useMyDomain"
-				shouldHideNavButtons={ isStartWritingFlow }
+				shouldHideNavButtons={ isStartWritingFlow( flow ) }
 				goBack={ goBack }
 				goNext={ goNext }
 				isHorizontalLayout={ false }

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -3,6 +3,7 @@ import {
 	START_WRITING_FLOW,
 	CONNECT_DOMAIN_FLOW,
 	HOSTING_SITE_CREATION_FLOW,
+	DESIGN_FIRST_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -79,6 +80,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	[ START_WRITING_FLOW ]: () =>
 		import( /* webpackChunkName: "start-writing-flow" */ './start-writing' ),
+
+	[ DESIGN_FIRST_FLOW ]: () =>
+		import( /* webpackChunkName: "design-first-flow" */ './design-first' ),
 
 	[ CONNECT_DOMAIN_FLOW ]: () =>
 		import( /* webpackChunkName: "connect-domain" */ '../declarative-flow/connect-domain' ),

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -85,10 +85,12 @@ const startWriting: Flow = {
 					// If we just created a new site.
 					if ( ! providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
 						setSelectedSite( providedDependencies?.siteId );
-						setIntentOnSite( providedDependencies?.siteSlug, START_WRITING_FLOW );
-						saveSiteSettings( providedDependencies?.siteId, {
-							launchpad_screen: 'full',
-						} );
+						await Promise.all( [
+							setIntentOnSite( providedDependencies?.siteSlug, START_WRITING_FLOW ),
+							saveSiteSettings( providedDependencies?.siteId, {
+								launchpad_screen: 'full',
+							} ),
+						] );
 
 						const siteOrigin = window.location.origin;
 

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -102,6 +102,10 @@ export const is2023PricingGridActivePage = (
 		return isPricingGridEnabled;
 	}
 
+	if ( currentRoutePath.startsWith( '/setup/design-first' ) ) {
+		return isPricingGridEnabled;
+	}
+
 	// Is this the stepper Plan step on the newsletter flow?
 	if ( currentRoutePath.startsWith( '/setup/newsletter/plans' ) ) {
 		return isPricingGridEnabled;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -97,8 +97,17 @@ export const isWriteFlow = ( flowName: string | null ) => {
 export const isUpdateDesignFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ UPDATE_DESIGN_FLOW ].includes( flowName ) );
 };
+
 export const isStartWritingFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ START_WRITING_FLOW ].includes( flowName ) );
+};
+
+export const isDesignFirstFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ DESIGN_FIRST_FLOW ].includes( flowName ) );
+};
+
+export const isDomainUpsellFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ DOMAIN_UPSELL_FLOW ].includes( flowName ) );
 };
 
 export const isSiteAssemblerFlow = ( flowName: string | null ) => {

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -19,6 +19,7 @@ export const COPY_SITE_FLOW = 'copy-site';
 export const BUILD_FLOW = 'build';
 export const WRITE_FLOW = 'write';
 export const START_WRITING_FLOW = 'start-writing';
+export const DESIGN_FIRST_FLOW = 'design-first';
 export const SITE_SETUP_FLOW = 'site-setup';
 export const WITH_THEME_FLOW = 'with-theme';
 export const WITH_THEME_ASSEMBLER_FLOW = 'with-theme-assembler';


### PR DESCRIPTION

## Proposed Changes

Sometimes on iOS/Safari, the start-writing flow does not redirect to the Launchpad after clicking "publish" from the post editor, apparently, this is caused by some delay in writing and getting the `siteIntent`, and could also be because when saving the post, it has >1 revisions (because of auto-save).

- [x] Wait for the site-intent to be saved before redirecting to the editor
- [x] Redirect to launchpad when the revision count is >= 1

## Testing Instructions

* You have to use the Xcode simulator
* You have to sandbox `widgets.wp.com`
* Follow these instructions to sandbox Safari: PCYsg-e-p2#sandboxing-safari
* Go to: [/setup/start-writing](http://calypso.localhost:3000/setup/start-writing)
* Test using Safari with and without using private browsing.
* You should always be redirected to the launchpad after publishing the post

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?