### PR TITLE
Plans 2023: Plan upgrade credit design updates

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -322,10 +322,10 @@ a.notice__action {
 			a,
 			a:visited,
 			button.is-link {
-				color: inherit;
+				color: var(--color-link);
 
 				&:hover {
-					color: inherit;
+					color: var(--color-link);
 				}
 			}
 		}
@@ -384,7 +384,10 @@ a.notice__action {
 		flex-shrink: 0;
 		padding: 16px;
 		cursor: pointer;
-
+		&:hover,
+		&:focus {
+			color: var(--color-text);
+		}
 		.gridicon {
 			width: 18px;
 			height: 18px;

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -24,11 +24,6 @@ interface Props {
 	isMonthlyPlan: boolean;
 }
 
-export const StrikethroughText = styled.span`
-	color: var( --studio-gray-20 );
-	text-decoration: line-through;
-`;
-
 function usePerMonthDescription( {
 	isMonthlyPlan,
 	planName,
@@ -99,47 +94,29 @@ function usePerMonthDescription( {
 
 				return displayNewPriceText
 					? translate(
-							'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
+							'per month, %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
 							{
-								args: { fullTermDiscountedPriceText, rawPrice },
-								components: {
-									discount: <StrikethroughText />,
-								},
+								args: { fullTermDiscountedPriceText },
 								comment: 'Excl. Taxes is short for excluding taxes',
 							}
 					  )
-					: translate(
-							'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year',
-							{
-								args: { fullTermDiscountedPriceText, rawPrice },
-								components: {
-									discount: <StrikethroughText />,
-								},
-							}
-					  );
+					: translate( 'per month, %(fullTermDiscountedPriceText)s for the first year', {
+							args: { fullTermDiscountedPriceText },
+					  } );
 			}
 
 			if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
 				return displayNewPriceText
 					? translate(
-							'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
+							'per month, %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
 							{
 								args: { fullTermDiscountedPriceText, rawPrice },
-								components: {
-									discount: <StrikethroughText />,
-								},
 								comment: 'Excl. Taxes is short for excluding taxes',
 							}
 					  )
-					: translate(
-							'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year',
-							{
-								args: { fullTermDiscountedPriceText, rawPrice },
-								components: {
-									discount: <StrikethroughText />,
-								},
-							}
-					  );
+					: translate( 'per month, %(fullTermDiscountedPriceText)s for the first year', {
+							args: { fullTermDiscountedPriceText },
+					  } );
 			}
 		} else if ( rawPrice ) {
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {

--- a/client/my-sites/plan-features-2023-grid/components/test/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/test/billing-timeframe.tsx
@@ -99,14 +99,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		const discountedPrice = formatCurrency( planPrices.planDiscountedRawPrice, 'INR', {
 			stripZeros: true,
 		} );
-		const rawPrice = formatCurrency( planPrices.rawPrice, 'INR', {
-			stripZeros: true,
-		} );
-
-		expect( container ).toHaveTextContent(
-			`per month, ${ rawPrice } billed annually ${ discountedPrice } for the first year`
-		);
-		expect( container ).toContainHTML( `StrikethroughText` );
+		expect( container ).toHaveTextContent( `per month, ${ discountedPrice } for the first year` );
 	} );
 
 	test( 'should show full-term discounted price when plan is 2-yearly', () => {
@@ -129,12 +122,6 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		const discountedPrice = formatCurrency( planPrices.planDiscountedRawPrice, 'INR', {
 			stripZeros: true,
 		} );
-		const rawPrice = formatCurrency( planPrices.rawPrice, 'INR', {
-			stripZeros: true,
-		} );
-		expect( container ).toHaveTextContent(
-			`per month, ${ rawPrice } billed annually ${ discountedPrice } for the first year`
-		);
-		expect( container ).toContainHTML( `StrikethroughText` );
+		expect( container ).toHaveTextContent( `per month, ${ discountedPrice } for the first year` );
 	} );
 } );


### PR DESCRIPTION
Fixes Automattic/martech#1747

## Proposed Changes

<img width="1331" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/21759759-a598-4c8b-984e-5e01c86d2cd5">


## Testing Instructions
* Select/create site with a business plan
* Go to the `/plans` page
* Make sure the page looks like above. And observe the following changes requested at Automattic/martech#1747
     *  Remove the cross-out text in the full description. e.g. in the following case:
     *  The link to the support documentation should be in the link blue #0675C4
     *  The hovering colour of the dismissing button is white. It should be the same as the text colour.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
