### PR TITLE
Blog Onboarding: SiteIntent saving & post-publish fix for start-writing flow

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -41,7 +41,7 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 		if (
 			! isSavingPost &&
 			( isCurrentPostPublished || isCurrentPostScheduled ) &&
-			getCurrentPostRevisionsCount === 1
+			getCurrentPostRevisionsCount >= 1
 		) {
 			unsubscribe();
 

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -102,7 +102,7 @@ const startWriting: Flow = {
 					// If the user's site has just been launched.
 					if ( providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
 						// Remove the site_intent.
-						setIntentOnSite( providedDependencies?.siteSlug, '' );
+						await setIntentOnSite( providedDependencies?.siteSlug, '' );
 
 						// If the user launched their site with a plan or domain in their cart, redirect them to
 						// checkout before sending them home.

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -85,10 +85,12 @@ const startWriting: Flow = {
 					// If we just created a new site.
 					if ( ! providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
 						setSelectedSite( providedDependencies?.siteId );
-						setIntentOnSite( providedDependencies?.siteSlug, START_WRITING_FLOW );
-						saveSiteSettings( providedDependencies?.siteId, {
-							launchpad_screen: 'full',
-						} );
+						await Promise.all( [
+							setIntentOnSite( providedDependencies?.siteSlug, START_WRITING_FLOW ),
+							saveSiteSettings( providedDependencies?.siteId, {
+								launchpad_screen: 'full',
+							} ),
+						] );
 
 						const siteOrigin = window.location.origin;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2507

## Proposed Changes

Sometimes on iOS/Safari, the start-writing flow does not redirect to the Launchpad after clicking "publish" from the post editor, apparently, this is caused by some delay in writing and getting the `siteIntent`, and could also be because when saving the post, it has >1 revisions (because of auto-save).

- [x] Wait for the site-intent to be saved before redirecting to the editor
- [x] Redirect to launchpad when the revision count is >= 1


> **Note**
> Disable `Prevent Cross-Site Tracking` in iOS simulator Safari, because we are using different domains (calypso+wordpress)

![image](https://github.com/Automattic/wp-calypso/assets/402286/cc888393-fa77-4735-be52-9469dddf7523)


## Testing Instructions

* You have to use the Xcode simulator
* You have to sandbox `widgets.wp.com`
* Follow these instructions to sandbox Safari: PCYsg-e-p2#sandboxing-safari
* Go to: [/setup/start-writing](http://calypso.localhost:3000/setup/start-writing)
* Test using Safari with and without using private browsing.
* You should always be redirected to the launchpad after publishing the post

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?