### PR TITLE
Design Picker: Go to theme preview after purchase

### DIFF
--- a/client/landing/stepper/hooks/use-checkout.ts
+++ b/client/landing/stepper/hooks/use-checkout.ts
@@ -40,7 +40,7 @@ const useCheckout = () => {
 			// See https://github.com/Automattic/wp-calypso/pull/64899
 			window.location.href = `/checkout/${ encodeURIComponent( siteSlug ) }?${ params }`;
 		} else {
-			openCheckoutModal( [ plan ] );
+			openCheckoutModal( [ plan ], { redirect_to: destination } );
 		}
 	};
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2434

## Proposed Changes

Fixes a regression introduced by the new checkout modal (https://github.com/Automattic/wp-calypso/pull/75697) which was sending users back to the Design Picker themes list screen rather than to the Design Picker theme preview screen.

## Testing Instructions

- Use the Calypso live link below.
- Go to `/setup?siteSlug=<SITE_DOMAIN>`.
- Continue until you land on the Design Picker.
- Pick a free theme with style variations.
- Select a non-default style variation.
- Click on "Unlock this style".
- Click on the upgrade button.
- Purchase the Premium plan.
- Make sure you are redirected to the preview screen of the theme you picked above.
