### PR TITLE
Sites page: use consistent URLs in the CTAs

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -1,7 +1,9 @@
 import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { useSelector } from 'react-redux';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { useSitesDashboardCreateSiteUrl } from '../hooks/use-sites-dashboard-create-site-url';
+import { TRACK_SOURCE_NAME } from '../utils';
 import { EmptyStateCTA } from './empty-state-cta';
 
 export const CreateSiteCTA = () => {
@@ -31,7 +33,10 @@ export const MigrateSiteCTA = () => {
 		<EmptyStateCTA
 			description={ __( 'Bring a site to WordPress.com' ) }
 			label={ __( 'Migrate a site' ) }
-			target="/start/import"
+			target={ addQueryArgs( '/start/import', {
+				source: TRACK_SOURCE_NAME,
+				ref: 'calypso-nosites',
+			} ) }
 		/>
 	);
 };

--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -1,9 +1,8 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { addQueryArgs } from '@wordpress/url';
 import { useSelector } from 'react-redux';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { useSitesDashboardCreateSiteUrl } from '../hooks/use-sites-dashboard-create-site-url';
-import { TRACK_SOURCE_NAME } from '../utils';
+import { getMigrateSiteUrl } from '../utils';
 import { EmptyStateCTA } from './empty-state-cta';
 
 export const CreateSiteCTA = () => {
@@ -33,10 +32,7 @@ export const MigrateSiteCTA = () => {
 		<EmptyStateCTA
 			description={ __( 'Bring a site to WordPress.com' ) }
 			label={ __( 'Migrate a site' ) }
-			target={ addQueryArgs( '/start/import', {
-				source: TRACK_SOURCE_NAME,
-				ref: 'calypso-nosites',
-			} ) }
+			target={ getMigrateSiteUrl() }
 		/>
 	);
 };

--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -1,28 +1,25 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
-import { addQueryArgs } from 'calypso/lib/url';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { useSitesDashboardCreateSiteUrl } from '../hooks/use-sites-dashboard-create-site-url';
 import { EmptyStateCTA } from './empty-state-cta';
 
 export const CreateSiteCTA = () => {
 	const { __ } = useI18n();
-	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
+
 	const isHostingFlow = useSelector(
 		( state ) => getCurrentQueryArguments( state )?.[ 'hosting-flow' ] === 'true'
 	);
 
-	const newHostedSiteURL = isHostingFlow
-		? addQueryArgs( { 'hosting-flow': true }, '/setup/new-hosted-site' )
-		: '/setup/new-hosted-site';
-
-	const newSiteURL = isDevAccount ? newHostedSiteURL : '/start';
+	const createSiteUrl = useSitesDashboardCreateSiteUrl( {
+		'hosting-flow': isHostingFlow ? true : null,
+	} );
 
 	return (
 		<EmptyStateCTA
 			description={ __( 'Build a new site from scratch' ) }
 			label={ __( 'Create a site' ) }
-			target={ addQueryArgs( { source: 'sites-dashboard', ref: 'calypso-nosites' }, newSiteURL ) }
+			target={ createSiteUrl }
 		/>
 	);
 };

