### PR TITLE
Hosting onboarding: Fix styling of "I'm a dev" checkbox

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { Button, FormInputValidation } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { CheckboxControl } from '@wordpress/components';
+import { SelectCardCheckbox } from '@automattic/onboarding';
 import classNames from 'classnames';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -938,14 +938,12 @@ class SignupForm extends Component {
 
 		const { translate } = this.props;
 		return (
-			<CheckboxControl
-				className={ classNames(
-					'signup-form__is-dev-account-checkbox',
-					'signup-form__span-columns',
-					{ 'is-checked': this.state.isDevAccount }
-				) }
-				__nextHasNoMarginBottom
-				label={ preventWidows(
+			<SelectCardCheckbox
+				className="signup-form__is-dev-account-checkbox signup-form__span-columns"
+				checked={ this.state.isDevAccount }
+				onChange={ ( isDevAccount ) => this.setState( { isDevAccount } ) }
+			>
+				{ preventWidows(
 					translate(
 						"{{strong}}I'm a developer.{{/strong}} Boost my WordPress.com experience and give me early access to developer features",
 						{
@@ -955,9 +953,7 @@ class SignupForm extends Component {
 						}
 					)
 				) }
-				checked={ this.state.isDevAccount }
-				onChange={ ( isDevAccount ) => this.setState( { isDevAccount } ) }
-			/>
+			</SelectCardCheckbox>
 		);
 	}
 

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -122,7 +122,7 @@
 	// The SelectCardCheckbox label is flex by default, which is good for badges, but makes
 	// the <strong> section of the label it's own block and not wrap nicely with the rest
 	// of the label.
-	.select-card-checkbox__label {
+	&.select-card-checkbox__container .select-card-checkbox__label {
 		display: inline;
 	}
 }

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -103,6 +103,7 @@
 // Uses the width of the columns to calculate how wide an element that spans all columns needs to be
 // The width variable is set in signup/style.scss and changes according to break points
 .signup-form__span-columns {
+	box-sizing: border-box;
 	margin-left: 16px;
 	margin-right: 16px;
 
@@ -116,27 +117,13 @@
 }
 
 .signup-form__is-dev-account-checkbox {
-	grid-column: span 3;
-	margin-left: 16px;
-	margin-right: 16px;
 	margin-bottom: 48px;
-	padding: 12px;
-	border-radius: 4px;
-	border: 1px solid rgb(220, 220, 222);
 
-	&:has(input:checked) {
-		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.03);
-		border: 2px solid var(--wp-admin-theme-color);
-		padding: 11px;
-	}
-
-	// Firefox doesn't support :has() yet, so the styling needs to be controlled by JS
-	// :has and .is-checked can't be in the same selector list (separated by a comma)
-	// because if a browser doesn't support the :has selector, the entire list fails.
-	&.is-checked {
-		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.03);
-		border: 2px solid var(--wp-admin-theme-color);
-		padding: 11px;
+	// The SelectCardCheckbox label is flex by default, which is good for badges, but makes
+	// the <strong> section of the label it's own block and not wrap nicely with the rest
+	// of the label.
+	.select-card-checkbox__label {
+		display: inline;
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -91,9 +91,8 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 					: goalOptions.map( ( { key, title, isPremium } ) => (
 							<SelectCardCheckbox
 								key={ key }
-								onChange={ handleChange }
-								selected={ selectedGoals.includes( key ) }
-								value={ key }
+								onChange={ ( checked ) => handleChange( checked, key ) }
+								checked={ selectedGoals.includes( key ) }
 							>
 								<span className="select-goals__goal-title">{ title }</span>
 								{ isPremium && <PremiumBadge shouldHideTooltip={ true } /> }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@automattic/components';
 import { Onboard } from '@automattic/data-stores';
 import { PremiumBadge } from '@automattic/design-picker';
+import { SelectCardCheckbox } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useGoals } from './goals';
-import SelectCard from './select-card';
 
 type SelectGoalsProps = {
 	onChange: ( selectedGoals: Onboard.SiteGoal[] ) => void;
@@ -89,7 +89,7 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 							</div>
 					  ) )
 					: goalOptions.map( ( { key, title, isPremium } ) => (
-							<SelectCard
+							<SelectCardCheckbox
 								key={ key }
 								onChange={ handleChange }
 								selected={ selectedGoals.includes( key ) }
@@ -97,7 +97,7 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 							>
 								<span className="select-goals__goal-title">{ title }</span>
 								{ isPremium && <PremiumBadge shouldHideTooltip={ true } /> }
-							</SelectCard>
+							</SelectCardCheckbox>
 					  ) ) }
 			</div>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -96,37 +96,6 @@
 	}
 }
 
-.select-card__container {
-	border: 1px solid #dcdcde;
-	border-radius: 4px;
-	padding: 17px 25px;
-	font-size: 0.875rem;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-
-	.select-card__label {
-		pointer-events: none;
-		user-select: none;
-		display: flex;
-		align-items: center;
-	}
-
-	&.selected {
-		border: 2px solid #0675c4;
-		background: #f9fbfd;
-		padding: 16px 24px;
-	}
-
-	.components-base-control__field {
-		margin-bottom: 0;
-	}
-
-	.components-checkbox-control__input[type="checkbox"] {
-		border-color: #a7aaad;
-	}
-}
-
 .goals-link {
 	&__container {
 		position: relative;

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -26,6 +26,7 @@ export { default as StepContainer } from './step-container';
 export { default as StepNavigationLink } from './step-navigation-link';
 export { default as MShotsImage } from './mshots-image';
 export { default as Notice } from './notice';
+export { default as SelectCardCheckbox } from './select-card-checkbox';
 export * from './utils';
 export type { SelectItem } from './select-items';
 export type { SelectItemAlt } from './select-items-alt';

--- a/packages/onboarding/src/select-card-checkbox/index.tsx
+++ b/packages/onboarding/src/select-card-checkbox/index.tsx
@@ -3,36 +3,31 @@ import { useInstanceId } from '@wordpress/compose';
 import classNames from 'classnames';
 import './style.scss';
 
-type SelectCardCheckboxProps< T > = {
+type SelectCardCheckboxProps = {
 	children: React.ReactNode;
 	className?: string;
-	onChange: ( checked: boolean, value: T ) => void;
-	selected: boolean;
-	value: T;
+	onChange: ( checked: boolean ) => void;
+	checked: boolean;
 };
 
-const SelectCardCheckbox = < T, >( {
+const SelectCardCheckbox = ( {
 	children,
 	className,
 	onChange,
-	selected,
-	value,
-}: SelectCardCheckboxProps< T > ) => {
-	const handleClick = ( evt: React.MouseEvent ) => {
-		onChange( ! selected, value );
-		evt.stopPropagation();
-	};
-
+	checked,
+}: SelectCardCheckboxProps ) => {
 	const instanceId = useInstanceId( CheckboxControl );
 	const id = `select-card-checkbox-${ instanceId }`;
 
 	return (
 		<div
-			className={ classNames( 'select-card-checkbox__container', className, { selected } ) }
-			onClickCapture={ handleClick }
+			className={ classNames( 'select-card-checkbox__container', className, {
+				'is-checked': checked,
+			} ) }
+			onClick={ () => onChange( ! checked ) }
 			role="presentation"
 		>
-			<CheckboxControl checked={ selected } id={ id } onChange={ () => undefined } />
+			<CheckboxControl checked={ checked } id={ id } onChange={ onChange } />
 			<label className="select-card-checkbox__label" htmlFor={ id }>
 				{ children }
 			</label>

--- a/packages/onboarding/src/select-card-checkbox/index.tsx
+++ b/packages/onboarding/src/select-card-checkbox/index.tsx
@@ -1,8 +1,9 @@
 import { CheckboxControl } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import classNames from 'classnames';
+import './style.scss';
 
-type SelectCardProps< T > = {
+type SelectCardCheckboxProps< T > = {
 	children: React.ReactNode;
 	className?: string;
 	onChange: ( checked: boolean, value: T ) => void;
@@ -10,13 +11,13 @@ type SelectCardProps< T > = {
 	value: T;
 };
 
-const SelectCard = < T, >( {
+const SelectCardCheckbox = < T, >( {
 	children,
 	className,
 	onChange,
 	selected,
 	value,
-}: SelectCardProps< T > ) => {
+}: SelectCardCheckboxProps< T > ) => {
 	const handleClick = ( evt: React.MouseEvent ) => {
 		onChange( ! selected, value );
 		evt.stopPropagation();
@@ -27,16 +28,16 @@ const SelectCard = < T, >( {
 
 	return (
 		<div
-			className={ classNames( 'select-card__container', className, { selected } ) }
+			className={ classNames( 'select-card-checkbox__container', className, { selected } ) }
 			onClickCapture={ handleClick }
 			role="presentation"
 		>
 			<CheckboxControl checked={ selected } id={ id } onChange={ () => undefined } />
-			<label className="select-card__label" htmlFor={ id }>
+			<label className="select-card-checkbox__label" htmlFor={ id }>
 				{ children }
 			</label>
 		</div>
 	);
 };
 
-export default SelectCard;
+export default SelectCardCheckbox;

--- a/packages/onboarding/src/select-card-checkbox/style.scss
+++ b/packages/onboarding/src/select-card-checkbox/style.scss
@@ -1,0 +1,30 @@
+.select-card-checkbox__container {
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	padding: 17px 25px;
+	font-size: 0.875rem;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+
+	.select-card-checkbox__label {
+		pointer-events: none;
+		user-select: none;
+		display: flex;
+		align-items: center;
+	}
+
+	&.selected {
+		border: 2px solid #0675c4;
+		background: #f9fbfd;
+		padding: 16px 24px;
+	}
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
+
+	.components-checkbox-control__input[type="checkbox"] {
+		border-color: #a7aaad;
+	}
+}

--- a/packages/onboarding/src/select-card-checkbox/style.scss
+++ b/packages/onboarding/src/select-card-checkbox/style.scss
@@ -14,7 +14,7 @@
 		align-items: center;
 	}
 
-	&.selected {
+	&.is-checked {
 		border: 2px solid #0675c4;
 		background: #f9fbfd;
 		padding: 16px 24px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2530

## Proposed Changes

* Refactor checkbox component from goals signup step to `@automattic/onboarding`
* Use the new shared checkbox in the hosting signup step

That is this component:
![image](https://github.com/Automattic/wp-calypso/assets/1500769/e4671e18-f64a-495b-a302-86e8ab92278b)

is now used here:
<img width="920" alt="CleanShot 2023-05-29 at 21 39 26@2x" src="https://github.com/Automattic/wp-calypso/assets/1500769/ac64210e-7fa5-4758-9d23-0b21ab2e706b">

This shares the onboarding component (which is documented in this Figma eqlepL7MHifK8Bgr1OWqLr-fi-47_2123) between two onboarding steps. The reason the component is called `<SelectCardCheckbox>` is because that's how this style of component has labeled inside Figma.

This addresses an issue where the label on the signup page wasn't aligned correctly and the label also didn't wrap nicely.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the signup checkbox works just like before (see `/start/hosting`)
* Ensure the goal checkboxes work just like before (start a new site at `/start` and keep going until you get to `/setup/site-setup/goals`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
