### PR TITLE
Social previews | Get rid of `dangerouslySetInnerHTML`

### DIFF
--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.0.1-beta.1",
+	"version": "2.0.1-beta.2",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
@@ -42,6 +42,7 @@
 	"dependencies": {
 		"@emotion/react": "^11.4.1",
 		"@wordpress/components": "^22.1.0",
+		"@wordpress/element": "^5.11.0",
 		"@wordpress/i18n": "^4.22.0",
 		"classnames": "^2.3.1",
 		"prop-types": "^15.7.2",

--- a/packages/social-previews/src/facebook-preview/custom-text.tsx
+++ b/packages/social-previews/src/facebook-preview/custom-text.tsx
@@ -1,5 +1,5 @@
-import { hasTag } from '../helpers';
-import { facebookCustomText } from './helpers';
+import { hasTag, preparePreviewText } from '../helpers';
+import { CUSTOM_TEXT_LENGTH } from './helpers';
 
 type Props = {
 	text: string;
@@ -25,10 +25,12 @@ const CustomText: React.FC< Props > = ( { text, url, forceUrlDisplay } ) => {
 
 	return (
 		<p className="facebook-preview__custom-text">
-			<span
-				// eslint-disable-next-line react/no-danger
-				dangerouslySetInnerHTML={ { __html: facebookCustomText( text, { allowedTags: [ 'a' ] } ) } }
-			/>
+			<span>
+				{ preparePreviewText( text, {
+					platform: 'facebook',
+					maxChars: CUSTOM_TEXT_LENGTH,
+				} ) }
+			</span>
 			{ postLink }
 		</p>
 	);

--- a/packages/social-previews/src/facebook-preview/helpers.ts
+++ b/packages/social-previews/src/facebook-preview/helpers.ts
@@ -2,7 +2,7 @@ import { firstValid, hardTruncation, shortEnough, stripHtmlTags, Formatter } fro
 
 const TITLE_LENGTH = 110;
 const DESCRIPTION_LENGTH = 200;
-const CUSTOM_TEXT_LENGTH = 440;
+export const CUSTOM_TEXT_LENGTH = 440;
 
 export const baseDomain: Formatter = ( url ) =>
 	url
@@ -20,9 +20,3 @@ export const facebookDescription: Formatter = ( text ) =>
 		shortEnough( DESCRIPTION_LENGTH ),
 		hardTruncation( DESCRIPTION_LENGTH )
 	)( stripHtmlTags( text ) ) || '';
-
-export const facebookCustomText: Formatter = ( text, options ) =>
-	firstValid(
-		shortEnough( CUSTOM_TEXT_LENGTH ),
-		hardTruncation( CUSTOM_TEXT_LENGTH )
-	)( stripHtmlTags( text, options?.allowedTags ) ) || '';

--- a/packages/social-previews/src/helpers.tsx
+++ b/packages/social-previews/src/helpers.tsx
@@ -1,3 +1,6 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
+
 export type Formatter = ( text: string, options?: any ) => string;
 type AugmentFormatterReturnType< T extends Formatter, TNewReturn > = (
 	...a: Parameters< T >
@@ -49,20 +52,35 @@ export const formatTweetDate = new Intl.DateTimeFormat( 'en-US', {
 	day: 'numeric',
 } ).format;
 
-type Platform = 'twitter' | 'facebook' | 'linkedin' | 'instagram';
+export type Platform = 'twitter' | 'facebook' | 'linkedin' | 'instagram';
 
 type PreviewTextOptions = {
 	platform: Platform;
 	maxChars?: number;
 	maxLines?: number;
 	hyperlinkUrls?: boolean;
+	hyperlinkHashtags?: boolean;
+};
+
+export const hashtagUrlMap: Record< Platform, string > = {
+	twitter: 'https://twitter.com/hashtag/%s',
+	facebook: 'https://www.facebook.com/hashtag/%s',
+	linkedin: 'https://www.linkedin.com/feed/hashtag/?keywords=%s',
+	instagram: 'https://www.instagram.com/explore/tags/%s',
 };
 
 /**
  * Prepares the text for the preview.
  */
-export function preparePreviewText( text: string, options: PreviewTextOptions ): string {
-	const { platform, maxChars, maxLines, hyperlinkUrls = true } = options;
+export function preparePreviewText( text: string, options: PreviewTextOptions ): React.ReactNode {
+	const {
+		platform,
+		maxChars,
+		maxLines,
+		hyperlinkHashtags = true,
+		// Instagram doesn't support hyperlink URLs at the moment.
+		hyperlinkUrls = 'instagram' !== platform,
+	} = options;
 
 	let result = stripHtmlTags( text );
 
@@ -78,35 +96,91 @@ export function preparePreviewText( text: string, options: PreviewTextOptions ):
 		}
 	}
 
+	const componentMap: Record< string, React.ReactNode > = {};
+
 	if ( hyperlinkUrls ) {
 		// Convert URLs to hyperlinks.
-		result = result.replace(
-			// TODO: Use a better regex here to match the URLs without protocol.
-			/(https?:\/\/\S+)/g,
-			'<a href="$1" rel="noopener noreferrer" target="_blank">$1</a>'
-		);
+		// TODO: Use a better regex here to match the URLs without protocol.
+		const urls = result.match( /(https?:\/\/\S+)/g ) || [];
+
+		/**
+		 * BEFORE:
+		 * result = 'Check out this cool site: https://wordpress.org and this one: https://wordpress.com'
+		 */
+		urls.forEach( ( url, index ) => {
+			// Add the element to the component map.
+			componentMap[ `Link${ index }` ] = (
+				<a href={ url } rel="noopener noreferrer" target="_blank">
+					{ url }
+				</a>
+			);
+			// Replace the URL with the component placeholder.
+			result = result.replace( url, `<Link${ index } />` );
+		} );
+		/**
+		 * AFTER:
+		 * result = 'Check out this cool site: <Link0 /> and this one: <Link1 />'
+		 * componentMap = {
+		 *     Link0: <a href="https://wordpress.org" ...>https://wordpress.org</a>,
+		 *     Link1: <a href="https://wordpress.com" ...>https://wordpress.com</a>
+		 * }
+		 */
 	}
 
-	let hashtagUrl;
+	// Convert hashtags to hyperlinks.
+	if ( hyperlinkHashtags && hashtagUrlMap[ platform ] ) {
+		/**
+		 * We need to ensure that only the standalone hashtags are matched.
+		 * For example, we don't want to match the hash in the URL.
+		 * Thus we need to match the whitespace character before the hashtag or the beginning of the string.
+		 */
+		const hashtags = result.matchAll( /(^|\s)#(\w+)/g );
 
-	if ( 'twitter' === platform ) {
-		hashtagUrl = 'https://twitter.com/hashtag/';
-	} else if ( 'linkedin' === platform ) {
-		hashtagUrl = 'https://www.linkedin.com/feed/hashtag/?keywords=';
-	} else if ( 'instagram' === platform ) {
-		hashtagUrl = 'https://www.instagram.com/explore/tags/';
-	}
+		const hashtagUrl = hashtagUrlMap[ platform ];
 
-	if ( hashtagUrl ) {
-		// Convert hashtags to hyperlinks.
-		result = result.replace(
-			/(^|\s)#(\w+)/g,
-			'$1<a href="' + hashtagUrl + '$2" rel="noopener noreferrer" target="_blank">#$2</a>'
-		);
+		/**
+		 * BEFORE:
+		 * result = `#breaking text with a #hashtag on the #web
+		 * with a url https://github.com/Automattic/wp-calypso#security that has a hash in it`
+		 */
+		[ ...hashtags ].forEach( ( [ fullMatch, whitespace, hashtag ], index ) => {
+			const url = sprintf( hashtagUrl, hashtag );
+
+			// Add the element to the component map.
+			componentMap[ `Hashtag${ index }` ] = (
+				<a href={ url } rel="noopener noreferrer" target="_blank">
+					{ `#${ hashtag }` }
+				</a>
+			);
+
+			// Replace the hashtag with the component placeholder.
+			result = result.replace( fullMatch, `${ whitespace }<Hashtag${ index } />` );
+		} );
+		/**
+		 * AFTER:
+		 * result = `<Hashtag0 /> text with a <Hashtag1 /> on the <Hashtag2 />
+		 * with a url https://github.com/Automattic/wp-calypso#security that has a hash in it`
+		 *
+		 * componentMap = {
+		 *    Hashtag0: <a href="https://twitter.com/hashtag/breaking" ...>#breaking</a>,
+		 *    Hashtag1: <a href="https://twitter.com/hashtag/hashtag" ...>#hashtag</a>,
+		 *    Hashtag2: <a href="https://twitter.com/hashtag/web" ...>#web</a>
+		 * }
+		 */
 	}
 
 	// Convert newlines to <br> tags.
-	result = result.replace( /\n/g, '<br/>' );
+	/**
+	 * BEFORE:
+	 * result = 'This is a text\nwith a newline\nin it'
+	 */
+	result = result.replace( /\n/g, '<br />' );
+	componentMap.br = <br />;
+	/**
+	 * AFTER:
+	 * result = 'This is a text<br />with a newline<br />in it'
+	 * componentMap = { br: <br /> }
+	 */
 
-	return result;
+	return createInterpolateElement( result, componentMap );
 }

--- a/packages/social-previews/src/instagram-preview/post-preview.tsx
+++ b/packages/social-previews/src/instagram-preview/post-preview.tsx
@@ -60,6 +60,7 @@ export function InstagramPostPreview( {
 										platform: 'instagram',
 										maxChars: FEED_TEXT_MAX_LENGTH,
 										maxLines: FEED_TEXT_MAX_LINES,
+										hyperlinkUrls: false,
 									} ),
 								} }
 							/>

--- a/packages/social-previews/src/instagram-preview/post-preview.tsx
+++ b/packages/social-previews/src/instagram-preview/post-preview.tsx
@@ -51,19 +51,14 @@ export function InstagramPostPreview( {
 						<div className="instagram-preview__content--name">{ username }</div>
 						&nbsp;
 						{ caption ? (
-							<div
-								className="instagram-preview__content--text"
-								// TODO: Replace `dangerouslySetInnerHTML` with `createInterpolateElement` inside `preparePreviewText`
-								// eslint-disable-next-line react/no-danger
-								dangerouslySetInnerHTML={ {
-									__html: preparePreviewText( caption, {
-										platform: 'instagram',
-										maxChars: FEED_TEXT_MAX_LENGTH,
-										maxLines: FEED_TEXT_MAX_LINES,
-										hyperlinkUrls: false,
-									} ),
-								} }
-							/>
+							<div className="instagram-preview__content--text">
+								{ preparePreviewText( caption, {
+									platform: 'instagram',
+									maxChars: FEED_TEXT_MAX_LENGTH,
+									maxLines: FEED_TEXT_MAX_LINES,
+									hyperlinkUrls: false,
+								} ) }
+							</div>
 						) : null }
 					</div>
 					<div className="instagram-preview__content--footer">

--- a/packages/social-previews/src/instagram-preview/post-preview.tsx
+++ b/packages/social-previews/src/instagram-preview/post-preview.tsx
@@ -56,7 +56,6 @@ export function InstagramPostPreview( {
 									platform: 'instagram',
 									maxChars: FEED_TEXT_MAX_LENGTH,
 									maxLines: FEED_TEXT_MAX_LINES,
-									hyperlinkUrls: false,
 								} ) }
 							</div>
 						) : null }

--- a/packages/social-previews/src/instagram-preview/post-preview.tsx
+++ b/packages/social-previews/src/instagram-preview/post-preview.tsx
@@ -60,7 +60,6 @@ export function InstagramPostPreview( {
 										platform: 'instagram',
 										maxChars: FEED_TEXT_MAX_LENGTH,
 										maxLines: FEED_TEXT_MAX_LINES,
-										hyperlinkUrls: false,
 									} ),
 								} }
 							/>

