### PR TITLE
PA: Determine which site to be used to render the patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -650,6 +650,7 @@ const PatternAssembler = ( {
 					stylesheet={ stylesheet }
 					patternIds={ patternIds }
 					siteInfo={ siteInfo }
+					isNewSite={ isNewSite }
 				>
 					{ stepContent }
 				</PatternAssemblerContainer>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
@@ -9,6 +9,7 @@ interface Props {
 	patternIds: string[];
 	children: JSX.Element;
 	siteInfo: SiteInfo;
+	isNewSite?: boolean;
 }
 
 const PatternAssemblerContainer = ( {
@@ -17,6 +18,7 @@ const PatternAssemblerContainer = ( {
 	patternIds,
 	children,
 	siteInfo,
+	isNewSite,
 }: Props ) => (
 	<BlockRendererProvider
 		siteId={ siteId }
@@ -26,8 +28,10 @@ const PatternAssemblerContainer = ( {
 	>
 		<PatternsRendererProvider
 			// Site used to render site-related things on the previews,
-			// such as the logo, title, and tagline.
-			siteId={ PLACEHOLDER_SITE_ID }
+			// such as the logo, title, tagline, pages, posts, etc.
+			// For the newly created site, we use the placeholder site to render the content.
+			// Otherwise, we use the current site to display the site-related blocks.
+			siteId={ isNewSite ? PLACEHOLDER_SITE_ID : siteId }
 			stylesheet={ stylesheet }
 			patternIds={ patternIds }
 			// Use siteInfo to overwrite site-related things such as title, and tagline.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/76932

## Proposed Changes

* Use the `isNewSite` parameter to determine we have to use which site to render the patterns, the current site or theme demo site.

![image](https://github.com/Automattic/wp-calypso/assets/13596067/1b823eee-57b0-4b5b-a1b6-5995089c8435)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D111982-code to your sandbox
* Create new pages/posts and upload the site logo to your site
* Go to `/setup/with-theme-assembler?theme=blank-canvas-3&siteSlug=<your_site>`
* Select patterns with posts or the site logo, and ensure the preview displays the data from your site correctly instead of the theme demo site.
* Append `isNewSite=true` to the URL and ensure those patterns display the data from the theme demo site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?