### PR TITLE
Simply Pricing Page for Jetpack Cloud

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -220,7 +220,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 								</ExternalLink>
 								{ shouldShowCart && <CloudCart /> }
 								<a
-									className="header__mobile-btn mobile-btn js-mobile-btn"
+									className="header__mobile-btn mobile-btn js-mobile-btn force-hide"
 									href="#mobile-menu"
 									aria-expanded="false"
 								>
@@ -229,7 +229,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 									</span>
 									<span className="mobile-btn__label">{ translate( 'Menu' ) }</span>
 								</a>
-								<div className="header__nav-wrapper js-mobile-menu" id="mobile-menu">
+								<div className="header__nav-wrapper js-mobile-menu force-hide" id="mobile-menu">
 									<ul className="header__sections-list js-nav-list">
 										{ sections.map( ( { label, id, href, items } ) => {
 											const hasChildren = Array.isArray( items );

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -1344,7 +1344,7 @@
 	}
 	//logo is really close to the top of the page on mobile
 	.jetpack-logo {
-		margin-top: 25px;
+		margin-top: 1.5rem;
 	}
 }
 

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -21,6 +21,13 @@
 		color: #101517;
 		font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 		transition: background 0.1s;
+		.jetpack-logo {
+			display: inline-block;
+			text-align: center;
+		}
+		.force-hide {
+			display: none !important;
+		}
 	}
 	.header__nav-wrapper {
 		text-align: left;
@@ -252,6 +259,7 @@
 		transition: none;
 		z-index: 2;
 		margin-inline-end: 3rem;
+		width: 100%;
 	}
 	.header__home-link:focus-visible {
 		border-radius: 2px;
@@ -1333,6 +1341,10 @@
 			//display mobile cart at the top most layer
 			z-index: 9999999;
 		}
+	}
+	//logo is really close to the top of the page on mobile
+	.jetpack-logo {
+		margin-top: 25px;
 	}
 }
 

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -183,6 +183,7 @@
 		margin: 0 auto;
 		display: flex;
 		align-items: center;
+		justify-content: center;
 	}
 	@media ( max-width: 1300px ) {
 		.header__content {
@@ -259,7 +260,6 @@
 		transition: none;
 		z-index: 2;
 		margin-inline-end: 3rem;
-		width: 100%;
 	}
 	.header__home-link:focus-visible {
 		border-radius: 2px;


### PR DESCRIPTION
This PR hides the navigation menu and login links from the pricing page via CSS rules. It also moves the Jetpack logo down a bit on mobile devices

<img width="1440" alt="Screenshot 2023-05-26 at 13 35 55" src="https://github.com/Automattic/wp-calypso/assets/4077604/8d578a43-4a99-4cf1-96ed-049ceb5ce53f">

Mobile device (old)
<img width="374" alt="Screenshot 2023-05-26 at 13 39 20" src="https://github.com/Automattic/wp-calypso/assets/4077604/f152621c-38ad-4357-9ebd-5142259f0c48">

Mobile device (new)

<img width="312" alt="Screenshot 2023-05-26 at 13 40 28" src="https://github.com/Automattic/wp-calypso/assets/4077604/0d5fea09-fc50-4620-89a5-6eb085b90abc">

