### PR TITLE
[Theme Switch Modal] Remove the preserve option

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -78,7 +78,7 @@ class AutoLoadingHomepageModal extends Component {
 	static getDerivedStateFromProps( nextProps, prevState ) {
 		// This component doesn't unmount when the dialog closes, so the state
 		// needs to be reset back to defaults each time it opens.
-		// Reseting `homepageAction` ensures the default option will be selected.
+		// Resetting `homepageAction` ensures the default option will be selected.
 		if ( nextProps.isVisible && ! prevState.wasVisible ) {
 			return { homepageAction: DEFAULT_HOMEPAGE_ACTION, wasVisible: true };
 		} else if ( ! nextProps.isVisible && prevState.wasVisible ) {

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Dialog, Gridicon, Spinner } from '@automattic/components';
+import { Dialog, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { translate } from 'i18n-calypso';
@@ -30,6 +30,8 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './auto-loading-homepage-modal.scss';
 
+const DEFAULT_HOMEPAGE_ACTION = 'use_new_homepage';
+
 class AutoLoadingHomepageModal extends Component {
 	static propTypes = {
 		source: PropTypes.oneOf( [ 'details', 'list', 'upload' ] ).isRequired,
@@ -51,7 +53,7 @@ class AutoLoadingHomepageModal extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			homepageAction: 'keep_current_homepage',
+			homepageAction: DEFAULT_HOMEPAGE_ACTION,
 			// Used to reset state when dialog re-opens, see `getDerivedStateFromProps`
 			wasVisible: props.isVisible,
 			// Don't render the iframe on mobile; Doing it here prevents unnecessary data fetching vs. CSS.
@@ -78,7 +80,7 @@ class AutoLoadingHomepageModal extends Component {
 		// needs to be reset back to defaults each time it opens.
 		// Reseting `homepageAction` ensures the default option will be selected.
 		if ( nextProps.isVisible && ! prevState.wasVisible ) {
-			return { homepageAction: 'keep_current_homepage', wasVisible: true };
+			return { homepageAction: DEFAULT_HOMEPAGE_ACTION, wasVisible: true };
 		} else if ( ! nextProps.isVisible && prevState.wasVisible ) {
 			return { wasVisible: false };
 		}
@@ -131,8 +133,6 @@ class AutoLoadingHomepageModal extends Component {
 			isCurrentTheme,
 			isVisible = false,
 		} = this.props;
-		const { isNarrow } = this.state;
-
 		// Nothing to do when it's the current theme.
 		if ( isCurrentTheme ) {
 			return null;
@@ -152,16 +152,7 @@ class AutoLoadingHomepageModal extends Component {
 			return null;
 		}
 
-		const {
-			name: themeName,
-			id: themeId,
-			stylesheet,
-			screenshot: themeScreenshot,
-		} = this.props.theme;
-
-		const iframeSrcKeepHomepage = `//${ this.props.siteDomain }?theme=${ encodeURIComponent(
-			stylesheet
-		) }&hide_banners=true&preview_overlay=true`;
+		const { name: themeName, id: themeId, screenshot: themeScreenshot } = this.props.theme;
 
 		return (
 			<Dialog
@@ -199,29 +190,6 @@ class AutoLoadingHomepageModal extends Component {
 						} ) }
 					</h1>
 					<div className="themes__theme-preview-items">
-						<div className="themes__theme-preview-item themes__theme-preview-item-iframe-container">
-							<FormLabel>
-								<div className="themes__iframe-wrapper">
-									<Spinner />
-									{ ! isNarrow && (
-										<iframe
-											scrolling="no"
-											loading="lazy"
-											title={ translate( 'Preview of current homepage with new theme applied' ) }
-											src={ iframeSrcKeepHomepage }
-										/>
-									) }
-								</div>
-								<FormRadio
-									value="keep_current_homepage"
-									checked={ 'keep_current_homepage' === this.state.homepageAction }
-									onChange={ this.handleHomepageAction }
-									label={ preventWidows(
-										translate( 'Switch theme, preserving my homepage content.' )
-									) }
-								/>
-							</FormLabel>
-						</div>
 						<div className="themes__theme-preview-item">
 							<FormLabel>
 								<div className="themes__theme-preview-image-wrapper">
@@ -244,22 +212,6 @@ class AutoLoadingHomepageModal extends Component {
 						</div>
 					</div>
 					<div className="themes__autoloading-homepage-option-description">
-						{ this.state.homepageAction === 'keep_current_homepage' && (
-							<p>
-								{ preventWidows(
-									translate(
-										'Your new theme design will be applied without changing your homepage content.'
-									)
-								) }{ ' ' }
-								<ExternalLink
-									href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
-									icon
-									target="__blank"
-								>
-									{ translate( 'Learn more.' ) }
-								</ExternalLink>
-							</p>
-						) }
 						{ this.state.homepageAction === 'use_new_homepage' && (
 							<p>
 								<span


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2222

## Proposed Changes



c.f.
- The logic for `POST /themes/mine`
	- Simple sites fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qnpgvir%2Qgurzr%2Qraqcbvag.cuc%3Se%3Q1p463405%2330-og
	- Atomic sites fbhepr%2Skers%2Swrgcnpx%2Scebwrpgf%2Scyhtvaf%2Swrgcnpx%2Swfba%2Qraqcbvagf%2Swrgcnpx%2Spynff.wrgcnpx%2Qwfba%2Qncv%2Qgurzrf%2Qnpgvir%2Qraqcbvag.cuc%3Se%3Q3n3p4nqp%2336-og

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
