### PR TITLE
Sites: use consistent import site URLs

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -3,7 +3,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import { addQueryArgs } from 'calypso/lib/url';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
-import { TRACK_SOURCE_NAME } from '../utils';
+import { getImportSiteUrl, TRACK_SOURCE_NAME } from '../utils';
 import { EmptyStateCTA } from './empty-state-cta';
 
 export const CreateSiteCTA = () => {
@@ -29,7 +29,7 @@ export const MigrateSiteCTA = () => {
 		<EmptyStateCTA
 			description={ __( 'Bring a site to WordPress.com' ) }
 			label={ __( 'Migrate a site' ) }
-			target={ addQueryArgs( { source: TRACK_SOURCE_NAME }, '/setup/import-focused' ) }
+			target={ getImportSiteUrl() }
 		/>
 	);
 };

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -17,7 +17,7 @@ import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query
 import { withoutHttp } from 'calypso/lib/url';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
-import { MEDIA_QUERIES } from '../utils';
+import { getImportSiteUrl, MEDIA_QUERIES } from '../utils';
 import { NoSitesMessage } from './no-sites-message';
 import {
 	SitesDashboardQueryParams,
@@ -199,7 +199,7 @@ export function SitesDashboard( {
 							onClick={ () => {
 								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
 							} }
-							href={ addQueryArgs( '/start/import' ) }
+							href={ getImportSiteUrl() }
 							icon="arrow-down"
 						>
 							<span>{ __( 'Import an existing site' ) }</span>

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -1,4 +1,12 @@
+import { addQueryArgs } from '@wordpress/url';
 import { SiteExcerptNetworkData } from 'calypso/data/sites/site-excerpt-types';
+
+export const TRACK_SOURCE_NAME = 'sites-dashboard';
+
+export const getImportSiteUrl = () =>
+	addQueryArgs( '/setup/import-focused', {
+		source: TRACK_SOURCE_NAME,
+	} );
 
 export const getLaunchpadUrl = ( slug: string, flow: string ) => {
 	return `/setup/${ flow }/launchpad?siteSlug=${ slug }`;
@@ -62,5 +70,3 @@ export const PLAN_RENEW_NAG_EVENT_NAMES = {
 	IN_VIEW: 'calypso_sites_dashboard_plan_renew_nag_inview',
 	ON_CLICK: 'calypso_sites_dashboard_plan_renew_nag_click',
 };
-
-export const TRACK_SOURCE_NAME = 'sites-dashboard';


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2365.

**This PR is blocked by https://github.com/Automattic/wp-calypso/pull/77414**.

## Proposed Changes

After https://github.com/Automattic/wp-calypso/pull/76697, we are using a new target for the import site flow: `/setup/import-focused`.

It makes sense to provide a consistent experience for the users, so now the CTA, both for users without a site (empty state) and users with a site to go to the same place, especially because they are using the more developer-focused flow.

The `/start/import` flow also doesn't look great. It starts asking for a domain for your new site, but we first need to check whether we can import the old site. So it makes sense to ask them for their existing site first -- the `/setup/import-focused` flow does exactly that.

## Testing Instructions

Open `/sites` with two different accounts: one with sites, and one without.

Check that the CTA for "Import a site" (user without sites) and "Import an existing site" (user with sites) points to `/setup/import-focused`.
