### PR TITLE
Blog onboarding: Update celebration screen for mobile devices 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/index.tsx
@@ -68,8 +68,6 @@ const CelebrationStep: Step = ( { flow } ) => {
 					id="celebration-step-header"
 					headerText={ translate( 'Your blog’s ready!' ) }
 					subHeaderText={ subtitleText }
-					align="center"
-					subHeaderAlign="center"
 				/>
 			}
 			stepContent={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/styles.scss
@@ -20,6 +20,27 @@
 		}
 	}
 
+	.step-container__header .formatted-header {
+		margin: 16px;
+
+		.formatted-header__title {
+			text-align: left;
+
+			@include break-small {
+				text-align: center;
+			}
+		}
+
+		.formatted-header__subtitle {
+			text-align: left;
+			margin-top: 5px;
+
+			@include break-small {
+				text-align: center;
+			}
+		}
+	}
+
 	&__top-content {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2556-gh-Automattic/dotcom-forge

## Proposed Changes

* Improved mobile view of celebration screen

| Before | After |
|--------|--------|
| <img width="489" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/17f53e79-aeb3-4633-ab58-b567185242ee"> | <img width="486" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/10b17163-b428-44b4-ab00-9c9678595533"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load https://github.com/Automattic/jetpack/pull/30871 to your WPCOM Sandbox, but since the Jetpack PR is now merged, if you can't load it with the command above, you can use this diff instead D111566-code
* Go to /setup/design-first on an account with 0 existing sites.
* Complete the process and you should see the celebration screen
* Replace design-first for start-writing to test both flows (it's the same implementation)
* It should continue centered on non small devices

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?