### PR TITLE
Plans: Fix "Suggested" label position

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -389,6 +389,7 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 		visiblePlans: visiblePlansProperties,
 		flowName,
 		currentSitePlanSlug,
+		selectedPlan,
 	} );
 	const headerClasses = classNames( 'plan-comparison-grid__header-cell', getPlanClass( planName ), {
 		'popular-plan-parent-class': highlightLabel,
@@ -566,6 +567,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 		visiblePlans: visiblePlansProperties,
 		flowName,
 		currentSitePlanSlug,
+		selectedPlan,
 	} );
 	const highlightLabel = useHighlightLabel( {
 		planName,

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -379,7 +379,12 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 } ) => {
 	const { planName, planConstantObj, availableForPurchase, current, ...planPropertiesObj } =
 		planProperties;
-	const highlightLabel = useHighlightLabel( { planName, flowName, currentSitePlanSlug } );
+	const highlightLabel = useHighlightLabel( {
+		planName,
+		flowName,
+		currentSitePlanSlug,
+		selectedPlan,
+	} );
 	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
 		visiblePlans: visiblePlansProperties,
 		flowName,
@@ -545,6 +550,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	isStorageFeature: boolean;
 	flowName: string;
 	currentSitePlanSlug?: string;
+	selectedPlan?: string;
 } > = ( {
 	feature,
 	visiblePlansProperties,
@@ -553,6 +559,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	isStorageFeature,
 	flowName,
 	currentSitePlanSlug,
+	selectedPlan,
 } ) => {
 	const translate = useTranslate();
 	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
@@ -560,7 +567,12 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 		flowName,
 		currentSitePlanSlug,
 	} );
-	const highlightLabel = useHighlightLabel( { planName, flowName, currentSitePlanSlug } );
+	const highlightLabel = useHighlightLabel( {
+		planName,
+		flowName,
+		currentSitePlanSlug,
+		selectedPlan,
+	} );
 	const featureSlug = feature?.getSlug();
 	const hasFeature =
 		isStorageFeature ||
@@ -639,6 +651,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	flowName: string;
 	currentSitePlanSlug?: string;
 	isHighlighted: boolean;
+	selectedPlan?: string;
 } > = ( {
 	feature,
 	isHiddenInMobile,
@@ -650,6 +663,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	flowName,
 	currentSitePlanSlug,
 	isHighlighted,
+	selectedPlan,
 } ) => {
 	const translate = useTranslate();
 	const rowClasses = classNames( 'plan-comparison-grid__feature-group-row', {
@@ -702,6 +716,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 					isStorageFeature={ isStorageFeature }
 					flowName={ flowName }
 					currentSitePlanSlug={ currentSitePlanSlug }
+					selectedPlan={ selectedPlan }
 				/>
 			) ) }
 		</Row>
@@ -974,6 +989,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									flowName={ flowName }
 									currentSitePlanSlug={ currentSitePlanSlug }
 									isHighlighted={ feature.getSlug() === selectedFeature }
+									selectedPlan={ selectedPlan }
 								/>
 							) ) }
 							{ featureGroup.slug === FEATURE_GROUP_ESSENTIAL_FEATURES ? (
@@ -988,6 +1004,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									flowName={ flowName }
 									currentSitePlanSlug={ currentSitePlanSlug }
 									isHighlighted={ false }
+									selectedPlan={ selectedPlan }
 								/>
 							) : null }
 						</div>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -188,8 +188,14 @@ const PlanLogo: React.FunctionComponent< {
 		visiblePlans: planPropertiesObj,
 		flowName,
 		currentSitePlanSlug,
+		selectedPlan,
 	} );
-	const highlightLabel = useHighlightLabel( { planName, flowName, currentSitePlanSlug } );
+	const highlightLabel = useHighlightLabel( {
+		planName,
+		flowName,
+		currentSitePlanSlug,
+		selectedPlan,
+	} );
 	const headerClasses = classNames(
 		'plan-features-2023-grid__header-logo',
 		getPlanClass( planName )


### PR DESCRIPTION
## Proposed Changes

Fixes the issue reported by @mikemayhem3030 in p1685088113454759-slack-C029GN3KD and introduced by https://github.com/Automattic/wp-calypso/pull/76497 which was causing the "Suggested" label of the filtered plans page to be wrongly positioned.

Before | After
--- | ---
<img width="1255" alt="Screenshot 2023-05-26 at 15 10 22" src="https://github.com/Automattic/wp-calypso/assets/1233880/ff460087-c9a0-4127-99af-e1efbbb4cb80"> | <img width="1250" alt="Screenshot 2023-05-26 at 15 21 37" src="https://github.com/Automattic/wp-calypso/assets/1233880/ddfc6936-ced1-4018-b18a-603be5c06073">
<img width="1244" alt="Screenshot 2023-05-26 at 15 25 30" src="https://github.com/Automattic/wp-calypso/assets/1233880/c54877e6-e9eb-44bf-93f8-8df0222f672b"> | <img width="1247" alt="Screenshot 2023-05-26 at 15 21 43" src="https://github.com/Automattic/wp-calypso/assets/1233880/2bd6c465-968f-4d79-ad5e-7b69bf2f755e">
<img width="1251" alt="Screenshot 2023-05-26 at 15 25 36" src="https://github.com/Automattic/wp-calypso/assets/1233880/0e1fba3b-3415-4903-a671-c1f64d644fe2"> | <img width="1250" alt="Screenshot 2023-05-26 at 15 21 49" src="https://github.com/Automattic/wp-calypso/assets/1233880/25115c0c-ae58-4262-bcbe-a65eba37ff17">
<img width="1242" alt="Screenshot 2023-05-26 at 15 25 42" src="https://github.com/Automattic/wp-calypso/assets/1233880/d7adbf06-9ed5-46b6-9156-c6b8650d77d1"> | <img width="1246" alt="Screenshot 2023-05-26 at 15 21 56" src="https://github.com/Automattic/wp-calypso/assets/1233880/0074a8bb-8db7-4786-a8d4-367d7f3b95f6">

## Testing Instructions

- Use the Calypso live link below.
- Switch to a free site and go to `/plans`.
- Add the `?plan=` query param to test all possible plans: `personal-bundle`, `value_bundle`, `business-bundle`, `ecommerce-bundle`.
- Make sure the "Suggested" label is correctly positioned.