### PR TITLE
Add back intent for start-writing

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/launchpad/use-launchpad.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/launchpad/use-launchpad.js
@@ -1,0 +1,34 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect, useCallback } from '@wordpress/element';
+
+const useLaunchpadTasksCompleted = () => {
+	const [ launchpadTasksCompleted, setLaunchpadTasksCompleted ] = useState( undefined );
+	const [ launchpadSiteIntent, setLaunchpadIntent ] = useState( undefined );
+	const [ launchpadFetched, setLaunchpadFetched ] = useState( false );
+
+	const fetchLaunchpad = useCallback( () => {
+		apiFetch( { path: '/wpcom/v2/launchpad' } )
+			.then( ( result ) => {
+				const checklist = result.checklist;
+				if ( checklist ) {
+					const lastTask = checklist[ checklist.length - 1 ];
+					if ( lastTask.completed ) {
+						setLaunchpadTasksCompleted( true );
+						setLaunchpadIntent( result.site_intent );
+						setLaunchpadFetched( true );
+					}
+				}
+			} )
+			.catch( () => {
+				setLaunchpadTasksCompleted( undefined );
+				setLaunchpadIntent( undefined );
+				setLaunchpadFetched( false );
+			} );
+	}, [] );
+
+	useEffect( () => {
+		fetchLaunchpad();
+	}, [ fetchLaunchpad ] );
+	return { launchpadTasksCompleted, launchpadFetched, launchpadSiteIntent };
+};
+export default useLaunchpadTasksCompleted;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -4,7 +4,7 @@ import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordp
 import { useEffect, createPortal, useState } from '@wordpress/element';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
 import { getQueryArg } from '@wordpress/url';
-import useSiteIntent from '../../dotcom-fse/lib/site-intent/use-site-intent';
+import useLaunchpadTasksCompleted from '../../dotcom-fse/lib/launchpad/use-launchpad';
 import WpcomBlockEditorNavSidebar from './components/nav-sidebar';
 import ToggleSidebarButton from './components/toggle-sidebar-button';
 
@@ -36,10 +36,18 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 				// eslint-disable-next-line react-hooks/exhaustive-deps
 			}, [] );
 
-			const { siteIntent: intent } = useSiteIntent();
+			const {
+				launchpadSiteIntent: intent,
+				launchpadTasksCompleted,
+				launchpadFetched,
+			} = useLaunchpadTasksCompleted();
+
+			const hasStartWritingFlowActiveFromApi = launchpadFetched
+				? intent === START_WRITING_FLOW && ! launchpadTasksCompleted
+				: false;
 			// We check the URL param along with site intent because the param loads faster and prevents element flashing.
 			const isStartWritingFlow =
-				intent === START_WRITING_FLOW ||
+				hasStartWritingFlowActiveFromApi ||
 				getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
 
 			const [ clickGuardRoot ] = useState( () => document.createElement( 'div' ) );

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -1,25 +1,45 @@
 import { dispatch, select, subscribe } from '@wordpress/data';
 import { getQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
-import useSiteIntent from './use-site-intent';
+import useLaunchpadTasksCompleted from './use-launchpad';
 
 const START_WRITING_FLOW = 'start-writing';
 
 export function RedirectOnboardingUserAfterPublishingPost() {
-	const { siteIntent: intent } = useSiteIntent();
+	// const { siteIntent: intent } = useSiteIntent();
+	const {
+		launchpadSiteIntent: intent,
+		launchpadTasksCompleted,
+		launchpadFetched,
+	} = useLaunchpadTasksCompleted();
 
 	useEffect( () => {
 		// We check the URL param along with site intent because the param loads faster and prevents element flashing.
 		const hasStartWritingFlowQueryArg =
 			getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
 
-		if ( intent === START_WRITING_FLOW || hasStartWritingFlowQueryArg ) {
+		const hasStartWritingFlowActiveFromApi = launchpadFetched
+			? intent === START_WRITING_FLOW && ! launchpadTasksCompleted
+			: false;
+
+		if ( hasStartWritingFlowActiveFromApi || hasStartWritingFlowQueryArg ) {
 			dispatch( 'core/edit-post' ).closeGeneralSidebar();
 			document.documentElement.classList.add( 'start-writing-hide' );
 		}
-	}, [ intent ] );
+	}, [ intent, launchpadTasksCompleted, launchpadFetched ] );
+
+	// Wait for API calls to return before going to the next step.
+	if ( ! launchpadFetched ) {
+		return false;
+	}
 
 	if ( intent !== START_WRITING_FLOW ) {
+		return false;
+	}
+
+	// If the user has already completed the launchpad tasks,
+	// treat this post as a regular post and don't do anything else.
+	if ( launchpadTasksCompleted ) {
 		return false;
 	}
 
@@ -44,7 +64,6 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 			getCurrentPostRevisionsCount >= 1
 		) {
 			unsubscribe();
-
 			dispatch( 'core/edit-post' ).closePublishSidebar();
 			window.location.href = `${ siteOrigin }/setup/start-writing/launchpad?siteSlug=${ siteSlug }&${ START_WRITING_FLOW }=true`;
 		}

