### PR TITLE
Launchpad: Add link to reset styles support doc

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -145,7 +145,8 @@ export function getEnhancedTasks(
 						recordTaskClickTracksEvent( flow, task.completed, task.id );
 						if ( displayGlobalStylesWarning ) {
 							recordTracksEvent(
-								'calypso_launchpad_global_styles_gating_plan_selected_task_clicked'
+								'calypso_launchpad_global_styles_gating_plan_selected_task_clicked',
+								{ flow }
 							);
 						}
 						const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
@@ -173,7 +174,8 @@ export function getEnhancedTasks(
 										onClick={ ( event ) => {
 											event.stopPropagation();
 											recordTracksEvent(
-												'calypso_launchpad_global_styles_gating_plan_selected_reset_styles'
+												'calypso_launchpad_global_styles_gating_plan_selected_reset_styles',
+												{ flow }
 											);
 										} }
 									/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -3,7 +3,7 @@ export interface Task {
 	completed: boolean;
 	disabled: boolean;
 	title?: string;
-	subtitle?: string;
+	subtitle?: string | React.ReactNode;
 	badge_text?: string;
 	actionDispatch?: () => void;
 	isLaunchTask?: boolean;

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -84,6 +84,20 @@
 	text-align: left;
 	font-size: $font-body-small;
 	line-height: 20px;
+
+	a,
+	a:visited {
+		text-decoration: underline;
+		color: var(--color-text);
+
+		&:hover {
+			color: var(--studio-blue-50);
+		}
+	}
+}
+
+.checklist-item__task-content:hover .checklist-item__subtext {
+	color: var(--color-text);
 }
 
 .checklist__has-primary-action .checklist-item__task:nth-last-child(2) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2263

## Proposed Changes

Adds a link to the Global Styles notice displayed in the "Choose a plan" task of the launchpad so users can learn how they can remove the custom styles.

Before | After
--- | ---
<img width="336" alt="Screenshot 2023-05-26 at 13 41 43" src="https://github.com/Automattic/wp-calypso/assets/1233880/964c9af2-b7c3-4fa3-b9db-f279f5a839be"> | <img width="335" alt="Screenshot 2023-05-26 at 13 41 28" src="https://github.com/Automattic/wp-calypso/assets/1233880/62aa0212-5d31-4d59-aa31-7fce3d2fd9bb">


## Testing Instructions

- Use the Calypso live link below.
- Go to `/setup/newsletter`.
- Pick a premium color and remain on the Free plan.
- Once you're in the launchpad, observe the "Choose a plan" task.
- Make sure the notice includes a link that opens the documentation explaining how to reset custom styles.
