### PR TITLE
Add views and url at blazepress ready to promote page

### DIFF
--- a/client/my-sites/promote-post-i2/components/post-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/post-item/index.tsx
@@ -24,7 +24,8 @@ export type BlazablePost = {
 	comment_count: number;
 	like_count: number;
 	view_count: number;
-	URL: string; // todo
+	monthly_view_count: number;
+	post_url: string;
 	featured_image: string;
 	post_thumbnail: string;
 };
@@ -93,11 +94,11 @@ export default function PostItem( { post }: Props ) {
 			</td>
 
 			{ /* TODO: put the number of visitors and likes */ }
-			<td className="post-item__post-views">{ post?.view_count ?? 0 }</td>
+			<td className="post-item__post-views">{ post?.monthly_view_count ?? 0 }</td>
 			<td className="post-item__post-likes">{ post?.like_count }</td>
 			<td className="post-item__post-comments">{ post.comment_count }</td>
 			<td className="post-item__post-link">
-				<a href={ post.URL } className="post-item__title-view">
+				<a href={ post.post_url } className="post-item__title-view">
 					{ __( 'View' ) }
 				</a>
 			</td>


### PR DESCRIPTION
This PR adds the url to the "view" label in "Ready to promote" tab in new blazepress redesign. It also includes the views since it has changed the label (from view_count to monthly_view_count)

![image](https://github.com/Automattic/wp-calypso/assets/43957544/e4b89d53-3518-48db-b47b-ac5db9b3c1f7)

you can see there the view counter

## Testing Instructions

- You need to get the wpcom patch D111879 and proxy your sandbox
- go to "ready to promote" page and see the view counter and the view button should send you to the selected article


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
