### PR TITLE
Turn on new migration plugin / import flow feature flag on wpcalypso

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
@@ -65,6 +65,7 @@ export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props
 						borderless={ true }
 						className="action-buttons__content-only"
 						onClick={ onContentOnlyClick }
+						role="button"
 					>
 						{ translate( 'Use the content-only import option' ) }
 					</Button>

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -111,6 +111,7 @@
 		"onboarding/import-light": false,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
+		"onboarding/import-redesign": true,
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/all-patterns-category": true,

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -14,8 +14,7 @@ const selectors = {
 	// The "content only" "continue" button of '/start/from/importing/wordpress'
 	wpContentOnlyContinueButton:
 		'.content-chooser .import-layout__column:nth-child(2) > div > div:last-child button:text("Continue")',
-	wpPlansContentOnlyOptionButton:
-		'.import__import-everything--redesign > .import__footer-button-container:last-child button:text("Use the content-only import option")',
+	wpPreMigrationContentOnlyOptionButton: 'role=button[name="Use the content-only import option"]',
 
 	// ImporterDrag page
 	importerDrag: ( text: string ) => `div.importer-wrapper__${ text }`,
@@ -117,10 +116,10 @@ export class StartImportFlow {
 	}
 
 	/**
-	 * Validates that we've landed on the WordPress plans page.
+	 * Validates that we've landed on the WordPress pre-migration page.
 	 */
-	async validateWordPressPlansPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.wpPlansContentOnlyOptionButton );
+	async validateWordPressPreMigrationPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.wpPreMigrationContentOnlyOptionButton );
 	}
 
 	/**
@@ -138,10 +137,10 @@ export class StartImportFlow {
 	}
 
 	/**
-	 * Continue 'content only' WordPress migration on plans page.
+	 * Continue 'content only' WordPress migration on pre-migration page.
 	 */
