### PR TITLE
enable sharing modal in non-english languages

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useLocale } from '@automattic/i18n-utils';
 import { Modal, Button, ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState, createInterpolateElement } from '@wordpress/element';
@@ -32,8 +31,6 @@ const SharingModal: React.FC = () => {
 	const { launchpadScreenOption } = window?.launchpadOptions || {};
 	const { isDismissed, updateIsDismissed } = useSharingModalDismissed( isDismissedDefault );
 	const { __ } = useI18n();
-	const localeSlug = useLocale();
-	const isEnglish = localeSlug?.startsWith( 'en' );
 	const isPrivateBlog = window?.wpcomGutenberg?.blogPublic === '-1';
 
 	const { link, title } = useSelect(
@@ -89,7 +86,7 @@ const SharingModal: React.FC = () => {
 		launchpadScreenOption,
 	] );
 
-	if ( ! isOpen || isDismissedDefault || isPrivateBlog || ! isEnglish ) {
+	if ( ! isOpen || isDismissedDefault || isPrivateBlog ) {
 		return null;
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/76267

Enable the sharing modal once translations are in for mag-16 languages

https://translate.wordpress.org/projects/wp-plugins/full-site-editing/dev/es/default/?page=2

Currently looking at the translation "Get more traffic to your post by sharing:" has 14/16 translations in, other translations are similarly close to being completed.

### Testing instructions. 
sandbox a test site.
```
cd apps/editing-toolkit
yarn dev --sync
```

Test the sharing modal in non-english languages.
