### PR TITLE
Update TeamCity Jetpack E2E triggers for new Jetpack directories

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -197,25 +197,14 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpack
 
 				// Trigger only when changes are made to the Jetpack staging directories in our WPCOM connection
 				triggerRules = """
-					+:root=wpcom:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/staging/**
-					+:root=wpcom:%WPCOM_JETPACK_PLUGIN_PATH%/staging/**
-				""".trimIndent()
-			}
-		} else if (jetpackTarget == "wpcom-production") {
-			vcs {
-				// Trigger only when the "trunk" branch is modified, i.e. back-end merges
-				branchFilter = """
-					+:trunk
-				""".trimIndent()
-
-				// Trigger only when changes are made to the Jetpack prod directories in our WPCOM connection
-				triggerRules = """
-					+:root=wpcom:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/production/**
-					+:root=wpcom:%WPCOM_JETPACK_PLUGIN_PATH%/production/**
+					+:root=wpcom:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/sun/**
+					+:root=wpcom:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/moon/**
+					+:root=wpcom:%WPCOM_JETPACK_PLUGIN_PATH%/sun/**
+					+:root=wpcom:%WPCOM_JETPACK_PLUGIN_PATH%/moon/**
 				""".trimIndent()
 			}
 		} else {
-			// For remote-site tests, we are just running daily for now. They aren't related to Jetpack releases on DotCom.
+			// For remote-site tests and production, we are just running daily for now.
 			schedule {
 				schedulingPolicy = daily {
 					hour = 5


### PR DESCRIPTION
Related to #

## Proposed Changes

See this Slack thread: p1685120521699549-slack-C01U2KGS2PQ

In short, instead of the staging vs production model for Jetpack deploys, the new daily deploys will use a sun/moon approach, where we just alternate directories with each daily deploy, and flip the constants.

This updates the `wpcom-staging` jetpack e2e tests trigger to account for that!

Also, for now, I've mode the `wpcom-production` e2e tests to just be a daily trigger. We haven't fully decided what we want to do with those, and we can set up other triggers in the future if we want! (Maybe based on changes that flip which directory is being used?)

## Testing Instructions

Should just be no errors in the TeamCity builds 👍 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?