### PR TITLE
Newsletter onboarding: skip intro step if ref newsletter-lp

### DIFF
--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -110,16 +110,15 @@ const newsletter: Flow = {
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
+			const logInUrl = getStartUrl();
 
 			switch ( _currentStep ) {
 				case 'intro':
 					clearSignupDestinationCookie();
-					// This redirect for non-logged in users nearly duplicates one above,
-					// but is needed to avoid a short flash of the newsletterSetup screen.
-					if ( ! userIsLoggedIn ) {
-						return window.location.assign( getStartUrl() );
+					if ( userIsLoggedIn ) {
+						return navigate( 'newsletterSetup' );
 					}
-					return navigate( 'newsletterSetup' );
+					return window.location.assign( logInUrl );
 
 				case 'newsletterSetup':
 					clearSignupDestinationCookie();

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -141,6 +141,8 @@ const newsletter: Flow = {
 						persistSignupDestination( destination );
 						setSignupCompleteSlug( providedDependencies?.siteSlug );
 						setSignupCompleteFlowName( flowName );
+
+						// Return to subscribers after checkout
 						const returnUrl = encodeURIComponent(
 							`/setup/${ flowName }/subscribers?siteSlug=${ providedDependencies?.siteSlug }`
 						);
@@ -151,7 +153,7 @@ const newsletter: Flow = {
 							) }?redirect_to=${ returnUrl }&signup=1`
 						);
 					}
-					// If the user chooses a free plan, we need to redirect to the subscribers and not checkout.
+					// If the user chooses a free plan, we need to redirect to the subscribers directly and not checkout.
 					return window.location.assign(
 						`/setup/${ flowName }/subscribers?siteSlug=${ providedDependencies?.siteSlug }`
 					);

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -26,9 +26,15 @@ const newsletter: Flow = {
 	},
 	useSteps() {
 		const query = useQuery();
-		const ref = query.get( 'ref' ) || '';
+		const isComingFromMarketingPage = query.get( 'ref' ) === 'newsletter-lp';
 
-		let steps = [
+		return [
+			// Load intro step component only when not coming from the marketing page
+			...( ! isComingFromMarketingPage
+				? [
+						{ slug: 'intro', asyncComponent: () => import( './internals/steps-repository/intro' ) },
+				  ]
+				: [] ),
 			{
 				slug: 'newsletterSetup',
 				asyncComponent: () => import( './internals/steps-repository/newsletter-setup' ),
@@ -52,13 +58,6 @@ const newsletter: Flow = {
 				asyncComponent: () => import( './internals/steps-repository/launchpad' ),
 			},
 		];
-		if ( ref !== 'newsletter-lp' ) {
-			steps = [
-				{ slug: 'intro', asyncComponent: () => import( './internals/steps-repository/intro' ) },
-				...steps,
-			];
-		}
-		return steps;
 	},
 	useSideEffect() {
 		const { setHidePlansFeatureComparison } = useDispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -74,8 +74,7 @@ const newsletter: Flow = {
 		const siteSlug = useSiteSlug();
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const query = useQuery();
-		const ref = query.get( 'ref' ) || '';
-		const initialStep = ref === 'newsletter-lp' ? 'newsletterSetup' : 'intro';
+		const isComingFromMarketingPage = query.get( 'ref' ) === 'newsletter-lp';
 
 		const flowProgress = useFlowProgress( {
 			stepName: _currentStep,
@@ -172,7 +171,7 @@ const newsletter: Flow = {
 				case 'launchpad':
 					return window.location.assign( `/view/${ siteSlug }` );
 				default:
-					return navigate( initialStep );
+					return navigate( isComingFromMarketingPage ? 'newsletterSetup' : 'intro' );
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -63,6 +63,7 @@ const newsletter: Flow = {
 		const { setHidePlansFeatureComparison } = useDispatch( ONBOARD_STORE );
 		useEffect( () => {
 			setHidePlansFeatureComparison( true );
+			clearSignupDestinationCookie();
 		}, [] );
 	},
 	useStepNavigation( _currentStep, navigate ) {
@@ -114,14 +115,12 @@ const newsletter: Flow = {
 
 			switch ( _currentStep ) {
 				case 'intro':
-					clearSignupDestinationCookie();
 					if ( userIsLoggedIn ) {
 						return navigate( 'newsletterSetup' );
 					}
 					return window.location.assign( logInUrl );
 
 				case 'newsletterSetup':
-					clearSignupDestinationCookie();
 					return navigate( 'domains' );
 
 				case 'domains':


### PR DESCRIPTION
Resolves: https://github.com/Automattic/wp-calypso/issues/77245
> Skip intro when coming from the landing page (?ref=newsletter-lp) but show it otherwise

### Proposed Changes
* Add and adjust conditional logic for Newsletter flows to handle both logged in state and ?ref=newsletter-lp.

### Testing Instructions

**Test Logged In User**
While logged into your WordPress.com account:
1) Go to http://calypso.localhost:3000/setup/newsletter - you should see the intro step
2) Go to http://calypso.localhost:3000/setup/newsletter/intro - you should see the intro step
3) Go to http://calypso.localhost:3000/setup/newsletter?ref=newsletter-lp - you should see the setupNewsletter step

**Test Non-Logged In User**
While NOT logged into your WordPress.com account:
1) Go to http://calypso.localhost:3000/setup/newsletter. Confirm you see the intro step. Click 'Launch you newsletter' button, and confirm you go to account creation. Create account or login, and confirm you go to Setup. 
2) Go to http://calypso.localhost:3000/setup/newsletter/intro. Confirm you see the intro step. Click 'Launch you newsletter' button, and confirm you go to account creation. Create account or login, and confirm you go to Setup. 
3) Go to http://calypso.localhost:3000/setup/newsletter?ref=newsletter-lp. Confirm you go directly to account creation. Create account or login, and confirm you go to Setup screen.