### PR TITLE
i18n: Remove variables from error message in require chunk translations handler

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -265,6 +265,22 @@ function getInstalledChunks() {
 }
 
 /**
+ * Capture exceptions from `getTranslationChunkFile`.
+ *
+ * @param  {Error}  error
+ * @param  {string} chunkId
+ * @param  {string} localeSlug
+ */
+function captureGetTranslationChunkFileException( error, chunkId, localeSlug ) {
+	captureException( error, {
+		tags: {
+			chunk_id: chunkId,
+			locale_slug: localeSlug,
+		},
+	} );
+}
+
+/**
  * Used to keep the reference to the require chunk translations handler.
  */
 let lastRequireChunkTranslationsHandler = null;
@@ -298,12 +314,7 @@ function addRequireChunkTranslationsHandler( localeSlug = i18n.getLocaleSlug(), 
 					`Encountered an error loading translation chunk in require chunk translations handler.`,
 					{ cause }
 				);
-				captureException( error, {
-					tags: {
-						chunk_id: chunkId,
-						locale_slug: localeSlug,
-					},
-				} );
+				captureGetTranslationChunkFileException( error, chunkId, localeSlug );
 				debug( error );
 			} );
 
@@ -395,12 +406,7 @@ export default async function switchLocale( localeSlug ) {
 							`Encountered an error loading translation chunk while switching the locale.`,
 							{ cause }
 						);
-						captureException( error, {
-							tags: {
-								chunk_id: chunkId,
-								locale_slug: localeSlug,
-							},
-						} );
+						captureGetTranslationChunkFileException( error, chunkId, localeSlug );
 						debug( error );
 					} )
 			);

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -295,10 +295,15 @@ function addRequireChunkTranslationsHandler( localeSlug = i18n.getLocaleSlug(), 
 			} )
 			.catch( ( cause ) => {
 				const error = new Error(
-					`Encountered an error loading translation chunk ${ chunkId } for "${ localeSlug }" in require chunk translations handler.`,
+					`Encountered an error loading translation chunk in require chunk translations handler.`,
 					{ cause }
 				);
-				captureException( error );
+				captureException( error, {
+					tags: {
+						chunk_id: chunkId,
+						locale_slug: localeSlug,
+					},
+				} );
 				debug( error );
 			} );
 
@@ -387,10 +392,15 @@ export default async function switchLocale( localeSlug ) {
 					.then( ( translations ) => addTranslations( translations ) )
 					.catch( ( cause ) => {
 						const error = new Error(
-							`Encountered an error loading translation chunk ${ chunkId } for "${ localeSlug }" while switching the locale.`,
+							`Encountered an error loading translation chunk while switching the locale.`,
 							{ cause }
 						);
-						captureException( error );
+						captureException( error, {
+							tags: {
+								chunk_id: chunkId,
+								locale_slug: localeSlug,
+							},
+						} );
 						debug( error );
 					} )
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
## Proposed Changes

* Remove variables from error messages in require translation chunk handlers reported to Sentry so that issues are grouped and not treated as unique.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
