### PR TITLE
WP Blaze widget flow redesign:  fix double scroll issue

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -40,7 +40,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ showCancelDialog, setShowCancelDialog ] = useState( false );
 	const [ showCancelButton, setShowCancelButton ] = useState( true );
-	const [ hiddenHeader, setHiddenHeader ] = useState( isV2Widget ? false : true );
+	const [ hiddenHeader, setHiddenHeader ] = useState( true );
 	const widgetContainer = useRef< HTMLDivElement >( null );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate() as BlazePressTranslatable;

--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -107,7 +107,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 					handleShowCancel,
 					handleShowTopBar,
 					localeSlug,
-					config.isEnabled( 'promote-post/redesign-i2' )
+					isV2Widget
 				);
 				setIsLoading( false );
 			} )();
@@ -140,7 +140,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 				<BlankCanvas
 					className={ classNames( 'blazepress-widget', {
 						'hidden-header': hiddenHeader,
-						'blazepress-widget-v2': config.isEnabled( 'promote-post/redesign-i2' ),
+						'blazepress-widget-v2': isV2Widget,
 					} ) }
 				>
 					<div className="blazepress-widget__header-bar">

--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -34,12 +34,13 @@ export function goToOriginalEndpoint() {
 }
 
 const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
+	const isV2Widget = config.isEnabled( 'promote-post/redesign-i2' );
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	const { isVisible = false, keyValue, siteId } = props;
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ showCancelDialog, setShowCancelDialog ] = useState( false );
 	const [ showCancelButton, setShowCancelButton ] = useState( true );
-	const [ hiddenHeader, setHiddenHeader ] = useState( true );
+	const [ hiddenHeader, setHiddenHeader ] = useState( isV2Widget ? false : true );
 	const widgetContainer = useRef< HTMLDivElement >( null );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate() as BlazePressTranslatable;
@@ -139,6 +140,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 				<BlankCanvas
 					className={ classNames( 'blazepress-widget', {
 						'hidden-header': hiddenHeader,
+						'blazepress-widget-v2': config.isEnabled( 'promote-post/redesign-i2' ),
 					} ) }
 				>
 					<div className="blazepress-widget__header-bar">

--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -8,6 +8,9 @@ $headerHeight: 72px;
 	flex-direction: column;
 	z-index: 1001;
 	height: 100vh;
+	&.blazepress-widget-v2 {
+		height: reset; // v2 allows horizontal scroll, so let's not restrict the height here to avoid double scrollbar
+	}
 
 	.blazepress-widget__header-bar {
 		align-items: center;

--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -9,7 +9,7 @@ $headerHeight: 72px;
 	z-index: 1001;
 	height: 100vh;
 	&.blazepress-widget-v2 {
-		height: reset; // v2 allows horizontal scroll, so let's not restrict the height here to avoid double scrollbar
+		height: reset; // v2 allows vertical scroll, so let's not restrict the height here to avoid double scrollbar
 	}
 
 	.blazepress-widget__header-bar {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fixed a double scroll bar issue when viewing calypso on iPhone safari.

## Testing Instructions

* Load up Calypso in iPhone safari (with notch), check if there is any double scrollbar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
