### PR TITLE
Import flow: Introduced a new redesigned/simplified progress screen

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -207,6 +207,47 @@ export class ImportEverything extends SectionMigrate {
 		);
 	}
 
+	renderMigrationProgressSimple() {
+		const { translate } = this.props;
+		const statusSteps: string[] = [
+			translate( 'Preparing your files' ),
+			translate( 'Gathering your data' ),
+			translate( 'Preparing your files' ),
+		];
+		const statusStep =
+			statusSteps[ Math.floor( this.state.percent / ( 100 / statusSteps.length ) ) ];
+
+		return (
+			<Progress className="onboarding-progress-simple">
+				<Interval onTick={ this.updateFromAPI } period={ EVERY_TEN_SECONDS } />
+				<Title>{ translate( 'We’re safely gathering all your data.' ) }</Title>
+				<SubTitle tagName="h2">
+					{ translate( 'This can take from a few minutes to a few hours.' ) }
+				</SubTitle>
+				<ProgressBar compact={ false } value={ this.state.percent ? this.state.percent : 0 } />
+				<SubTitle tagName="h3">
+					{ statusStep ? statusStep : statusSteps[ statusSteps.length - 1 ] }...
+				</SubTitle>
+
+				<div className="progress-status">{ translate( 'Site migration in progress' ) }...</div>
+
+				<p className="support-block">
+					{ translate( 'Do you need help? {{a}}Contact us{{/a}}.', {
+						components: {
+							a: (
+								<a
+									href="https://wordpress.com/help/contact"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					} ) }
+				</p>
+			</Progress>
+		);
+	}
+
 	renderMigrationComplete() {
 		const { isMigrateFromWp } = this.props;
 		return (
@@ -296,6 +337,8 @@ export class ImportEverything extends SectionMigrate {
 	}
 
 	render() {
+		const { isMigrateFromWp } = this.props;
+
 		switch ( this.state.migrationStatus ) {
 			case MigrationStatus.UNKNOWN:
 				return this.renderLoading();
@@ -306,7 +349,9 @@ export class ImportEverything extends SectionMigrate {
 			case MigrationStatus.NEW:
 			case MigrationStatus.BACKING_UP:
 			case MigrationStatus.RESTORING:
-				return this.renderMigrationProgress();
+				return isMigrateFromWp
+					? this.renderMigrationProgressSimple()
+					: this.renderMigrationProgress();
 
 			case MigrationStatus.DONE:
 				return this.renderMigrationComplete();

--- a/client/blocks/importer/wordpress/import-everything/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/style.scss
@@ -93,6 +93,53 @@
 	}
 }
 
+.import__onboarding-page--redesign {
+	.onboarding-progress-simple {
+		min-width: 100% !important;
+
+		.onboarding-title {
+			font-size: rem(48px);
+		}
+
+		h2.onboarding-subtitle {
+			color: var(--studio-gray-60);
+			font-size: rem(18px);
+			line-height: rem(26px);
+			margin-bottom: rem(40px);
+		}
+
+		h3.onboarding-subtitle {
+			margin-bottom: rem(50px);
+		}
+
+		.progress-bar {
+			max-width: 385px;
+			margin-bottom: rem(14px);
+		}
+
+		.progress-status {
+			display: inline-block;
+			font-size: rem(14px);
+			font-weight: 500;
+			color: var(--studio-gray-60);
+			border: solid 1px var(--studio-gray-10);
+			border-radius: 4px;
+			margin-bottom: rem(24px);
+			padding: rem(10px) rem(24px);
+		}
+
+		.support-block {
+			font-size: rem(14px);
+			color: var(--studio-gray-50);
+
+			a {
+				color: var(--studio-gray-50);
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
 .import__import-everything--redesign {
 	.onboarding-title {
 		@include onboarding-font-recoleta;
@@ -151,7 +198,6 @@
 			}
 		}
 	}
-
 }
 
 .import__upgrade-plan {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -8,7 +8,6 @@ import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import NotAuthorized from 'calypso/blocks/importer/components/not-authorized';
 import NotFound from 'calypso/blocks/importer/components/not-found';
-import { Importer, ImportJob } from 'calypso/blocks/importer/types';
 import { getImporterTypeForEngine } from 'calypso/blocks/importer/util';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySites from 'calypso/components/data/query-sites';
@@ -35,6 +34,7 @@ import { useInitialQueryRun } from './hooks/use-initial-query-run';
 import { useStepNavigator } from './hooks/use-step-navigator';
 import type { ImporterCompType } from './types';
 import type { OnboardSelect } from '@automattic/data-stores';
+import type { Importer, ImportJob } from 'calypso/blocks/importer/types';
 
 interface Props {
 	importer: Importer;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/77195

## Proposed Changes

* Introduced a new redesigned/simplified progress screen

<img width="929" alt="Screenshot 2023-05-25 at 10 19 38" src="https://github.com/Automattic/wp-calypso/assets/1241413/c951c982-72cf-4e77-8155-8452f1908ffd">


## Testing Instructions

* Run the migration process from the Move to WordPress.com plugin (you can use the JN site with an established connection with the WP.COM)
* Pass through each step until you see Progress Screen
* Check if there is a new redesigned progress screen

NOTE: The new screen is only presentable when the user initiate migration from the plugin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
