### PR TITLE
Import flow: Replace useSiteQuery with useSourceMigrationStatusQuery

### DIFF
--- a/client/data/site-migration/use-source-migration-status-query.ts
+++ b/client/data/site-migration/use-source-migration-status-query.ts
@@ -1,19 +1,21 @@
 import { SourceSiteMigrationDetails } from '@automattic/data-stores/src/site';
 import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
-import type { SiteId } from 'calypso/types';
+import type { SiteId, SiteSlug } from 'calypso/types';
 
-export const useSourceMigrationStatusQuery = ( sourceId: SiteId | undefined ) => {
+export const useSourceMigrationStatusQuery = (
+	sourceIdOrSlug: SiteId | SiteSlug | null | undefined
+) => {
 	return useQuery( {
-		queryKey: [ 'source-migration-status', sourceId ],
+		queryKey: [ 'source-migration-status', sourceIdOrSlug ],
 		queryFn: (): Promise< SourceSiteMigrationDetails > =>
 			wp.req.get( {
-				path: '/migrations/from-source/' + encodeURIComponent( sourceId as number ),
+				path: '/migrations/from-source/' + encodeURIComponent( sourceIdOrSlug as string ),
 				apiNamespace: 'wpcom/v2',
 			} ),
 		meta: {
 			persist: false,
 		},
-		enabled: !! sourceId,
+		enabled: !! sourceIdOrSlug,
 	} );
 };

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -3,8 +3,8 @@ import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import useAddTempSiteToSourceOptionMutation from 'calypso/data/site-migration/use-add-temp-site-mutation';
+import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
-import { useSiteQuery } from 'calypso/data/sites/use-site-query';
 import { SITE_PICKER_FILTER_CONFIG } from 'calypso/landing/stepper/constants';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
@@ -62,7 +62,7 @@ const importFlow: Flow = {
 		const { addTempSiteToSourceOption } = useAddTempSiteToSourceOptionMutation();
 		const urlQueryParams = useQuery();
 		const fromParam = urlQueryParams.get( 'from' );
-		const { data: sourceSite } = useSiteQuery( fromParam as string );
+		const { data: migrationStatus } = useSourceMigrationStatusQuery( fromParam );
 		const siteSlugParam = useSiteSlugParam();
 		const selectedDesign = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
@@ -195,11 +195,11 @@ const importFlow: Flow = {
 						case 'select-site': {
 							const selectedSite = providedDependencies.site as SiteExcerptData;
 
-							if ( selectedSite && sourceSite ) {
+							if ( selectedSite && migrationStatus ) {
 								// Store temporary target blog id to source site option
 								selectedSite &&
-									sourceSite &&
-									addTempSiteToSourceOption( selectedSite.ID, sourceSite.ID );
+									migrationStatus?.source_blog_id &&
+									addTempSiteToSourceOption( selectedSite.ID, migrationStatus.source_blog_id );
 
 								urlQueryParams.set( 'siteSlug', selectedSite.slug );
 								urlQueryParams.set( 'option', 'everything' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
-import { useSiteQuery } from 'calypso/data/sites/use-site-query';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
@@ -20,11 +20,10 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 		[]
 	);
 	const { setIsMigrateFromWp } = useDispatch( ONBOARD_STORE );
-	const search = window.location.search;
-	const sourceSiteSlug = new URLSearchParams( search ).get( 'from' ) || '';
-	const { data: sourceSite, isError: isErrorSourcSite } = useSiteQuery( sourceSiteSlug );
+	const urlQueryParams = useQuery();
+	const sourceSiteSlug = urlQueryParams.get( 'from' ) || '';
 	const { data: sourceSiteMigrationStatus, isError: isErrorSourceSiteMigrationStatus } =
-		useSourceMigrationStatusQuery( sourceSite?.ID );
+		useSourceMigrationStatusQuery( sourceSiteSlug );
 	const errorDependency = {
 		isFromMigrationPlugin: true,
 		hasError: true,
@@ -37,7 +36,7 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 
 	useEffect( () => {
 		if ( submit ) {
-			if ( isErrorSourcSite || isErrorSourceSiteMigrationStatus ) {
+			if ( isErrorSourceSiteMigrationStatus ) {
 				return submit( errorDependency );
 			}
 			if ( sourceSiteMigrationStatus ) {
@@ -52,7 +51,7 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ isErrorSourcSite, isErrorSourceSiteMigrationStatus, sourceSiteMigrationStatus ] );
+	}, [ isErrorSourceSiteMigrationStatus, sourceSiteMigrationStatus ] );
 
 	const getCurrentMessage = () => {
 		return __( 'Scanning your site' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -22,7 +22,8 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import useAddTempSiteToSourceOptionMutation from 'calypso/data/site-migration/use-add-temp-site-mutation';
-import { useSiteQuery } from 'calypso/data/sites/use-site-query';
+import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
@@ -118,9 +119,9 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 	);
 	const blogTitle = isFreeFlow( 'free' ) ? getSelectedSiteTitle : '';
 	const { addTempSiteToSourceOption } = useAddTempSiteToSourceOptionMutation();
-	const search = window.location.search;
-	const sourceSiteSlug = new URLSearchParams( search ).get( 'from' ) || '';
-	const { data: siteData } = useSiteQuery( sourceSiteSlug, isCopySiteFlow( flow ) );
+	const urlQueryParams = useQuery();
+	const sourceSiteSlug = urlQueryParams.get( 'from' ) || '';
+	const { data: sourceMigrationStatus } = useSourceMigrationStatusQuery( sourceSiteSlug );
 	const useThemeHeadstart = ! isStartWritingFlow( flow );
 
 	async function createSite() {
@@ -154,9 +155,9 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			await addProductsToCart( site.siteSlug, flow, productCartItems );
 		}
 
-		if ( isMigrationFlow( flow ) && site?.siteSlug && siteData?.ID ) {
+		if ( isMigrationFlow( flow ) && site?.siteSlug && sourceMigrationStatus?.source_blog_id ) {
 			// Store temporary target blog id to source site option
-			addTempSiteToSourceOption( site.siteId, siteData.ID );
+			addTempSiteToSourceOption( site.siteId, sourceMigrationStatus?.source_blog_id );
 		}
 
 		return {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -505,6 +505,7 @@ export type SiteSelect = SelectFromMap< typeof selectors >;
 
 export interface SourceSiteMigrationDetails {
 	status: string;
+	source_blog_id?: number;
 	target_blog_id?: number;
 	is_target_blog_admin?: boolean;
 	is_target_blog_upgraded?: boolean;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/77234

## Proposed Changes

* Extended `useSourceMigrationStatusQuery` since the `/migrations/from-source/` endpoint now supports siteSlug as a parameter
* Import-focused onboarding flow: Replaced `useSiteQuery` with `useSourceMigrationStatusQuery`.
For more info, check https://github.com/Automattic/wp-calypso/issues/77234

## Testing Instructions

* Create a JN site
* Install the `Move to WordPress.com` plugin
* Press `Get started` CTA
* Pass through the migration flow
* Check if everything works as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
