### PR TITLE
Jetpack Pro Dashboard: Implement showing monitor settings unsaved changes warning alert.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -281,7 +281,7 @@ export default function EmailAddressEditor( {
 							/>
 							{ ! isVerifyAction && (
 								<div className="configure-email-notification__help-text" id="name-help-text">
-									{ translate( 'Give this email a nickname for your personal reference' ) }
+									{ translate( 'Give this email a nickname for your personal reference.' ) }
 								</div>
 							) }
 						</FormFieldset>
@@ -342,7 +342,7 @@ export default function EmailAddressEditor( {
 				<div className="notification-settings__footer">
 					<div className="notification-settings__footer-buttons">
 						<Button onClick={ showCodeVerification ? onSaveLater : toggleModal }>
-							{ showCodeVerification ? translate( 'Later' ) : translate( 'Cancel' ) }
+							{ showCodeVerification ? translate( 'Later' ) : translate( 'Back' ) }
 						</Button>
 						<Button
 							disabled={

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -167,7 +167,7 @@ export default function NotificationSettings( {
 				} ) ) ?? [];
 			let siteEmailItems: Array< MonitorSettingsEmail > = [];
 
-			// If it is not bulk update, we should not show the site email addresses.
+			// If it is bulk update, we should not show the site email addresses.
 			if ( ! isBulkUpdate && settings.monitor_notify_additional_user_emails ) {
 				siteEmailItems = settings.monitor_notify_additional_user_emails.map( ( item ) => ( {
 					email: item.email_address,
@@ -231,11 +231,27 @@ export default function NotificationSettings( {
 		}
 	}, [ setInitialMonitorSettings, settings ] );
 
+	const setBulkUpdateSettings = useCallback(
+		( settings: MonitorSettings ) => {
+			// Set all email items
+			handleSetEmailItems( settings );
+
+			// Set initial settings
+			setInitialSettings( {
+				enableEmailNotification: false,
+				enableMobileNotification: false,
+				selectedDuration: defaultDuration,
+				...( isMultipleEmailEnabled && { emailContacts: getAllEmailItems( settings ) } ),
+			} );
+		},
+		[ defaultDuration, getAllEmailItems, handleSetEmailItems, isMultipleEmailEnabled ]
+	);
+
 	useEffect( () => {
 		if ( bulkUpdateSettings ) {
-			handleSetEmailItems( bulkUpdateSettings );
+			setBulkUpdateSettings( bulkUpdateSettings );
 		}
-	}, [ handleSetEmailItems, bulkUpdateSettings ] );
+	}, [ bulkUpdateSettings, setBulkUpdateSettings ] );
 
 	useEffect( () => {
 		if ( enableMobileNotification || enableEmailNotification ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -87,10 +87,11 @@ export default function NotificationSettings( {
 			enableMobileNotification !== initialSettings.enableMobileNotification ||
 			enableEmailNotification !== initialSettings.enableEmailNotification ||
 			selectedDuration?.time !== initialSettings.selectedDuration?.time ||
-			JSON.stringify( allEmailItems.map( ( { name, email } ) => ( { name, email } ) ) ) !==
-				JSON.stringify(
-					initialSettings.emailContacts.map( ( { name, email } ) => ( { name, email } ) )
-				);
+			( isMultipleEmailEnabled &&
+				JSON.stringify( allEmailItems.map( ( { name, email } ) => ( { name, email } ) ) ) !==
+					JSON.stringify(
+						initialSettings?.emailContacts?.map( ( { name, email } ) => ( { name, email } ) )
+					) );
 
 		if ( hasUnsavedChanges || ! unsavedChangesExist ) {
 			return onClose();
@@ -102,6 +103,7 @@ export default function NotificationSettings( {
 		enableMobileNotification,
 		hasUnsavedChanges,
 		initialSettings,
+		isMultipleEmailEnabled,
 		onClose,
 		selectedDuration?.time,
 	] );
@@ -226,10 +228,10 @@ export default function NotificationSettings( {
 				enableEmailNotification: isEmailEnabled,
 				enableMobileNotification: isMobileEnabled,
 				selectedDuration: foundDuration,
-				emailContacts: getAllEmailItems( settings ),
+				...( isMultipleEmailEnabled && { emailContacts: getAllEmailItems( settings ) } ),
 			} );
 		},
-		[ defaultDuration, getAllEmailItems, handleSetEmailItems ]
+		[ defaultDuration, getAllEmailItems, handleSetEmailItems, isMultipleEmailEnabled ]
 	);
 
 	useEffect( () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -406,7 +406,10 @@ export default function NotificationSettings( {
 							{ translate( 'Cancel' ) }
 						</Button>
 						<Button
-							disabled={ !! validationError || isLoading || ! unsavedChangesExist }
+							disabled={
+								// Disable save button if there is no change and not bulk update
+								!! validationError || isLoading || ( ! isBulkUpdate && ! unsavedChangesExist )
+							}
 							type="submit"
 							primary
 							aria-label={ translate( 'Save notification settings' ) }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -77,36 +77,27 @@ export default function NotificationSettings( {
 	} );
 	const [ hasUnsavedChanges, setHasUnsavedChanges ] = useState< boolean >( false );
 
-	const isMultipleEmailEnabled = isEnabled(
+	const isMultipleEmailEnabled: boolean = isEnabled(
 		'jetpack/pro-dashboard-monitor-multiple-email-recipients'
 	);
 
+	const unsavedChangesExist =
+		enableMobileNotification !== initialSettings.enableMobileNotification ||
+		enableEmailNotification !== initialSettings.enableEmailNotification ||
+		selectedDuration?.time !== initialSettings.selectedDuration?.time ||
+		( isMultipleEmailEnabled &&
+			JSON.stringify( allEmailItems.map( ( { name, email } ) => ( { name, email } ) ) ) !==
+				JSON.stringify(
+					initialSettings?.emailContacts?.map( ( { name, email } ) => ( { name, email } ) )
+				) );
+
 	// Check if any unsaved changes are present and prompt user to confirm before closing the modal.
 	const handleOnClose = useCallback( () => {
-		const unsavedChangesExist =
-			enableMobileNotification !== initialSettings.enableMobileNotification ||
-			enableEmailNotification !== initialSettings.enableEmailNotification ||
-			selectedDuration?.time !== initialSettings.selectedDuration?.time ||
-			( isMultipleEmailEnabled &&
-				JSON.stringify( allEmailItems.map( ( { name, email } ) => ( { name, email } ) ) ) !==
-					JSON.stringify(
-						initialSettings?.emailContacts?.map( ( { name, email } ) => ( { name, email } ) )
-					) );
-
 		if ( hasUnsavedChanges || ! unsavedChangesExist ) {
 			return onClose();
 		}
 		return setHasUnsavedChanges( true );
-	}, [
-		allEmailItems,
-		enableEmailNotification,
-		enableMobileNotification,
-		hasUnsavedChanges,
-		initialSettings,
-		isMultipleEmailEnabled,
-		onClose,
-		selectedDuration?.time,
-	] );
+	}, [ hasUnsavedChanges, onClose, unsavedChangesExist ] );
 
 	const toggleAddEmailModal = (
 		item?: StateMonitorSettingsEmail,
@@ -415,7 +406,7 @@ export default function NotificationSettings( {
 							{ translate( 'Cancel' ) }
 						</Button>
 						<Button
-							disabled={ !! validationError || isLoading }
+							disabled={ !! validationError || isLoading || ! unsavedChangesExist }
 							type="submit"
 							primary
 							aria-label={ translate( 'Save notification settings' ) }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -399,7 +399,7 @@ export default function NotificationSettings( {
 
 				<div className="notification-settings__footer">
 					{ ( validationError || hasUnsavedChanges ) && (
-						<div className="notification-settings__footer-validation-error">
+						<div className="notification-settings__footer-validation-error" role="alert">
 							{ hasUnsavedChanges
 								? translate( 'You have unsaved changes. Are you sure you want to close?' )
 								: validationError }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -312,5 +312,5 @@ export interface InitialMonitorSettings {
 	enableEmailNotification: boolean;
 	enableMobileNotification: boolean;
 	selectedDuration: MonitorDuration | undefined;
-	emailContacts: MonitorSettingsEmail[] | [];
+	emailContacts?: MonitorSettingsEmail[] | [];
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -305,3 +305,12 @@ export interface ValidateVerificationCodeParams {
 export interface MonitorContactsResponse {
 	emails: [ { verified: boolean; email_address: string } ];
 }
+
+export type MonitorDuration = { label: string; time: number };
+
+export interface InitialMonitorSettings {
+	enableEmailNotification: boolean;
+	enableMobileNotification: boolean;
+	selectedDuration: MonitorDuration | undefined;
+	emailContacts: MonitorSettingsEmail[] | [];
+}


### PR DESCRIPTION
Related to 1204408201748644-as-1204666762460281

## Proposed Changes

This PR implements showing monitor settings unsaved changes warning alert.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/show-email-verified-badge-for-10sec` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Make any change to duration, toggle mobile and email notifications, or add/edit/remove the email items. Click the `Cancel` or `X` button or `ESC` key and verify that an error message is as shown below. Clicking on the `Cancel` or `X` button or the `ESC` key should close the popup. Please test all the changes individually and verify the error is shown as expected. 

<img width="476" alt="Screenshot 2023-05-29 at 3 38 29 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c217ab81-ca4d-4b76-a794-1ac16f358e38">

<img width="472" alt="Screenshot 2023-06-01 at 5 00 35 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/78922a49-aecd-4825-a0d1-a3ab87ea262f">


6. Open the Jetpack live link and perform the same steps and verify the error message is shown when only duration, toggle mobile/email is changed. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?