### PR TITLE
Error step for migration flow

### DIFF
--- a/client/blocks/importer/components/error-message/index.tsx
+++ b/client/blocks/importer/components/error-message/index.tsx
@@ -1,19 +1,20 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { BackButton, NextButton, SubTitle, Title } from '@automattic/onboarding';
-import { createElement, createInterpolateElement } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
+import { NextButton, SubTitle, Title } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
+import './style.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 interface Props {
 	onBackToStart?: () => void;
 	onStartBuilding?: () => void;
+	onBackToStartText?: string;
 }
 
 const ErrorMessage: React.FunctionComponent< Props > = ( props ) => {
-	const { __ } = useI18n();
-	const { onBackToStart, onStartBuilding } = props;
+	const translate = useTranslate();
+	const { onBackToStart, onStartBuilding, onBackToStartText } = props;
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_site_importer_start_import_failure' );
@@ -22,21 +23,33 @@ const ErrorMessage: React.FunctionComponent< Props > = ( props ) => {
 	return (
 		<div className="import-layout__center">
 			<div className="import__header">
-				<div className="import__heading import__heading-center">
-					<Title>
-						{ createInterpolateElement( __( 'Oops, <br />something went wrong.' ), {
-							br: createElement( 'br' ),
+				<div className="import__heading-center">
+					<Title>{ translate( 'Oops, something went wrong' ) }</Title>
+					<SubTitle>
+						{ translate( 'Please try again soon or {{a}}contact support{{/a}} for help.', {
+							components: {
+								a: (
+									<a
+										href="https://wordpress.com/help/contact"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
 						} ) }
-					</Title>
-					<SubTitle>{ __( 'Please try again soon or contact support for help.' ) }</SubTitle>
+					</SubTitle>
 
 					<div className="import__buttons-group">
 						{ onStartBuilding && (
-							<NextButton onClick={ onStartBuilding }>{ __( 'Start building' ) }</NextButton>
+							<NextButton type="button" onClick={ onStartBuilding }>
+								{ translate( 'Start building' ) }
+							</NextButton>
 						) }
 						{ onBackToStart && (
 							<div>
-								<BackButton onClick={ onBackToStart }>{ __( 'Back to start' ) }</BackButton>
+								<NextButton className="" type="submit" onClick={ onBackToStart }>
+									{ onBackToStartText ?? translate( 'Back to start' ) }
+								</NextButton>
 							</div>
 						) }
 					</div>

--- a/client/blocks/importer/components/error-message/style.scss
+++ b/client/blocks/importer/components/error-message/style.scss
@@ -1,0 +1,15 @@
+@import "~calypso/blocks/import/style/base";
+
+.import__error-message {
+	.onboarding-title,
+	.onboarding-subtitle {
+		max-width: 100%;
+		margin-bottom: rem(40px);
+	}
+
+	.onboarding-subtitle a {
+		font-weight: 500;
+		text-decoration: underline;
+		color: var(--studio-gray-100);
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-error/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-error/index.tsx
@@ -1,0 +1,44 @@
+import { StepContainer } from '@automattic/onboarding';
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import ErrorMessage from 'calypso/blocks/importer/components/error-message';
+import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+
+const MigrationError: Step = function ( props ) {
+	const { navigation } = props;
+	const { submit, goBack } = navigation;
+	const translate = useTranslate();
+
+	function renderError() {
+		return (
+			<>
+				<ErrorMessage
+					onBackToStart={ () => submit?.( { url: 'migrationHandler' } ) }
+					onBackToStartText={ translate( 'Try again' ) }
+				/>
+			</>
+		);
+	}
+	return (
+		<StepContainer
+			className={ classnames(
+				'import__onboarding-page',
+				'import-layout__center',
+				'importer-wrapper',
+				'import__error-message',
+				'importer-wrapper__wordpress',
+				'is-wide-layout'
+			) }
+			stepName="importer-step"
+			hideSkip={ true }
+			hideFormattedHeader={ true }
+			isWideLayout={ true }
+			goBack={ goBack }
+			stepContent={ renderError() }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default MigrationError;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-error/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-error/index.tsx
@@ -6,37 +6,31 @@ import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const MigrationError: Step = function ( props ) {
-	const { navigation } = props;
-	const { submit, goBack } = navigation;
+	const { submit } = props.navigation;
 	const translate = useTranslate();
+
+	function goToMigrationHandler() {
+		submit?.( { url: 'migrationHandler' } );
+	}
 
 	function renderError() {
 		return (
-			<>
-				<ErrorMessage
-					onBackToStart={ () => submit?.( { url: 'migrationHandler' } ) }
-					onBackToStartText={ translate( 'Try again' ) }
-				/>
-			</>
+			<ErrorMessage
+				onBackToStart={ goToMigrationHandler }
+				onBackToStartText={ translate( 'Try again' ) }
+			/>
 		);
 	}
 	return (
 		<StepContainer
-			className={ classnames(
-				'import__onboarding-page',
-				'import-layout__center',
-				'importer-wrapper',
-				'import__error-message',
-				'importer-wrapper__wordpress',
-				'is-wide-layout'
-			) }
-			stepName="importer-step"
+			className={ classnames( 'import__onboarding-page', 'import__error-message' ) }
+			stepName="migration-error"
 			hideSkip={ true }
 			hideFormattedHeader={ true }
 			isWideLayout={ true }
-			goBack={ goBack }
 			stepContent={ renderError() }
 			recordTracksEvent={ recordTracksEvent }
+			goBack={ goToMigrationHandler }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-error/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-error/index.tsx
@@ -26,11 +26,11 @@ const MigrationError: Step = function ( props ) {
 			className={ classnames( 'import__onboarding-page', 'import__error-message' ) }
 			stepName="migration-error"
 			hideSkip={ true }
+			hideBack={ true }
 			hideFormattedHeader={ true }
 			isWideLayout={ true }
 			stepContent={ renderError() }
 			recordTracksEvent={ recordTracksEvent }
-			goBack={ goToMigrationHandler }
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77197 

## Proposed Changes

* Add a new step component to display an error during the migration flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There is no easy way to test this as this screen will be displayed when an error occurs and we do not have any particular reproducible error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
