### PR TITLE
Hosting onboarding i2: Use `/start/import` as empty sites' import CTA

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -28,7 +28,7 @@ export const MigrateSiteCTA = () => {
 		<EmptyStateCTA
 			description={ __( 'Bring a site to WordPress.com' ) }
 			label={ __( 'Migrate a site' ) }
-			target="/setup/import-focused"
+			target="/start/import"
 		/>
 	);
 };


### PR DESCRIPTION
Related to p1685091240480409-slack-C0347E545HR.

## Proposed Changes

The `/setup/import-focused` flow is not yet ready to handle starts without a `siteSlug` (see discussion on Slack linked above).

So we need to use `/start/import` for the time being.

## Testing Instructions

1. Open `/sites` with an account that has zero sites;
2. Check that "Import a site" links to `/start/import`.