### PR TITLE
Connect the WPCOM SVN VCS root for Jetpack test triggering

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -2,6 +2,7 @@ package _self.lib.customBuildType
 
 import Settings
 import _self.bashNodeScript
+import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
@@ -56,6 +57,7 @@ open class E2EBuildType(
 	var enableCommitStatusPublisher: Boolean = false,
 	var buildTriggers: Triggers.() -> Unit = {},
 	var buildDependencies: Dependencies.() -> Unit = {},
+	var addWpcomVcsRoot: Boolean = false,
 
 ): BuildType() {
 	init {
@@ -68,6 +70,7 @@ open class E2EBuildType(
 		val buildTriggers = buildTriggers
 		val buildDependencies = buildDependencies
 		val params = params
+		val addWpcomVcsRoot = addWpcomVcsRoot
 
 		id( buildId )
 		uuid = buildUuid
@@ -83,6 +86,9 @@ open class E2EBuildType(
 
 		vcs {
 			root(Settings.WpCalypso)
+			if (addWpcomVcsRoot) {
+				root(AbsoluteId("wpcom"), "-:.")
+			}
 			cleanCheckout = true
 		}
 

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -247,7 +247,8 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpack
 			param("env.JETPACK_TARGET", jetpackTarget)
 		},
 		buildFeatures = {},
-		buildTriggers = triggers
+		buildTriggers = triggers,
+		addWpcomVcsRoot = true
 	)
 }
 

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -197,8 +197,8 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpack
 
 				// Trigger only when changes are made to the Jetpack staging directories in our WPCOM connection
 				triggerRules = """
-					+:root=%WPCOM_VCS_ROOT_ID%:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/staging/**
-					+:root=%WPCOM_VCS_ROOT_ID%:%WPCOM_JETPACK_PLUGIN_PATH%/staging/**
+					+:root=wpcom:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/staging/**
+					+:root=wpcom:%WPCOM_JETPACK_PLUGIN_PATH%/staging/**
 				""".trimIndent()
 			}
 		} else if (jetpackTarget == "wpcom-production") {
@@ -210,8 +210,8 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpack
 
 				// Trigger only when changes are made to the Jetpack prod directories in our WPCOM connection
 				triggerRules = """
-					+:root=%WPCOM_VCS_ROOT_ID%:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/production/**
-					+:root=%WPCOM_VCS_ROOT_ID%:%WPCOM_JETPACK_PLUGIN_PATH%/production/**
+					+:root=wpcom:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/production/**
+					+:root=wpcom:%WPCOM_JETPACK_PLUGIN_PATH%/production/**
 				""".trimIndent()
 			}
 		} else {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -92,7 +92,6 @@ project {
 		text("CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT", "s3://a8c-calypso-e2e-reports", label = "Calypso E2E Dashboard S3 bucket root")
 
 		// Values related to the WPCOM VCS
-		password("WPCOM_VCS_ROOT_ID", "credentialsJSON:f7437cc0-c8f2-4b10-bdfa-271946bb5f72", display = ParameterDisplay.HIDDEN)
 		password("WPCOM_JETPACK_PLUGIN_PATH", "credentialsJSON:db955a02-2a79-4167-a823-ac4840fd71d7", display = ParameterDisplay.HIDDEN)
 		password("WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH", "credentialsJSON:81683f57-784e-4535-9af0-26212c9e599b", display = ParameterDisplay.HIDDEN)
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Our trigger rules for Jetpack E2E tests based on WPCOM commits didn't work because the VCS wasn't attached to the build.

This PR attaches the VCS!

**Note -- the param/password string interpolation doesn't seem to work passed to the AbsoluteId constructor (it has certain limitations where it does work), but I have confirmed internally that it is okay to include the ID in the repo.

## Testing Instructions

We can't really test until this merges to trunk. But, there shouldn't be any errors on the branch builds!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
