### PR TITLE
Checkout: Update colors, spacing, and typography for new design

### DIFF
--- a/client/assets/stylesheets/shared/_variables.scss
+++ b/client/assets/stylesheets/shared/_variables.scss
@@ -5,6 +5,7 @@
 :root {
 	// Masterbar
 	--masterbar-height: 46px;
+	--masterbar-checkout-height: 72px;
 
 	@media only screen and ( min-width: 782px ) {
 		--masterbar-height: 32px;

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -9,17 +9,29 @@
 	bottom: auto;
 	left: 0;
 
+	.is-section-checkout & {
+		top: var(--masterbar-checkout-height);
+	}
+
 	@include breakpoint-deprecated( ">660px" ) {
 		top: calc(var(--masterbar-height) + 16px);
 		right: 16px;
 		left: auto;
 		max-width: calc(100% - 32px);
+
+		.is-section-checkout & {
+			top: calc(var(--masterbar-checkout-height) + 16px);
+		}
 	}
 
 	@include breakpoint-deprecated( ">960px" ) {
 		top: calc(var(--masterbar-height) + 24px);
 		right: 24px;
 		max-width: calc(100% - 48px);
+
+		.is-section-checkout & {
+			top: calc(var(--masterbar-checkout-height) + 24px);
+		}
 	}
 
 	@include breakpoint-deprecated( ">1040px" ) {

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -105,14 +105,16 @@ const CheckoutMasterbar = ( {
 			<div className="masterbar__secure-checkout">
 				{ showCloseButton && (
 					<Item
-						icon="cross"
+						icon="chevron-left"
 						className="masterbar__close-button"
 						onClick={ clickClose }
 						tooltip={ String( translate( 'Close Checkout' ) ) }
 						tipTarget="close"
 					/>
 				) }
-				{ checkoutType === 'wpcom' && <WordPressWordmark className="masterbar__wpcom-wordmark" /> }
+				{ checkoutType === 'wpcom' && (
+					<WordPressWordmark className="masterbar__wpcom-wordmark" color="#2c3338" />
+				) }
 				{ checkoutType === 'jetpack' && (
 					<JetpackLogo className="masterbar__jetpack-wordmark" full />
 				) }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -42,15 +42,16 @@ $masterbar-color-secondary: #101517;
 		border-bottom: 1px solid var(--studio-orange-60);
 	}
 
-	&.masterbar--is-checkout.masterbar--is-jetpack {
-		background-color: var(--color-jetpack-masterbar-background);
-		border-bottom: 1px solid var(--color-jetpack-masterbar-border);
-		color: var(--color-jetpack-masterbar-text);
-	}
+	&.masterbar--is-checkout {
+		background-color: var(--studio-white);
+		border-bottom: none 0;
+		color: var(--color-checkout-masterbar-text);
+		height: var(--masterbar-checkout-height);
+		position: absolute;
 
-	&.masterbar--is-checkout.masterbar--is-akismet {
-		background-color: var(--color-akismet-masterbar-background);
-		border-bottom: 1px solid var(--color-akismet-masterbar-border);
+		@include breakpoint-deprecated( ">960px" ) {
+			background-color: var(--color-checkout-masterbar-background);
+		}
 	}
 
 	// stylelint-disable-next-line unit-allowed-list
@@ -202,6 +203,11 @@ $masterbar-color-secondary: #101517;
 	transition: all 0.2s ease-in-out;
 	justify-content: center;
 
+	.masterbar--is-checkout & {
+		height: var(--masterbar-checkout-height);
+		line-height: var(--masterbar-checkout-height);
+	}
+
 	&:visited {
 		color: var(--color-masterbar-text);
 	}
@@ -213,13 +219,17 @@ $masterbar-color-secondary: #101517;
 	.masterbar__item-content {
 		white-space: nowrap;
 		color: var(--color-masterbar-text);
+
+		.masterbar--is-checkout & {
+			color: var(--color-checkout-masterbar-text);
+		}
 	}
 
 	.gridicon {
 		fill: var(--color-masterbar-text); // only because safari gets currentColor wrong
 
-		.masterbar--is-checkout.masterbar--is-jetpack & {
-			fill: var(--color-jetpack-masterbar-text);
+		.masterbar--is-checkout & {
+			fill: var(--color-checkout-masterbar-text);
 		}
 	}
 
@@ -232,9 +242,9 @@ $masterbar-color-secondary: #101517;
 			background: var(--color-masterbar-item-hover-background);
 			color: var(--color-masterbar-text);
 
-			.masterbar--is-checkout.masterbar--is-jetpack & {
-				background: var(--color-jetpack-masterbar-item-hover-background);
-				color: var(--color-jetpack-masterbar-text);
+			.masterbar--is-checkout & {
+				background: var(--color-checkout-masterbar-item-hover-background);
+				color: var(--color-checkout-masterbar-text);
 			}
 		}
 	}
@@ -247,9 +257,9 @@ $masterbar-color-secondary: #101517;
 			color: var(--color-masterbar-text);
 		}
 
-		.masterbar--is-checkout.masterbar--is-jetpack & {
-			box-shadow: inset 0 0 0 2px var(--color-jetpack-masterbar-item-hover-background);
-			color: var(--color-jetpack-masterbar-text);
+		.masterbar--is-checkout & {
+			box-shadow: inset 0 0 0 2px var(--color-checkout-masterbar-item-hover-background);
+			color: var(--color-checkout-masterbar-text);
 		}
 	}
 
@@ -275,13 +285,8 @@ $masterbar-color-secondary: #101517;
 	}
 
 	&.masterbar__close-button {
-		border-right: 1px solid var(--color-masterbar-border);
-		margin-right: 15px;
+		color: var(--color-checkout-masterbar-text);
 		cursor: pointer;
-
-		.masterbar--is-checkout.masterbar--is-jetpack & {
-			border-right: 1px solid var(--color-jetpack-masterbar-border);
-		}
 
 		.masterbar__item-content {
 			display: none;
@@ -837,8 +842,11 @@ a.masterbar__quick-language-switcher {
 .masterbar__secure-checkout {
 	display: flex;
 	align-items: center;
+	margin-left: 24px;
 
 	.masterbar__wpcom-wordmark {
+		color: var(--color-checkout-masterbar-text);
+		fill: var(--color-checkout-masterbar-text);
 		margin-right: 5px;
 	}
 
@@ -852,8 +860,7 @@ a.masterbar__quick-language-switcher {
 	}
 
 	.masterbar__secure-checkout-text {
-		color: var(--color-primary-5);
-		transform: translateY(1px);
+		color: var(--color-checkout-masterbar-text);
 		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		line-height: 1.2em;
 		font-size: 0.75rem;
@@ -866,12 +873,10 @@ a.masterbar__quick-language-switcher {
 		}
 
 		.masterbar--is-jetpack & {
-			color: var(--color-jetpack-masterbar-text);
 			transform: translateY(-1px);
 		}
 
 		.masterbar--is-akismet & {
-			color: var(--color-jetpack-masterbar-text);
 			transform: translateY(4px);
 		}
 	}
@@ -880,8 +885,17 @@ a.masterbar__quick-language-switcher {
 .masterbar__item-help {
 	padding: 0 11px;
 
+	.masterbar--is-checkout & {
+		padding: 0 24px;
+	}
+
 	svg {
 		fill: var(--color-masterbar-text);
+
+		.masterbar--is-checkout & {
+			fill: var(--color-checkout-masterbar-text);
+			margin-right: 6px;
+		}
 	}
 }
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -53,6 +53,7 @@ body.is-focus-sites {
 
 	// Checkout sets it own padding/margin
 	.is-section-checkout &,
+	.theme-default .focus-content &,
 	.is-section-checkout.has-no-sidebar & {
 		padding: 0;
 		margin: 0;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -53,8 +53,8 @@ body.is-focus-sites {
 
 	// Checkout sets it own padding/margin
 	.is-section-checkout &,
-	.theme-default .focus-content &,
-	.is-section-checkout.has-no-sidebar & {
+	.is-section-checkout.has-no-sidebar &,
+	.is-section-checkout.has-no-sidebar .theme-default .focus-content & {
 		padding: 0;
 		margin: 0;
 	}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -51,6 +51,13 @@ body.is-focus-sites {
 		padding-left: 32px;
 	}
 
+	// Checkout sets it own padding/margin
+	.is-section-checkout &,
+	.is-section-checkout.has-no-sidebar & {
+		padding: 0;
+		margin: 0;
+	}
+
 	// Themes sets it own padding/margin
 	.is-section-theme &,
 	.is-section-themes.has-no-sidebar & {

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -1,12 +1,13 @@
 import config from '@automattic/calypso-config';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
+import colorStudio from '@automattic/color-studio';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
+import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { captureException } from 'calypso/lib/sentry';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
-import { CheckoutOrderBanner } from 'calypso/my-sites/checkout/composite-checkout/components/checkout-order-banner';
 import Recaptcha from 'calypso/signup/recaptcha';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
@@ -30,6 +31,10 @@ const logCheckoutError = ( error: Error ) => {
 	} );
 	captureException( error );
 };
+
+const CheckoutMainWrapperStyles = styled.div`
+	background-color: ${ colorStudio.colors[ 'White' ] };
+`;
 
 export default function CheckoutMainWrapper( {
 	productAliasFromUrl,
@@ -99,14 +104,13 @@ export default function CheckoutMainWrapper( {
 	}
 
 	return (
-		<>
+		<CheckoutMainWrapperStyles>
 			<CheckoutErrorBoundary
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logCheckoutError }
 			>
 				<CalypsoShoppingCartProvider shouldShowPersistentErrors>
 					<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
-						<CheckoutOrderBanner />
 						<CheckoutMain
 							siteSlug={ siteSlug }
 							siteId={ selectedSiteId }
@@ -131,6 +135,6 @@ export default function CheckoutMainWrapper( {
 				</CalypsoShoppingCartProvider>
 			</CheckoutErrorBoundary>
 			{ isLoggedOutCart && <Recaptcha badgePosition="bottomright" /> }
-		</>
+		</CheckoutMainWrapperStyles>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -146,10 +146,14 @@ export default function CheckoutHelpLink() {
 	}, [ isChatActive, setShowMessagingLauncher, isMessagingWidgetShown ] );
 
 	const shouldShowHelpLink = ! isChatActive && ! isPresalesChatAvailable;
+	if ( ! shouldShowHelpLink ) {
+		return null;
+	}
+
 	return (
 		<CheckoutHelpLinkWrapper>
 			{ isLoadingChat && <LoadingButton /> }
-			{ ! isLoadingChat && shouldShowHelpLink && (
+			{ ! isLoadingChat && (
 				<CheckoutSummaryHelpButton onClick={ handleHelpButtonClicked }>
 					{ translate(
 						'Questions? {{underline}}Read more about plans and purchases{{/underline}}',

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -23,10 +23,13 @@ type StyledProps = {
 };
 
 const CheckoutHelpLinkWrapper = styled.div< StyledProps >`
-	background: ${ ( props ) => props.theme.colors.surface };
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	margin: 0;
 	padding: 20px;
+
+	&:empty {
+		display: none;
+	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		background: transparent;

--- a/client/my-sites/checkout/composite-checkout/components/checkout-order-banner/gifting-checkout-banner/style.scss
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-order-banner/gifting-checkout-banner/style.scss
@@ -7,12 +7,7 @@
 	margin: 0 auto 32px;
 	background: url(calypso/assets/images/gifting/pink-background.jpg) no-repeat top left;
 	background-size: cover;
-	@media ( min-width: 700px ) {
-		width: 554px;
-	}
-	@include break-large {
-		width: 905px;
-	}
+	width: 100%;
 }
 
 .gifting-checkout-banner img {

--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/style.scss
@@ -1,5 +1,6 @@
 .checkout-sidebar-plan-upsell {
 	margin-top: 24px;
+	margin-bottom: 24px;
 }
 
 .promo-card.checkout-sidebar-plan-upsell {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -65,7 +65,7 @@ const Option = styled.li< OptionProps >`
 const Dropdown = styled.div`
 	position: relative;
 	width: 100%;
-	margin: 20px 0 0;
+	margin: 16px 0;
 	> ${ Option } {
 		border-radius: 3px;
 	}

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -13,13 +13,13 @@ import { WPOrderReviewSection } from './wp-order-review-line-items';
 
 const CheckoutTermsWrapper = styled.div`
 	& > * {
-		margin: 16px 0 16px -24px;
+		margin: 16px 0;
 		padding-left: 24px;
 		position: relative;
 	}
 
 	.rtl & > * {
-		margin: 16px -24px 16px 0;
+		margin: 16px 0;
 		padding-right: 24px;
 		padding-left: 0;
 	}
@@ -41,6 +41,17 @@ const CheckoutTermsWrapper = styled.div`
 	}
 `;
 
+const NonTotalPrices = styled.div`
+	font-size: 12px;
+	border-top: ${ ( props ) => '1px solid ' + props.theme.colors.borderColorLight };
+	border-bottom: ${ ( props ) => '1px solid ' + props.theme.colors.borderColorLight };
+	padding: 16px 0;
+`;
+const TotalPrice = styled.div`
+	font-size: 14px;
+	padding: 16px 0;
+`;
+
 export default function PaymentMethodStep() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
@@ -53,14 +64,18 @@ export default function PaymentMethodStep() {
 			</CheckoutTermsWrapper>
 
 			<WPOrderReviewSection>
-				<NonProductLineItem subtotal lineItem={ getSubtotalLineItemFromCart( responseCart ) } />
-				{ taxLineItems.map( ( taxLineItem ) => (
-					<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
-				) ) }
-				{ creditsLineItem && responseCart.sub_total_integer > 0 && (
-					<NonProductLineItem subtotal lineItem={ creditsLineItem } />
-				) }
-				<NonProductLineItem total lineItem={ getTotalLineItemFromCart( responseCart ) } />
+				<NonTotalPrices>
+					<NonProductLineItem subtotal lineItem={ getSubtotalLineItemFromCart( responseCart ) } />
+					{ taxLineItems.map( ( taxLineItem ) => (
+						<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
+					) ) }
+					{ creditsLineItem && responseCart.sub_total_integer > 0 && (
+						<NonProductLineItem subtotal lineItem={ creditsLineItem } />
+					) }
+				</NonTotalPrices>
+				<TotalPrice>
+					<NonProductLineItem total lineItem={ getTotalLineItemFromCart( responseCart ) } />
+				</TotalPrice>
 			</WPOrderReviewSection>
 		</>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/style.scss
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/style.scss
@@ -23,4 +23,8 @@ button.button.payment-method-tax-info__edit-button svg.gridicon {
 	display: flex;
 	align-items: center;
 	flex-wrap: wrap;
+
+	@include breakpoint-deprecated( ">960px" ) {
+		display: inline-flex;
+	}
 }

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/style.scss
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/style.scss
@@ -1,7 +1,6 @@
 .prepurchase-notices__container {
-	padding: 32px 32px 20px;
-
-	border-bottom: solid 1px var(--color-border-subtle);
+	padding: 32px 0 0;
+	width: 100%;
 
 	.notice {
 		margin: 0;

--- a/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
@@ -35,16 +35,12 @@ const UpsellWrapper = styled.div< DivProps >`
 	.cart__upsell-header {
 		border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 		box-shadow: none;
-		margin-left: 20px;
-		margin-right: 20px;
-		padding-left: 0;
-		padding-right: 0;
+		padding-left: 20px;
+		padding-right: 20px;
 
 		@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 			border-top: none;
 			border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-			margin-left: 0;
-			margin-right: 0;
 			padding-left: 24px;
 			padding-right: 24px;
 		}

--- a/client/my-sites/checkout/composite-checkout/components/third-party-plugins-developer-account.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/third-party-plugins-developer-account.tsx
@@ -4,29 +4,44 @@ import { useState } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 
-const CheckboxTermsWrapper = styled( FormLabel )< { displayErrorMessage: boolean } >`
-	padding: 24px 24px 24px 59px;
-	border: ${ ( props ) =>
-		props.displayErrorMessage ? '3px solid var( --color-error )' : 'initial' };
-	border-radius: ${ ( props ) => ( props.displayErrorMessage ? '3px' : 'initial' ) };
-`;
+const CheckboxTermsWrapper = styled( FormLabel )`
+	column-gap: 8px;
+	display: grid;
+	grid-template-areas:
+		'checkbox message'
+		'. error-message';
+	grid-template-columns: 16px 1fr;
+	row-gap: 4px;
+	align-items: center;
+	padding: 0;
+	margin: 0;
 
-const StyledFormCheckbox = styled( FormCheckbox )`
-	// Increase specificity with && to avoid form-checkbox overriding the margin
-	// Source: https://stackoverflow.com/a/64486501
-	&& {
-		margin: 8px 0 16px -24px;
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		padding: 24px 0;
 	}
 `;
 
-const MessageWrapper = styled.div`
+const StyledFormCheckbox = styled( FormCheckbox )`
+	grid-area: checkbox;
+
+	// Increase specificity with && to avoid form-checkbox overriding the margin
+	// Source: https://stackoverflow.com/a/64486501
+	&& {
+		margin: 0;
+	}
+`;
+
+const MessageWrapper = styled.div< { displayErrorMessage: boolean } >`
+	color: ${ ( props ) => ( props.displayErrorMessage ? 'var( --color-error )' : 'inherit' ) };
 	font-size: 12px;
+	grid-area: message;
 	margin-left: 0;
 `;
 
 const ErrorMessage = styled.small`
 	color: var( --color-error );
 	font-weight: normal;
+	grid-area: error-message;
 `;
 
 interface ExternalProps {
@@ -50,13 +65,13 @@ function ThirdPartyDevsAccount( { isAccepted, isSubmitted, onChange, translate }
 	};
 
 	return (
-		<CheckboxTermsWrapper displayErrorMessage={ displayErrorMessage }>
+		<CheckboxTermsWrapper>
 			<StyledFormCheckbox
 				onChange={ handleChange }
 				onBlur={ () => setTouched( true ) }
 				checked={ isAccepted }
 			/>
-			<MessageWrapper>{ message }</MessageWrapper>
+			<MessageWrapper displayErrorMessage={ displayErrorMessage }>{ message }</MessageWrapper>
 			{ displayErrorMessage && (
 				<ErrorMessage>{ translate( 'The terms above need to be accepted' ) }</ErrorMessage>
 			) }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -25,34 +25,23 @@ import type { RemoveProductFromCart, CouponStatus } from '@automattic/shopping-c
 const SiteSummary = styled.div`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	font-size: 14px;
-	margin-top: -10px;
+	margin-top: 0px;
 	word-break: break-word;
 
 	.is-summary & {
 		margin-bottom: 10px;
 	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		margin-top: -8px;
+	}
 `;
 
 const CouponLinkWrapper = styled.div`
 	font-size: 14px;
-	margin: 10px 0 20px;
-
-	.is-summary & {
-		margin-bottom: 0;
-	}
 `;
 
-const CouponField = styled( Coupon )`
-	margin: 20px 30px 20px 0;
-
-	.rtl & {
-		margin: 20px 0 20px 30px;
-	}
-
-	.is-summary & {
-		margin: 10px 0 0;
-	}
-`;
+const CouponField = styled( Coupon )``;
 
 const CouponEnableButton = styled.button`
 	cursor: pointer;

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -633,32 +633,33 @@ const CheckoutSummaryCard = styled( CheckoutSummaryCardUnstyled )`
 `;
 
 const CheckoutSummaryFeatures = styled.div`
-	padding: 24px 24px 0;
+	padding: 24px 0;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		padding: 24px;
+		padding: 50px 0 24px;
 	}
 `;
 
 const CheckoutSummaryFeaturesUpsell = styled( CheckoutSummaryFeatures )`
-	padding: 12px 24px 0;
-
-	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		padding: 0 24px 24px;
-	}
+	padding: 0 0 24px;
 
 	& svg {
 		opacity: 50%;
 	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		padding: 0 0 24px;
+	}
 `;
 
 const CheckoutSummaryFeaturesTitle = styled.h3`
-	font-size: 14px;
+	font-size: 20px;
 	font-weight: ${ ( props ) => props.theme.weights.bold };
-	margin-bottom: 6px;
+	line-height: 26px;
+	margin-bottom: 12px;
 
 	& button {
-		font-size: 14px;
+		font-size: 20px;
 		font-weight: ${ ( props ) => props.theme.weights.bold };
 		text-decoration: none;
 	}
@@ -718,18 +719,23 @@ CheckoutSummaryFeaturesListItem.defaultProps = {
 };
 
 const CheckoutSummaryAmountWrapper = styled.div`
-	padding: 24px;
-
-	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-	}
+	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+	padding: 20px 0;
 `;
 
 const CheckoutSummaryLineItem = styled.div`
 	display: flex;
 	flex-wrap: wrap;
+	font-size: 14px;
 	justify-content: space-between;
+	line-heigh: 20px;
 	margin-bottom: 4px;
+
+	&:nth-last-of-type( 2 ) {
+		border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+		margin-bottom: 20px;
+		padding-bottom: 20px;
+	}
 
 	.is-loading & {
 		animation: ${ pulse } 1.5s ease-in-out infinite;
@@ -737,7 +743,10 @@ const CheckoutSummaryLineItem = styled.div`
 `;
 
 const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
+	color: ${ ( props ) => props.theme.colors.textColorDark };
+	font-size: 20px;
 	font-weight: ${ ( props ) => props.theme.weights.bold };
+	line-height: 26px;
 `;
 
 const LoadingCopy = styled.p`

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -380,6 +380,7 @@ export default function WPCheckout( {
 			/>
 			{ contactDetailsType !== 'none' && (
 				<CheckoutStep
+					className="checkout-contact-form-step"
 					stepId="contact-form"
 					isCompleteCallback={ async () => {
 						// Touch the fields so they display validation errors

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -7,7 +7,6 @@ import {
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
-	MainContentWrapper,
 	SubmitButtonWrapper,
 	Button,
 	useTransactionStatus,
@@ -23,12 +22,15 @@ import {
 	CheckoutErrorBoundary,
 	CheckoutFormSubmit,
 	PaymentMethodStep,
+	FormStatus,
 } from '@automattic/composite-checkout';
+import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
+import { keyframes } from '@emotion/react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import MaterialIcon from 'calypso/components/material-icon';
 import {
@@ -42,6 +44,7 @@ import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { areVatDetailsSame } from 'calypso/me/purchases/vat-info/are-vat-details-same';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
+import { CheckoutOrderBanner } from 'calypso/my-sites/checkout/composite-checkout/components/checkout-order-banner';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
 import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/leave-checkout';
 import { prepareDomainContactValidationRequest } from 'calypso/my-sites/checkout/composite-checkout/types/wpcom-store-state';
@@ -79,10 +82,59 @@ import type { RemoveProductFromCart, MinimalRequestCartProduct } from '@automatt
 import type { CountryListItem } from '@automattic/wpcom-checkout';
 import type { ReactNode } from 'react';
 
-const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
+const debug = debugFactory( 'calypso:wp-checkout' );
 
 // This will make converting to TS less noisy. The order of components can be reorganized later
 /* eslint-disable @typescript-eslint/no-use-before-define */
+const LoadingSidebar = styled.div`
+	display: none;
+	width: 100%;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		display: block;
+		padding: 24px;
+		box-sizing: border-box;
+		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+		max-width: 328px;
+		background: ${ ( props ) => props.theme.colors.surface };
+		margin-top: 46px;
+	}
+`;
+
+const pulse = keyframes`
+	0% {
+		opacity: 1;
+	}
+
+	70% {
+		opacity: 0.5;
+	}
+
+	100% {
+		opacity: 1;
+	}
+`;
+
+const SideBarLoadingCopy = styled.p`
+	font-size: 14px;
+	height: 16px;
+	content: '';
+	background: ${ ( props ) => props.theme.colors.borderColorLight };
+	color: ${ ( props ) => props.theme.colors.borderColorLight };
+	margin: 8px 0 0 0;
+	padding: 0;
+	animation: ${ pulse } 2s ease-in-out infinite;
+`;
+
+function LoadingSidebarContent() {
+	return (
+		<LoadingSidebar>
+			<SideBarLoadingCopy />
+			<SideBarLoadingCopy />
+			<SideBarLoadingCopy />
+		</LoadingSidebar>
+	);
+}
 
 const ContactFormTitle = () => {
 	const translate = useTranslate();
@@ -175,6 +227,7 @@ export default function WPCheckout( {
 	customizedPreviousPath?: string;
 	loadingContent: ReactNode;
 } ) {
+	const locale = useLocale();
 	const cartKey = useCartKey();
 	const {
 		responseCart,
@@ -209,6 +262,7 @@ export default function WPCheckout( {
 	// always visible. It is not a step and its visibility is managed manually.
 	const [ isSummaryVisible, setIsSummaryVisible ] = useState( false );
 	const { formStatus } = useFormStatus();
+	const isLoading = formStatus === FormStatus.LOADING;
 
 	const onReviewError = useCallback(
 		( error: Error ) =>
@@ -272,19 +326,19 @@ export default function WPCheckout( {
 	if ( transactionStatus === TransactionStatus.COMPLETE ) {
 		debug( 'rendering post-checkout redirecting page' );
 		return (
-			<MainContentWrapper>
-				<NonCheckoutContentWrapper>
-					<NonCheckoutContentInnerWrapper>
-						<PerformanceTrackerStop />
-						<CheckoutCompleteRedirecting />
-						<SubmitButtonWrapper>
-							<Button buttonType="primary" fullWidth isBusy disabled>
-								{ translate( 'Please wait…' ) }
-							</Button>
-						</SubmitButtonWrapper>
-					</NonCheckoutContentInnerWrapper>
-				</NonCheckoutContentWrapper>
-			</MainContentWrapper>
+			<WPCheckoutWrapper>
+				<WPCheckoutSidebarContent></WPCheckoutSidebarContent>
+				<WPCheckoutMainContent>
+					<PerformanceTrackerStop />
+					<WPCheckoutTitle>{ translate( 'Checkout' ) }</WPCheckoutTitle>
+					<CheckoutCompleteRedirecting />
+					<SubmitButtonWrapper>
+						<Button buttonType="primary" fullWidth isBusy disabled>
+							{ translate( 'Please wait…' ) }
+						</Button>
+					</SubmitButtonWrapper>
+				</WPCheckoutMainContent>
+			</WPCheckoutWrapper>
 		);
 	}
 
@@ -299,246 +353,266 @@ export default function WPCheckout( {
 	) {
 		debug( 'rendering empty cart page' );
 		return (
-			<MainContentWrapper>
-				<NonCheckoutContentWrapper>
-					<NonCheckoutContentInnerWrapper>
-						<PerformanceTrackerStop />
-						<EmptyCart />
-						<SubmitButtonWrapper>
-							<Button buttonType="primary" fullWidth onClick={ goToPreviousPage }>
-								{ translate( 'Go back' ) }
-							</Button>
-						</SubmitButtonWrapper>
-					</NonCheckoutContentInnerWrapper>
-				</NonCheckoutContentWrapper>
-			</MainContentWrapper>
+			<WPCheckoutWrapper>
+				<WPCheckoutSidebarContent></WPCheckoutSidebarContent>
+				<WPCheckoutMainContent>
+					<PerformanceTrackerStop />
+					<WPCheckoutTitle>{ translate( 'Checkout' ) }</WPCheckoutTitle>
+					<EmptyCart />
+					<SubmitButtonWrapper>
+						<Button buttonType="primary" fullWidth onClick={ goToPreviousPage }>
+							{ translate( 'Go back' ) }
+						</Button>
+					</SubmitButtonWrapper>
+				</WPCheckoutMainContent>
+			</WPCheckoutWrapper>
 		);
 	}
 
 	const isDIFMInCart = hasDIFMProduct( responseCart );
 	const hasMonthlyProduct = responseCart?.products?.some( isMonthlyProduct );
 
+	const nextStepButtonText =
+		locale.startsWith( 'en' ) || i18n.hasTranslation( 'Continue to payment' )
+			? translate( 'Continue to payment', { textOnly: true } )
+			: translate( 'Continue', { textOnly: true } );
+
 	return (
-		<CheckoutStepGroup
-			loadingContent={ loadingContent }
-			stepAreaHeader={
-				<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
-					<CheckoutErrorBoundary
-						errorMessage={ translate( 'Sorry, there was an error loading this information.' ) }
-						onError={ onSummaryError }
-					>
-						<CheckoutSummaryTitleLink onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }>
-							<CheckoutSummaryTitle>
-								<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
-								{ translate( 'Purchase Details' ) }
-								<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" />
-							</CheckoutSummaryTitle>
-							<CheckoutSummaryTitlePrice className="wp-checkout__total-price">
-								{ total.amount.displayValue }
-							</CheckoutSummaryTitlePrice>
-						</CheckoutSummaryTitleLink>
-						<CheckoutSummaryBody className="checkout__summary-body">
-							<WPCheckoutOrderSummary
-								siteId={ siteId }
+		<WPCheckoutWrapper>
+			<WPCheckoutSidebarContent>
+				{ isLoading && <LoadingSidebarContent /> }
+				{ ! isLoading && (
+					<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
+						<CheckoutErrorBoundary
+							errorMessage={ translate( 'Sorry, there was an error loading this information.' ) }
+							onError={ onSummaryError }
+						>
+							<CheckoutSummaryTitleLink onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }>
+								<CheckoutSummaryTitleContent>
+									<CheckoutSummaryTitle>
+										<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
+										{ translate( 'Purchase Details' ) }
+										<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" />
+									</CheckoutSummaryTitle>
+									<CheckoutSummaryTitlePrice className="wp-checkout__total-price">
+										{ total.amount.displayValue }
+									</CheckoutSummaryTitlePrice>
+								</CheckoutSummaryTitleContent>
+							</CheckoutSummaryTitleLink>
+							<CheckoutSummaryBody className="checkout__summary-body">
+								<WPCheckoutOrderSummary
+									siteId={ siteId }
+									onChangePlanLength={ changePlanLength }
+									nextDomainIsFree={ responseCart?.next_domain_is_free }
+								/>
+								{ ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct && (
+									<CheckoutSidebarPlanUpsell />
+								) }
+								<SecondaryCartPromotions
+									responseCart={ responseCart }
+									addItemToCart={ addItemToCart }
+									isCartPendingUpdate={ isCartPendingUpdate }
+								/>
+								<CheckoutHelpLink />
+								<CheckoutNextSteps responseCart={ responseCart } />
+							</CheckoutSummaryBody>
+						</CheckoutErrorBoundary>
+					</CheckoutSummaryArea>
+				) }
+			</WPCheckoutSidebarContent>
+
+			<WPCheckoutMainContent>
+				<CheckoutOrderBanner />
+				<WPCheckoutTitle>{ translate( 'Checkout' ) }</WPCheckoutTitle>
+				<CheckoutStepGroup loadingContent={ loadingContent }>
+					<PerformanceTrackerStop />
+					{ infoMessage }
+					<CheckoutStepBody
+						onError={ onReviewError }
+						className="wp-checkout__review-order-step"
+						stepId="review-order-step"
+						isStepActive={ false }
+						isStepComplete={ true }
+						titleContent={ <OrderReviewTitle /> }
+						completeStepContent={
+							<WPCheckoutOrderReview
+								removeProductFromCart={ removeProductFromCart }
+								couponFieldStateProps={ couponFieldStateProps }
 								onChangePlanLength={ changePlanLength }
-								nextDomainIsFree={ responseCart?.next_domain_is_free }
+								siteUrl={ siteUrl }
+								createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 							/>
-							{ ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct && (
-								<CheckoutSidebarPlanUpsell />
-							) }
-							<SecondaryCartPromotions
-								responseCart={ responseCart }
-								addItemToCart={ addItemToCart }
-								isCartPendingUpdate={ isCartPendingUpdate }
-							/>
-							<CheckoutHelpLink />
-							<CheckoutNextSteps responseCart={ responseCart } />
-						</CheckoutSummaryBody>
-					</CheckoutErrorBoundary>
-				</CheckoutSummaryArea>
-			}
-		>
-			<PerformanceTrackerStop />
-			{ infoMessage }
-			<CheckoutStepBody
-				onError={ onReviewError }
-				className="wp-checkout__review-order-step"
-				stepId="review-order-step"
-				isStepActive={ false }
-				isStepComplete={ true }
-				titleContent={ <OrderReviewTitle /> }
-				completeStepContent={
-					<WPCheckoutOrderReview
-						removeProductFromCart={ removeProductFromCart }
-						couponFieldStateProps={ couponFieldStateProps }
-						onChangePlanLength={ changePlanLength }
-						siteUrl={ siteUrl }
-						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
+						}
+						formStatus={ formStatus }
 					/>
-				}
-				formStatus={ formStatus }
-			/>
-			{ contactDetailsType !== 'none' && (
-				<CheckoutStep
-					className="checkout-contact-form-step"
-					stepId="contact-form"
-					isCompleteCallback={ async () => {
-						// Touch the fields so they display validation errors
-						shouldShowContactDetailsValidationErrors && touchContactFields();
-						const validationResponse = await validateContactDetails(
-							contactInfo,
-							isLoggedOutCart,
-							responseCart,
-							showErrorMessageBriefly,
-							applyDomainContactValidationResults,
-							clearDomainContactErrorMessages,
-							reduxDispatch,
-							translate,
-							shouldShowContactDetailsValidationErrors
-						);
-						if ( validationResponse ) {
-							// When the contact details change, update the VAT details on the server.
-							try {
-								if (
-									! isLoggedOutCart &&
-									vatDetailsInForm.id &&
-									! areVatDetailsSame( vatDetailsInForm, vatDetailsFromServer )
-								) {
-									await setVatDetails( vatDetailsInForm );
-								}
-							} catch ( error ) {
-								reduxDispatch( removeNotice( 'vat_info_notice' ) );
-								if ( shouldShowContactDetailsValidationErrors ) {
+					{ contactDetailsType !== 'none' && (
+						<CheckoutStep
+							className="checkout-contact-form-step"
+							stepId="contact-form"
+							isCompleteCallback={ async () => {
+								// Touch the fields so they display validation errors
+								shouldShowContactDetailsValidationErrors && touchContactFields();
+								const validationResponse = await validateContactDetails(
+									contactInfo,
+									isLoggedOutCart,
+									responseCart,
+									showErrorMessageBriefly,
+									applyDomainContactValidationResults,
+									clearDomainContactErrorMessages,
+									reduxDispatch,
+									translate,
+									shouldShowContactDetailsValidationErrors
+								);
+								if ( validationResponse ) {
+									// When the contact details change, update the VAT details on the server.
+									try {
+										if (
+											! isLoggedOutCart &&
+											vatDetailsInForm.id &&
+											! areVatDetailsSame( vatDetailsInForm, vatDetailsFromServer )
+										) {
+											await setVatDetails( vatDetailsInForm );
+										}
+									} catch ( error ) {
+										reduxDispatch( removeNotice( 'vat_info_notice' ) );
+										if ( shouldShowContactDetailsValidationErrors ) {
+											reduxDispatch(
+												errorNotice( ( error as Error ).message, { id: 'vat_info_notice' } )
+											);
+										}
+										return false;
+									}
+									reduxDispatch( removeNotice( 'vat_info_notice' ) );
+
+									// When the contact details change, update the cart's tax location to match.
+									try {
+										await updateCartContactDetailsForCheckout(
+											countriesList,
+											responseCart,
+											updateLocation,
+											contactInfo,
+											vatDetailsInForm
+										);
+									} catch {
+										// If updating the cart fails, we should not continue. No need
+										// to do anything else, though, because CartMessages will
+										// display the error.
+										return false;
+									}
+
+									// When the contact details change, update the cached contact details on
+									// the server. This can fail if validation fails but we will silently
+									// ignore failures here because the validation call will handle them better
+									// than this will.
 									reduxDispatch(
-										errorNotice( ( error as Error ).message, { id: 'vat_info_notice' } )
+										saveContactDetailsCache( prepareDomainContactValidationRequest( contactInfo ) )
+									);
+
+									reduxDispatch(
+										recordTracksEvent( 'calypso_checkout_composite_step_complete', {
+											step: 1,
+											step_name: 'contact-form',
+										} )
 									);
 								}
-								return false;
+								return validationResponse;
+							} }
+							activeStepContent={
+								<WPContactForm
+									countriesList={ countriesList }
+									shouldShowContactDetailsValidationErrors={
+										shouldShowContactDetailsValidationErrors
+									}
+									contactDetailsType={ contactDetailsType }
+									isLoggedOutCart={ isLoggedOutCart }
+									setShouldShowContactDetailsValidationErrors={
+										setShouldShowContactDetailsValidationErrors
+									}
+								/>
 							}
-							reduxDispatch( removeNotice( 'vat_info_notice' ) );
-
-							// When the contact details change, update the cart's tax location to match.
-							try {
-								await updateCartContactDetailsForCheckout(
-									countriesList,
-									responseCart,
-									updateLocation,
-									contactInfo,
-									vatDetailsInForm
-								);
-							} catch {
-								// If updating the cart fails, we should not continue. No need
-								// to do anything else, though, because CartMessages will
-								// display the error.
-								return false;
+							completeStepContent={
+								<WPContactFormSummary
+									areThereDomainProductsInCart={ areThereDomainProductsInCart }
+									isGSuiteInCart={ isGSuiteInCart }
+									isLoggedOutCart={ isLoggedOutCart }
+								/>
 							}
-
-							// When the contact details change, update the cached contact details on
-							// the server. This can fail if validation fails but we will silently
-							// ignore failures here because the validation call will handle them better
-							// than this will.
-							reduxDispatch(
-								saveContactDetailsCache( prepareDomainContactValidationRequest( contactInfo ) )
-							);
-
-							reduxDispatch(
-								recordTracksEvent( 'calypso_checkout_composite_step_complete', {
-									step: 1,
-									step_name: 'contact-form',
-								} )
-							);
-						}
-						return validationResponse;
-					} }
-					activeStepContent={
-						<WPContactForm
-							countriesList={ countriesList }
-							shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
-							contactDetailsType={ contactDetailsType }
-							isLoggedOutCart={ isLoggedOutCart }
-							setShouldShowContactDetailsValidationErrors={
-								setShouldShowContactDetailsValidationErrors
-							}
+							titleContent={ <ContactFormTitle /> }
+							editButtonText={ String( translate( 'Edit' ) ) }
+							editButtonAriaLabel={ String( translate( 'Edit the contact details' ) ) }
+							nextStepButtonText={ nextStepButtonText }
+							nextStepButtonAriaLabel={ String(
+								translate( 'Continue with the entered contact details' )
+							) }
+							validatingButtonText={ validatingButtonText }
+							validatingButtonAriaLabel={ validatingButtonText }
 						/>
-					}
-					completeStepContent={
-						<WPContactFormSummary
-							areThereDomainProductsInCart={ areThereDomainProductsInCart }
-							isGSuiteInCart={ isGSuiteInCart }
-							isLoggedOutCart={ isLoggedOutCart }
-						/>
-					}
-					titleContent={ <ContactFormTitle /> }
-					editButtonText={ String( translate( 'Edit' ) ) }
-					editButtonAriaLabel={ String( translate( 'Edit the contact details' ) ) }
-					nextStepButtonText={ String( translate( 'Continue' ) ) }
-					nextStepButtonAriaLabel={ String(
-						translate( 'Continue with the entered contact details' )
 					) }
-					validatingButtonText={ validatingButtonText }
-					validatingButtonAriaLabel={ validatingButtonText }
-				/>
-			) }
-			<PaymentMethodStep
-				activeStepFooter={ <PaymentMethodStepContent /> }
-				editButtonText={ String( translate( 'Edit' ) ) }
-				editButtonAriaLabel={ String( translate( 'Edit the payment method' ) ) }
-				nextStepButtonText={ String( translate( 'Continue' ) ) }
-				nextStepButtonAriaLabel={ String(
-					translate( 'Continue with the selected payment method' )
-				) }
-				validatingButtonText={ validatingButtonText }
-				validatingButtonAriaLabel={ validatingButtonText }
-				isCompleteCallback={ () => false }
-			/>
-			{ hasMarketplaceProduct && (
-				<ThirdPartyDevsAccount
-					isAccepted={ is3PDAccountConsentAccepted }
-					onChange={ setIs3PDAccountConsentAccepted }
-					isSubmitted={ isSubmitted }
-				/>
-			) }
-			<CheckoutFormSubmit
-				validateForm={ validateForm }
-				submitButtonHeader={ <SubmitButtonHeader /> }
-				submitButtonFooter={ <JetpackCheckoutSeals /> }
-			/>
-		</CheckoutStepGroup>
+					<PaymentMethodStep
+						activeStepFooter={
+							<>
+								<PaymentMethodStepContent />
+								{ hasMarketplaceProduct && (
+									<ThirdPartyDevsAccount
+										isAccepted={ is3PDAccountConsentAccepted }
+										onChange={ setIs3PDAccountConsentAccepted }
+										isSubmitted={ isSubmitted }
+									/>
+								) }
+							</>
+						}
+						editButtonText={ String( translate( 'Edit' ) ) }
+						editButtonAriaLabel={ String( translate( 'Edit the payment method' ) ) }
+						nextStepButtonText={ String( translate( 'Continue' ) ) }
+						nextStepButtonAriaLabel={ String(
+							translate( 'Continue with the selected payment method' )
+						) }
+						validatingButtonText={ validatingButtonText }
+						validatingButtonAriaLabel={ validatingButtonText }
+						isCompleteCallback={ () => false }
+					/>
+					<CheckoutFormSubmit
+						validateForm={ validateForm }
+						submitButtonHeader={ <SubmitButtonHeader /> }
+						submitButtonFooter={ <JetpackCheckoutSeals /> }
+					/>
+				</CheckoutStepGroup>
+			</WPCheckoutMainContent>
+		</WPCheckoutWrapper>
 	);
 }
 
 const CheckoutSummaryArea = styled( CheckoutSummaryAreaUnstyled )`
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		margin: 0;
+		max-width: 288px;
 		position: relative;
+		padding: 0;
 	}
 `;
 
 const CheckoutSummaryTitleLink = styled.button`
 	background: ${ ( props ) => props.theme.colors.background };
 	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+	width: 100%;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		display: none;
+	}
+`;
+
+const CheckoutSummaryTitleContent = styled.span`
 	color: ${ ( props ) => props.theme.colors.textColor };
 	display: flex;
 	font-size: 16px;
 	font-weight: ${ ( props ) => props.theme.weights.bold };
 	justify-content: space-between;
-	padding: 20px 23px 20px 14px;
-	width: 100%;
+	margin: 0 auto;
+	padding: 24px;
+	max-width: 600px;
 
-	.rtl & {
-		padding: 20px 14px 20px 23px;
-	}
-
-	.is-visible & {
-		border-bottom: none;
-	}
-
-	@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
-		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-		border-bottom: none 0;
-	}
-
-	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		display: none;
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		padding: 24px 0;
 	}
 `;
 
@@ -580,27 +654,28 @@ const CheckoutSummaryTitlePrice = styled.span`
 `;
 
 const CheckoutSummaryBody = styled.div`
-	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+	box-sizing: border-box;
 	display: none;
+	margin: 0 auto;
+	max-width: 600px;
+	width: 100%;
+	padding: 0 24px 25px;
 
 	.is-visible & {
 		display: block;
 	}
 
-	@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
-		border-bottom: none;
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		padding: 0 0 25px;
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		display: block;
 		max-width: 328px;
-		position: fixed;
-		width: 100%;
-		overflow-y: auto;
-		height: 100vh;
+		padding: 0;
+
 		& .card {
-			border-left: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-			border-right: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+			box-shadow: none;
 		}
 	}
 `;
@@ -735,28 +810,74 @@ const SubmitButtonHeaderWrapper = styled.div`
 	}
 `;
 
-const NonCheckoutContentWrapper = styled.div`
-	display: flex;
+const WPCheckoutWrapper = styled.div`
+	display: grid;
+	grid-template-rows: auto;
+	grid-template-columns: 1fr;
+	grid-template-areas: 'sidebar-content' 'main-content';
+	justify-content: center;
+	justify-items: center;
+	min-height: 100vh;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		align-items: flex-start;
-		flex-direction: row;
-		justify-content: center;
+		grid-template-columns: 1fr minmax( 500px, 688px ) 376px 1fr;
+		grid-template-areas: 'main-content main-content sidebar-content sidebar-content';
+		justify-items: end;
+	}
+
+	& > * {
+		box-sizing: border-box;
 		width: 100%;
+
+		@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+			min-height: 100vh;
+		}
 	}
 `;
 
-const NonCheckoutContentInnerWrapper = styled.div`
-	background: ${ ( props ) => props.theme.colors.surface };
-	width: 100%;
+const WPCheckoutMainContent = styled.div`
+	grid-area: main-content;
+	margin-top: 50px;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-		max-width: 556px;
-		margin: 0 auto;
+		padding: 0 24px;
+		max-width: 648px;
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		margin: 0;
+		margin-top: calc( var( --masterbar-checkout-height ) + 24px );
+		max-width: 688px;
+		padding: 0 64px 0 24px;
+
+		.rtl & {
+			padding: 0 24px 0 64px;
+		}
+	}
+`;
+
+const WPCheckoutSidebarContent = styled.div`
+	background: ${ ( props ) => props.theme.colors.background };
+	grid-area: sidebar-content;
+	margin-top: var( --masterbar-checkout-height );
+
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		margin-top: 0;
+		padding: 144px 24px 0 64px;
+
+		.rtl & {
+			padding: 144px 64px 0 24px;
+		}
+	}
+`;
+
+const WPCheckoutTitle = styled.div`
+	font-size: 44px;
+	font-family: 'Recoleta', serif;
+	font-weight: ${ ( props ) => props.theme.weights.bold };
+	line-height: 1em;
+	padding: 0 24px;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		padding: 0;
 	}
 `;

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -29,7 +29,6 @@ import type {
 import type { PropsWithChildren } from 'react';
 
 const WPOrderReviewList = styled.ul< { theme?: Theme } >`
-	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	box-sizing: border-box;
 	margin: 20px 0;
 	padding: 0;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -39,6 +39,7 @@ import type { StripeConfiguration, StripeLoadingError } from '@automattic/calyps
 import type { PaymentMethod } from '@automattic/composite-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
 import type { Stripe } from '@stripe/stripe-js';
+import type { ReactNode } from 'react';
 
 export { useCreateExistingCards };
 
@@ -70,7 +71,7 @@ export function useCreateCreditCard( {
 	stripeLoadingError: StripeLoadingError;
 	shouldUseEbanx: boolean;
 	shouldShowTaxFields?: boolean;
-	activePayButtonText?: string | undefined;
+	activePayButtonText?: ReactNode;
 	initialUseForAllSubscriptions?: boolean;
 	allowUseForAllSubscriptions?: boolean;
 } ): PaymentMethod | null {

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -1,15 +1,19 @@
 import { useStripe } from '@automattic/calypso-stripe';
 import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
+import { styled } from '@automattic/wpcom-checkout';
 import { useElements, CardNumberElement } from '@stripe/react-stripe-js';
 import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
+import i18n, { getLocaleSlug } from 'i18n-calypso';
+import MaterialIcon from 'calypso/components/material-icon';
 import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
 import { actions, selectors } from './store';
 import type { WpcomCreditCardSelectors } from './store';
 import type { CardFieldState, CardStoreType } from './types';
 import type { ProcessPayment, LineItem } from '@automattic/composite-checkout';
+import type { ReactNode } from 'react';
 
 const debug = debugFactory( 'calypso:composite-checkout:credit-card' );
 
@@ -24,7 +28,7 @@ export default function CreditCardPayButton( {
 	onClick?: ProcessPayment;
 	store: CardStoreType;
 	shouldUseEbanx?: boolean;
-	activeButtonText?: string;
+	activeButtonText?: ReactNode;
 } ) {
 	const { __ } = useI18n();
 	const total = useTotal();
@@ -114,6 +118,21 @@ export default function CreditCardPayButton( {
 	);
 }
 
+const CreditCardPayButtonWrapper = styled[ 'span' ]`
+	display: inline-flex;
+	align-items: flex-end;
+`;
+
+const StyledMaterialIcon = styled( MaterialIcon )`
+	fill: ${ ( { theme } ) => theme.colors.surface };
+	margin-right: 0.7em;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 0.7em;
+	}
+`;
+
 function ButtonContents( {
 	formStatus,
 	total,
@@ -121,15 +140,28 @@ function ButtonContents( {
 }: {
 	formStatus: FormStatus;
 	total: LineItem;
-	activeButtonText?: string;
+	activeButtonText?: ReactNode;
 } ) {
 	const { __ } = useI18n();
 	if ( formStatus === FormStatus.SUBMITTING ) {
 		return <>{ __( 'Processing…' ) }</>;
 	}
 	if ( formStatus === FormStatus.READY ) {
-		/* translators: %s is the total to be paid in localized currency */
-		return <>{ activeButtonText || sprintf( __( 'Pay %s' ), total.amount.displayValue ) }</>;
+		const defaultText = (
+			<CreditCardPayButtonWrapper>
+				<StyledMaterialIcon icon="credit_card" />
+				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'Pay %s now' )
+					? sprintf(
+							/* translators: %s is the total to be paid in localized currency */
+							__( 'Pay %s now' ),
+							total.amount.displayValue
+					  )
+					: /* translators: %s is the total to be paid in localized currency */
+					  sprintf( __( 'Pay %s' ), total.amount.displayValue ) }
+			</CreditCardPayButtonWrapper>
+		);
+
+		return <>{ activeButtonText || defaultText } </>;
 	}
 	return <>{ __( 'Please wait…' ) }</>;
 }

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/form-layout-components.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/form-layout-components.tsx
@@ -67,26 +67,10 @@ export const StripeErrorMessage = styled.span`
 `;
 
 export const CreditCardFieldsWrapper = styled.div< { isLoaded?: boolean } >`
-	padding: 16px;
+	padding: 0 24px 24px 24px;
 	position: relative;
 	display: ${ ( props ) => ( props.isLoaded ? 'block' : 'none' ) };
 	position: relative;
-
-	::after {
-		display: block;
-		width: calc( 100% - 6px );
-		height: 1px;
-		content: '';
-		background: ${ ( props ) => props.theme.colors.borderColorLight };
-		position: absolute;
-		top: 0;
-		left: 3px;
-
-		.rtl & {
-			right: 3px;
-			left: auto;
-		}
-	}
 `;
 
 export const CreditCardField = styled( Field )`

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/index.tsx
@@ -16,6 +16,7 @@ import CreditCardFields from './credit-card-fields';
 import CreditCardPayButton from './credit-card-pay-button';
 import type { WpcomCreditCardSelectors } from './store';
 import type { CardFieldState, CardStoreType } from './types';
+import type { ReactNode } from 'react';
 
 export { createCreditCardPaymentMethodStore } from './store';
 
@@ -29,7 +30,7 @@ export function createCreditCardMethod( {
 	store: CardStoreType;
 	shouldUseEbanx?: boolean;
 	shouldShowTaxFields?: boolean;
-	activePayButtonText?: string;
+	activePayButtonText?: ReactNode;
 	allowUseForAllSubscriptions?: boolean;
 } ) {
 	return {

--- a/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
@@ -5,12 +5,13 @@ import {
 	useFormStatus,
 	PaymentLogo,
 } from '@automattic/composite-checkout';
-import styled from '@emotion/styled';
+import { styled } from '@automattic/wpcom-checkout';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { Fragment } from 'react';
+import MaterialIcon from 'calypso/components/material-icon';
 import {
 	TaxInfoArea,
 	usePaymentMethodTaxInfo,
@@ -234,6 +235,21 @@ function ExistingCardPayButton( {
 	);
 }
 
+const CreditCardPayButtonWrapper = styled[ 'span' ]`
+	display: inline-flex;
+	align-items: flex-end;
+`;
+
+const StyledMaterialIcon = styled( MaterialIcon )`
+	fill: ${ ( { theme } ) => theme.colors.surface };
+	margin-right: 0.7em;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 0.7em;
+	}
+`;
+
 function ButtonContents( {
 	formStatus,
 	total,
@@ -248,8 +264,21 @@ function ButtonContents( {
 		return <>{ __( 'Processing…' ) }</>;
 	}
 	if ( formStatus === FormStatus.READY ) {
+		const defaultText = (
+			<CreditCardPayButtonWrapper>
+				<StyledMaterialIcon icon="credit_card" />
+				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'Pay %s now' )
+					? sprintf(
+							/* translators: %s is the total to be paid in localized currency */
+							__( 'Pay %s now' ),
+							total.amount.displayValue
+					  )
+					: /* translators: %s is the total to be paid in localized currency */
+					  sprintf( __( 'Pay %s' ), total.amount.displayValue ) }
+			</CreditCardPayButtonWrapper>
+		);
 		/* translators: %s is the total to be paid in localized currency */
-		return <>{ activeButtonText || sprintf( __( 'Pay %s' ), total.amount.displayValue ) }</>;
+		return <>{ activeButtonText || defaultText }</>;
 	}
 	return <>{ __( 'Please wait…' ) }</>;
 }

--- a/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
@@ -262,6 +262,9 @@ function TaxLabel() {
 		[]
 	);
 	const taxString = [ countryCode.value, postalCode.value ].filter( isValueTruthy ).join( ', ' );
+	if ( taxString.length < 1 ) {
+		return null;
+	}
 	return (
 		<div>
 			<span>{ taxString }</span>

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
@@ -265,7 +265,7 @@ describe( 'Checkout contact step', () => {
 				validContactDetails.postal_code
 			);
 
-			await user.click( screen.getByText( 'Continue' ) );
+			await user.click( screen.getByText( 'Continue to payment' ) );
 
 			/* eslint-disable jest/no-conditional-expect */
 			if ( complete === 'does' ) {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
@@ -244,7 +244,7 @@ describe( 'Checkout contact step extra tax fields', () => {
 				}
 			}
 
-			await user.click( screen.getByText( 'Continue' ) );
+			await user.click( screen.getByText( 'Continue to payment' ) );
 			expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 			expect( setCart ).toHaveBeenCalledWith(
 				mainCartKey,
@@ -309,7 +309,7 @@ describe( 'Checkout contact step extra tax fields', () => {
 			}
 			await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 
-			await user.click( screen.getByText( 'Continue' ) );
+			await user.click( screen.getByText( 'Continue to payment' ) );
 			expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 			expect( setCart ).toHaveBeenCalledWith(
 				mainCartKey,
@@ -378,7 +378,7 @@ describe( 'Checkout contact step extra tax fields', () => {
 				await user.type( await screen.findByLabelText( 'Address for GST' ), vatAddress );
 			}
 
-			await user.click( screen.getByText( 'Continue' ) );
+			await user.click( screen.getByText( 'Continue to payment' ) );
 			expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 			expect( setCart ).toHaveBeenCalledWith(
 				mainCartKey,

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -147,7 +147,7 @@ describe( 'CheckoutMain', () => {
 		expect( screen.getAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 1 );
 		await user.click( removeProductButton );
 		const confirmModal = await screen.findByRole( 'dialog' );
-		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
+		const confirmButton = await within( confirmModal ).findByText( 'Continue to payment' );
 		await user.click( confirmButton );
 		await waitFor( async () => {
 			expect( screen.queryByLabelText( 'WordPress.com Personal' ) ).not.toBeInTheDocument();
@@ -170,7 +170,7 @@ describe( 'CheckoutMain', () => {
 		const user = userEvent.setup();
 		await user.click( removeProductButton );
 		const confirmModal = await screen.findByRole( 'dialog' );
-		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
+		const confirmButton = await within( confirmModal ).findByText( 'Continue to payment' );
 		await user.click( confirmButton );
 		await waitFor( () => {
 			expect( navigate ).toHaveBeenCalledWith( '/plans/foo.com' );
@@ -193,7 +193,7 @@ describe( 'CheckoutMain', () => {
 		const user = userEvent.setup();
 		await user.click( removeProductButton );
 		const confirmModal = await screen.findByRole( 'dialog' );
-		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
+		const confirmButton = await within( confirmModal ).findByText( 'Continue to payment' );
 		await user.click( confirmButton );
 		await waitFor( async () => {
 			expect( navigate ).not.toHaveBeenCalledWith( '/plans/foo.com' );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -147,7 +147,7 @@ describe( 'CheckoutMain', () => {
 		expect( screen.getAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 1 );
 		await user.click( removeProductButton );
 		const confirmModal = await screen.findByRole( 'dialog' );
-		const confirmButton = await within( confirmModal ).findByText( 'Continue to payment' );
+		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
 		await user.click( confirmButton );
 		await waitFor( async () => {
 			expect( screen.queryByLabelText( 'WordPress.com Personal' ) ).not.toBeInTheDocument();
@@ -170,7 +170,7 @@ describe( 'CheckoutMain', () => {
 		const user = userEvent.setup();
 		await user.click( removeProductButton );
 		const confirmModal = await screen.findByRole( 'dialog' );
-		const confirmButton = await within( confirmModal ).findByText( 'Continue to payment' );
+		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
 		await user.click( confirmButton );
 		await waitFor( () => {
 			expect( navigate ).toHaveBeenCalledWith( '/plans/foo.com' );
@@ -193,7 +193,7 @@ describe( 'CheckoutMain', () => {
 		const user = userEvent.setup();
 		await user.click( removeProductButton );
 		const confirmModal = await screen.findByRole( 'dialog' );
-		const confirmButton = await within( confirmModal ).findByText( 'Continue to payment' );
+		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
 		await user.click( confirmButton );
 		await waitFor( async () => {
 			expect( navigate ).not.toHaveBeenCalledWith( '/plans/foo.com' );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
@@ -272,7 +272,7 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
 			id: vatId,
@@ -301,7 +301,7 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 	} );
 
@@ -337,7 +337,7 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 	} );
 
@@ -360,7 +360,7 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.type( await screen.findByLabelText( 'VAT ID' ), countryCode + vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
 			id: vatId,
@@ -389,7 +389,7 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.type( await screen.findByLabelText( 'GST ID' ), 'CHE-' + vatId );
 		await user.type( await screen.findByLabelText( 'Organization for GST' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for GST' ), vatAddress );
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
 			id: vatId,
@@ -418,7 +418,7 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.type( await screen.findByLabelText( 'GST ID' ), 'CHE' + vatId );
 		await user.type( await screen.findByLabelText( 'Organization for GST' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for GST' ), vatAddress );
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
 			id: vatId,
@@ -447,7 +447,7 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.type( await screen.findByLabelText( 'GST ID' ), 'che' + vatId );
 		await user.type( await screen.findByLabelText( 'Organization for GST' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for GST' ), vatAddress );
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
 			id: vatId,
@@ -495,7 +495,7 @@ describe( 'Checkout contact step VAT form', () => {
 		const mockVatEndpoint = mockSetVatInfoEndpoint();
 
 		// Submit the form.
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
@@ -522,7 +522,7 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
 			id: vatId,
@@ -554,7 +554,7 @@ describe( 'Checkout contact step VAT form', () => {
 		// Uncheck the box
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).not.toHaveBeenCalled();
 	} );
@@ -589,7 +589,7 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( setCart ).toHaveBeenCalledWith(
 			mainCartKey,
@@ -644,7 +644,7 @@ describe( 'Checkout contact step VAT form', () => {
 		// Uncheck the box
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( setCart ).toHaveBeenCalledWith(
 			mainCartKey,
@@ -693,7 +693,7 @@ describe( 'Checkout contact step VAT form', () => {
 		// Change the country to one that does not support VAT
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), nonVatCountryCode );
 
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( setCart ).toHaveBeenCalledWith(
 			mainCartKey,
@@ -723,7 +723,7 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
-		await user.click( screen.getByText( 'Continue' ) );
+		await user.click( screen.getByText( 'Continue to payment' ) );
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
 	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/test/credit-card.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/credit-card.tsx
@@ -49,7 +49,7 @@ const customerName = 'Human Person';
 const cardNumber = '4242424242424242';
 const cardExpiry = '05/99';
 const cardCvv = '123';
-const activePayButtonText = 'Pay 0';
+const activePayButtonText = 'Pay 0 now';
 function getPaymentMethod( store: CardStoreType, additionalArgs = {} ) {
 	return createCreditCardMethod( {
 		store,

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -264,11 +264,10 @@
 	--color-masterbar-toggle-drafts-editor-hover-background: var(--studio-gray-40);
 	--color-masterbar-toggle-drafts-editor-border: var(--studio-gray-10);
 
-	--color-jetpack-masterbar-background: var(--studio-white);
-	--color-jetpack-masterbar-border: var(--studio-gray-5);
-	--color-jetpack-masterbar-text: var(--studio-gray-50);
-	--color-jetpack-masterbar-item-hover-background: var(--studio-gray-5);
-	--color-jetpack-masterbar-item-active-background: var(--studio-gray-20);
+	--color-checkout-masterbar-background: transparent;
+	--color-checkout-masterbar-text: var(--studio-gray-80);
+	--color-checkout-masterbar-item-hover-background: var(--studio-gray-5);
+	--color-checkout-masterbar-item-active-background: var(--studio-gray-20);
 
 	--color-sidebar-background: #23282d;
 	--color-sidebar-background-rgb: 35, 40, 45;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -264,15 +264,10 @@
 	--color-masterbar-toggle-drafts-editor-hover-background: var(--studio-gray-40);
 	--color-masterbar-toggle-drafts-editor-border: var(--studio-gray-10);
 
-	--color-jetpack-masterbar-background: var(--studio-white);
-	--color-jetpack-masterbar-border: var(--studio-gray-5);
-	--color-jetpack-masterbar-text: var(--studio-gray-50);
-	--color-jetpack-masterbar-item-hover-background: var(--studio-gray-5);
-	--color-jetpack-masterbar-item-active-background: var(--studio-gray-20);
-
-	--color-akismet-masterbar-background: var(--studio-white);
-	--color-akismet-masterbar-border: var(--studio-gray-5);
-	--color-akismet-masterbar-text: var(--studio-gray-50);
+	--color-checkout-masterbar-background: transparent;
+	--color-checkout-masterbar-text: var(--studio-gray-50);
+	--color-checkout-masterbar-item-hover-background: var(--studio-gray-5);
+	--color-checkout-masterbar-item-active-background: var(--studio-gray-20);
 
 	--color-sidebar-background: var(--color-surface);
 	--color-sidebar-background-rgb: var(--studio-white-rgb);

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -46,6 +46,7 @@
 	"devDependencies": {
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
+		"@automattic/color-studio": "2.5.0",
 		"@storybook/cli": "^7.0.18",
 		"@storybook/react": "^7.0.18",
 		"@testing-library/dom": "^8.13.0",

--- a/packages/composite-checkout/src/components/button.tsx
+++ b/packages/composite-checkout/src/components/button.tsx
@@ -7,21 +7,16 @@ const CallToAction = styled( 'button' )< CallToActionProps >`
 	display: block;
 	width: ${ ( props: CallToActionProps ) => ( props.fullWidth ? '100%' : 'auto' ) };
 	font-size: 16px;
-	border-radius: ${ ( props ) => ( props.buttonType === 'paypal' ? '50px' : '2px' ) };
+	border-radius: 4px;
 	padding: ${ ( props ) => ( props.buttonType === 'text-button' ? '0' : '10px 15px' ) };
-	border: ${ ( props ) =>
-		! props.buttonType || ( props.disabled && props.buttonType !== 'text-button' )
-			? '1px solid ' + props.theme.colors.borderColor
-			: '0' };
 	background: ${ getBackgroundColor };
 	color: ${ getTextColor };
-	font-weight: ${ ( props ) => props.theme.weights.normal };
+	font-weight: ${ ( props ) =>
+		props.buttonType === 'primary' ? props.theme.weights.bold : props.theme.weights.normal };
 	text-decoration: ${ getTextDecoration };
 
 	:hover {
 		background: ${ getRollOverColor };
-		border-color: ${ ( props ) =>
-			! props.buttonType ? props.theme.colors.borderColorDark : 'inherit' };
 		text-decoration: none;
 		color: ${ getTextColor };
 		cursor: ${ ( props ) => ( props.disabled ? 'not-allowed' : 'pointer' ) };

--- a/packages/composite-checkout/src/components/checkout-next-step-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-next-step-button.tsx
@@ -8,7 +8,13 @@ function CheckoutNextStepButton( {
 	...props
 }: CheckoutNextStepButtonProps & ButtonProps & React.ButtonHTMLAttributes< HTMLButtonElement > ) {
 	return (
-		<Button onClick={ onClick } buttonType="primary" aria-label={ ariaLabel } { ...props }>
+		<Button
+			className="checkout-next-step-button"
+			onClick={ onClick }
+			buttonType="primary"
+			aria-label={ ariaLabel }
+			{ ...props }
+		>
 			{ value }
 		</Button>
 	);

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -21,6 +21,10 @@ import type { ReactNode } from 'react';
 
 const debug = debugFactory( 'composite-checkout:checkout-payment-methods' );
 
+const CheckoutPaymentMethodsWrapper = styled.div`
+	padding-top: 4px;
+`;
+
 export const RadioButtons = styled.div`
 	margin-bottom: 16px;
 `;
@@ -53,7 +57,9 @@ export default function CheckoutPaymentMethods( {
 	if ( summary && isComplete && paymentMethod ) {
 		debug( 'rendering selected paymentMethod', paymentMethod );
 		return (
-			<div className={ joinClasses( [ className, 'checkout-payment-methods' ] ) }>
+			<CheckoutPaymentMethodsWrapper
+				className={ joinClasses( [ className, 'checkout-payment-methods' ] ) }
+			>
 				<CheckoutErrorBoundary
 					errorMessage={ __( 'There was a problem with this payment method.' ) }
 					onError={ onError }
@@ -68,7 +74,7 @@ export default function CheckoutPaymentMethods( {
 						ariaLabel={ paymentMethod.getAriaLabel( __ as ( text: string ) => string ) }
 					/>
 				</CheckoutErrorBoundary>
-			</div>
+			</CheckoutPaymentMethodsWrapper>
 		);
 	}
 
@@ -84,7 +90,9 @@ export default function CheckoutPaymentMethods( {
 	debug( 'rendering paymentMethods', paymentMethods );
 
 	return (
-		<div className={ joinClasses( [ className, 'checkout-payment-methods' ] ) }>
+		<CheckoutPaymentMethodsWrapper
+			className={ joinClasses( [ className, 'checkout-payment-methods' ] ) }
+		>
 			<RadioButtons>
 				{ paymentMethods.map( ( method ) => (
 					<CheckoutErrorBoundary
@@ -108,7 +116,7 @@ export default function CheckoutPaymentMethods( {
 					</CheckoutErrorBoundary>
 				) ) }
 			</RadioButtons>
-		</div>
+		</CheckoutPaymentMethodsWrapper>
 	);
 }
 

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -27,7 +27,6 @@ import CheckoutSubmitButton from './checkout-submit-button';
 import LoadingContent from './loading-content';
 import { CheckIcon } from './shared-icons';
 import { useCustomPropertyForHeight } from './use-custom-property-for-height';
-import type { Theme } from '../lib/theme';
 import type {
 	CheckoutStepProps,
 	StepCompleteCallback,
@@ -200,17 +199,13 @@ const CheckoutWrapper = styled.div`
 `;
 
 export const MainContentWrapper = styled.div`
-	display: flex;
-	flex-direction: column;
-	flex-wrap: wrap;
 	width: 100%;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		margin: 0 auto 32px;
+		margin: 0 auto;
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		align-items: flex-start;
 		flex-direction: row;
 		justify-content: center;
 		max-width: none;
@@ -221,21 +216,12 @@ const CheckoutSummary = styled.div`
 	box-sizing: border-box;
 	margin: 0 auto;
 	width: 100%;
-
-	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		max-width: 556px;
-	}
+	display: flex;
+	flex-direction: column;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		margin-right: 0;
-		margin-left: 24px;
-		order: 2;
-		width: 328px;
-
-		.rtl & {
-			margin-right: 24px;
-			margin-left: 0;
-		}
+		padding-left: 24px;
+		padding-right: 24px;
 	}
 `;
 
@@ -252,19 +238,7 @@ export const CheckoutSummaryArea = ( {
 	);
 };
 
-export const CheckoutSummaryCard = styled.div`
-	background: ${ ( props ) => props.theme.colors.surface };
-	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-
-	@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
-		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-		border-bottom: none 0;
-	}
-
-	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-	}
-`;
+export const CheckoutSummaryCard = styled.div``;
 
 function isElementAStep( el: ReactNode ): boolean {
 	const childStep = el as { type?: { isCheckoutStep?: boolean } };
@@ -507,42 +481,33 @@ export const CheckoutStepAreaWrapper = styled.div`
 	background: ${ ( props ) => props.theme.colors.surface };
 	box-sizing: border-box;
 	margin: 0 auto;
-	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
 
 	&.checkout__step-wrapper--last-step {
 		margin-bottom: var( ${ customPropertyForSubmitButtonHeight }, 100px );
 	}
 
-	@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
-		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-	}
-
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		max-width: 556px;
 		margin-bottom: 0;
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		margin: 0;
-		order: 1;
-		width: 556px;
 	}
 `;
 
 export const SubmitButtonWrapper = styled.div`
-	background: ${ ( props ) => props.theme.colors.background };
-	padding: 24px;
+	background: ${ ( props ) => props.theme.colors.surface };
+	padding: 24px 16px;
 	bottom: 0;
 	left: 0;
 	box-sizing: border-box;
 	width: 100%;
 	z-index: 10;
-	border-top-width: 0;
-	border-top-style: solid;
-	border-top-color: ${ ( props ) => props.theme.colors.borderColorLight };
 
 	.checkout__step-wrapper--last-step & {
-		border-top-width: 1px;
 		position: fixed;
 	}
 
@@ -552,18 +517,22 @@ export const SubmitButtonWrapper = styled.div`
 	}
 
 	.checkout-button {
-		width: calc( 100% - 60px );
 		margin: 0 auto;
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		padding: 24px 0px 24px 40px;
+
 		.checkout-button {
 			width: 100%;
 		}
 
 		.checkout__step-wrapper--last-step & {
 			position: relative;
-			border: 0;
+		}
+
+		.rtl & {
+			padding: 24px 40px 24px 0px;
 		}
 	}
 `;
@@ -635,31 +604,29 @@ export function CheckoutFormSubmit( {
 
 const StepWrapper = styled.div< HTMLAttributes< HTMLDivElement > >`
 	position: relative;
-	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-	padding: 16px;
-
-	&.checkout-step {
-		background: ${ ( props ) => props.theme.colors.background };
-	}
-
-	&.checkout-step.is-active,
-	&.checkout-step.is-complete {
-		background: ${ ( props ) => props.theme.colors.surface };
-	}
+	padding: 24px;
+	width: 100%;
+	box-sizing: border-box;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		padding: 24px;
+		padding: 50px 0 0 0;
 	}
 `;
 
 const StepContentWrapper = styled.div< StepContentWrapperProps & HTMLAttributes< HTMLDivElement > >`
 	color: ${ ( props ) => props.theme.colors.textColor };
 	display: ${ ( props ) => ( props.isVisible ? 'block' : 'none' ) };
-	padding-left: 35px;
+	box-sizing: border-box;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		padding-left: 40px;
+	}
 
 	.rtl & {
-		padding-right: 35px;
-		padding-left: 0;
+		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+			padding-left: 0;
+			padding-right: 40px;
+		}
 	}
 `;
 
@@ -671,11 +638,17 @@ const StepSummaryWrapper = styled.div< StepContentWrapperProps & HTMLAttributes<
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	font-size: 14px;
 	display: ${ ( props ) => ( props.isVisible ? 'block' : 'none' ) };
-	padding-left: 35px;
+	box-sizing: border-box;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		padding-left: 40px;
+	}
 
 	.rtl & {
-		padding-right: 35px;
-		padding-left: 0;
+		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+			padding-left: 0;
+			padding-right: 40px;
+		}
 	}
 `;
 
@@ -831,9 +804,10 @@ export function useSetStepComplete(): SetStepComplete {
 
 const StepTitle = styled.span< StepTitleProps & HTMLAttributes< HTMLSpanElement > >`
 	color: ${ ( props ) =>
-		props.isActive ? props.theme.colors.textColorDark : props.theme.colors.textColor };
-	font-weight: ${ ( props ) =>
-		props.isActive ? props.theme.weights.bold : props.theme.weights.normal };
+		props.isActive || props.isComplete
+			? props.theme.colors.textColorDark
+			: props.theme.colors.textColorDisabled };
+	font-weight: ${ ( props ) => props.theme.weights.bold };
 	margin-right: ${ ( props ) => ( props.fullWidth ? '0' : '8px' ) };
 	flex: 1;
 
@@ -844,12 +818,13 @@ const StepTitle = styled.span< StepTitleProps & HTMLAttributes< HTMLSpanElement 
 `;
 
 interface StepTitleProps {
+	isComplete?: boolean;
 	isActive?: boolean;
 	fullWidth?: boolean;
 }
 
 const StepHeader = styled.h2< StepHeaderProps & HTMLAttributes< HTMLHeadingElement > >`
-	font-size: 16px;
+	font-size: 20px;
 	display: flex;
 	width: 100%;
 	align-items: center;
@@ -900,7 +875,11 @@ function CheckoutStepHeader( {
 			<Stepper isComplete={ isComplete } isActive={ isActive } id={ id }>
 				{ stepNumber || null }
 			</Stepper>
-			<StepTitle fullWidth={ ! shouldShowEditButton } isActive={ isActive }>
+			<StepTitle
+				fullWidth={ ! shouldShowEditButton }
+				isComplete={ isComplete }
+				isActive={ isActive }
+			>
 				{ title }
 			</StepTitle>
 			{ shouldShowEditButton && (
@@ -919,13 +898,22 @@ function CheckoutStepHeader( {
 
 const StepNumberOuterWrapper = styled.div`
 	position: relative;
-	width: 27px;
-	height: 27px;
+	width: 26px;
+	height: 26px;
 	margin-right: 8px;
 
 	.rtl & {
 		margin-right: 0;
 		margin-left: 8px;
+	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		margin-right: 12px;
+
+		.rtl & {
+			margin-right: 0;
+			margin-left: 12px;
+		}
 	}
 `;
 
@@ -944,15 +932,23 @@ interface StepNumberInnerWrapperProps {
 }
 
 const StepNumber = styled.div< StepNumberProps & HTMLAttributes< HTMLDivElement > >`
-	background: ${ getStepNumberBackgroundColor };
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: ${ ( props ) => props.theme.colors.surface };
 	font-weight: normal;
-	width: 27px;
-	height: 27px;
-	line-height: 27px;
+	font-size: 16px;
+	width: 26px;
+	height: 26px;
 	box-sizing: border-box;
 	text-align: center;
 	border-radius: 50%;
-	color: ${ getStepNumberForegroundColor };
+	border-width: 1px;
+	border-style: solid;
+	border-color: ${ ( props ) =>
+		props.isActive ? props.theme.colors.textColor : props.theme.colors.textColorDisabled };
+	color: ${ ( props ) =>
+		props.isActive ? props.theme.colors.textColor : props.theme.colors.textColorDisabled };
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -977,16 +973,13 @@ interface StepNumberProps {
 
 const StepNumberCompleted = styled( StepNumber )`
 	background: ${ ( props ) => props.theme.colors.success };
+	border-color: ${ ( props ) => props.theme.colors.success };
 	transform: rotateY( 180deg );
 	// Reason: media query needs to not have spaces within brackets otherwise ie11 doesn't read them
 	// prettier-ignore
 	@media all and (-ms-high-contrast:none), (-ms-high-contrast:active) {
 		backface-visibility: visible;
 		z-index: ${ ( props ) => ( props.isComplete ? '1' : '0' ) };
-	}
-
-	svg {
-		margin-top: 4px;
 	}
 `;
 
@@ -1037,39 +1030,6 @@ Stepper.propTypes = {
 	isComplete: PropTypes.bool,
 	isActive: PropTypes.bool,
 };
-
-function getStepNumberBackgroundColor( {
-	isComplete,
-	isActive,
-	theme,
-}: {
-	isComplete?: boolean;
-	isActive?: boolean;
-	theme: Theme;
-} ) {
-	if ( isActive ) {
-		return theme.colors.highlight;
-	}
-	if ( isComplete ) {
-		return theme.colors.success;
-	}
-	return theme.colors.upcomingStepBackground;
-}
-
-function getStepNumberForegroundColor( {
-	isComplete,
-	isActive,
-	theme,
-}: {
-	isComplete?: boolean;
-	isActive?: boolean;
-	theme: Theme;
-} ) {
-	if ( isComplete || isActive ) {
-		return theme.colors.surface;
-	}
-	return theme.colors.textColor;
-}
 
 function saveStepNumberToUrl( stepNumber: number ) {
 	if ( ! window?.history || ! window?.location ) {

--- a/packages/composite-checkout/src/components/loading-content.tsx
+++ b/packages/composite-checkout/src/components/loading-content.tsx
@@ -4,6 +4,7 @@ import { useI18n } from '@wordpress/react-i18n';
 
 const LoadingContentWrapper = styled.div`
 	display: flex;
+	padding-top: 50px;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		align-items: flex-start;
@@ -25,21 +26,6 @@ const LoadingContentInnerWrapper = styled.div`
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		margin: 0;
-	}
-`;
-
-const LoadingSidebar = styled.div`
-	display: none;
-	width: 100%;
-
-	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		display: block;
-		padding: 24px;
-		box-sizing: border-box;
-		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-		max-width: 328px;
-		background: ${ ( props ) => props.theme.colors.surface };
-		margin-left: 24px;
 	}
 `;
 
@@ -115,17 +101,6 @@ const LoadingCopy = styled.p`
 	}
 `;
 
-const SideBarLoadingCopy = styled.p`
-	font-size: 14px;
-	height: 16px;
-	content: '';
-	background: ${ ( props ) => props.theme.colors.borderColorLight };
-	color: ${ ( props ) => props.theme.colors.borderColorLight };
-	margin: 8px 0 0 0;
-	padding: 0;
-	animation: ${ pulse } 2s ease-in-out infinite;
-`;
-
 const LoadingFooter = styled.div`
 	background: ${ ( props ) => props.theme.colors.background };
 	content: '';
@@ -167,12 +142,6 @@ export default function LoadingContent() {
 				</LoadingCard>
 				<LoadingFooter />
 			</LoadingContentInnerWrapper>
-
-			<LoadingSidebar>
-				<SideBarLoadingCopy />
-				<SideBarLoadingCopy />
-				<SideBarLoadingCopy />
-			</LoadingSidebar>
 		</LoadingContentWrapper>
 	);
 }

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -9,15 +9,10 @@ const RadioButtonWrapper = styled.div<
 >`
 	position: relative;
 	display: ${ ( props ) => ( props.hidden ? 'none' : 'block' ) };
-	margin-top: 8px;
 	border-radius: 3px;
 	box-sizing: border-box;
 	width: 100%;
 	outline: ${ getOutline };
-
-	:first-of-type {
-		margin: 0;
-	}
 
 	::before {
 		display: ${ ( props ) => ( props.hidden ? 'none' : 'block' ) };
@@ -27,8 +22,9 @@ const RadioButtonWrapper = styled.div<
 		top: 0;
 		left: 0;
 		content: '';
-		border: ${ getBorderWidth } solid ${ getBorderColor };
-		border-radius: 3px;
+		border: ${ ( props ) => ( props.checked ? '1px solid ' + getBorderColor( props ) : 'none' ) };
+		border-bottom: ${ ( props ) => '1px solid ' + getBorderColor( props ) };
+		border-radius: ${ ( props ) => ( props.checked ? '3px' : '0px' ) };
 		box-sizing: border-box;
 
 		.rtl & {
@@ -96,21 +92,28 @@ const Radio = styled.input`
 interface LabelProps {
 	disabled?: boolean;
 	checked?: boolean;
-	isFixedHeight?: boolean;
 }
 
+/**
+ * This is the label used by radio buttons. It includes a before/after which
+ * are fake radio button dots whereas the actual radio button dots are hidden.
+ *
+ * The inner `span` is where the contents of the label actually goes.
+ */
+// TODO: fix RTL
 const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelElement > >`
 	position: relative;
-	padding: 16px 14px 16px 40px;
+	padding: 24px;
 	border-radius: 3px;
 	box-sizing: border-box;
 	width: 100%;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
-	align-items: ${ ( props ) => ( props.isFixedHeight ? 'center' : 'flex-start' ) };
+	align-items: center;
+	align-content: center;
 	font-size: 14px;
-	height: ${ ( props ) => ( props.isFixedHeight ? '72px' : 'auto' ) };
+	height: 72px;
 
 	.rtl & {
 		padding: 16px 40px 16px 14px;
@@ -127,8 +130,8 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		content: '';
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
 		border-radius: 100%;
-		top: ${ ( props ) => ( props.isFixedHeight ? '28px' : '19px' ) };
-		left: 16px;
+		top: 28px;
+		left: 24px;
 		position: absolute;
 		background: ${ ( props ) => props.theme.colors.surface };
 		box-sizing: border-box;
@@ -146,8 +149,8 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		height: 8px;
 		content: '';
 		border-radius: 100%;
-		top: ${ ( props ) => ( props.isFixedHeight ? '32px' : '23px' ) };
-		left: 20px;
+		top: 32px;
+		left: 28px;
 		position: absolute;
 		background: ${ getRadioColor };
 		box-sizing: border-box;
@@ -158,6 +161,11 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 			left: auto;
 		}
 	}
+
+	span {
+		padding-left: 32px;
+	}
+}
 
 	${ handleLabelDisabled };
 `;
@@ -178,7 +186,6 @@ export default function RadioButton( {
 	disabled,
 	hidden,
 	id,
-	isFixedHeight,
 	ariaLabel,
 	...otherProps
 }: RadioButtonProps ) {
@@ -209,12 +216,7 @@ export default function RadioButton( {
 				aria-label={ ariaLabel }
 				{ ...otherProps }
 			/>
-			<Label
-				checked={ checked }
-				htmlFor={ id }
-				disabled={ disabled }
-				isFixedHeight={ isFixedHeight }
-			>
+			<Label checked={ checked } htmlFor={ id } disabled={ disabled }>
 				{ label }
 			</Label>
 			{ children && <RadioButtonChildren checked={ checked }>{ children }</RadioButtonChildren> }
@@ -232,7 +234,6 @@ interface RadioButtonProps {
 	value: string;
 	onChange?: () => void;
 	ariaLabel?: string;
-	isFixedHeight?: boolean;
 	children?: React.ReactNode;
 }
 
@@ -300,10 +301,6 @@ function getBorderColor( { checked, theme }: { checked?: boolean; theme: Theme }
 
 function getRadioColor( { checked, theme }: { checked?: boolean; theme: Theme } ) {
 	return checked ? theme.colors.highlight : theme.colors.surface;
-}
-
-function getBorderWidth( { checked }: { checked?: boolean } ) {
-	return checked ? '3px' : '1px';
 }
 
 function getGrayscaleValue( { checked }: { checked?: boolean } ) {

--- a/packages/composite-checkout/src/components/shared-icons.tsx
+++ b/packages/composite-checkout/src/components/shared-icons.tsx
@@ -7,7 +7,7 @@ const CheckIconSvg = styled.svg`
 export function CheckIcon( { className, id }: { className?: string; id: string } ) {
 	return (
 		<CheckIconSvg
-			width="20"
+			width="16"
 			height="20"
 			viewBox="0 0 20 20"
 			xmlns="http://www.w3.org/2000/svg"

--- a/packages/composite-checkout/src/lib/theme.ts
+++ b/packages/composite-checkout/src/lib/theme.ts
@@ -1,3 +1,4 @@
+import colorStudio from '@automattic/color-studio';
 import { swatches } from './swatches';
 
 export type Theme = {
@@ -22,6 +23,7 @@ export type Theme = {
 		textColor: string;
 		textColorLight: string;
 		textColorDark: string;
+		textColorDisabled: string;
 		error: string;
 		warningBackground: string;
 		outline: string;
@@ -58,24 +60,25 @@ const theme: Theme = {
 	colors: {
 		background: swatches.gray0,
 		surface: swatches.white,
-		primary: swatches.pink50,
+		primary: colorStudio.colors[ 'Blue 50' ],
 		primaryBorder: swatches.pink80,
-		primaryOver: swatches.pink60,
+		primaryOver: colorStudio.colors[ 'Blue 60' ],
 		highlight: swatches.blue50,
 		highlightBorder: swatches.blue80,
 		highlightOver: swatches.blue60,
-		success: swatches.green50,
-		discount: swatches.green50,
-		disabledPaymentButtons: swatches.gray0,
-		disabledPaymentButtonsAccent: swatches.gray5,
-		disabledButtons: swatches.gray20,
+		success: colorStudio.colors[ 'Green 30' ],
+		discount: colorStudio.colors[ 'Green 30' ],
+		disabledPaymentButtons: colorStudio.colors[ 'Gray 5' ],
+		disabledPaymentButtonsAccent: colorStudio.colors[ 'Gray 5' ],
+		disabledButtons: colorStudio.colors[ 'White' ],
 		borderColor: swatches.gray10,
 		borderColorLight: swatches.gray5,
 		borderColorDark: swatches.gray50,
 		upcomingStepBackground: swatches.gray5,
-		textColor: swatches.gray80,
-		textColorLight: swatches.gray50,
-		textColorDark: swatches.black,
+		textColor: colorStudio.colors[ 'Gray 60' ],
+		textColorLight: colorStudio.colors[ 'Gray 50' ],
+		textColorDark: colorStudio.colors[ 'Gray 100' ],
+		textColorDisabled: colorStudio.colors[ 'Gray 10' ],
 		error: swatches.red50,
 		warningBackground: swatches.red0,
 		outline: swatches.blue30,
@@ -87,7 +90,7 @@ const theme: Theme = {
 		paypalGold: '#F0C443',
 		paypalGoldHover: '#FFB900',
 		modalBackground: 'rgba( 255,255,255,0.9 )',
-		disabledField: swatches.gray0,
+		disabledField: colorStudio.colors[ 'Gray 0' ],
 		placeHolderTextColor: swatches.gray30,
 	},
 	breakpoints: {
@@ -97,7 +100,7 @@ const theme: Theme = {
 		smallPhoneUp: 'min-width: 400px',
 	},
 	weights: {
-		bold: '600',
+		bold: '500',
 		normal: '400',
 	},
 	fonts: {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -56,13 +56,17 @@ export const NonProductLineItem = styled( WPNonProductLineItem )< {
 	justify-content: space-between;
 	font-weight: ${ ( { theme, total } ) => ( total ? theme.weights.bold : theme.weights.normal ) };
 	color: ${ ( { theme, total } ) =>
-		total ? theme.colors.textColorDark : theme.colors.textColor };
+		total ? theme.colors.textColorDark : theme.colors.textColorLight };
 	font-size: ${ ( { total } ) => ( total ? '1.2em' : '1.1em' ) };
+	line-height: 1em;
 	padding: ${ ( { total, tax, subtotal, coupon } ) =>
-		total || subtotal || tax || coupon ? '10px 0' : '20px 0' };
-	border-bottom: ${ ( { theme, total } ) =>
-		total ? 0 : '1px solid ' + theme.colors.borderColorLight };
+		total || subtotal || tax || coupon ? '0' : '20px 0' };
 	position: relative;
+	margin-bottom: 8px;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
 
 	.checkout-line-item__price {
 		position: relative;
@@ -76,10 +80,9 @@ export const LineItem = styled( WPLineItem )< {
 	flex-wrap: wrap;
 	justify-content: space-between;
 	font-weight: ${ ( { theme } ) => theme.weights.normal };
-	color: ${ ( { theme } ) => theme.colors.textColor };
+	color: ${ ( { theme } ) => theme.colors.textColorDark };
 	font-size: 1.1em;
 	padding: 20px 0;
-	border-bottom: ${ ( { theme } ) => '1px solid ' + theme.colors.borderColorLight };
 	position: relative;
 
 	.checkout-line-item__price {
@@ -90,16 +93,6 @@ export const LineItem = styled( WPLineItem )< {
 export const CouponLineItem = styled( WPCouponLineItem )< {
 	theme?: Theme;
 } >`
-	border-bottom: ${ ( { theme } ) => '1px solid ' + theme.colors.borderColorLight };
-
-	&[data-partner-coupon='true'] ${ NonProductLineItem } {
-		border-bottom: none;
-	}
-
-	&:last-child {
-		border-bottom: none;
-	}
-
 	.jetpack-partner-logo {
 		padding-bottom: 20px;
 	}
@@ -146,14 +139,13 @@ const NotApplicableCallout = styled.div< { theme?: Theme } >`
 const LineItemTitle = styled.div< { theme?: Theme; isSummary?: boolean } >`
 	flex: 1;
 	word-break: break-word;
-	font-size: 16px;
 	display: flex;
 	gap: 0.5em;
+	font-weight: ${ ( { theme } ) => theme.weights.bold };
 `;
 
 const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean } >`
 	margin-left: 12px;
-	font-size: 16px;
 
 	.rtl & {
 		margin-right: 12px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -504,6 +504,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/color-studio": 2.5.0
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
     "@storybook/cli": ^7.0.18


### PR DESCRIPTION
## Proposed Changes

This PR modifies the appearance of checkout in relatively small ways (although the visual effect is considerable) to match an updated design. This should not really change any functionality; checkout's step behavior should remain the same before and after this change.

This is part of a larger project of redesigning checkout: p9Jlb4-6FB-p2 Specifically this is the first milestone: pbOQVh-3pj-p2

## Screenshots

### Before

<img width="1280" alt="Screenshot 2023-06-20 at 6 49 42 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/6de9716f-b583-41c1-8761-c199f1f922bd">

<img width="1275" alt="jetpack-before" src="https://github.com/Automattic/wp-calypso/assets/2036909/605b9e52-2786-4378-99fc-a11ca9916d34">

### After

<img width="1279" alt="Screenshot 2023-06-20 at 6 26 35 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/1a4c0435-6a39-4c4a-8219-daab01e5b4fd">

<img width="1273" alt="jetpack-after" src="https://github.com/Automattic/wp-calypso/assets/2036909/b47aef9e-64be-4f0a-a45c-284e49f061b7">


## Testing Instructions

This is a hard thing to test completely because checkout has so many variations. This should not change any functionality, so the first thing is to make sure that checkout renders successfully. Beyond that, it's a good idea to test any variation you can think of. Here are some suggestions:

- Checkout (and any of the other variations) at wide ("desktop") widths.
- Checkout (and any of the other variations) at around 900px wide ("tablet") widths.
- Checkout (and any of the other variations) at around 500px wide ("mobile") widths.
- Checkout for a Jetpack product.
- Checkout for an Akismet product.
- Checkout for a Gift product.
- Checkout with and without having a coupon added.
- Checkout with and without a domain in the cart.
- Checkout with an empty cart.
- Checkout after completing a synchronous (ie: non-3DS credit card) payment before being redirected.
- Checkout with a third-party-developer (eg: Yoast) plugin in the cart.
- Checkout in an RTL locale.
- Checkout with a monthly, yearly, and biennial WPCom plan in the cart.

Some non-checkout things that should be tested as well because they may be affected by this:

- Adding a payment method to an existing subscription.
- Viewing the mini-cart in the masterbar.
- Viewing the one-click checkout upsell after checkout completes.
