### PR TITLE
Add plural support to translate function passed to the BlazePress widget

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -26,7 +26,11 @@ export type BlazePressPromotionProps = {
 	source?: string;
 };
 
-type BlazePressTranslatable = ( original: string, extra?: TranslateOptionsText ) => string;
+type BlazePressTranslatable = (
+	original: string,
+	plural_or_extra?: string | TranslateOptionsText,
+	extra?: TranslateOptionsPluralText
+) => string;
 
 export function goToOriginalEndpoint() {
 	const { pathname } = getUrlParts( window.location.href );
@@ -94,7 +98,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 					(
 						original: string,
 						plural_or_options?: string | TranslateOptionsText,
-						options?: TranslateOptionsText
+						options?: TranslateOptionsPluralText
 					): string => {
 						if ( plural_or_options && options ) {
 							// This is a special case where we re-use the translate in another application

--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -91,12 +91,20 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 					props.postId,
 					onClose,
 					source,
-					( original: string, options?: TranslateOptionsText ): string => {
-						if ( options ) {
+					(
+						original: string,
+						plural_or_options?: string | TranslateOptionsText,
+						options?: TranslateOptionsText
+					): string => {
+						if ( plural_or_options && options ) {
 							// This is a special case where we re-use the translate in another application
 							// that is mounted inside calypso
 							// eslint-disable-next-line wpcalypso/i18n-no-variables
-							return translate( original, options );
+							return translate( original, plural_or_options, options );
+						}
+						if ( plural_or_options ) {
+							// eslint-disable-next-line wpcalypso/i18n-no-variables
+							return translate( original, plural_or_options );
 						}
 						// eslint-disable-next-line wpcalypso/i18n-no-variables
 						return translate( original );

--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -4,7 +4,7 @@ import { Dialog } from '@automattic/components';
 import { useLocale, useLocalizeUrl } from '@automattic/i18n-utils';
 import { useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
-import { TranslateOptionsText, TranslateOptionsPluralText, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -26,12 +26,6 @@ export type BlazePressPromotionProps = {
 	source?: string;
 };
 
-type BlazePressTranslatable = (
-	original: string,
-	plural_or_extra?: string | TranslateOptionsText,
-	extra?: TranslateOptionsPluralText
-) => string;
-
 export function goToOriginalEndpoint() {
 	const { pathname } = getUrlParts( window.location.href );
 	page( pathname );
@@ -46,7 +40,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	const [ hiddenHeader, setHiddenHeader ] = useState( true );
 	const widgetContainer = useRef< HTMLDivElement >( null );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
-	const translate = useTranslate() as BlazePressTranslatable;
+	const translate = useTranslate();
 	const localizeUrl = useLocalizeUrl();
 	const previousRoute = useSelector( getPreviousRoute );
 	const selectedSiteId = useSelector( getSelectedSiteId );
@@ -95,24 +89,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 					props.postId,
 					onClose,
 					source,
-					(
-						original: string,
-						plural_or_options?: string | TranslateOptionsText,
-						options?: TranslateOptionsPluralText
-					): string => {
-						if ( plural_or_options && options ) {
-							// This is a special case where we re-use the translate in another application
-							// that is mounted inside calypso
-							// eslint-disable-next-line wpcalypso/i18n-no-variables
-							return translate( original, plural_or_options, options );
-						}
-						if ( plural_or_options ) {
-							// eslint-disable-next-line wpcalypso/i18n-no-variables
-							return translate( original, plural_or_options );
-						}
-						// eslint-disable-next-line wpcalypso/i18n-no-variables
-						return translate( original );
-					},
+					translate,
 					localizeUrl,
 					widgetContainer.current,
 					handleShowCancel,

--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -4,7 +4,7 @@ import { Dialog } from '@automattic/components';
 import { useLocale, useLocalizeUrl } from '@automattic/i18n-utils';
 import { useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
-import { TranslateOptionsText, useTranslate } from 'i18n-calypso';
+import { TranslateOptionsText, TranslateOptionsPluralText, useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { loadScript } from '@automattic/load-script';
 import { __ } from '@wordpress/i18n';
+import { translate } from 'i18n-calypso/types';
 import { useSelector } from 'react-redux';
 import request, { requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
@@ -25,7 +26,7 @@ declare global {
 				urn: string;
 				onLoaded?: () => void;
 				onClose?: () => void;
-				translateFn?: ( value: string, plural_or_options?: any, options?: any ) => string;
+				translateFn?: typeof translate;
 				localizeUrlFn?: ( fullUrl: string ) => string;
 				locale?: string;
 				showDialog?: boolean;

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -63,7 +63,7 @@ export async function showDSP(
 	postId: number | string,
 	onClose: () => void,
 	source: string,
-	translateFn: ( value: string, plural_or_options?: any, options?: any ) => string,
+	translateFn: typeof translate,
 	localizeUrlFn: ( fullUrl: string ) => string,
 	domNodeOrId?: HTMLElement | string | null,
 	setShowCancelButton?: ( show: boolean ) => void,

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -25,7 +25,7 @@ declare global {
 				urn: string;
 				onLoaded?: () => void;
 				onClose?: () => void;
-				translateFn?: ( value: string, options?: any ) => string;
+				translateFn?: ( value: string, plural_or_options?: any, options?: any ) => string;
 				localizeUrlFn?: ( fullUrl: string ) => string;
 				locale?: string;
 				showDialog?: boolean;
@@ -62,7 +62,7 @@ export async function showDSP(
 	postId: number | string,
 	onClose: () => void,
 	source: string,
-	translateFn: ( value: string, options?: any ) => string,
+	translateFn: ( value: string, plural_or_options?: any, options?: any ) => string,
 	localizeUrlFn: ( fullUrl: string ) => string,
 	domNodeOrId?: HTMLElement | string | null,
 	setShowCancelButton?: ( show: boolean ) => void,


### PR DESCRIPTION
Related to 622-gh-Automattic/i18n-issues

## Proposed Changes

* Add support for the third parameter in the translate function passed to the BlazePress widget, to support translations with plural forms.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the instructions from 135-gh-Tumblr/a8c-dsp

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
