### PR TITLE
i18n: Remove old require translations chunk handler when switching the locale

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -353,6 +353,7 @@ export default async function switchLocale( localeSlug ) {
 
 			i18n.setLocale( locale );
 			setLocaleInDOM();
+			removeRequireChunkTranslationsHandler();
 			addRequireChunkTranslationsHandler( localeSlug, { translatedChunks } );
 
 			const translatedInstalledChunks = getInstalledChunks().filter( ( chunkId ) =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Reported in https://github.com/Automattic/wp-calypso/pull/77210#issuecomment-1559147554

## Proposed Changes

* Remove old require translations chunk handler prior to adding the new handler when switching the locale. This change prevents from having multiple handlers for fetching translation chunks, which may result in requesting translations for locale different the than currently selected one.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use calypso.live image or boot locally with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks,quick-language-switcher yarn start`.
* Add `?flags=quick-language-switcher` to the URL of the Calypso instance you are testing on.
* Using the quick language switcher in the master bar, change the locale a few times to a different Mag-16 language.
* Open the devtools and inspect the network requests.
* Navigate through Calypso screens, e.g. posts, pages, settings, account, etc.
* Confirm only language files for the currently selected locale are being requested. The translation chunk filenames should be like `{localeSlug}-{chunk}.json`,

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
