### PR TITLE
Site transfer: Add container component

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -11,7 +11,7 @@ import DeleteSite from './delete-site';
 import DisconnectSite from './disconnect-site';
 import ConfirmDisconnection from './disconnect-site/confirm';
 import ManageConnection from './manage-connection';
-import StartSiteOwnerTransfer from './site-owner-transfer/start-site-owner-transfer';
+import SiteOwnerTransfer from './site-owner-transfer/site-owner-transfer';
 import StartOver from './start-over';
 
 function canDeleteSite( state, siteId ) {
@@ -86,7 +86,7 @@ export function manageConnection( context, next ) {
 }
 
 export function startSiteOwnerTransfer( context, next ) {
-	context.primary = <StartSiteOwnerTransfer path={ context.path } />;
+	context.primary = <SiteOwnerTransfer />;
 	next();
 }
 

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
@@ -1,0 +1,41 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import ActionPanel from 'calypso/components/action-panel';
+import FormattedHeader from 'calypso/components/formatted-header';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import StartSiteOwnerTransfer from './start-site-owner-transfer';
+
+const SiteOwnerTransfer = () => {
+	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+
+	const translate = useTranslate();
+	if ( ! selectedSiteId || ! selectedSiteSlug ) {
+		return null;
+	}
+
+	return (
+		<Main>
+			<FormattedHeader
+				headerText={ translate( 'Site Transfer' ) }
+				subHeaderText={ translate( 'Transfer your site to another WordPress.com user.' ) }
+				align="left"
+			/>
+			<PageViewTracker
+				path="/settings/start-site Transfer/:site"
+				title="Settings > Start Site Transfer"
+			/>
+			<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug } isCompact={ true }>
+				<h1>{ translate( 'Site Transfer' ) }</h1>
+			</HeaderCake>
+			<ActionPanel>
+				<StartSiteOwnerTransfer />
+			</ActionPanel>
+		</Main>
+	);
+};
+
+export default SiteOwnerTransfer;

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
@@ -25,7 +25,7 @@ const SiteOwnerTransfer = () => {
 				align="left"
 			/>
 			<PageViewTracker
-				path="/settings/start-site Transfer/:site"
+				path="/settings/start-site-transfer/:site"
 				title="Settings > Start Site Transfer"
 			/>
 			<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug } isCompact={ true }>

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import ActionPanel from 'calypso/components/action-panel';
@@ -5,6 +6,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { TRANSFER_SITE } from 'calypso/lib/url/support';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import StartSiteOwnerTransfer from './start-site-owner-transfer';
 
