### PR TITLE
Migrate remaining plan notices to the Plans2023 Grid

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -1,4 +1,4 @@
-import { PlanSlug } from '@automattic/calypso-products';
+import { PlanSlug, isProPlan, isStarterPlan } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
@@ -7,18 +7,14 @@ import { useSelector } from 'react-redux';
 import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
 import { getDiscountByName } from 'calypso/lib/discounts';
+import { ActiveDiscount } from 'calypso/lib/discounts/active-discounts';
 import { useCalculateMaxPlanUpgradeCredit } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-calculate-max-plan-upgrade-credit';
 import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
-import { isCurrentPlanPaid } from 'calypso/state/sites/selectors';
+import { getSitePlan, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 
-export default function PlanNotice( {
-	siteId,
-	isInSignup,
-	visiblePlans = [],
-	discountInformation: { withDiscount, discountEndDate },
-}: {
+export type PlanNoticeProps = {
 	visiblePlans: PlanSlug[];
 	isInSignup: boolean;
 	siteId: number;
@@ -26,87 +22,145 @@ export default function PlanNotice( {
 		withDiscount: string;
 		discountEndDate: Date;
 	};
-} ) {
-	const translate = useTranslate();
-	const [ isNoticeDismissed, setIsNoticeDismissed ] = useState( false );
-	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
+};
+const NO_NOTICE = 'no-notice';
+const USER_CANNOT_PURCHASE_NOTICE = 'user-cannot-purchase-notice';
+const ACTIVE_DISCOUNT_NOTICE = 'active-discount-notice';
+const PLAN_UPGRADE_CREDIT_NOTICE = 'plan-upgrade-credit-notice';
+const MARKETING_NOTICE = 'plan-upgrade-credit-notice';
+const PLAN_RETIREMENT_NOTICE = 'plan-retirement-notice';
+const CURRENT_PLAN_IN_APP_PURCHASE_NOTICE = 'current-plan-in-app-purchase-notice';
+
+export type PlanNoticeTypes =
+	| typeof NO_NOTICE
+	| typeof USER_CANNOT_PURCHASE_NOTICE
+	| typeof ACTIVE_DISCOUNT_NOTICE
+	| typeof PLAN_UPGRADE_CREDIT_NOTICE
+	| typeof MARKETING_NOTICE
+	| typeof PLAN_RETIREMENT_NOTICE
+	| typeof CURRENT_PLAN_IN_APP_PURCHASE_NOTICE;
+
+function useResolveNoticeType(
+	{
+		siteId,
+		isInSignup,
+		visiblePlans = [],
+		discountInformation: { withDiscount, discountEndDate },
+	}: PlanNoticeProps,
+	isNoticeDismissed: boolean
+): PlanNoticeTypes {
 	const canUserPurchasePlan = useSelector(
 		( state ) =>
 			! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
 	);
 	const activeDiscount = getDiscountByName( withDiscount, discountEndDate );
-	const creditsValue = useCalculateMaxPlanUpgradeCredit( siteId, visiblePlans );
 	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible( siteId, visiblePlans );
-
-	const handleDismissNotice = () => setIsNoticeDismissed( true );
+	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
+	const sitePlanSlug = sitePlan?.product_slug ?? '';
+	const isCurrentPlanRetired = isProPlan( sitePlanSlug ) || isStarterPlan( sitePlanSlug );
 
 	if ( isNoticeDismissed || isInSignup ) {
-		return null;
+		return NO_NOTICE;
 	} else if ( ! canUserPurchasePlan ) {
-		return (
-			<Notice
-				className="plan-features-main__notice"
-				showDismiss={ true }
-				onDismissClick={ handleDismissNotice }
-				icon="info-outline"
-				status="is-success"
-				isReskinned={ true }
-			>
-				{ translate(
-					'This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner.'
-				) }
-			</Notice>
-		);
+		return USER_CANNOT_PURCHASE_NOTICE;
+	} else if ( isCurrentPlanRetired ) {
+		return PLAN_RETIREMENT_NOTICE;
 	} else if ( activeDiscount ) {
-		return (
-			<Notice
-				className="plan-features-main__notice"
-				showDismiss={ true }
-				onDismissClick={ handleDismissNotice }
-				icon="info-outline"
-				status="is-success"
-				isReskinned={ true }
-			>
-				{ activeDiscount?.plansPageNoticeTextTitle && (
-					<strong>
-						{ activeDiscount?.plansPageNoticeTextTitle }
-						<br />
-					</strong>
-				) }
-				{ activeDiscount.plansPageNoticeText }
-			</Notice>
-		);
+		return ACTIVE_DISCOUNT_NOTICE;
 	} else if ( isPlanUpgradeCreditEligible ) {
-		return (
-			<Notice
-				className="plan-features-main__notice"
-				showDismiss={ true }
-				onDismissClick={ handleDismissNotice }
-				icon="info-outline"
-				status="is-success"
-				isReskinned={ true }
-			>
-				{ translate(
-					'We’ve applied the {{b}}%(amountInCurrency)s{{/b}} {{a}}upgrade credit{{/a}} from your current plan as a deduction to your new plan, below. This remaining credit will be applied at checkout if you upgrade today!',
-					{
-						args: {
-							amountInCurrency: formatCurrency( creditsValue, currencyCode ?? '' ),
-						},
-						components: {
-							b: <strong />,
-							a: (
-								<a
-									href={ localizeUrl(
-										'https://wordpress.com/support/manage-purchases/#upgrade-credit'
-									) }
-									className="get-apps__desktop-link"
-								/>
-							),
-						},
-					}
-				) }
-			</Notice>
-		);
+		return PLAN_UPGRADE_CREDIT_NOTICE;
 	}
-	return <MarketingMessage siteId={ siteId } />;
+	return MARKETING_NOTICE;
+}
+
+export default function PlanNotice( props: PlanNoticeProps ) {
+	const {
+		siteId,
+		visiblePlans,
+		discountInformation: { withDiscount, discountEndDate },
+	} = props;
+	const translate = useTranslate();
+	const [ isNoticeDismissed, setIsNoticeDismissed ] = useState( false );
+	const noticeType = useResolveNoticeType( props, isNoticeDismissed );
+	const handleDismissNotice = () => setIsNoticeDismissed( true );
+	let activeDiscount = getDiscountByName( withDiscount, discountEndDate );
+	const creditsValue = useCalculateMaxPlanUpgradeCredit( siteId, visiblePlans );
+	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
+
+	switch ( noticeType ) {
+		case NO_NOTICE:
+			return null;
+		case USER_CANNOT_PURCHASE_NOTICE:
+			return (
+				<Notice
+					className="plan-features-main__notice"
+					showDismiss={ true }
+					onDismissClick={ handleDismissNotice }
+					icon="info-outline"
+					status="is-success"
+					isReskinned={ true }
+				>
+					{ translate(
+						'This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner.'
+					) }
+				</Notice>
+			);
+		case ACTIVE_DISCOUNT_NOTICE:
+			activeDiscount = activeDiscount as ActiveDiscount;
+			return (
+				<Notice
+					className="plan-features-main__notice"
+					showDismiss={ true }
+					onDismissClick={ handleDismissNotice }
+					icon="info-outline"
+					status="is-success"
+					isReskinned={ true }
+				>
+					{ activeDiscount.plansPageNoticeTextTitle && (
+						<strong>
+							{ activeDiscount.plansPageNoticeTextTitle }
+							<br />
+						</strong>
+					) }
+					{ activeDiscount.plansPageNoticeText }
+				</Notice>
+			);
+		case PLAN_UPGRADE_CREDIT_NOTICE:
+			return (
+				<Notice
+					className="plan-features-main__notice"
+					showDismiss={ true }
+					onDismissClick={ handleDismissNotice }
+					icon="info-outline"
+					status="is-success"
+					isReskinned={ true }
+				>
+					{ translate(
+						'We’ve applied the {{b}}%(amountInCurrency)s{{/b}} {{a}}upgrade credit{{/a}} from your current plan as a deduction to your new plan, below. This remaining credit will be applied at checkout if you upgrade today!',
+						{
+							args: {
+								amountInCurrency: formatCurrency( creditsValue, currencyCode ?? '' ),
+							},
+							components: {
+								b: <strong />,
+								a: (
+									<a
+										href={ localizeUrl(
+											'https://wordpress.com/support/manage-purchases/#upgrade-credit'
+										) }
+										className="get-apps__desktop-link"
+									/>
+								),
+							},
+						}
+					) }
+				</Notice>
+			);
+		case MARKETING_NOTICE:
+			return <MarketingMessage siteId={ siteId } />;
+		case PLAN_RETIREMENT_NOTICE:
+		case CURRENT_PLAN_IN_APP_PURCHASE_NOTICE:
+		default:
+			return 'Implementation in progress';
+	}
 }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -34,7 +34,6 @@ import { Button } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { hasTranslation } from '@wordpress/i18n';
 import warn from '@wordpress/warning';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -49,7 +48,6 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HappychatConnection from 'calypso/components/happychat/connection-connected';
-import Notice from 'calypso/components/notice';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import { getTld } from 'calypso/lib/domains';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
@@ -271,7 +269,6 @@ export class PlansFeaturesMain extends Component {
 		const {
 			basePlansPath,
 			busyOnUpgradeClick,
-			currentPurchaseIsInAppPurchase,
 			customerType,
 			disableBloggerPlanWithNonBlogDomain,
 			domainName,
@@ -279,7 +276,6 @@ export class PlansFeaturesMain extends Component {
 			isJetpack,
 			isLandingPage,
 			isLaunchPage,
-			isCurrentPlanRetired,
 			isFAQCondensedExperiment,
 			isReskinned,
 			onUpgradeClick,
@@ -294,27 +290,9 @@ export class PlansFeaturesMain extends Component {
 			isInVerticalScrollingPlansExperiment,
 			redirectToAddDomainFlow,
 			hidePlanTypeSelector,
-			translate,
-			locale,
 			flowName,
 			isPlansInsideStepper,
 		} = this.props;
-
-		const legacyText =
-			locale === 'en' ||
-			hasTranslation(
-				'Your current plan is no longer available for new subscriptions. ' +
-					'You’re all set to continue with the plan for as long as you like. ' +
-					'Alternatively, you can switch to any of our current plans by selecting it below. ' +
-					'Please keep in mind that switching plans will be irreversible.'
-			)
-				? translate(
-						'Your current plan is no longer available for new subscriptions. ' +
-							'You’re all set to continue with the plan for as long as you like. ' +
-							'Alternatively, you can switch to any of our current plans by selecting it below. ' +
-							'Please keep in mind that switching plans will be irreversible.'
-				  )
-				: null;
 
 		if ( shouldShowPlansFeatureComparison ) {
 			return (
@@ -373,18 +351,6 @@ export class PlansFeaturesMain extends Component {
 				) }
 				data-e2e-plans="wpcom"
 			>
-				{ isCurrentPlanRetired && legacyText && (
-					<Notice showDismiss={ false } status="is-info" text={ legacyText } />
-				) }
-				{ ! isCurrentPlanRetired && currentPurchaseIsInAppPurchase && (
-					<Notice
-						showDismiss={ false }
-						status="is-info"
-						text={ translate(
-							'Your current plan is an in-app purchase. You can upgrade to a different plan from within the WordPress app.'
-						) }
-					></Notice>
-				) }
 				<PlanFeatures
 					redirectToAddDomainFlow={ redirectToAddDomainFlow }
 					hidePlanTypeSelector={ hidePlanTypeSelector }

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -38,6 +38,9 @@ import {
 import { screen } from '@testing-library/react';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { PlansFeaturesMain } from '../index';
+jest.mock( 'calypso/state/purchases/selectors', () => ( {
+	getByPurchaseId: jest.fn(),
+} ) );
 
 const props = {
 	selectedPlan: PLAN_FREE,


### PR DESCRIPTION
Fixes Automattic/wp-calypso#77378

## Proposed Changes
* Moves the notices related to retired plans and in app purchases to the new plans 2023 grid

### Retired plan notice

<img width="1665" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/e67f26cf-e131-4b4e-a85f-8039558dcfa9">

## Testing Instructions
* Unit tests should work
* Add the pro plan to a site and make sure the above notice is visible
* @hannahtinkler can you please let us know how we can reproduce the notice visible at #58518

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
