### PR TITLE
Draft: Hot reload messaging over websocket instead of eventsource

### DIFF
--- a/client/server/bundler/index.js
+++ b/client/server/bundler/index.js
@@ -3,8 +3,9 @@ const config = require( '@automattic/calypso-config' );
 const chalk = require( 'chalk' );
 const webpack = require( 'webpack' );
 const webpackMiddleware = require( 'webpack-dev-middleware' );
-const hotMiddleware = require( 'webpack-hot-middleware' );
+//const hotMiddleware = require( 'webpack-hot-middleware' );
 const webpackConfig = require( 'calypso/webpack.config' );
+const hotMiddleware = require( './webpack-hot-middleware-ws.js' );
 
 const protocol = config( 'protocol' );
 const host = config( 'hostname' );

--- a/client/server/bundler/webpack-hot-middleware-ws.js
+++ b/client/server/bundler/webpack-hot-middleware-ws.js
@@ -1,0 +1,219 @@
+// Based on: webpack-hot-middleware v2.25.3, but modified to use websockets instead of EventSource
+const parse = require( 'url' ).parse;
+const WebSocket = require( 'ws' );
+
+function pathMatch( url, path ) {
+	try {
+		return parse( url ).pathname === path;
+	} catch ( e ) {
+		return false;
+	}
+}
+
+function webpackHotMiddleware( compiler, opts ) {
+	opts = opts || {};
+	opts.log = typeof opts.log === 'undefined' ? console.log.bind( console ) : opts.log;
+	opts.path = opts.path || '/__webpack_hmr';
+	opts.heartbeat = opts.heartbeat || 10 * 1000;
+
+	const webSocketServer = createWebSocketServer( opts.port );
+	let latestStats = null;
+	let closed = false;
+
+	if ( compiler.hooks ) {
+		compiler.hooks.invalid.tap( 'webpack-hot-middleware', onInvalid );
+		compiler.hooks.done.tap( 'webpack-hot-middleware', onDone );
+	} else {
+		compiler.plugin( 'invalid', onInvalid );
+		compiler.plugin( 'done', onDone );
+	}
+
+	function onInvalid() {
+		if ( closed ) {
+			return;
+		}
+		latestStats = null;
+		if ( opts.log ) {
+			opts.log( 'webpack building...' );
+		}
+		webSocketServer.publish( { action: 'building' } );
+	}
+
+	function onDone( statsResult ) {
+		if ( closed ) {
+			return;
+		}
+		latestStats = statsResult;
+		publishStats( 'built', latestStats, webSocketServer, opts.log );
+	}
+
+	const middleware = function ( req, res, next ) {
+		if ( closed ) {
+			return next();
+		}
+		// TODO: This whole path thing might not be neeeded any more. Investigate.
+		if ( ! pathMatch( req.url, opts.path ) ) {
+			return next();
+		}
+		if ( latestStats ) {
+			publishStats( 'sync', latestStats, webSocketServer );
+		}
+	};
+
+	middleware.publish = function ( payload ) {
+		if ( closed ) {
+			return;
+		}
+		webSocketServer.publish( payload );
+	};
+
+	middleware.close = function () {
+		if ( closed ) {
+			return;
+		}
+		closed = true;
+		webSocketServer.close();
+	};
+
+	return middleware;
+}
+
+function createWebSocketServer( port = 8355 ) {
+	const clients = new Set();
+	const wss = new WebSocket.Server( { port } );
+
+	wss.on( 'connection', ( ws /*, req */ ) => {
+		clients.add( ws );
+
+		ws.on( 'message', ( message ) => {
+			console.log( `Received: ${ message }` );
+		} );
+
+		ws.on( 'close', () => {
+			clients.delete( ws );
+		} );
+	} );
+
+	return {
+		wss,
+		close: function () {
+			wss.close();
+			for ( const client of clients ) {
+				client.close();
+			}
+			clients.clear();
+		},
+		publish: function ( payload ) {
+			const data = JSON.stringify( payload );
+			clients.forEach( ( client ) => {
+				if ( client.readyState === WebSocket.OPEN ) {
+					client.send( data );
+				}
+			} );
+		},
+	};
+}
+
+function publishStats( action, statsResult, eventStream, log ) {
+	const statsOptions = {
+		all: false,
+		cached: true,
+		children: true,
+		modules: true,
+		timings: true,
+		hash: true,
+		errors: true,
+		warnings: true,
+	};
+
+	let bundles = [];
+
+	// multi-compiler stats have stats for each child compiler
+	// see https://github.com/webpack/webpack/blob/main/lib/MultiCompiler.js#L97
+	if ( statsResult.stats ) {
+		const processed = statsResult.stats.map( function ( stats ) {
+			return extractBundles( normalizeStats( stats, statsOptions ) );
+		} );
+
+		bundles = processed.flat();
+	} else {
+		bundles = extractBundles( normalizeStats( statsResult, statsOptions ) );
+	}
+
+	bundles.forEach( function ( stats ) {
+		let name = stats.name || '';
+
+		// Fallback to compilation name in case of 1 bundle (if it exists)
+		if ( ! name && stats.compilation ) {
+			name = stats.compilation.name || '';
+		}
+
+		if ( log ) {
+			log(
+				'webpack built ' + ( name ? name + ' ' : '' ) + stats.hash + ' in ' + stats.time + 'ms'
+			);
+		}
+
+		eventStream.publish( {
+			name: name,
+			action: action,
+			time: stats.time,
+			hash: stats.hash,
+			warnings: formatErrors( stats.warnings || [] ),
+			errors: formatErrors( stats.errors || [] ),
+			modules: buildModuleMap( stats.modules ),
+		} );
+	} );
+}
+
+function formatErrors( errors ) {
+	if ( ! errors || ! errors.length ) {
+		return [];
+	}
+
+	if ( typeof errors[ 0 ] === 'string' ) {
+		return errors;
+	}
+
+	// Convert webpack@5 error info into a backwards-compatible flat string
+	return errors.map( function ( error ) {
+		return error.moduleName + ' ' + error.loc + '\n' + error.message;
+	} );
+}
+
+function normalizeStats( stats, statsOptions ) {
+	const statsJson = stats.toJson( statsOptions );
+
+	if ( stats.compilation ) {
+		// webpack 5 has the compilation property directly on stats object
+		Object.assign( statsJson, {
+			compilation: stats.compilation,
+		} );
+	}
+
+	return statsJson;
+}
+
+function extractBundles( stats ) {
+	// Stats has modules, single bundle
+	if ( stats.modules ) {
+		return [ stats ];
+	}
+
+	// Stats has children, multiple bundles
+	if ( stats.children && stats.children.length ) {
+		return stats.children;
+	}
+
+	// Not sure, assume single
+	return [ stats ];
+}
+
+function buildModuleMap( modules ) {
+	const map = {};
+	modules.forEach( function ( module ) {
+		map[ module.id ] = module.name;
+	} );
+	return map;
+}
+module.exports = webpackHotMiddleware;

