### PR TITLE
Stats: Add static weekly highlights period toggle panel

### DIFF
--- a/config/client.json
+++ b/config/client.json
@@ -25,6 +25,7 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
+	"stats/highlights-settings",
 	"stats/new-video-summary",
 	"stats/subscribers-section",
 	"wpcom_concierge_schedule_id",

--- a/config/development.json
+++ b/config/development.json
@@ -181,6 +181,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": false,
+		"stats/highlights-settings": false,
 		"stats/new-video-summary": true,
 		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -120,6 +120,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
+		"stats/highlights-settings": false,
 		"stats/new-video-summary": false,
 		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,

--- a/config/production.json
+++ b/config/production.json
@@ -147,6 +147,7 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
+		"stats/highlights-settings": false,
 		"stats/new-video-summary": false,
 		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -139,6 +139,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
+		"stats/highlights-settings": false,
 		"stats/new-video-summary": false,
 		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,

--- a/config/test.json
+++ b/config/test.json
@@ -98,6 +98,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
+		"stats/highlights-settings": false,
 		"stats/new-video-summary": false,
 		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -151,6 +151,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
+		"stats/highlights-settings": false,
 		"stats/new-video-summary": false,
 		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -198,6 +198,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		}
 	}
 
+	// @TODO: Introduce the support for the border of white background arrows in the popover component.
 	// Set the border of the white background bottom arrows.
 	&.highlight-card-popover {
 		&.is-bottom,

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -53,6 +53,22 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	@include stats-section-header;
 
 	margin-bottom: $header-margin-bottom;
+	display: flex;
+	align-items: center;
+
+	.highlight-cards-heading__tooltip {
+		margin-left: 6px;
+	}
+
+	.highlight-cards-heading__settings {
+		margin-left: auto;
+	}
+
+	.highlight-cards-heading__settings-action {
+		width: 24px;
+		height: 24px;
+		cursor: pointer;
+	}
 
 	small {
 		font-family: $highlight-card-heading-font;
@@ -171,14 +187,81 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		margin-bottom: $header-margin-bottom;
 	}
 }
