### PR TITLE
Add _locale=user query parameter to Launchpad API calls

### DIFF
--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -46,9 +46,10 @@ export const fetchLaunchpad = (
 	checklist_slug?: string | 0 | null | undefined
 ): Promise< LaunchpadResponse > => {
 	const slug = encodeURIComponent( siteSlug as string );
-	const requestUrl = checklist_slug
-		? `/sites/${ slug }/launchpad?checklist_slug=${ checklist_slug }`
-		: `/sites/${ slug }/launchpad`;
+	const checklistSlug = checklist_slug ? encodeURIComponent( checklist_slug ) : null;
+	const requestUrl = checklistSlug
+		? `/sites/${ slug }/launchpad?_locale=user&checklist_slug=${ checklistSlug }`
+		: `/sites/${ slug }/launchpad?_locale=user`;
 
 	return canAccessWpcomApis()
 		? wpcomRequest( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/30915

## Proposed Changes

* This PR updates the hook we use to fetch launchpad data from the server to add the `_locale=user` URL parameter to ensure that we use the user's locale when translating strings
  - The PR also ensures that we URL-encode the checklist slug if it is supplied

## Testing Instructions

* This change depends on https://github.com/Automattic/jetpack/pull/30915 being available, as it doesn't have any impact without that change
* Assuming you have that change in place, ensure that your user is configured to use a non-English language (you can change your WordPress.com language via [/me/account](https://wordpress.com/me/account).
* Run this branch locally or via Calypso.live
* Pick an existing newsletter site, or create a new newsletter site by visiting `/setup/newsletter` and work through the flow until you get to the launchpad
   - If you have an existing newsletter site, you can navigate to `/setup/newsletter/launchpad?siteSlug=:siteSlug`
* Verify that the tasks in the launchpad are translated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?