### PR TITLE
Isolate listend for blazepress to reduce any possible leakage

### DIFF
--- a/client/components/list-end/index.js
+++ b/client/components/list-end/index.js
@@ -4,7 +4,7 @@ import './style.scss';
 
 export default function ListEnd() {
 	return (
-		<div className="list-end promote-post-i2__aux-wrapper">
+		<div className="list-end">
 			<Gridicon icon="my-sites" />
 		</div>
 	);

--- a/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx
@@ -96,9 +96,9 @@ export default function CampaignsList( props: Props ) {
 					</div>
 
 					{ ! isEmpty && ! isError && (
-						<>
+						<div className="promote-post-i2__aux-wrapper">
 							<ListEnd />
-						</>
+						</div>
 					) }
 				</>
 			) }

--- a/client/my-sites/promote-post-i2/components/posts-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/posts-list/index.tsx
@@ -105,7 +105,11 @@ export default function PostsList( props: Props ) {
 							/>
 						) }
 					</div>
-					{ ! isEmpty && ! isError && <ListEnd /> }
+					{ ! isEmpty && ! isError && (
+						<div className="promote-post-i2__aux-wrapper">
+							<ListEnd />
+						</div>
+					) }
 				</>
 			) }
 


### PR DESCRIPTION
Isolate any possible css leakage by removing the CSS class in <ListEnd> and bring these css changes in the parent where they're needed

## Pre-merge Checklist


- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
