### PR TITLE
Adding upgrade plugin screen information

### DIFF
--- a/client/blocks/importer/hooks/use-site-can-migrate.ts
+++ b/client/blocks/importer/hooks/use-site-can-migrate.ts
@@ -1,34 +1,83 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { MigrationEnabledResponse } from 'calypso/data/site-migration/types';
+import { useMigrationEnabledInfoQuery } from 'calypso/data/site-migration/use-migration-enabled';
+import { requestSites } from 'calypso/state/sites/actions';
+import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
+import { SiteId } from 'calypso/types';
 
-export function useSiteCanMigrate( isMigrateFromWp: boolean ) {
-	const siteCanMigrate = useCallback(
-		( data: MigrationEnabledResponse ) => {
-			if ( ! data ) {
-				return false;
-			}
-			const { jetpack_activated, jetpack_compatible, migration_activated, migration_compatible } =
-				data as MigrationEnabledResponse;
-
-			return isMigrateFromWp
-				? migration_activated && migration_compatible
-				: jetpack_activated && jetpack_compatible;
-		},
-		[ isMigrateFromWp ]
-	);
-
-	return siteCanMigrate;
-}
-
-export function useSiteMigrateInfo( data: MigrationEnabledResponse ) {
+export function useSiteMigrateInfo(
+	targetSiteId: SiteId,
+	sourceSiteSlug: string,
+	fetchMigrationEnabledOnMount: boolean,
+	isMigrateFromWp: boolean,
+	onfetchCallback?: ( checkCanSiteMigrate: boolean ) => void
+) {
 	const [ sourceSiteId, setSourceSiteId ] = useState( 0 );
-	useEffect( () => {
-		if ( data ) {
-			return setSourceSiteId( data.source_blog_id );
-		}
+	const [ siteCanMigrate, setSiteCanMigrate ] = useState( false );
+	const isRequestingAllSites = useSelector( ( state ) => isRequestingSites( state ) );
+	const sourceSite = useSelector( ( state ) => getSite( state, sourceSiteId ) );
+	const dispatch = useDispatch();
+
+	const resetMigrationEnabled = () => {
+		setSiteCanMigrate( false );
 		setSourceSiteId( 0 );
-	}, [ data ] );
+	};
+
+	const checkCanSiteMigrate = ( isMigrateFromWp: boolean, data: MigrationEnabledResponse ) => {
+		if ( ! data ) {
+			return false;
+		}
+		const { jetpack_activated, jetpack_compatible, migration_activated, migration_compatible } =
+			data as MigrationEnabledResponse;
+		return isMigrateFromWp
+			? migration_activated && migration_compatible
+			: jetpack_activated && jetpack_compatible;
+	};
+
+	const onMigrationEnabledSuccess = ( data: MigrationEnabledResponse ) => {
+		if ( checkCanSiteMigrate( isMigrateFromWp, data ) ) {
+			setSiteCanMigrate( true );
+			setSourceSiteId( data.source_blog_id );
+		} else {
+			resetMigrationEnabled();
+		}
+	};
+
+	const onMigrationEnabledError = () => {
+		resetMigrationEnabled();
+	};
+	const {
+		refetch,
+		isFetching: isMigrationEnabledFetching,
+		isFetched,
+		isError,
+	} = useMigrationEnabledInfoQuery(
+		targetSiteId,
+		sourceSiteSlug,
+		fetchMigrationEnabledOnMount,
+		onMigrationEnabledSuccess,
+		onMigrationEnabledError
+	);
+	useEffect( () => {
+		// After the data is fetched or error, we call the callback if it is provided
+		if ( isFetched || isError ) {
+			onfetchCallback && onfetchCallback( siteCanMigrate );
+		}
+	}, [ isFetched, isError, siteCanMigrate, onfetchCallback ] );
+
+	useEffect( () => {
+		// If has source site id and we do not have the source site, it means the data is not up to date, so we request the site
+		if ( sourceSiteId && ! sourceSite && ! isRequestingAllSites ) {
+			dispatch( requestSites() );
+		}
+	}, [ sourceSiteId, sourceSite, isRequestingAllSites, dispatch ] );
+
 	return {
-		sourceSiteId: sourceSiteId,
+		sourceSiteId,
+		sourceSite,
+		siteCanMigrate,
+		fetchMigrationEnabledStatus: refetch,
+		isFetchingData: isMigrationEnabledFetching || isRequestingAllSites,
 	};
 }

--- a/client/blocks/importer/hooks/use-site-can-migrate.ts
+++ b/client/blocks/importer/hooks/use-site-can-migrate.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from 'react';
+import { MigrationEnabledResponse } from 'calypso/data/site-migration/types';
+
+export function useSiteCanMigrate( isMigrateFromWp: boolean ) {
+	const siteCanMigrate = useCallback(
+		( data: MigrationEnabledResponse ) => {
+			if ( ! data ) {
+				return false;
+			}
+			const { jetpack_activated, jetpack_compatible, migration_activated, migration_compatible } =
+				data as MigrationEnabledResponse;
+
+			return isMigrateFromWp
+				? migration_activated && migration_compatible
+				: jetpack_activated && jetpack_compatible;
+		},
+		[ isMigrateFromWp ]
+	);
+
+	return siteCanMigrate;
+}
+
+export function useSiteMigrateInfo( data: MigrationEnabledResponse ) {
+	const [ sourceSiteId, setSourceSiteId ] = useState( 0 );
+	useEffect( () => {
+		if ( data ) {
+			return setSourceSiteId( data.source_blog_id );
+		}
+		setSourceSiteId( 0 );
+	}, [ data ] );
+	return {
+		sourceSiteId: sourceSiteId,
+	};
+}

--- a/client/blocks/importer/util.ts
+++ b/client/blocks/importer/util.ts
@@ -15,8 +15,8 @@ export function formatSlugToURL( inputUrl: string ) {
 	if ( ! inputUrl ) {
 		return '';
 	}
-	// If it's already a URL, return it
-	if ( CAPTURE_URL_RGX.test( inputUrl ) ) {
+	// If it's not a valid URL, return it
+	if ( ! CAPTURE_URL_RGX.test( inputUrl ) ) {
 		return inputUrl;
 	}
 	let url = inputUrl.trim().toLowerCase();

--- a/client/blocks/importer/util.ts
+++ b/client/blocks/importer/util.ts
@@ -1,4 +1,6 @@
 import { FEATURE_UPLOAD_THEMES_PLUGINS, planHasFeature } from '@automattic/calypso-products';
+import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
+import { untrailingslashit } from 'calypso/lib/route';
 import type { Importer } from './types';
 import type { SiteDetails } from '@automattic/data-stores';
 
@@ -7,4 +9,20 @@ export const getImporterTypeForEngine = ( engine: Importer ) => `importer-type-$
 export function isTargetSitePlanCompatible( targetSite: SiteDetails | undefined ) {
 	const planSlug = targetSite?.plan?.product_slug;
 	return planSlug && planHasFeature( planSlug, FEATURE_UPLOAD_THEMES_PLUGINS );
+}
+
+export function formatSlugToURL( inputUrl: string ) {
+	if ( ! inputUrl ) {
+		return '';
+	}
+	// If it's already a URL, return it
+	if ( CAPTURE_URL_RGX.test( inputUrl ) ) {
+		return inputUrl;
+	}
+	let url = inputUrl.trim().toLowerCase();
+	if ( url && url.substr( 0, 4 ) !== 'http' ) {
+		url = 'http://' + url;
+	}
+	url = url.replace( /wp-admin\/?$/, '' );
+	return untrailingslashit( url );
 }

--- a/client/blocks/importer/wordpress/import-everything/confirm-upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm-upgrade-plan.tsx
@@ -17,7 +17,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 import type { FunctionComponent } from 'react';
 
 interface Props {
-	sourceSite: SiteDetails | null;
+	sourceSiteSlug: string;
 	targetSite: SiteDetails | null;
 }
 
@@ -25,7 +25,7 @@ export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
 	const initialFeaturesNumber = 6;
 
-	const { sourceSite, targetSite } = props;
+	const { sourceSiteSlug, targetSite } = props;
 	const targetSiteEligibleForProPlan = useSelector( ( state ) =>
 		isEligibleForProPlan( state, targetSite?.ID )
 	);
@@ -77,7 +77,7 @@ export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
 						__(
 							'To import your themes, plugins, users, and settings from %(website)s we need to upgrade your WordPress.com site. Select a plan below:'
 						),
-						{ website: sourceSite?.slug }
+						{ website: sourceSiteSlug }
 					) }
 				</p>
 			) }

--- a/client/blocks/importer/wordpress/import-everything/confirm.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm.tsx
@@ -165,7 +165,7 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 
 				{ showUpgradePlanScreen && (
 					<>
-						<ConfirmUpgradePlan sourceSite={ sourceSite } targetSite={ targetSite } />
+						<ConfirmUpgradePlan sourceSiteSlug={ sourceSite?.slug } targetSite={ targetSite } />
 						<NextButton onClick={ () => showConfirmDialogOrStartImport() }>
 							{ __( 'Upgrade and import' ) }
 						</NextButton>

--- a/client/blocks/importer/wordpress/import-everything/confirm.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm.tsx
@@ -46,6 +46,7 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 	} = props;
 	const [ isModalDetailsOpen, setIsModalDetailsOpen ] = useState( false );
 	const [ showUpgradePlanScreen, setShowUpgradePlanScreen ] = useState( false );
+	const sourceSiteSlug = sourceSite?.slug ?? '';
 
 	/**
 	 ↓ Effects
@@ -165,7 +166,7 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 
 				{ showUpgradePlanScreen && (
 					<>
-						<ConfirmUpgradePlan sourceSiteSlug={ sourceSite?.slug } targetSite={ targetSite } />
+						<ConfirmUpgradePlan sourceSiteSlug={ sourceSiteSlug } targetSite={ targetSite } />
 						<NextButton onClick={ () => showConfirmDialogOrStartImport() }>
 							{ __( 'Upgrade and import' ) }
 						</NextButton>

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -144,18 +144,19 @@ export class ImportEverything extends SectionMigrate {
 			onContentOnlySelection,
 		} = this.props;
 
+		if ( isEnabled( 'onboarding/import-redesign' ) ) {
+			return (
+				<PreMigrationScreen
+					startImport={ this.startMigration }
+					isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
+					targetSite={ targetSite }
+					onContentOnlyClick={ onContentOnlySelection }
+					isMigrateFromWp={ isMigrateFromWp }
+				/>
+			);
+		}
+
 		if ( sourceSite ) {
-			if ( isEnabled( 'onboarding/import-redesign' ) ) {
-				return (
-					<PreMigrationScreen
-						startImport={ this.startMigration }
-						isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
-						targetSite={ targetSite }
-						sourceSite={ sourceSite }
-						onContentOnlyClick={ onContentOnlySelection }
-					/>
-				);
-			}
 			return (
 				<Confirm
 					startImport={ this.startMigration }

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -112,7 +112,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 			setSourceSiteId( 0 );
 			return;
 		}
-		const { source_blog_id } = migrationEnabledData as MigrationEnabledResponse;
+		const { source_blog_id } = migrationEnabledData;
 		if ( ! sourceSiteId ) {
 			setSourceSiteId( source_blog_id );
 			dispatch( requestSites() );

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -4,33 +4,46 @@ import { SiteDetails } from '@automattic/data-stores';
 import { NextButton, Title } from '@automattic/onboarding';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { formatSlugToURL } from 'calypso/blocks/importer/util';
 import MigrationCredentialsForm from 'calypso/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form';
 import { PreMigrationUpgradePlan } from 'calypso/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan';
+import { UpgradePluginInfo } from 'calypso/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plugins';
 import { FormState } from 'calypso/components/advanced-credentials/form';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { MigrationEnabledResponse } from 'calypso/data/site-migration/types';
+import { useMigrationEnabledInfoQuery } from 'calypso/data/site-migration/use-migration-enabled';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCredentials } from 'calypso/state/jetpack/credentials/actions';
 import getJetpackCredentials from 'calypso/state/selectors/get-jetpack-credentials';
 import isRequestingSiteCredentials from 'calypso/state/selectors/is-requesting-site-credentials';
+import { requestSites } from 'calypso/state/sites/actions';
+import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
 import { CredentialsHelper } from './credentials-helper';
 import { StartImportTrackingProps } from './types';
 import './style.scss';
 
 interface PreMigrationProps {
-	sourceSite: SiteDetails;
 	targetSite: SiteDetails;
 	startImport: ( props?: StartImportTrackingProps ) => void;
 	isTargetSitePlanCompatible: boolean;
 	onContentOnlyClick: () => void;
+	isMigrateFromWp: boolean;
 }
 
 export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = (
 	props: PreMigrationProps
 ) => {
-	const { startImport, targetSite, sourceSite, isTargetSitePlanCompatible, onContentOnlyClick } =
-		props;
+	const {
+		startImport,
+		targetSite,
+		isTargetSitePlanCompatible,
+		onContentOnlyClick,
+		isMigrateFromWp,
+	} = props;
 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -39,21 +52,32 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	const [ selectedHost, setSelectedHost ] = useState( 'generic' );
 	const [ selectedProtocol, setSelectedProtocol ] = useState< 'ftp' | 'ssh' >( 'ftp' );
 	const [ hasLoaded, setHasLoaded ] = useState( false );
+	const [ showUpgradePluginInfo, setShowUpgradePluginInfo ] = useState( false );
+	const fetchMigrationEnabledOnMount = isTargetSitePlanCompatible ? true : false;
+	const [ continueImport, setContinueImport ] = useState( false );
+	const urlQueryParams = useQuery();
+	const sourceSiteSlug = urlQueryParams.get( 'from' ) ?? '';
+	const sourceSiteUrl = formatSlugToURL( sourceSiteSlug );
 
 	const toggleCredentialsForm = () => {
 		setShowCredentials( ! showCredentials );
 		dispatch( recordTracksEvent( 'calypso_site_migration_credentials_form_toggle' ) );
 	};
 
+	const [ sourceSiteId, setSourceSiteId ] = useState( 0 );
+	const sourceSite = useSelector( ( state ) => getSite( state, sourceSiteId ) );
+
 	const credentials = useSelector( ( state ) =>
-		getJetpackCredentials( state, sourceSite.ID, 'main' )
+		getJetpackCredentials( state, sourceSiteId, 'main' )
 	) as FormState & { abspath: string };
 
 	const hasCredentials = credentials && Object.keys( credentials ).length > 0;
 
 	const isRequestingCredentials = useSelector( ( state ) =>
-		isRequestingSiteCredentials( state, sourceSite.ID as number )
+		isRequestingSiteCredentials( state, sourceSiteId as number )
 	);
+
+	const isRequestingAllSites = useSelector( ( state ) => isRequestingSites( state ) );
 
 	const changeCredentialsHelperHost = ( host: string ) => {
 		setSelectedHost( host );
@@ -63,10 +87,85 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		setSelectedProtocol( protocol );
 	};
 
+	const shouldBlockedByPluginUpgradeCheck = useCallback(
+		( data: MigrationEnabledResponse | unknown ) => {
+			let shouldBlockedByPluginUpgradeCheck = true;
+			if ( ! data ) {
+				return shouldBlockedByPluginUpgradeCheck;
+			}
+			const { jetpack_activated, jetpack_compatible, migration_activated, migration_compatible } =
+				data as MigrationEnabledResponse;
+			if ( isMigrateFromWp && migration_activated && migration_compatible ) {
+				shouldBlockedByPluginUpgradeCheck = false;
+			} else if ( jetpack_activated && jetpack_compatible ) {
+				shouldBlockedByPluginUpgradeCheck = false;
+			}
+			return shouldBlockedByPluginUpgradeCheck;
+		},
+		[ isMigrateFromWp ]
+	);
+
+	const checkMigrationEnabledCallback = ( migrationEnabledData: MigrationEnabledResponse ) => {
+		const shouldShowUpgradePluginInfo = shouldBlockedByPluginUpgradeCheck( migrationEnabledData );
+		setShowUpgradePluginInfo( shouldShowUpgradePluginInfo );
+		if ( shouldShowUpgradePluginInfo ) {
+			setSourceSiteId( 0 );
+			return;
+		}
+		const { source_blog_id } = migrationEnabledData as MigrationEnabledResponse;
+		if ( ! sourceSiteId ) {
+			setSourceSiteId( source_blog_id );
+			dispatch( requestSites() );
+		}
+	};
+
+	const {
+		refetch,
+		isError: migrationEnabledError,
+		isFetching: migrationEnabledFetching,
+	} = useMigrationEnabledInfoQuery(
+		targetSite?.ID ?? 0,
+		sourceSiteSlug,
+		fetchMigrationEnabledOnMount,
+		checkMigrationEnabledCallback
+	);
+
+	const onUpgradeAndMigrateClick = () => {
+		setContinueImport( true );
+		refetch();
+	};
+
 	useEffect( () => {
-		dispatch( getCredentials( sourceSite.ID ) );
-		setHasLoaded( true );
-	}, [] );
+		if ( isTargetSitePlanCompatible && sourceSiteId ) {
+			dispatch( getCredentials( sourceSiteId ) );
+			setHasLoaded( true );
+		}
+	}, [ isTargetSitePlanCompatible, sourceSiteId, dispatch ] );
+
+	useEffect( () => {
+		if ( migrationEnabledError ) {
+			setShowUpgradePluginInfo( true );
+		}
+	}, [ migrationEnabledError ] );
+
+	useEffect( () => {
+		// If we are blocked by plugin upgrade check, we do not need to request sites
+		if ( showUpgradePluginInfo || ! continueImport ) {
+			return;
+		}
+		if ( sourceSite ) {
+			startImport();
+		} else if ( ! isRequestingAllSites ) {
+			dispatch( requestSites() );
+		}
+	}, [
+		continueImport,
+		sourceSite,
+		isRequestingAllSites,
+		startImport,
+		dispatch,
+		showUpgradePluginInfo,
+	] );
 
 	function renderCredentialsFormSection() {
 		// We do not show the credentials form if we already have credentials
@@ -94,7 +193,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 						) }
 					</div>
 				) }
-				{ showCredentials && (
+				{ showCredentials && sourceSite && (
 					<div className="pre-migration__form-container pre-migration__credentials-form">
 						<div className="pre-migration__form">
 							<MigrationCredentialsForm
@@ -151,7 +250,21 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		);
 	}
 
+	function renderUpgradePluginInfo() {
+		return (
+			<>
+				<UpgradePluginInfo isMigrateFromWp={ isMigrateFromWp } sourceSiteUrl={ sourceSiteUrl } />
+				<Interval onTick={ refetch } period={ EVERY_FIVE_SECONDS } />
+			</>
+		);
+	}
+
 	function render() {
+		// If the source site is not capable of being migrated, we show the update info screen
+		if ( showUpgradePluginInfo ) {
+			return renderUpgradePluginInfo();
+		}
+
 		// If the target site is plan compatible, we show the pre-migration screen
 		if ( isTargetSitePlanCompatible ) {
 			return renderPreMigration();
@@ -160,10 +273,12 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		// If the target site is not plan compatible, we show the upgrade plan screen
 		return (
 			<PreMigrationUpgradePlan
-				sourceSite={ sourceSite }
+				sourceSiteSlug={ sourceSiteSlug }
+				sourceSiteUrl={ sourceSiteUrl }
 				targetSite={ targetSite }
-				startImport={ startImport }
+				startImport={ onUpgradeAndMigrateClick }
 				onContentOnlyClick={ onContentOnlyClick }
+				isBusy={ migrationEnabledFetching || isRequestingAllSites }
 			/>
 		);
 	}

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
@@ -7,20 +7,23 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { convertToFriendlyWebsiteName } from 'calypso/blocks/import/util';
+import { URL } from 'calypso/types';
 import ConfirmUpgradePlan from './../confirm-upgrade-plan';
 
 interface Props {
-	sourceSite: SiteDetails;
+	sourceSiteSlug: string;
+	sourceSiteUrl: URL;
 	targetSite: SiteDetails;
-
 	startImport: () => void;
 	onContentOnlyClick: () => void;
+	isBusy: boolean;
 }
 
 export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props: Props ) => {
 	const translate = useTranslate();
 	const plan = getPlan( PLAN_BUSINESS );
-	const { sourceSite, targetSite, startImport, onContentOnlyClick } = props;
+	const { sourceSiteSlug, sourceSiteUrl, targetSite, startImport, onContentOnlyClick, isBusy } =
+		props;
 
 	return (
 		<>
@@ -47,15 +50,15 @@ export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props
 						'Your entire site %(from)s will be migrated to %(to)s, overriding the content in your destination site',
 						{
 							args: {
-								from: convertToFriendlyWebsiteName( sourceSite.URL ),
+								from: convertToFriendlyWebsiteName( sourceSiteUrl ),
 								to: convertToFriendlyWebsiteName( targetSite.URL ),
 							},
 						}
 					) }
 				</p>
-				<ConfirmUpgradePlan sourceSite={ sourceSite } targetSite={ targetSite } />
+				<ConfirmUpgradePlan sourceSiteSlug={ sourceSiteSlug } targetSite={ targetSite } />
 				<div className="import__footer-button-container">
-					<NextButton onClick={ () => startImport() }>
+					<NextButton isBusy={ isBusy } onClick={ () => startImport() }>
 						{ translate( 'Upgrade and migrate' ) }
 					</NextButton>
 					<Button

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plugins.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plugins.tsx
@@ -1,0 +1,115 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
+import { Button, Gridicon } from '@automattic/components';
+import { Title, SubTitle, SelectItems } from '@automattic/onboarding';
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import { preventWidows } from 'calypso/lib/formatting';
+import { jetpack } from 'calypso/signup/icons';
+import { URL } from 'calypso/types';
+
+interface Props {
+	isMigrateFromWp: boolean;
+	sourceSiteUrl: URL;
+}
+
+export const UpgradePluginInfo: React.FunctionComponent< Props > = ( props: Props ) => {
+	const translate = useTranslate();
+	const { isMigrateFromWp, sourceSiteUrl } = props;
+
+	function renderTitle() {
+		return isMigrateFromWp
+			? translate( `Upgrade ‘Move to WordPress.com’` )
+			: translate( `Install Jetpack` );
+	}
+
+	function renderSubTitle() {
+		return isMigrateFromWp
+			? translate( `The latest version of the plugin is required to migrate all the content` )
+			: translate( `Jetpack is required to migrate all the content` );
+	}
+
+	function renderSelectBoxContent() {
+		const jetpackContentObj = {
+			key: 'jetpack',
+			title: translate( 'Jetpack required' ),
+			description: (
+				<p>
+					{ translate(
+						'Jetpack will allow WordPress.com to communicate with your self-hosted WordPress site. '
+					) }
+				</p>
+			),
+			icon: jetpack,
+			actionText: translate( 'Install Jetpack' ),
+			value: '',
+		};
+		const wpcomMigrationContentObj = {
+			key: 'wordpress',
+			title: translate( 'Move to WordPress.com' ),
+			description: (
+				<p>
+					{ translate(
+						'This free plugin offers a simple way to migrate any site to WordPress.com managed hosting.'
+					) }
+				</p>
+			),
+			icon: <Gridicon icon="plugins" />,
+			actionText: translate( 'Upgrade plugin' ),
+			value: '',
+		};
+		return isMigrateFromWp ? wpcomMigrationContentObj : jetpackContentObj;
+	}
+
+	function installJetpack() {
+		recordTracksEvent( 'calypso_site_importer_install_jetpack' );
+		const source = 'import';
+		window.open( `/jetpack/connect/?url=${ sourceSiteUrl }&source=${ source }`, '_blank' );
+	}
+
+	function onMigrationPluginUpgrade() {
+		recordTracksEvent( 'calypso_site_importer_upgrade_wp_migration_plugin' );
+		window.open( `${ sourceSiteUrl }/wp-admin/plugins.php`, '_blank' );
+	}
+
+	function onActionClick() {
+		return isMigrateFromWp ? onMigrationPluginUpgrade() : installJetpack();
+	}
+
+	function onIntallJetpackManuallyClick() {
+		recordTracksEvent( 'calypso_site_importer_install_jetpack_manually' );
+		window.open( `https://jetpack.com/support/getting-started-with-jetpack/` );
+	}
+
+	return (
+		<div
+			className={ classnames( 'import__import-everything', {
+				'import__import-everything--redesign': isEnabled( 'onboarding/import-redesign' ),
+			} ) }
+		>
+			<div className="import__heading-title">
+				<Title>{ renderTitle() }</Title>
+				<SubTitle>{ renderSubTitle() }</SubTitle>
+			</div>
+			<div className="select-items-wrapper">
+				<SelectItems
+					onSelect={ onActionClick }
+					items={ [ renderSelectBoxContent() ] }
+					preventWidows={ preventWidows }
+				/>
+			</div>
+			{ ! isMigrateFromWp && (
+				<div className="import__footer-button-container">
+					<Button
+						borderless={ true }
+						className="action-buttons__install-jetpack-manually"
+						onClick={ onIntallJetpackManuallyClick }
+					>
+						{ translate( 'Install Jetpack manually' ) }
+					</Button>
+				</div>
+			) }
+		</div>
+	);
+};

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plugins.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plugins.tsx
@@ -4,7 +4,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { Title, SubTitle, SelectItems } from '@automattic/onboarding';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
 import { jetpack } from 'calypso/signup/icons';
 import { URL } from 'calypso/types';
@@ -17,6 +17,12 @@ interface Props {
 export const UpgradePluginInfo: React.FunctionComponent< Props > = ( props: Props ) => {
 	const translate = useTranslate();
 	const { isMigrateFromWp, sourceSiteUrl } = props;
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_site_importer_show_upgrade_info', {
+			plugins_info: isMigrateFromWp ? 'wpcom_migration_plugin' : 'jetpack',
+		} );
+	}, [] );
 
 	function renderTitle() {
 		return isMigrateFromWp

--- a/client/blocks/importer/wordpress/import-everything/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/style.scss
@@ -197,6 +197,37 @@
 				margin: 0 8px;
 			}
 		}