--- a/package.json
+++ b/package.json
@@ -287,6 +287,7 @@
 		"webpack-cli": "^4.9.2",
 		"webpack-dev-middleware": "^5.3.1",
 		"whybundled": "^2.0.0",
+		"ws": "^8.13.0",
 		"yargs": "^17.0.1"
 	},
 	"resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -34007,6 +34007,7 @@ fsevents@^1.2.7:
     webpack-dev-middleware: ^5.3.1
     whybundled: ^2.0.0
     wpcom: "workspace:^"
+    ws: ^8.13.0
     yargs: ^17.0.1
   dependenciesMeta:
     "@react-spring/core@9.3.0":
@@ -34245,6 +34246,21 @@ fsevents@^1.2.7:
     utf-8-validate:
       optional: true
   checksum: aec4ef4eb65821a7dde7b44790f8699cfafb7978c9b080f6d7a98a7f8fc0ce674c027073a78574c94786ba7112cc90fa2cc94fc224ceba4d4b1030cff9662494
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.13.0":
+  version: 8.13.0
+  resolution: "ws@npm:8.13.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 579817dbbab3ee46669129c220cfd81ba6cdb9ab5c3e9a105702dd045743c4ab72e33bb384573827c0c481213417cc880e41bc097e0fc541a0b79fa3eb38207d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Try to fix issue where hot-reloading stops working at about 6 tabs open
* Uses websocket to send hot reload messaging
* Requires a modified version of the `webpack-hot-middleware` package
  * This PR should remove the package if it isn't used elsewhere
* Sets up a websocket server
  * Currently uses a hardcoded port number
  * Adds the `ws` package to do so
* Would need to verify none of this code affects the production build
* Not tested very much