### PR TITLE
Newsletter: Change text to lower case

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -85,11 +85,11 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 
 		if ( flowName === NEWSLETTER_FLOW ) {
 			return {
-				title: __( 'The Newsletter. Elevated.' ),
+				title: __( 'The newsletter. Elevated.' ),
 				text: __(
 					'Everything you need to reach and grow an audience, with the power and permanence of WordPress.com.'
 				),
-				buttonText: __( 'Launch your Newsletter' ),
+				buttonText: __( 'Launch your newsletter' ),
 			};
 		}
 
@@ -121,7 +121,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 
 		return {
 			title: createInterpolateElement(
-				__( 'You’re 3 minutes away from<br />a launch-ready Newsletter. ' ),
+				__( 'You’re 3 minutes away from<br />a launch-ready newsletter. ' ),
 				{ br: <br /> }
 			),
 			buttonText: __( 'Get started' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
@@ -104,7 +104,7 @@ const NewsletterPostSetup: Step = ( { navigation } ) => {
 			formattedHeader={
 				<FormattedHeader
 					id="newsletter-setup-header"
-					headerText={ createInterpolateElement( translate( 'Personalize your<br />Newsletter' ), {
+					headerText={ createInterpolateElement( translate( 'Personalize your<br />newsletter' ), {
 						br: <br />,
 					} ) }
 					align="center"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR update Newsletter to newsletter in cases where the meaning is generic. See this P2 and comment for context: pdZzpt-rd-p2#comment-1156.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this branch and run yarn and yarn start if need. 
2. Go to http://calypso.localhost:3000/setup/newsletter/intro. Confirm screen loads as expected and the text changes from the first screenshot above are visible. 
3. Start a newsletter site, go through to Launchpad, then click Personalize your newsletter to open 'personalize' screen. Confirm screen loads as expected and that the text change from the second screenshot above is visible. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?