### PR TITLE
Revert "Site Settings: Use TypeScript plugin selectors in site settings"

### DIFF
--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -16,6 +16,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getPlugins } from 'calypso/state/plugins/installed/selectors';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -234,6 +235,7 @@ const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const isAnalyticsEligible = siteHasFeature( state, siteId, FEATURE_GOOGLE_ANALYTICS );
 	const siteIsJetpack = isJetpackSite( state, siteId );
+	const sitePlugins = site ? getPlugins( state, [ site.ID ] ) : [];
 	const path = getCurrentRouteParameterized( state, siteId );
 
 	return {
@@ -241,6 +243,7 @@ const mapStateToProps = ( state ) => {
 		site,
 		siteId,
 		siteIsJetpack,
+		sitePlugins,
 		showUpgradeNudge: ! isAnalyticsEligible,
 		enableForm: isAnalyticsEligible,
 	};

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -55,9 +55,8 @@ const GoogleAnalyticsJetpackForm = ( {
 		? 'https://wordpress.com/support/google-analytics/'
 		: 'https://jetpack.com/support/google-analytics/';
 	const nudgeTitle = translate( 'Connect your site to Google Analytics' );
-	// TODO: it would be better to get wooCommercePlugin directly in form-google-analytics using getAllPluginsIndexedByPluginSlug
 	const wooCommercePlugin = find( sitePlugins, { slug: 'woocommerce' } );
-	const wooCommerceActive = wooCommercePlugin ? wooCommercePlugin.sites[ siteId ].active : false;
+	const wooCommerceActive = wooCommercePlugin ? wooCommercePlugin.active : false;
 
 	useEffect( () => {
 		if ( jetpackModuleActive ) {

--- a/client/my-sites/site-settings/analytics/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics.jsx
@@ -3,7 +3,7 @@ import { pick } from 'lodash';
 import { useState } from 'react';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getFilteredAndSortedPlugins } from 'calypso/state/plugins/installed/selectors-ts';
+import { getPlugins } from 'calypso/state/plugins/installed/selectors';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -97,7 +97,7 @@ const mapStateToProps = ( state ) => {
 	const jetpackModuleActive = isJetpackModuleActive( state, siteId, 'google-analytics' );
 	const siteIsJetpack = isJetpackSite( state, siteId );
 	const googleAnalyticsEnabled = site && ( ! siteIsJetpack || jetpackModuleActive );
-	const sitePlugins = site ? getFilteredAndSortedPlugins( state, [ site.ID ] ) : [];
+	const sitePlugins = site ? getPlugins( state, [ site.ID ] ) : [];
 	const path = getCurrentRouteParameterized( state, siteId );
 
 	return {

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -28,7 +28,7 @@ import { PRODUCT_UPSELLS_BY_FEATURE } from 'calypso/my-sites/plans/jetpack-plans
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
-import { getFilteredAndSortedPlugins } from 'calypso/state/plugins/installed/selectors-ts';
+import { getPlugins } from 'calypso/state/plugins/installed/selectors';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import isHiddenSite from 'calypso/state/selectors/is-hidden-site';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
@@ -429,7 +429,7 @@ const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
 
-	const activePlugins = getFilteredAndSortedPlugins( state, [ siteId ], 'active' );
+	const activePlugins = getPlugins( state, [ siteId ], 'active' );
 	const conflictedSeoPlugin = siteIsJetpack
 		? getFirstConflictingPlugin( activePlugins ) // Pick first one to keep the notice short.
 		: null;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#76791