### PR TITLE
Subscription Manager: filter by paid status is back in the comment list and is added to the site list

### DIFF
--- a/client/landing/subscriptions/components/tab-views/comments/comments.tsx
+++ b/client/landing/subscriptions/components/tab-views/comments/comments.tsx
@@ -1,13 +1,15 @@
 import { SubscriptionManager, Reader } from '@automattic/data-stores';
+import { SiteSubscriptionsFilterBy } from '@automattic/data-stores/src/reader/queries';
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { CommentList } from 'calypso/landing/subscriptions/components/comment-list';
 import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
 import { Notice, NoticeType } from 'calypso/landing/subscriptions/components/notice';
 import { SortControls, Option } from 'calypso/landing/subscriptions/components/sort-controls';
 import { useSearch } from 'calypso/landing/subscriptions/hooks';
+import { getFilterLabel, useFilterOptions } from '../tab-filters/tab-filters';
 import TabView from '../tab-view';
 
 const { PostSubscriptionsSortBy: SortBy, SiteSubscriptionsFilterBy: FilterBy } = Reader;
@@ -20,24 +22,6 @@ const useSortOptions = (): Option[] => {
 		{ value: SortBy.PostName, label: translate( 'Post name' ) },
 	];
 };
-
-const useFilterOptions = () => {
-	const translate = useTranslate();
-
-	return useMemo(
-		() => [
-			{ value: FilterBy.All, label: translate( 'All' ) },
-			// { value: SiteSubscriptionsFilterBy.Paid, label: translate( 'Paid' ) },		// todo: add back when we have paid subscriptions support
-			{ value: FilterBy.P2, label: translate( 'P2' ) },
-		],
-		[ translate ]
-	);
-};
-
-const getFilterLabel = (
-	availableFilterOptions: Option[],
-	filterValue: Reader.SiteSubscriptionsFilterBy
-) => availableFilterOptions.find( ( option ) => option.value === filterValue )?.label;
 
 const Comments = () => {
 	const translate = useTranslate();

--- a/client/landing/subscriptions/components/tab-views/comments/comments.tsx
+++ b/client/landing/subscriptions/components/tab-views/comments/comments.tsx
@@ -1,5 +1,4 @@
 import { SubscriptionManager, Reader } from '@automattic/data-stores';
-import { SiteSubscriptionsFilterBy } from '@automattic/data-stores/src/reader/queries';
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';

--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -1,13 +1,16 @@
 import config from '@automattic/calypso-config';
 import { SubscriptionManager, Reader } from '@automattic/data-stores';
+import { SiteSubscriptionsFilterBy } from '@automattic/data-stores/src/reader/queries';
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
+import SelectDropdown from 'calypso/components/select-dropdown';
 import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
 import { Notice, NoticeType } from 'calypso/landing/subscriptions/components/notice';
 import { SiteList } from 'calypso/landing/subscriptions/components/site-list';
 import { SortControls, Option } from 'calypso/landing/subscriptions/components/sort-controls';
 import { useSearch } from 'calypso/landing/subscriptions/hooks';
+import { getFilterLabel, useFilterOptions } from '../tab-filters/tab-filters';
 import TabView from '../tab-view';
 
 const SortBy = Reader.SiteSubscriptionsSortBy;
@@ -25,9 +28,14 @@ const Sites = () => {
 	const translate = useTranslate();
 	const { searchTerm, handleSearch } = useSearch();
 	const [ sortTerm, setSortTerm ] = useState( SortBy.DateSubscribed );
+	const availableFilterOptions = useFilterOptions();
+	const [ filterOption, setFilterOption ] = useState< SiteSubscriptionsFilterBy >(
+		SiteSubscriptionsFilterBy.All
+	);
 	const { data, isLoading, error } = SubscriptionManager.useSiteSubscriptionsQuery( {
 		searchTerm,
 		sortTerm,
+		filterOption,
 	} );
 	const { subscriptions, totalCount } = data ?? {};
 	const sortOptions = useSortOptions( translate );
@@ -53,6 +61,18 @@ const Sites = () => {
 						searchIcon={ <SearchIcon size={ 18 } /> }
 						onSearch={ handleSearch }
 					/>
+
+					<SelectDropdown
+						className="subscriptions-manager__filter-control"
+						options={ availableFilterOptions }
+						onSelect={ ( selectedOption: Option ) =>
+							setFilterOption( selectedOption.value as SiteSubscriptionsFilterBy )
+						}
+						selectedText={
+							translate( 'View: ' ) + getFilterLabel( availableFilterOptions, filterOption )
+						}
+					/>
+
 					<SortControls options={ sortOptions } value={ sortTerm } onChange={ setSortTerm } />
 				</div>
 			) }
@@ -63,7 +83,7 @@ const Sites = () => {
 				<Notice type={ NoticeType.Warning }>
 					{ translate( 'Sorry, no sites match {{italic}}%s.{{/italic}}', {
 						components: { italic: <i /> },
-						args: searchTerm,
+						args: searchTerm || filterOption,
 					} ) }
 				</Notice>
 			) }

