### PR TITLE
Toggle chat launcher when presales enabled and eligible in Checkout

### DIFF
--- a/client/components/presales-zendesk-chat/index.tsx
+++ b/client/components/presales-zendesk-chat/index.tsx
@@ -1,11 +1,15 @@
+import { HelpCenter } from '@automattic/data-stores';
 import { loadScript } from '@automattic/load-script';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
+import type { HelpCenterSelect } from '@automattic/data-stores';
 
 interface Props {
 	chatKey: string | false;
 }
 
 const ZENDESK_SCRIPT_ID = 'ze-snippet';
+const HELP_CENTER_STORE = HelpCenter.register();
 
 const ZendeskChat = ( { chatKey }: Props ) => {
 	useEffect( () => {
@@ -23,6 +27,23 @@ const ZendeskChat = ( { chatKey }: Props ) => {
 			{ id: ZENDESK_SCRIPT_ID }
 		);
 	}, [ chatKey ] );
+
+	const { setShowMessagingLauncher } = useDispatch( HELP_CENTER_STORE );
+	const { isMessagingWidgetShown } = useSelect( ( select ) => {
+		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
+		return {
+			isMessagingWidgetShown: helpCenterSelect.isMessagingWidgetShown(),
+		};
+	}, [] );
+
+	useEffect( () => {
+		setShowMessagingLauncher( true );
+		return () => {
+			if ( ! isMessagingWidgetShown ) {
+				setShowMessagingLauncher( false );
+			}
+		};
+	}, [ setShowMessagingLauncher, isMessagingWidgetShown ] );
 
 	return null;
 };


### PR DESCRIPTION
Related to #77404
This fixes the case for paid users that already have chat support. So instead of loading the pre-sales chat widget, we just toggle the support one.

## Proposed Changes

* Toggle the Zendesk Messaging launcher when the paid user is in Checkout, is eligible and presales is available.

## Testing Instructions

For the free user case, see #77404.
<img width="598" alt="Screenshot 2023-05-25 at 18 07 11" src="https://github.com/Automattic/wp-calypso/assets/3392497/c6a4ab68-0ee7-4b84-9247-4bf461df4e9f">


For paid user case:
 - Have a user with livechat support (lets say, on Premium plan).
 - Try upgrading to a higher plan or purchasing a domain.
 - Verify that the Zendesk Messaging launcher shows up in Checkout. And it should disappear once you leave it - unless you have the widget opened.

<img width="598" alt="Screenshot 2023-05-26 at 13 56 15" src="https://github.com/Automattic/wp-calypso/assets/3392497/dfcdecc2-4d00-4a3e-b316-e485be23709e">