+
+		.action-buttons__install-jetpack-manually {
+			text-decoration: underline;
+		}
+	}
+	.select-items-wrapper {
+		display: flex;
+		justify-content: center;
+
+		.select-items {
+			border: solid 1px var(--studio-gray-5);
+			border-radius: 4px;
+			margin: 12px 0 24px;
+			padding-left: 50px;
+			max-width: 525px;
+			box-sizing: border-box;
+
+			.select-items__item {
+				padding: 1rem 0;
+				width: 100%;
+			}
+
+			.select-items__item-icon {
+				top: 20px;
+				left: -38px;
+			}
+
+			.select-items__item-button {
+				margin-right: 1rem;
+			}
+		}
 	}
 }
 

--- a/client/data/site-migration/types.ts
+++ b/client/data/site-migration/types.ts
@@ -1,0 +1,7 @@
+export interface MigrationEnabledResponse {
+	source_blog_id: number;
+	jetpack_activated: boolean;
+	jetpack_compatible: boolean;
+	migration_activated: boolean;
+	migration_compatible: boolean;
+}

--- a/client/data/site-migration/use-migration-enabled.ts
+++ b/client/data/site-migration/use-migration-enabled.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { MigrationEnabledResponse } from './types';
 import type { SiteId, URL } from 'calypso/types';
