### PR TITLE
Enable sharing modal on atomic

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-sharing-modal-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-sharing-modal-controller.php
@@ -26,7 +26,7 @@ class WP_REST_WPCOM_Block_Editor_Sharing_Modal_Controller extends \WP_REST_Contr
 	 */
 	public function enqueue_script() {
 		$modal_options = array(
-			'isDismissed' => $this->get_sharing_modal_dismissed(),
+			'isDismissed' => $this->get_wpcom_sharing_modal_dismissed(),
 		);
 
 		wp_add_inline_script(
@@ -46,7 +46,7 @@ class WP_REST_WPCOM_Block_Editor_Sharing_Modal_Controller extends \WP_REST_Contr
 			array(
 				array(
 					'methods'             => \WP_REST_Server::EDITABLE,
-					'callback'            => array( $this, 'set_sharing_modal_dismissed' ),
+					'callback'            => array( $this, 'set_wpcom_sharing_modal_dismissed' ),
 					'permission_callback' => array( $this, 'permission_callback' ),
 				),
 			)
@@ -67,8 +67,12 @@ class WP_REST_WPCOM_Block_Editor_Sharing_Modal_Controller extends \WP_REST_Contr
 	 *
 	 * @return boolean
 	 */
-	public function get_sharing_modal_dismissed() {
-		return (bool) get_option( 'sharing_modal_dismissed', false );
+	public function get_wpcom_sharing_modal_dismissed() {
+		$old_sharing_modal_dismissed = (bool) get_option( 'sharing_modal_dismissed', false );
+		if ( $old_sharing_modal_dismissed ) {
+			return true;
+		}
+		return (bool) get_option( 'wpcom_sharing_modal_dismissed', false );
 	}
 
 	/**
@@ -77,9 +81,9 @@ class WP_REST_WPCOM_Block_Editor_Sharing_Modal_Controller extends \WP_REST_Contr
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */
-	public function set_sharing_modal_dismissed( $request ) {
+	public function set_wpcom_sharing_modal_dismissed( $request ) {
 		$params = $request->get_json_params();
-		update_option( 'sharing_modal_dismissed', $params['sharing_modal_dismissed'] );
-		return rest_ensure_response( array( 'sharing_modal_dismissed' => $this->get_sharing_modal_dismissed() ) );
+		update_option( 'wpcom_sharing_modal_dismissed', $params['wpcom_sharing_modal_dismissed'] );
+		return rest_ensure_response( array( 'wpcom_sharing_modal_dismissed' => $this->get_wpcom_sharing_modal_dismissed() ) );
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-sharing-modal-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-sharing-modal-controller.php
@@ -68,12 +68,6 @@ class WP_REST_WPCOM_Block_Editor_Sharing_Modal_Controller extends \WP_REST_Contr
 	 * @return boolean
 	 */
 	public function get_sharing_modal_dismissed() {
-		// It appears that we are unable to set the `sharing_modal_dismissed` option on atomic sites
-		// Therefore, hide the modal by default.
-		// See D69932-code and apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-first-post-published-modal-controller.php.
-		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-			return true;
-		}
 		return (bool) get_option( 'sharing_modal_dismissed', false );
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/use-sharing-modal-dismissed.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/use-sharing-modal-dismissed.ts
@@ -8,7 +8,7 @@ const useSharingModalDismissed = ( initial: boolean ) => {
 		apiFetch( {
 			method: 'PUT',
 			path: '/wpcom/v2/block-editor/sharing-modal-dismissed',
-			data: { sharing_modal_dismissed: value },
+			data: { wpcom_sharing_modal_dismissed: value },
 		} ).finally( () => {
 			setSharingModalDismissed( value );
 		} );


### PR DESCRIPTION
Enables the post publish sharing modal on Atomic sites.

see https://github.com/Automattic/wp-calypso/pull/76267

Also should be released after D112153-code has enabled transferring the 'sharing_modal_dismissed' option

### Testing instructions
see: PCYsg-ly5-p2#atomic-testing
With this version of the ETK installed on your atomic site, create a test post and publish it
You should see the modal
Select the "Don't show again" checkbox.
Publish another post and you should not see the modal.