### PR TITLE
Subscription Management: Clicking on site icon and site title should go to individual site subscription page.

### DIFF
--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -75,8 +75,8 @@ export default function SiteRow( {
 	const locale = useLocale();
 
 	const individualPagePath = useMemo( () => {
-		return `/subscriptions/site/${ blog_ID }` + ( locale !== 'en' ? '/' + locale : '' );
-	}, [ blog_ID, locale ] );
+		return `/subscriptions/site/${ blog_ID }`;
+	}, [ blog_ID ] );
 
 	const navigateToIndividualSubscriptionPage = ( event: React.MouseEvent ) => {
 		event.preventDefault();

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -1,7 +1,9 @@
 import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import TimeSince from 'calypso/components/time-since';
 import { SiteSettingsPopover } from '../settings';
 import { SiteIcon } from '../site-icon';
@@ -68,25 +70,37 @@ export default function SiteRow( {
 		SubscriptionManager.useSiteEmailMeNewCommentsMutation();
 	const { mutate: unsubscribe, isLoading: unsubscribing } =
 		SubscriptionManager.useSiteUnsubscribeMutation();
+
+	const navigate = useNavigate();
+	const locale = useLocale();
+
+	const individualPagePath = useMemo( () => {
+		return `/subscriptions/site/${ blog_ID }` + ( locale !== 'en' ? '/' + locale : '' );
+	}, [ blog_ID, locale ] );
+
+	const navigateToIndividualSubscriptionPage = ( event: React.MouseEvent ) => {
+		event.preventDefault();
+		navigate( individualPagePath );
+	};
+
 	return (
 		<li className="row" role="row">
-			<a
-				{ ...( url && { href: url } ) }
-				rel="noreferrer noopener"
-				className="title-box"
-				target="_blank"
-			>
-				<span className="title-box" role="cell">
+			<span className="title-box" role="cell">
+				<a href={ individualPagePath } onClick={ navigateToIndividualSubscriptionPage }>
 					<SiteIcon iconUrl={ site_icon } size={ 48 } siteName={ name } />
-					<span className="title-column">
+				</a>
+				<span className="title-column">
+					<a href={ individualPagePath } onClick={ navigateToIndividualSubscriptionPage }>
 						<span className="name">
 							{ name }
 							{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
 						</span>
+					</a>
+					<a { ...( url && { href: url } ) } rel="noreferrer noopener" target="_blank">
 						<span className="url">{ hostname }</span>
-					</span>
+					</a>
 				</span>
-			</a>
+			</span>
 			<span className="date" role="cell">
 				<TimeSince
 					date={

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -1,6 +1,5 @@
 import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
-import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -72,7 +71,6 @@ export default function SiteRow( {
 		SubscriptionManager.useSiteUnsubscribeMutation();
 
 	const navigate = useNavigate();
-	const locale = useLocale();
 
 	const individualPagePath = useMemo( () => {
 		return `/subscriptions/site/${ blog_ID }`;

--- a/client/landing/subscriptions/components/site-list/styles.scss
+++ b/client/landing/subscriptions/components/site-list/styles.scss
@@ -32,6 +32,10 @@
 			flex: 1.83;
 			min-width: 0;
 
+			> a {
+				flex: 0;
+			}
+
 			.icon {
 				fill: var(--color-text-subtle);
 				width: 40px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/77382

## Proposed Changes

* When clicking on the site icon and site title on the sites list, it should go to the individual site subscription page.

## Testing Instructions

* Do the `return next()` on that file.
* Go to `/subscriptions/sites`.
* Click on site title or site logo.
* It should go to the individual subscription page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
