### PR TITLE
Limited Global Styles: Improve "Unlock style" modal

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -10,9 +10,7 @@ import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import './style.scss';
 
 export interface PremiumGlobalStylesUpgradeModalProps {
-	title?: string;
-	customizeDescription?: ( description: React.ReactChild ) => JSX.Element;
-	tryItOutText?: string;
+	description?: string | React.ReactNode;
 	checkout: () => void;
 	closeModal: () => void;
 	isOpen: boolean;
@@ -20,9 +18,7 @@ export interface PremiumGlobalStylesUpgradeModalProps {
 }
 
 export default function PremiumGlobalStylesUpgradeModal( {
-	title,
-	tryItOutText,
-	customizeDescription = ( description ) => <p>{ description }</p>,
+	description,
 	checkout,
 	closeModal,
 	isOpen,
@@ -53,25 +49,24 @@ export default function PremiumGlobalStylesUpgradeModal( {
 				{ ! isLoading && (
 					<>
 						<div className="upgrade-modal__col">
-							<h1 className="upgrade-modal__heading">
-								{ title ?? translate( 'Unlock this style' ) }
-							</h1>
-							{ customizeDescription(
-								translate(
-									'Get access to all theme styles, fonts, colors, and tons of other features by upgrading to {{strong}}%s{{/strong}}.',
-									{
-										components: {
-											strong: <strong />,
-										},
-										args: premiumPlanProduct?.product_name,
-										comment:
-											'The variable is the plan name: "...by upgrading to WordPress.com Premium."',
-									}
-								)
+							<h1 className="upgrade-modal__heading">{ translate( 'Unlock custom styles' ) }</h1>
+							{ description ?? (
+								<>
+									<p>
+										{ translate(
+											"You've selected a custom style that will only be visible to visitors after upgrading to the Premium plan or higher."
+										) }
+									</p>
+									<p>
+										{ translate(
+											'Upgrade now to unlock it and get access to tons of other features. Or you can try it out first and decide later.'
+										) }
+									</p>
+								</>
 							) }
 							<div className="upgrade-modal__actions bundle">
 								<Button className="upgrade-modal__cancel" onClick={ () => tryStyle() }>
-									{ tryItOutText ?? translate( 'Try it out first' ) }
+									{ translate( 'Decide later' ) }
 								</Button>
 								<Button
 									className="upgrade-modal__upgrade-plan"

--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -59,7 +59,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 									</p>
 									<p>
 										{ translate(
-											'Upgrade now to unlock it and get access to tons of other features. Or you can try it out first and decide later.'
+											'Upgrade now to unlock your custom style and get access to tons of other features. Or you can decide later and try it out first.'
 										) }
 									</p>
 								</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -559,20 +559,20 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			);
 		}
 
-		if (
-			shouldLimitGlobalStyles &&
-			selectedStyleVariation &&
-			selectedStyleVariation.slug !== DEFAULT_VARIATION_SLUG
-		) {
-			return (
-				<Button primary borderless={ false } onClick={ () => unlockPremiumGlobalStyles() }>
-					{ translate( 'Unlock this style' ) }
-				</Button>
-			);
-		}
+		const selectStyle = () => {
+			if (
+				shouldLimitGlobalStyles &&
+				selectedStyleVariation &&
+				selectedStyleVariation.slug !== DEFAULT_VARIATION_SLUG
+			) {
+				unlockPremiumGlobalStyles();
+			} else {
+				pickDesign();
+			}
+		};
 
 		return (
-			<Button primary borderless={ false } onClick={ () => pickDesign() }>
+			<Button primary borderless={ false } onClick={ selectStyle }>
 				{ translate( 'Continue' ) }
 			</Button>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
@@ -14,6 +14,7 @@ interface Props {
 	hasSelectedColorVariation?: boolean;
 	hasSelectedFontVariation?: boolean;
 	onCheckout?: () => void;
+	onUpgradeLater?: () => void;
 	recordTracksEvent: ( eventName: string, eventProps?: { [ key: string ]: unknown } ) => void;
 }
 
@@ -23,10 +24,10 @@ const useGlobalStylesUpgradeModal = ( {
 	hasSelectedColorVariation = false,
 	hasSelectedFontVariation = false,
 	onCheckout,
+	onUpgradeLater,
 	recordTracksEvent,
 }: Props ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
-	const [ isDismissed, setIsDismissed ] = useState( false );
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();
 	const siteUrl = siteSlug || urlToSlug( site?.URL || '' ) || '';
@@ -34,27 +35,32 @@ const useGlobalStylesUpgradeModal = ( {
 	const translate = useTranslate();
 	const { goToCheckout } = useCheckout();
 
-	const customizeDescription = () => {
-		let description;
+	let description;
 
-		if ( hasSelectedColorVariation && hasSelectedFontVariation ) {
-			description = translate(
-				'Your font and color choices are exclusive to the Premium plan and above.'
-			);
-		} else if ( hasSelectedColorVariation ) {
-			description = translate( 'Your color choices are exclusive to the Premium plan and above.' );
-		} else if ( hasSelectedFontVariation ) {
-			description = translate( 'Your font choices are exclusive to the Premium plan and above.' );
-		}
-
-		return (
-			<p>
-				{ description }
-				&nbsp;
-				{ translate( 'You can upgrade now to keep your current choices, or upgrade later.' ) }
-			</p>
+	if ( hasSelectedColorVariation && hasSelectedFontVariation ) {
+		description = translate(
+			'Your font and color choices will be only visible to visitors after upgrading to the Premium plan or higher.'
 		);
-	};
+	} else if ( hasSelectedColorVariation ) {
+		description = translate(
+			'Your color choices will be only visible to visitors after upgrading to the Premium plan or higher.'
+		);
+	} else if ( hasSelectedFontVariation ) {
+		description = translate(
+			'Your font choices will be only visible to visitors after upgrading to the Premium plan or higher.'
+		);
+	}
+
+	description = (
+		<>
+			<p>{ description }</p>
+			<p>
+				{ translate(
+					'Upgrade now to unlock your current choices and get access to tons of other features. Or you can decide later and try them out first in the editor.'
+				) }
+			</p>
+		</>
+	);
 
 	const openModal = () => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_SHOW );
@@ -88,19 +94,16 @@ const useGlobalStylesUpgradeModal = ( {
 		recordTracksEvent(
 			PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_UPGRADE_LATER_BUTTON_CLICK
 		);
-		setIsDismissed( true );
+		onUpgradeLater?.();
 		setIsOpen( false );
 	};
 
 	return {
-		isDismissed,
 		shouldUnlockGlobalStyles:
 			( hasSelectedColorVariation || hasSelectedFontVariation ) && shouldLimitGlobalStyles,
 		globalStylesUpgradeModalProps: {
 			isOpen,
-			title: translate( 'Unlock custom styles' ),
-			tryItOutText: translate( 'Upgrade later' ),
-			customizeDescription,
+			description,
 			closeModal,
 			checkout,
 			tryStyle: upgradeLater,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -383,7 +383,6 @@ const PatternAssembler = ( {
 	};
 
 	const {
-		isDismissed: isDismissedGlobalStylesUpgradeModal,
 		shouldUnlockGlobalStyles,
 		openModal: openGlobalStylesUpgradeModal,
 		globalStylesUpgradeModalProps,
@@ -393,6 +392,7 @@ const PatternAssembler = ( {
 		hasSelectedColorVariation: !! colorVariation,
 		hasSelectedFontVariation: !! fontVariation,
 		onCheckout: snapshotRecipe,
+		onUpgradeLater: onSubmit,
 		recordTracksEvent,
 	} );
 
@@ -415,7 +415,7 @@ const PatternAssembler = ( {
 	const onContinueClick = () => {
 		trackEventContinue();
 
-		if ( shouldUnlockGlobalStyles && ! isDismissedGlobalStylesUpgradeModal ) {
+		if ( shouldUnlockGlobalStyles ) {
 			openGlobalStylesUpgradeModal();
 			return;
 		}
@@ -506,10 +506,6 @@ const PatternAssembler = ( {
 			<div className="pattern-assembler__sidebar">
 				<NavigatorScreen path={ NAVIGATOR_PATHS.MAIN }>
 					<ScreenMain
-						shouldUnlockGlobalStyles={ shouldUnlockGlobalStyles }
-						isDismissedGlobalStylesUpgradeModal={ isDismissedGlobalStylesUpgradeModal }
-						hasSelectedColorVariation={ !! colorVariation }
-						hasSelectedFontVariation={ !! fontVariation }
 						onSelect={ onMainItemSelect }
 						onContinueClick={ onContinueClick }
 						recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -17,24 +17,12 @@ import type { OnboardSelect } from '@automattic/data-stores';
 import type { MouseEvent } from 'react';
 
 interface Props {
-	shouldUnlockGlobalStyles: boolean;
-	isDismissedGlobalStylesUpgradeModal?: boolean;
-	hasSelectedColorVariation?: boolean;
-	hasSelectedFontVariation?: boolean;
 	onSelect: ( name: string ) => void;
 	onContinueClick: () => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 }
 
-const ScreenMain = ( {
-	shouldUnlockGlobalStyles,
-	isDismissedGlobalStylesUpgradeModal,
-	hasSelectedColorVariation,
-	hasSelectedFontVariation,
-	onSelect,
-	onContinueClick,
-	recordTracksEvent,
-}: Props ) => {
+const ScreenMain = ( { onSelect, onContinueClick, recordTracksEvent }: Props ) => {
 	const translate = useTranslate();
 	const [ disabled, setDisabled ] = useState( true );
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
@@ -48,38 +36,6 @@ const ScreenMain = ( {
 	const headerDescription = selectedDesign?.is_virtual
 		? translate( 'Customize your homepage with our library of styles and patterns.' )
 		: translate( 'Use our library of styles and patterns to build a homepage.' );
-
-	const getDescription = () => {
-		if ( ! shouldUnlockGlobalStyles ) {
-			return translate( 'Ready? Go to the Site Editor to continue editing.' );
-		}
-
-		if ( isDismissedGlobalStylesUpgradeModal ) {
-			return translate(
-				'Ready to continue? Keep your selected styles and upgrade to the Premium plan later.'
-			);
-		}
-
-		if ( hasSelectedColorVariation && hasSelectedFontVariation ) {
-			return translate(
-				'Your font and color choices are exclusive to the Premium plan and above.'
-			);
-		} else if ( hasSelectedColorVariation ) {
-			return translate( 'Your color choices are exclusive to the Premium plan and above.' );
-		} else if ( hasSelectedFontVariation ) {
-			return translate( 'Your font choices are exclusive to the Premium plan and above.' );
-		}
-	};
-
-	const getContinueText = () => {
-		if ( isDismissedGlobalStylesUpgradeModal ) {
-			return translate( 'Continue to the editor' );
-		}
-
-		return shouldUnlockGlobalStyles && ! isDismissedGlobalStylesUpgradeModal
-			? translate( 'Unlock this style' )
-			: translate( 'Continue' );
-	};
 
 	// Use the mousedown event to prevent either the button focusing or text selection
 	const handleMouseDown = ( event: MouseEvent< HTMLButtonElement > ) => {
@@ -179,7 +135,9 @@ const ScreenMain = ( {
 				</HStack>
 			</div>
 			<div className="screen-container__footer">
-				<span className="screen-container__description">{ getDescription() }</span>
+				<span className="screen-container__description">
+					{ translate( 'Ready? Go to the Site Editor to continue editing.' ) }
+				</span>
 				<Button
 					className="pattern-assembler__button"
 					primary
@@ -187,7 +145,7 @@ const ScreenMain = ( {
 					onMouseDown={ handleMouseDown }
 					onClick={ handleClick }
 				>
-					{ getContinueText() }
+					{ translate( 'Continue' ) }
 				</Button>
 			</div>
 		</>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -954,7 +954,7 @@ class ThemeSheet extends Component {
 				disabled={ this.isLoading() }
 				onClick={ this.onUnlockStyleButtonClick }
 			>
-				{ this.props.translate( 'Unlock this style' ) }
+				{ this.getDefaultOptionLabel() }
 			</Button>
 		);
 	};

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -207,9 +207,14 @@ class ThemePreview extends Component {
 	};
 
 	renderUnlockStyleButton = () => {
+		const primaryOption = this.getPrimaryOption();
+		if ( ! primaryOption ) {
+			return;
+		}
+
 		return (
 			<Button primary onClick={ this.onUnlockStyleButtonClick }>
-				{ this.props.translate( 'Unlock this style' ) }
+				{ primaryOption.label }
 			</Button>
 		);
 	};


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2548

## Proposed Changes

Applies the improvements discussed in pekYwv-1EW-p2 to the "Unlock style" modal so it's more clear what's locked and what happens if the user decides not to upgrade.

**Design picker and Theme showcase**

The copy has been adapted to better communicate that clicking on the secondary button will activate the selected style variation and continue the flow:

Before | After
--- | ---
<img width="807" alt="Screenshot 2023-05-25 at 17 22 53" src="https://github.com/Automattic/wp-calypso/assets/1233880/da29be84-7fbb-4f5e-97d0-91578330d722"> | <img width="785" alt="Screenshot 2023-05-26 at 11 57 14" src="https://github.com/Automattic/wp-calypso/assets/1233880/4b090dc7-3af9-4182-9397-0db5d3053e73">

To reinforce that idea, the text of the button that opens this modal no longer says "Unlock this style":

Before | After
--- | ---
<img width="200" alt="Screenshot 2023-05-26 at 12 02 29" src="https://github.com/Automattic/wp-calypso/assets/1233880/b9e4fe2a-7d74-40bd-a6da-ea27d5fbd036"> | <img width="200" alt="Screenshot 2023-05-26 at 12 02 40" src="https://github.com/Automattic/wp-calypso/assets/1233880/d68dc61c-f757-4cba-a968-1a069c210ea0">
<img width="636" alt="Screenshot 2023-05-26 at 12 17 05" src="https://github.com/Automattic/wp-calypso/assets/1233880/62c00724-4eb1-42b4-a0ce-0211f1ba546d"> | <img width="629" alt="Screenshot 2023-05-26 at 12 19 45" src="https://github.com/Automattic/wp-calypso/assets/1233880/ee323414-1797-4101-9efe-95ea40e4955f">
<img width="977" alt="Screenshot 2023-05-26 at 12 21 46" src="https://github.com/Automattic/wp-calypso/assets/1233880/c3cc25d9-53f6-4e8e-819f-16bd783c54dd"> | <img width="979" alt="Screenshot 2023-05-26 at 12 22 43" src="https://github.com/Automattic/wp-calypso/assets/1233880/494ae798-5166-453c-a637-42db3c348979">


**Site assembler**

Previously, clicking on the secondary button would send the user back. This PR changes that behavior so the user is sent to the site editor instead. The new copy should make that clear:

Before | After
--- | ---
<img width="800" alt="Screenshot 2023-05-25 at 17 23 28" src="https://github.com/Automattic/wp-calypso/assets/1233880/777a3cea-eeaa-4e8b-b5c2-d8cca3b3b589"> | <img width="818" alt="Screenshot 2023-05-25 at 17 19 56" src="https://github.com/Automattic/wp-calypso/assets/1233880/2b83065d-44a4-4c62-8641-27e925311a5c">

Similarly, and to also reinforce that idea, the footer and button text of the sidebar have been simplified too:

Before | After
--- | ---
<img width="321" alt="Screenshot 2023-05-26 at 12 08 00" src="https://github.com/Automattic/wp-calypso/assets/1233880/f22dbd60-cf72-40e3-88d9-efdc67efec99"> | <img width="308" alt="Screenshot 2023-05-26 at 12 08 12" src="https://github.com/Automattic/wp-calypso/assets/1233880/f9f72922-be66-498f-aa28-af47a3fc2301">


## Testing Instructions

- Use the Calypso live link below.

**Design picker and Theme showcase**

- Go to `/start` and pick a Free plan.
- In the Design picker, choose Free theme with style variations.
- Select a non-default style variation.
- Make sure the sidebar button still says "Continue".
- Click on it.
- Make sure the "Unlock custom styles" modal show up.
- Make sure the copy is clear.
- Click on "Decide later".
- Make sure your site gets the theme and style variation you have selected.
- Go to Appearance > Themes.
- Choose another Free theme with style variations.
- Select a non-default style variation.
- Make sure the primary button still says "Activate this design".
- Click on it.
- Make sure the "Unlock custom styles" modal show up.
- Click on the "X" icon to close it.
- Click on the "Open live demo" button now.
- Make sure the primary button in the preview modal says "Activate".
- Click on it.
- Make sure the "Unlock custom styles" modal show up.

**Site assembler**
- Go to `/start` to create a new site again and pick a Free plan.
- In the Design picker, scroll down and choose the "Design your own" option.
- Add some custom colors and/or fonts.
- Make sure the sidebar footer still says "Ready? Go to the Site Editor to continue editing".
- Make sure the sidebar button still says "Continue".
- Click on "Continue".
- Make sure the "Unlock custom styles" modal show up.
- Make sure the copy is clear.
- Click on "Decide later".
- Make sure your are redirected to the site editor.