### PR TITLE
Launchpad: Show "Choose a plan" task as completed when Global Styles are limited

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -63,10 +63,7 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 							/>
 						</div>
 					) }
-					<div className="launchpad__checklist-item-text-container">
-						<span className="launchpad__checklist-item-text">{ title }</span>
-						{ subtitle && <p className="launchpad__checklist-item-subtext">{ subtitle }</p> }
-					</div>
+					<span className="launchpad__checklist-item-text">{ title }</span>
 					{ task.badge_text ? <Badge type="info-blue">{ task.badge_text }</Badge> : null }
 					{ shouldDisplayChevron && (
 						<Gridicon
@@ -76,6 +73,7 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 							size={ 18 }
 						/>
 					) }
+					{ subtitle && <p className="launchpad__checklist-item-subtext">{ subtitle }</p> }
 				</Button>
 			) }
 		</li>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -6,7 +6,7 @@ import { Task } from './types';
 
 const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction?: boolean } ) => {
 	const isRtl = useRtl();
-	const { id, completed, disabled, title, subtitle, actionDispatch, warning } = task;
+	const { id, completed, disabled, title, subtitle, actionDispatch } = task;
 
 	// Display chevron if task is incomplete. Don't display chevron and badge at the same time.
 	const shouldDisplayChevron = ! completed && ! disabled && ! task.badge_text;
@@ -48,17 +48,6 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 								aria-label={ translate( 'Task complete' ) }
 								className="launchpad__checklist-item-checkmark"
 								icon="checkmark"
-								size={ 18 }
-							/>
-						</div>
-					) }
-					{ ! completed && warning && (
-						// show exclamation mark for tasks with warnings
-						<div className="launchpad__checklist-item-warning-container">
-							<Gridicon
-								aria-label={ translate( 'Task has a warning' ) }
-								className="launchpad__checklist-item-warning"
-								icon="notice-outline"
 								size={ 18 }
 							/>
 						</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -382,19 +382,14 @@
 	color: var(--color-text);
 }
 
-.launchpad__checklist-item-checkmark-container,
-.launchpad__checklist-item-warning-container {
+.launchpad__checklist-item-checkmark-container {
 	margin-right: 8px;
 	width: 20px;
 
-	.launchpad__checklist-item-checkmark,
-	.launchpad__checklist-item-warning {
+	.launchpad__checklist-item-checkmark {
 		top: 2px;
 		vertical-align: text-bottom;
 	}
-}
-.launchpad__checklist-item-warning {
-	fill: var(--color-warning);
 }
 
 // general styles

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -330,6 +330,7 @@
 	border-right: none;
 	border-top: none;
 	display: flex;
+	flex-wrap: wrap;
 	padding: 16px;
 	width: 100%;
 	margin: 0;
@@ -365,6 +366,7 @@
 
 .launchpad__checklist-item .badge,
 .launchpad__domain-upgrade-badge {
+	margin-left: auto;
 	background-color: var(--studio-blue-5);
 	color: var(--studio-blue-80);
 	font-size: $font-body-extra-small;
@@ -396,14 +398,17 @@
 }
 
 // general styles
-.launchpad__checklist-item-text-container {
-	flex-grow: 1;
-	font-size: $font-body-small;
-	line-height: 20px;
-	text-align: left;
-}
 .launchpad__checklist-item-text {
 	font-weight: 600;
+}
+
+.launchpad__checklist-item-subtext {
+	flex-basis: 100%;
+	margin-left: 28px;
+	margin-top: 8px;
+	text-align: left;
+	font-size: $font-body-small;
+	line-height: 20px;
 }
 
 .launchpad__task:nth-last-child(2) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -146,8 +146,7 @@ export function getEnhancedTasks(
 							} );
 							window.location.assign( plansUrl );
 						},
-						badgeText: isVideoPressFlowWithUnsupportedPlan ? null : translatedPlanName,
-						completed: task.completed && ! shouldDisplayWarning,
+						completed: task.completed && ! isVideoPressFlowWithUnsupportedPlan,
 						warning: shouldDisplayWarning,
 					};
 					break;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -147,7 +147,6 @@ export function getEnhancedTasks(
 							window.location.assign( plansUrl );
 						},
 						completed: task.completed && ! isVideoPressFlowWithUnsupportedPlan,
-						warning: shouldDisplayWarning,
 					};
 					break;
 				case 'plan_completed':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -19,33 +19,6 @@ describe( 'Task Helpers', () => {
 				).toEqual( fakeTasks );
 			} );
 		} );
-		describe( 'when it is plan_selected task', () => {
-			it( 'marks plan_selected as incomplete if styles used but not part of plan', () => {
-				const fakeTasks = [ buildTask( { id: 'plan_selected', completed: true } ) ];
-				const enhancedTasks = getEnhancedTasks(
-					fakeTasks,
-					'fake.wordpress.com',
-					null,
-					// eslint-disable-next-line @typescript-eslint/no-empty-function
-					() => {},
-					true
-				);
-				expect( enhancedTasks[ 0 ].completed ).toEqual( false );
-				expect( enhancedTasks[ 0 ].warning ).toEqual( true );
-			} );
-			it( 'leaves plan_selected if styles warning is unnecessary', () => {
-				const fakeTasks = [ buildTask( { id: 'plan_selected', completed: true } ) ];
-				const enhancedTasks = getEnhancedTasks(
-					fakeTasks,
-					'fake.wordpress.com',
-					null,
-					// eslint-disable-next-line @typescript-eslint/no-empty-function
-					() => {},
-					false
-				);
-				expect( enhancedTasks[ 0 ].completed ).toEqual( true );
-			} );
-		} );
 		describe( 'when creating the email verification task', () => {
 			describe( 'and the user email has been verified', () => {
 				it( 'marks the task as complete', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -7,7 +7,6 @@ export interface Task {
 	badge_text?: string;
 	actionDispatch?: () => void;
 	isLaunchTask?: boolean;
-	warning?: boolean;
 }
 
 export type LaunchpadChecklist = Task[];

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -287,10 +287,6 @@ body.is-videopress-stepper {
 			}
 		}
 
-		.launchpad__checklist-item-warning-container {
-			display: none;
-		}
-
 		.launchpad__checklist-item-subtext {
 			padding-right: 8px;
 		}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2262

## Proposed Changes

- Displays the "Choose a plan" task in the Launchpad as completed when Global Styles are limited, so it looks more positive.
- Removes the plan name from the badge text since it can confuse users (see pekYwv-1ax-p2#comment-1204). In a follow-up PR (https://github.com/Automattic/jetpack/pull/30906) we'll use "Upgrade plan" as badge text for cases where Global Styles are limited.

Before | After
--- | ---
<img width="390" alt="Screenshot 2023-05-24 at 18 01 09" src="https://github.com/Automattic/wp-calypso/assets/1233880/b78e3ecb-ca49-4f13-901c-291501d32101"> | <img width="402" alt="Screenshot 2023-05-24 at 18 01 41" src="https://github.com/Automattic/wp-calypso/assets/1233880/29358b79-d73b-4ac4-8f68-a54e3e6e0825">


## Testing Instructions

- Use the Calypso live link below.
- Go to `/setup/newsletter`.
- Pick a "premium" color.
- Complete the onboarding flow until you reach the launchpad step.
- Make sure the "Choose a plan" task is displayed as completed.
- Make sure the "Choose a plan" task does not have any badge.