### PR TITLE
Dynamically show/hide cta sidebar on pricing modal for mobiles on scroll

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -457,18 +457,29 @@
 	.product-lightbox__content-wrapper {
 		padding: 0;
 		flex-direction: column;
+		overflow: hidden;
 	}
 
 	.product-lightbox__detail {
 		padding: 24px;
 		width: auto;
+		max-height: 100%;
 	}
 
 	.product-lightbox__sidebar {
+		width: 100%;
+		position: absolute;
+		bottom: 0;
+		left: 0;
 		border-radius: 0;
 		padding: 24px;
-		position: relative;
-		width: auto;
+		box-sizing: border-box;
+		transition: transform 0.2s;
+		transform: translateY(100%);
+
+		&.is-expanded {
+			transform: translateY(0);
+		}
 	}
 
 	.product-lightbox__variants-options {


### PR DESCRIPTION

## Proposed Changes

- Add styles to hide modal sidebar on mobile by default
- Add hook to dynamically show/hide sidebar on mobiles

## Testing Instructions

* Checkout this PR
* Run `yarn start-jetpack-cloud-p`
* Go to `http://jetpack.cloud.localhost:3001/pricing` and enable mobile (width < 782) viewport
* Click on "More about ..." links
* Check that if modal is scrollable vertically - price sidebar will pop up only when user scrolls down
* Fiddle around with expanding / collapsing sections (to see if sidebar is responsive for increase/decrease of scrollable area, changing viewport (to make sure the hook unloads and don't run on desktops) etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
