### PR TITLE
Launchpad: Fix chevron position

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -462,6 +462,7 @@
 	line-height: 20px;
 	text-align: left;
 	width: 30px;
+	margin-left: auto;
 }
 
 .gridicon.launchpad__checklist-item-chevron {


### PR DESCRIPTION
## Proposed Changes

Fixes a regression introduced by https://github.com/Automattic/wp-calypso/pull/77338 which places the chevron of the launchpad tasks in a wrong position.

Before | After
--- | ---
<img width="383" alt="Screenshot 2023-05-25 at 11 50 10" src="https://github.com/Automattic/wp-calypso/assets/1233880/f12d6634-f4d3-4c26-bc66-c9fe40ba7801"> | <img width="389" alt="Screenshot 2023-05-25 at 11 55 42" src="https://github.com/Automattic/wp-calypso/assets/1233880/1e7e1b23-bedb-440f-b845-ff008b3678cd">

## Testing Instructions

- Use the Calypso live link below
- Go to `/start` and select "Other" as site goal
- Proceed with the onboarding until you reach the launchpad
- Make sure the chevron of incomplete tasks is aligned to the right