### PR TITLE
i18n: Disable exception capture temporary for translation chunks

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -271,6 +271,7 @@ function getInstalledChunks() {
  * @param  {string} chunkId
  * @param  {string} localeSlug
  */
+// eslint-disable-next-line no-unused-vars
 function captureGetTranslationChunkFileException( error, chunkId, localeSlug ) {
 	captureException( error, {
 		tags: {
@@ -314,7 +315,8 @@ function addRequireChunkTranslationsHandler( localeSlug = i18n.getLocaleSlug(), 
 					`Encountered an error loading translation chunk in require chunk translations handler.`,
 					{ cause }
 				);
-				captureGetTranslationChunkFileException( error, chunkId, localeSlug );
+				// @todo: Enable again when figure out how to prevent the spam caused by these errors.
+				// captureGetTranslationChunkFileException( error, chunkId, localeSlug );
 				debug( error );
 			} );
 
@@ -406,7 +408,8 @@ export default async function switchLocale( localeSlug ) {
 							`Encountered an error loading translation chunk while switching the locale.`,
 							{ cause }
 						);
-						captureGetTranslationChunkFileException( error, chunkId, localeSlug );
+						// @todo: Enable again when figure out how to prevent the spam caused by these errors.
+						// captureGetTranslationChunkFileException( error, chunkId, localeSlug );
 						debug( error );
 					} )
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1685112647841309-slack-C04U5A26MJB

## Proposed Changes

* Disable error reporting to Sentry when requiring translation chunk fails to prevent getting spammed in Slack due to multiple reports.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
