### PR TITLE
temporarily re-add calypso params for reader sharing

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -54,6 +54,13 @@ const actionMap = {
 
 function buildQuerystringForPost( post ) {
 	const args = {};
+
+	if ( post.content_embeds && post.content_embeds.length ) {
+		args.embed = post.content_embeds[ 0 ].embedUrl || post.content_embeds[ 0 ].src;
+	}
+
+	args.title = `${ post.title } — ${ post.site_name }`;
+	args.text = post.excerpt;
 	args.url = post.URL;
 	args.is_post_share = true; // There is a dependency on this here https://github.com/Automattic/wp-calypso/blob/a69ded693a99fa6a957b590b1a538f32a581eb8a/client/gutenberg/editor/controller.js#L209
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -206,8 +206,8 @@ export const redirect = async ( context, next ) => {
 };
 
 function getPressThisData( query ) {
-	const { url } = query;
-	return url ? { url } : null;
+	const { text, url, title, embed } = query;
+	return url ? { text, url, title, embed } : null;
 }
 
 function getAnchorFmData( query ) {


### PR DESCRIPTION
Reverts calypso side changes from https://github.com/Automattic/wp-calypso/pull/76776 to allow atomic to continue working until the wpcom block editor cache updates.  This PR recently added changes to both wpcom-block-editor and calypso. The calypso side got rid of some params that are no longer necessary given the changes to wpcom-block-editor. 
 However, because of how atomic cache works, this means the flow in atomic would be broken until the cache updates tomorrow. So here we will just re-add these soon-to-be unnecessary params to cover the gap, and we can revert this specific PR next week.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
