### PR TITLE
Hide Site logs menu item unless site is already transferred to Atomic

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -97,17 +97,10 @@ const SettingsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 
 const SiteLogsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
-	const hasFeatureSFTP = useSafeSiteHasFeature( site.ID, FEATURE_SFTP );
-
-	const href = hasFeatureSFTP
-		? getSiteLogsUrl( site.slug )
-		: // There's no upsell message on the logging page, so we send users to the hosting page instead.
-		  getHostingConfigUrl( site.slug );
 
 	return (
 		<MenuItemLink
-			info={ ! hasFeatureSFTP && __( 'Requires a Business Plan' ) }
-			href={ href }
+			href={ getSiteLogsUrl( site.slug ) }
 			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_site_logs_click' ) }
 		>
 			{ __( 'Site logs' ) }
@@ -420,7 +413,7 @@ export const SitesEllipsisMenu = ( {
 					{ ! isWpcomStagingSite && ! isLaunched && <LaunchItem { ...props } /> }
 					<SettingsItem { ...props } />
 					{ hasHostingFeatures && <HostingConfigurationSubmenu { ...props } /> }
-					{ hasHostingFeatures && <SiteLogsItem { ...props } /> }
+					{ site.is_wpcom_atomic && <SiteLogsItem { ...props } /> }
 					{ ! isP2Site( site ) && <ManagePluginsItem { ...props } /> }
 					{ site.is_coming_soon && <PreviewSiteModalItem { ...props } /> }
 					{ ! isWpcomStagingSite && shouldShowSiteCopyItem && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77402

## Proposed Changes

* Hide "Site logs" from `/sites` ellipsis menu unless the site is already atomic

Changes in #77402 make the "Site logs" menu item look like the other hosting related menu items, with a message to upgrade to Business in order to unlock this feature.

![CleanShot 2023-05-26 at 11 52 01@2x](https://github.com/Automattic/wp-calypso/assets/1500769/fb4fcfb3-8c99-42f3-aed6-654a3ed3af63)

**The problem is that if the site has a Business Plan, and is a Simple site, when they click the menu item they are redirected to `/home`**

"Site logs" doesn't quite work like the plugins and hosting page. If the site doesn't support the site logs feature we don't show an upsell or a UI that allows them to transfer to Atomic. We might add those features in the future but we didn't in the logging i1 project. That's why we hide "Site logs" in the Calypso menu unless the site is already on Atomic.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites` and check the ellipsis menu of:
* An atomic site (Business or Commerce plan); the Site logs menu item is present
* A Simple site with Business plan; the Site logs menu item isn't present
* A Simple site with a plan lower than Business; the Site logs menu isn't present

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
