### PR TITLE
Gluing new migration plugin flow steps

### DIFF
--- a/client/blocks/import/util.ts
+++ b/client/blocks/import/util.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { capitalize } from 'lodash';
 import { ImporterPlatform } from './types';
 
@@ -77,6 +78,10 @@ export function getWpComOnboardingUrl(
 
 		case 'stepper':
 		default:
+			if ( platform === 'wordpress' && isEnabled( 'onboarding/import-redesign' ) ) {
+				route = 'importer{importer}?siteSlug={siteSlug}&from={fromSite}&option=everything&run=true';
+				break;
+			}
 			route = 'importer{importer}?siteSlug={siteSlug}&from={fromSite}&run=true';
 			break;
 	}

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Design, isBlankCanvasDesign } from '@automattic/design-picker';
 import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -160,6 +161,15 @@ const importFlow: Flow = {
 
 				case 'processing': {
 					if ( providedDependencies?.siteSlug ) {
+						if ( isEnabled( 'onboarding/import-redesign' ) && fromParam ) {
+							const slectedSiteSlug = providedDependencies?.siteSlug as string;
+							urlQueryParams.set( 'siteSlug', slectedSiteSlug );
+							urlQueryParams.set( 'from', fromParam );
+							urlQueryParams.set( 'option', 'everything' );
+
+							return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
+						}
+
 						return ! fromParam
 							? navigate( `import?siteSlug=${ providedDependencies?.siteSlug }` )
 							: navigate(

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { planHasFeature, FEATURE_UPLOAD_THEMES_PLUGINS } from '@automattic/calypso-products';
 import { Button, Card, CompactCard, ProgressBar, Gridicon, Spinner } from '@automattic/components';
 import { getLocaleSlug, localize } from 'i18n-calypso';
@@ -232,7 +233,8 @@ export class SectionMigrate extends Component {
 	setUrl = ( event ) => this.setState( { url: event.target.value } );
 
 	startMigration = ( trackingProps = {} ) => {
-		const { sourceSiteId, targetSiteId, targetSite } = this.props;
+		const { sourceSiteId, targetSiteId, targetSite, isMigrateFromWp } = this.props;
+		const shouldCheckMigrationPlugin = isMigrateFromWp && isEnabled( 'onboarding/import-redesign' );
 
 		if ( ! sourceSiteId || ! targetSiteId ) {
 			return;
@@ -256,6 +258,9 @@ export class SectionMigrate extends Component {
 			.post( {
 				path: `/sites/${ targetSiteId }/migrate-from/${ sourceSiteId }`,
 				apiNamespace: 'wpcom/v2',
+				body: {
+					check_migration_plugin: shouldCheckMigrationPlugin,
+				},
 			} )
 			.then( () => this.updateFromAPI() )
 			.catch( ( error ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77196, #77235, #77386

## Proposed Changes

This PR is gluing everything together for the new migration plugin flow, and also tweak a little for normal flow as well. It does:
* Adding a new `check_migration_plugin` params to the migration endpoint, since we do not want to break the current user experience on production, we can only check and see if it's true on the latest development version, it'll take care by `isMigrateFromWp` props after the new version of the plugin is out.
* Once user clicks `create a new one` button from the site picker, they should be navigate to the plans/ migrate ready page.
* For the current importer flow, we no longer navigate to the content chooser screen, we navigate to plans page instead. See Zrk1NoQocqdk3uTphuuey4-fi-74_7073 for the flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test scenario 1:**
- Create a JN site with the latest developing version of `Move to WordPress.com` plugin, go through the steps and start a migration. Looking into the network tab and looking for `migrate-from` endpoint. See if there's a `check_migration_plugin` param, it should be `true`.
- Create a JN site with Jetpack plugin only, connect to your WordPress.com user account first, and go through the normal importer flow. Looking into the network tab and looking for `migrate-from` endpoint. See if there's a `check_migration_plugin` param, it should be `true`.

**Test scenario 2:**
- Create a JN site with the latest developing version of `Move to WordPress.com` plugin, go to the plugin homepage and click `Get started` CTA. Connecting to your WordPress.com user account, and click `create a new one` on the site picker step, see if it navigates you to the plans page after the site creation.

**Test scenario 3:**
- Start with normal importer flow. Navigate to`http://calypso.localhost:3000/setup/import-focused/import?siteSlug=${your_target_site}`. Fill in your source site url, once you landed on the ready preview page, click `Import your content` button, make sure it's going to the plans page and not the content chooser screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?