### PR TITLE
Blog onboarding: Implement write your first post action for design-first flow

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -1,9 +1,8 @@
-import { START_WRITING_FLOW } from '@automattic/onboarding';
+import { START_WRITING_FLOW, DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
 import { useEffect, createPortal, useState } from '@wordpress/element';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
-import { getQueryArg } from '@wordpress/url';
 import useSiteIntent from '../../dotcom-fse/lib/site-intent/use-site-intent';
 import WpcomBlockEditorNavSidebar from './components/nav-sidebar';
 import ToggleSidebarButton from './components/toggle-sidebar-button';
@@ -36,11 +35,9 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 				// eslint-disable-next-line react-hooks/exhaustive-deps
 			}, [] );
 
-			const { siteIntent: intent } = useSiteIntent();
+			const { siteIntent: intent, siteIntentFetched } = useSiteIntent();
 			// We check the URL param along with site intent because the param loads faster and prevents element flashing.
-			const isStartWritingFlow =
-				intent === START_WRITING_FLOW ||
-				getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
+			const isBlogOnboardingFlow = intent === START_WRITING_FLOW || intent === DESIGN_FIRST_FLOW;
 
 			const [ clickGuardRoot ] = useState( () => document.createElement( 'div' ) );
 			useEffect( () => {
@@ -62,7 +59,7 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 				[]
 			);
 
-			if ( isStartWritingFlow ) {
+			if ( ! siteIntentFetched || isBlogOnboardingFlow ) {
 				return <MainDashboardButton></MainDashboardButton>;
 			}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -1,11 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useLocale } from '@automattic/i18n-utils';
-import { START_WRITING_FLOW } from '@automattic/onboarding';
+import { START_WRITING_FLOW, DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { WpcomTourKit, usePrefetchTourAssets } from '@automattic/tour-kit';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { useEffect, useMemo } from '@wordpress/element';
-import { getQueryArg } from '@wordpress/url';
 import useSiteIntent from '../../../dotcom-fse/lib/site-intent/use-site-intent';
 import useSitePlan from '../../../dotcom-fse/lib/site-plan/use-site-plan';
 import { selectors as starterPageTemplatesSelectors } from '../../../starter-page-templates/store';
@@ -51,15 +50,12 @@ function LaunchWpcomWelcomeTour() {
 	const editorType = getEditorType();
 	const { siteIntent: intent } = useSiteIntent();
 	// We check the URL param along with site intent because the param loads faster and prevents element flashing.
-	const isStartWritingFlow =
-		intent === START_WRITING_FLOW ||
-		getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
-
+	const isBlogOnboardingFlow = intent === START_WRITING_FLOW || intent === DESIGN_FIRST_FLOW;
 	// Preload first card image (others preloaded after open state confirmed)
 	usePrefetchTourAssets( [ getTourSteps( localeSlug, false, false, null, siteIntent )[ 0 ] ] );
 
 	useEffect( () => {
-		if ( isStartWritingFlow ) {
+		if ( isBlogOnboardingFlow ) {
 			return;
 		}
 		if ( ! show && ! isNewPageLayoutModalOpen ) {
@@ -84,10 +80,10 @@ function LaunchWpcomWelcomeTour() {
 		siteIntent,
 		siteIntentFetched,
 		editorType,
-		isStartWritingFlow,
+		isBlogOnboardingFlow,
 	] );
 
-	if ( ! show || isNewPageLayoutModalOpen || isStartWritingFlow ) {
+	if ( ! show || isNewPageLayoutModalOpen || isBlogOnboardingFlow ) {
 		return null;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/editor.scss
+++ b/apps/wpcom-block-editor/src/wpcom/editor.scss
@@ -1,6 +1,6 @@
 @import "./features/use-classic-block-guide";
 
-.start-writing-hide {
+.blog-onboarding-hide {
 	.components-external-link, // "Connect an account" link in Jetpack sidebar
 	.editor-post-trash, // "Move to trash" button in sidebar.
 	.launchpad__save-modal, // "Great progress" modal popup after publishing a post. Used in other flows.

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -1,7 +1,6 @@
 import { dispatch, select, subscribe } from '@wordpress/data';
 import { getQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
-import { inIframe } from '../../utils';
 import useSiteIntent from './use-site-intent';
 
 const START_WRITING_FLOW = 'start-writing';
@@ -53,12 +52,7 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 
 			dispatch( 'core/edit-post' ).closePublishSidebar();
 
-			const postPublishURL = `${ siteOrigin }/setup/${ intent }/launchpad?siteSlug=${ siteSlug }`;
-			if ( ! inIframe ) {
-				window.location.href = postPublishURL;
-			} else {
-				window.open( postPublishURL, '_top' );
-			}
+			window.location.href = `${ siteOrigin }/setup/${ intent }/launchpad?siteSlug=${ siteSlug }`;
 		}
 	} );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -4,7 +4,12 @@ import {
 	PLAN_PREMIUM,
 	FEATURE_STYLE_CUSTOMIZATION,
 } from '@automattic/calypso-products';
-import { isBlogOnboardingFlow, isNewsletterFlow, isStartWritingFlow } from '@automattic/onboarding';
+import {
+	isBlogOnboardingFlow,
+	isDesignFirstFlow,
+	isNewsletterFlow,
+	isStartWritingFlow,
+} from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -180,7 +185,11 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published':
 					taskData = {
-						disabled: mustVerifyEmailBeforePosting || isBlogOnboardingFlow( flow || null ) || false,
+						disabled:
+							mustVerifyEmailBeforePosting ||
+							isStartWritingFlow( flow || null ) ||
+							( task.completed && isDesignFirstFlow( flow || null ) ) ||
+							false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign( `/post/${ siteSlug }` );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -192,9 +192,12 @@ export function getEnhancedTasks(
 							false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							! isDesignFirstFlow( flow || null )
-								? window.location.assign( `/post/${ siteSlug }` )
-								: window.location.assign( `https://${ siteSlug }/wp-admin/post-new.php` );
+							const newPostUrl = ! isDesignFirstFlow( flow || null )
+								? `/post/${ siteSlug }`
+								: addQueryArgs( `https://${ siteSlug }/wp-admin/post-new.php`, {
+										origin: window.location.origin,
+								  } );
+							window.location.assign( newPostUrl );
 						},
 					};
 					break;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -4,12 +4,7 @@ import {
 	PLAN_PREMIUM,
 	FEATURE_STYLE_CUSTOMIZATION,
 } from '@automattic/calypso-products';
-import {
-	isBlogOnboardingFlow,
-	isDesignFirstFlow,
-	isNewsletterFlow,
-	isStartWritingFlow,
-} from '@automattic/onboarding';
+import { isBlogOnboardingFlow, isNewsletterFlow, isStartWritingFlow } from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -46,14 +41,6 @@ export function getEnhancedTasks(
 ) {
 	if ( ! tasks ) {
 		return [];
-	}
-
-	/**
-	 * Remove the first_post_published task from the task list if the flow is design-first.
-	 * This is temporary until we proper implement the editor flow.
-	 */
-	if ( isDesignFirstFlow( flow ) ) {
-		tasks = tasks.filter( ( task ) => task.id !== 'first_post_published' );
 	}
 
 	const enhancedTaskList: Task[] = [];
@@ -193,7 +180,7 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published':
 					taskData = {
-						disabled: mustVerifyEmailBeforePosting || isStartWritingFlow( flow || null ) || false,
+						disabled: mustVerifyEmailBeforePosting || isBlogOnboardingFlow( flow || null ) || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign( `/post/${ siteSlug }` );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -192,7 +192,9 @@ export function getEnhancedTasks(
 							false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign( `/post/${ siteSlug }` );
+							! isDesignFirstFlow( flow || null )
+								? window.location.assign( `/post/${ siteSlug }` )
+								: window.location.assign( `https://${ siteSlug }/wp-admin/post-new.php` );
 						},
 					};
 					break;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2523

## Proposed Changes

Enable `Write a post` on `design-first` flow.

## Tasks

- [x] Enable `Write your first post` for `design-first` flow
- [x] After publishing the post, it should redirect to Launchpad
- [x] In the editor, hide the W icon, Welcome tour, Schedule the post & move to trash as we did in the start-writing flow.
- [x] After completing the process, we expect to have it marked as complete in the `design-first` flow
- [ ] Ensure we don't have the verify email warning in the editor: 

![Image](https://user-images.githubusercontent.com/1044309/240428723-ef01c293-19b6-452f-bfea-612f80a5d0e2.png)

## Screenshots
| Before Writing a post | After Writing a post |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/f4b3bd06-fcdf-4a17-80f9-879ce2587542) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/bc95fc8c-a16a-4287-bd5d-363ea82dcd01) |

## Testing Instructions

* As the Jetpack PR to enable the flow is now merged and may not be deployed yet, you can apply this diff D111566-code
* You have to sandbox `widgets.wp.com`
* Run `yarn dev --sync` for editing-toolkit and wpcom-block-editor
* Go to `/setup/design-first` on an account with 0 existing sites.
* Before `Write a post` you have to sandbox the newly created site.
* Check for the `Write a post` step on Launchpad
* Verify the `Launch your blog` button is enabled without publishing a post (as it is not a required step)
* When Writing a post, check the tasks from the top of the comment.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
