### PR TITLE
Help Center: move useFormTitle to hooks

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -36,7 +36,7 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
-import useZendeskConfig from '../hooks/use-zendesk-config';
+import { useZendeskConfig, useContactFormTitle } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
 import { getSupportVariationFromMode } from '../support-variations';
 import { BackButton } from './back-button';
@@ -63,41 +63,6 @@ const fakeFaces = [
 	'tony',
 ].map( ( name ) => `https://s0.wp.com/i/support-engineers/${ name }.jpg` );
 const randomTwoFaces = fakeFaces.sort( () => Math.random() - 0.5 ).slice( 0, 2 );
-
-function useFormTitles( mode: Mode ): {
-	formTitle: string;
-	formSubtitle?: string;
-	trayText?: string;
-	formDisclaimer?: string;
-	buttonLabel: string;
-	buttonSubmittingLabel: string;
-	buttonLoadingLabel?: string;
-} {
-	return {
-		CHAT: {
-			formTitle: __( 'Start live chat', __i18n_text_domain__ ),
-			trayText: __( 'Our WordPress experts will be with you right away', __i18n_text_domain__ ),
-			buttonLabel: __( 'Chat with us', __i18n_text_domain__ ),
-			buttonSubmittingLabel: __( 'Connecting to chat', __i18n_text_domain__ ),
-		},
-		EMAIL: {
-			formTitle: __( '', __i18n_text_domain__ ),
-			trayText: __( 'Our WordPress experts will get back to you soon', __i18n_text_domain__ ),
-			buttonLabel: __( 'Email us', __i18n_text_domain__ ),
-			buttonSubmittingLabel: __( 'Sending email', __i18n_text_domain__ ),
-		},
-		FORUM: {
-			formTitle: __( 'Ask in our community forums', __i18n_text_domain__ ),
-			formDisclaimer: __(
-				'Please do not provide financial or contact information when submitting this form.',
-				__i18n_text_domain__
-			),
-			buttonLabel: __( 'Ask in the forums', __i18n_text_domain__ ),
-			buttonSubmittingLabel: __( 'Posting in the forums', __i18n_text_domain__ ),
-			buttonLoadingLabel: __( 'Analyzing site…', __i18n_text_domain__ ),
-		},
-	}[ mode ];
-}
 
 const getSupportedLanguages = ( supportType: string, locale: string ) => {
 	const isLiveChatLanguageSupported = (
@@ -183,7 +148,7 @@ export const HelpCenterContactForm = () => {
 		}
 	}, [ userWithNoSites ] );
 
