### PR TITLE
Subscriptions management: Add 'Subscription not found' state

### DIFF
--- a/client/landing/subscriptions/components/fields/block-emails-setting/block-emails-setting.tsx
+++ b/client/landing/subscriptions/components/fields/block-emails-setting/block-emails-setting.tsx
@@ -1,5 +1,3 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEventHandler } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
@@ -14,9 +12,6 @@ export type BlockEmailsSettingProps = {
 
 const BlockEmailsSetting = ( { value, onChange }: BlockEmailsSettingProps ) => {
 	const translate = useTranslate();
-	const { hasTranslation } = useI18n();
-	const isEnglishLocale = useIsEnglishLocale();
-
 	return (
 		<FormFieldset className="block-emails-setting">
 			<FormLabel htmlFor="blocked" className="title">
@@ -27,17 +22,7 @@ const BlockEmailsSetting = ( { value, onChange }: BlockEmailsSettingProps ) => {
 					<FormInputCheckbox id="blocked" name="blocked" checked={ value } onChange={ onChange } />
 				</div>
 				<span>
-					{
-						// todo: remove translation check once translations are in place
-						isEnglishLocale ||
-						hasTranslation(
-							'Pause all email updates from sites you’re subscribing on WordPress.com'
-						)
-							? translate(
-									'Pause all email updates from sites you’re subscribing on WordPress.com'
-							  )
-							: translate( 'Pause all email updates from sites you’re following on WordPress.com' )
-					}
+					{ translate( 'Pause all email updates from sites you’re subscribing on WordPress.com' ) }
 				</span>
 			</FormLabel>
 		</FormFieldset>

--- a/client/landing/subscriptions/components/notice/notice.tsx
+++ b/client/landing/subscriptions/components/notice/notice.tsx
@@ -1,4 +1,5 @@
 import './style.scss';
+import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import closeIcon from './images/close.svg';
 import errorIcon from './images/error.svg';
@@ -20,6 +21,7 @@ export type NoticeState = {
 
 type NoticeProps = {
 	children: React.ReactNode;
+	className?: string;
 	action?: React.ReactNode;
 	type?: NoticeType;
 	onClose?: () => void;
@@ -28,13 +30,20 @@ type NoticeProps = {
 
 const Notice = ( {
 	children,
+	className,
 	action,
 	type = NoticeType.Success,
 	onClose,
 	visible = true,
 }: NoticeProps ) => {
 	return visible ? (
-		<div className={ `subscription-management__notice subscription-management__notice--${ type }` }>
+		<div
+			className={ classNames(
+				'subscription-management__notice',
+				`subscription-management__notice--${ type }`,
+				className
+			) }
+		>
 			{ onClose && (
 				<a
 					className="subscription-management__notice-close"

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -2,12 +2,13 @@ import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { EmailDeliveryFrequency } from 'calypso/../packages/data-stores/src/reader';
 import TimeSince from 'calypso/components/time-since';
 import { SiteSettingsPopover } from '../settings';
 import { SiteIcon } from '../site-icon';
 import type { SiteSubscription } from '@automattic/data-stores/src/reader/types';
 
-const useDeliveryFrequencyLabel = ( deliveryFrequencyValue: Reader.EmailDeliveryFrequency ) => {
+const useDeliveryFrequencyLabel = ( deliveryFrequencyValue?: Reader.EmailDeliveryFrequency ) => {
 	const translate = useTranslate();
 
 	const deliveryFrequencyLabels = useMemo(
@@ -19,7 +20,10 @@ const useDeliveryFrequencyLabel = ( deliveryFrequencyValue: Reader.EmailDelivery
 		[ translate ]
 	);
 
-	return deliveryFrequencyLabels[ deliveryFrequencyValue ] || translate( 'Paused' );
+	return (
+		deliveryFrequencyLabels[ deliveryFrequencyValue as Reader.EmailDeliveryFrequency ] ??
+		translate( 'Paused' )
+	);
 };
 
 const useSelectedNewPostDeliveryMethodsLabel = (
@@ -52,11 +56,11 @@ export default function SiteRow( {
 	}, [ url ] );
 	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 	const newPostDelivery = useSelectedNewPostDeliveryMethodsLabel(
-		delivery_methods.email.send_posts,
+		!! delivery_methods.email?.send_posts,
 		!! delivery_methods.notification?.send_posts
 	);
 	const deliveryFrequencyLabel = useDeliveryFrequencyLabel(
-		delivery_methods.email.post_delivery_frequency
+		delivery_methods.email?.post_delivery_frequency
 	);
 	const { mutate: updateNotifyMeOfNewPosts, isLoading: updatingNotifyMeOfNewPosts } =
 		SubscriptionManager.useSiteNotifyMeOfNewPostsMutation();
@@ -121,19 +125,21 @@ export default function SiteRow( {
 					}
 					updatingNotifyMeOfNewPosts={ updatingNotifyMeOfNewPosts }
 					// EmailMeNewPosts
-					emailMeNewPosts={ delivery_methods.email.send_posts }
+					emailMeNewPosts={ !! delivery_methods.email?.send_posts }
 					updatingEmailMeNewPosts={ updatingEmailMeNewPosts }
 					onEmailMeNewPostsChange={ ( send_posts ) =>
 						updateEmailMeNewPosts( { blog_id: blog_ID, send_posts } )
 					}
 					// DeliveryFrequency
-					deliveryFrequency={ delivery_methods.email.post_delivery_frequency }
+					deliveryFrequency={
+						delivery_methods.email?.post_delivery_frequency ?? EmailDeliveryFrequency.Instantly
+					}
 					onDeliveryFrequencyChange={ ( delivery_frequency ) =>
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )
 					}
 					updatingFrequency={ updatingFrequency }
 					// EmailMeNewComments
-					emailMeNewComments={ !! delivery_methods.email.send_comments }
+					emailMeNewComments={ !! delivery_methods.email?.send_comments }
 					onEmailMeNewCommentsChange={ ( send_comments ) =>
 						updateEmailMeNewComments( { blog_id: blog_ID, send_comments } )
 					}

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -2,7 +2,6 @@ import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { EmailDeliveryFrequency } from 'calypso/../packages/data-stores/src/reader';
 import TimeSince from 'calypso/components/time-since';
 import { SiteSettingsPopover } from '../settings';
 import { SiteIcon } from '../site-icon';
@@ -132,7 +131,8 @@ export default function SiteRow( {
 					}
 					// DeliveryFrequency
 					deliveryFrequency={
-						delivery_methods.email?.post_delivery_frequency ?? EmailDeliveryFrequency.Instantly
+						delivery_methods.email?.post_delivery_frequency ??
+						Reader.EmailDeliveryFrequency.Instantly
 					}
 					onDeliveryFrequencyChange={ ( delivery_frequency ) =>
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -52,11 +52,11 @@ export default function SiteRow( {
 	}, [ url ] );
 	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 	const newPostDelivery = useSelectedNewPostDeliveryMethodsLabel(
-		delivery_methods?.email?.send_posts,
-		delivery_methods?.notification?.send_posts
+		delivery_methods.email.send_posts,
+		!! delivery_methods.notification?.send_posts
 	);
 	const deliveryFrequencyLabel = useDeliveryFrequencyLabel(
-		delivery_methods?.email?.post_delivery_frequency
+		delivery_methods.email.post_delivery_frequency
 	);
 	const { mutate: updateNotifyMeOfNewPosts, isLoading: updatingNotifyMeOfNewPosts } =
 		SubscriptionManager.useSiteNotifyMeOfNewPostsMutation();
@@ -115,25 +115,25 @@ export default function SiteRow( {
 			<span className="actions" role="cell">
 				<SiteSettingsPopover
 					// NotifyMeOfNewPosts
-					notifyMeOfNewPosts={ delivery_methods?.notification?.send_posts }
+					notifyMeOfNewPosts={ !! delivery_methods.notification?.send_posts }
 					onNotifyMeOfNewPostsChange={ ( send_posts ) =>
 						updateNotifyMeOfNewPosts( { blog_id: blog_ID, send_posts } )
 					}
 					updatingNotifyMeOfNewPosts={ updatingNotifyMeOfNewPosts }
 					// EmailMeNewPosts
-					emailMeNewPosts={ delivery_methods?.email?.send_posts }
+					emailMeNewPosts={ delivery_methods.email.send_posts }
 					updatingEmailMeNewPosts={ updatingEmailMeNewPosts }
 					onEmailMeNewPostsChange={ ( send_posts ) =>
 						updateEmailMeNewPosts( { blog_id: blog_ID, send_posts } )
 					}
 					// DeliveryFrequency
-					deliveryFrequency={ delivery_methods?.email?.post_delivery_frequency }
+					deliveryFrequency={ delivery_methods.email.post_delivery_frequency }
 					onDeliveryFrequencyChange={ ( delivery_frequency ) =>
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )
 					}
 					updatingFrequency={ updatingFrequency }
 					// EmailMeNewComments
-					emailMeNewComments={ delivery_methods?.email?.send_comments }
+					emailMeNewComments={ !! delivery_methods.email.send_comments }
 					onEmailMeNewCommentsChange={ ( send_comments ) =>
 						updateEmailMeNewComments( { blog_id: blog_ID, send_comments } )
 					}

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
@@ -144,10 +144,10 @@ const SiteSubscriptionDetails = ( {
 				<>
 					<SiteSubscriptionSettings
 						blogId={ blogId }
-						notifyMeOfNewPosts={ Boolean( deliveryMethods.notification?.send_posts ) }
+						notifyMeOfNewPosts={ !! deliveryMethods.notification?.send_posts }
 						emailMeNewPosts={ deliveryMethods.email.send_posts }
 						deliveryFrequency={ deliveryMethods.email.post_delivery_frequency }
-						emailMeNewComments={ Boolean( deliveryMethods.email.send_comments ) }
+						emailMeNewComments={ !! deliveryMethods.email.send_comments }
 					/>
 
 					<hr className="subscriptions__separator" />

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
@@ -145,9 +145,12 @@ const SiteSubscriptionDetails = ( {
 					<SiteSubscriptionSettings
 						blogId={ blogId }
 						notifyMeOfNewPosts={ !! deliveryMethods.notification?.send_posts }
-						emailMeNewPosts={ deliveryMethods.email.send_posts }
-						deliveryFrequency={ deliveryMethods.email.post_delivery_frequency }
-						emailMeNewComments={ !! deliveryMethods.email.send_comments }
+						emailMeNewPosts={ !! deliveryMethods.email?.send_posts }
+						deliveryFrequency={
+							deliveryMethods.email?.post_delivery_frequency ??
+							Reader.EmailDeliveryFrequency.Instantly
+						}
+						emailMeNewComments={ !! deliveryMethods.email?.send_comments }
 					/>
 
 					<hr className="subscriptions__separator" />

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
@@ -1,0 +1,187 @@
+import { SubscriptionManager, Reader } from '@automattic/data-stores';
+import { Button } from '@wordpress/components';
+import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import TimeSince from 'calypso/components/time-since';
+import { Notice, NoticeState, NoticeType } from 'calypso/landing/subscriptions/components/notice';
+import { SiteIcon } from 'calypso/landing/subscriptions/components/site-icon';
+import SiteSubscriptionSettings from './site-subscription-settings';
+import './styles.scss';
+
+type SiteSubscriptionDetailsProps = {
+	subscriberCount: number;
+	dateSubscribed: Date;
+	siteIcon: string;
+	name: string;
+	blogId: string;
+	deliveryMethods: Reader.SiteSubscriptionDeliveryMethods;
+	url: string;
+};
+
+const SiteSubscriptionDetails = ( {
+	subscriberCount,
+	dateSubscribed,
+	siteIcon,
+	name,
+	blogId,
+	deliveryMethods,
+	url,
+}: SiteSubscriptionDetailsProps ) => {
+	const translate = useTranslate();
+	const [ notice, setNotice ] = useState< NoticeState | null >( null );
+
+	const {
+		mutate: subscribe,
+		isLoading: subscribing,
+		isSuccess: subscribed,
+		error: subscribeError,
+	} = SubscriptionManager.useSiteSubscribeMutation( blogId );
+	const {
+		mutate: unsubscribe,
+		isLoading: unsubscribing,
+		isSuccess: unsubscribed,
+		error: unsubscribeError,
+	} = SubscriptionManager.useSiteUnsubscribeMutation( blogId );
+
+	const [ siteSubscribed, setSiteSubscribed ] = useState( true );
+	useEffect( () => {
+		if ( subscribed ) {
+			setSiteSubscribed( true );
+		}
+	}, [ subscribed ] );
+	useEffect( () => {
+		if ( unsubscribed ) {
+			setSiteSubscribed( false );
+		}
+	}, [ unsubscribed ] );
+
+	const subHeaderText = subscriberCount
+		? translate( '%s subscriber', '%s subscribers', {
+				count: subscriberCount,
+				args: [ numberFormat( subscriberCount, 0 ) ],
+				comment: '%s is the number of subscribers. For example: "12,000,000"',
+		  } )
+		: '';
+
+	useEffect( () => {
+		// todo: style the button (underline, color?, etc.)
+		const Resubscribe = () => (
+			<Button
+				onClick={ () => subscribe( { blog_id: blogId, url } ) }
+				disabled={ subscribing || unsubscribing }
+			>
+				{ translate( 'Resubscribe' ) }
+			</Button>
+		);
+
+		if ( siteSubscribed ) {
+			setNotice( null );
+		}
+		if ( ! siteSubscribed && ! subscribeError ) {
+			setNotice( {
+				type: NoticeType.Success,
+				action: <Resubscribe />,
+				message: translate(
+					'You have successfully unsubscribed and will no longer receive emails from %s.',
+					{
+						args: [ name ],
+						comment: 'Name of the site that the user has unsubscribed from.',
+					}
+				),
+			} );
+		}
+		if ( unsubscribeError ) {
+			setNotice( {
+				type: NoticeType.Error,
+				onClose: () => setNotice( null ),
+				message: translate( 'There was an error when trying to unsubscribe from %s.', {
+					args: [ name ],
+					comment: 'Name of the site that the user tried to unsubscribe from.',
+				} ),
+			} );
+		}
+		if ( subscribeError ) {
+			setNotice( {
+				type: NoticeType.Error,
+				action: <Resubscribe />,
+				message: translate( 'There was an error when trying to resubscribe to %s.', {
+					args: [ name ],
+					comment: 'Name of the site that the user tried to resubscribe to.',
+				} ),
+			} );
+		}
+	}, [
+		siteSubscribed,
+		unsubscribeError,
+		subscribeError,
+		subscribing,
+		unsubscribing,
+		translate,
+		blogId,
+		subscribe,
+		url,
+		name,
+	] );
+
+	return (
+		<>
+			<header className="site-subscription-page__header site-subscription-page__centered-content">
+				<SiteIcon iconUrl={ siteIcon } size={ 116 } />
+				<FormattedHeader brandFont headerText={ name } subHeaderText={ subHeaderText } />
+			</header>
+
+			<Notice
+				onClose={ notice?.onClose }
+				visible={ !! notice }
+				type={ notice?.type }
+				action={ notice?.action }
+			>
+				{ notice?.message }
+			</Notice>
+
+			{ siteSubscribed && (
+				<>
+					<SiteSubscriptionSettings
+						blogId={ blogId }
+						notifyMeOfNewPosts={ Boolean( deliveryMethods.notification?.send_posts ) }
+						emailMeNewPosts={ deliveryMethods.email.send_posts }
+						deliveryFrequency={ deliveryMethods.email.post_delivery_frequency }
+						emailMeNewComments={ Boolean( deliveryMethods.email.send_comments ) }
+					/>
+
+					<hr className="subscriptions__separator" />
+
+					{ /* TODO: Move to SiteSubscriptionInfo component when payment details are in. */ }
+					<div className="site-subscription-info">
+						<h2 className="site-subscription-info__heading">{ translate( 'Subscription' ) }</h2>
+						<dl className="site-subscription-info__list">
+							<dt>{ translate( 'Date' ) }</dt>
+							<dd>
+								<TimeSince
+									date={
+										( dateSubscribed?.valueOf()
+											? dateSubscribed
+											: new Date( 0 )
+										).toISOString?.() ?? dateSubscribed
+									}
+								/>
+							</dd>
+						</dl>
+					</div>
+
+					<Button
+						className="site-subscription-page__unsubscribe-button"
+						isSecondary
+						onClick={ () => unsubscribe( { blog_id: blogId, url } ) }
+						disabled={ unsubscribing }
+					>
+						{ translate( 'Cancel subscription' ) }
+					</Button>
+				</>
+			) }
+		</>
+	);
+};
+
+export default SiteSubscriptionDetails;

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -9,14 +9,6 @@ import PoweredByWPFooter from 'calypso/layout/powered-by-wp-footer';
 import './styles.scss';
 import SiteSubscriptionDetails from './site-subscription-details';
 
-const isSiteSubscriptionDetailsErrorResponse = (
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	response: any
-): response is Reader.SiteSubscriptionDetailsErrorResponse => {
-	// This is good enough for us to know that the response is an error response
-	return response && ( response.errors || response.error_data );
-};
-
 const SiteSubscriptionPage = () => {
 	const translate = useTranslate();
 	const navigate = useNavigate();
@@ -39,7 +31,7 @@ const SiteSubscriptionPage = () => {
 
 			<div className="site-subscription-page__centered-content">
 				<div className="site-subscription-page__main-content">
-					{ error || ! blogId || ! data || isSiteSubscriptionDetailsErrorResponse( data ) ? (
+					{ error || ! blogId || ! data || Reader.isErrorResponse( data ) ? (
 						<Notice
 							className="site-subscription-page__fetch-details-error"
 							type={ NoticeType.Error }
@@ -48,11 +40,11 @@ const SiteSubscriptionPage = () => {
 						</Notice>
 					) : (
 						<SiteSubscriptionDetails
+							blogId={ data.blog_ID }
 							name={ data.name }
 							subscriberCount={ data.subscriber_count }
 							dateSubscribed={ data.date_subscribed }
 							siteIcon={ data.site_icon }
-							blogId={ data.blog_ID }
 							deliveryMethods={ data.delivery_methods }
 							url={ data.URL }
 						/>

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -1,132 +1,31 @@
 import { Gridicon } from '@automattic/components';
-import { SubscriptionManager } from '@automattic/data-stores';
+import { SubscriptionManager, Reader } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
-import { useTranslate, numberFormat } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useTranslate } from 'i18n-calypso';
 import { useNavigate, useParams } from 'react-router-dom';
-import FormattedHeader from 'calypso/components/formatted-header';
-import TimeSince from 'calypso/components/time-since';
 import WordPressLogo from 'calypso/components/wordpress-logo';
-import { Notice, NoticeState, NoticeType } from 'calypso/landing/subscriptions/components/notice';
-import { SiteIcon } from 'calypso/landing/subscriptions/components/site-icon';
+import { Notice, NoticeType } from 'calypso/landing/subscriptions/components/notice';
 import PoweredByWPFooter from 'calypso/layout/powered-by-wp-footer';
-import SiteSubscriptionSettings from './site-subscription-settings';
 import './styles.scss';
+import SiteSubscriptionDetails from './site-subscription-details';
+
+const isSiteSubscriptionDetailsErrorResponse = (
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	response: any
+): response is Reader.SiteSubscriptionDetailsErrorResponse => {
+	// This is good enough for us to know that the response is an error response
+	return response && ( response.errors || response.error_data );
+};
 
 const SiteSubscriptionPage = () => {
 	const translate = useTranslate();
 	const navigate = useNavigate();
 	const { blogId = '' } = useParams();
-
-	const { data, isLoading, isError } =
-		SubscriptionManager.useSiteSubscriptionDetailsQuery( blogId );
-
-	const [ notice, setNotice ] = useState< NoticeState | null >( null );
-	const [ siteSubscribed, setSiteSubscribed ] = useState( true );
-
-	const {
-		mutate: subscribe,
-		isLoading: subscribing,
-		isSuccess: subscribed,
-		error: subscribeError,
-	} = SubscriptionManager.useSiteSubscribeMutation( blogId );
-
-	const {
-		mutate: unsubscribe,
-		isLoading: unsubscribing,
-		isSuccess: unsubscribed,
-		error: unsubscribeError,
-	} = SubscriptionManager.useSiteUnsubscribeMutation( blogId );
-
-	useEffect( () => {
-		if ( subscribed ) {
-			setSiteSubscribed( true );
-		}
-	}, [ subscribed ] );
-
-	useEffect( () => {
-		if ( unsubscribed ) {
-			setSiteSubscribed( false );
-		}
-	}, [ unsubscribed ] );
-
-	useEffect( () => {
-		// todo: style the button (underline, color?, etc.)
-		const Resubscribe = () => (
-			<Button
-				onClick={ () => subscribe( { blog_id: blogId, url: data?.URL } ) }
-				disabled={ subscribing || unsubscribing }
-			>
-				{ translate( 'Resubscribe' ) }
-			</Button>
-		);
-
-		if ( siteSubscribed ) {
-			setNotice( null );
-		}
-		if ( ! siteSubscribed && ! subscribeError ) {
-			setNotice( {
-				type: NoticeType.Success,
-				action: <Resubscribe />,
-				message: translate(
-					'You have successfully unsubscribed and will no longer receive emails from %s.',
-					{
-						args: [ data?.name ],
-						comment: 'Name of the site that the user has unsubscribed from.',
-					}
-				),
-			} );
-		}
-		if ( unsubscribeError ) {
-			setNotice( {
-				type: NoticeType.Error,
-				onClose: () => setNotice( null ),
-				message: translate( 'There was an error when trying to unsubscribe from %s.', {
-					args: [ data?.name ],
-					comment: 'Name of the site that the user tried to unsubscribe from.',
-				} ),
-			} );
-		}
-		if ( subscribeError ) {
-			setNotice( {
-				type: NoticeType.Error,
-				action: <Resubscribe />,
-				message: translate( 'There was an error when trying to resubscribe to %s.', {
-					args: [ data?.name ],
-					comment: 'Name of the site that the user tried to resubscribe to.',
-				} ),
-			} );
-		}
-	}, [
-		siteSubscribed,
-		unsubscribeError,
-		subscribeError,
-		subscribing,
-		unsubscribing,
-		data,
-		translate,
-		blogId,
-		subscribe,
-	] );
-
-	if ( ! blogId || isError ) {
-		return <div>Something went wrong.</div>;
-	}
+	const { data, isLoading, error } = SubscriptionManager.useSiteSubscriptionDetailsQuery( blogId );
 
 	if ( isLoading ) {
 		return <WordPressLogo size={ 72 } className="wpcom-site__logo" />;
 	}
-
-	const subscriberCount = data?.subscriber_count;
-	const subHeaderText = subscriberCount
-		? translate( '%s subscriber', '%s subscribers', {
-				count: subscriberCount,
-				args: [ numberFormat( subscriberCount, 0 ) ],
-				comment: '%s is the number of subscribers. For example: "12,000,000"',
-		  } )
-		: '';
-
-	const date_subscribed = data?.date_subscribed;
 
 	return (
 		<div className="site-subscription-page">
@@ -140,59 +39,23 @@ const SiteSubscriptionPage = () => {
 
 			<div className="site-subscription-page__centered-content">
 				<div className="site-subscription-page__main-content">
-					<header className="site-subscription-page__header site-subscription-page__centered-content">
-						<SiteIcon iconUrl={ data?.site_icon } size={ 116 } />
-						<FormattedHeader brandFont headerText={ data?.name } subHeaderText={ subHeaderText } />
-					</header>
-
-					<Notice
-						onClose={ notice?.onClose }
-						visible={ !! notice }
-						type={ notice?.type }
-						action={ notice?.action }
-					>
-						{ notice?.message }
-					</Notice>
-
-					{ siteSubscribed && (
-						<>
-							<SiteSubscriptionSettings
-								blogId={ blogId }
-								notifyMeOfNewPosts={ data.delivery_methods?.notification?.send_posts }
-								emailMeNewPosts={ data.delivery_methods?.email?.send_posts }
-								deliveryFrequency={ data.delivery_methods?.email?.post_delivery_frequency }
-								emailMeNewComments={ data.delivery_methods?.email?.send_comments }
-							/>
-
-							<hr className="subscriptions__separator" />
-
-							{ /* TODO: Move to SiteSubscriptionInfo component when payment details are in. */ }
-							<div className="site-subscription-info">
-								<h2 className="site-subscription-info__heading">{ translate( 'Subscription' ) }</h2>
-								<dl className="site-subscription-info__list">
-									<dt>{ translate( 'Date' ) }</dt>
-									<dd>
-										<TimeSince
-											date={
-												( date_subscribed?.valueOf()
-													? date_subscribed
-													: new Date( 0 )
-												).toISOString?.() ?? date_subscribed
-											}
-										/>
-									</dd>
-								</dl>
-							</div>
-
-							<Button
-								className="site-subscription-page__unsubscribe-button"
-								isSecondary
-								onClick={ () => unsubscribe( { blog_id: blogId, url: data.URL } ) }
-								disabled={ unsubscribing }
-							>
-								{ translate( 'Cancel subscription' ) }
-							</Button>
-						</>
+					{ error || ! blogId || ! data || isSiteSubscriptionDetailsErrorResponse( data ) ? (
+						<Notice
+							className="site-subscription-page__fetch-details-error"
+							type={ NoticeType.Error }
+						>
+							Subscription not found
+						</Notice>
+					) : (
+						<SiteSubscriptionDetails
+							name={ data.name }
+							subscriberCount={ data.subscriber_count }
+							dateSubscribed={ data.date_subscribed }
+							siteIcon={ data.site_icon }
+							blogId={ data.blog_ID }
+							deliveryMethods={ data.delivery_methods }
+							url={ data.URL }
+						/>
 					) }
 				</div>
 			</div>

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -40,7 +40,7 @@ const SiteSubscriptionPage = () => {
 						</Notice>
 					) : (
 						<SiteSubscriptionDetails
-							blogId={ data.blog_ID }
+							blogId={ blogId }
 							name={ data.name }
 							subscriberCount={ data.subscriber_count }
 							dateSubscribed={ data.date_subscribed }

--- a/client/landing/subscriptions/components/site-subscription-page/styles.scss
+++ b/client/landing/subscriptions/components/site-subscription-page/styles.scss
@@ -131,6 +131,10 @@
 	&__unsubscribe-button.components-button {
 		margin: 40px 0;
 	}
+
+	&__fetch-details-error {
+		margin: 64px 0 32px;
+	}
 }
 
 // Mobile screens

--- a/client/landing/subscriptions/components/tab-views/comments/comments.tsx
+++ b/client/landing/subscriptions/components/tab-views/comments/comments.tsx
@@ -1,5 +1,4 @@
-import { SubscriptionManager } from '@automattic/data-stores';
-import { SiteSubscriptionsFilterBy } from '@automattic/data-stores/src/reader/queries/use-post-subscriptions-query';
+import { SubscriptionManager, Reader } from '@automattic/data-stores';
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
@@ -11,7 +10,7 @@ import { SortControls, Option } from 'calypso/landing/subscriptions/components/s
 import { useSearch } from 'calypso/landing/subscriptions/hooks';
 import TabView from '../tab-view';
 
-const SortBy = SubscriptionManager.PostSubscriptionsSortBy;
+const { PostSubscriptionsSortBy: SortBy, SiteSubscriptionsFilterBy: FilterBy } = Reader;
 
 const useSortOptions = (): Option[] => {
 	const translate = useTranslate();
@@ -27,9 +26,9 @@ const useFilterOptions = () => {
 
 	return useMemo(
 		() => [
-			{ value: SiteSubscriptionsFilterBy.All, label: translate( 'All' ) },
+			{ value: FilterBy.All, label: translate( 'All' ) },
 			// { value: SiteSubscriptionsFilterBy.Paid, label: translate( 'Paid' ) },		// todo: add back when we have paid subscriptions support
-			{ value: SiteSubscriptionsFilterBy.P2, label: translate( 'P2' ) },
+			{ value: FilterBy.P2, label: translate( 'P2' ) },
 		],
 		[ translate ]
 	);
@@ -37,7 +36,7 @@ const useFilterOptions = () => {
 
 const getFilterLabel = (
 	availableFilterOptions: Option[],
-	filterValue: SiteSubscriptionsFilterBy
+	filterValue: Reader.SiteSubscriptionsFilterBy
 ) => availableFilterOptions.find( ( option ) => option.value === filterValue )?.label;
 
 const Comments = () => {
@@ -46,9 +45,7 @@ const Comments = () => {
 	const { searchTerm, handleSearch } = useSearch();
 	const sortOptions = useSortOptions();
 	const availableFilterOptions = useFilterOptions();
-	const [ filterOption, setFilterOption ] = useState< SiteSubscriptionsFilterBy >(
-		SiteSubscriptionsFilterBy.All
-	);
+	const [ filterOption, setFilterOption ] = useState( FilterBy.All );
 
 	const {
 		data: { posts, totalCount },
@@ -80,7 +77,7 @@ const Comments = () => {
 					className="subscriptions-manager__filter-control"
 					options={ availableFilterOptions }
 					onSelect={ ( selectedOption: Option ) =>
-						setFilterOption( selectedOption.value as SiteSubscriptionsFilterBy )
+						setFilterOption( selectedOption.value as Reader.SiteSubscriptionsFilterBy )
 					}
 					selectedText={
 						translate( 'View: ' ) + getFilterLabel( availableFilterOptions, filterOption )

--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { SubscriptionManager } from '@automattic/data-stores';
+import { SubscriptionManager, Reader } from '@automattic/data-stores';
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
@@ -10,7 +10,7 @@ import { SortControls, Option } from 'calypso/landing/subscriptions/components/s
 import { useSearch } from 'calypso/landing/subscriptions/hooks';
 import TabView from '../tab-view';
 
-const SortBy = SubscriptionManager.SiteSubscriptionsSortBy;
+const SortBy = Reader.SiteSubscriptionsSortBy;
 
 const getSortOptions = ( translate: ReturnType< typeof useTranslate > ): Option[] => [
 	{ value: SortBy.LastUpdated, label: translate( 'Recently updated' ) },

--- a/packages/data-stores/src/reader/constants.ts
+++ b/packages/data-stores/src/reader/constants.ts
@@ -3,3 +3,21 @@ export enum EmailDeliveryFrequency {
 	Daily = 'daily',
 	Weekly = 'weekly',
 }
+
+export enum PostSubscriptionsSortBy {
+	PostName = 'post_name',
+	RecentlyCommented = 'recently_commented',
+	RecentlySubscribed = 'recently_subscribed',
+}
+
+export enum SiteSubscriptionsFilterBy {
+	All = 'all',
+	Paid = 'paid',
+	P2 = 'p2',
+}
+
+export enum SiteSubscriptionsSortBy {
+	SiteName = 'site_name',
+	LastUpdated = 'last_updated',
+	DateSubscribed = 'date_subscribed',
+}

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -1,5 +1,6 @@
 import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
 import wpcomRequest from 'wpcom-proxy-request';
+import { ErrorResponse } from '../types';
 
 type callApiParams = {
 	apiNamespace?: string;
@@ -104,4 +105,12 @@ const getSubscriptionMutationParams = (
 	};
 };
 
-export { callApi, applyCallbackToPages, getSubkey, getSubscriptionMutationParams };
+const isErrorResponse = (
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	response: any
+): response is ErrorResponse => {
+	// This is good enough for us to know that the response is an error response
+	return response && ( response.errors || response.error_data );
+};
+
+export { callApi, applyCallbackToPages, getSubkey, getSubscriptionMutationParams, isErrorResponse };

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -14,8 +14,6 @@ import {
 	useSiteEmailMeNewCommentsMutation,
 } from './mutations';
 import {
-	PostSubscriptionsSortBy,
-	SiteSubscriptionsSortBy,
 	useSiteSubscriptionsQuery,
 	usePostSubscriptionsQuery,
 	useSubscriptionsCountQuery,
@@ -26,8 +24,6 @@ import {
 } from './queries';
 
 export const SubscriptionManager = {
-	PostSubscriptionsSortBy,
-	SiteSubscriptionsSortBy,
 	usePostUnsubscribeMutation,
 	useSiteDeliveryFrequencyMutation,
 	useSiteSubscriptionsQuery,
@@ -51,5 +47,13 @@ export const SubscriptionManager = {
 	useSiteSubscriptionDetailsQuery,
 };
 
-export { EmailDeliveryFrequency } from './constants';
+export {
+	EmailDeliveryFrequency,
+	PostSubscriptionsSortBy,
+	SiteSubscriptionsFilterBy,
+	SiteSubscriptionsSortBy,
+} from './constants';
+
+export { isErrorResponse } from './helpers';
+
 export * from './types';

--- a/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
@@ -83,7 +83,7 @@ const useSiteDeliveryFrequencyMutation = ( blog_id?: string ) => {
 								delivery_methods: {
 									...siteSubscription.delivery_methods,
 									email: {
-										...siteSubscription.delivery_methods?.email,
+										...( siteSubscription.delivery_methods?.email ?? { send_posts: false } ),
 										post_delivery_frequency: params.delivery_frequency,
 									},
 								},

--- a/packages/data-stores/src/reader/queries/index.ts
+++ b/packages/data-stores/src/reader/queries/index.ts
@@ -1,13 +1,7 @@
 export { default as useUserSettingsQuery } from './use-user-settings-query';
 export { default as useSubscriptionsCountQuery } from './use-subscriptions-count-query';
-export {
-	default as useSiteSubscriptionsQuery,
-	SiteSubscriptionsSortBy,
-} from './use-site-subscriptions-query';
-export {
-	default as usePostSubscriptionsQuery,
-	PostSubscriptionsSortBy,
-} from './use-post-subscriptions-query';
+export { default as useSiteSubscriptionsQuery } from './use-site-subscriptions-query';
+export { default as usePostSubscriptionsQuery } from './use-post-subscriptions-query';
 export { default as usePendingSiteSubscriptionsQuery } from './use-pending-site-subscriptions-query';
 export { default as usePendingPostSubscriptionsQuery } from './use-pending-post-subscriptions-query';
 export { default as useSiteSubscriptionDetailsQuery } from './use-site-subscription-details-query';

--- a/packages/data-stores/src/reader/queries/test/use-site-subscriptions-query.tsx
+++ b/packages/data-stores/src/reader/queries/test/use-site-subscriptions-query.tsx
@@ -5,10 +5,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
+import { SiteSubscriptionsSortBy } from '../../constants';
 import { callApi, getSubkey } from '../../helpers';
-import useSiteSubscriptionsQuery, {
-	SiteSubscriptionsSortBy,
-} from '../../queries/use-site-subscriptions-query';
+import useSiteSubscriptionsQuery from '../../queries/use-site-subscriptions-query';
 
 jest.mock( '../../helpers', () => ( {
 	callApi: jest.fn(),

--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -1,20 +1,9 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo } from 'react';
+import { PostSubscriptionsSortBy, SiteSubscriptionsFilterBy } from '../constants';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { PostSubscription } from '../types';
-
-export enum PostSubscriptionsSortBy {
-	PostName = 'post_name',
-	RecentlyCommented = 'recently_commented',
-	RecentlySubscribed = 'recently_subscribed',
-}
-
-export enum SiteSubscriptionsFilterBy {
-	All = 'all',
-	Paid = 'paid',
-	P2 = 'p2',
-}
 
 type SubscriptionManagerPostSubscriptions = {
 	comment_subscriptions: PostSubscription[];

--- a/packages/data-stores/src/reader/queries/use-site-subscription-details-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscription-details-query.ts
@@ -1,16 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
-import type { SiteSubscriptionDetails, SiteSubscriptionDetailsAPIResponse } from '../types';
+import type { SiteSubscriptionDetailsResponse } from '../types';
 
 const useSiteSubscriptionDetailsQuery = ( siteId: string ) => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 	const cacheKey = useCacheKey( [ 'read', 'site-subscription-details', siteId ] );
-	return useQuery< SiteSubscriptionDetails >( {
+	return useQuery( {
 		queryKey: cacheKey,
 		queryFn: async () => {
-			const subscriptionDetails = await callApi< SiteSubscriptionDetailsAPIResponse >( {
+			const subscriptionDetails = await callApi< SiteSubscriptionDetailsResponse >( {
 				path: '/read/sites/' + siteId + '/subscription-details',
 				isLoggedIn,
 				apiNamespace: 'wpcom/v2',

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -1,14 +1,9 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useMemo, useEffect } from 'react';
+import { SiteSubscriptionsSortBy } from '../constants';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { SiteSubscription } from '../types';
-
-export enum SiteSubscriptionsSortBy {
-	SiteName = 'site_name',
-	LastUpdated = 'last_updated',
-	DateSubscribed = 'date_subscribed',
-}
 
 type SubscriptionManagerSiteSubscriptions = {
 	subscriptions: SiteSubscription[];

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -34,14 +34,14 @@ type SiteSubscriptionMeta = {
 	};
 };
 
-type SiteSubscriptionDeliveryMethods = {
+export type SiteSubscriptionDeliveryMethods = {
 	email: {
 		send_posts: boolean;
-		send_comments: boolean;
+		send_comments?: boolean;
 		post_delivery_frequency: EmailDeliveryFrequency;
-		date_subscribed: Date;
+		date_subscribed?: Date;
 	};
-	notification: {
+	notification?: {
 		send_posts: boolean;
 	};
 };
@@ -145,13 +145,21 @@ export type SiteSubscriptionDetails = {
 	delivery_methods: SiteSubscriptionDeliveryMethods;
 };
 
-export type SiteSubscriptionDetailsAPIResponse = {
-	ID: string;
-	blog_ID: string;
-	name: string;
-	URL: string;
-	site_icon: string;
-	date_subscribed: Date;
-	subscriber_count: number;
-	delivery_methods: SiteSubscriptionDeliveryMethods;
+export type SiteSubscriptionDetailsErrorResponse = {
+	error_data: {
+		invalid_blog?: { status: 404 };
+		invalid_user?: { status: 403 };
+		subscription_not_found?: { status: 404 };
+		unauthorized?: { status: 401 };
+	};
+	errors: {
+		invalid_blog?: string[];
+		invalid_user?: string[];
+		subscription_not_found?: string[];
+		unauthorized?: string[];
+	};
 };
+
+export type SiteSubscriptionDetailsResponse =
+	| SiteSubscriptionDetails
+	| SiteSubscriptionDetailsErrorResponse;

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -35,7 +35,7 @@ type SiteSubscriptionMeta = {
 };
 
 export type SiteSubscriptionDeliveryMethods = {
-	email: {
+	email?: {
 		send_posts: boolean;
 		send_comments?: boolean;
 		post_delivery_frequency: EmailDeliveryFrequency;
@@ -145,20 +145,25 @@ export type SiteSubscriptionDetails = {
 	delivery_methods: SiteSubscriptionDeliveryMethods;
 };
 
-export type SiteSubscriptionDetailsErrorResponse = {
-	error_data: {
-		invalid_blog?: { status: 404 };
-		invalid_user?: { status: 403 };
-		subscription_not_found?: { status: 404 };
-		unauthorized?: { status: 401 };
-	};
-	errors: {
+export type ErrorResponse< Errors = unknown, ErrorData = unknown > = {
+	errors: Errors;
+	error_data: ErrorData;
+};
+
+export type SiteSubscriptionDetailsErrorResponse = ErrorResponse<
+	{
 		invalid_blog?: string[];
 		invalid_user?: string[];
 		subscription_not_found?: string[];
 		unauthorized?: string[];
-	};
-};
+	},
+	{
+		invalid_blog?: { status: 404 };
+		invalid_user?: { status: 403 };
+		subscription_not_found?: { status: 404 };
+		unauthorized?: { status: 401 };
+	}
+>;
 
 export type SiteSubscriptionDetailsResponse =
 	| SiteSubscriptionDetails


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

![Screen Shot 2023-05-25 at 16 17 35](https://github.com/Automattic/wp-calypso/assets/2019970/48222b87-e671-434b-bb2c-488b5aad2fe7)


Closes https://github.com/Automattic/wp-calypso/issues/77305

## Proposed Changes

* Display the error notice when fetching a site subscription details is unsuccessful
* Handle both type of response errors
    1. Where the server itself is reporting an error. This is the classical HTTP error response.
    2. Where the endpoint is reporting an error. This is an error that is wrapped in a payload of 200 "OK" response.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
1. Test the classical HTTP error response:
    * Go to http://calypso.localhost:3000/subscriptions/site/a to test for the classical HTTP error response
    * Ensure the error message is displayed

2. Test the classical HTTP error response:
    * Go to http://calypso.localhost:3000/subscriptions/site/$site-id, where the `$site-id` is a valid ID of a site that you are not subscribed to (it can be an existing site, or not, but it is important that it matches blog ID regex on the server side), e.g. https://wordpress.com/subscriptions/site/12345678.
    * Ensure the error message is displayed

3. Test for no regressions
    * Go to http://calypso.localhost:3000/subscriptions/site/$site-id, where the `$site-id` is a valid ID of a site that you  subscribed to
    * Ensure the error message is not displayed 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
