### PR TITLE
Theme Showcase: dotorg themes show the wrong popover message

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -385,6 +385,15 @@ export class Theme extends Component {
 					},
 				}
 			);
+		} else if ( isWporgOnlyTheme ) {
+			return createInterpolateElement(
+				translate(
+					'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
+				),
+				{
+					Link: <LinkButton isLink onClick={ () => this.goToCheckout( 'business' ) } />,
+				}
+			);
 		} else if ( isUsablePremiumTheme ) {
 			return translate( 'This premium theme is included in your plan.' );
 		} else if ( isUsableBundledTheme ) {
@@ -392,15 +401,6 @@ export class Theme extends Component {
 		} else if ( doesThemeBundleSoftwareSet ) {
 			return createInterpolateElement(
 				translate( 'This WooCommerce theme is included in the <Link>Business plan</Link>.' ),
-				{
-					Link: <LinkButton isLink onClick={ () => this.goToCheckout( 'business' ) } />,
-				}
-			);
-		} else if ( isWporgOnlyTheme ) {
-			return createInterpolateElement(
-				translate(
-					'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
-				),
 				{
 					Link: <LinkButton isLink onClick={ () => this.goToCheckout( 'business' ) } />,
 				}


### PR DESCRIPTION
## Proposed Changes

As discussed in p1684885105924079-slack-C048CUFRGFQ, Atomic sites will see the wrong popover message for Community themes. This PR fixes the issue by showing the same popover message on Simple and Atomic sites.

| Before | After |
| --- | --- |
| ![Screenshot 2023-05-26 at 10 56 12 AM](https://github.com/Automattic/wp-calypso/assets/797888/6144631a-d690-40ac-b7d3-802ba975b6c1) | ![Screenshot 2023-05-26 at 10 56 28 AM](https://github.com/Automattic/wp-calypso/assets/797888/7be0cfa3-af9e-450d-9477-f797a0fbb35e) |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase with a Business site or higher.
* Search for a Community theme, such as Astra or Hotel.
* Ensure that the popover message is updated as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?