### PR TITLE
Import hosted site flow: allow going back to /sites

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -220,6 +220,16 @@ const importFlow: Flow = {
 
 		const goBack = () => {
 			switch ( _currentStep ) {
+				case 'import': {
+					const source = urlQueryParams.get( 'source' );
+
+					if ( source === 'sites-dashboard' ) {
+						return window.location.assign( '/sites' );
+					}
+
+					return;
+				}
+
 				case 'importList':
 					// eslint-disable-next-line no-case-declarations
 					const backToStep = urlQueryParams.get( 'backToStep' );

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -113,6 +113,8 @@ const importFlow: Flow = {
 		};
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
+			const source = urlQueryParams.get( 'source' );
+
 			switch ( _currentStep ) {
 				case 'importReady': {
 					const depUrl = ( providedDependencies?.url as string ) || '';
@@ -126,7 +128,7 @@ const importFlow: Flow = {
 						return exitFlow( providedDependencies?.url as string );
 					}
 
-					return navigate( providedDependencies?.url as string );
+					return navigate( addQueryArgs( providedDependencies?.url as string, { source } ) );
 				}
 				case 'importReadyPreview': {
 					return navigate( providedDependencies?.url as string );

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -1,6 +1,7 @@
 import { Design, isBlankCanvasDesign } from '@automattic/design-picker';
 import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import useAddTempSiteToSourceOptionMutation from 'calypso/data/site-migration/use-add-temp-site-mutation';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
@@ -219,10 +220,10 @@ const importFlow: Flow = {
 		};
 
 		const goBack = () => {
+			const source = urlQueryParams.get( 'source' );
+
 			switch ( _currentStep ) {
 				case 'import': {
-					const source = urlQueryParams.get( 'source' );
-
 					if ( source === 'sites-dashboard' ) {
 						return window.location.assign( '/sites' );
 					}
@@ -235,7 +236,7 @@ const importFlow: Flow = {
 					const backToStep = urlQueryParams.get( 'backToStep' );
 
 					if ( backToStep ) {
-						const path = `${ backToStep }?siteSlug=${ siteSlugParam }`;
+						const path = addQueryArgs( backToStep, { siteSlug: siteSlugParam, source } );
 
 						return navigate( path );
 					}
@@ -252,7 +253,7 @@ const importFlow: Flow = {
 				case 'importerSquarespace':
 				case 'importerWordpress':
 				case 'designSetup':
-					return navigate( `import?siteSlug=${ siteSlugParam }` );
+					return navigate( addQueryArgs( 'import', { siteSlug: siteSlugParam, source } ) );
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -7,6 +7,7 @@ import CaptureStep from 'calypso/blocks/import/capture';
 import CaptureStepRetired from 'calypso/blocks/import/capture-retired';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useCurrentRoute } from 'calypso/landing/stepper/hooks/use-current-route';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { BASE_ROUTE } from './config';
 import { generateStepPath } from './helper';
@@ -19,7 +20,10 @@ export const ImportWrapper: Step = function ( props ) {
 	const { __ } = useI18n();
 	const { navigation, children, stepName, flow } = props;
 	const currentRoute = useCurrentRoute();
-	const shouldHideBackBtn = currentRoute === `${ IMPORT_FOCUSED_FLOW }/${ BASE_ROUTE }`;
+	const source = useQuery().get( 'source' );
+	const shouldHideBackBtn = source
+		? false
+		: currentRoute === `${ IMPORT_FOCUSED_FLOW }/${ BASE_ROUTE }`;
 	const skipLabelText =
 		flow === IMPORT_FOCUSED_FLOW ? __( 'Skip to dashboard' ) : __( "I don't have a site address" );
 
@@ -41,7 +45,7 @@ export const ImportWrapper: Step = function ( props ) {
 				stepName={ stepName || 'import-step' }
 				flowName="importer"
 				className="import__onboarding-page"
-				hideSkip={ shouldHideSkipBtn() }
+				hideSkip={ !! source || shouldHideSkipBtn() }
 				hideBack={ shouldHideBackBtn }
 				hideFormattedHeader={ true }
 				goBack={ navigation.goBack }

--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -3,6 +3,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import { addQueryArgs } from 'calypso/lib/url';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { TRACK_SOURCE_NAME } from '../utils';
 import { EmptyStateCTA } from './empty-state-cta';
 
 export const CreateSiteCTA = () => {
@@ -16,7 +17,7 @@ export const CreateSiteCTA = () => {
 		<EmptyStateCTA
 			description={ __( 'Build a new site from scratch' ) }
 			label={ __( 'Create a site' ) }
-			target={ addQueryArgs( { source: 'sites-dashboard', ref: 'calypso-nosites' }, newSiteURL ) }
+			target={ addQueryArgs( { source: TRACK_SOURCE_NAME, ref: 'calypso-nosites' }, newSiteURL ) }
 		/>
 	);
 };
@@ -28,7 +29,7 @@ export const MigrateSiteCTA = () => {
 		<EmptyStateCTA
 			description={ __( 'Bring a site to WordPress.com' ) }
 			label={ __( 'Migrate a site' ) }
-			target="/setup/import-focused"
+			target={ addQueryArgs( { source: TRACK_SOURCE_NAME }, '/setup/import-focused' ) }
 		/>
 	);
 };

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -62,3 +62,5 @@ export const PLAN_RENEW_NAG_EVENT_NAMES = {
 	IN_VIEW: 'calypso_sites_dashboard_plan_renew_nag_inview',
 	ON_CLICK: 'calypso_sites_dashboard_plan_renew_nag_click',
 };
+
+export const TRACK_SOURCE_NAME = 'sites-dashboard';


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2365.

## Proposed Changes

This PR adds the capability to go back after clicking "Import a site" from the `/sites` page.

One thing I don't like is that a full-page refresh happens. How to replace the component instead?

## Testing Instructions

1. Enable the `hosting-onboarding-i2` flag;
2. In an account with no sites, click the "Import a site" button;
3. Verify that the "Skip to dashboard" button on the top-right corner is gone;
4. Verify that the "Back" button in the top-left corner shows up;
5. Click it and you should be redirected to `/sites`.