--- a/apps/wpcom-block-editor/src/wpcom/features/use-launchpad.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/use-launchpad.js
@@ -1,0 +1,34 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect, useCallback } from '@wordpress/element';
+
+const useLaunchpadTasksCompleted = () => {
+	const [ launchpadTasksCompleted, setLaunchpadTasksCompleted ] = useState( undefined );
+	const [ launchpadSiteIntent, setLaunchpadIntent ] = useState( undefined );
+	const [ launchpadFetched, setLaunchpadFetched ] = useState( false );
+
+	const fetchLaunchpad = useCallback( () => {
+		apiFetch( { path: '/wpcom/v2/launchpad' } )
+			.then( ( result ) => {
+				const checklist = result.checklist;
+				if ( checklist ) {
+					const lastTask = checklist[ checklist.length - 1 ];
+					if ( lastTask.completed ) {
+						setLaunchpadTasksCompleted( true );
+						setLaunchpadIntent( result.site_intent );
+						setLaunchpadFetched( true );
+					}
+				}
+			} )
+			.catch( () => {
+				setLaunchpadTasksCompleted( undefined );
+				setLaunchpadIntent( undefined );
+				setLaunchpadFetched( false );
+			} );
+	}, [] );
+
+	useEffect( () => {
+		fetchLaunchpad();
+	}, [ fetchLaunchpad ] );
+	return { launchpadTasksCompleted, launchpadFetched, launchpadSiteIntent };
+};
+export default useLaunchpadTasksCompleted;

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -101,9 +101,6 @@ const startWriting: Flow = {
 
 					// If the user's site has just been launched.
 					if ( providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
-						// Remove the site_intent.
-						await setIntentOnSite( providedDependencies?.siteSlug, '' );
-
 						// If the user launched their site with a plan or domain in their cart, redirect them to
 						// checkout before sending them home.
 						if ( getPlanCartItem() || getDomainCartItem() ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2552

## Proposed Changes

KNOWN ISSUES: I haven't figured out how the hide "W" icon works or maybe I didn't sync the correct code while sandboxing, so would love some help on this.

Our previous approach was to remove the intent to fix an editor issue: https://github.com/Automattic/wp-calypso/pull/77041, but it made it hard to know whether the user has launched their site AND also completed the launchpad tasks (since without the intent, it will use the wrong task checklist).

* Add back intent so that the launchpad can redirect normally after all tasks have been completed
* Make sure that the bug below is fixed:

https://github.com/Automattic/wp-calypso/assets/6586048/4dabb17a-6a1c-4e98-91e0-5c2aff907811


Related thread to the bug above☝️ : p1684353622930969/1684353585.804819-slack-CKZHG0QCR

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout to this branch
* Make sure you're in sandboxed environment, also sandbox `widgets.wp.com`
* Sync editing-toolkit to sandbox by `cd apps/editing-toolkit` and `yarn dev --sync`
* Sync wpcom-block-editor to sandbox by `cd apps/wpcom-block-editor` and `yarn dev --sync`
* Go through the `/setup/start-writing` flow with an account that has 0 sites
* Finish all launchpad tasks and launch the site
* Go to posts and edit the original (first) post made when you were going through the flow
* Make sure you stay on the page and no weird redirects as in the above video
* Since the right sidebar will be closed due to the initial setting, open the right sidebar and refresh and make sure it stays there
![sidebar](https://github.com/Automattic/wp-calypso/assets/6586048/6fdd022a-cad0-4850-8562-00d0c0ca03fd)

* test around the start-writing flow and make sure we didn't break anything that was working already


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?