-.tooltip.popover.highlight-card-tooltip { // overload tooltip's styles
-	.popover__inner {
-		padding: 16px 24px;
-		width: 244px;
-		box-sizing: border-box;
-		border-radius: 5px; // stylelint-disable-line scales/radii
+.tooltip.popover {
+	&.highlight-card-tooltip,
+	&.highlight-card-popover { // overload tooltip's styles
+		.popover__inner {
+			padding: 16px 24px;
+			width: 244px;
+			box-sizing: border-box;
+			border-radius: 5px; // stylelint-disable-line scales/radii
+		}
+	}
+
+	// Set the border of the white background bottom arrows.
+	&.highlight-card-popover {
+		&.is-bottom,
+		&.is-bottom-left,
+		&.is-bottom-right {
+			.popover__arrow {
+				border-bottom-color: var(--studio-white);
+
+				&::before {
+					display: block;
+					position: absolute;
+					content: "";
+					border: 6px solid var(--studio-gray-5);
+					border-top: 0;
+					border-left-color: transparent;
+					border-right-color: transparent;
+					left: 4px;
+					top: 0;
+				}
+
+				&::after {
+					display: block;
+					position: absolute;
+					content: "";
+					border: 6px solid var(--studio-white);
+					border-top: 0;
+					border-left-color: transparent;
+					border-right-color: transparent;
+					left: -6px;
+					top: 1px;
+				}
+			}
+		}
+
+		.popover__inner {
+			background-color: var(--studio-white);
+			border: 1px solid var(--studio-gray-5);
+			box-shadow: 0 12px 20px rgba(0, 0, 0, 0.08);
+
+			& > button {
+				width: 100%;
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				cursor: pointer;
+				color: var(--studio-gray-80);
+				font-family: $font-sf-pro-text;
+				font-weight: 500;
+				font-size: $font-body-small;
+				line-height: 24px;
+				letter-spacing: -0.02em;
+
+				svg {
+					fill: var(--studio-gray-30);
+				}
+
+				&:not(:first-child) {
+					margin-top: 12px;
+				}
+			}
+		}
 	}
 }
+
 .highlight-card-tooltip-content {
 	display: flex;
 	align-items: center;

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -53,7 +53,7 @@ export default function WeeklyHighlightCards( {
 	const textRef = useRef( null );
 	const settingsActionRef = useRef( null );
 	const [ isTooltipVisible, setTooltipVisible ] = useState( false );
-	const [ isPopoverVisible, setPopoverVisible ] = useState( true );
+	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
 
 	const togglePopoverMenu = () => {
 		setPopoverVisible( ! isPopoverVisible );
@@ -128,7 +128,7 @@ export default function WeeklyHighlightCards( {
 							</button>
 							<button>
 								{ translate( '30-day highlights' ) }
-								<Icon className="gridicon" icon={ check } />
+								{ false && <Icon className="gridicon" icon={ check } /> }
 							</button>
 						</Popover>
 					</div>

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -1,4 +1,12 @@
-import { commentContent, Icon, people, starEmpty, info } from '@wordpress/icons';
+import {
+	commentContent,
+	Icon,
+	people,
+	starEmpty,
+	info,
+	moreVertical,
+	check,
+} from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
@@ -42,48 +50,84 @@ export default function WeeklyHighlightCards( {
 	const translate = useTranslate();
 
 	const textRef = useRef( null );
+	const settingsActionRef = useRef( null );
 	const [ isTooltipVisible, setTooltipVisible ] = useState( false );
+	const [ isPopoverVisible, setPopoverVisible ] = useState( true );
+
+	const togglePopoverMenu = () => {
+		setPopoverVisible( ! isPopoverVisible );
+	};
 
 	return (
 		<div className={ classNames( 'highlight-cards', className ?? null ) }>
 			<h3 className="highlight-cards-heading">
-				{ translate( '7-day highlights' ) }{ ' ' }
-				<span
-					className="highlight-cards-heading-icon"
-					ref={ textRef }
-					onMouseEnter={ () => setTooltipVisible( true ) }
-					onMouseLeave={ () => setTooltipVisible( false ) }
-				>
-					<Icon className="gridicon" icon={ info } />
-				</span>
-				<Popover
-					className="tooltip tooltip--darker highlight-card-tooltip"
-					isVisible={ isTooltipVisible }
-					position="bottom right"
-					context={ textRef.current }
-				>
-					<div className="highlight-card-tooltip-content comparing-info">
-						<p>{ translate( 'Highlights displayed are for the last 7 days, excluding today.' ) }</p>
-						<p>
-							{ translate( 'Trends shown are in comparison to the previous 7 days before that.' ) }
-						</p>
-						<div className="comparing-info-chart">
-							<small>
-								{ translate( '%(fourteen)d days {{vs/}} %(seven)d days', {
-									components: {
-										vs: <span>vs</span>,
-									},
-									args: {
-										fourteen: 14,
-										seven: 7,
-									},
-								} ) }
-							</small>
-							{ comparingInfoRangeChart }
-							{ comparingInfoBarsChart }
+				<span>{ translate( '7-day highlights' ) }</span>
+				<div className="highlight-cards-heading__tooltip">
+					<span
+						className="highlight-cards-heading-icon"
+						ref={ textRef }
+						onMouseEnter={ () => setTooltipVisible( true ) }
+						onMouseLeave={ () => setTooltipVisible( false ) }
+					>
+						<Icon className="gridicon" icon={ info } />
+					</span>
+					<Popover
+						className="tooltip tooltip--darker highlight-card-tooltip"
+						isVisible={ isTooltipVisible }
+						position="bottom right"
+						context={ textRef.current }
+					>
+						<div className="highlight-card-tooltip-content comparing-info">
+							<p>
+								{ translate( 'Highlights displayed are for the last 7 days, excluding today.' ) }
+							</p>
+							<p>
+								{ translate(
+									'Trends shown are in comparison to the previous 7 days before that.'
+								) }
+							</p>
+							<div className="comparing-info-chart">
+								<small>
+									{ translate( '%(fourteen)d days {{vs/}} %(seven)d days', {
+										components: {
+											vs: <span>vs</span>,
+										},
+										args: {
+											fourteen: 14,
+											seven: 7,
+										},
+									} ) }
+								</small>
+								{ comparingInfoRangeChart }
+								{ comparingInfoBarsChart }
+							</div>
 						</div>
-					</div>
-				</Popover>
+					</Popover>
+				</div>
+				<div className="highlight-cards-heading__settings">
+					<button
+						className="highlight-cards-heading__settings-action"
+						ref={ settingsActionRef }
+						onClick={ togglePopoverMenu }
+					>
+						<Icon className="gridicon" icon={ moreVertical } />
+					</button>
+					<Popover
+						className="tooltip highlight-card-popover"
+						isVisible={ isPopoverVisible }
+						position="bottom left"
+						context={ settingsActionRef.current }
+					>
+						<button>
+							{ translate( '7-day highlights' ) }
+							<Icon className="gridicon" icon={ check } />
+						</button>
+						<button>
+							{ translate( '30-day highlights' ) }
+							<Icon className="gridicon" icon={ check } />
+						</button>
+					</Popover>
+				</div>
 			</h3>
 
 			<div className="highlight-cards-list">

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	commentContent,
 	Icon,
@@ -58,6 +59,8 @@ export default function WeeklyHighlightCards( {
 		setPopoverVisible( ! isPopoverVisible );
 	};
 
+	const isHighlightsSettingsEnabled = config.isEnabled( 'stats/highlights-settings' );
+
 	return (
 		<div className={ classNames( 'highlight-cards', className ?? null ) }>
 			<h3 className="highlight-cards-heading">
@@ -104,30 +107,32 @@ export default function WeeklyHighlightCards( {
 						</div>
 					</Popover>
 				</div>
-				<div className="highlight-cards-heading__settings">
-					<button
-						className="highlight-cards-heading__settings-action"
-						ref={ settingsActionRef }
-						onClick={ togglePopoverMenu }
-					>
-						<Icon className="gridicon" icon={ moreVertical } />
-					</button>
-					<Popover
-						className="tooltip highlight-card-popover"
-						isVisible={ isPopoverVisible }
-						position="bottom left"
-						context={ settingsActionRef.current }
-					>
-						<button>
-							{ translate( '7-day highlights' ) }
-							<Icon className="gridicon" icon={ check } />
+				{ isHighlightsSettingsEnabled && (
+					<div className="highlight-cards-heading__settings">
+						<button
+							className="highlight-cards-heading__settings-action"
+							ref={ settingsActionRef }
+							onClick={ togglePopoverMenu }
+						>
+							<Icon className="gridicon" icon={ moreVertical } />
 						</button>
-						<button>
-							{ translate( '30-day highlights' ) }
-							<Icon className="gridicon" icon={ check } />
-						</button>
-					</Popover>
-				</div>
+						<Popover
+							className="tooltip highlight-card-popover"
+							isVisible={ isPopoverVisible }
+							position="bottom left"
+							context={ settingsActionRef.current }
+						>
+							<button>
+								{ translate( '7-day highlights' ) }
+								<Icon className="gridicon" icon={ check } />
+							</button>
+							<button>
+								{ translate( '30-day highlights' ) }
+								<Icon className="gridicon" icon={ check } />
+							</button>
+						</Popover>
+					</div>
+				) }
 			</h3>
 
 			<div className="highlight-cards-list">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77425 

## Proposed Changes

> Note: The functionality of data toggling is still in progress.
* Introduce the period toggle panel with the component `Popover`.
* Gate the feature with the flag `stats/highlights-settings`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the live branch link.
* Ensure the highlights section of the `Traffic` page works as previously.
* Append the feature flag to the URL: `?flags=stats/highlights-settings`.
* Ensure the toggle button and panel are in line with the design.

<img width="1293" alt="截圖 2023-05-26 下午4 43 48" src="https://github.com/Automattic/wp-calypso/assets/6869813/88bd7dd1-613c-4227-af3f-ef44e1540c01">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
