### PR TITLE
Social previews: fix Mastodon hashtag

### DIFF
--- a/client/components/share/mastodon-share-preview/index.jsx
+++ b/client/components/share/mastodon-share-preview/index.jsx
@@ -18,8 +18,6 @@ export class MastodonSharePreview extends PureComponent {
 			message,
 		} = this.props;
 
-		const userName = externalDisplay?.replace( '@mastodon.social', '' );
-
 		return (
 			<MastodonPreviews
 				siteName={ siteName }
@@ -32,8 +30,8 @@ export class MastodonSharePreview extends PureComponent {
 				isSocialPost={ isSocialPost }
 				user={ {
 					displayName: externalName,
-					userName,
 					avatarUrl: externalProfilePicture,
+					address: externalDisplay,
 				} }
 			/>
 		);

--- a/packages/social-previews/src/helpers.tsx
+++ b/packages/social-previews/src/helpers.tsx
@@ -60,14 +60,15 @@ type PreviewTextOptions = {
 	maxLines?: number;
 	hyperlinkUrls?: boolean;
 	hyperlinkHashtags?: boolean;
+	hashtagDomain?: string;
 };
 
 export const hashtagUrlMap: Record< Platform, string > = {
-	twitter: 'https://twitter.com/hashtag/%s',
-	facebook: 'https://www.facebook.com/hashtag/%s',
-	linkedin: 'https://www.linkedin.com/feed/hashtag/?keywords=%s',
-	instagram: 'https://www.instagram.com/explore/tags/%s',
-	mastodon: 'https://mastodon.social/tags/%s',
+	twitter: 'https://twitter.com/hashtag/%1$s',
+	facebook: 'https://www.facebook.com/hashtag/%1$s',
+	linkedin: 'https://www.linkedin.com/feed/hashtag/?keywords=%1$s',
+	instagram: 'https://www.instagram.com/explore/tags/%1$s',
+	mastodon: 'https://%2$s/tags/%1$s',
 };
 
 /**
@@ -145,7 +146,7 @@ export function preparePreviewText( text: string, options: PreviewTextOptions ):
 		 * with a url https://github.com/Automattic/wp-calypso#security that has a hash in it`
 		 */
 		[ ...hashtags ].forEach( ( [ fullMatch, whitespace, hashtag ], index ) => {
-			const url = sprintf( hashtagUrl, hashtag );
+			const url = sprintf( hashtagUrl, hashtag, options.hashtagDomain );
 
 			// Add the element to the component map.
 			componentMap[ `Hashtag${ index }` ] = (

--- a/packages/social-previews/src/mastodon-preview/constants.ts
+++ b/packages/social-previews/src/mastodon-preview/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_MASTODON_INSTANCE = 'mastodon.social';

--- a/packages/social-previews/src/mastodon-preview/helpers.ts
+++ b/packages/social-previews/src/mastodon-preview/helpers.ts
@@ -6,10 +6,14 @@ import {
 	preparePreviewText,
 	Formatter,
 } from '../helpers';
+import { DEFAULT_MASTODON_INSTANCE } from './constants';
+import { MastodonAddressDetails } from './types';
 
 const TITLE_LENGTH = 200;
 const BODY_LENGTH = 500;
 const URL_LENGTH = 30;
+
+const ADDRESS_PATTERN = /^@([^@]*)@([^@]*)$/i;
 
 export const mastodonTitle: Formatter = ( text ) =>
 	firstValid(
@@ -17,13 +21,25 @@ export const mastodonTitle: Formatter = ( text ) =>
 		hardTruncation( TITLE_LENGTH )
 	)( stripHtmlTags( text ) ) || '';
 
-export const mastodonBody = ( text: string, offset = 0 ) => {
+export const mastodonBody = ( text: string, options: { offset: number; instance: string } ) => {
+	const { instance, offset } = options;
+
 	return preparePreviewText( text, {
 		platform: 'mastodon',
 		maxChars: BODY_LENGTH - URL_LENGTH - offset,
+		hashtagDomain: instance,
 	} );
 };
 
 export const mastodonUrl: Formatter = ( text ) =>
 	firstValid( shortEnough( URL_LENGTH ), hardTruncation( URL_LENGTH ) )( stripHtmlTags( text ) ) ||
 	'';
+
+export const getMastodonAddressDetails = ( address: string ): MastodonAddressDetails => {
+	const matches = address.match( ADDRESS_PATTERN );
+
+	return {
+		username: matches?.[ 1 ] || '',
+		instance: matches?.[ 2 ] || DEFAULT_MASTODON_INSTANCE,
+	};
+};

--- a/packages/social-previews/src/mastodon-preview/post/body/index.tsx
+++ b/packages/social-previews/src/mastodon-preview/post/body/index.tsx
@@ -1,5 +1,5 @@
 import { stripHtmlTags } from '../../../helpers';
-import { mastodonBody, mastodonUrl } from '../../helpers';
+import { getMastodonAddressDetails, mastodonBody, mastodonUrl } from '../../helpers';
 import type { MastodonPreviewProps } from '../../types';
 
 import './styles.scss';
@@ -7,23 +7,30 @@ import './styles.scss';
 type Props = MastodonPreviewProps & { children?: React.ReactNode };
 
 const MastonPostBody: React.FC< Props > = ( props ) => {
-	const { title, description, customText, url, children } = props;
+	const { title, description, customText, url, user, children } = props;
+	const instance = user?.address ? getMastodonAddressDetails( user.address ).instance : '';
+	const options = {
+		instance,
+		offset: 0,
+	};
 
 	let bodyTxt;
 
 	if ( customText ) {
-		bodyTxt = <p>{ mastodonBody( customText ) }</p>;
+		bodyTxt = <p>{ mastodonBody( customText, options ) }</p>;
 	} else if ( description ) {
 		const renderedTitle = stripHtmlTags( title );
+
+		options.offset = renderedTitle.length;
 
 		bodyTxt = (
 			<>
 				<p>{ renderedTitle }</p>
-				<p>{ mastodonBody( description, renderedTitle.length ) }</p>
+				<p>{ mastodonBody( description, options ) }</p>
 			</>
 		);
 	} else {
-		bodyTxt = <p>{ mastodonBody( title ) }</p>;
+		bodyTxt = <p>{ mastodonBody( title, options ) }</p>;
 	}
 
 	return (

--- a/packages/social-previews/src/mastodon-preview/post/header/index.tsx
+++ b/packages/social-previews/src/mastodon-preview/post/header/index.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { DEFAULT_MASTODON_INSTANCE } from '../../constants';
 import MastodonPostIcon from '../icons';
 import type { MastodonPreviewProps } from '../../types';
 
@@ -7,7 +8,7 @@ import './styles.scss';
 type Props = Pick< MastodonPreviewProps, 'user' >;
 
 const MastodonPostHeader: React.FC< Props > = ( { user } ) => {
-	const { displayName, userName, avatarUrl } = user || {};
+	const { displayName, address, avatarUrl } = user || {};
 
 	return (
 		<div className="mastodon-preview__post-header">
@@ -19,7 +20,9 @@ const MastodonPostHeader: React.FC< Props > = ( { user } ) => {
 							// translators: username of a fictional Mastodon User
 							__( 'anonymous-user', 'social-previews' ) }
 					</div>
-					<div className="mastodon-preview__post-header-username">{ userName }</div>
+					<div className="mastodon-preview__post-header-username">
+						{ address?.replace( DEFAULT_MASTODON_INSTANCE, '' ) }
+					</div>
 				</div>
 			</div>
 			<div className="mastodon-preview__post-header-audience">

--- a/packages/social-previews/src/mastodon-preview/post/header/index.tsx
+++ b/packages/social-previews/src/mastodon-preview/post/header/index.tsx
@@ -21,7 +21,7 @@ const MastodonPostHeader: React.FC< Props > = ( { user } ) => {
 							__( 'anonymous-user', 'social-previews' ) }
 					</div>
 					<div className="mastodon-preview__post-header-username">
-						{ address?.replace( DEFAULT_MASTODON_INSTANCE, '' ) }
+						{ address?.replace( `@${ DEFAULT_MASTODON_INSTANCE }`, '' ) }
 					</div>
 				</div>
 			</div>

--- a/packages/social-previews/src/mastodon-preview/types.ts
+++ b/packages/social-previews/src/mastodon-preview/types.ts
@@ -2,8 +2,13 @@ import type { SocialPreviewBaseProps } from '../types';
 
 export type MastodonUser = {
 	displayName: string;
-	userName: string;
 	avatarUrl: string;
+	address: string;
+};
+
+export type MastodonAddressDetails = {
+	username: string;
+	instance: string;
 };
 
 export type MastodonPreviewProps = SocialPreviewBaseProps & {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77460

## Proposed Changes

In the `social-previews` package, the Mastodon preview renders hashtags as links to mastodon.social. It should use the connected Mastodon instance instead. This PR fixes it.

Here's the terminology used in this PR: `address = @username@instance`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure you have a Mastodon account in another instance that mastodon.social (e.g. hachyderm.io)
- Note the blog id of your test site
- Add the proper blog sticker to your site, as described in D111014-code
- Visit `wordpress.com/marketing/connections/:site` and connect your Mastodon account

### Testing
- Spin up Calypso by running this branch locally or by using the live link below
- Visit `/posts/:site`
- Click _Share_ in the post options
- Add a custom text that includes a hashtag
- Then click _Preview_
- Notice in the Mastodon preview that the hashtag is clickable and directs to the proper instance

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