-	async contentOnlyWordPressPlansPage(): Promise< void > {
-		await this.page.click( selectors.wpPlansContentOnlyOptionButton );
+	async contentOnlyWordPressPreMigrationPage(): Promise< void > {
+		await this.page.click( selectors.wpPreMigrationContentOnlyOptionButton );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -14,6 +14,8 @@ const selectors = {
 	// The "content only" "continue" button of '/start/from/importing/wordpress'
 	wpContentOnlyContinueButton:
 		'.content-chooser .import-layout__column:nth-child(2) > div > div:last-child button:text("Continue")',
+	wpPlansContentOnlyOptionButton:
+		'.import__import-everything--redesign > .import__footer-button-container:last-child button:text("Use the content-only import option")',
 
 	// ImporterDrag page
 	importerDrag: ( text: string ) => `div.importer-wrapper__${ text }`,
@@ -115,6 +117,13 @@ export class StartImportFlow {
 	}
 
 	/**
+	 * Validates that we've landed on the WordPress plans page.
+	 */
+	async validateWordPressPlansPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.wpPlansContentOnlyOptionButton );
+	}
+
+	/**
 	 * Validates that we've landed on the importer drag page.
 	 */
 	async validateImporterDragPage( importer: string ): Promise< void > {
@@ -126,6 +135,13 @@ export class StartImportFlow {
 	 */
 	async contentOnlyWordPressPage(): Promise< void > {
 		await this.page.click( selectors.wpContentOnlyContinueButton );
+	}
+
+	/**
+	 * Continue 'content only' WordPress migration on plans page.
+	 */
+	async contentOnlyWordPressPlansPage(): Promise< void > {
+		await this.page.click( selectors.wpPlansContentOnlyOptionButton );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -116,13 +116,6 @@ export class StartImportFlow {
 	}
 
 	/**
-	 * Validates that we've landed on the WordPress pre-migration page.
-	 */
-	async validateWordPressPreMigrationPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.wpPreMigrationContentOnlyOptionButton );
-	}
-
-	/**
 	 * Validates that we've landed on the importer drag page.
 	 */
 	async validateImporterDragPage( importer: string ): Promise< void > {
@@ -139,8 +132,8 @@ export class StartImportFlow {
 	/**
 	 * Continue 'content only' WordPress migration on pre-migration page.
 	 */
-	async contentOnlyWordPressPreMigrationPage(): Promise< void > {
-		await this.page.click( selectors.wpPreMigrationContentOnlyOptionButton );
+	async clickPremigrationOptionButton(): Promise< void > {
+		await this.page.locator( selectors.wpPreMigrationContentOnlyOptionButton ).click();
 	}
 
 	/**

--- a/test/e2e/specs/onboarding/setup__importer.ts
+++ b/test/e2e/specs/onboarding/setup__importer.ts
@@ -46,8 +46,8 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
 			if ( redesignImporterFeature ) {
-				await startImportFlow.validateWordPressPlansPage();
-				await startImportFlow.contentOnlyWordPressPlansPage();
+				await startImportFlow.validateWordPressPreMigrationPage();
+				await startImportFlow.contentOnlyWordPressPreMigrationPage();
 			} else {
 				await startImportFlow.validateWordPressPage();
 				await startImportFlow.contentOnlyWordPressPage();

--- a/test/e2e/specs/onboarding/setup__importer.ts
+++ b/test/e2e/specs/onboarding/setup__importer.ts
@@ -9,7 +9,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
-
+	// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
 	let redesignImporterFeature = false;
 	let page: Page;
 	let startImportFlow: StartImportFlow;
@@ -20,6 +20,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
+		// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
 		redesignImporterFeature = await page.evaluate(
 			`configData.features['onboarding/import-redesign']`
 		);
@@ -45,6 +46,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
+			// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
 			if ( redesignImporterFeature ) {
 				await startImportFlow.clickPremigrationOptionButton();
 			} else {

--- a/test/e2e/specs/onboarding/setup__importer.ts
+++ b/test/e2e/specs/onboarding/setup__importer.ts
@@ -46,8 +46,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
 			if ( redesignImporterFeature ) {
-				await startImportFlow.validateWordPressPreMigrationPage();
-				await startImportFlow.contentOnlyWordPressPreMigrationPage();
+				await startImportFlow.clickPremigrationOptionButton();
 			} else {
 				await startImportFlow.validateWordPressPage();
 				await startImportFlow.contentOnlyWordPressPage();

--- a/test/e2e/specs/onboarding/setup__importer.ts
+++ b/test/e2e/specs/onboarding/setup__importer.ts
@@ -10,6 +10,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
 
+	let redesignImporterFeature = false;
 	let page: Page;
 	let startImportFlow: StartImportFlow;
 
@@ -19,6 +20,9 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
+		redesignImporterFeature = await page.evaluate(
+			`configData.features['onboarding/import-redesign']`
+		);
 	} );
 
 	/**
@@ -41,8 +45,13 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
-			await startImportFlow.validateWordPressPage();
-			await startImportFlow.contentOnlyWordPressPage();
+			if ( redesignImporterFeature ) {
+				await startImportFlow.validateWordPressPlansPage();
+				await startImportFlow.contentOnlyWordPressPlansPage();
+			} else {
+				await startImportFlow.validateWordPressPage();
+				await startImportFlow.contentOnlyWordPressPage();
+			}
 			await startImportFlow.validateImporterDragPage( 'wordpress' );
 		} );
 	} );

--- a/test/e2e/specs/onboarding/start__importer.ts
+++ b/test/e2e/specs/onboarding/start__importer.ts
@@ -46,8 +46,8 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
 			if ( redesignImporterFeature ) {
-				await startImportFlow.validateWordPressPlansPage();
-				await startImportFlow.contentOnlyWordPressPlansPage();
+				await startImportFlow.validateWordPressPreMigrationPage();
+				await startImportFlow.contentOnlyWordPressPreMigrationPage();
 			} else {
 				await startImportFlow.validateWordPressPage();
 				await startImportFlow.contentOnlyWordPressPage();

--- a/test/e2e/specs/onboarding/start__importer.ts
+++ b/test/e2e/specs/onboarding/start__importer.ts
@@ -9,7 +9,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
-
+	// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
 	let redesignImporterFeature = false;
 	let page: Page;
 	let startImportFlow: StartImportFlow;
@@ -20,6 +20,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
+		// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
 		redesignImporterFeature = await page.evaluate(
 			`configData.features['onboarding/import-redesign']`
 		);
@@ -45,6 +46,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
+			// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
 			if ( redesignImporterFeature ) {
 				await startImportFlow.clickPremigrationOptionButton();
 			} else {

--- a/test/e2e/specs/onboarding/start__importer.ts
+++ b/test/e2e/specs/onboarding/start__importer.ts
@@ -46,8 +46,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
 			if ( redesignImporterFeature ) {
-				await startImportFlow.validateWordPressPreMigrationPage();
-				await startImportFlow.contentOnlyWordPressPreMigrationPage();
+				await startImportFlow.clickPremigrationOptionButton();
 			} else {
 				await startImportFlow.validateWordPressPage();
 				await startImportFlow.contentOnlyWordPressPage();

--- a/test/e2e/specs/onboarding/start__importer.ts
+++ b/test/e2e/specs/onboarding/start__importer.ts
@@ -10,6 +10,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
 
+	let redesignImporterFeature = false;
 	let page: Page;
 	let startImportFlow: StartImportFlow;
 
@@ -19,6 +20,9 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
+		redesignImporterFeature = await page.evaluate(
+			`configData.features['onboarding/import-redesign']`
+		);
 	} );
 
 	/**
@@ -41,8 +45,13 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
-			await startImportFlow.validateWordPressPage();
-			await startImportFlow.contentOnlyWordPressPage();
+			if ( redesignImporterFeature ) {
+				await startImportFlow.validateWordPressPlansPage();
+				await startImportFlow.contentOnlyWordPressPlansPage();
+			} else {
+				await startImportFlow.validateWordPressPage();
+				await startImportFlow.contentOnlyWordPressPage();
+			}
 			await startImportFlow.validateImporterDragPage( 'wordpress' );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77472 

## Proposed Changes

* This PR adds the new migration plugin flow feature flag to the `wpcalypso` env to prepare for the upcoming CfT.
* Based on the flow changes on the feature flag, we also needs to update our existing e2e tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

TeamCity test run against the live link of this PR

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
