### PR TITLE
Subscription Management: Fix infinite fetching of comment subscriptions.

### DIFF
--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -1,5 +1,5 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { PostSubscription } from '../types';
@@ -53,7 +53,6 @@ const usePostSubscriptionsQuery = ( {
 	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 	const cacheKey = useCacheKey( [ 'read', 'post-subscriptions' ] );
-	const stopFetchingRef = useRef( false );
 
 	const { data, isFetching, isFetchingNextPage, fetchNextPage, hasNextPage, ...rest } =
 		useInfiniteQuery< SubscriptionManagerPostSubscriptions >(
@@ -66,22 +65,20 @@ const usePostSubscriptionsQuery = ( {
 					apiNamespace: 'wpcom/v2',
 				} );
 
-				if ( pageParam * number >= result.total_comment_subscriptions_count ) {
-					stopFetchingRef.current = true;
-				}
-
 				return result;
 			},
 			{
 				enabled,
 				getNextPageParam: ( lastPage, pages ) =>
-					stopFetchingRef.current ? undefined : pages.length + 1,
+					pages.length * number >= lastPage.total_comment_subscriptions_count
+						? undefined
+						: pages.length + 1,
 				refetchOnWindowFocus: false,
 			}
 		);
 
 	useEffect( () => {
-		if ( hasNextPage && ! isFetchingNextPage && ! isFetching && ! stopFetchingRef.current ) {
+		if ( hasNextPage && ! isFetchingNextPage && ! isFetching ) {
 			fetchNextPage();
 		}
 	}, [ hasNextPage, isFetchingNextPage, isFetching, fetchNextPage ] );

--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -66,7 +66,7 @@ const usePostSubscriptionsQuery = ( {
 					apiNamespace: 'wpcom/v2',
 				} );
 
-				if ( result.comment_subscriptions.length === 0 ) {
+				if ( pageParam * number >= result.total_comment_subscriptions_count ) {
 					stopFetchingRef.current = true;
 				}
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes the infinite calls to the comment list endpoint. It's far from perfect, but it's a temporal fix, only valid while we fix the backend to return the correct number of comment subscriptions.

It still makes more calls than needed, but that's due to the asynchronous nature of the state hook used to stop the fetching.

## Testing Instructions

1. Apply this patch.
2. Add `return next();` right after the line `app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res, next ) {` in the file `client/server/pages/index.js`.
3. Start the application.
4. Go to `http://calypso.localhost:3000/subscriptions/comments` with the network tab from the developer tools open.
5. Check that the calls to `/wpcom/v2/post-comment-subscriptions` stops after some of them.

