### PR TITLE
Social-previews: add hashtag support for Mastodon

### DIFF
--- a/packages/social-previews/src/helpers.tsx
+++ b/packages/social-previews/src/helpers.tsx
@@ -52,7 +52,7 @@ export const formatTweetDate = new Intl.DateTimeFormat( 'en-US', {
 	day: 'numeric',
 } ).format;
 
-export type Platform = 'twitter' | 'facebook' | 'linkedin' | 'instagram';
+export type Platform = 'twitter' | 'facebook' | 'linkedin' | 'instagram' | 'mastodon';
 
 type PreviewTextOptions = {
 	platform: Platform;
@@ -67,6 +67,7 @@ export const hashtagUrlMap: Record< Platform, string > = {
 	facebook: 'https://www.facebook.com/hashtag/%s',
 	linkedin: 'https://www.linkedin.com/feed/hashtag/?keywords=%s',
 	instagram: 'https://www.instagram.com/explore/tags/%s',
+	mastodon: 'https://mastodon.social/tags/%s',
 };
 
 /**

--- a/packages/social-previews/src/mastodon-preview/helpers.ts
+++ b/packages/social-previews/src/mastodon-preview/helpers.ts
@@ -1,14 +1,28 @@
-import { firstValid, hardTruncation, shortEnough, stripHtmlTags, Formatter } from '../helpers';
+import {
+	firstValid,
+	hardTruncation,
+	shortEnough,
+	stripHtmlTags,
+	preparePreviewText,
+	Formatter,
+} from '../helpers';
 
-export const TITLE_LENGTH = 200;
-export const BODY_LENGTH = 500;
-export const URL_LENGTH = 30;
+const TITLE_LENGTH = 200;
+const BODY_LENGTH = 500;
+const URL_LENGTH = 30;
 
 export const mastodonTitle: Formatter = ( text ) =>
 	firstValid(
 		shortEnough( TITLE_LENGTH ),
 		hardTruncation( TITLE_LENGTH )
 	)( stripHtmlTags( text ) ) || '';
+
+export const mastodonBody = ( text: string, offset = 0 ) => {
+	return preparePreviewText( text, {
+		platform: 'mastodon',
+		maxChars: BODY_LENGTH - URL_LENGTH - offset,
+	} );
+};
 
 export const mastodonUrl: Formatter = ( text ) =>
 	firstValid( shortEnough( URL_LENGTH ), hardTruncation( URL_LENGTH ) )( stripHtmlTags( text ) ) ||

--- a/packages/social-previews/src/mastodon-preview/helpers.ts
+++ b/packages/social-previews/src/mastodon-preview/helpers.ts
@@ -1,19 +1,13 @@
 import { firstValid, hardTruncation, shortEnough, stripHtmlTags, Formatter } from '../helpers';
 
-const TITLE_LENGTH = 200;
-const BODY_LENGTH = 500;
-const URL_LENGTH = 30;
+export const TITLE_LENGTH = 200;
+export const BODY_LENGTH = 500;
+export const URL_LENGTH = 30;
 
 export const mastodonTitle: Formatter = ( text ) =>
 	firstValid(
 		shortEnough( TITLE_LENGTH ),
 		hardTruncation( TITLE_LENGTH )
-	)( stripHtmlTags( text ) ) || '';
-
-export const mastodonBody: Formatter = ( text, offset = 0 ) =>
-	firstValid(
-		shortEnough( BODY_LENGTH - URL_LENGTH - offset ),
-		hardTruncation( BODY_LENGTH - URL_LENGTH - offset )
 	)( stripHtmlTags( text ) ) || '';
 
 export const mastodonUrl: Formatter = ( text ) =>

--- a/packages/social-previews/src/mastodon-preview/post/body/index.tsx
+++ b/packages/social-previews/src/mastodon-preview/post/body/index.tsx
@@ -1,17 +1,10 @@
-import { stripHtmlTags, preparePreviewText } from '../../../helpers';
-import { mastodonUrl, BODY_LENGTH, URL_LENGTH } from '../../helpers';
+import { stripHtmlTags } from '../../../helpers';
+import { mastodonBody, mastodonUrl } from '../../helpers';
 import type { MastodonPreviewProps } from '../../types';
 
 import './styles.scss';
 
 type Props = MastodonPreviewProps & { children?: React.ReactNode };
-
-const body = ( text: string, offset = 0 ) => {
-	return preparePreviewText( text, {
-		platform: 'mastodon',
-		maxChars: BODY_LENGTH - URL_LENGTH - offset,
-	} );
-};
 
 const MastonPostBody: React.FC< Props > = ( props ) => {
 	const { title, description, customText, url, children } = props;
@@ -19,18 +12,18 @@ const MastonPostBody: React.FC< Props > = ( props ) => {
 	let bodyTxt;
 
 	if ( customText ) {
-		bodyTxt = <p>{ body( customText ) }</p>;
+		bodyTxt = <p>{ mastodonBody( customText ) }</p>;
 	} else if ( description ) {
 		const renderedTitle = stripHtmlTags( title );
 
 		bodyTxt = (
 			<>
 				<p>{ renderedTitle }</p>
-				<p>{ body( description, renderedTitle.length ) }</p>
+				<p>{ mastodonBody( description, renderedTitle.length ) }</p>
 			</>
 		);
 	} else {
-		bodyTxt = <p>{ body( title ) }</p>;
+		bodyTxt = <p>{ mastodonBody( title ) }</p>;
 	}
 
 	return (

--- a/packages/social-previews/src/mastodon-preview/post/body/index.tsx
+++ b/packages/social-previews/src/mastodon-preview/post/body/index.tsx
@@ -1,10 +1,17 @@
-import { stripHtmlTags } from '../../../helpers';
-import { mastodonBody, mastodonUrl } from '../../helpers';
+import { stripHtmlTags, preparePreviewText } from '../../../helpers';
+import { mastodonUrl, BODY_LENGTH, URL_LENGTH } from '../../helpers';
 import type { MastodonPreviewProps } from '../../types';
 
 import './styles.scss';
 
 type Props = MastodonPreviewProps & { children?: React.ReactNode };
+
+const body = ( text: string, offset = 0 ) => {
+	return preparePreviewText( text, {
+		platform: 'mastodon',
+		maxChars: BODY_LENGTH - URL_LENGTH - offset,
+	} );
+};
 
 const MastonPostBody: React.FC< Props > = ( props ) => {
 	const { title, description, customText, url, children } = props;
@@ -12,18 +19,18 @@ const MastonPostBody: React.FC< Props > = ( props ) => {
 	let bodyTxt;
 
 	if ( customText ) {
-		bodyTxt = <p>{ mastodonBody( customText ) }</p>;
+		bodyTxt = <p>{ body( customText ) }</p>;
 	} else if ( description ) {
 		const renderedTitle = stripHtmlTags( title );
 
 		bodyTxt = (
 			<>
 				<p>{ renderedTitle }</p>
-				<p>{ mastodonBody( description, renderedTitle.length ) }</p>
+				<p>{ body( description, renderedTitle.length ) }</p>
 			</>
 		);
 	} else {
-		bodyTxt = <p>{ mastodonBody( title ) }</p>;
+		bodyTxt = <p>{ body( title ) }</p>;
 	}
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77444

## Proposed Changes

This diff adds hashtag support to the Mastodon post preview, in the `social-previews` package.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


### Prerequisites
- Make sure you have a Mastodon account
- Note the blog id of your test site
- Add the proper blog sticker to your site, as described in D111014-code
- Visit `wordpress.com/marketing/connections/:site` and connect your Mastodon account

### Testing
- Spin up Calypso by running this branch locally or by using the live link below
- Visit `/posts/:site`
- Click _Share_ in the post options
- Add a custom text that includes a hashtag
- Then click _Preview_
- Notice in the Mastodon preview that the hashtag is clickable

| Before | After |
| -------|------ |
|<img width="300" alt="Screenshot 2023-05-26 at 10 28 34 AM" src="https://github.com/Automattic/wp-calypso/assets/1620183/58eddb58-596c-48f8-8909-8a6a38580765">|<img width="300" alt="Screenshot 2023-05-26 at 10 28 25 AM" src="https://github.com/Automattic/wp-calypso/assets/1620183/2b0404c8-f09d-4b54-a7fe-875a46991e8d">|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
