### PR TITLE
Revert "Marketplace: Use TypeScript plugin selectors in Marketplace"

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -26,7 +26,7 @@ import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/sel
 import { getPurchaseFlowState } from 'calypso/state/marketplace/purchase-flow/selectors';
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
 import { installPlugin, activatePlugin } from 'calypso/state/plugins/installed/actions';
-import { getPluginOnSite, getStatusForPlugin } from 'calypso/state/plugins/installed/selectors-ts';
+import { getPluginOnSite, getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -56,6 +56,11 @@ import './style.scss';
 import { MarketplacePluginInstallProps } from './types';
 import type { IAppState } from 'calypso/state/types';
 
+interface InstalledPlugin {
+	slug?: string;
+	id?: number;
+}
+
 const MarketplaceProductInstall = ( {
 	pluginSlug = '',
 	themeSlug = '',
@@ -83,7 +88,7 @@ const MarketplaceProductInstall = ( {
 		getUploadedPluginId( state, siteId )
 	) as string;
 	const pluginUploadComplete = useSelector( ( state ) => isPluginUploadComplete( state, siteId ) );
-	const installedPlugin = useSelector( ( state: DefaultRootState ) =>
+	const installedPlugin = useSelector( ( state: DefaultRootState ): InstalledPlugin | undefined =>
 		getPluginOnSite( state, siteId, isPluginUploadFlow ? uploadedPluginSlug : pluginSlug )
 	);
 	const pluginActive = useSelector( ( state ) =>

--- a/client/my-sites/marketplace/pages/marketplace-test/index.jsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.jsx
@@ -23,9 +23,9 @@ import { getAutomatedTransfer, getEligibility } from 'calypso/state/automated-tr
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import {
 	getPluginOnSite,
-	getFilteredAndSortedPlugins,
+	getPlugins,
 	isRequestingForSites,
-} from 'calypso/state/plugins/installed/selectors-ts';
+} from 'calypso/state/plugins/installed/selectors';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import {
 	getSelectedSite,
@@ -51,9 +51,7 @@ export default function MarketplaceTest() {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const isAtomicSite = useSelector( ( state ) => isSiteWpcomAtomic( state, selectedSiteId ?? 0 ) );
-	const pluginDetails = useSelector( ( state ) =>
-		getFilteredAndSortedPlugins( state, [ selectedSiteId ] )
-	);
+	const pluginDetails = useSelector( ( state ) => getPlugins( state, [ selectedSiteId ] ) );
 	const { data = [], isFetching } = useWPCOMPluginsList( 'all' );
 
 	const {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#76788