--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -68,9 +68,9 @@ const Sites = () => {
 						onSelect={ ( selectedOption: Option ) =>
 							setFilterOption( selectedOption.value as SiteSubscriptionsFilterBy )
 						}
-						selectedText={
-							translate( 'View: ' ) + getFilterLabel( availableFilterOptions, filterOption )
-						}
+						selectedText={ translate( 'View: %s', {
+							args: getFilterLabel( availableFilterOptions, filterOption ) || '',
+						} ) }
 					/>
 
 					<SortControls options={ sortOptions } value={ sortTerm } onChange={ setSortTerm } />

--- a/client/landing/subscriptions/components/tab-views/tab-filters/tab-filters.tsx
+++ b/client/landing/subscriptions/components/tab-views/tab-filters/tab-filters.tsx
@@ -1,0 +1,22 @@
+import { SiteSubscriptionsFilterBy } from '@automattic/data-stores/src/reader/queries';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { Option } from 'calypso/landing/subscriptions/components/sort-controls';
+
+export const useFilterOptions = () => {
+	const translate = useTranslate();
+
+	return useMemo(
+		() => [
+			{ value: SiteSubscriptionsFilterBy.All, label: translate( 'All' ) },
+			{ value: SiteSubscriptionsFilterBy.Paid, label: translate( 'Paid' ) },
+			{ value: SiteSubscriptionsFilterBy.P2, label: translate( 'P2' ) },
+		],
+		[ translate ]
+	);
+};
+
+export const getFilterLabel = (
+	availableFilterOptions: Option[],
+	filterValue: SiteSubscriptionsFilterBy
+) => availableFilterOptions.find( ( option ) => option.value === filterValue )?.label;

--- a/packages/data-stores/src/reader/queries/index.ts
+++ b/packages/data-stores/src/reader/queries/index.ts
@@ -5,3 +5,4 @@ export { default as usePostSubscriptionsQuery } from './use-post-subscriptions-q
 export { default as usePendingSiteSubscriptionsQuery } from './use-pending-site-subscriptions-query';
 export { default as usePendingPostSubscriptionsQuery } from './use-pending-post-subscriptions-query';
 export { default as useSiteSubscriptionDetailsQuery } from './use-site-subscription-details-query';
+export { SiteSubscriptionsFilterBy } from '../constants';

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useMemo, useEffect } from 'react';
-import { SiteSubscriptionsSortBy } from '../constants';
+import { useMemo, useEffect, useCallback } from 'react';
+import { SiteSubscriptionsFilterBy, SiteSubscriptionsSortBy } from '../constants';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { SiteSubscription } from '../types';
@@ -13,7 +13,7 @@ type SubscriptionManagerSiteSubscriptions = {
 
 type SubscriptionManagerSiteSubscriptionsQueryProps = {
 	searchTerm?: string;
-	filter?: ( item?: SiteSubscription ) => boolean;
+	filterOption?: SiteSubscriptionsFilterBy;
 	sortTerm?: SiteSubscriptionsSortBy;
 	number?: number;
 };
@@ -44,11 +44,9 @@ const getSortFunction = ( sortTerm: SiteSubscriptionsSortBy ) => {
 	}
 };
 
-const defaultFilter = () => true;
-
 const useSiteSubscriptionsQuery = ( {
 	searchTerm = '',
-	filter = defaultFilter,
+	filterOption = SiteSubscriptionsFilterBy.All,
 	sortTerm = SiteSubscriptionsSortBy.LastUpdated,
 	number = 100,
 }: SubscriptionManagerSiteSubscriptionsQueryProps = {} ) => {
@@ -96,6 +94,21 @@ const useSiteSubscriptionsQuery = ( {
 		}
 	}, [ nextPage, fetchNextPage ] );
 
+	const filterFunction = useCallback(
+		( item: SiteSubscription ) => {
+			switch ( filterOption ) {
+				case SiteSubscriptionsFilterBy.Paid:
+					return item.is_paid_subscription;
+				case SiteSubscriptionsFilterBy.P2:
+					return item.is_wpforteams_site;
+				case SiteSubscriptionsFilterBy.All:
+				default:
+					return true;
+			}
+		},
+		[ filterOption ]
+	);
+
 	const resultData = useMemo( () => {
 		// Flatten all the pages into a single array containing all subscriptions
 		const flattenedData = data?.pages?.map( ( page ) => page.subscriptions ).flat();
@@ -116,12 +129,12 @@ const useSiteSubscriptionsQuery = ( {
 		return {
 			subscriptions:
 				flattenedData
-					?.filter( ( item ) => item !== null && filter( item ) && searchFilter( item ) )
+					?.filter( ( item ) => item !== null && filterFunction( item ) && searchFilter( item ) )
 					.sort( sort ) ?? [],
 			totalCount: data?.pages?.[ 0 ]?.total_subscriptions ?? 0,
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ data?.pages, filter, searchTerm, sortTerm ] );
+	}, [ data?.pages, filterOption, searchTerm, sortTerm ] );
 
 	return {
 		data: resultData,


### PR DESCRIPTION
☢️☢️☢️ Alert: don't merge this PR until this patch is in production: D111591-code ☢️☢️☢️

Fixes https://github.com/Automattic/wp-calypso/issues/77231
Fixes https://github.com/Automattic/wp-calypso/issues/77232

## Proposed Changes

The changes in this PR make the "Paid" filter come back in the comment list on the new Subscription Manager. It also adds filters to the site list. 

## Testing Instructions

In order to test this, you should have P2, Paid and non-paid site subscriptions, and post subscriptions:

1. Apply this patch.
2. Add `return next();` right after the line `app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res, next ) {` in the file `client/server/pages/index.js`.
3. Start the application with `yarn start`.
4. Go to `http://calypso.localhost:3000/subscriptions/sites` and use the filters. You should see only the right site type in each case.
5. Go to `http://calypso.localhost:3000/subscriptions/comments` and use the filters. You should see only the right post type in each case.
