### PR TITLE
Update/domain filter css

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -327,8 +327,9 @@ $videopress-background: #010101;
 	}
 }
 
-.start-writing, .design-first {
-	.register-domain-step, {
+.start-writing,
+.design-first {
+	.register-domain-step {
 		box-shadow: none;
 		background: none;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -327,11 +327,17 @@ $videopress-background: #010101;
 	}
 }
 
-.start-writing .register-domain-step {
-	box-shadow: none;
-	background: none;
-}
+.start-writing, .design-first {
+	.register-domain-step, {
+		box-shadow: none;
+		background: none;
+	}
 
-.start-writing .register-domain-step__next-page-button {
-	padding-bottom: 8px !important;
+	.register-domain-step__next-page-button {
+		padding-bottom: 8px !important;
+	}
+
+	.is-borderless {
+		border: none;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2484

## Proposed Changes

* Removes the border when hovering over the Filter button.

Before | After
--|--
![filter-before](https://github.com/Automattic/wp-calypso/assets/140841/fce2a722-95fe-42be-a0d3-165f0b6782dd)  | ![filter-after](https://github.com/Automattic/wp-calypso/assets/140841/d92e9330-fa6c-40d7-aae1-8b333ec49037)




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Go to /setup/start-writing on an account with 0 existing sites.
* Get to the Domain selection step and confirm the bolded boarder is no longer visible on the Filter button when hovering or clicked.
* Confirm there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
