### PR TITLE
Reader: Fix follow sources

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -38,7 +38,6 @@ import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { isDiscoverPost, isDiscoverSitePick } from 'calypso/reader/discover/helper';
 import DiscoverSiteAttribution from 'calypso/reader/discover/site-attribution';
-import { READER_FULL_POST } from 'calypso/reader/follow-sources';
 import { canBeMarkedAsSeen, getSiteName, isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import readerContentWidth from 'calypso/reader/lib/content-width';
 import LikeButton from 'calypso/reader/like-button';
@@ -640,7 +639,6 @@ export class FullPostView extends Component {
 									maxDepth={ 1 }
 									commentsFilterDisplay={ COMMENTS_FILTER_ALL }
 									showConversationFollowButton={ true }
-									followSource={ READER_FULL_POST }
 									shouldPollForNewComments={ config.isEnabled( 'reader/comment-polling' ) }
 									shouldHighlightNew={ true }
 								/>

--- a/client/reader/discover/follow-button.jsx
+++ b/client/reader/discover/follow-button.jsx
@@ -4,7 +4,6 @@ import { Component } from 'react';
 import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
 import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';
 import FollowButton from 'calypso/reader/follow-button';
-import { DISCOVER_POST } from 'calypso/reader/follow-sources';
 import { recordFollowToggle } from './stats';
 
 class DiscoverFollowButton extends Component {
@@ -42,7 +41,6 @@ class DiscoverFollowButton extends Component {
 				onFollowToggle={ this.recordFollowToggle }
 				followLabel={ followLabel }
 				followingLabel={ followingLabel }
-				followSource={ DISCOVER_POST }
 				followIcon={ ReaderFollowFeedIcon( { iconSize: 20 } ) }
 				followingIcon={ ReaderFollowingFeedIcon( { iconSize: 20 } ) }
 			/>

--- a/client/reader/follow-sources.jsx
+++ b/client/reader/follow-sources.jsx
@@ -1,17 +1,7 @@
 /* Follow Source Constants */
 export const IN_STREAM_RECOMMENDATION = 'in-stream-recommendation';
-export const EMPTY_SEARCH_RECOMMENDATIONS = 'empty-search-rec';
-export const SEARCH_RESULTS = 'search-results';
 export const SEARCH_RESULTS_SITES = 'search-results-sites';
-export const SEARCH_RESULTS_URL_INPUT = 'search-results-url-input';
-export const READER_SUBSCRIPTIONS = 'reader-subscriptions';
-export const READER_CONVERSATIONS = 'reader-conversations';
-export const READER_FEED_SEARCH = 'reader-feed-search-result';
-export const READER_FOLLOWING_MANAGE_URL_INPUT = 'reader-following-manage-url-input';
 export const READER_FOLLOWING_MANAGE_SEARCH_RESULT = 'reader-following-manage-search-result';
 export const READER_FOLLOWING_MANAGE_RECOMMENDATION = 'reader-following-manage-recommendation';
-export const READER_FULL_POST = 'reader-full-post';
 export const READER_POST_OPTIONS_MENU = 'reader-post-options-menu';
-export const TAG_PAGE = 'reader-tag-page';
-export const DISCOVER_POST = 'reader-discover-post';
 export const READER_SUGGESTED_FOLLOWS_DIALOG = 'reader-suggested-follows-dialog';

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -16,7 +16,6 @@ import UrlSearch from 'calypso/lib/url-search';
 import InfiniteStream from 'calypso/reader/components/reader-infinite-stream';
 import { siteRowRenderer } from 'calypso/reader/components/reader-infinite-stream/row-renderers';
 import { filterFollowsByQuery } from 'calypso/reader/follow-helpers';
-import { READER_SUBSCRIPTIONS } from 'calypso/reader/follow-sources';
 import { formatUrlForDisplay, getFeedTitle } from 'calypso/reader/lib/feed-display-helper';
 import { getReaderFollows, getReaderFollowsCount } from 'calypso/state/reader/follows/selectors';
 import FollowingManageSearchFollowed from './search-followed';
@@ -115,9 +114,6 @@ class FollowingManageSubscriptions extends Component {
 					{ ! noSitesMatchQuery && (
 						<InfiniteStream
 							items={ sortedFollows }
-							extraRenderItemProps={ {
-								followSource: READER_SUBSCRIPTIONS,
-							} }
 							width={ width }
 							totalCount={ sortedFollows.length }
 							windowScrollerRef={ this.props.windowScrollerRef }

--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -2,7 +2,6 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
-import { SEARCH_RESULTS } from 'calypso/reader/follow-sources';
 import HeaderBack from 'calypso/reader/header-back';
 import Stream from 'calypso/reader/stream';
 import PostPlaceholder from 'calypso/reader/stream/post-placeholder';
@@ -37,7 +36,6 @@ class PostResults extends Component {
 		return (
 			<Stream
 				{ ...this.props }
-				followSource={ SEARCH_RESULTS }
 				listName={ translate( 'Search' ) }
 				emptyContent={ emptyContent }
 				showFollowInHeader={ true }

--- a/client/reader/search-stream/search-follow-button.jsx
+++ b/client/reader/search-stream/search-follow-button.jsx
@@ -8,7 +8,6 @@ import { resemblesUrl, withoutHttp, addSchemeIfMissing } from 'calypso/lib/url';
 import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
 import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';
 import FollowButton from 'calypso/reader/follow-button';
-import { SEARCH_RESULTS_URL_INPUT } from 'calypso/reader/follow-sources';
 import { getReaderAliasedFollowFeedUrl } from 'calypso/state/reader/follows/selectors';
 import { commonExtensions } from 'calypso/state/reader/follows/selectors/get-reader-aliased-follow-feed-url';
 import './style.scss';
@@ -80,7 +79,6 @@ class SearchFollowButton extends Component {
 						comment: '%s is the name of the site being followed. For example: "Discover"',
 					} ) }
 					siteUrl={ addSchemeIfMissing( readerAliasedFollowFeedUrl, 'http' ) }
-					followSource={ SEARCH_RESULTS_URL_INPUT }
 					followIcon={ ReaderFollowFeedIcon( { iconSize: 20 } ) }
 					followingIcon={ ReaderFollowingFeedIcon( { iconSize: 20 } ) }
 				/>

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -213,7 +213,7 @@ export function pageViewForPost( blogId, blogUrl, postId, isPrivate ) {
 }
 
 export function recordFollow( url, railcar, additionalProps = {} ) {
-	const source = additionalProps.source || getLocation( window.location.pathname );
+	const source = additionalProps.follow_source || getLocation( window.location.pathname );
 	bumpStat( 'reader_follows', source );
 	recordAction( 'followed_blog' );
 	recordGaEvent( 'Clicked Follow Blog', source );
@@ -228,7 +228,7 @@ export function recordFollow( url, railcar, additionalProps = {} ) {
 }
 
 export function recordUnfollow( url, railcar, additionalProps = {} ) {
-	const source = getLocation( window.location.pathname );
+	const source = additionalProps.follow_source || getLocation( window.location.pathname );
 	bumpStat( 'reader_unfollows', source );
 	recordAction( 'unfollowed_blog' );
 	recordGaEvent( 'Clicked Unfollow Blog', source );

--- a/client/reader/stream/empty-search-recommended-post.jsx
+++ b/client/reader/stream/empty-search-recommended-post.jsx
@@ -1,5 +1,4 @@
 import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
-import { EMPTY_SEARCH_RECOMMENDATIONS } from 'calypso/reader/follow-sources';
 import { recordTrackForPost, recordAction } from 'calypso/reader/stats';
 
 export default function EmptySearchRecommendedPost( { post } ) {
@@ -27,7 +26,6 @@ export default function EmptySearchRecommendedPost( { post } ) {
 				site={ site }
 				onSiteClick={ handleSiteClick }
 				onPostClick={ handlePostClick }
-				followSource={ EMPTY_SEARCH_RECOMMENDATIONS }
 			/>
 		</div>
 	);

--- a/client/reader/stream/empty-search-recommended-site.jsx
+++ b/client/reader/stream/empty-search-recommended-site.jsx
@@ -1,5 +1,4 @@
 import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
-import { EMPTY_SEARCH_RECOMMENDATIONS } from 'calypso/reader/follow-sources';
 import { recordTrackForPost, recordAction } from 'calypso/reader/stats';
 
 export default function EmptySearchRecommendedSite( { post } ) {
@@ -27,7 +26,6 @@ export default function EmptySearchRecommendedSite( { post } ) {
 				site={ site }
 				onSiteClick={ handleSiteClick }
 				onPostClick={ handlePostClick }
-				followSource={ EMPTY_SEARCH_RECOMMENDATIONS }
 			/>
 		</div>
 	);

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -7,7 +7,6 @@ import {
 	trackScrollPage,
 	getStartDate,
 } from 'calypso/reader/controller-helper';
-import { TAG_PAGE } from 'calypso/reader/follow-sources';
 import { recordTrack } from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
@@ -64,7 +63,6 @@ export const tagListing = ( context, next ) => {
 			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) } // eslint-disable-line
 			showBack={ !! context.lastRoute }
 			showPrimaryFollowButtonOnCards={ false }
-			followSource={ TAG_PAGE }
 		/>
 	);
 	next();


### PR DESCRIPTION
I found a bug in Reader Follow source when logging stats/track events.

The `source` is assigned to a prop `source` but this is never set, the prop `follow_source` is.

The trouble with fixing this is that it has potential to break stats already in place. Since the prop wasn't being set, the source falls back to the path location.

This PR removes the use of `followSource` prop (that eventually gets set to `follow_source`) in most cases where we want to continue using the path location.

There are a few exceptions where I think there is value in including the `followSource` prop.

### Exceptions

The Reader Follows Manage page has multiple places where the follow button is rendered.

<img width="793" alt="Screenshot 2023-05-26 at 11 58 23" src="https://github.com/Automattic/wp-calypso/assets/5560595/7fa306c1-b502-43a3-83a9-2dab794aa1c3">
<img width="774" alt="Screenshot 2023-05-26 at 11 59 51" src="https://github.com/Automattic/wp-calypso/assets/5560595/3858ab9c-30fc-41c1-b441-fe84af209ce4">

1. Followed Site - source continue to be `following_manage`
2. Following Site Recommendations - source will now be `reader-following-manage-recommendation`
3. Following Site Search - source will now be `reader-following-manage-search-result`

The Reader Suggested Follows dialog/modal will now register the source `reader-suggested-follows-dialog` rather than the path location of where the modal is rendered.

The Reader Search page also renders the follow button in a few places. We'll continue to register the source in stats as `search` except in one place; 

<img width="978" alt="Screenshot 2023-05-26 at 12 03 02" src="https://github.com/Automattic/wp-calypso/assets/5560595/3461b9c8-1ff7-4ff6-b3e4-991f2a9ecb76">

* Reader site search results (sidebar) - source will now be `search-results-sites`

### Testing
I tested this by adding;
`console.log( 'compare follows', getLocation( window.location.pathname ), source );` to [recordFollow](https://github.com/Automattic/wp-calypso/blob/1c80ab46a1ca80e382ad477ea5ca27f45675db50/client/reader/stats.js#L217)
and
`console.log( 'compare unfollows', getLocation( window.location.pathname ), source );` to [recordUnfollow](https://github.com/Automattic/wp-calypso/blob/1c80ab46a1ca80e382ad477ea5ca27f45675db50/client/reader/stats.js#L215)

Confirm expected stat source is logged to stats already in use at `reader_follows` on mc stats.