--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -2,7 +2,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { useSitesDashboardCreateSiteUrl } from '../hooks/use-sites-dashboard-create-site-url';
-import { getMigrateSiteUrl } from '../utils';
+import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
 import { EmptyStateCTA } from './empty-state-cta';
 
 export const CreateSiteCTA = () => {
@@ -27,12 +27,13 @@ export const CreateSiteCTA = () => {
 
 export const MigrateSiteCTA = () => {
 	const { __ } = useI18n();
+	const importSiteUrl = useSitesDashboardImportSiteUrl();
 
 	return (
 		<EmptyStateCTA
 			description={ __( 'Bring a site to WordPress.com' ) }
 			label={ __( 'Migrate a site' ) }
-			target={ getMigrateSiteUrl() }
+			target={ importSiteUrl }
 		/>
 	);
 };

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -18,7 +18,7 @@ import { withoutHttp } from 'calypso/lib/url';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
 import { useSitesDashboardCreateSiteUrl } from '../hooks/use-sites-dashboard-create-site-url';
-import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from '../utils';
+import { getMigrateSiteUrl, MEDIA_QUERIES, TRACK_SOURCE_NAME } from '../utils';
 import { NoSitesMessage } from './no-sites-message';
 import {
 	SitesDashboardQueryParams,
@@ -197,9 +197,7 @@ export function SitesDashboard( {
 							onClick={ () => {
 								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
 							} }
-							href={ addQueryArgs( '/start/import', {
-								source: TRACK_SOURCE_NAME,
-							} ) }
+							href={ getMigrateSiteUrl() }
 							icon="arrow-down"
 						>
 							<span>{ __( 'Import an existing site' ) }</span>

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -17,7 +17,8 @@ import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query
 import { withoutHttp } from 'calypso/lib/url';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
-import { MEDIA_QUERIES } from '../utils';
+import { useSitesDashboardCreateSiteUrl } from '../hooks/use-sites-dashboard-create-site-url';
+import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from '../utils';
 import { NoSitesMessage } from './no-sites-message';
 import {
 	SitesDashboardQueryParams,
@@ -33,8 +34,6 @@ import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 interface SitesDashboardProps {
 	queryParams: SitesDashboardQueryParams;
 }
-
-const TRACK_SOURCE_NAME = 'sites-dashboard';
 
 const MAX_PAGE_WIDTH = '1280px';
 
@@ -145,6 +144,7 @@ const SitesDashboardSitesList = createSitesListComponent();
 export function SitesDashboard( {
 	queryParams: { page = 1, perPage = 96, search, status = 'all', newSiteID },
 }: SitesDashboardProps ) {
+	const createSiteUrl = useSitesDashboardCreateSiteUrl();
 	const { __, _n } = useI18n();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
@@ -179,9 +179,7 @@ export function SitesDashboard( {
 						onClick={ () => {
 							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
 						} }
-						href={ addQueryArgs( '/start', {
-							ref: TRACK_SOURCE_NAME,
-						} ) }
+						href={ createSiteUrl }
 					>
 						<PopoverMenuItem
 							onClick={ () => {

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -18,7 +18,8 @@ import { withoutHttp } from 'calypso/lib/url';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
 import { useSitesDashboardCreateSiteUrl } from '../hooks/use-sites-dashboard-create-site-url';
-import { getMigrateSiteUrl, MEDIA_QUERIES, TRACK_SOURCE_NAME } from '../utils';
+import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
+import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from '../utils';
 import { NoSitesMessage } from './no-sites-message';
 import {
 	SitesDashboardQueryParams,
@@ -145,6 +146,7 @@ export function SitesDashboard( {
 	queryParams: { page = 1, perPage = 96, search, status = 'all', newSiteID },
 }: SitesDashboardProps ) {
 	const createSiteUrl = useSitesDashboardCreateSiteUrl();
+	const importSiteUrl = useSitesDashboardImportSiteUrl();
 	const { __, _n } = useI18n();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
@@ -197,7 +199,7 @@ export function SitesDashboard( {
 							onClick={ () => {
 								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
 							} }
-							href={ getMigrateSiteUrl() }
+							href={ importSiteUrl }
 							icon="arrow-down"
 						>
 							<span>{ __( 'Import an existing site' ) }</span>

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -197,7 +197,9 @@ export function SitesDashboard( {
 							onClick={ () => {
 								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
 							} }
-							href={ addQueryArgs( '/start/import' ) }
+							href={ addQueryArgs( '/start/import', {
+								source: TRACK_SOURCE_NAME,
+							} ) }
 							icon="arrow-down"
 						>
 							<span>{ __( 'Import an existing site' ) }</span>

--- a/client/sites-dashboard/hooks/use-sites-dashboard-create-site-url.ts
+++ b/client/sites-dashboard/hooks/use-sites-dashboard-create-site-url.ts
@@ -1,0 +1,22 @@
+import { useSelector } from 'react-redux';
+import { Primitive } from 'utility-types';
+import { addQueryArgs } from 'calypso/lib/url';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { TRACK_SOURCE_NAME } from '../utils';
+
+export const useSitesDashboardCreateSiteUrl = (
+	additionalParams: Record< string, Primitive > = {}
+) => {
+	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
+	const siteCount = useSelector( getCurrentUserSiteCount );
+
+	return addQueryArgs(
+		{
+			source: TRACK_SOURCE_NAME,
+			ref: siteCount === 0 ? 'calypso-nosites' : null,
+			...additionalParams,
+		},
+		isDevAccount ? '/setup/new-hosted-site' : '/start'
+	);
+};

--- a/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
+++ b/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
@@ -1,0 +1,16 @@
+import { useSelector } from 'react-redux';
+import { addQueryArgs } from 'calypso/lib/url';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import { TRACK_SOURCE_NAME } from '../utils';
+
+export const useSitesDashboardImportSiteUrl = () => {
+	const siteCount = useSelector( getCurrentUserSiteCount );
+
+	return addQueryArgs(
+		{
+			source: TRACK_SOURCE_NAME,
+			ref: siteCount === 0 ? 'calypso-nosites' : null,
+		},
+		'/start/import'
+	);
+};

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -62,3 +62,5 @@ export const PLAN_RENEW_NAG_EVENT_NAMES = {
 	IN_VIEW: 'calypso_sites_dashboard_plan_renew_nag_inview',
 	ON_CLICK: 'calypso_sites_dashboard_plan_renew_nag_click',
 };
+
+export const TRACK_SOURCE_NAME = 'sites-dashboard';

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -1,4 +1,13 @@
+import { addQueryArgs } from '@wordpress/url';
 import { SiteExcerptNetworkData } from 'calypso/data/sites/site-excerpt-types';
+
+export const TRACK_SOURCE_NAME = 'sites-dashboard';
+
+export const getMigrateSiteUrl = () =>
+	addQueryArgs( '/start/import', {
+		source: TRACK_SOURCE_NAME,
+		ref: 'calypso-nosites',
+	} );
 
 export const getLaunchpadUrl = ( slug: string, flow: string ) => {
 	return `/setup/${ flow }/launchpad?siteSlug=${ slug }`;
@@ -62,5 +71,3 @@ export const PLAN_RENEW_NAG_EVENT_NAMES = {
 	IN_VIEW: 'calypso_sites_dashboard_plan_renew_nag_inview',
 	ON_CLICK: 'calypso_sites_dashboard_plan_renew_nag_click',
 };
-
-export const TRACK_SOURCE_NAME = 'sites-dashboard';

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -1,13 +1,6 @@
-import { addQueryArgs } from '@wordpress/url';
 import { SiteExcerptNetworkData } from 'calypso/data/sites/site-excerpt-types';
 
 export const TRACK_SOURCE_NAME = 'sites-dashboard';
-
-export const getMigrateSiteUrl = () =>
-	addQueryArgs( '/start/import', {
-		source: TRACK_SOURCE_NAME,
-		ref: 'calypso-nosites',
-	} );
 
 export const getLaunchpadUrl = ( slug: string, flow: string ) => {
 	return `/setup/${ flow }/launchpad?siteSlug=${ slug }`;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2365.

## Proposed Changes

Standardizes and centralizes the generation of the Sites page CTAs. This is necessary because we're sharing query parameters between states and at least two variations of the CTA's target so we need to extract this logic and reuse it.

## Testing Instructions

The "Create site"/"Add new site" button should point to...

Developer account in the hosting flow: `/start/new-hosted-site?hosting-flow=true`
Developer account not in the hosting flow: `/start/new-hosted-site`
Not a developer account: `/start`

Check that the "Import existing site" CTA points to the exact same place in both of the experiences: `/start/import?source=sites-dashboard`.

The `ref=calypso-nosites` property should be added conditionally, checking if the user has a site or not.