### PR TITLE
Plans 2023: Single pricing grid. Remove feature flag

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/index.php
+++ b/apps/happy-blocks/block-library/pricing-plans/index.php
@@ -18,11 +18,7 @@ function happyblocks_pricing_plans_enqueue_config_data( $handle ) {
 		$handle,
 		sprintf(
 			'window.A8C_HAPPY_BLOCKS_CONFIG = %s;
-			window.configData ||= {
-				features: {
-					"onboarding/2023-pricing-grid": true,
-				}
-			} ;',
+			window.configData ||= {};',
 			wp_json_encode( happyblocks_pricing_plans_get_config() )
 		),
 		'before'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -1,4 +1,3 @@
-import { is2023PricingGridEnabled } from '@automattic/calypso-products';
 import {
 	isBlogOnboardingFlow,
 	isDomainUpsellFlow,
@@ -27,7 +26,6 @@ const plans: Step = function Plans( { navigation, flow } ) {
 
 		submit?.( providedDependencies );
 	};
-	const is2023PricingGridVisible = true;
 
 	const isAllowedToGoBack =
 		isDomainUpsellFlow( flow ) || ( isNewHostedSiteCreationFlow( flow ) && hostingFlow );
@@ -37,18 +35,12 @@ const plans: Step = function Plans( { navigation, flow } ) {
 			stepName="plans"
 			goBack={ goBack }
 			isHorizontalLayout={ false }
-			isWideLayout={ ! is2023PricingGridVisible }
-			isFullLayout={ is2023PricingGridVisible }
+			isWideLayout={ false }
+			isFullLayout={ true }
 			hideFormattedHeader={ true }
 			isLargeSkipLayout={ false }
 			hideBack={ ! isAllowedToGoBack }
-			stepContent={
-				<PlansWrapper
-					flowName={ flow }
-					onSubmit={ handleSubmit }
-					is2023PricingGridVisible={ is2023PricingGridVisible }
-				/>
-			}
+			stepContent={ <PlansWrapper flowName={ flow } onSubmit={ handleSubmit } /> }
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -27,7 +27,7 @@ const plans: Step = function Plans( { navigation, flow } ) {
 
 		submit?.( providedDependencies );
 	};
-	const is2023PricingGridVisible = is2023PricingGridEnabled();
+	const is2023PricingGridVisible = true;
 
 	const isAllowedToGoBack =
 		isDomainUpsellFlow( flow ) || ( isNewHostedSiteCreationFlow( flow ) && hostingFlow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -2,7 +2,6 @@
 import {
 	getPlan,
 	PLAN_FREE,
-	is2023PricingGridEnabled,
 	TYPE_FREE,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
@@ -49,7 +48,6 @@ interface Props {
 	flowName: string | null;
 	onSubmit: ( pickedPlan: MinimalRequestCartProduct | null ) => void;
 	plansLoaded: boolean;
-	is2023PricingGridVisible: boolean;
 	hostingFlow: boolean;
 }
 
@@ -179,7 +177,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					shouldShowPlansFeatureComparison={ isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
 					isReskinned={ isReskinned }
-					is2023PricingGridVisible={ props.is2023PricingGridVisible }
 					hidePlansFeatureComparison={ hidePlansFeatureComparison }
 				/>
 			</div>
@@ -232,7 +229,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 
 		return;
 	};
-	const is2023PricingGridVisible = true;
 
 	const plansFeaturesSelection = () => {
 		const { flowName } = props;
@@ -250,8 +246,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					shouldHideNavButtons={ true }
 					fallbackHeaderText={ fallbackHeaderText }
 					fallbackSubHeaderText={ fallbackSubHeaderText }
-					isWideLayout={ ! is2023PricingGridVisible }
-					isExtraWideLayout={ is2023PricingGridVisible }
+					isWideLayout={ false }
+					isExtraWideLayout={ true }
 					stepContent={ plansFeaturesList() }
 					allowBackFirstStep={ false }
 				/>
@@ -262,8 +258,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const classes = classNames( 'plans-step', {
 		'in-vertically-scrolled-plans-experiment': isInVerticalScrollingPlansExperiment,
 		'has-no-sidebar': true,
-		'is-wide-layout': ! is2023PricingGridVisible,
-		'is-extra-wide-layout': is2023PricingGridVisible,
+		'is-wide-layout': false,
+		'is-extra-wide-layout': true,
 	} );
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -232,7 +232,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 
 		return;
 	};
-	const is2023PricingGridVisible = is2023PricingGridEnabled();
+	const is2023PricingGridVisible = true;
 
 	const plansFeaturesSelection = () => {
 		const { flowName } = props;

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -302,8 +302,6 @@ import ExternalLinkWithTracking from 'calypso/components/external-link/with-trac
 import MaterialIcon from 'calypso/components/material-icon';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'calypso/lib/url/support';
 
-const is2023OnboardingPricingGrid = true;
-
 export type FeatureObject = {
 	getSlug: () => string;
 	getTitle: ( domainName?: string ) => TranslateResult;
@@ -648,30 +646,12 @@ export const FEATURES_LIST: FeatureList = {
 					args: domainName,
 				} );
 			}
-			if ( is2023OnboardingPricingGrid ) {
-				return i18n.translate(
-					'Get a custom domain – like {{i}}yourgroovydomain.com{{/i}} – free for the first year.',
-					{
-						components: {
-							i: <i />,
-						},
-					}
-				);
-			}
+
 			return i18n.translate(
-				'All paid WordPress.com plans purchased for an annual term include one year of free domain registration. ' +
-					'Domains registered through this promotion will renew at our {{a}}standard rate{{/a}}, plus applicable taxes, after the first year.{{br /}}{{br /}}' +
-					'This offer is redeemable one time only, and does not apply to plan upgrades, renewals, or premium domains.',
+				'Get a custom domain – like {{i}}yourgroovydomain.com{{/i}} – free for the first year.',
 				{
 					components: {
-						a: (
-							<a
-								href={ localizeUrl( DOMAIN_PRICING_AND_AVAILABLE_TLDS ) }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-						br: <br />,
+						i: <i />,
 					},
 				}
 			);
@@ -958,9 +938,7 @@ export const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_PREMIUM_SUPPORT,
 		getTitle: () => i18n.translate( 'Priority Support' ),
 		getDescription: () =>
-			is2023OnboardingPricingGrid
-				? i18n.translate( 'Realtime help and guidance from professional WordPress experts.' )
-				: i18n.translate( 'Live chat support to help you get started with Jetpack.' ),
+			i18n.translate( 'Realtime help and guidance from professional WordPress experts.' ),
 	},
 
 	[ FEATURE_STANDARD_SECURITY_TOOLS ]: {

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -231,7 +231,6 @@ import {
 	FEATURE_PREMIUM_CONTENT_JP,
 	FEATURE_SITE_ACTIVITY_LOG_JP,
 	FEATURE_GLOBAL_EDGE_CACHING,
-	is2023PricingGridEnabled,
 	FEATURE_AUTOMATED_EMAIL_TRIGGERS,
 	FEATURE_CART_ABANDONMENT_EMAILS,
 	FEATURE_REFERRAL_PROGRAMS,
@@ -303,7 +302,7 @@ import ExternalLinkWithTracking from 'calypso/components/external-link/with-trac
 import MaterialIcon from 'calypso/components/material-icon';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'calypso/lib/url/support';
 
-const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
+const is2023OnboardingPricingGrid = true;
 
 export type FeatureObject = {
 	getSlug: () => string;

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -2,7 +2,6 @@ import {
 	getPlanClass,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_P2_FREE,
-	is2023PricingGridEnabled,
 	TERM_BIENNIALLY,
 	TERM_TRIENNIALLY,
 	planMatches,
@@ -268,7 +267,7 @@ const LoggedInPlansFeatureActionButton = ( {
 		);
 	}
 
-	const is2023PricingGridVisible = is2023PricingGridEnabled();
+	const is2023PricingGridVisible = true;
 	if ( ! availableForPurchase ) {
 		if ( is2023PricingGridVisible ) {
 			return (

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -26,7 +26,6 @@ type PlanFeaturesActionsButtonProps = {
 	className: string;
 	currentSitePlanSlug?: string;
 	current: boolean;
-	forceDisplayButton?: boolean;
 	freePlan: boolean;
 	manageHref: string;
 	isPlaceholder?: boolean;
@@ -141,7 +140,6 @@ const LoggedInPlansFeatureActionButton = ( {
 	canUserPurchasePlan,
 	currentSitePlanSlug,
 	buttonText,
-	forceDisplayButton,
 	planActionOverrides,
 }: {
 	freePlan: boolean;
@@ -155,7 +153,6 @@ const LoggedInPlansFeatureActionButton = ( {
 	canUserPurchasePlan?: boolean;
 	currentSitePlanSlug?: string;
 	buttonText?: string;
-	forceDisplayButton: boolean;
 	selectedSiteSlug: string | null;
 	planActionOverrides?: PlanActionOverrides;
 } ) => {
@@ -267,28 +264,17 @@ const LoggedInPlansFeatureActionButton = ( {
 		);
 	}
 
-	const is2023PricingGridVisible = true;
 	if ( ! availableForPurchase ) {
-		if ( is2023PricingGridVisible ) {
-			return (
-				<Plans2023Tooltip text={ translate( 'Please contact support to downgrade your plan.' ) }>
-					<DummyDisabledButton>
-						{ translate( 'Downgrade', { context: 'verb' } ) }
-					</DummyDisabledButton>
-					{ isMobile() && (
-						<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
-							{ translate( 'Please contact support to downgrade your plan.' ) }
-						</div>
-					) }
-				</Plans2023Tooltip>
-			);
-		} else if ( forceDisplayButton ) {
-			return (
-				<Button className={ classes } disabled={ true }>
-					{ buttonText }
-				</Button>
-			);
-		}
+		return (
+			<Plans2023Tooltip text={ translate( 'Please contact support to downgrade your plan.' ) }>
+				<DummyDisabledButton>{ translate( 'Downgrade', { context: 'verb' } ) }</DummyDisabledButton>
+				{ isMobile() && (
+					<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
+						{ translate( 'Please contact support to downgrade your plan.' ) }
+					</div>
+				) }
+			</Plans2023Tooltip>
+		);
 	}
 
 	return null;
@@ -300,7 +286,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	className,
 	currentSitePlanSlug,
 	current = false,
-	forceDisplayButton = false,
 	freePlan = false,
 	manageHref,
 	isPlaceholder = false,
@@ -414,7 +399,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			canUserPurchasePlan={ canUserPurchasePlan }
 			currentSitePlanSlug={ currentSitePlanSlug }
 			buttonText={ buttonText }
-			forceDisplayButton={ forceDisplayButton }
 			selectedSiteSlug={ selectedSiteSlug }
 			planActionOverrides={ planActionOverrides }
 		/>

--- a/client/my-sites/plan-features-2023-grid/components/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/header-price.tsx
@@ -103,7 +103,7 @@ const HeaderPriceContainer = styled.div`
 	.plan-price.is-discounted {
 		color: var( --color-neutral-70 );
 
-		.plan-price__integer-fraction {
+		.plans-grid-2023__html-price-display-wrapper {
 			color: inherit;
 		}
 	}
@@ -160,6 +160,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							rawPrice={ planPrices.originalPrice }
 							displayPerMonthNotation={ false }
 							isLargeCurrency={ isLargeCurrency }
+							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
 							original
 						/>
 						<PlanPrice
@@ -167,6 +168,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							rawPrice={ planPrices.discountedPrice }
 							displayPerMonthNotation={ false }
 							isLargeCurrency={ isLargeCurrency }
+							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
 							discounted
 						/>
 					</PricesGroup>
@@ -178,6 +180,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 					rawPrice={ planPrices.originalPrice }
 					displayPerMonthNotation={ false }
 					isLargeCurrency={ isLargeCurrency }
+					priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
 				/>
 			) }
 		</HeaderPriceContainer>

--- a/client/my-sites/plan-features-2023-grid/components/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/header-price.tsx
@@ -9,7 +9,6 @@ import type { PlanProperties } from '../types';
 
 interface PlanFeatures2023GridHeaderPriceProps {
 	planProperties: PlanProperties;
-	is2023OnboardingPricingGrid: boolean;
 	isLargeCurrency: boolean;
 	isPlanUpgradeCreditEligible: boolean;
 	currentSitePlanSlug?: string;
@@ -126,7 +125,6 @@ const HeaderPriceContainer = styled.div`
 
 const PlanFeatures2023GridHeaderPrice = ( {
 	planProperties,
-	is2023OnboardingPricingGrid,
 	isLargeCurrency,
 	isPlanUpgradeCreditEligible,
 	currentSitePlanSlug,
@@ -161,7 +159,6 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							currencyCode={ currencyCode }
 							rawPrice={ planPrices.originalPrice }
 							displayPerMonthNotation={ false }
-							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 							isLargeCurrency={ isLargeCurrency }
 							original
 						/>
@@ -169,7 +166,6 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							currencyCode={ currencyCode }
 							rawPrice={ planPrices.discountedPrice }
 							displayPerMonthNotation={ false }
-							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 							isLargeCurrency={ isLargeCurrency }
 							discounted
 						/>
@@ -181,7 +177,6 @@ const PlanFeatures2023GridHeaderPrice = ( {
 					currencyCode={ currencyCode }
 					rawPrice={ planPrices.originalPrice }
 					displayPerMonthNotation={ false }
-					is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 					isLargeCurrency={ isLargeCurrency }
 				/>
 			) }

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -447,7 +447,6 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 			<PlanFeatures2023GridHeaderPrice
 				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 				planProperties={ planProperties }
-				is2023OnboardingPricingGrid={ true }
 				isLargeCurrency={ isLargeCurrency }
 				currentSitePlanSlug={ currentSitePlanSlug }
 				siteId={ siteId }

--- a/client/my-sites/plan-features-2023-grid/components/test/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/test/header-price.tsx
@@ -31,7 +31,6 @@ describe( 'PlanFeatures2023GridHeaderPrice', () => {
 		showMonthlyPrice: false,
 	} as PlanProperties;
 	const defaultProps = {
-		is2023OnboardingPricingGrid: true,
 		isLargeCurrency: false,
 		planProperties,
 	};

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -532,7 +532,6 @@ export class PlanFeatures2023Grid extends Component<
 							<PlanFeatures2023GridHeaderPrice
 								isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 								planProperties={ properties }
-								is2023OnboardingPricingGrid={ true }
 								isLargeCurrency={ isLargeCurrency }
 								currentSitePlanSlug={ currentSitePlanSlug }
 								siteId={ siteId }

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -21,6 +21,7 @@ export class PlanPrice extends Component< PlanPriceProps > {
 			isOnSale,
 			taxText,
 			omitHeading,
+			priceDisplayWrapperClassName,
 			isLargeCurrency,
 		} = this.props;
 
@@ -80,6 +81,7 @@ export class PlanPrice extends Component< PlanPriceProps > {
 				taxText={ taxText }
 				displayPerMonthNotation={ displayPerMonthNotation }
 				isOnSale={ isOnSale }
+				priceDisplayWrapperClassName={ priceDisplayWrapperClassName }
 				isSmallestUnit={ isSmallestUnit }
 			/>
 		);
@@ -185,6 +187,16 @@ export interface PlanPriceProps {
 	displayFlatPrice?: boolean;
 
 	/**
+	 * If set, this renders each price inside a `div` with the class passed,
+	 * but is otherwise identical to the output normally used by `rawPrice`.
+	 *
+	 * Ignored if `displayFlatPrice` is set.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 */
+	priceDisplayWrapperClassName?: string;
+
+	/**
 	 * If true, this renders the price with a smaller font size by adding the `is-large-currency` class.
 	 */
 	isLargeCurrency?: boolean;
@@ -275,6 +287,7 @@ function MultiPriceDisplay( {
 	taxText,
 	displayPerMonthNotation,
 	isOnSale,
+	priceDisplayWrapperClassName,
 	isSmallestUnit,
 }: {
 	tagName: 'h4' | 'span';
@@ -285,6 +298,7 @@ function MultiPriceDisplay( {
 	taxText?: string;
 	displayPerMonthNotation?: boolean;
 	isOnSale?: boolean;
+	priceDisplayWrapperClassName?: string;
 	isSmallestUnit?: boolean;
 } ) {
 	const { symbol: currencySymbol, symbolPosition } = getCurrencyObject(
@@ -305,6 +319,7 @@ function MultiPriceDisplay( {
 				<HtmlPriceDisplay
 					price={ smallerPrice }
 					currencyCode={ currencyCode }
+					priceDisplayWrapperClassName={ priceDisplayWrapperClassName }
 					isSmallestUnit={ isSmallestUnit }
 				/>
 			) }
@@ -315,6 +330,7 @@ function MultiPriceDisplay( {
 							<HtmlPriceDisplay
 								price={ smallerPrice }
 								currencyCode={ currencyCode }
+								priceDisplayWrapperClassName={ priceDisplayWrapperClassName }
 								isSmallestUnit={ isSmallestUnit }
 							/>
 						),
@@ -322,6 +338,7 @@ function MultiPriceDisplay( {
 							<HtmlPriceDisplay
 								price={ higherPrice }
 								currencyCode={ currencyCode }
+								priceDisplayWrapperClassName={ priceDisplayWrapperClassName }
 								isSmallestUnit={ isSmallestUnit }
 							/>
 						),
@@ -361,20 +378,33 @@ function MultiPriceDisplay( {
 function HtmlPriceDisplay( {
 	price,
 	currencyCode,
+	priceDisplayWrapperClassName,
 	isSmallestUnit,
 }: {
 	price: number;
 	currencyCode: string;
+	priceDisplayWrapperClassName?: string;
 	isSmallestUnit?: boolean;
 } ) {
 	const priceObj = getCurrencyObject( price, currencyCode, { isSmallestUnit } );
 
+	if ( priceDisplayWrapperClassName ) {
+		return (
+			<div className={ priceDisplayWrapperClassName }>
+				<span className="plan-price__integer">
+					{ priceObj.integer }
+					{ priceObj.hasNonZeroFraction && priceObj.fraction }
+				</span>
+			</div>
+		);
+	}
+
 	return (
-		<div className="plan-price__integer-fraction">
-			<span className="plan-price__integer">
-				{ priceObj.integer }
+		<>
+			<span className="plan-price__integer">{ priceObj.integer }</span>
+			<sup className="plan-price__fraction">
 				{ priceObj.hasNonZeroFraction && priceObj.fraction }
-			</span>
-		</div>
+			</sup>
+		</>
 	);
 }

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -21,7 +21,6 @@ export class PlanPrice extends Component< PlanPriceProps > {
 			isOnSale,
 			taxText,
 			omitHeading,
-			is2023OnboardingPricingGrid,
 			isLargeCurrency,
 		} = this.props;
 
@@ -81,7 +80,6 @@ export class PlanPrice extends Component< PlanPriceProps > {
 				taxText={ taxText }
 				displayPerMonthNotation={ displayPerMonthNotation }
 				isOnSale={ isOnSale }
-				is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 				isSmallestUnit={ isSmallestUnit }
 			/>
 		);
@@ -187,16 +185,6 @@ export interface PlanPriceProps {
 	displayFlatPrice?: boolean;
 
 	/**
-	 * If true, this renders each price inside a `div` with the class
-	 * `plan-price__integer-fraction` but is otherwise identical to the output normally used by `rawPrice`.
-	 *
-	 * Ignored if `displayFlatPrice` is set.
-	 *
-	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
-	 */
-	is2023OnboardingPricingGrid?: boolean;
-
-	/**
 	 * If true, this renders the price with a smaller font size by adding the `is-large-currency` class.
 	 */
 	isLargeCurrency?: boolean;
@@ -287,7 +275,6 @@ function MultiPriceDisplay( {
 	taxText,
 	displayPerMonthNotation,
 	isOnSale,
-	is2023OnboardingPricingGrid,
 	isSmallestUnit,
 }: {
 	tagName: 'h4' | 'span';
@@ -298,7 +285,6 @@ function MultiPriceDisplay( {
 	taxText?: string;
 	displayPerMonthNotation?: boolean;
 	isOnSale?: boolean;
-	is2023OnboardingPricingGrid?: boolean;
 	isSmallestUnit?: boolean;
 } ) {
 	const { symbol: currencySymbol, symbolPosition } = getCurrencyObject(
@@ -319,7 +305,6 @@ function MultiPriceDisplay( {
 				<HtmlPriceDisplay
 					price={ smallerPrice }
 					currencyCode={ currencyCode }
-					is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 					isSmallestUnit={ isSmallestUnit }
 				/>
 			) }
@@ -330,7 +315,6 @@ function MultiPriceDisplay( {
 							<HtmlPriceDisplay
 								price={ smallerPrice }
 								currencyCode={ currencyCode }
-								is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 								isSmallestUnit={ isSmallestUnit }
 							/>
 						),
@@ -338,7 +322,6 @@ function MultiPriceDisplay( {
 							<HtmlPriceDisplay
 								price={ higherPrice }
 								currencyCode={ currencyCode }
-								is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 								isSmallestUnit={ isSmallestUnit }
 							/>
 						),
@@ -378,33 +361,20 @@ function MultiPriceDisplay( {
 function HtmlPriceDisplay( {
 	price,
 	currencyCode,
-	is2023OnboardingPricingGrid,
 	isSmallestUnit,
 }: {
 	price: number;
 	currencyCode: string;
-	is2023OnboardingPricingGrid?: boolean;
 	isSmallestUnit?: boolean;
 } ) {
 	const priceObj = getCurrencyObject( price, currencyCode, { isSmallestUnit } );
 
-	if ( is2023OnboardingPricingGrid ) {
-		return (
-			<div className="plan-price__integer-fraction">
-				<span className="plan-price__integer">
-					{ priceObj.integer }
-					{ priceObj.hasNonZeroFraction && priceObj.fraction }
-				</span>
-			</div>
-		);
-	}
-
 	return (
-		<>
-			<span className="plan-price__integer">{ priceObj.integer }</span>
-			<sup className="plan-price__fraction">
+		<div className="plan-price__integer-fraction">
+			<span className="plan-price__integer">
+				{ priceObj.integer }
 				{ priceObj.hasNonZeroFraction && priceObj.fraction }
-			</sup>
-		</>
+			</span>
+		</div>
 	);
 }

--- a/client/my-sites/plan-price/test/index.tsx
+++ b/client/my-sites/plan-price/test/index.tsx
@@ -249,33 +249,20 @@ describe( 'PlanPrice', () => {
 		expect( document.querySelector( 'h4' ) ).toBeFalsy();
 	} );
 
-	it( 'renders a price without an outer div if is2023OnboardingPricingGrid is not set', () => {
+	it( 'renders a price with an outer div', () => {
 		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
-		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
-		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeFalsy();
-	} );
-
-	it( 'renders a price with an outer div if is2023OnboardingPricingGrid is set', () => {
-		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" is2023OnboardingPricingGrid /> );
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
 		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeTruthy();
 	} );
 
-	it( 'renders a price without an outer div if productDisplayPrice is set and is2023OnboardingPricingGrid is set', () => {
-		render( <PlanPrice productDisplayPrice="$45" is2023OnboardingPricingGrid /> );
+	it( 'renders a price without an outer div if productDisplayPrice is set', () => {
+		render( <PlanPrice productDisplayPrice="$45" /> );
 		expect( document.body ).toHaveTextContent( '$45' );
 		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeFalsy();
 	} );
 
-	it( 'renders a price without an outer div if displayFlatPrice is set and is2023OnboardingPricingGrid is set', () => {
-		render(
-			<PlanPrice
-				rawPrice={ 44700.5 }
-				currencyCode="IDR"
-				displayFlatPrice
-				is2023OnboardingPricingGrid
-			/>
-		);
+	it( 'renders a price without an outer div if displayFlatPrice is set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" displayFlatPrice /> );
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
 		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeFalsy();
 	} );

--- a/client/my-sites/plan-price/test/index.tsx
+++ b/client/my-sites/plan-price/test/index.tsx
@@ -249,22 +249,46 @@ describe( 'PlanPrice', () => {
 		expect( document.querySelector( 'h4' ) ).toBeFalsy();
 	} );
 
-	it( 'renders a price with an outer div', () => {
+	it( 'renders a price without an outer div if priceDisplayWrapperClassName is not set', () => {
 		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
-		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeTruthy();
+		expect( document.querySelector( 'div.foo-price-display-wrapper-class' ) ).toBeFalsy();
 	} );
 
-	it( 'renders a price without an outer div if productDisplayPrice is set', () => {
-		render( <PlanPrice productDisplayPrice="$45" /> );
-		expect( document.body ).toHaveTextContent( '$45' );
-		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeFalsy();
-	} );
-
-	it( 'renders a price without an outer div if displayFlatPrice is set', () => {
-		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" displayFlatPrice /> );
+	it( 'renders a price with an outer div if priceDisplayWrapperClassName is set', () => {
+		render(
+			<PlanPrice
+				rawPrice={ 44700.5 }
+				currencyCode="IDR"
+				priceDisplayWrapperClassName="foo-price-display-wrapper-class"
+			/>
+		);
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
-		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeFalsy();
+		expect( document.querySelector( 'div.foo-price-display-wrapper-class' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price without an outer div if productDisplayPrice is set and priceDisplayWrapperClassName is set', () => {
+		render(
+			<PlanPrice
+				productDisplayPrice="$45"
+				priceDisplayWrapperClassName="foo-price-display-wrapper-class"
+			/>
+		);
+		expect( document.body ).toHaveTextContent( '$45' );
+		expect( document.querySelector( 'div.foo-price-display-wrapper-class' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price without an outer div if displayFlatPrice is set and priceDisplayWrapperClassName is set', () => {
+		render(
+			<PlanPrice
+				rawPrice={ 44700.5 }
+				currencyCode="IDR"
+				displayFlatPrice
+				priceDisplayWrapperClassName="foo-price-display-wrapper-class"
+			/>
+		);
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'div.foo-price-display-wrapper-class' ) ).toBeFalsy();
 	} );
 
 	it( 'renders a price without the "is-discounted" class if discounted is not set', () => {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -785,7 +785,7 @@ export default connect(
 		) {
 			customerType = 'business';
 		}
-		const is2023PricingGridVisible = props.is2023PricingGridVisible ?? is2023PricingGridEnabled();
+		const is2023PricingGridVisible = props.is2023PricingGridVisible ?? true;
 		const planTypeSelectorProps = {
 			basePlansPath: props.basePlansPath,
 			isStepperUpgradeFlow: props.isStepperUpgradeFlow,

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -434,14 +434,14 @@ export class PlansFeaturesMain extends Component {
 			intervalType,
 			selectedPlan,
 			planTypeSelector,
-			planTypes = this.getDefaultPlanTypes(),
+			planTypes,
 		} = this.props;
 		const term = this.getPlanBillingPeriod( intervalType, getPlan( selectedPlan )?.term );
 		const defaultPlanTypes = this.getDefaultPlanTypes();
 		// We need all the plans in order to show the correct features in the plan comparison table
 		const plans = this.getPlansFromTypes( defaultPlanTypes, GROUP_WPCOM, term );
 		const visiblePlans = this.getVisiblePlansForPlanFeatures(
-			this.getPlansFromTypes( planTypes, GROUP_WPCOM, term )
+			this.getPlansFromTypes( planTypes || defaultPlanTypes, GROUP_WPCOM, term )
 		);
 
 		// If advertising plans for a certain feature, ensure user has pressed "View all plans" before they can see others

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -28,7 +28,6 @@ import {
 	PLAN_PERSONAL,
 	TITAN_MAIL_MONTHLY_SLUG,
 	PLAN_FREE,
-	is2023PricingGridEnabled,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
@@ -51,8 +50,6 @@ import HappychatConnection from 'calypso/components/happychat/connection-connect
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import { getTld } from 'calypso/lib/domains';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
-import PlanFeatures from 'calypso/my-sites/plan-features';
-import PlanFeaturesComparison from 'calypso/my-sites/plan-features-comparison';
 import PlanFAQ from 'calypso/my-sites/plans-features-main/components/plan-faq';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import PlanTypeSelector from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
@@ -137,7 +134,7 @@ const OnboardingPricingGrid2023 = ( props ) => {
 		isLandingPage,
 		isLaunchPage,
 		onUpgradeClick,
-		plans,
+		plans, // We need all the plans in order to show the correct features in the plan comparison table
 		flowName,
 		redirectTo,
 		visiblePlans,
@@ -209,14 +206,13 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	isDisplayingPlansNeededForFeature() {
-		const { selectedFeature, selectedPlan, previousRoute } = this.props;
+		const { selectedFeature, selectedPlan, previousRoute, planTypeSelector } = this.props;
 
 		if (
 			isValidFeatureKey( selectedFeature ) &&
 			getPlan( selectedPlan ) &&
 			! isPersonalPlan( selectedPlan ) &&
-			( this.getKindOfPlanTypeSelector( this.props ) === 'interval' ||
-				! previousRoute.startsWith( '/plans/' ) )
+			( 'interval' === planTypeSelector || ! previousRoute.startsWith( '/plans/' ) )
 		) {
 			return true;
 		}
@@ -230,22 +226,27 @@ export class PlansFeaturesMain extends Component {
 
 	onUpgradeClick = ( cartItemForPlan ) => {
 		const { domainName, onUpgradeClick, siteSlug, flowName } = this.props;
+
 		// The `cartItemForPlan` var is null if the free plan is selected
 		if ( cartItemForPlan == null && 'onboarding' === flowName && domainName ) {
 			this.toggleIsFreePlanPaidDomainDialogOpen();
 			return;
 		}
+
 		if ( onUpgradeClick ) {
 			onUpgradeClick( cartItemForPlan );
 			return;
 		}
+
 		const planPath = getPlanPath( cartItemForPlan?.product_slug ) || '';
 		const checkoutUrlWithArgs = `/checkout/${ siteSlug }/${ planPath }`;
+
 		page( checkoutUrlWithArgs );
 	};
 
 	renderFreePlanPaidDomainModal = () => {
 		const { domainName, replacePaidDomainWithFreeDomain, onUpgradeClick } = this.props;
+
 		return (
 			<FreePlanPaidDomainDialog
 				domainName={ domainName }
@@ -263,129 +264,6 @@ export class PlansFeaturesMain extends Component {
 		);
 	};
 
-	// TODO:
-	// These legacy components should also be loaded in async.
-	renderLegacyPricingGrid( plans, visiblePlans ) {
-		const {
-			basePlansPath,
-			busyOnUpgradeClick,
-			customerType,
-			disableBloggerPlanWithNonBlogDomain,
-			domainName,
-			isInSignup,
-			isJetpack,
-			isLandingPage,
-			isLaunchPage,
-			isFAQCondensedExperiment,
-			isReskinned,
-			onUpgradeClick,
-			selectedFeature,
-			selectedPlan,
-			shouldShowPlansFeatureComparison,
-			withDiscount,
-			discountEndDate,
-			redirectTo,
-			siteId,
-			plansWithScroll,
-			isInVerticalScrollingPlansExperiment,
-			redirectToAddDomainFlow,
-			hidePlanTypeSelector,
-			flowName,
-			isPlansInsideStepper,
-		} = this.props;
-
-		if ( shouldShowPlansFeatureComparison ) {
-			return (
-				<div
-					className={ classNames(
-						'plans-features-main__group',
-						'is-wpcom',
-						`is-customer-${ customerType }`,
-						{
-							'is-scrollable': plansWithScroll,
-						}
-					) }
-					data-e2e-plans="wpcom"
-				>
-					<PlanFeaturesComparison
-						basePlansPath={ basePlansPath }
-						domainName={ domainName }
-						isInSignup={ isInSignup }
-						isLandingPage={ isLandingPage }
-						isLaunchPage={ isLaunchPage }
-						onUpgradeClick={ onUpgradeClick }
-						plans={ plans }
-						flowName={ flowName }
-						redirectTo={ redirectTo }
-						visiblePlans={ visiblePlans }
-						selectedFeature={ selectedFeature }
-						selectedPlan={ selectedPlan }
-						withDiscount={ withDiscount }
-						discountEndDate={ discountEndDate }
-						withScroll={ plansWithScroll }
-						popularPlanSpec={ getPopularPlanSpec( {
-							flowName,
-							customerType,
-							isJetpack,
-							availablePlans: visiblePlans,
-						} ) }
-						siteId={ siteId }
-						isReskinned={ isReskinned }
-						isFAQCondensedExperiment={ isFAQCondensedExperiment }
-						isPlansInsideStepper={ isPlansInsideStepper }
-						busyOnUpgradeClick={ busyOnUpgradeClick }
-					/>
-				</div>
-			);
-		}
-
-		return (
-			<div
-				className={ classNames(
-					'plans-features-main__group',
-					'is-wpcom',
-					`is-customer-${ customerType }`,
-					{
-						'is-scrollable': plansWithScroll,
-					}
-				) }
-				data-e2e-plans="wpcom"
-			>
-				<PlanFeatures
-					redirectToAddDomainFlow={ redirectToAddDomainFlow }
-					hidePlanTypeSelector={ hidePlanTypeSelector }
-					basePlansPath={ basePlansPath }
-					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-					domainName={ domainName }
-					nonDotBlogDomains={ this.filterDotBlogDomains() }
-					isInSignup={ isInSignup }
-					isLandingPage={ isLandingPage }
-					isLaunchPage={ isLaunchPage }
-					onUpgradeClick={ onUpgradeClick }
-					plans={ plans }
-					redirectTo={ redirectTo }
-					visiblePlans={ visiblePlans }
-					selectedFeature={ selectedFeature }
-					selectedPlan={ selectedPlan }
-					withDiscount={ withDiscount }
-					discountEndDate={ discountEndDate }
-					withScroll={ plansWithScroll }
-					popularPlanSpec={ getPopularPlanSpec( {
-						flowName,
-						customerType,
-						isJetpack,
-						availablePlans: visiblePlans,
-					} ) }
-					flowName={ flowName }
-					siteId={ siteId }
-					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
-					kindOfPlanTypeSelector={ this.getKindOfPlanTypeSelector( this.props ) }
-					isPlansInsideStepper={ isPlansInsideStepper }
-				/>
-			</div>
-		);
-	}
-
 	getPlanBillingPeriod( intervalType, defaultValue = null ) {
 		const plans = {
 			monthly: TERM_MONTHLY,
@@ -399,9 +277,7 @@ export class PlansFeaturesMain extends Component {
 
 	getDefaultPlanTypes() {
 		const { selectedPlan, sitePlanSlug, hideEnterprisePlan, is2023PricingGridVisible } = this.props;
-
 		const isBloggerAvailable = isBloggerPlan( selectedPlan ) || isBloggerPlan( sitePlanSlug );
-
 		// TODO:
 		// this should fall into the processing function for the visible plans
 		// however, the Enterprise plan isn't a real plan and lack of some required support
@@ -526,8 +402,6 @@ export class PlansFeaturesMain extends Component {
 			);
 		}
 
-		const withIntervalSelector = this.getKindOfPlanTypeSelector( this.props ) === 'interval';
-
 		if ( isInMarketplace ) {
 			// workaround to show free plan on both monthly/yearly toggle
 			if ( sitePlanSlug === PLAN_FREE && ! plans.includes( PLAN_FREE ) ) {
@@ -540,7 +414,7 @@ export class PlansFeaturesMain extends Component {
 			);
 		}
 
-		if ( isAllPaidPlansShown || withIntervalSelector ) {
+		if ( isAllPaidPlansShown || 'interval' === this.props.planTypeSelector ) {
 			return plans.filter( ( plan ) =>
 				isPlanOneOfType( plan, [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ] )
 			);
@@ -601,23 +475,6 @@ export class PlansFeaturesMain extends Component {
 		return <WpcomFAQ />;
 	}
 
-	getKindOfPlanTypeSelector( props ) {
-		return props.planTypeSelector;
-	}
-
-	renderPlansGrid( plans, visiblePlans ) {
-		return this.props.is2023PricingGridVisible ? (
-			<OnboardingPricingGrid2023
-				{ ...this.props }
-				plans={ plans }
-				visiblePlans={ visiblePlans }
-				onUpgradeClick={ this.onUpgradeClick }
-			/>
-		) : (
-			this.renderLegacyPricingGrid( plans, visiblePlans )
-		);
-	}
-
 	render() {
 		const {
 			siteId,
@@ -627,34 +484,20 @@ export class PlansFeaturesMain extends Component {
 			planTypeSelectorProps,
 			intervalType,
 			selectedPlan,
+			planTypeSelector,
+			planTypes = this.getDefaultPlanTypes(),
 		} = this.props;
-
-		/*
-		 * We need to pass all the plans in order to show the correct features in the plan comparison table.
-		 * Pleas use the getVisiblePlansForPlanFeatures selector to filter out the plans that should not be visible.
-		 * we pass `visiblePlans` to its `plans` prop.
-		 */
 		const term = this.getPlanBillingPeriod( intervalType, getPlan( selectedPlan )?.term );
 		const defaultPlanTypes = this.getDefaultPlanTypes();
-		const planTypes = this.props.planTypes || defaultPlanTypes;
-		let plans = this.getPlansFromTypes( planTypes, GROUP_WPCOM, term );
-		const filteredPlans = plans;
-
-		/*
-		 * We need to keep all the plans in the plans variable,
-		 * The filtered planTypes should be reflected in visible plans only.
-		 */
-		if ( is2023PricingGridVisible ) {
-			plans = this.getPlansFromTypes( defaultPlanTypes, GROUP_WPCOM, term );
-		}
-
-		const visiblePlans = this.getVisiblePlansForPlanFeatures( filteredPlans );
-
-		const kindOfPlanTypeSelector = this.getKindOfPlanTypeSelector( this.props );
+		// We need all the plans in order to show the correct features in the plan comparison table
+		const plans = this.getPlansFromTypes( defaultPlanTypes, GROUP_WPCOM, term );
+		const visiblePlans = this.getVisiblePlansForPlanFeatures(
+			this.getPlansFromTypes( planTypes, GROUP_WPCOM, term )
+		);
 
 		// If advertising plans for a certain feature, ensure user has pressed "View all plans" before they can see others
 		let hidePlanSelector =
-			kindOfPlanTypeSelector === 'customer' && this.isDisplayingPlansNeededForFeature();
+			'customer' === planTypeSelector && this.isDisplayingPlansNeededForFeature();
 
 		// In the "purchase a plan and free domain" flow we do not want to show
 		// monthly plans because monthly plans do not come with a free domain.
@@ -685,12 +528,17 @@ export class PlansFeaturesMain extends Component {
 				{ ! hidePlanSelector && (
 					<PlanTypeSelector
 						{ ...planTypeSelectorProps }
-						kind={ kindOfPlanTypeSelector }
+						kind={ planTypeSelector }
 						plans={ visiblePlans }
 					/>
 				) }
 				{ this.state.isFreePlanPaidDomainDialogOpen && this.renderFreePlanPaidDomainModal() }
-				{ this.renderPlansGrid( plans, visiblePlans ) }
+				<OnboardingPricingGrid2023
+					{ ...this.props }
+					plans={ plans }
+					visiblePlans={ visiblePlans }
+					onUpgradeClick={ this.onUpgradeClick }
+				/>
 				{ this.mayRenderFAQ() }
 			</div>
 		);

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -3,7 +3,7 @@
  */
 
 jest.mock( 'calypso/components/marketing-message', () => () => null );
-jest.mock( 'calypso/my-sites/plan-features', () => ( { visiblePlans, popularPlanSpec } ) => (
+jest.mock( 'calypso/components/async-load', () => ( { visiblePlans, popularPlanSpec } ) => (
 	<div data-testid="plan-features">
 		<div data-testid="visible-plans">{ JSON.stringify( visiblePlans ) }</div>
 		<div data-testid="popular-plan-spec">{ JSON.stringify( popularPlanSpec ) }</div>
@@ -34,6 +34,7 @@ import {
 	TYPE_FREE,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
+	PLAN_ENTERPRISE_GRID_WPCOM,
 } from '@automattic/calypso-products';
 import { screen } from '@testing-library/react';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
@@ -119,7 +120,14 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
 		renderWithProvider( <PlansFeaturesMain { ...props } planTypeSelector={ null } /> );
 
 		expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent(
-			JSON.stringify( [ PLAN_FREE, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE ] )
+			JSON.stringify( [
+				PLAN_FREE,
+				PLAN_PERSONAL,
+				PLAN_PREMIUM,
+				PLAN_BUSINESS,
+				PLAN_ECOMMERCE,
+				PLAN_ENTERPRISE_GRID_WPCOM,
+			] )
 		);
 	} );
 
@@ -136,7 +144,13 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
 		renderWithProvider( <PlansFeaturesMain { ...props } hideFreePlan /> );
 
 		expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent(
-			JSON.stringify( [ PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE ] )
+			JSON.stringify( [
+				PLAN_PERSONAL,
+				PLAN_PREMIUM,
+				PLAN_BUSINESS,
+				PLAN_ECOMMERCE,
+				PLAN_ENTERPRISE_GRID_WPCOM,
+			] )
 		);
 	} );
 
@@ -145,10 +159,12 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
 
 		expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent(
 			JSON.stringify( [
+				PLAN_FREE,
 				PLAN_PERSONAL_MONTHLY,
 				PLAN_PREMIUM_MONTHLY,
 				PLAN_BUSINESS_MONTHLY,
 				PLAN_ECOMMERCE_MONTHLY,
+				PLAN_ENTERPRISE_GRID_WPCOM,
 			] )
 		);
 	} );
@@ -164,10 +180,12 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
 
 		expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent(
 			JSON.stringify( [
+				PLAN_FREE,
 				PLAN_PERSONAL_2_YEARS,
 				PLAN_PREMIUM_2_YEARS,
 				PLAN_BUSINESS_2_YEARS,
 				PLAN_ECOMMERCE_2_YEARS,
+				PLAN_ENTERPRISE_GRID_WPCOM,
 			] )
 		);
 	} );
@@ -177,10 +195,12 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
 
 		expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent(
 			JSON.stringify( [
+				PLAN_FREE,
 				PLAN_PERSONAL_2_YEARS,
 				PLAN_PREMIUM_2_YEARS,
 				PLAN_BUSINESS_2_YEARS,
 				PLAN_ECOMMERCE_2_YEARS,
+				PLAN_ENTERPRISE_GRID_WPCOM,
 			] )
 		);
 	} );
@@ -209,7 +229,13 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		renderWithProvider( <PlansFeaturesMain { ...myProps } customerType="personal" /> );
 
 		expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent(
-			JSON.stringify( [ PLAN_PERSONAL, PLAN_PREMIUM ] )
+			JSON.stringify( [
+				PLAN_PERSONAL,
+				PLAN_PREMIUM,
+				PLAN_BUSINESS,
+				PLAN_ECOMMERCE,
+				PLAN_ENTERPRISE_GRID_WPCOM,
+			] )
 		);
 	} );
 
@@ -219,7 +245,13 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		);
 
 		expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent(
-			JSON.stringify( [ PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ] )
+			JSON.stringify( [
+				PLAN_PERSONAL_2_YEARS,
+				PLAN_PREMIUM_2_YEARS,
+				PLAN_BUSINESS_2_YEARS,
+				PLAN_ECOMMERCE_2_YEARS,
+				PLAN_ENTERPRISE_GRID_WPCOM,
+			] )
 		);
 	} );
 
@@ -258,10 +290,12 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 } );
 
 describe( 'PlansFeaturesMain.getPlansFromProps', () => {
-	test( 'Should return an empty array if planTypes are not specified', () => {
+	test( 'Should return PLAN_FREE if planTypes are not specified', () => {
 		renderWithProvider( <PlansFeaturesMain { ...props } planTypes={ [ TYPE_FREE ] } /> );
 
-		expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent( JSON.stringify( [] ) );
+		expect( screen.getByTestId( 'visible-plans' ) ).toHaveTextContent(
+			JSON.stringify( [ PLAN_FREE ] )
+		);
 	} );
 
 	test( 'Should filter out invalid plan types and print a warning in the console', () => {

--- a/client/my-sites/plans/components/plans-header/index.tsx
+++ b/client/my-sites/plans/components/plans-header/index.tsx
@@ -1,4 +1,3 @@
-import { is2023PricingGridEnabled } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { useDispatch } from '@wordpress/data';
@@ -12,7 +11,7 @@ import './style.scss';
 const DomainUpsellHeader: React.FunctionComponent = () => {
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
 	const translate = useTranslate();
-	const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
+	const is2023OnboardingPricingGrid = true;
 	const plansDescription = translate(
 		'See and compare the features available on each WordPress.com plan.'
 	);

--- a/client/my-sites/plans/components/plans-header/index.tsx
+++ b/client/my-sites/plans/components/plans-header/index.tsx
@@ -11,11 +11,10 @@ import './style.scss';
 const DomainUpsellHeader: React.FunctionComponent = () => {
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
 	const translate = useTranslate();
-	const is2023OnboardingPricingGrid = true;
 	const plansDescription = translate(
 		'See and compare the features available on each WordPress.com plan.'
 	);
-	const withSkipButton = ! is2023OnboardingPricingGrid;
+	const withSkipButton = false;
 	const classes = classNames(
 		'plans__formatted-header',
 		'plans__section-header',

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -1,4 +1,3 @@
-import { is2023PricingGridEnabled } from '@automattic/calypso-products/src/plans-utilities';
 import page from 'page';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import { productSelect } from 'calypso/my-sites/plans/jetpack-plans/controller';
@@ -40,7 +39,6 @@ export function plans( context, next ) {
 			}
 			domainAndPlanPackage={ context.query.domainAndPlanPackage === 'true' }
 			jetpackAppPlans={ context.query.jetpackAppPlans === 'true' }
-			is2023PricingGridVisible={ is2023PricingGridEnabled() }
 		/>
 	);
 	next();

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -12,7 +12,6 @@ import {
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
 } from '@automattic/calypso-products';
-import { is2023PricingGridEnabled } from '@automattic/calypso-products/src/plans-utilities';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { useDispatch } from '@wordpress/data';
@@ -476,7 +475,7 @@ const ConnectedPlans = connect( ( state, props ) => {
 		isWPForTeamsSite: isSiteWPForTeams( state, selectedSiteId ),
 		isSiteEligibleForMonthlyPlan: isEligibleForWpComMonthlyPlan( state, selectedSiteId ),
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
-		is2023PricingGridVisible: props.is2023PricingGridVisible ?? is2023PricingGridEnabled(),
+		is2023PricingGridVisible: props.is2023PricingGridVisible ?? true,
 		isDomainAndPlanPackageFlow: !! getCurrentQueryArguments( state )?.domainAndPlanPackage,
 		isJetpackNotAtomic: isJetpackSite( state, selectedSiteId, { treatAtomicAsJetpackSite: false } ),
 		isDomainUpsell:

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -233,13 +233,7 @@ class Plans extends Component {
 	};
 
 	renderPlansMain() {
-		const {
-			currentPlan,
-			selectedSite,
-			isWPForTeamsSite,
-			currentPlanIntervalType,
-			is2023PricingGridVisible,
-		} = this.props;
+		const { currentPlan, selectedSite, isWPForTeamsSite, currentPlanIntervalType } = this.props;
 
 		if ( ! this.props.plansLoaded || ! currentPlan ) {
 			// Maybe we should show a loading indicator here?
@@ -258,7 +252,7 @@ class Plans extends Component {
 			);
 		}
 
-		const hideFreePlan = ! is2023PricingGridVisible || this.props.isDomainAndPlanPackageFlow;
+		const hideFreePlan = this.props.isDomainAndPlanPackageFlow;
 		// The Jetpack mobile app only wants to display two plans -- personal and premium
 		const planTypes = this.props.jetpackAppPlans ? [ TYPE_PERSONAL, TYPE_PREMIUM ] : null;
 
@@ -281,7 +275,6 @@ class Plans extends Component {
 				site={ selectedSite }
 				plansWithScroll={ false }
 				hidePlansFeatureComparison={ this.props.isDomainAndPlanPackageFlow }
-				is2023PricingGridVisible={ is2023PricingGridVisible }
 				planTypes={ planTypes }
 			/>
 		);
@@ -345,7 +338,6 @@ class Plans extends Component {
 			canAccessPlans,
 			currentPlan,
 			domainAndPlanPackage,
-			is2023PricingGridVisible,
 			isDomainAndPlanPackageFlow,
 			isJetpackNotAtomic,
 			isDomainUpsell,
@@ -434,10 +426,7 @@ class Plans extends Component {
 						) }
 						<div id="plans" className="plans plans__has-sidebar">
 							{ showPlansNavigation && <PlansNavigation path={ this.props.context.path } /> }
-							<Main
-								fullWidthLayout={ is2023PricingGridVisible && ! isEcommerceTrial }
-								wideLayout={ ! is2023PricingGridVisible || isEcommerceTrial }
-							>
+							<Main fullWidthLayout={ ! isEcommerceTrial } wideLayout={ isEcommerceTrial }>
 								{ ! isDomainAndPlanPackageFlow && domainAndPlanPackage && (
 									<DomainAndPlanUpsellNotice />
 								) }
@@ -458,9 +447,8 @@ class Plans extends Component {
 	}
 }
 
-const ConnectedPlans = connect( ( state, props ) => {
+const ConnectedPlans = connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
-
 	const currentPlan = getCurrentPlan( state, selectedSiteId );
 	const currentPlanIntervalType = getIntervalTypeForTerm(
 		getPlan( currentPlan?.productSlug )?.term
@@ -475,7 +463,6 @@ const ConnectedPlans = connect( ( state, props ) => {
 		isWPForTeamsSite: isSiteWPForTeams( state, selectedSiteId ),
 		isSiteEligibleForMonthlyPlan: isEligibleForWpComMonthlyPlan( state, selectedSiteId ),
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
-		is2023PricingGridVisible: props.is2023PricingGridVisible ?? true,
 		isDomainAndPlanPackageFlow: !! getCurrentQueryArguments( state )?.domainAndPlanPackage,
 		isJetpackNotAtomic: isJetpackSite( state, selectedSiteId, { treatAtomicAsJetpackSite: false } ),
 		isDomainUpsell:

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -3,7 +3,6 @@ import {
 	isDomainRegistration,
 	isDomainTransfer,
 	isDomainMapping,
-	is2023PricingGridEnabled,
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { camelToSnakeCase } from '@automattic/js-utils';
@@ -752,7 +751,6 @@ class Signup extends Component {
 	}
 
 	renderCurrentStep( isReskinned ) {
-		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } );
 		const CurrentComponent = this.props.stepComponent;
 		const propsFromConfig = {
@@ -761,23 +759,7 @@ class Signup extends Component {
 		};
 		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : this.props.stepName;
 		const flow = flows.getFlow( this.props.flowName, this.props.isLoggedIn );
-		const planWithDomain =
-			this.props.domainsWithPlansOnly &&
-			domainItem &&
-			( isDomainRegistration( domainItem ) ||
-				isDomainTransfer( domainItem ) ||
-				isDomainMapping( domainItem ) );
 
-		// Hide the free option in the signup flow
-		const selectedHideFreePlan = get( this.props, 'signupDependencies.shouldHideFreePlan', false );
-
-		// For the onboarding/2023-pricing-grid hiding the free plan is not yet supported and breaks the plans comparison grid
-		// If there is any condition upon which the free plan should be hidden these issues need to be resolved.
-		// For now we always show the free plan for the 2023-pricing-grid
-		// More Context : Automattic/martech#1464
-		const hideFreePlan = is2023PricingGridEnabled()
-			? false
-			: planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		let propsForCurrentStep = propsFromConfig;
@@ -818,7 +800,7 @@ class Signup extends Component {
 							signupDependencies={ this.props.signupDependencies }
 							stepSectionName={ this.props.stepSectionName }
 							positionInFlow={ this.getPositionInFlow() }
-							hideFreePlan={ hideFreePlan }
+							hideFreePlan={ false }
 							isReskinned={ isReskinned }
 							queryParams={ this.getCurrentFlowSupportedQueryParams() }
 							{ ...propsForCurrentStep }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -199,8 +199,7 @@ export class PlansStep extends Component {
 	}
 
 	getHeaderText() {
-		const { headerText, translate, eligibleForProPlan, locale, is2023PricingGridVisible } =
-			this.props;
+		const { headerText, translate, eligibleForProPlan, locale } = this.props;
 
 		if ( headerText ) {
 			return headerText;
@@ -212,26 +211,12 @@ export class PlansStep extends Component {
 				: translate( 'Choose the plan that’s right for you' );
 		}
 
-		if ( is2023PricingGridVisible ) {
-			return translate( 'Choose your flavor of WordPress' );
-		}
-
-		if ( this.state.isDesktop ) {
-			return translate( 'Choose a plan' );
-		}
-
-		return translate( "Pick a plan that's right for you." );
+		return translate( 'Choose your flavor of WordPress' );
 	}
 
 	getSubHeaderText() {
-		const {
-			eligibleForProPlan,
-			hideFreePlan,
-			locale,
-			translate,
-			useEmailOnboardingSubheader,
-			is2023PricingGridVisible,
-		} = this.props;
+		const { eligibleForProPlan, hideFreePlan, locale, translate, useEmailOnboardingSubheader } =
+			this.props;
 
 		const freePlanButton = (
 			<Button onClick={ () => buildUpgradeFunction( this.props, null ) } borderless />
@@ -259,29 +244,6 @@ export class PlansStep extends Component {
 				{ components: { link: freePlanButton } }
 			);
 		}
-
-		if ( is2023PricingGridVisible ) {
-			return;
-		}
-
-		if ( this.state.isDesktop ) {
-			if ( hideFreePlan ) {
-				return translate( "Pick one that's right for you and unlock features that help you grow." );
-			}
-
-			return translate(
-				"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
-				{ components: { link: freePlanButton } }
-			);
-		}
-
-		if ( hideFreePlan ) {
-			return translate( 'Choose a plan.' );
-		}
-
-		return translate( 'Choose a plan or {{link}}start with a free site{{/link}}.', {
-			components: { link: freePlanButton },
-		} );
 	}
 
 	shouldHideEcommercePlan() {
@@ -290,15 +252,8 @@ export class PlansStep extends Component {
 	}
 
 	plansFeaturesSelection() {
-		const {
-			flowName,
-			stepName,
-			positionInFlow,
-			translate,
-			hasInitializedSitesBackUrl,
-			steps,
-			is2023PricingGridVisible,
-		} = this.props;
+		const { flowName, stepName, positionInFlow, translate, hasInitializedSitesBackUrl, steps } =
+			this.props;
 
 		const headerText = this.getHeaderText();
 		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
@@ -340,8 +295,8 @@ export class PlansStep extends Component {
 					fallbackHeaderText={ fallbackHeaderText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ fallbackSubHeaderText }
-					isWideLayout={ ! is2023PricingGridVisible }
-					isExtraWideLayout={ is2023PricingGridVisible }
+					isWideLayout={ false }
+					isExtraWideLayout={ true }
 					stepContent={ this.plansFeaturesList() }
 					allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 					backUrl={ backUrl }
@@ -354,11 +309,10 @@ export class PlansStep extends Component {
 
 	render() {
 		const classes = classNames( 'plans plans-step', {
-			'in-vertically-scrolled-plans-experiment':
-				! this.props.is2023PricingGridVisible && this.props.isInVerticalScrollingPlansExperiment,
+			'in-vertically-scrolled-plans-experiment': this.props.isInVerticalScrollingPlansExperiment, // TODO clk: confirm this is still needed
 			'has-no-sidebar': true,
-			'is-wide-layout': ! this.props.is2023PricingGridVisible,
-			'is-extra-wide-layout': this.props.is2023PricingGridVisible,
+			'is-wide-layout': false,
+			'is-extra-wide-layout': true,
 		} );
 
 		return (
@@ -419,7 +373,6 @@ export default connect(
 		isInVerticalScrollingPlansExperiment: true,
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
 		eligibleForProPlan: isEligibleForProPlan( state, getSiteBySlug( state, siteSlug )?.ID ),
-		is2023PricingGridVisible: true,
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep, errorNotice }
 )( localize( PlansStep ) );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,4 +1,4 @@
-import { is2023PricingGridEnabled, getPlan, PLAN_FREE } from '@automattic/calypso-products';
+import { getPlan, PLAN_FREE } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { isSiteAssemblerFlow, isTailoredSignupFlow } from '@automattic/onboarding';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
@@ -419,7 +419,7 @@ export default connect(
 		isInVerticalScrollingPlansExperiment: true,
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
 		eligibleForProPlan: isEligibleForProPlan( state, getSiteBySlug( state, siteSlug )?.ID ),
-		is2023PricingGridVisible: is2023PricingGridEnabled(),
+		is2023PricingGridVisible: true,
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep, errorNotice }
 )( localize( PlansStep ) );

--- a/config/development.json
+++ b/config/development.json
@@ -141,7 +141,6 @@
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/import-redesign": true,
-		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/all-patterns-category": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -85,7 +85,6 @@
 		"network-connection": true,
 		"newsletter/stats": true,
 		"onboarding/import-light-url-screen": true,
-		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/all-patterns-category": true,
 		"pattern-assembler/logged-in-showcase": true,

--- a/config/production.json
+++ b/config/production.json
@@ -105,7 +105,6 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
-		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/all-patterns-category": true,
 		"pattern-assembler/logged-in-showcase": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -99,7 +99,6 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
-		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/all-patterns-category": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -113,7 +113,6 @@
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/import-redesign": true,
-		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/all-patterns-category": true,
 		"pattern-assembler/logged-in-showcase": true,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -408,7 +408,6 @@ import {
 	FEATURE_SHIPPING_INTEGRATIONS,
 	FEATURE_THE_READER,
 } from './constants';
-import { is2023PricingGridEnabled } from './plans-utilities';
 import type {
 	BillingTerm,
 	Plan,
@@ -872,7 +871,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	} ),
 } );
 
-const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
+const is2023OnboardingPricingGrid = true;
 
 const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 	...getDotcomPlanDetails(),

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -871,14 +871,11 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	} ),
 } );
 
-const is2023OnboardingPricingGrid = true;
-
 const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 	...getDotcomPlanDetails(),
 	group: GROUP_WPCOM,
 	type: TYPE_ECOMMERCE,
-	getTitle: () =>
-		is2023OnboardingPricingGrid ? i18n.translate( 'Commerce' ) : i18n.translate( 'eCommerce' ),
+	getTitle: () => i18n.translate( 'Commerce' ),
 	getAudience: () => i18n.translate( 'Best for online stores' ),
 	getBlogAudience: () => i18n.translate( 'Best for online stores' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for online stores' ),

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN,
 	BEST_VALUE_PLANS,
@@ -41,12 +40,3 @@ export function getTermDuration( term: string ): number | undefined {
 }
 
 export const redirectCheckoutToWpAdmin = (): boolean => !! JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN;
-
-/**
- * Returns if the 2023 Pricing grid feature has been enabled.
- * Currently this depends on the feature flag.
- *
- */
-export const is2023PricingGridEnabled = (): boolean => {
-	return isEnabled( 'onboarding/2023-pricing-grid' );
-};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/76766
Closes https://github.com/Automattic/wp-calypso/issues/77651

## Proposed Changes

Cleans up all the plumbing needed previously to render the new grid along with the old in Signup/start and Stepper.

Technically removes all references to:
- `is2023OnboardingPricingGrid`
- `onboarding/2023-pricing-grid` flag
- `is2023PricingGridEnabled`
- `is2023PricingGridVisible`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Same as in https://github.com/Automattic/wp-calypso/pull/76768

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
