### PR TITLE
Staging Sites: Add remaining Staging Site card content to storybook

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -1,0 +1,118 @@
+import { Button, Gridicon } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import SiteIcon from 'calypso/blocks/site-icon';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import { urlToSlug } from 'calypso/lib/url';
+import { DeleteStagingSite } from 'calypso/my-sites/hosting/staging-site-card/delete-staging-site';
+import { StagingSite } from 'calypso/my-sites/hosting/staging-site-card/use-staging-site';
+import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
+
+const SiteRow = styled.div( {
+	display: 'flex',
+	alignItems: 'center',
+	marginBottom: 24,
+	'.site-icon': { flexShrink: 0 },
+} );
+
+const SiteInfo = styled.div( {
+	display: 'flex',
+	flexDirection: 'column',
+	marginLeft: 10,
+} );
+
+const SiteNameContainer = styled.div( {
+	display: 'block',
+} );
+
+const SiteName = styled.a( {
+	fontWeight: 500,
+	marginInlineEnd: '8px',
+	'&:hover': {
+		textDecoration: 'underline',
+	},
+	'&, &:hover, &:visited': {
+		color: 'var( --studio-gray-100 )',
+	},
+} );
+
+const StagingSiteLink = styled.div( {
+	wordBreak: 'break-word',
+} );
+
+const ActionButtons = styled.div( {
+	display: 'flex',
+	gap: '1em',
+
+	'@media screen and (max-width: 768px)': {
+		gap: '0.5em',
+		flexDirection: 'column',
+		'.button': { flexGrow: 1 },
+	},
+} );
+
+type CardContentProps = {
+	stagingSite: StagingSite;
+	onDeleteClick: () => void;
+	isButtonDisabled: boolean;
+	isBusy: boolean;
+};
+
+export const ManageStagingSiteCardContent = ( {
+	stagingSite,
+	onDeleteClick,
+	isButtonDisabled,
+	isBusy,
+}: CardContentProps ) => {
+	{
+		const translate = useTranslate();
+		return (
+			<>
+				<p>
+					{ translate(
+						'Your staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}.',
+						{
+							components: {
+								a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,
+							},
+						}
+					) }
+				</p>
+				<SiteRow>
+					<SiteIcon siteId={ stagingSite.id } size={ 40 } />
+					<SiteInfo>
+						<SiteNameContainer>
+							<SiteName
+								href={ `/hosting-config/${ urlToSlug( stagingSite.url ) }` }
+								title={ translate( 'Visit Dashboard' ) }
+							>
+								{ stagingSite.name }
+							</SiteName>
+							<SitesStagingBadge>{ translate( 'Staging' ) }</SitesStagingBadge>
+						</SiteNameContainer>
+						<StagingSiteLink>
+							<a href={ stagingSite.url }>{ stagingSite.url }</a>
+						</StagingSiteLink>
+					</SiteInfo>
+				</SiteRow>
+				<ActionButtons>
+					<Button
+						primary
+						href={ `/hosting-config/${ urlToSlug( stagingSite.url ) }` }
+						disabled={ isButtonDisabled }
+					>
+						<span>{ translate( 'Manage staging site' ) }</span>
+					</Button>
+					<DeleteStagingSite
+						disabled={ isButtonDisabled }
+						onClickDelete={ onDeleteClick }
+						isBusy={ isBusy }
+					>
+						<Gridicon icon="trash" />
+						<span>{ translate( 'Delete staging site' ) }</span>
+					</DeleteStagingSite>
+				</ActionButtons>
+			</>
+		);
+	}
+};

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-site-loading-bar-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-site-loading-bar-card-content.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { LoadingBar } from 'calypso/components/loading-bar';
+
+const StyledLoadingBar = styled( LoadingBar )( {
+	marginBottom: '1em',
+} );
+
+type CardContentProps = {
+	isReverting: boolean;
+	isOwner: boolean;
+	progress: number;
+};
+
+export const StagingSiteLoadingBarCardContent = ( {
+	isReverting,
+	progress,
+	isOwner,
+}: CardContentProps ) => {
+	{
+		const translate = useTranslate();
+		if ( isReverting ) {
+			return (
+				<>
+					<StyledLoadingBar key="delete-loading-bar" progress={ progress } />
+					<p>{ translate( 'We are deleting your staging site.' ) }</p>
+				</>
+			);
+		}
+
+		const message = isOwner
+			? translate( 'We are setting up your staging site. We’ll email you once it is ready.' )
+			: translate(
+					'We are setting up the staging site. We’ll email the site owner once it is ready.'
+			  );
+		return (
+			<div data-testid="transferring-staging-content">
+				<StyledLoadingBar progress={ progress } />
+				<p>{ message }</p>
+			</div>
+		);
+	}
+};

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-site-loading-error-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-site-loading-error-card-content.tsx
@@ -2,16 +2,15 @@ import Notice from 'calypso/components/notice';
 
 type CardContentProps = {
 	message: string;
+	testId?: string;
 };
 