-	const formTitles = useFormTitles( mode );
+	const formTitles = useContactFormTitle( mode );
 
 	let ownershipResult: AnalysisReport = useSiteAnalysis(
 		// pass user email as query cache key
@@ -642,11 +607,6 @@ export const HelpCenterContactForm = () => {
 		<main className="help-center-contact-form">
 			<BackButton />
 			<h1 className="help-center-contact-form__site-picker-title">{ formTitles.formTitle }</h1>
-			{ formTitles.formSubtitle && (
-				<p className="help-center-contact-form__site-picker-form-subtitle">
-					{ formTitles.formSubtitle }
-				</p>
-			) }
 
 			{ formTitles.formDisclaimer && (
 				<p className="help-center-contact-form__site-picker-form-warning">

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -20,10 +20,12 @@ import { getSectionName } from 'calypso/state/ui/selectors';
  * Internal Dependencies
  */
 import { BackButton } from '..';
-import useMessagingAuth from '../hooks/use-messaging-auth';
-import { useShouldRenderChatOption } from '../hooks/use-should-render-chat-option';
-import { useShouldRenderEmailOption } from '../hooks/use-should-render-email-option';
-import { useStillNeedHelpURL } from '../hooks/use-still-need-help-url';
+import {
+	useShouldRenderChatOption,
+	useMessagingAuth,
+	useShouldRenderEmailOption,
+	useStillNeedHelpURL,
+} from '../hooks';
 import { Mail, Forum } from '../icons';
 import { HelpCenterActiveTicketNotice } from './help-center-notice';
 

--- a/packages/help-center/src/components/help-center-gpt.tsx
+++ b/packages/help-center/src/components/help-center-gpt.tsx
@@ -11,7 +11,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState } from 'react';
 import stripTags from 'striptags';
 import './help-center-article-content.scss';
-import useTyper from '../hooks/use-typer';
+import { useTyper } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
 
 const GPTResponsePlaceholder = styled( LoadingPlaceholder )< { width?: string } >`

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -30,7 +30,7 @@ import getAdminHelpResults from 'calypso/state/inline-help/selectors/get-admin-h
 import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
 import { useSiteOption } from 'calypso/state/sites/hooks';
 import { getSectionName } from 'calypso/state/ui/selectors';
-import { useHelpSearchQuery } from '../hooks/use-help-search-query';
+import { useHelpSearchQuery } from '../hooks';
 import PlaceholderLines from './placeholder-lines';
 import type { SearchResult } from '../types';
 

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -13,9 +13,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
-import useMessagingAuth from '../hooks/use-messaging-auth';
-import { useStillNeedHelpURL } from '../hooks/use-still-need-help-url';
-import useZendeskConfig from '../hooks/use-zendesk-config';
+import { useStillNeedHelpURL, useMessagingAuth, useZendeskConfig } from '../hooks';
 import { HELP_CENTER_STORE, USER_STORE, SITE_STORE } from '../stores';
 import { Container } from '../types';
 import HelpCenterContainer from './help-center-container';

--- a/packages/help-center/src/hooks/index.ts
+++ b/packages/help-center/src/hooks/index.ts
@@ -1,0 +1,9 @@
+export { useContactFormTitle } from './use-contact-form-title';
+export { useHelpSearchQuery } from './use-help-search-query';
+export { useShouldRenderChatOption } from './use-should-render-chat-option';
+export { useShouldRenderEmailOption } from './use-should-render-email-option';
+export { useStillNeedHelpURL } from './use-still-need-help-url';
+export { default as useMessagingAuth } from './use-messaging-auth';
+export { default as useMessagingAvailability } from './use-messaging-availability';
+export { default as useTyper } from './use-typer';
+export { default as useZendeskConfig } from './use-zendesk-config';

--- a/packages/help-center/src/hooks/use-contact-form-title.ts
+++ b/packages/help-center/src/hooks/use-contact-form-title.ts
@@ -1,0 +1,38 @@
+import { __ } from '@wordpress/i18n';
+import { Mode } from '../types';
+
+export const useContactFormTitle = (
+	mode: Mode
+): {
+	formTitle: string;
+	trayText?: string;
+	formDisclaimer?: string;
+	buttonLabel: string;
+	buttonSubmittingLabel: string;
+	buttonLoadingLabel?: string;
+} => {
+	return {
+		CHAT: {
+			formTitle: __( 'Start live chat', __i18n_text_domain__ ),
+			trayText: __( 'Our WordPress experts will be with you right away', __i18n_text_domain__ ),
+			buttonLabel: __( 'Chat with us', __i18n_text_domain__ ),
+			buttonSubmittingLabel: __( 'Connecting to chat', __i18n_text_domain__ ),
+		},
+		EMAIL: {
+			formTitle: __( '', __i18n_text_domain__ ),
+			trayText: __( 'Our WordPress experts will get back to you soon', __i18n_text_domain__ ),
+			buttonLabel: __( 'Email us', __i18n_text_domain__ ),
+			buttonSubmittingLabel: __( 'Sending email', __i18n_text_domain__ ),
+		},
+		FORUM: {
+			formTitle: __( 'Ask in our community forums', __i18n_text_domain__ ),
+			formDisclaimer: __(
+				'Please do not provide financial or contact information when submitting this form.',
+				__i18n_text_domain__
+			),
+			buttonLabel: __( 'Ask in the forums', __i18n_text_domain__ ),
+			buttonSubmittingLabel: __( 'Posting in the forums', __i18n_text_domain__ ),
+			buttonLoadingLabel: __( 'Analyzing site…', __i18n_text_domain__ ),
+		},
+	}[ mode ];
+};


### PR DESCRIPTION
## Proposed Changes

This is part 2 of refactoring the Help Center contact form. I have broken these changes out to make my original PR smaller. Original PR #72699

The `useFormTitles` did not need to be in the contact form itself. I am moving it into `hooks` in an effort to minimize the code inside the contact form component.

The other part is adding an index to the hooks directory and adjusting all the imports in Help Center.

## Testing Instructions

1. Open Calypso live link and navigate to the Help Center
2. Test all three contact forms (Forums, Chat, Email) and compare against production
3. Look for regressions and bugs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
