### PR TITLE
Subscriptions management: Display red cross for empty 'New Posts' cell value in Sites subscriptions list

### DIFF
--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -25,16 +25,29 @@ const useDeliveryFrequencyLabel = ( deliveryFrequencyValue?: Reader.EmailDeliver
 	);
 };
 
-const useSelectedNewPostDeliveryMethodsLabel = (
-	isEmailMeNewPostsSelected: boolean,
-	isNotifyMeOfNewPostsSelected: boolean
-) => {
+const RedCross = () => <Gridicon icon="cross" size={ 16 } className="red" />;
+
+const GreenCheck = () => <Gridicon icon="checkmark" size={ 16 } className="green" />;
+
+const SelectedNewPostDeliveryMethods = ( {
+	isEmailMeNewPostsSelected,
+	isNotifyMeOfNewPostsSelected,
+}: {
+	isEmailMeNewPostsSelected: boolean;
+	isNotifyMeOfNewPostsSelected: boolean;
+} ) => {
 	const translate = useTranslate();
-	return useMemo( () => {
-		const emailDelivery = isEmailMeNewPostsSelected ? translate( 'Email' ) : null;
-		const notificationDelivery = isNotifyMeOfNewPostsSelected ? translate( 'Notifications' ) : null;
-		return [ emailDelivery, notificationDelivery ].filter( Boolean ).join( ', ' );
-	}, [ isEmailMeNewPostsSelected, isNotifyMeOfNewPostsSelected, translate ] );
+
+	if ( ! isEmailMeNewPostsSelected && ! isNotifyMeOfNewPostsSelected ) {
+		return <RedCross />;
+	}
+
+	const emailDelivery = isEmailMeNewPostsSelected ? translate( 'Email' ) : null;
+	const notificationDelivery = isNotifyMeOfNewPostsSelected ? translate( 'Notifications' ) : null;
+	const selectedNewPostDeliveryMethods = [ emailDelivery, notificationDelivery ]
+		.filter( Boolean )
+		.join( ', ' );
+	return <>{ selectedNewPostDeliveryMethods }</>;
 };
 
 export default function SiteRow( {
@@ -56,10 +69,6 @@ export default function SiteRow( {
 		}
 	}, [ url ] );
 	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
-	const newPostDelivery = useSelectedNewPostDeliveryMethodsLabel(
-		!! delivery_methods.email?.send_posts,
-		!! delivery_methods.notification?.send_posts
-	);
 	const deliveryFrequencyLabel = useDeliveryFrequencyLabel(
 		delivery_methods.email?.post_delivery_frequency
 	);
@@ -107,16 +116,15 @@ export default function SiteRow( {
 			</span>
 			{ isLoggedIn && (
 				<span className="new-posts" role="cell">
-					{ newPostDelivery }
+					<SelectedNewPostDeliveryMethods
+						isEmailMeNewPostsSelected={ !! delivery_methods.email?.send_posts }
+						isNotifyMeOfNewPostsSelected={ !! delivery_methods.notification?.send_posts }
+					/>
 				</span>
 			) }
 			{ isLoggedIn && (
 				<span className="new-comments" role="cell">
-					{ delivery_methods?.email?.send_comments ? (
-						<Gridicon icon="checkmark" size={ 16 } className="green" />
-					) : (
-						<Gridicon icon="cross" size={ 16 } className="red" />
-					) }
+					{ delivery_methods.email?.send_comments ? <GreenCheck /> : <RedCross /> }
 				</span>
 			) }
 			<span className="email-frequency" role="cell">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
| Before | After |
|:---:|:---:|
| <img src="https://github.com/Automattic/wp-calypso/assets/2019970/b6a29807-7bab-4fa7-a38a-c4f330efec61" width="400"> | <img src="https://github.com/Automattic/wp-calypso/assets/2019970/469afd59-65bd-4dd2-828c-90744862be83" width="400"> |


Closes https://github.com/Automattic/wp-calypso/issues/77336

## Proposed Changes

* Extract out the code for red cross in the table, into a reusable component, and use it for when the user has both the "Email me new posts" and the "Notify me of new posts" set to `false`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/subscriptions/sites
* Toggle off the "Email me new posts" and "Notify me of new posts" for one of the subscriptions in your list
* Ensure that the red cross is displayed when both of the above settings are toggled off

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
