### PR TITLE
ReactRefreshWebpackPlugin: Disable for devdocs

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -406,7 +406,11 @@ const webpackConfig = {
 				},
 			} ),
 		isDevelopment && new webpack.HotModuleReplacementPlugin(),
-		isDevelopment && new ReactRefreshWebpackPlugin( { overlay: false } ),
+		isDevelopment &&
+			new ReactRefreshWebpackPlugin( {
+				overlay: false,
+				exclude: [ /node_modules/, /devdocs/ ],
+			} ),
 	].filter( Boolean ),
 	externals: [ 'keytar' ],
 


### PR DESCRIPTION

## Proposed Changes

* ReactRefreshWebpackPlugin: Stops processing files with 'devdocs' in the path

It looks like #76101 broke the http://calypso.localhost:3000/devdocs/design page.

## Testing Instructions

* Visit http://calypso.localhost:3000/devdocs/design
  * On this branch, all components should load
  * On trunk branch, they will not load
* Visit `http://calypso.localhost:3000/home/<yoursite>`
  * Make a change to `client/my-sites/customer-home/main.jsx`
  * This should continue to hot-reload

