### PR TITLE
Sites Dashboard: Fix a11y issue with nested h2 tags in empty /sites dashboard

### DIFF
--- a/client/sites-dashboard/components/empty-sites-dashboard.tsx
+++ b/client/sites-dashboard/components/empty-sites-dashboard.tsx
@@ -21,7 +21,7 @@ export const EmptySitesDashboard = () => {
 				},
 			} }
 			title={
-				<h2
+				<span
 					css={ {
 						color: 'var(--studio-gray-100)',
 						fontSize: '3rem',
@@ -31,7 +31,7 @@ export const EmptySitesDashboard = () => {
 					} }
 				>
 					{ __( 'Let’s add your first site' ) }
-				</h2>
+				</span>
 			}
 			illustration=""
 		>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

There's an a11y issue with the `/sites` page empty state. The title has two `<h2>`s nested right after the other

![CleanShot 2023-05-26 at 17 40 39@2x](https://github.com/Automattic/wp-calypso/assets/1500769/9986255b-5caf-4506-aa13-16533558f516)


![CleanShot 2023-05-26 at 17 39 32@2x](https://github.com/Automattic/wp-calypso/assets/1500769/44b7097c-5802-4139-bd3a-20d28ec2c314)

This PR fixes that issue. It looks like it was only done so we could add custom styles to the heading. Luckily a `<span>` works just as well for adding the custom styles.

Another option would be to add a `titleClassName` prop to the `<EmptyContent>` component so you can add custom styles. And that'd do away with the need for the extra element.

**Before**
![before](https://github.com/Automattic/wp-calypso/assets/1500769/3709ed65-6452-4b82-b129-46158f2b9a55)


**After**
![after](https://github.com/Automattic/wp-calypso/assets/1500769/f2b0fa30-f0ea-41af-9b2e-35fefd9f1916)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There should be no visual change

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
