### PR TITLE
Created e2e test for start-writing flow

### DIFF
--- a/test/e2e/specs/onboarding/setup__start-writing.ts
+++ b/test/e2e/specs/onboarding/setup__start-writing.ts
@@ -9,7 +9,6 @@ import {
 	RestAPIClient,
 	DomainSearchComponent,
 	EditorPage,
-	CartCheckoutPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -23,7 +22,6 @@ describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), ()
 	let page: Page;
 	let domainSearchComponent: DomainSearchComponent;
 	let newUserDetails: NewUserResponse;
-	let cartCheckoutPage: CartCheckoutPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
@@ -96,29 +94,13 @@ describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), ()
 			await page.getByRole( 'button', { name: 'Choose a plan' } ).click();
 		} );
 
-		it( 'Select WordPress.com Personal plan', async function () {
-			await page.getByRole( 'button', { name: 'Get Personal' } ).click();
+		it( 'Select WordPress.com Free plan', async function () {
+			await page.getByRole( 'button', { name: 'Start with Free' } ).click();
 		} );
 
 		it( 'Launch site', async function () {
 			await page.waitForURL( /.*start-writing\/launchpad.*/ );
 			await page.getByRole( 'button', { name: 'Launch your blog' } ).click();
-		} );
-
-		it( 'Land in checkout cart', async function () {
-			cartCheckoutPage = new CartCheckoutPage( page );
-			const totalAmount = await cartCheckoutPage.getCheckoutTotalAmount();
-			expect( totalAmount ).toBeGreaterThan( 0 );
-		} );
-
-		it( 'Enter billing and payment details', async function () {
-			const paymentDetails = DataHelper.getTestPaymentDetails();
-			await cartCheckoutPage.enterBillingDetails( paymentDetails );
-			await cartCheckoutPage.enterPaymentDetails( paymentDetails );
-		} );
-
-		it( 'Make purchase', async function () {
-			await cartCheckoutPage.purchase( { timeout: 90 * 1000 } );
 		} );
 
 		it( "Ensure we're redirected to celebration screen", async function () {

--- a/test/e2e/specs/onboarding/setup__start-writing.ts
+++ b/test/e2e/specs/onboarding/setup__start-writing.ts
@@ -15,7 +15,7 @@ import { apiCloseAccount } from '../shared';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), () => {
+describe( 'Start Writing Tailored Onboarding', () => {
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'start_writing',
 	} );
@@ -64,15 +64,15 @@ describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), ()
 		it( 'Add blog name and description', async function () {
 			await page.getByRole( 'button', { name: 'Name your blog' } ).click();
 			await page.getByPlaceholder( 'A catchy name to make your blog memorable' );
-			await page.fill(
-				'input[name="setup-form-input-name"]',
-				`Start writing site ${ testUser.username }`
-			);
-			await page.fill(
-				'textarea[name="setup-form-input-description"]',
-				`The place of ${ testUser.username }`
-			);
-			await page.click( 'button.setup-form__submit' );
+
+			await page
+				.locator( 'input[name="setup-form-input-name"]' )
+				.fill( `Start writing site ${ testUser.username }` );
+			await page
+				.locator( 'textarea[name="setup-form-input-description"]' )
+				.fill( `The place of ${ testUser.username }` );
+
+			await page.locator( 'button.setup-form__submit' ).click();
 		} );
 
 		it( 'Navigate choose a domain', async function () {
@@ -86,7 +86,10 @@ describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), ()
 		} );
 
 		it( 'Skip selecting a domain', async function () {
-			await Promise.all( [ page.waitForNavigation(), page.click( 'text=Decide later' ) ] );
+			await Promise.all( [
+				page.waitForURL( /.*start-writing\/domains.*/ ),
+				page.click( 'text=Decide later' ),
+			] );
 		} );
 
 		it( 'Navigate choose a plan', async function () {

--- a/test/e2e/specs/onboarding/setup__start-writing.ts
+++ b/test/e2e/specs/onboarding/setup__start-writing.ts
@@ -64,8 +64,8 @@ describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), ()
 		} );
 
 		it( 'Add blog name and description', async function () {
-			await page.click( '.launchpad__task:nth-child(2) .button' );
-			await page.waitForLoadState( 'networkidle' );
+			await page.click( 'text=Name your blog' );
+			await page.waitForSelector( 'form.setup-form__form' );
 			await page.fill(
 				'input[name="setup-form-input-name"]',
 				`Start writing site ${ testUser.username }`
@@ -79,7 +79,7 @@ describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), ()
 
 		it( 'Navigate choose a domain', async function () {
 			await page.waitForURL( /.*start-writing\/launchpad.*/ );
-			await page.click( '.launchpad__task:nth-child(3) .button' );
+			await page.click( 'text=Choose a domain' );
 		} );
 
 		it( 'Search for a domain', async function () {
@@ -93,7 +93,7 @@ describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), ()
 
 		it( 'Navigate choose a plan', async function () {
 			await page.waitForURL( /.*start-writing\/launchpad.*/ );
-			await page.click( '.launchpad__task:nth-child(4) .button' );
+			await page.click( 'text=Choose a plan' );
 		} );
 
 		it( 'Select WordPress.com Personal plan', async function () {
@@ -103,7 +103,7 @@ describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), ()
 
 		it( 'Launch site', async function () {
 			await page.waitForURL( /.*start-writing\/launchpad.*/ );
-			await page.click( '.launchpad__task:nth-child(5) .button' );
+			await page.click( 'text=Launch your blog' );
 		} );
 
 		it( 'Land in checkout cart', async function () {

--- a/test/e2e/specs/onboarding/setup__start-writing.ts
+++ b/test/e2e/specs/onboarding/setup__start-writing.ts
@@ -1,0 +1,133 @@
+/**
+ * @group calypso-release
+ */
+import {
+	DataHelper,
+	UserSignupPage,
+	BrowserManager,
+	NewUserResponse,
+	RestAPIClient,
+	DomainSearchComponent,
+	EditorPage,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import { apiCloseAccount } from '../shared';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), () => {
+	const testUser = DataHelper.getNewTestUser( {
+		usernamePrefix: 'start_writing',
+	} );
+	let page: Page;
+	let domainSearchComponent: DomainSearchComponent;
+	let newUserDetails: NewUserResponse;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		await BrowserManager.setStoreCookie( page, { currency: 'EUR' } );
+	} );
+
+	describe( 'Signup via /setup/start-writing', function () {
+		let editorPage: EditorPage;
+		const postTitle = 'my first post title';
+
+		it( 'Navigate to /setup/start-writing', async function () {
+			await page.goto( DataHelper.getCalypsoURL( '/setup/start-writing' ) );
+		} );
+
+		it( 'Enter account details', async function () {
+			await page.waitForURL( /.*start-writing.*/ );
+			const userSignupPage = new UserSignupPage( page );
+			newUserDetails = await userSignupPage.signup(
+				testUser.email,
+				testUser.username,
+				testUser.password
+			);
+		} );
+
+		it( "Start user's first post", async function () {
+			await page.waitForURL( /.*post-new.php\?start-writing=true.*/ );
+			editorPage = new EditorPage( page );
+		} );
+
+		it( 'Enter blog title', async function () {
+			await editorPage.enterTitle( postTitle );
+		} );
+
+		it( 'Publish post and open Launchpad', async function () {
+			await editorPage.publish();
+			await page.waitForURL( /.*start-writing\/launchpad.*/ );
+			await page.locator( ':text("Your blog\'s almost ready!")' ).waitFor();
+		} );
+
+		it( 'Add blog name and description', async function () {
+			await page.click( '.launchpad__task:nth-child(2) .button' );
+			await page.waitForLoadState( 'networkidle' );
+			await page.fill(
+				'input[name="setup-form-input-name"]',
+				`Start writing site ${ testUser.username }`
+			);
+			await page.fill(
+				'textarea[name="setup-form-input-description"]',
+				`The place of ${ testUser.username }`
+			);
+			await page.click( 'button.setup-form__submit' );
+		} );
+
+		it( 'Navigate choose a domain', async function () {
+			await page.waitForURL( /.*start-writing\/launchpad.*/ );
+			await page.click( '.launchpad__task:nth-child(3) .button' );
+		} );
+
+		it( 'Search for a domain', async function () {
+			domainSearchComponent = new DomainSearchComponent( page );
+			await domainSearchComponent.search( testUser.username );
+		} );
+
+		it( 'Skip selecting a domain', async function () {
+			await Promise.all( [ page.waitForNavigation(), page.click( 'text=Decide later' ) ] );
+		} );
+
+		it( 'Navigate choose a plan', async function () {
+			await page.waitForURL( /.*start-writing\/launchpad.*/ );
+			await page.click( '.launchpad__task:nth-child(4) .button' );
+		} );
+
+		it( 'Select WordPress.com Free plan', async function () {
+			await page.waitForLoadState( 'networkidle' );
+			await page.click( 'text="Start with Free"' );
+		} );
+
+		it( 'Launch site', async function () {
+			await page.waitForURL( /.*start-writing\/launchpad.*/ );
+			await page.click( '.launchpad__task:nth-child(5) .button' );
+			await page.waitForURL( /.*start-writing\/celebration-step.*/ );
+		} );
+
+		it( 'Navigate to connect to social', async function () {
+			await page.click( '.celebration-step__top-content-cta-social' );
+			await page.waitForURL( /.*marketing\/connections.*/ );
+		} );
+	} );
+
+	afterAll( async function () {
+		if ( ! newUserDetails ) {
+			return;
+		}
+
+		const restAPIClient = new RestAPIClient(
+			{
+				username: testUser.username,
+				password: testUser.password,
+			},
+			newUserDetails.body.bearer_token
+		);
+
+		await apiCloseAccount( restAPIClient, {
+			userID: newUserDetails.body.user_id,
+			username: newUserDetails.body.username,
+			email: testUser.email,
+		} );
+	} );
+} );

--- a/test/e2e/specs/onboarding/setup__start-writing.ts
+++ b/test/e2e/specs/onboarding/setup__start-writing.ts
@@ -64,8 +64,8 @@ describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), ()
 		} );
 
 		it( 'Add blog name and description', async function () {
-			await page.click( 'text=Name your blog' );
-			await page.waitForSelector( 'form.setup-form__form' );
+			await page.getByRole( 'button', { name: 'Name your blog' } ).click();
+			await page.getByPlaceholder( 'A catchy name to make your blog memorable' );
 			await page.fill(
 				'input[name="setup-form-input-name"]',
 				`Start writing site ${ testUser.username }`
@@ -79,7 +79,7 @@ describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), ()
 
 		it( 'Navigate choose a domain', async function () {
 			await page.waitForURL( /.*start-writing\/launchpad.*/ );
-			await page.click( 'text=Choose a domain' );
+			await page.getByRole( 'button', { name: 'Choose a domain' } ).click();
 		} );
 
 		it( 'Search for a domain', async function () {
@@ -93,17 +93,16 @@ describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), ()
 
 		it( 'Navigate choose a plan', async function () {
 			await page.waitForURL( /.*start-writing\/launchpad.*/ );
-			await page.click( 'text=Choose a plan' );
+			await page.getByRole( 'button', { name: 'Choose a plan' } ).click();
 		} );
 
 		it( 'Select WordPress.com Personal plan', async function () {
-			await page.waitForLoadState( 'networkidle' );
-			await page.click( 'text="Get Personal"' );
+			await page.getByRole( 'button', { name: 'Get Personal' } ).click();
 		} );
 
 		it( 'Launch site', async function () {
 			await page.waitForURL( /.*start-writing\/launchpad.*/ );
-			await page.click( 'text=Launch your blog' );
+			await page.getByRole( 'button', { name: 'Launch your blog' } ).click();
 		} );
 
 		it( 'Land in checkout cart', async function () {
@@ -128,7 +127,7 @@ describe( DataHelper.createSuiteTitle( 'Start Writing Tailored Onboarding' ), ()
 
 		it( 'Navigate to connect to social', async function () {
 			await page.waitForURL( /.*start-writing\/celebration-step.*/ );
-			await page.click( '.celebration-step__top-content-cta-social' );
+			await page.getByRole( 'link', { name: 'Connect to social' } ).click();
 			await page.waitForURL( /.*marketing\/connections.*/ );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/76135

## Proposed Changes

* Added e2e test for the new `start-writing` flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### E2E testing instructions
- First of all, build the calypso-e2e package with `yarn build` on `/packages/calypso-e2e`.
- Follow [this guide](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/README.md#quick-start) to make sure to have the environment working.
- Run `yarn workspace wp-e2e-tests test -- setup__start-writing`
- Make sure all test passes and are covering enough steps:

<img width="789" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/98188506-bfb4-4e10-be60-2e6f2ecef9ac">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
