### PR TITLE
Fix screen category list storybook CSS leaking to other components

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.stories.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.stories.tsx
@@ -7,7 +7,6 @@ import ScreenCategoryList from './screen-category-list';
 /**
  * FIXME: This component should depend only on local `./style.scss`.
  */
-import '../../../internals/global.scss';
 import './navigator-buttons/style.scss';
 import './style.scss';
 
@@ -30,7 +29,12 @@ export default {
 					 * The following style is for fixing the position of the PatternListPanel.
 					 * It depends on `348px` since it uses `margin-inline-start: 348px;` for its position.
 					 */
-					style={ { width: '348px', padding: '32px', boxSizing: 'border-box' } }
+					style={ {
+						width: '348px',
+						padding: '32px',
+						boxSizing: 'border-box',
+						backgroundColor: '#fdfdfd',
+					} }
 				>
 					<Story></Story>
 				</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -49,6 +49,10 @@ $font-family: "SF Pro Text", $sans;
 		overflow-x: visible;
 	}
 
+	p {
+		margin: 0;
+	}
+
 	/**
 	 * Pattern Layout
 	 */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p7H4VZ-4gp-p2#comment-11251

## Proposed Changes

In this PR I propose to remove ScreenCategoryList storybook component dependence on global styles to ensure they are not leaking to other components in storybook.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run storybook in root
```
yarn storybook:start
```
2. Test components and confirm they are styled correctly
3. Check pattern assembler in Calypso and confirm it still looks fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?