### PR TITLE
Use hosting CTA URL on sites page when user in in the hosting flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -16,7 +16,7 @@ export function generateFlows( {
 	getDestinationFromIntent = noop,
 	getDIFMSignupDestination = noop,
 	getDIFMSiteContentCollectionDestination = noop,
-	getSitesDestination = noop,
+	getHostingFlowDestination = noop,
 } = {} ) {
 	const flows = [
 		{
@@ -24,7 +24,7 @@ export function generateFlows( {
 			steps: isEnabled( 'hosting-onboarding-i2' )
 				? [ 'user-hosting' ]
 				: [ 'plans-hosting', 'user-hosting', 'domains' ],
-			destination: getSitesDestination,
+			destination: getHostingFlowDestination,
 			description:
 				'Create an account and a blog and give the user the option of adding a domain and plan to the cart.',
 			lastModified: '2023-05-19',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
 import { isSiteAssemblerFlow } from '@automattic/onboarding';
 import { isDesktop } from '@automattic/viewport';
@@ -187,8 +188,14 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 	return `/home/${ siteSlug }`;
 }
 
-function getSitesDestination( { siteSlug } ) {
-	return addQueryArgs( { 'new-site': siteSlug }, '/sites' );
+function getHostingFlowDestination( { siteSlug } ) {
+	return addQueryArgs(
+		{
+			'new-site': siteSlug,
+			'hosting-flow': isEnabled( 'hosting-onboarding-i2' ) ? true : null,
+		},
+		'/sites'
+	);
 }
 
 const flows = generateFlows( {
@@ -204,7 +211,7 @@ const flows = generateFlows( {
 	getDestinationFromIntent,
 	getDIFMSignupDestination,
 	getDIFMSiteContentCollectionDestination,
-	getSitesDestination,
+	getHostingFlowDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -1,22 +1,16 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useI18n } from '@wordpress/react-i18n';
-import { useSelector } from 'react-redux';
-import { addQueryArgs } from 'calypso/lib/url';
-import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { useSitesDashboardCreateSiteUrl } from '../hooks/use-sites-dashboard-create-site-url';
 import { EmptyStateCTA } from './empty-state-cta';
 
 export const CreateSiteCTA = () => {
 	const { __ } = useI18n();
-	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
-
-	const newSiteURL =
-		isEnabled( 'hosting-onboarding-i2' ) && isDevAccount ? '/setup/new-hosted-site' : '/start';
+	const createSiteUrl = useSitesDashboardCreateSiteUrl();
 
 	return (
 		<EmptyStateCTA
 			description={ __( 'Build a new site from scratch' ) }
 			label={ __( 'Create a site' ) }
-			target={ addQueryArgs( { source: 'sites-dashboard', ref: 'calypso-nosites' }, newSiteURL ) }
+			target={ createSiteUrl }
 		/>
 	);
 };

--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -1,5 +1,7 @@
 import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { useSitesDashboardCreateSiteUrl } from '../hooks/use-sites-dashboard-create-site-url';
+import { TRACK_SOURCE_NAME } from '../utils';
 import { EmptyStateCTA } from './empty-state-cta';
 
 export const CreateSiteCTA = () => {
@@ -22,7 +24,7 @@ export const MigrateSiteCTA = () => {
 		<EmptyStateCTA
 			description={ __( 'Bring a site to WordPress.com' ) }
 			label={ __( 'Migrate a site' ) }
-			target="/setup/import-focused"
+			target={ addQueryArgs( '/setup/import-focused', { source: TRACK_SOURCE_NAME } ) }
 		/>
 	);
 };

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -17,7 +17,8 @@ import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query
 import { withoutHttp } from 'calypso/lib/url';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
-import { MEDIA_QUERIES } from '../utils';
+import { useSitesDashboardCreateSiteUrl } from '../hooks/use-sites-dashboard-create-site-url';
+import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from '../utils';
 import { NoSitesMessage } from './no-sites-message';
 import {
 	SitesDashboardQueryParams,
@@ -33,8 +34,6 @@ import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 interface SitesDashboardProps {
 	queryParams: SitesDashboardQueryParams;
 }
-
-const TRACK_SOURCE_NAME = 'sites-dashboard';
 
 const MAX_PAGE_WIDTH = '1280px';
 
@@ -145,6 +144,7 @@ const SitesDashboardSitesList = createSitesListComponent();
 export function SitesDashboard( {
 	queryParams: { page = 1, perPage = 96, search, status = 'all', newSiteSlug },
 }: SitesDashboardProps ) {
+	const createSiteUrl = useSitesDashboardCreateSiteUrl();
 	const { __, _n } = useI18n();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
@@ -179,9 +179,7 @@ export function SitesDashboard( {
 						onClick={ () => {
 							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
 						} }
-						href={ addQueryArgs( '/start', {
-							ref: TRACK_SOURCE_NAME,
-						} ) }
+						href={ createSiteUrl }
 					>
 						<PopoverMenuItem
 							onClick={ () => {

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -197,7 +197,9 @@ export function SitesDashboard( {
 							onClick={ () => {
 								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
 							} }
-							href={ addQueryArgs( '/start/import' ) }
+							href={ addQueryArgs( '/start/import', {
+								source: TRACK_SOURCE_NAME,
+							} ) }
 							icon="arrow-down"
 						>
 							<span>{ __( 'Import an existing site' ) }</span>

--- a/client/sites-dashboard/hooks/use-sites-dashboard-create-site-url.ts
+++ b/client/sites-dashboard/hooks/use-sites-dashboard-create-site-url.ts
@@ -1,0 +1,16 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useSelector } from 'react-redux';
+import { addQueryArgs } from 'calypso/lib/url';
+import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
+import { TRACK_SOURCE_NAME } from '../utils';
+
+export const useSitesDashboardCreateSiteUrl = () => {
+	const { 'hosting-flow': hostingFlow } = useSelector( getCurrentQueryArguments ) ?? {};
+
+	const newSiteURL =
+		isEnabled( 'hosting-onboarding-i2' ) && hostingFlow === 'true'
+			? '/setup/new-hosted-site'
+			: '/start';
+
+	return addQueryArgs( { source: TRACK_SOURCE_NAME, ref: 'calypso-nosites' }, newSiteURL );
+};

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -62,3 +62,5 @@ export const PLAN_RENEW_NAG_EVENT_NAMES = {
 	IN_VIEW: 'calypso_sites_dashboard_plan_renew_nag_inview',
 	ON_CLICK: 'calypso_sites_dashboard_plan_renew_nag_click',
 };
+
+export const TRACK_SOURCE_NAME = 'sites-dashboard';

--- a/client/state/selectors/get-current-query-arguments.js
+++ b/client/state/selectors/get-current-query-arguments.js
@@ -6,7 +6,7 @@ import 'calypso/state/route/init';
  * Gets the last query parameters set by a ROUTE_SET action
  *
  * @param {Object} state - global redux state
- * @returns {Object.<string, string|string[]>|null} current state value
+ * @returns {Record<string, string|string[]>|null} current state value
  */
 export const getCurrentQueryArguments = ( state ) => get( state, 'route.query.current', null );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
