### PR TITLE
useCheckSiteTransferStatus: rework logic and apply hook conditionally

### DIFF
--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -7,7 +7,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import { memo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
-import { useCheckSiteTransferStatus } from '../hooks/use-check-site-transfer-status';
 import { displaySiteUrl, getDashboardUrl, isStagingSite } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import { SitesGridActionRenew } from './sites-grid-action-renew';
@@ -21,6 +20,7 @@ import { SiteUrl, Truncated } from './sites-site-url';
 import SitesStagingBadge from './sites-staging-badge';
 import TransferNoticeWrapper from './sites-transfer-notice-wrapper';
 import { ThumbnailLink } from './thumbnail-link';
+import { WithAtomicTransfer } from './with-atomic-transfer';
 
 const SIZES_ATTR = [
 	'(min-width: 1345px) calc((1280px - 64px) / 3)',
@@ -107,10 +107,6 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 	const isWpcomStagingSite = isStagingSite( site );
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 	const isECommerceTrialSite = site.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
-	const { isTransferring, wasTransferring, isTransferCompleted, isErrored } =
-		useCheckSiteTransferStatus( {
-			siteId: site.ID,
-		} );
 
 	const { ref, inView } = useInView( { triggerOnce: true } );
 
@@ -185,14 +181,15 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 					<SiteUrl href={ siteUrl } title={ siteUrl }>
 						<Truncated>{ displaySiteUrl( siteUrl ) }</Truncated>
 					</SiteUrl>
-					{ ! wasTransferring && showLaunchNag && <SiteLaunchNag site={ site } /> }
-					{ wasTransferring && (
-						<TransferNoticeWrapper
-							isTransfering={ isTransferring }
-							isTransferCompleted={ isTransferCompleted }
-							hasError={ isErrored }
-						/>
-					) }
+					<WithAtomicTransfer site={ site }>
+						{ ( result ) =>
+							result.wasTransferring ? (
+								<TransferNoticeWrapper { ...result } />
+							) : (
+								<>{ showLaunchNag && <SiteLaunchNag site={ site } /> }</>
+							)
+						}
+					</WithAtomicTransfer>
 				</SitesGridItemSecondary>
 			}
 		/>

--- a/client/sites-dashboard/components/sites-transfer-notice-wrapper.tsx
+++ b/client/sites-dashboard/components/sites-transfer-notice-wrapper.tsx
@@ -1,23 +1,23 @@
 import { SitesTransferNotice } from './sites-transfer-notice';
 
 type TransferNoticeWrapperProps = {
-	isTransfering: boolean;
-	hasError: boolean;
+	isTransferring: boolean;
+	isErrored: boolean;
 	isTransferCompleted: boolean;
 	className?: string;
 };
 
 const TransferNoticeWrapper = ( {
-	isTransfering,
-	hasError,
+	isTransferring,
+	isErrored,
 	isTransferCompleted,
 	className,
 }: TransferNoticeWrapperProps ) => {
 	return (
 		<div className={ className }>
-			{ isTransfering && <SitesTransferNotice isTransfering={ true } /> }
-			{ ! isTransfering && ( hasError || isTransferCompleted ) && (
-				<SitesTransferNotice isTransfering={ false } hasError={ hasError } />
+			{ isTransferring && <SitesTransferNotice isTransferring={ true } /> }
+			{ ! isTransferring && ( isErrored || isTransferCompleted ) && (
+				<SitesTransferNotice isTransferring={ false } hasError={ isErrored } />
 			) }
 		</div>
 	);

--- a/client/sites-dashboard/components/sites-transfer-notice.tsx
+++ b/client/sites-dashboard/components/sites-transfer-notice.tsx
@@ -24,12 +24,12 @@ const NoticeText = styled.span( {
 } );
 
 type SitesTransferNoticeProps = {
-	isTransfering: boolean;
+	isTransferring: boolean;
 	hasError?: boolean;
 };
 
 export const SitesTransferNotice = ( {
-	isTransfering = false,
+	isTransferring = false,
 	hasError = false,
 }: SitesTransferNoticeProps ) => {
 	const { __ } = useI18n();
@@ -45,13 +45,13 @@ export const SitesTransferNotice = ( {
 	} else {
 		icon = 'checkmark';
 		color = 'green';
-		text = isTransfering ? __( 'Activating site' ) : __( 'Activated!' );
+		text = isTransferring ? __( 'Activating site' ) : __( 'Activated!' );
 	}
 
 	return (
 		<Container>
 			<span>
-				{ isTransfering ? <Spinner /> : <StatusIcon color={ color } icon={ icon } size={ 18 } /> }
+				{ isTransferring ? <Spinner /> : <StatusIcon color={ color } icon={ icon } size={ 18 } /> }
 			</span>
 			<NoticeText>{ text }</NoticeText>
 		</Container>

--- a/client/sites-dashboard/components/with-atomic-transfer.tsx
+++ b/client/sites-dashboard/components/with-atomic-transfer.tsx
@@ -1,0 +1,38 @@
+import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
+import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+import { useCheckSiteTransferStatus } from '../hooks/use-check-site-transfer-status';
+
+const PollAtomicTransfer = ( { site, children }: WithAtomicTransferProps ) => {
+	const result = useCheckSiteTransferStatus( { siteId: site.ID, intervalTime: 5000 } );
+
+	return children( result );
+};
+
+type AtomicTransferResult =
+	| { wasTransferring: false }
+	| ( { wasTransferring: true } & ReturnType< typeof useCheckSiteTransferStatus > );
+
+interface WithAtomicTransferProps {
+	site: SiteExcerptData;
+	children: ( props: AtomicTransferResult ) => React.ReactElement | null;
+}
+
+export const WithAtomicTransfer = ( { site, children }: WithAtomicTransferProps ) => {
+	if ( site.is_wpcom_atomic ) {
+		return children( { wasTransferring: false } );
+	}
+
+	const sitePlan = site.plan?.product_slug;
+
+	if ( ! sitePlan ) {
+		return children( { wasTransferring: false } );
+	}
+
+	const isBusinessOrEcommerceSite = isBusinessPlan( sitePlan ) || isEcommercePlan( sitePlan );
+
+	if ( ! isBusinessOrEcommerceSite ) {
+		return children( { wasTransferring: false } );
+	}
+
+	return <PollAtomicTransfer site={ site } children={ children } />;
+};

--- a/client/sites-dashboard/components/with-atomic-transfer.tsx
+++ b/client/sites-dashboard/components/with-atomic-transfer.tsx
@@ -8,16 +8,7 @@ const PollAtomicTransfer = ( { site, children }: WithAtomicTransferProps ) => {
 	return children( result );
 };
 
-type AtomicTransferResult =
-	| { wasTransferring: false }
-	| ( { wasTransferring: true } & ReturnType< typeof useCheckSiteTransferStatus > );
-
-interface WithAtomicTransferProps {
-	site: SiteExcerptData;
-	children: ( props: AtomicTransferResult ) => React.ReactElement | null;
-}
-
-export const WithAtomicTransfer = ( { site, children }: WithAtomicTransferProps ) => {
+const MaybePollAtomicTransfer = ( { site, children }: WithAtomicTransferProps ) => {
 	if ( site.is_wpcom_atomic ) {
 		return children( { wasTransferring: false } );
 	}
@@ -35,4 +26,17 @@ export const WithAtomicTransfer = ( { site, children }: WithAtomicTransferProps 
 	}
 
 	return <PollAtomicTransfer site={ site } children={ children } />;
+};
+
+type AtomicTransferResult =
+	| { wasTransferring: false }
+	| ( { wasTransferring: true } & ReturnType< typeof useCheckSiteTransferStatus > );
+
+interface WithAtomicTransferProps {
+	site: SiteExcerptData;
+	children: ( props: AtomicTransferResult ) => React.ReactElement | null;
+}
+
+export const WithAtomicTransfer = ( props: WithAtomicTransferProps ) => {
+	return <MaybePollAtomicTransfer key={ props.site.slug } { ...props } />;
 };

--- a/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
+++ b/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
@@ -25,7 +25,10 @@ export const useCheckSiteTransferStatus = ( {
 
 	const isTransferCompleted = transferStatus === transferStates.COMPLETE;
 	const isTransferring =
-		transferStatus !== null && transferStatus !== transferStates.NONE && ! isTransferCompleted;
+		transferStatus !== null &&
+		transferStatus !== transferStates.NONE &&
+		transferStatus !== transferStates.REVERTED &&
+		! isTransferCompleted;
 	const isErrored =
 		transferStatus === transferStates.ERROR || transferStatus === transferStates.FAILURE;
 

--- a/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
+++ b/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
@@ -57,7 +57,7 @@ export const useCheckSiteTransferStatus = ( {
 
 	useEffect( () => {
 		dispatch( requestLatestAtomicTransfer( siteId ) );
-	}, [ isTransferCompleted, siteId, dispatch ] );
+	}, [ siteId, dispatch ] );
 
 	useEffect( () => {
 		if ( isTransferring && ! wasTransferring ) {

--- a/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
+++ b/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
@@ -33,7 +33,12 @@ export const useCheckSiteTransferStatus = ( {
 	const dismissTransferNoticeRef = useRef< NodeJS.Timeout >();
 
 	useEffect( () => {
-		if ( ! siteId || transferStatus === transferStates.COMPLETE ) {
+		if (
+			! siteId ||
+			transferStatus === transferStates.COMPLETE ||
+			transferStatus === transferStates.NONE ||
+			transferStatus === transferStates.REVERTED
+		) {
 			return;
 		}
 

--- a/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
+++ b/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
@@ -8,7 +8,7 @@ import {
 } from 'calypso/state/automated-transfer/selectors';
 
 interface SiteTransferStatusProps {
-	siteId: number | null;
+	siteId: number;
 	intervalTime?: number;
 }
 
@@ -51,7 +51,7 @@ export const useCheckSiteTransferStatus = ( {
 	const dismissTransferNoticeRef = useRef< NodeJS.Timeout >();
 
 	useEffect( () => {
-		if ( ! siteId || isTransferInProgress( transferStatus ) ) {
+		if ( isTransferInProgress( transferStatus ) ) {
 			return;
 		}
 

--- a/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
+++ b/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
@@ -9,12 +9,13 @@ interface SiteTransferStatusProps {
 	intervalTime?: number;
 }
 
-const terminatedTransferStatuses = [
+const inactiveTransferStatuses = [
 	transferStates.NONE,
 	transferStates.ERROR,
 	transferStates.FAILURE,
 	transferStates.REVERTED,
 	transferStates.COMPLETE,
+	transferStates.RELOCATING_REVERT,
 ] as const;
 
 const isTransferInProgress = ( transferStatus: string | null ) => {
@@ -22,10 +23,9 @@ const isTransferInProgress = ( transferStatus: string | null ) => {
 		return false;
 	}
 
-	const terminatedTransferStatus =
-		transferStatus as ( typeof terminatedTransferStatuses )[ number ];
+	const typedTransferStatus = transferStatus as ( typeof inactiveTransferStatuses )[ number ];
 
-	return ! terminatedTransferStatuses.includes( terminatedTransferStatus );
+	return ! inactiveTransferStatuses.includes( typedTransferStatus );
 };
 
 export const useCheckSiteTransferStatus = ( {

--- a/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
+++ b/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
@@ -12,6 +12,25 @@ interface SiteTransferStatusProps {
 	intervalTime?: number;
 }
 
+const terminatedTransferStatuses = [
+	transferStates.NONE,
+	transferStates.ERROR,
+	transferStates.FAILURE,
+	transferStates.REVERTED,
+	transferStates.COMPLETE,
+] as const;
+
+const isTransferInProgress = ( transferStatus: string | null ) => {
+	if ( ! transferStatus ) {
+		return false;
+	}
+
+	const terminatedTransferStatus =
+		transferStatus as ( typeof terminatedTransferStatuses )[ number ];
+
+	return ! terminatedTransferStatuses.includes( terminatedTransferStatus );
+};
+
 export const useCheckSiteTransferStatus = ( {
 	siteId,
 	intervalTime = 3000,
@@ -24,11 +43,7 @@ export const useCheckSiteTransferStatus = ( {
 	);
 
 	const isTransferCompleted = transferStatus === transferStates.COMPLETE;
-	const isTransferring =
-		transferStatus !== null &&
-		transferStatus !== transferStates.NONE &&
-		transferStatus !== transferStates.REVERTED &&
-		! isTransferCompleted;
+	const isTransferring = isTransferInProgress( transferStatus );
 	const isErrored =
 		transferStatus === transferStates.ERROR || transferStatus === transferStates.FAILURE;
 
@@ -36,12 +51,7 @@ export const useCheckSiteTransferStatus = ( {
 	const dismissTransferNoticeRef = useRef< NodeJS.Timeout >();
 
 	useEffect( () => {
-		if (
-			! siteId ||
-			transferStatus === transferStates.COMPLETE ||
-			transferStatus === transferStates.NONE ||
-			transferStatus === transferStates.REVERTED
-		) {
+		if ( ! siteId || isTransferInProgress( transferStatus ) ) {
 			return;
 		}
 

--- a/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
+++ b/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
@@ -47,7 +47,7 @@ export const useCheckSiteTransferStatus = ( {
 	const dismissTransferNoticeRef = useRef< NodeJS.Timeout >();
 
 	useEffect( () => {
-		if ( ! isTransferInProgress( transferStatus ) ) {
+		if ( ! isTransferring ) {
 			return;
 		}
 
@@ -56,13 +56,11 @@ export const useCheckSiteTransferStatus = ( {
 		}, intervalTime );
 
 		return () => clearInterval( intervalId );
-	}, [ siteId, dispatch, transferStatus, isTransferCompleted, intervalTime ] );
+	}, [ siteId, dispatch, isTransferring, intervalTime ] );
 
 	useEffect( () => {
-		if ( siteId ) {
-			dispatch( requestLatestAtomicTransfer( siteId ) );
-		}
-	}, [ siteId, dispatch ] );
+		dispatch( requestLatestAtomicTransfer( siteId ) );
+	}, [ isTransferCompleted, siteId, dispatch ] );
 
 	useEffect( () => {
 		if ( isTransferring && ! wasTransferring ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This was reported in Slack p1685094051348909-slack-C0347E545HR

## Proposed Changes

We can funnel the REST API calls if we follow a set of conditionals.

Also, I changed the endpoint to one that doesn't poll by default. We want to have more control over the polling mechanism.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Reproduce the issue on `trunk` (see Slack for more details)
* Apply this patch and check the Chrome network traffic to see that the calls to `sites/19734/automated-transfers/status` are not happening infinitely. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?