### PR TITLE
Show requires business plan for site logs menu item.

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -98,11 +98,12 @@ const SettingsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 const SiteLogsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
 	const hasFeatureSFTP = useSafeSiteHasFeature( site.ID, FEATURE_SFTP );
+	const href = hasFeatureSFTP ? getSiteLogsUrl( site.slug ) : getHostingConfigUrl( site.slug );
 
 	return (
 		<MenuItemLink
 			info={ ! hasFeatureSFTP && __( 'Requires a Business Plan' ) }
-			href={ getSiteLogsUrl( site.slug ) }
+			href={ href }
 			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_site_logs_click' ) }
 		>
 			{ __( 'Site logs' ) }

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -98,7 +98,11 @@ const SettingsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 const SiteLogsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
 	const hasFeatureSFTP = useSafeSiteHasFeature( site.ID, FEATURE_SFTP );
-	const href = hasFeatureSFTP ? getSiteLogsUrl( site.slug ) : getHostingConfigUrl( site.slug );
+
+	const href = hasFeatureSFTP
+		? getSiteLogsUrl( site.slug )
+		: // There's no upsell message on the logging page, so we send users to the hosting page instead.
+		  getHostingConfigUrl( site.slug );
 
 	return (
 		<MenuItemLink

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -97,9 +97,11 @@ const SettingsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 
 const SiteLogsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
+	const hasFeatureSFTP = useSafeSiteHasFeature( site.ID, FEATURE_SFTP );
 
 	return (
 		<MenuItemLink
+			info={ ! hasFeatureSFTP && __( 'Requires a Business Plan' ) }
 			href={ getSiteLogsUrl( site.slug ) }
 			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_site_logs_click' ) }
 		>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add menu item info to show that Site Logs requires a business plan.
* 
![image](https://github.com/Automattic/wp-calypso/assets/47489215/3d4aa4ae-bf1f-4f50-8eb6-259e9eceabff)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Go `/sites`
* Select the ellipsis menu from a simple site and confirm `Site Logs` menu option shows `Requires a Business plan.`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
