### PR TITLE
Fix: Replace target="__blank" with target="_blank"

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
@@ -115,7 +115,7 @@ const SellerCelebrationModalInner = () => {
 			actionButtons={
 				<>
 					<Button onClick={ closeModal }>{ __( 'Continue editing', 'full-site-editing' ) }</Button>
-					<Button isPrimary href={ linkUrl } target="__blank" rel="noopener noreferrer">
+					<Button isPrimary href={ linkUrl } target="_blank" rel="noopener noreferrer">
 						{ __( 'View your product', 'full-site-editing' ) }
 					</Button>
 				</>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/index.jsx
@@ -88,7 +88,7 @@ const VideoCelebrationModalInner = () => {
 					<Button
 						isPrimary
 						href={ `https://wordpress.com/setup/videopress/launchpad?siteSlug=${ window.location.hostname }` }
-						target="__blank"
+						target="_blank"
 						rel="noopener noreferrer"
 					>
 						{ __( 'Continue and launch', 'full-site-editing' ) }

--- a/apps/odyssey-stats/src/widget/index.tsx
+++ b/apps/odyssey-stats/src/widget/index.tsx
@@ -45,7 +45,8 @@ export function init() {
 						<div className="stats-widget-footer">
 							<a
 								href="https://jetpack.com/redirect/?source=jetpack-stats-widget-logo-link"
-								target="__blank"
+								target="_blank"
+								rel="noreferrer noopener"
 								aria-label="Jetpack Stats Website"
 							>
 								<JetpackLogo size={ 20 } monochrome full />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.tsx
@@ -35,11 +35,15 @@ const ThemeInfoPopup = ( { slug }: ThemeInfoPopupProps ) => {
 			<div className="theme-info-popup__support-links popup-item">
 				<h2>Support</h2>
 				<p>
-					<a href="https://wordpress.com/help/contact" target="__blank">
+					<a href="https://wordpress.com/help/contact" target="_blank" rel="noreferrer noopener">
 						Contact us
 					</a>{ ' ' }
 					or visit the{ ' ' }
-					<a href="https://en.forums.wordpress.com/forum/themes/" target="__blank">
+					<a
+						href="https://en.forums.wordpress.com/forum/themes/"
+						target="_blank"
+						rel="noreferrer noopener"
+					>
 						support forum
 					</a>
 				</p>

--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -31,7 +31,7 @@ export default function HelpResults( {
 					/>
 				) ) }
 				{ footer && (
-					<a href={ searchLink } target="__blank">
+					<a href={ searchLink } target="_blank" rel="noreferrer noopener">
 						<CompactCard className="help-results__footer">
 							<span className="help-results__footer-text">{ footer }</span>
 						</CompactCard>

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -54,7 +54,8 @@ export default class HelpResult extends Component {
 			<a
 				className="help-result"
 				href={ localizeUrl( helpLink.link ) }
-				target="__blank"
+				target="_blank"
+				rel="noreferrer noopener"
 				onClick={ this.onClick }
 			>
 				<CompactCard className="help-result__wrapper">

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -128,7 +128,7 @@ class Help extends PureComponent {
 				<CompactCard
 					className="help__support-link"
 					href={ localizeUrl( 'https://wordpress.com/support/video-tutorials/' ) }
-					target="__blank"
+					target="_blank"
 				>
 					<Gridicon icon="video" size={ 36 } />
 					<div className="help__support-link-section">
@@ -145,7 +145,7 @@ class Help extends PureComponent {
 				<CompactCard
 					className="help__support-link"
 					href="https://wpcourses.com/?ref=wpcom-help-more-resources"
-					target="__blank"
+					target="_blank"
 				>
 					<Gridicon icon="mail" size={ 36 } />
 					<div className="help__support-link-section">
@@ -160,7 +160,7 @@ class Help extends PureComponent {
 				<CompactCard
 					className="help__support-link"
 					href="https://learn.wordpress.com"
-					target="__blank"
+					target="_blank"
 				>
 					<Gridicon icon="list-ordered" size={ 36 } />
 					<div className="help__support-link-section">
@@ -182,7 +182,7 @@ class Help extends PureComponent {
 				className="help__support-link"
 				href={ localizeUrl( 'https://wordpress.com/webinars/' ) }
 				onClick={ this.trackCoursesButtonClick }
-				target="__blank"
+				target="_blank"
 			>
 				<Gridicon icon="chat" size={ 36 } />
 				<div className="help__support-link-section">

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -254,7 +254,7 @@ class AutoLoadingHomepageModal extends Component {
 								<ExternalLink
 									href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
 									icon
-									target="__blank"
+									target="_blank"
 								>
 									{ translate( 'Learn more.' ) }
 								</ExternalLink>
@@ -275,7 +275,7 @@ class AutoLoadingHomepageModal extends Component {
 								<ExternalLink
 									href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
 									icon
-									target="__blank"
+									target="_blank"
 								>
 									{ translate( 'Learn more.' ) }
 								</ExternalLink>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -356,7 +356,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						{
 							Button: createElement( Button, {
 								isLink: true,
-								target: '__blank',
+								target: '_blank',
 								href: localizeUrl(
 									'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/'
 								),
@@ -377,7 +377,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 			uploadBtn: formFileUploadElement,
 			Button: createElement( Button, {
 				isLink: true,
-				target: '__blank',
+				target: '_blank',
 				rel: 'noreferrer',
 				href: localizeUrl(
 					'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/'


### PR DESCRIPTION
## Proposed Changes

Fixing all `target="__blank"` (note the double underscore) to be `target="_blank"` (with a single underscore).

Came up in https://github.com/Automattic/wp-calypso/pull/77319#discussion_r1206599911

## Testing Instructions

Not needed.