### PR TITLE
Reader: Add suggested follows modal to full post page on Reader

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -19,6 +19,7 @@ class AuthorCompactProfile extends Component {
 		siteUrl: PropTypes.string,
 		feedUrl: PropTypes.string,
 		followCount: PropTypes.number,
+		onFollowToggle: PropTypes.func,
 		feedId: PropTypes.number,
 		siteId: PropTypes.number,
 		siteIcon: PropTypes.string,
@@ -35,6 +36,7 @@ class AuthorCompactProfile extends Component {
 			siteUrl,
 			feedUrl,
 			followCount,
+			onFollowToggle,
 			feedId,
 			siteId,
 			post,
@@ -90,7 +92,9 @@ class AuthorCompactProfile extends Component {
 						</div>
 					) : null }
 
-					{ followUrl && <ReaderFollowButton siteUrl={ followUrl } /> }
+					{ followUrl && (
+						<ReaderFollowButton siteUrl={ followUrl } onFollowToggle={ onFollowToggle } />
+					) }
 				</div>
 			</div>
 		);

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -16,6 +16,7 @@ import { isDailyPostChallengeOrPrompt } from 'calypso/blocks/daily-post-button/h
 import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
 import WPiFrameResize from 'calypso/blocks/reader-full-post/wp-iframe-resize';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
+import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import AutoDirection from 'calypso/components/auto-direction';
 import BackButton from 'calypso/components/back-button';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -99,6 +100,18 @@ export class FullPostView extends Component {
 	hasScrolledToCommentAnchor = false;
 	commentsWrapper = createRef();
 	postContentWrapper = createRef();
+
+	state = {
+		isSuggestedFollowsModalOpen: false,
+	};
+
+	openSuggestedFollowsModal = ( followClicked ) => {
+		this.setState( { isSuggestedFollowsModalOpen: followClicked } );
+	};
+
+	onCloseSuggestedFollowModal = () => {
+		this.setState( { isSuggestedFollowsModalOpen: false } );
+	};
 
 	componentDidMount() {
 		// Send page view
@@ -514,6 +527,7 @@ export class FullPostView extends Component {
 								siteUrl={ post.site_URL }
 								feedUrl={ get( post, 'feed_URL' ) }
 								followCount={ site && site.subscribers_count }
+								onFollowToggle={ this.openSuggestedFollowsModal }
 								feedId={ +post.feed_ID }
 								siteId={ +post.site_ID }
 								post={ post }
@@ -646,6 +660,13 @@ export class FullPostView extends Component {
 						) }
 					</article>
 				</div>
+				{ post.site_ID && (
+					<ReaderSuggestedFollowsDialog
+						onClose={ this.onCloseSuggestedFollowModal }
+						siteId={ +post.site_ID }
+						isVisible={ this.state.isSuggestedFollowsModalOpen }
+					/>
+				) }
 			</ReaderMain>
 		);
 	}


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/77300

This adds the suggested follows modal to the Reader full post page.

When a user clicks on the follow button, they should get a modal showing a list of related/suggested sites to follow;

### Example
https://github.com/Automattic/wp-calypso/assets/5560595/94d2fe00-7d7d-4433-aabc-453d07f67c9d

### Testing
* Apply PR
* Go to Reader full post page like - http://calypso.localhost:3000/read/feeds/40850725/posts/4725497207
* If already following, click to unfollow and click the follow again
* You should see modal like in example above

