### PR TITLE
Update Jetpack tests for Premium Content block rename

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -9,7 +9,7 @@ export * from './contact-form';
 export * from './blog-posts';
 export * from './post-carousel';
 export * from './timeline';
-export * from './premium-content';
+export * from './paid-content';
 export * from './subscribe';
 export * from './payments';
 export * from './contact-info';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
@@ -5,7 +5,7 @@ interface ConfigurationData {
 	subscriberText: string;
 }
 
-const blockParentSelector = '[aria-label="Block: Premium Content"]';
+const blockParentSelector = '[aria-label="Block: Paid Content"]';
 const selectors = {
 	subscriberViewButton: 'button:has-text("Subscriber View")',
 	subscriberHeader: '[aria-label="Block: Subscriber View"] [aria-label="Block: Heading"]',
@@ -13,9 +13,9 @@ const selectors = {
 };
 
 /**
- * Class representing the flow of using a Premium Content block in the editor.
+ * Class representing the flow of using a Paid Content block in the editor.
  */
-export class PremiumContentBlockFlow implements BlockFlow {
+export class PaidContentBlockFlow implements BlockFlow {
 	private configurationData: ConfigurationData;
 
 	/**
@@ -27,7 +27,7 @@ export class PremiumContentBlockFlow implements BlockFlow {
 		this.configurationData = configurationData;
 	}
 
-	blockSidebarName = 'Premium Content';
+	blockSidebarName = 'Paid Content';
 	blockEditorSelector = blockParentSelector;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
@@ -1,3 +1,4 @@
+import { envVariables } from '../../..';
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
 interface ConfigurationData {
@@ -37,6 +38,12 @@ export class PaidContentBlockFlow implements BlockFlow {
 	 */
 	async configure( context: EditorContext ): Promise< void > {
 		const editorParent = await context.editorPage.getEditorParent();
+
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// Mobile viewport hides the Subscriber/Guest view
+			// into a pseudo-dropdown.
+			await editorParent.getByRole( 'button', { name: 'Change view' } ).click();
+		}
 
 		const subscriberViewButtonLocator = editorParent.locator( selectors.subscriberViewButton );
 		await subscriberViewButtonLocator.click();

--- a/test/e2e/specs/blocks/blocks__jetpack-grow.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-grow.ts
@@ -7,7 +7,7 @@ import {
 	BusinessHoursFlow,
 	WhatsAppButtonFlow,
 	ContactFormFlow,
-	PremiumContentBlockFlow,
+	PaidContentBlockFlow,
 	SubscribeFlow,
 	ContactInfoBlockFlow,
 	DataHelper,
@@ -23,12 +23,10 @@ const blockFlows: BlockFlow[] = [
 	new WhatsAppButtonFlow( { phoneNumber: 1234567890, buttonText: 'Porpoises swim happily' } ),
 ];
 
-// Interacting with the Premium Content toolbar is currently broken on mobile, so only adding for desktop:
-// https://github.com/Automattic/jetpack/issues/22745
 // Stripe is not connected to this WordPress.com account, so skipping on Atomic
-if ( envVariables.VIEWPORT_NAME === 'desktop' && ! envVariables.TEST_ON_ATOMIC ) {
+if ( ! envVariables.TEST_ON_ATOMIC ) {
 	blockFlows.push(
-		new PremiumContentBlockFlow( {
+		new PaidContentBlockFlow( {
 			subscriberTitle: DataHelper.getRandomPhrase(),
 			subscriberText: DataHelper.getRandomPhrase(),
 		} )

--- a/test/e2e/specs/blocks/blocks__jetpack-grow.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-grow.ts
@@ -24,7 +24,7 @@ const blockFlows: BlockFlow[] = [
 ];
 
 // Stripe is not connected to this WordPress.com account, so skipping on Atomic
-if ( ! envVariables.TEST_ON_ATOMIC ) {
+if ( envVariables.VIEWPORT_NAME === 'desktop' && ! envVariables.TEST_ON_ATOMIC ) {
 	blockFlows.push(
 		new PaidContentBlockFlow( {
 			subscriberTitle: DataHelper.getRandomPhrase(),

--- a/test/e2e/specs/blocks/blocks__jetpack-grow.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-grow.ts
@@ -24,7 +24,7 @@ const blockFlows: BlockFlow[] = [
 ];
 
 // Stripe is not connected to this WordPress.com account, so skipping on Atomic
-if ( envVariables.VIEWPORT_NAME === 'desktop' && ! envVariables.TEST_ON_ATOMIC ) {
+if ( ! envVariables.TEST_ON_ATOMIC ) {
 	blockFlows.push(
 		new PaidContentBlockFlow( {
 			subscriberTitle: DataHelper.getRandomPhrase(),

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -1,5 +1,4 @@
 import {
-	DataHelper,
 	BlockFlow,
 	EditorPage,
 	EditorContext,
@@ -20,7 +19,7 @@ declare const browser: Browser;
  * @param blockFlows A list of block flows to put under test.
  */
 export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): void {
-	describe( DataHelper.createSuiteTitle( specName ), function () {
+	describe( specName, function () {
 		const features = envToFeatureKey( envVariables );
 		// @todo Does it make sense to create a `simpleSitePersonalPlanUserEdge` with GB edge?
 		// for now, it will pick up the default `gutenbergAtomicSiteEdgeUser` if edge is set.


### PR DESCRIPTION
The latest version of Jetpack (12.2-a.13) included the change to rename the Premium Content block to Paid Content (https://github.com/Automattic/jetpack/pull/30775). This PR updates the `blocks__jetpack-grow` test to use the new name, which should get it passing again. The new Jetpack has been deployed to Atomic and should be on Simple shortly.

I also re-enabled the test to run on mobile, which was previously disabled because of https://github.com/Automattic/jetpack/issues/22745. After some manual testing, it appears to work now.

## Testing Instructions

* The test should pass on desktop and mobile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
