### PR TITLE
Add links to the tags page

### DIFF
--- a/client/reader/components/reader-blank-suggestions/index.js
+++ b/client/reader/components/reader-blank-suggestions/index.js
@@ -12,8 +12,7 @@ function BlankSuggestions( props ) {
 							suggestions: props.suggestions,
 							tagsLink: (
 								<a href="/tags" onClick={ props.trackTagsPageLinkClick }>
-									{ ' ' }
-									{ props.translate( 'See all tags' ) }{ ' ' }
+									{ props.translate( 'See all tags' ) }
 								</a>
 							),
 						},

--- a/client/reader/components/reader-blank-suggestions/index.js
+++ b/client/reader/components/reader-blank-suggestions/index.js
@@ -5,12 +5,21 @@ import './style.scss';
 function BlankSuggestions( props ) {
 	return (
 		<div className="reader-blank-suggestions">
-			{ props.suggestions &&
-				props.translate( 'Suggestions: {{suggestions /}}', {
-					components: {
-						suggestions: props.suggestions,
-					},
-				} ) }
+			{ props.suggestions && props.suggestions.length > 0 && (
+				<>
+					{ props.translate( 'Suggestions: {{suggestions /}}, {{tagsLink /}}', {
+						components: {
+							suggestions: props.suggestions,
+							tagsLink: (
+								<a href="/tags" onClick={ props.trackTagsPageLinkClick }>
+									{ ' ' }
+									{ props.translate( 'See all tags' ) }{ ' ' }
+								</a>
+							),
+						},
+					} ) }
+				</>
+			) }
 			&nbsp;
 		</div>
 	);

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -97,6 +97,11 @@ class SearchStream extends React.Component {
 		updateQueryArg( { sort } );
 	};
 
+	trackTagsPageLinkClick = () => {
+		recordAction( 'clicked_reader_search_tags_page_link' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_search_tags_page_link_clicked' );
+	};
+
 	handleFixedAreaMounted = ( ref ) => ( this.fixedAreaRef = ref );
 
 	handleSearchTypeSelection = ( searchType ) => updateQueryArg( { show: searchType } );
@@ -189,7 +194,12 @@ class SearchStream extends React.Component {
 							wideDisplay={ wideDisplay }
 						/>
 					) }
-					{ ! query && <BlankSuggestions suggestions={ suggestionList } /> }
+					{ ! query && (
+						<BlankSuggestions
+							suggestions={ suggestionList }
+							trackTagsPageLinkClick={ this.trackTagsPageLinkClick }
+						/>
+					) }
 				</div>
 				<SpacerDiv domTarget={ this.fixedAreaRef } />
 				{ ! hidePostsAndSites && wideDisplay && (

--- a/client/reader/sidebar/reader-sidebar-tags/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list.jsx
@@ -2,6 +2,8 @@ import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import ReaderSidebarTagsListItem from './list-item';
 
 export class ReaderSidebarTagsList extends Component {
@@ -23,11 +25,20 @@ export class ReaderSidebarTagsList extends Component {
 			/>
 		) );
 	}
-
+	trackTagsPageClick() {
+		recordAction( 'clicked_reader_sidebar_tags_page_link' );
+		recordGaEvent( 'Clicked Reader Sidebar Tags Page Link' );
+		recordReaderTracksEvent( 'calypso_reader_sidebar_tags_page_link_clicked' );
+	}
 	render() {
 		return (
 			<li className="reader-sidebar-tags__list">
 				<ul>{ this.renderItems() }</ul>
+				<a className="sidebar__menu-link" href="/tags" onClick={ this.trackTagsPageClick }>
+					<span className="reader-sidebar-tags__all-tags-link">
+						{ this.props.translate( 'See all tags' ) }
+					</span>
+				</a>
 			</li>
 		);
 	}

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -33,6 +33,12 @@
 			}
 		}
 	}
+
+	.reader-sidebar-tags__all-tags-link {
+		color: var(--studio-white);
+		font-weight: bold;
+		margin-bottom: 2px;
+	}
 }
 
 .is-section-reader {

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -28,6 +28,11 @@ const ReaderTagSidebar = ( { tag } ) => {
 		);
 	};
 
+	const trackTagsPageLinkClick = () => {
+		recordAction( 'clicked_reader_sidebar_tags_page_link' );
+		dispatch( recordReaderTracksEvent( 'calypso_reader_sidebar_tags_page_link_clicked' ) );
+	};
+
 	const tagLinks = relatedMetaByTag.data?.related_tags?.map( ( relatedTag ) => (
 		<TagLink tag={ relatedTag } key={ relatedTag.slug } onClick={ handleTagSidebarClick } />
 	) );
@@ -59,6 +64,9 @@ const ReaderTagSidebar = ( { tag } ) => {
 					<div className="reader-post-card__tags">{ tagLinks }</div>
 				</div>
 			) }
+			<a className="reader-tag-sidebar-tags-page" href="/tags" onClick={ trackTagsPageLinkClick }>
+				{ translate( 'See all tags' ) }
+			</a>
 			{ relatedSitesLinks && (
 				<div className="reader-tag-sidebar-related-sites">
 					<h2>{ translate( 'Related Sites' ) }</h2>

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -698,7 +698,8 @@
 	.reader-tag-sidebar-tags-page {
 		display: block;
 		font-size: $font-body-small;
-		font-weight: 600;
+		text-decoration: underline;
+		font-weight: 500;
 		margin-bottom: 32px;
 		color: var(--color-neutral-100);
 	}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -695,6 +695,13 @@
 			margin-bottom: 14px;
 		}
 	}
+	.reader-tag-sidebar-tags-page {
+		display: block;
+		font-size: $font-body-small;
+		font-weight: 600;
+		margin-bottom: 32px;
+		color: var(--color-neutral-100);
+	}
 
 	.reader-tag-sidebar-stats {
 		display: flex;


### PR DESCRIPTION
part of pe7F0s-Qa-p2 adds links to the logged in tags page


### Testing instructions
Go to logged in search page  `/read/search`. There should be a search suggestion and also a link in the sidebar

<img width="883" alt="Screen Shot 2023-05-26 at 2 13 16 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/4a7e5756-282d-4199-a3bb-a18f716e3c11">

On the `/tags` page, there is a link in the right hand sidebar 
<img width="1030" alt="Screen Shot 2023-05-26 at 2 13 56 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/ea1a6b51-91b8-4d93-86e8-ee5de5b1d6b8">