@@ -16,12 +18,18 @@ const SiteOwnerTransfer = () => {
 	if ( ! selectedSiteId || ! selectedSiteSlug ) {
 		return null;
 	}
-
 	return (
 		<Main>
 			<FormattedHeader
 				headerText={ translate( 'Site Transfer' ) }
-				subHeaderText={ translate( 'Transfer your site to another WordPress.com user.' ) }
+				subHeaderText={ translate(
+					'Transfer your site to another WordPress.com user. {{a}}Learn More.{{/a}}',
+					{
+						components: {
+							a: <a target="blank" href={ localizeUrl( TRANSFER_SITE ) } />,
+						},
+					}
+				) }
 				align="left"
 			/>
 			<PageViewTracker

--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -1,14 +1,11 @@
-import { Button, Gridicon } from '@automattic/components';
-import { useLocalizeUrl } from '@automattic/i18n-utils';
+import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { ToggleControl, TextControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { useState, FormEvent } from 'react';
 import { connect } from 'react-redux';
 import ActionPanelBody from 'calypso/components/action-panel/body';
-import ActionPanelFooter from 'calypso/components/action-panel/footer';
 import Notice from 'calypso/components/notice';
-import { TRANSFER_SITE } from 'calypso/lib/url/support';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import {
 	getSelectedSiteId,
@@ -40,7 +37,6 @@ const StartSiteOwnerTransfer = ( {
 	selectedSiteTitle,
 	translate,
 }: Props ) => {
-	const localizeUrl = useLocalizeUrl();
 	const [ confirmFirstToggle, setConfirmFirstToggle ] = useState( false );
 	const [ confirmSecondToggle, setConfirmSecondToggle ] = useState( false );
 	const [ newOwnerUsername, setNewOwnerUsername ] = useState( '' );
@@ -186,21 +182,6 @@ const StartSiteOwnerTransfer = ( {
 				) }
 				{ ! startSiteTransferSuccess && startSiteTransferForm }
 			</SiteOwnerTransferActionPanelBody>
-			<ActionPanelFooter>
-				<Button
-					className="action-panel__support-button is-external" // eslint-disable-line wpcalypso/jsx-classname-namespace
-					href={ localizeUrl( TRANSFER_SITE ) }
-				>
-					{ translate( 'Follow the steps' ) }
-					<Gridicon icon="external" size={ 48 } />
-				</Button>
-				<Button
-					className="action-panel__support-button" // eslint-disable-line wpcalypso/jsx-classname-namespace
-					href="/help/contact"
-				>
-					{ translate( 'Contact support' ) }
-				</Button>
-			</ActionPanelFooter>
 		</>
 	);
 };

--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -5,13 +5,9 @@ import { ToggleControl, TextControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { useState, FormEvent } from 'react';
 import { connect } from 'react-redux';
-import ActionPanel from 'calypso/components/action-panel';
 import ActionPanelBody from 'calypso/components/action-panel/body';
 import ActionPanelFooter from 'calypso/components/action-panel/footer';
-import ActionPanelTitle from 'calypso/components/action-panel/title';
-import HeaderCake from 'calypso/components/header-cake';
 import Notice from 'calypso/components/notice';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { TRANSFER_SITE } from 'calypso/lib/url/support';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import {
@@ -132,93 +128,80 @@ const StartSiteOwnerTransfer = ( {
 	);
 
 	return (
-		<div
-			className="main main-column" // eslint-disable-line wpcalypso/jsx-classname-namespace
-			role="main"
-		>
-			<PageViewTracker
-				path="/settings/start-site Transfer/:site"
-				title="Settings > Start Site Transfer"
-			/>
-			<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>
-				<h1>{ translate( 'Start Site Transfer' ) }</h1>
-			</HeaderCake>
-			<ActionPanel>
-				<SiteOwnerTransferActionPanelBody>
-					<ActionPanelTitle>{ translate( 'Start Site Transfer' ) }</ActionPanelTitle>
-					<p>
-						{ translate(
-							'Transferring a site cannot be undone. Please read the following actions that will take place when you transfer this site:'
-						) }
-					</p>
-					<ul>
-						<li>
-							{ translate( 'You will be removed as owner of %(selectedSiteSlug)s', {
-								args: { selectedSiteSlug },
-							} ) }
-						</li>
-						<li>
-							{ translate(
-								'You will not be able to access %(selectedSiteSlug)s unless allowed by the new owner',
-								{
-									args: { selectedSiteSlug },
-								}
-							) }
-						</li>
-						<li>
-							{ translate(
-								'Your posts on %(selectedSiteSlug)s will be transferred to the new owner and will no longer be authored by your account.',
-								{
-									args: { selectedSiteSlug },
-								}
-							) }
-						</li>
-						<li>
-							{ translate(
-								'Your paid upgrades on %(selectedSiteSlug)s will be transferred to the new owner, and will remain with the blog',
-								{
-									args: { selectedSiteSlug },
-								}
-							) }
-						</li>
-						<li>
-							{ translate(
-								'You must authorize the transfer via a confirmation email sent to %(currentUserEmail)s. The transfer will not proceed unless you authorize it.',
-								{
-									args: { currentUserEmail },
-								}
-							) }
-						</li>
-					</ul>
-					{ startSiteTransferSuccess && (
-						<Notice status="is-success" showDismiss={ false }>
-							{ translate(
-								'You have been sent a transfer confirmation email to %(currentUserEmail)s. Please check your inbox and spam folder. The transfer will not proceed unless you authorize it using the link in the email.',
-								{
-									args: { currentUserEmail },
-								}
-							) }
-						</Notice>
+		<>
+			<SiteOwnerTransferActionPanelBody>
+				<p>
+					{ translate(
+						'Transferring a site cannot be undone. Please read the following actions that will take place when you transfer this site:'
 					) }
-					{ ! startSiteTransferSuccess && startSiteTransferForm }
-				</SiteOwnerTransferActionPanelBody>
-				<ActionPanelFooter>
-					<Button
-						className="action-panel__support-button is-external" // eslint-disable-line wpcalypso/jsx-classname-namespace
-						href={ localizeUrl( TRANSFER_SITE ) }
-					>
-						{ translate( 'Follow the steps' ) }
-						<Gridicon icon="external" size={ 48 } />
-					</Button>
-					<Button
-						className="action-panel__support-button" // eslint-disable-line wpcalypso/jsx-classname-namespace
-						href="/help/contact"
-					>
-						{ translate( 'Contact support' ) }
-					</Button>
-				</ActionPanelFooter>
-			</ActionPanel>
-		</div>
+				</p>
+				<ul>
+					<li>
+						{ translate( 'You will be removed as owner of %(selectedSiteSlug)s', {
+							args: { selectedSiteSlug },
+						} ) }
+					</li>
+					<li>
+						{ translate(
+							'You will not be able to access %(selectedSiteSlug)s unless allowed by the new owner',
+							{
+								args: { selectedSiteSlug },
+							}
+						) }
+					</li>
+					<li>
+						{ translate(
+							'Your posts on %(selectedSiteSlug)s will be transferred to the new owner and will no longer be authored by your account.',
+							{
+								args: { selectedSiteSlug },
+							}
+						) }
+					</li>
+					<li>
+						{ translate(
+							'Your paid upgrades on %(selectedSiteSlug)s will be transferred to the new owner, and will remain with the blog',
+							{
+								args: { selectedSiteSlug },
+							}
+						) }
+					</li>
+					<li>
+						{ translate(
+							'You must authorize the transfer via a confirmation email sent to %(currentUserEmail)s. The transfer will not proceed unless you authorize it.',
+							{
+								args: { currentUserEmail },
+							}
+						) }
+					</li>
+				</ul>
+				{ startSiteTransferSuccess && (
+					<Notice status="is-success" showDismiss={ false }>
+						{ translate(
+							'You have been sent a transfer confirmation email to %(currentUserEmail)s. Please check your inbox and spam folder. The transfer will not proceed unless you authorize it using the link in the email.',
+							{
+								args: { currentUserEmail },
+							}
+						) }
+					</Notice>
+				) }
+				{ ! startSiteTransferSuccess && startSiteTransferForm }
+			</SiteOwnerTransferActionPanelBody>
+			<ActionPanelFooter>
+				<Button
+					className="action-panel__support-button is-external" // eslint-disable-line wpcalypso/jsx-classname-namespace
+					href={ localizeUrl( TRANSFER_SITE ) }
+				>
+					{ translate( 'Follow the steps' ) }
+					<Gridicon icon="external" size={ 48 } />
+				</Button>
+				<Button
+					className="action-panel__support-button" // eslint-disable-line wpcalypso/jsx-classname-namespace
+					href="/help/contact"
+				>
+					{ translate( 'Contact support' ) }
+				</Button>
+			</ActionPanelFooter>
+		</>
 	);
 };
 


### PR DESCRIPTION
## Proposed Changes


In order to work more effectively to [Site Transfers: Implement the final design for the initiating transfer UI #2553](https://github.com/Automattic/dotcom-forge/issues/2553), this pr adds a container component so the work of the above issue can be easily split and worked as separate prs.

## Testing Instructions

1. Create a simple site
2. Navigate to `Settings > General > Transfer your site`
3. Make sure that everything is working as before. (You can visit wpcalypso for reference). Ensure that the "Start site transfer" title is removed.

![image](https://github.com/Automattic/wp-calypso/assets/497103/dfa9bde2-e690-464a-a976-c1f613f7e61a)

5. Ensure that there is a new title on top of the page as shown below (Note that the link is not there yet, as we don't have any support links. It is missing on purpose. Will be added in a later pr. Ignore the rest of the image. The title is the only thing that was added):

![image](https://github.com/Automattic/wp-calypso/assets/497103/606cfaac-ad3d-486e-a0ab-c0dadce09497)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2553

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