--- a/packages/social-previews/src/linkedin-preview/post-preview.tsx
+++ b/packages/social-previews/src/linkedin-preview/post-preview.tsx
@@ -56,18 +56,13 @@ export function LinkedInPostPreview( {
 				</div>
 				<div className="linkedin-preview__content">
 					{ description ? (
-						<div
-							className="linkedin-preview__caption"
-							// TODO: Replace `dangerouslySetInnerHTML` with `createInterpolateElement` inside `preparePreviewText`
-							// eslint-disable-next-line react/no-danger
-							dangerouslySetInnerHTML={ {
-								__html: preparePreviewText( description, {
-									platform: 'linkedin',
-									maxChars: FEED_TEXT_MAX_LENGTH,
-									maxLines: FEED_TEXT_MAX_LINES,
-								} ),
-							} }
-						/>
+						<div className="linkedin-preview__caption">
+							{ preparePreviewText( description, {
+								platform: 'linkedin',
+								maxChars: FEED_TEXT_MAX_LENGTH,
+								maxLines: FEED_TEXT_MAX_LINES,
+							} ) }
+						</div>
 					) : null }
 					{ hasMedia ? (
 						<div className="linkedin-preview__media">

--- a/packages/social-previews/src/twitter-preview/text.tsx
+++ b/packages/social-previews/src/twitter-preview/text.tsx
@@ -11,15 +11,9 @@ export const Text: React.FC< TextProps > = ( { text, url, retainUrl } ) => {
 			? text.substring( 0, text.lastIndexOf( url ) )
 			: text;
 
-	const __html = preparePreviewText( tweetText, { platform: 'twitter' } );
-
 	return (
-		<div
-			className="twitter-preview__text"
-			// We can enable dangerouslySetInnerHTML here, since the text we're using is stripped
-			// of all HTML tags, then only has safe tags added in createTweetMarkup().
-			// eslint-disable-next-line react/no-danger
-			dangerouslySetInnerHTML={ { __html } }
-		/>
+		<div className="twitter-preview__text">
+			{ preparePreviewText( tweetText, { platform: 'twitter' } ) }
+		</div>
 	);
 };

--- a/packages/social-previews/test/helpers.js
+++ b/packages/social-previews/test/helpers.js
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* eslint-disable jest/no-conditional-expect */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { preparePreviewText } from '../src/helpers';
+
+const platformsWithHyperlinkUrls = [ 'facebook', 'linkedin', 'twitter' ];
+
+const platformsWithoutHyperlinkUrls = [ 'instagram' ];
+
+const allPlatforms = [ ...platformsWithHyperlinkUrls, ...platformsWithoutHyperlinkUrls ];
+
+describe( 'preparePreviewText', () => {
+	it( 'should do nothing if there are no hashtags, URLs or new lines', () => {
+		const text = `Some text here which has no URL, no hashtag and no line break`;
+
+		for ( const platform of allPlatforms ) {
+			const { container } = render( preparePreviewText( text, { platform } ) );
+
+			expect( container.innerHTML ).toBe(
+				'Some text here which has no URL, no hashtag and no line break'
+			);
+
+			expect( render( preparePreviewText( '', { platform } ) ).container.innerHTML ).toBe( '' );
+		}
+	} );
+
+	it( 'should convert new lines to `<br /> tags', () => {
+		const text = `Some text with a \n here and another one here\n That is it.`;
+
+		for ( const platform of allPlatforms ) {
+			const { container } = render( preparePreviewText( text, { platform } ) );
+
+			expect( container.innerHTML ).toBe(
+				'Some text with a <br> here and another one here<br> That is it.'
+			);
+		}
+	} );
+
+	it( 'should limit the text to the given number of lines', () => {
+		const text = `This is the first line\nThis is the second line\nthis third and\this 4th`;
+
+		for ( const platform of allPlatforms ) {
+			const { container } = render( preparePreviewText( text, { platform, maxLines: 2 } ) );
+
+			expect( container.innerHTML ).toBe( 'This is the first line<br>This is the second line' );
+		}
+	} );
+
+	it( 'should limit the text to the given number of characters', () => {
+		const text = `This is the first line\nThis is the second line\nthis third and\this 4th`;
+
+		for ( const platform of allPlatforms ) {
+			const { container } = render( preparePreviewText( text, { platform, maxChars: 60 } ) );
+
+			expect( container.innerHTML ).toBe(
+				'This is the first line<br>This is the second line<br>this third an'
+			);
+		}
+	} );
+
+	it( "should convert URLs to hyperlinks by default except for the platforms that don't support it", () => {
+		const text = `Check out this cool site: https://wordpress.org and this one https://wordpress.com also.`;
+
+		for ( const platform of platformsWithHyperlinkUrls ) {
+			const { container } = render( preparePreviewText( text, { platform } ) );
+
+			expect( container.innerHTML ).toBe(
+				'Check out this cool site: <a href="https://wordpress.org" rel="noopener noreferrer" target="_blank">https://wordpress.org</a> and this one <a href="https://wordpress.com" rel="noopener noreferrer" target="_blank">https://wordpress.com</a> also.'
+			);
+		}
+
+		for ( const platform of platformsWithoutHyperlinkUrls ) {
+			const { container } = render( preparePreviewText( text, { platform } ) );
+
+			expect( container.innerHTML ).toBe(
+				'Check out this cool site: https://wordpress.org and this one https://wordpress.com also.'
+			);
+		}
+	} );
+
+	it( 'should NOT convert URLs to hyperlinks when `hyperlinkUrls` is `false`', () => {
+		const text = `Check out this cool site: https://wordpress.org and this one https://wordpress.com also.`;
+
+		for ( const platform of allPlatforms ) {
+			const { container } = render(
+				preparePreviewText( text, { platform, hyperlinkUrls: false } )
+			);
+
+			expect( container.innerHTML ).toBe(
+				'Check out this cool site: https://wordpress.org and this one https://wordpress.com also.'
+			);
+		}
+	} );
+
+	it( 'should convert hashtags to hyperlinks by default', () => {
+		const text = `#breaking text with a #hashtag on the #web\nwith a url https://github.com/Automattic/wp-calypso#security that has a hash in it\n#thisone after a new line`;
+
+		expect(
+			render( preparePreviewText( text, { platform: 'facebook' } ) ).container.innerHTML
+		).toBe(
+			'<a href="https://www.facebook.com/hashtag/breaking" rel="noopener noreferrer" target="_blank">#breaking</a> text with a <a href="https://www.facebook.com/hashtag/hashtag" rel="noopener noreferrer" target="_blank">#hashtag</a> on the <a href="https://www.facebook.com/hashtag/web" rel="noopener noreferrer" target="_blank">#web</a><br>with a url <a href="https://github.com/Automattic/wp-calypso#security" rel="noopener noreferrer" target="_blank">https://github.com/Automattic/wp-calypso#security</a> that has a hash in it<br><a href="https://www.facebook.com/hashtag/thisone" rel="noopener noreferrer" target="_blank">#thisone</a> after a new line'
+		);
+
+		expect(
+			render( preparePreviewText( text, { platform: 'instagram' } ) ).container.innerHTML
+		).toBe(
+			'<a href="https://www.instagram.com/explore/tags/breaking" rel="noopener noreferrer" target="_blank">#breaking</a> text with a <a href="https://www.instagram.com/explore/tags/hashtag" rel="noopener noreferrer" target="_blank">#hashtag</a> on the <a href="https://www.instagram.com/explore/tags/web" rel="noopener noreferrer" target="_blank">#web</a><br>with a url https://github.com/Automattic/wp-calypso#security that has a hash in it<br><a href="https://www.instagram.com/explore/tags/thisone" rel="noopener noreferrer" target="_blank">#thisone</a> after a new line'
+		);
+
+		expect(
+			render( preparePreviewText( text, { platform: 'linkedin' } ) ).container.innerHTML
+		).toBe(
+			'<a href="https://www.linkedin.com/feed/hashtag/?keywords=breaking" rel="noopener noreferrer" target="_blank">#breaking</a> text with a <a href="https://www.linkedin.com/feed/hashtag/?keywords=hashtag" rel="noopener noreferrer" target="_blank">#hashtag</a> on the <a href="https://www.linkedin.com/feed/hashtag/?keywords=web" rel="noopener noreferrer" target="_blank">#web</a><br>with a url <a href="https://github.com/Automattic/wp-calypso#security" rel="noopener noreferrer" target="_blank">https://github.com/Automattic/wp-calypso#security</a> that has a hash in it<br><a href="https://www.linkedin.com/feed/hashtag/?keywords=thisone" rel="noopener noreferrer" target="_blank">#thisone</a> after a new line'
+		);
+
+		expect(
+			render( preparePreviewText( text, { platform: 'twitter' } ) ).container.innerHTML
+		).toBe(
+			'<a href="https://twitter.com/hashtag/breaking" rel="noopener noreferrer" target="_blank">#breaking</a> text with a <a href="https://twitter.com/hashtag/hashtag" rel="noopener noreferrer" target="_blank">#hashtag</a> on the <a href="https://twitter.com/hashtag/web" rel="noopener noreferrer" target="_blank">#web</a><br>with a url <a href="https://github.com/Automattic/wp-calypso#security" rel="noopener noreferrer" target="_blank">https://github.com/Automattic/wp-calypso#security</a> that has a hash in it<br><a href="https://twitter.com/hashtag/thisone" rel="noopener noreferrer" target="_blank">#thisone</a> after a new line'
+		);
+	} );
+
+	it( 'should NOT convert hashtags to hyperlinks when `hyperlinkHashtags` is `false`', () => {
+		const text = `#breaking text with a #hashtag on the #web\nwith a url https://github.com/Automattic/wp-calypso#security that has a hash in it\n#thisone after a new line`;
+
+		for ( const platform of platformsWithHyperlinkUrls ) {
+			const { container } = render(
+				preparePreviewText( text, { platform, hyperlinkHashtags: false } )
+			);
+
+			expect( container.innerHTML ).toBe(
+				'#breaking text with a #hashtag on the #web<br>with a url <a href="https://github.com/Automattic/wp-calypso#security" rel="noopener noreferrer" target="_blank">https://github.com/Automattic/wp-calypso#security</a> that has a hash in it<br>#thisone after a new line'
+			);
+		}
+
+		for ( const platform of platformsWithoutHyperlinkUrls ) {
+			const { container } = render(
+				preparePreviewText( text, { platform, hyperlinkHashtags: false } )
+			);
+
+			expect( container.innerHTML ).toBe(
+				'#breaking text with a #hashtag on the #web<br>with a url https://github.com/Automattic/wp-calypso#security that has a hash in it<br>#thisone after a new line'
+			);
+		}
+	} );
+} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,6 +1400,7 @@ __metadata:
     "@testing-library/react": ^12.1.3
     "@types/wordpress__components": ^14.0.10
     "@wordpress/components": ^22.1.0
+    "@wordpress/element": ^5.11.0
     "@wordpress/i18n": ^4.22.0
     classnames: ^2.3.1
     postcss: ^8.4.5


### PR DESCRIPTION
In `social-previews` package, `dangerouslySetInnerHTML` used at many places to simplify the preview text processing but you know it's never good to try dangerous stuff.

Completes 1203820933396971-as-1204665149016902/f and address this comment - https://github.com/Automattic/wp-calypso/pull/77372#discussion_r1206023723

## Proposed Changes

* Refactor `preparePreviewText` utility function to use `createInterpolateElement`
* Remove `dangerouslySetInnerHTML` from all the preview components
* Write unit tests for `preparePreviewText` utility function

## Testing Instructions

- Make sure you have a self-hosted site connected to Jetpack, with a subscription that includes Social.
- Spin up Calypso, by running this branch locally.
- Ensure that you have Social Media accounts connected for a self-hosted WP Site
- Go to `/posts/:site` for a self-hosted WP site or a JN site
- Click on the 3 dots for any post and Click "Share"
- Click on "Preview"
- Confirm that everything works as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?