### PR TITLE
What's new modal: allow html

### DIFF
--- a/packages/whats-new/src/whats-new-page.tsx
+++ b/packages/whats-new/src/whats-new-page.tsx
@@ -34,7 +34,8 @@ const WhatsNewPage: React.FC< Props > = ( {
 			<div className="whats-new-page__text">
 				{ heading && <h1 className="whats-new-page__heading">{ heading }</h1> }
 				<div className="whats-new-page__description">
-					{ description && <p>{ description }</p> }
+					{ /* eslint-disable-next-line react/no-danger */ }
+					{ description && <p dangerouslySetInnerHTML={ { __html: description } } /> }
 					{ link && (
 						<Button
 							className="whats-new-page__link"


### PR DESCRIPTION
## Proposed Changes

* Allow HTML in "What's new?" modal, coming from read-only API, where content is managed by Automatticians only.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In your sandbox, apply test patch temporarily to send HTML from the API (3080b-pb)
* Open help center
* Open "What's new?"
<img width="350" alt="Screenshot 2023-05-29 at 15 08 33" src="https://github.com/Automattic/wp-calypso/assets/87168/483dd31d-3e1e-494c-8a8e-bd61d8e04173">

* See HTML example
<img width="834" alt="Screenshot 2023-05-29 at 15 45 56" src="https://github.com/Automattic/wp-calypso/assets/87168/b734bd1e-d4d9-407b-b9ae-7d8c99643755">

In production you'd see:

<img width="847" alt="Screenshot 2023-05-29 at 15 46 25" src="https://github.com/Automattic/wp-calypso/assets/87168/14a89283-fada-4f0a-9fee-be4df15d7a05">

(Note that you're seeing unreleased announcement when sandboxied.)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