@@ -14,8 +14,10 @@ export const useMigrationEnabledInfoQuery = (
 	targetSiteId: SiteId,
 	sourcSite: SiteId | URL,
 	enabled = true,
-	onSuccessCallback?: ( data: MigrationEnabledResponse ) => void
+	onSuccessCallback?: ( data: MigrationEnabledResponse ) => void,
+	onErrorCallback?: () => void
 ) => {
+	const queryClient = useQueryClient();
 	const queryKey = [ 'migration-enabled', sourcSite ];
 
 	return useQuery(
@@ -32,6 +34,11 @@ export const useMigrationEnabledInfoQuery = (
 			enabled: !! ( enabled && targetSiteId && sourcSite ),
 			retry: false,
 			onSuccess: onSuccessCallback,
+			onError: () => {
+				// Clear data on error
+				queryClient.setQueryData( queryKey, null );
+				onErrorCallback && onErrorCallback();
+			},
 		}
 	);
 };

--- a/client/data/site-migration/use-migration-enabled.ts
+++ b/client/data/site-migration/use-migration-enabled.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { MigrationEnabledResponse } from './types';
+import type { SiteId, URL } from 'calypso/types';
+/**
+ * Fetches migration enabled information for a specific target site and source site.
+ *
+ * @param targetSiteId - The ID of the target site.
+ * @param sourcSite - The ID or URL of the source site.
+ * @param enabled - Optional flag to enable/disable the query. Default is true.
+ * @returns The migration enabled information query result.
+ */
+export const useMigrationEnabledInfoQuery = (
+	targetSiteId: SiteId,
+	sourcSite: SiteId | URL,
+	enabled = true,
+	onSuccessCallback?: ( data: MigrationEnabledResponse ) => void
+) => {
+	const queryKey = [ 'migration-enabled', sourcSite ];
+
+	return useQuery(
+		queryKey,
+		(): Promise< MigrationEnabledResponse > =>
+			wpcom.req.get( {
+				apiNamespace: 'wpcom/v2/',
+				path: `sites/${ targetSiteId }/migration-enabled/${ encodeURIComponent( sourcSite ) }`,
+			} ),
+		{
+			meta: {
+				persist: false,
+			},
+			enabled: !! ( enabled && targetSiteId && sourcSite ),
+			retry: false,
+			onSuccess: onSuccessCallback,
+		}
+	);
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76726, #77124

## Proposed Changes

* In this PR, we add screens to show upgrade plugin information if needed. In our new plugin flow, we show the plans page first and wait until a user clicks the migration button we then check for the plugin information. There's no point in checking it if a user is going to choose content-only import. In order to do so, we check it when:
    * User is on a plans page, and then clicks the `Upgrade and migrate` button
    * User already has a Business plan. We'll check it on page load.
    * When the upgrade screen shows up, it keeps pinging the API every five seconds, if user has established the connection, they can continue on the migration steps. 
* This PR also remove `sourceSite` object from being used if it's not needed.

![Screen Shot 2023-05-25 at 1 34 55 PM](https://github.com/Automattic/wp-calypso/assets/4074459/843a0a2e-2e8c-4be8-a3ca-04855ae2ec9a)

![Screen Shot 2023-05-25 at 1 49 39 PM](https://github.com/Automattic/wp-calypso/assets/4074459/c5778680-7a62-4f70-a6f1-2f19fbc9f63b)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a JN site, with and without WordPress.com user connected
* Navigate to `http://calypso.localhost:3000/setup/import-focused/importerWordpress?from=${source_site}&siteSlug=${target_site}&option=everything`
**Test case 1**
* Try with a simple site, you'll see the plans page first, click on `Upgrade and migrate` button
* It should come up with the upgrade plans screen if you don't have user account connected
* It should go to checkout page directly if you have Jetpack installed and user account connected
* Once it shows up the upgrade screen, it should go directly to the checkout page after you establish the connection.
**Test case 2**
* Try with an Atomic site, you'll see the migration ready screen if you have user account connected.
* It should show the upgrade screen if you don't have a user account connected
* Click on those action buttons on the upgrade screen and see if it guide you correctly

**Try with `Move to WordPress.com` scenario**

* Add this key value pair to your session storage in browser. key: `is_migrate_from_wp` value: `true` so we can identify it as a plugin flow
* Follow the steps above but install the Move to WordPress.com plugin with the current version, so if the upgrade plan screen shows up on a simple site
* Try another site with latest develop plugin version by creating it in JN site or Jetpack Beta, and see if you can go to migrate ready page without blocking.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
