### PR TITLE
Pattern Assembler: Add a site option to ID assembler sites in a8c tools

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -398,7 +398,7 @@ const PatternAssembler = ( {
 							// Newly created sites should reset the starter content created from the default Headstart annotation
 							shouldResetContent: isNewSite,
 							// Also, new sites except for virtual themes set the option wpcom_site_setup=assembler
-							shouldSetSiteSetupOption: ( isNewSite && ! design.is_virtual ) ?? 'assembler',
+							setSiteSetupOption: ( isNewSite && ! design.is_virtual ) ?? 'assembler',
 						} )
 					)
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -398,7 +398,7 @@ const PatternAssembler = ( {
 							// Newly created sites should reset the starter content created from the default Headstart annotation
 							shouldResetContent: isNewSite,
 							// Also, new sites except for virtual themes set the option wpcom_site_setup=assembler
-							setSiteSetupOption: isNewSite && ! design.is_virtual ? 'assembler' : '',
+							siteSetupOption: isNewSite && ! design.is_virtual ? 'assembler' : '',
 						} )
 					)
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -81,6 +81,7 @@ const PatternAssembler = ( {
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const locale = useLocale();
+	// New sites are created from 'site-setup' and 'with-site-assembler' flows
 	const isNewSite = !! useQuery().get( 'isNewSite' ) || isSiteSetupFlow( flow );
 	const isSiteJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 
@@ -394,7 +395,10 @@ const PatternAssembler = ( {
 							headerHtml: header?.html,
 							footerHtml: footer?.html,
 							globalStyles: syncedGlobalStylesUserConfig,
+							// Newly created sites should reset the starter content created from the default Headstart annotation
 							shouldResetContent: isNewSite,
+							// Also, new sites except for virtual themes set the option wpcom_site_setup=assembler
+							shouldSetSiteSetupOption: ( isNewSite && ! design.is_virtual ) ?? 'assembler',
 						} )
 					)
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -398,7 +398,7 @@ const PatternAssembler = ( {
 							// Newly created sites should reset the starter content created from the default Headstart annotation
 							shouldResetContent: isNewSite,
 							// Also, new sites except for virtual themes set the option wpcom_site_setup=assembler
-							setSiteSetupOption: ( isNewSite && ! design.is_virtual ) ?? 'assembler',
+							setSiteSetupOption: isNewSite && ! design.is_virtual ? 'assembler' : '',
 						} )
 					)
 			);

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -544,7 +544,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			footerHtml,
 			globalStyles,
 			shouldResetContent,
-			setSiteSetupOption,
+			siteSetupOption,
 		}: AssembleSiteOptions = {}
 	) {
 		const templates: RequestTemplate[] = [
@@ -578,7 +578,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 				templates,
 				global_styles: globalStyles,
 				should_reset_content: shouldResetContent,
-				set_site_setup_option: setSiteSetupOption,
+				set_site_setup_option: siteSetupOption,
 			},
 			method: 'POST',
 		} );

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -578,7 +578,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 				templates,
 				global_styles: globalStyles,
 				should_reset_content: shouldResetContent,
-				set_site_setup_option: siteSetupOption,
+				site_setup_option: siteSetupOption,
 			},
 			method: 'POST',
 		} );

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -538,7 +538,14 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 	function* assembleSite(
 		siteSlug: string,
 		stylesheet = '',
-		{ homeHtml, headerHtml, footerHtml, globalStyles, shouldResetContent }: AssembleSiteOptions = {}
+		{
+			homeHtml,
+			headerHtml,
+			footerHtml,
+			globalStyles,
+			shouldResetContent,
+			setSiteSetupOption,
+		}: AssembleSiteOptions = {}
 	) {
 		const templates: RequestTemplate[] = [
 			{
@@ -571,6 +578,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 				templates,
 				global_styles: globalStyles,
 				should_reset_content: shouldResetContent,
+				set_site_setup_option: setSiteSetupOption,
 			},
 			method: 'POST',
 		} );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -517,4 +517,5 @@ export interface AssembleSiteOptions {
 	footerHtml?: string;
 	globalStyles?: GlobalStyles;
 	shouldResetContent?: boolean;
+	setSiteSetupOption?: string;
 }

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -517,5 +517,5 @@ export interface AssembleSiteOptions {
 	footerHtml?: string;
 	globalStyles?: GlobalStyles;
 	shouldResetContent?: boolean;
-	setSiteSetupOption?: string;
+	siteSetupOption?: string;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #71988 
Related #77152 https://github.com/Automattic/nosara/pull/6352 D113373-code 

## Proposed Changes

* Set the option `wpcom_site_setup=assembler` for newly created sites except for virtual themes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Sandbox D111997-code

**Test 1**
- Create a new site from `/start`
- Continue until the Design picker and choose
  - a) A virtual theme (Their name start with `Link in Bio:`)
  - b) Start designing 
- Continue to complete the assembler flow
- Verify that the site has the site option `wpcom_site_setup=assembler` in `{ YOUR SITE }/wp-admin/options.php` **only if you selected a non-virtual theme**

<img width="687" alt="Screenshot 2566-05-26 at 15 03 26" src="https://github.com/Automattic/wp-calypso/assets/1881481/d0a0b432-e22a-4df9-a514-da4ac85ff34a">

**Test 2**

- Create a new site from the logged-out theme showcase `/themes`
- Click on Start designing 
- Log in
- Click Continue to complete the assembler flow
- Verify that the site has the site option `wpcom_site_setup=assembler` in `{ YOUR SITE }/wp-admin/options.php`



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?