### PR TITLE
Fetch the credit balance from the DSP

### DIFF
--- a/client/data/promote-post/use-promote-post-credit-balance-query.ts
+++ b/client/data/promote-post/use-promote-post-credit-balance-query.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { requestDSP } from 'calypso/lib/promote-post';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+
+const useCreditBalanceQuery = ( queryOptions = {} ) => {
+	const currentUser = useSelector( getCurrentUser );
+	const wpcomUserId = currentUser?.ID;
+
+	return useQuery( {
+		queryKey: [ 'promote-post-credit-balance', wpcomUserId ],
+		queryFn: async () => {
+			if ( typeof wpcomUserId === 'number' ) {
+				const { balance } = await requestDSP< { balance: string } >(
+					wpcomUserId,
+					`/credits/balance`
+				);
+				return balance;
+			}
+			throw new Error( 'wpcomUserId is undefined' );
+		},
+		...queryOptions,
+		enabled: !! wpcomUserId,
+		retryDelay: 3000,
+		meta: {
+			persist: false,
+		},
+	} );
+};
+
+export default useCreditBalanceQuery;

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -6,7 +6,6 @@ import { useSelector } from 'react-redux';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import wpcom from 'calypso/lib/wp';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -170,11 +169,6 @@ export enum PromoteWidgetStatus {
 	DISABLED = 'disabled',
 }
 
-export enum BlazeCreditStatus {
-	ENABLED = 'enabled',
-	DISABLED = 'disabled',
-}
-
 /**
  * Hook to verify if we should enable the promote widget.
  *
@@ -193,16 +187,4 @@ export const usePromoteWidget = (): PromoteWidgetStatus => {
 		default:
 			return PromoteWidgetStatus.FETCHING;
 	}
-};
-
-/**
- * Hook to verify if we should enable blaze credits
- *
- * @returns bool
- */
-export const useBlazeCredits = (): BlazeCreditStatus => {
-	return useSelector( ( state ) => {
-		const userData = getCurrentUser( state );
-		return userData?.blaze_credits_enabled ? BlazeCreditStatus.ENABLED : BlazeCreditStatus.DISABLED;
-	} );
 };

--- a/client/my-sites/promote-post/components/credit-balance/index.tsx
+++ b/client/my-sites/promote-post/components/credit-balance/index.tsx
@@ -1,16 +1,16 @@
 import './style.scss';
-import { memo, useState } from '@wordpress/element';
+import { memo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { BlazeCreditStatus, useBlazeCredits } from 'calypso/lib/promote-post';
+import useCreditBalanceQuery from 'calypso/data/promote-post/use-promote-post-credit-balance-query';
 
 const CreditBalance = () => {
-	const [ balance ] = useState( 200 ); // Todo: Fetch balance from the API
-	const creditsEnabled = useBlazeCredits() === BlazeCreditStatus.ENABLED;
+	const creditBalance = useCreditBalanceQuery();
+	const { data: balance } = creditBalance;
 
-	if ( ! balance || ! creditsEnabled ) {
+	if ( ! balance ) {
 		return null;
 	}
 

--- a/client/my-sites/promote-post/test/credit-balance.test.tsx
+++ b/client/my-sites/promote-post/test/credit-balance.test.tsx
@@ -3,58 +3,26 @@
  */
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { BlazeCreditStatus, useBlazeCredits } from 'calypso/lib/promote-post';
+import useCreditBalanceQuery from 'calypso/data/promote-post/use-promote-post-credit-balance-query';
 import CreditBalance from '../components/credit-balance';
 
-// Mock the useBlazeCredits hook, so we can tell TS about MockReturnValue
-type UseBlazeCreditsMock = jest.Mock< BlazeCreditStatus >;
-
-jest.mock( 'calypso/lib/promote-post', () => {
-	const module = jest.requireActual( 'calypso/lib/promote-post' );
-	return {
-		...module,
-		useBlazeCredits: jest.fn< UseBlazeCreditsMock, [] >(),
-	};
-} );
+jest.mock( 'calypso/data/promote-post/use-promote-post-credit-balance-query' );
 
 describe( 'CreditBalance component', () => {
-	test( 'displays null when balance is 0', () => {
-		const { container } = render( <CreditBalance /> );
-		expect( container.firstChild ).toBeNull();
+	test( 'displays null when balance is not available', () => {
+		useCreditBalanceQuery.mockReturnValue( { data: null } );
+
+		render( <CreditBalance /> );
+
+		expect( screen.queryByText( /Credits: \$.+/ ) ).toBeNull();
 	} );
 
-	describe( 'CreditBalance component when balance is set', () => {
+	test( 'displays "Credits: $10" when balance is set to 10', () => {
 		const mockBalance = 10;
+		useCreditBalanceQuery.mockReturnValue( { data: mockBalance } );
 
-		beforeEach( () => {
-			jest.clearAllMocks();
+		render( <CreditBalance /> );
 
-			// Set the balance
-			const useStateSpy = jest.spyOn( React, 'useState' );
-			useStateSpy.mockReturnValueOnce( [ mockBalance, jest.fn() ] );
-		} );
-
-		test( 'still returns null when credits are not enabled for the user', () => {
-			// Disable credits for this user
-			( useBlazeCredits as UseBlazeCreditsMock ).mockReturnValue( BlazeCreditStatus.DISABLED );
-
-			// Render the component
-			const { container } = render( <CreditBalance /> );
-
-			// Expectations
-			expect( container.firstChild ).toBeNull();
-		} );
-
-		test( 'displays "Credits: $10" when balance is set to 10', () => {
-			// Enable credits for this user
-			( useBlazeCredits as UseBlazeCreditsMock ).mockReturnValue( BlazeCreditStatus.ENABLED );
-
-			// Render the component
-			render( <CreditBalance /> );
-
-			// Expectations
-			const balance = screen.getByText( /Credits: \$\d+/ );
-			expect( balance ).toHaveTextContent( `Credits: $${ mockBalance }` );
-		} );
+		expect( screen.getByText( /Credits: \$.+/ ) ).toHaveTextContent( `Credits: $${ mockBalance }` );
 	} );
 } );

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -125,7 +125,7 @@
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": true,
 		"press-this": true,
-		"promote-post/redesign-i2": true,
+		"promote-post/redesign-i2": false,
 		"pre-cancellation-modal": false,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,


### PR DESCRIPTION
## Proposed Changes

* Pulls the credit balance from the ownership registry

## Testing Instructions

<img width="1655" alt="Screenshot 2023-05-26 at 14 48 30" src="https://github.com/Automattic/wp-calypso/assets/6440498/28350e75-0921-4046-9f0c-740032f2842e">

hit `/advertising/yoursite.com` using the [live link](https://calypso.live/?image=registry.a8c.com/calypso/app:build-68188) below.

The first rule of credit club:
- [ ] if you don't have credits, you don't see credits

The second rule of credit club:
- [ ] if you do have credits, you do see credits

Ping me if you need any more credits 👍 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
