### PR TITLE
Add-ons: Storage Add On Filtering

### DIFF
--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -1,3 +1,4 @@
+import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
@@ -104,6 +105,17 @@ const AddOnCard = ( {
 		actionSecondary?.handler( addOnMeta.productSlug );
 	};
 
+	// if product is space upgrade choose the action based on the purchased status
+	const shouldRenderPrimaryAction =
+		addOnMeta.productSlug === PRODUCT_1GB_SPACE
+			? ! addOnMeta.purchased
+			: availabilityStatus?.available;
+
+	const shouldRenderSecondaryAction =
+		addOnMeta.productSlug === PRODUCT_1GB_SPACE
+			? addOnMeta.purchased
+			: ! availabilityStatus?.available;
+
 	return (
 		<Container>
 			<Card className="add-ons-card">
@@ -125,7 +137,7 @@ const AddOnCard = ( {
 				</CardHeader>
 				<CardBody className="add-ons-card__body">{ addOnMeta.description }</CardBody>
 				<CardFooter isBorderless={ true } className="add-ons-card__footer">
-					{ ! availabilityStatus?.available && (
+					{ shouldRenderSecondaryAction && (
 						<>
 							{ actionSecondary && (
 								<Button onClick={ onActionSecondary }>{ actionSecondary.text }</Button>
@@ -138,7 +150,7 @@ const AddOnCard = ( {
 							) }
 						</>
 					) }
-					{ availabilityStatus?.available && actionPrimary && (
+					{ shouldRenderPrimaryAction && actionPrimary && (
 						<Button onClick={ onActionPrimary } primary>
 							{ actionPrimary.text }
 						</Button>

--- a/client/my-sites/add-ons/components/add-ons-grid.tsx
+++ b/client/my-sites/add-ons/components/add-ons-grid.tsx
@@ -30,7 +30,9 @@ const AddOnsGrid = ( {
 			{ addOns.map( ( addOn ) =>
 				addOn ? (
 					<AddOnCard
-						key={ addOn.productSlug }
+						key={
+							addOn.quantity ? `${ addOn.productSlug }-${ addOn.quantity }` : addOn.productSlug
+						}
 						actionPrimary={ actionPrimary }
 						actionSecondary={ actionSecondary }
 						useAddOnAvailabilityStatus={ useAddOnAvailabilityStatus }

--- a/client/my-sites/add-ons/constants.ts
+++ b/client/my-sites/add-ons/constants.ts
@@ -1,0 +1,1 @@
+export const STORAGE_LIMIT = 200;

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -14,7 +14,7 @@ import {
 	getProductName,
 } from 'calypso/state/products-list/selectors';
 import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
-import getPastBillingTransactions from 'calypso/state/selectors/get-past-billing-transactions';
+import { useBillingTransactions } from 'calypso/state/sites/hooks/use-billing-history';
 import { STORAGE_LIMIT } from '../constants';
 import customDesignIcon from '../icons/custom-design';
 import spaceUpgradeIcon from '../icons/space-upgrade';
@@ -85,11 +85,12 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 	// if upgrade is bought - show as manage
 	// if upgrade is not bought - only show it if available storage and if it's larger than previously bought upgrade
 	const { data: mediaStorage } = useMediaStorageQuery( siteId );
+	const { billingTransactions } = useBillingTransactions( 'past' );
 
 	return useSelector( ( state ): ( AddOnMeta | null )[] => {
-		const transactions = getPastBillingTransactions( state );
 		const filter = getBillingTransactionFilters( state, 'past' );
-		const filteredTransactions = transactions && filterTransactions( transactions, filter, siteId );
+		const filteredTransactions =
+			billingTransactions && filterTransactions( billingTransactions, filter, siteId );
 
 		const spaceUpgradesPurchased: BillingTransactionItem[] = [];
 

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -7,6 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
 import { filterTransactions } from 'calypso/me/purchases/billing-history/filter-transactions';
 import { useSelector } from 'calypso/state';
+import { BillingTransactionItem } from 'calypso/state/billing-transactions/types';
 import {
 	getProductBySlug,
 	getProductDescription,
@@ -90,7 +91,7 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 		const filter = getBillingTransactionFilters( state, 'past' );
 		const filteredTransactions = transactions && filterTransactions( transactions, filter, siteId );
 
-		const spaceUpgradesPurchased = [];
+		const spaceUpgradesPurchased: BillingTransactionItem[] = [];
 
 		if ( filteredTransactions?.length ) {
 			for ( const transaction of filteredTransactions ) {
@@ -116,7 +117,7 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 				// if storage add on is already purchased
 				if (
 					spaceUpgradesPurchased.findIndex(
-						( item ) => parseInt( item.licensed_quantity ) === addOn.quantity
+						( item ) => Number( item.licensed_quantity ) === addOn.quantity
 					) >= 0
 				) {
 					return {
@@ -131,7 +132,7 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 				const availableStorageUpgrade = STORAGE_LIMIT - currentMaxStorage;
 
 				// if the current storage add on option is greater than the available upgrade, remove it
-				if ( ( addOn.quantity as number ) > availableStorageUpgrade ) {
+				if ( ( addOn.quantity ?? 0 ) > availableStorageUpgrade ) {
 					return null;
 				}
 			}

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -7,14 +7,13 @@ import { useTranslate } from 'i18n-calypso';
 import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
 import { filterTransactions } from 'calypso/me/purchases/billing-history/filter-transactions';
 import { useSelector } from 'calypso/state';
-import { BillingTransactionItem } from 'calypso/state/billing-transactions/types';
 import {
 	getProductBySlug,
 	getProductDescription,
 	getProductName,
 } from 'calypso/state/products-list/selectors';
 import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
-import { useBillingTransactions } from 'calypso/state/sites/hooks/use-billing-history';
+import { usePastBillingTransactions } from 'calypso/state/sites/hooks/use-billing-history';
 import { STORAGE_LIMIT } from '../constants';
 import customDesignIcon from '../icons/custom-design';
 import spaceUpgradeIcon from '../icons/space-upgrade';
@@ -85,71 +84,83 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 	// if upgrade is bought - show as manage
 	// if upgrade is not bought - only show it if available storage and if it's larger than previously bought upgrade
 	const { data: mediaStorage } = useMediaStorageQuery( siteId );
-	const { billingTransactions } = useBillingTransactions( 'past' );
+	const { billingTransactions } = usePastBillingTransactions();
 
 	return useSelector( ( state ): ( AddOnMeta | null )[] => {
 		const filter = getBillingTransactionFilters( state, 'past' );
 		const filteredTransactions =
 			billingTransactions && filterTransactions( billingTransactions, filter, siteId );
 
-		const spaceUpgradesPurchased: BillingTransactionItem[] = [];
+		const spaceUpgradesPurchased: number[] = [];
 
 		if ( filteredTransactions?.length ) {
 			for ( const transaction of filteredTransactions ) {
 				transaction.items?.length &&
 					spaceUpgradesPurchased.push(
-						...transaction.items.filter( ( item ) => item.wpcom_product_slug === PRODUCT_1GB_SPACE )
+						...transaction.items
+							.filter( ( item ) => item.wpcom_product_slug === PRODUCT_1GB_SPACE )
+							.map( ( item ) => Number( item.licensed_quantity ) )
 					);
 			}
 		}
 
-		return addOnsActive.map( ( addOn ) => {
-			const product = getProductBySlug( state, addOn.productSlug );
-			const name = addOn.name ? addOn.name : getProductName( state, addOn.productSlug );
-			const description = addOn.description ?? getProductDescription( state, addOn.productSlug );
+		return addOnsActive
+			.filter( ( addOn ) => {
+				// if a user already has purchased a storage upgrade
+				// remove all upgrades smaller than the smallest purchased upgrade (we only allow purchasing upgrades in ascending order)
+				if ( spaceUpgradesPurchased.length && addOn.productSlug === PRODUCT_1GB_SPACE ) {
+					return ( addOn.quantity ?? 0 ) >= Math.min( ...spaceUpgradesPurchased );
+				}
 
-			// if it's a storage add on
-			if ( addOn.productSlug === PRODUCT_1GB_SPACE ) {
-				// if storage add ons are not enabled in the config, remove them
-				if ( ! isStorageAddonEnabled() ) {
+				return true;
+			} )
+			.map( ( addOn ) => {
+				const product = getProductBySlug( state, addOn.productSlug );
+				const name = addOn.name ? addOn.name : getProductName( state, addOn.productSlug );
+				const description = addOn.description ?? getProductDescription( state, addOn.productSlug );
+
+				// if it's a storage add on
+				if ( addOn.productSlug === PRODUCT_1GB_SPACE ) {
+					// if storage add ons are not enabled in the config, remove them
+					if ( ! isStorageAddonEnabled() ) {
+						return null;
+					}
+
+					// if storage add on is already purchased
+					if (
+						spaceUpgradesPurchased.findIndex(
+							( spaceUpgrade ) => spaceUpgrade === addOn.quantity
+						) >= 0
+					) {
+						return {
+							...addOn,
+							name,
+							description,
+							purchased: true,
+						};
+					}
+
+					const currentMaxStorage = mediaStorage?.max_storage_bytes / Math.pow( 1024, 3 );
+					const availableStorageUpgrade = STORAGE_LIMIT - currentMaxStorage;
+
+					// if the current storage add on option is greater than the available upgrade, remove it
+					if ( ( addOn.quantity ?? 0 ) > availableStorageUpgrade ) {
+						return null;
+					}
+				}
+
+				if ( ! product ) {
+					// will not render anything if product not fetched from API
+					// probably need some sort of placeholder in the add-ons page instead
 					return null;
 				}
 
-				// if storage add on is already purchased
-				if (
-					spaceUpgradesPurchased.findIndex(
-						( item ) => Number( item.licensed_quantity ) === addOn.quantity
-					) >= 0
-				) {
-					return {
-						...addOn,
-						name,
-						description,
-						purchased: true,
-					};
-				}
-
-				const currentMaxStorage = mediaStorage?.max_storage_bytes / Math.pow( 1024, 3 );
-				const availableStorageUpgrade = STORAGE_LIMIT - currentMaxStorage;
-
-				// if the current storage add on option is greater than the available upgrade, remove it
-				if ( ( addOn.quantity ?? 0 ) > availableStorageUpgrade ) {
-					return null;
-				}
-			}
-
-			if ( ! product ) {
-				// will not render anything if product not fetched from API
-				// probably need some sort of placeholder in the add-ons page instead
-				return null;
-			}
-
-			return {
-				...addOn,
-				name,
-				description,
-			};
-		} );
+				return {
+					...addOn,
+					name,
+					description,
+				};
+			} );
 	} );
 };
 

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -118,8 +118,8 @@ interface Props {
 
 const AddOnsMain: React.FunctionComponent< Props > = () => {
 	const translate = useTranslate();
-	const addOns = useAddOns();
 	const selectedSite = useSelector( getSelectedSite );
+	const addOns = useAddOns( selectedSite?.ID );
 	const checkoutLink = useAddOnCheckoutLink();
 
 	const canManageSite = useSelector( ( state ) => {

--- a/client/state/sites/hooks/use-billing-history.ts
+++ b/client/state/sites/hooks/use-billing-history.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import {
+	BillingTransaction,
+	BillingTransactionsType,
+} from 'calypso/state/billing-transactions/types';
+
+export const billingTransactionsQueryKey = 'use-stored-payment-methods';
+
+interface BillingHistory {
+	billing_history: BillingTransaction[];
+}
+
+const fetchBillingTransactions = ( transactionType?: BillingTransactionsType ) =>
+	wp.req.get( `/me/billing-history` + ( transactionType ? `/${ transactionType }` : '' ), {
+		apiVersion: '1.3',
+	} );
+
+export const useBillingTransactions = ( transactionType?: BillingTransactionsType ) => {
+	const queryKey = [ billingTransactionsQueryKey, transactionType ];
+
+	const { data, isLoading, error } = useQuery< BillingHistory, Error >( {
+		queryKey,
+		queryFn: () => fetchBillingTransactions( transactionType ),
+	} );
+
+	return {
+		billingTransactions: data?.billing_history || null,
+		isLoading,
+		error: error?.message || null,
+	};
+};

--- a/client/state/sites/hooks/use-billing-history.ts
+++ b/client/state/sites/hooks/use-billing-history.ts
@@ -1,9 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
-import {
-	BillingTransaction,
-	BillingTransactionsType,
-} from 'calypso/state/billing-transactions/types';
+import { BillingTransaction } from 'calypso/state/billing-transactions/types';
 
 export const billingTransactionsQueryKey = 'use-stored-payment-methods';
 
@@ -11,17 +8,17 @@ interface BillingHistory {
 	billing_history: BillingTransaction[];
 }
 
-const fetchBillingTransactions = ( transactionType?: BillingTransactionsType ) =>
-	wp.req.get( `/me/billing-history` + ( transactionType ? `/${ transactionType }` : '' ), {
+const fetchPastBillingTransactions = () =>
+	wp.req.get( '/me/billing-history/past', {
 		apiVersion: '1.3',
 	} );
 
-export const useBillingTransactions = ( transactionType?: BillingTransactionsType ) => {
-	const queryKey = [ billingTransactionsQueryKey, transactionType ];
+export const usePastBillingTransactions = () => {
+	const queryKey = [ billingTransactionsQueryKey ];
 
 	const { data, isLoading, error } = useQuery< BillingHistory, Error >( {
 		queryKey,
-		queryFn: () => fetchBillingTransactions( transactionType ),
+		queryFn: () => fetchPastBillingTransactions(),
 	} );
 
 	return {


### PR DESCRIPTION
This PR is based on https://github.com/Automattic/wp-calypso/pull/76754
Fixes 1721-gh-Automattic/martech

### Proposed Changes
Implement filtering for the available storage options based on the current max storage:

1. We want to offer 50 and 100 GB for now (this will likely change in the future)
2. A site should not have more than 200 GB of storage. If a user already has 200 GB of storage (e.g. provided by a plan), they should not have the option to add more storage.
3. Potentially, a user may be eligible for 50 GB, not 100 GB, depending on their current allowed storage.
4. User should be able to purchase each space upgrade only once

### Testing
1. Checkout this branch
2. Run `yarn` & `yarn start`
3. Create a new test site
4. Go to `http://calypso.localhost:3000/add-ons/YOUR_SITE_SLUG`
5. You should see the 2 new storage upgrades: 50 GB and 100 GB:

<img width="1162" alt="image" src="https://github.com/Automattic/wp-calypso/assets/20927667/ee20578b-87f7-4ff1-87b4-90b4ad42e80a">

6. Sandbox store and `public-api.wordpress.com`
7. Use a test card to buy the 50 GB upgrade
8. Once the purchase is complete, click on the Add-Ons link in the side menu so you can go back to `http://calypso.localhost:3000/add-ons/YOUR_SITE_SLUG`.

Note: You probably won't see the updated data just yet because there seems to be an issue with`getPastBillingTransactions` not being able to read the data consistently. I've found a workaround for now that allows for testing:
9. Visit `http://calypso.localhost:3000/purchases/billing-history/calffff.wordpress.com` and verify you can see the storage purchase in the billing history tab
10. Manually change the URL back to `http://calypso.localhost:3000/add-ons/YOUR_SITE_SLUG`
11. You should see the 50 GB storage showing as "Manage" and the 100 GB storage should be available for purchase

https://github.com/Automattic/wp-calypso/assets/20927667/96a32b94-bda3-4dfb-adb8-2cf38139e549

12. You should then be able to purchase the 100 GB storage upgrade
13. Repeat the workaround from before and verify you can manage both add ons

<img width="1096" alt="image" src="https://github.com/Automattic/wp-calypso/assets/20927667/ca6824a7-783b-4536-84c8-fa68956e08fb">

14. Do some more general testing:
• Verify the add ons display correctly according to the 200 GB storage limit 
• Verify that you can only buy the add ons in an ascending order - you should be able to buy the 50 GB and then the 100 GB but if you start out with the 100 GB the 50 GB shouldn't be visible