-export const StagingSiteLoadingErrorCardContent = ( { message }: CardContentProps ) => {
+export const StagingSiteLoadingErrorCardContent = ( { message, testId }: CardContentProps ) => {
 	{
 		return (
-			<>
-				<Notice status="is-error" showDismiss={ false }>
-					{ message }
-				</Notice>
-			</>
+			<Notice status="is-error" showDismiss={ false }>
+				<div data-testid={ testId }>{ message }</div>
+			</Notice>
 		);
 	}
 };

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-site-loading-error-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-site-loading-error-card-content.tsx
@@ -1,0 +1,17 @@
+import Notice from 'calypso/components/notice';
+
+type CardContentProps = {
+	message: string;
+};
+
+export const StagingSiteLoadingErrorCardContent = ( { message }: CardContentProps ) => {
+	{
+		return (
+			<>
+				<Notice status="is-error" showDismiss={ false }>
+					{ message }
+				</Notice>
+			</>
+		);
+	}
+};

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/manage-staging-site-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/manage-staging-site-card-content.stories.tsx
@@ -1,0 +1,71 @@
+import { action } from '@storybook/addon-actions';
+import { Story, Meta } from '@storybook/react';
+import { ComponentProps } from 'react';
+import { documentHeadStoreMock, ReduxDecorator } from 'calypso/__mocks__/storybook/redux';
+import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
+import { ManageStagingSiteCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content';
+
+/**
+ * Ideally, this component should depend only on local `./style.scss`. However, currently, some card styles are defined
+ * in hosting page CSS file, so we need to include it here.
+ */
+import '../../../style.scss';
+
+export default {
+	title: 'client/components/StagingSite',
+	component: ManageStagingSiteCardContent,
+	decorators: [
+		( Story ) => {
+			return (
+				<ReduxDecorator
+					store={ {
+						...documentHeadStoreMock,
+						sites: {
+							items: { 25: { ID: 25 } },
+						},
+					} }
+				>
+					<Story></Story>
+				</ReduxDecorator>
+			);
+		},
+		( Story ) => {
+			return (
+				<CardContentWrapper>
+					<Story></Story>
+				</CardContentWrapper>
+			);
+		},
+		( Story ) => {
+			return (
+				<div className="hosting" style={ { padding: '20px', backgroundColor: '#f6f7f7' } }>
+					<Story></Story>
+				</div>
+			);
+		},
+	],
+} as Meta;
+
+type ManageStagingSiteCardContentStory = Story<
+	ComponentProps< typeof ManageStagingSiteCardContent >
+>;
+const Template: ManageStagingSiteCardContentStory = ( args ) => {
+	return <ManageStagingSiteCardContent { ...args } />;
+};
+
+const defaultArgs = {
+	stagingSite: {
+		id: 25,
+		url: 'http://example.com',
+		name: 'Test Staging Site',
+		user_has_permission: true,
+	},
+	onDeleteClick: action( 'onClick' ),
+	isButtonDisabled: false,
+	isBusy: false,
+};
+
+export const ManageStagingSiteCard = Template.bind( {} );
+ManageStagingSiteCard.args = {
+	...defaultArgs,
+};

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/manage-staging-site-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/manage-staging-site-card-content.stories.tsx
@@ -12,7 +12,7 @@ import { ManageStagingSiteCardContent } from 'calypso/my-sites/hosting/staging-s
 import '../../../style.scss';
 
 export default {
-	title: 'client/components/StagingSite',
+	title: 'client/my-sites/hosting/StagingSiteCard',
 	component: ManageStagingSiteCardContent,
 	decorators: [
 		( Story ) => {

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/manage-staging-site-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/manage-staging-site-card-content.stories.tsx
@@ -65,7 +65,7 @@ const defaultArgs = {
 	isBusy: false,
 };
 
-export const ManageStagingSiteCard = Template.bind( {} );
-ManageStagingSiteCard.args = {
+export const ManageStagingSite = Template.bind( {} );
+ManageStagingSite.args = {
 	...defaultArgs,
 };

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/new-staging-site-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/new-staging-site-card-content.stories.tsx
@@ -12,7 +12,7 @@ import { NewStagingSiteCardContent } from '../new-staging-site-card-content';
 import '../../../style.scss';
 
 export default {
-	title: 'client/components/StagingSite',
+	title: 'client/my-sites/hosting/StagingSiteCard',
 	component: NewStagingSiteCardContent,
 	decorators: [
 		( Story ) => {

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/new-staging-site-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/new-staging-site-card-content.stories.tsx
@@ -50,13 +50,13 @@ const defaultArgs = {
 	showQuotaError: false,
 };
 
-export const NewStagingSiteCard = Template.bind( {} );
-NewStagingSiteCard.args = {
+export const NewStagingSite = Template.bind( {} );
+NewStagingSite.args = {
 	...defaultArgs,
 };
 
-export const NewStagingSiteCardWithQuotaError = Template.bind( {} );
-NewStagingSiteCardWithQuotaError.args = {
+export const NewStagingSiteWithQuotaError = Template.bind( {} );
+NewStagingSiteWithQuotaError.args = {
 	...defaultArgs,
 	isButtonDisabled: true,
 	showQuotaError: true,

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/new-staging-site-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/new-staging-site-card-content.stories.tsx
@@ -3,13 +3,13 @@ import { Story, Meta } from '@storybook/react';
 import { ComponentProps } from 'react';
 import { documentHeadStoreMock, ReduxDecorator } from 'calypso/__mocks__/storybook/redux';
 import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
-import { NewStagingSiteCardContent } from './card-content/new-staging-site-card-content';
+import { NewStagingSiteCardContent } from '../new-staging-site-card-content';
 
 /**
  * Ideally, this component should depend only on local `./style.scss`. However, currently, some card styles are defined
  * in hosting page CSS file, so we need to include it here.
  */
-import '../style.scss';
+import '../../../style.scss';
 
 export default {
 	title: 'client/components/StagingSite',

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-bar-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-bar-card-content.stories.tsx
@@ -1,0 +1,57 @@
+import { Story, Meta } from '@storybook/react';
+import { ComponentProps } from 'react';
+import { documentHeadStoreMock, ReduxDecorator } from 'calypso/__mocks__/storybook/redux';
+import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
+import { StagingSiteLoadingBarCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/staging-site-loading-bar-card-content';
+
+/**
+ * Ideally, this component should depend only on local `./style.scss`. However, currently, some card styles are defined
+ * in hosting page CSS file, so we need to include it here.
+ */
+import '../../../style.scss';
+
+export default {
+	title: 'client/my-sites/hosting/StagingSiteCard',
+	component: StagingSiteLoadingBarCardContent,
+	decorators: [
+		( Story ) => {
+			return (
+				<ReduxDecorator store={ { ...documentHeadStoreMock } }>
+					<Story></Story>
+				</ReduxDecorator>
+			);
+		},
+		( Story ) => {
+			return (
+				<CardContentWrapper>
+					<Story></Story>
+				</CardContentWrapper>
+			);
+		},
+		( Story ) => {
+			return (
+				<div className="hosting" style={ { padding: '20px', backgroundColor: '#f6f7f7' } }>
+					<Story></Story>
+				</div>
+			);
+		},
+	],
+} as Meta;
+
+type StagingSiteLoadingBarCardContentStory = Story<
+	ComponentProps< typeof StagingSiteLoadingBarCardContent >
+>;
+const Template: StagingSiteLoadingBarCardContentStory = ( args ) => {
+	return <StagingSiteLoadingBarCardContent { ...args } />;
+};
+
+const defaultArgs = {
+	isReverting: true,
+	progress: 10,
+	isOwner: true,
+};
+
+export const StagingSiteLoadingBarCard = Template.bind( {} );
+StagingSiteLoadingBarCard.args = {
+	...defaultArgs,
+};

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-bar-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-bar-card-content.stories.tsx
@@ -51,7 +51,7 @@ const defaultArgs = {
 	isOwner: true,
 };
 
-export const StagingSiteLoadingBarCard = Template.bind( {} );
-StagingSiteLoadingBarCard.args = {
+export const StagingSiteLoadingBar = Template.bind( {} );
+StagingSiteLoadingBar.args = {
 	...defaultArgs,
 };

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-bar-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-bar-card-content.stories.tsx
@@ -46,12 +46,24 @@ const Template: StagingSiteLoadingBarCardContentStory = ( args ) => {
 };
 
 const defaultArgs = {
-	isReverting: true,
+	isReverting: false,
 	progress: 10,
-	isOwner: true,
+	isOwner: false,
 };
 
 export const StagingSiteLoadingBar = Template.bind( {} );
 StagingSiteLoadingBar.args = {
 	...defaultArgs,
+};
+
+export const StagingSiteLoadingBarForOwner = Template.bind( {} );
+StagingSiteLoadingBarForOwner.args = {
+	...defaultArgs,
+	isOwner: true,
+};
+
+export const StagingSiteLoadingBarDeleting = Template.bind( {} );
+StagingSiteLoadingBarDeleting.args = {
+	...defaultArgs,
+	isReverting: true,
 };

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-error-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-error-card-content.stories.tsx
@@ -12,7 +12,7 @@ import { StagingSiteLoadingErrorCardContent } from 'calypso/my-sites/hosting/sta
 import '../../../style.scss';
 
 export default {
-	title: 'client/components/StagingSite',
+	title: 'client/my-sites/hosting/StagingSiteCard',
 	component: StagingSiteLoadingErrorCardContent,
 	decorators: [
 		( Story ) => {

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-error-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-error-card-content.stories.tsx
@@ -1,0 +1,55 @@
+import { Story, Meta } from '@storybook/react';
+import { ComponentProps } from 'react';
+import { documentHeadStoreMock, ReduxDecorator } from 'calypso/__mocks__/storybook/redux';
+import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
+import { StagingSiteLoadingErrorCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/staging-site-loading-error-card-content';
+
+/**
+ * Ideally, this component should depend only on local `./style.scss`. However, currently, some card styles are defined
+ * in hosting page CSS file, so we need to include it here.
+ */
+import '../../../style.scss';
+
+export default {
+	title: 'client/components/StagingSite',
+	component: StagingSiteLoadingErrorCardContent,
+	decorators: [
+		( Story ) => {
+			return (
+				<ReduxDecorator store={ { ...documentHeadStoreMock } }>
+					<Story></Story>
+				</ReduxDecorator>
+			);
+		},
+		( Story ) => {
+			return (
+				<CardContentWrapper>
+					<Story></Story>
+				</CardContentWrapper>
+			);
+		},
+		( Story ) => {
+			return (
+				<div className="hosting" style={ { padding: '20px', backgroundColor: '#f6f7f7' } }>
+					<Story></Story>
+				</div>
+			);
+		},
+	],
+} as Meta;
+
+type StagingSiteLoadingErrorCardContentStory = Story<
+	ComponentProps< typeof StagingSiteLoadingErrorCardContent >
+>;
+const Template: StagingSiteLoadingErrorCardContentStory = ( args ) => {
+	return <StagingSiteLoadingErrorCardContent { ...args } />;
+};
+
+const defaultArgs = {
+	message: 'Something went wrong',
+};
+
+export const StagingSiteLoadingErrorCard = Template.bind( {} );
+StagingSiteLoadingErrorCard.args = {
+	...defaultArgs,
+};

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-error-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-error-card-content.stories.tsx
@@ -1,4 +1,5 @@
 import { Story, Meta } from '@storybook/react';
+import { translate, TranslateOptionsText } from 'i18n-calypso';
 import { ComponentProps } from 'react';
 import { documentHeadStoreMock, ReduxDecorator } from 'calypso/__mocks__/storybook/redux';
 import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
@@ -46,7 +47,19 @@ const Template: StagingSiteLoadingErrorCardContentStory = ( args ) => {
 };
 
 const defaultArgs = {
-	message: 'Something went wrong',
+	message: translate(
+		'Unable to access the staging site {{a}}%(stagingSiteName)s{{/a}}. Please contact the site owner.',
+		{
+			args: {
+				stagingSiteName: 'Test Site',
+			},
+			components: {
+				a: <a href="http://example.com/" />,
+			},
+			textOnly: true,
+		} as TranslateOptionsText
+	) as string,
+	testId: 'staging-sites-access-message',
 };
 
 export const StagingSiteLoadingErrorCard = Template.bind( {} );

--- a/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-error-card-content.stories.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/stories/staging-site-loading-error-card-content.stories.tsx
@@ -62,7 +62,7 @@ const defaultArgs = {
 	testId: 'staging-sites-access-message',
 };
 
-export const StagingSiteLoadingErrorCard = Template.bind( {} );
-StagingSiteLoadingErrorCard.args = {
+export const StagingSiteLoadingError = Template.bind( {} );
+StagingSiteLoadingError.args = {
 	...defaultArgs,
 };

--- a/client/my-sites/hosting/staging-site-card/delete-staging-site.tsx
+++ b/client/my-sites/hosting/staging-site-card/delete-staging-site.tsx
@@ -5,8 +5,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 
 interface DeleteStagingSiteProps {
-	siteId: number;
-	stagingSiteId: number;
 	disabled: boolean;
 	children: React.ReactNode;
 	onClickDelete: () => void;

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -1,15 +1,14 @@
-import styled from '@emotion/styled';
 import { useQueryClient } from '@tanstack/react-query';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { localize } from 'i18n-calypso';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { connect, useDispatch } from 'react-redux';
-import { LoadingBar } from 'calypso/components/loading-bar';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
 import { ManageStagingSiteCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content';
 import { NewStagingSiteCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content';
+import { StagingSiteLoadingBarCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/staging-site-loading-bar-card-content';
 import { StagingSiteLoadingErrorCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/staging-site-loading-error-card-content';
 import { LoadingPlaceholder } from 'calypso/my-sites/hosting/staging-site-card/loading-placeholder';
 import { useAddStagingSiteMutation } from 'calypso/my-sites/hosting/staging-site-card/use-add-staging-site';
@@ -27,10 +26,6 @@ const stagingSiteAddSuccessNoticeId = 'staging-site-add-success';
 const stagingSiteAddFailureNoticeId = 'staging-site-add-failure';
 const stagingSiteDeleteSuccessNoticeId = 'staging-site-remove-success';
 const stagingSiteDeleteFailureNoticeId = 'staging-site-remove-failure';
-
-const StyledLoadingBar = styled( LoadingBar )( {
-	marginBottom: '1em',
-} );
 
 export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId, translate } ) => {
 	const { __ } = useI18n();
@@ -201,24 +196,14 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 	};
 
 	const getTransferringStagingSiteContent = useCallback( () => {
-		if ( isReverting ) {
-			return (
-				<>
-					<StyledLoadingBar key="delete-loading-bar" progress={ progress } />
-					<p>{ __( 'We are deleting your staging site.' ) }</p>
-				</>
-			);
-		}
-
-		const message =
-			siteOwnerId === currentUserId
-				? __( 'We are setting up your staging site. We’ll email you once it is ready.' )
-				: __( 'We are setting up the staging site. We’ll email the site owner once it is ready.' );
 		return (
-			<div data-testid="transferring-staging-content">
-				<StyledLoadingBar progress={ progress } />
-				<p>{ message }</p>
-			</div>
+			<>
+				<StagingSiteLoadingBarCardContent
+					isOwner={ siteOwnerId === currentUserId }
+					isReverting={ isReverting }
+					progress={ progress }
+				/>
+			</>
 		);
 	}, [ progress, __, siteOwnerId, currentUserId, isReverting ] );
 

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -14,6 +14,7 @@ import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpt
 import { urlToSlug } from 'calypso/lib/url';
 import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
 import { NewStagingSiteCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content';
+import { StagingSiteLoadingErrorCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/staging-site-loading-error-card-content';
 import { LoadingPlaceholder } from 'calypso/my-sites/hosting/staging-site-card/loading-placeholder';
 import { useAddStagingSiteMutation } from 'calypso/my-sites/hosting/staging-site-card/use-add-staging-site';
 import { useCheckStagingSiteStatus } from 'calypso/my-sites/hosting/staging-site-card/use-check-staging-site-status';
@@ -321,14 +322,6 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		);
 	}, [ progress, __, siteOwnerId, currentUserId, isReverting ] );
 
-	const getLoadingErrorContent = ( message ) => {
-		return (
-			<Notice status="is-error" showDismiss={ false }>
-				{ message }
-			</Notice>
-		);
-	};
-
 	const getAccessError = () => {
 		return (
 			<Notice status="is-error" showDismiss={ false }>
@@ -352,16 +345,20 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 	let stagingSiteCardContent;
 
 	if ( ! isLoadingStagingSites && loadingError ) {
-		stagingSiteCardContent = getLoadingErrorContent(
-			__(
-				'Unable to load staging sites. Please contact support if you believe you are seeing this message in error.'
-			)
+		stagingSiteCardContent = (
+			<StagingSiteLoadingErrorCardContent
+				message={ __(
+					'Unable to load staging sites. Please contact support if you believe you are seeing this message in error.'
+				) }
+			/>
 		);
 	} else if ( ! isLoadingQuotaValidation && isErrorValidQuota ) {
-		stagingSiteCardContent = getLoadingErrorContent(
-			__(
-				'Unable to validate your site quota. Please contact support if you believe you are seeing this message in error.'
-			)
+		stagingSiteCardContent = (
+			<StagingSiteLoadingErrorCardContent
+				message={ __(
+					'Unable to validate your site quota. Please contact support if you believe you are seeing this message in error.'
+				) }
+			/>
 		);
 	} else if ( ! wasCreating && ! hasSiteAccess && transferStatus !== null ) {
 		stagingSiteCardContent = getAccessError();

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -9,7 +9,6 @@ import { connect, useDispatch } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { LoadingBar } from 'calypso/components/loading-bar';
-import Notice from 'calypso/components/notice';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { urlToSlug } from 'calypso/lib/url';
 import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
@@ -322,26 +321,6 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		);
 	}, [ progress, __, siteOwnerId, currentUserId, isReverting ] );
 
-	const getAccessError = () => {
-		return (
-			<Notice status="is-error" showDismiss={ false }>
-				<div data-testid="staging-sites-access-message">
-					{ translate(
-						'Unable to access the staging site {{a}}%(stagingSiteName)s{{/a}}. Please contact the site owner.',
-						{
-							args: {
-								stagingSiteName: stagingSite.url,
-							},
-							components: {
-								a: <a href={ stagingSite.url } />,
-							},
-						}
-					) }
-				</div>
-			</Notice>
-		);
-	};
-
 	let stagingSiteCardContent;
 
 	if ( ! isLoadingStagingSites && loadingError ) {
@@ -361,7 +340,22 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 			/>
 		);
 	} else if ( ! wasCreating && ! hasSiteAccess && transferStatus !== null ) {
-		stagingSiteCardContent = getAccessError();
+		stagingSiteCardContent = (
+			<StagingSiteLoadingErrorCardContent
+				message={ translate(
+					'Unable to access the staging site {{a}}%(stagingSiteName)s{{/a}}. Please contact the site owner.',
+					{
+						args: {
+							stagingSiteName: stagingSite.url,
+						},
+						components: {
+							a: <a href={ stagingSite.url } />,
+						},
+					}
+				) }
+				testId="staging-sites-access-message"
+			/>
+		);
 	} else if ( addingStagingSite || isTrasferInProgress || isReverting ) {
 		stagingSiteCardContent = getTransferringStagingSiteContent();
 	} else if ( showManageStagingSite && isStagingSiteTransferComplete ) {

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -1,4 +1,3 @@
-import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useQueryClient } from '@tanstack/react-query';
 import { sprintf } from '@wordpress/i18n';
@@ -6,12 +5,10 @@ import { useI18n } from '@wordpress/react-i18n';
 import { localize } from 'i18n-calypso';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { connect, useDispatch } from 'react-redux';
-import SiteIcon from 'calypso/blocks/site-icon';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
-import { urlToSlug } from 'calypso/lib/url';
 import { CardContentWrapper } from 'calypso/my-sites/hosting/staging-site-card/card-content/card-content-wrapper';
+import { ManageStagingSiteCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content';
 import { NewStagingSiteCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content';
 import { StagingSiteLoadingErrorCardContent } from 'calypso/my-sites/hosting/staging-site-card/card-content/staging-site-loading-error-card-content';
 import { LoadingPlaceholder } from 'calypso/my-sites/hosting/staging-site-card/loading-placeholder';
@@ -19,13 +16,11 @@ import { useAddStagingSiteMutation } from 'calypso/my-sites/hosting/staging-site
 import { useCheckStagingSiteStatus } from 'calypso/my-sites/hosting/staging-site-card/use-check-staging-site-status';
 import { useHasValidQuotaQuery } from 'calypso/my-sites/hosting/staging-site-card/use-has-valid-quota';
 import { useStagingSite } from 'calypso/my-sites/hosting/staging-site-card/use-staging-site';
-import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
-import { DeleteStagingSite } from './delete-staging-site';
 import { useDeleteStagingSite } from './use-delete-staging-site';
 
 const stagingSiteAddSuccessNoticeId = 'staging-site-add-success';
@@ -35,49 +30,6 @@ const stagingSiteDeleteFailureNoticeId = 'staging-site-remove-failure';
 
 const StyledLoadingBar = styled( LoadingBar )( {
 	marginBottom: '1em',
-} );
-
-const ActionButtons = styled.div( {
-	display: 'flex',
-	gap: '1em',
-
-	'@media screen and (max-width: 768px)': {
-		gap: '0.5em',
-		flexDirection: 'column',
-		'.button': { flexGrow: 1 },
-	},
-} );
-
-const SiteRow = styled.div( {
-	display: 'flex',
-	alignItems: 'center',
-	marginBottom: 24,
-	'.site-icon': { flexShrink: 0 },
-} );
-
-const SiteInfo = styled.div( {
-	display: 'flex',
-	flexDirection: 'column',
-	marginLeft: 10,
-} );
-
-const SiteNameContainer = styled.div( {
-	display: 'block',
-} );
-
-const SiteName = styled.a( {
-	fontWeight: 500,
-	marginInlineEnd: '8px',
-	'&:hover': {
-		textDecoration: 'underline',
-	},
-	'&, &:hover, &:visited': {
-		color: 'var( --studio-gray-100 )',
-	},
-} );
-
-const StagingSiteLink = styled.div( {
-	wordBreak: 'break-word',
 } );
 
 export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId, translate } ) => {
@@ -248,57 +200,6 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		addStagingSite();
 	};
 
-	const getManageStagingSiteContent = () => {
-		return (
-			<>
-				<p>
-					{ translate(
-						'Your staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}.',
-						{
-							components: {
-								a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,
-							},
-						}
-					) }
-				</p>
-				<SiteRow>
-					<SiteIcon siteId={ stagingSite.id } size={ 40 } />
-					<SiteInfo>
-						<SiteNameContainer>
-							<SiteName
-								href={ `/hosting-config/${ urlToSlug( stagingSite.url ) }` }
-								title={ __( 'Visit Dashboard' ) }
-							>
-								{ stagingSite.name }
-							</SiteName>
-							<SitesStagingBadge>{ translate( 'Staging' ) }</SitesStagingBadge>
-						</SiteNameContainer>
-						<StagingSiteLink>
-							<a href={ stagingSite.url }>{ stagingSite.url }</a>
-						</StagingSiteLink>
-					</SiteInfo>
-				</SiteRow>
-				<ActionButtons>
-					<Button
-						primary
-						href={ `/hosting-config/${ urlToSlug( stagingSite.url ) }` }
-						disabled={ disabled }
-					>
-						<span>{ translate( 'Manage staging site' ) }</span>
-					</Button>
-					<DeleteStagingSite
-						disabled={ disabled }
-						onClickDelete={ deleteStagingSite }
-						isBusy={ isReverting }
-					>
-						<Gridicon icon="trash" />
-						<span>{ __( 'Delete staging site' ) }</span>
-					</DeleteStagingSite>
-				</ActionButtons>
-			</>
-		);
-	};
-
 	const getTransferringStagingSiteContent = useCallback( () => {
 		if ( isReverting ) {
 			return (
@@ -359,7 +260,14 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 	} else if ( addingStagingSite || isTrasferInProgress || isReverting ) {
 		stagingSiteCardContent = getTransferringStagingSiteContent();
 	} else if ( showManageStagingSite && isStagingSiteTransferComplete ) {
-		stagingSiteCardContent = getManageStagingSiteContent();
+		stagingSiteCardContent = (
+			<ManageStagingSiteCardContent
+				stagingSite={ stagingSite }
+				onDeleteClick={ deleteStagingSite }
+				isButtonDisabled={ disabled }
+				isBusy={ isReverting }
+			/>
+		);
 	} else if ( showAddStagingSite && ! addingStagingSite ) {
 		stagingSiteCardContent = (
 			<NewStagingSiteCardContent


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2212

## Proposed Changes

In this PR, I propose to extract staging sites loading error content to the separate component, and add it to the storybook.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run the storybook

```
yarn storybook:start
```

2. Test component state
3. Test staging sites UI in Calypso to ensure nothing is broken

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
