### PR TITLE
Update the link to the support doc regarding "upgrade credits"

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -97,7 +97,7 @@ export default function PlanNotice( {
 							a: (
 								<a
 									href={ localizeUrl(
-										'https://wordpress.com/support/manage-purchases/#pro-rated-credits'
+										'https://wordpress.com/support/manage-purchases/#upgrade-credit'
 									) }
 									className="get-apps__desktop-link"
 								/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
# Proposed Changes

This PR updates the link to the support doc regarding "upgrade credits" to the latest one.
<img width="962" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/44eca565-5ab8-4c8f-aba4-3b9492f15488">


## Testing Instructions

* Log-in into a site on a paid plan.
* Go to `/plans`
* In the upgrade credits notice, make sure the anchor "upgrade credits" now links to https://wordpress.com/support/manage-purchases/#update-credits

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
