### PR TITLE
Import focused flow: Introduce confirm modal prompt

### DIFF
--- a/client/blocks/importer/components/confirm-modal/index.tsx
+++ b/client/blocks/importer/components/confirm-modal/index.tsx
@@ -1,0 +1,53 @@
+import { Button } from '@automattic/components';
+import { NextButton } from '@automattic/onboarding';
+import { Modal } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
+import React from 'react';
+
+import './style.scss';
+
+interface Props {
+	compact?: boolean;
+	title?: string;
+	children?: React.ReactNode;
+	cancelText?: string;
+	confirmText?: string;
+	onClose?: () => void;
+	onConfirm?: () => void;
+}
+
+const ConfirmModal: React.FunctionComponent< Props > = ( props ) => {
+	const { __ } = useI18n();
+	const {
+		compact = true,
+		title = __( 'Confirm your choice' ),
+		children,
+		cancelText = __( 'Cancel' ),
+		confirmText = __( 'Continue' ),
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		onClose = () => {},
+		onConfirm,
+	} = props;
+
+	return (
+		<Modal
+			className={ classnames( 'components-modal-new__frame', 'import__confirm-modal', {
+				compact: compact,
+			} ) }
+			title={ title }
+			onRequestClose={ onClose }
+		>
+			{ children }
+			<div className="components-modal__button-actions">
+				{ compact && <div className="components-modal__divider" /> }
+				<Button className="action-buttons__cancel" onClick={ onClose }>
+					{ cancelText }
+				</Button>
+				{ onConfirm && <NextButton onClick={ onConfirm }>{ confirmText }</NextButton> }
+			</div>
+		</Modal>
+	);
+};
+
+export default ConfirmModal;

--- a/client/blocks/importer/components/confirm-modal/style.scss
+++ b/client/blocks/importer/components/confirm-modal/style.scss
@@ -1,0 +1,38 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.components-modal__frame.components-modal-new__frame.import__confirm-modal.compact {
+	@include break-medium {
+		width: 420px;
+	}
+
+	.components-modal__content {
+		padding: rem(24px) rem(24px) rem(16px);
+	}
+
+	.components-modal__header-heading {
+		font-size: rem(20px);
+		font-weight: 500;
+		line-height: rem(26px);
+	}
+
+	.components-modal__divider {
+		margin-bottom: rem(16px);
+		margin-left: rem(-24px);
+		margin-right: rem(-24px);
+		border-top: solid 1px var(--studio-gray-5);
+	}
+
+	.components-modal__button-actions button {
+		min-width: 100px;
+	}
+
+	.components-modal__header button svg {
+		width: 24px;
+		height: 24px;
+	}
+
+	.action-buttons__next {
+		min-width: auto;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -3,8 +3,10 @@ import {
 	DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE,
 	GroupableSiteLaunchStatuses,
 } from '@automattic/sites';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import React from 'react';
+import React, { useState } from 'react';
+import ConfirmModal from 'calypso/blocks/importer/components/confirm-modal';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -17,11 +19,15 @@ import './styles.scss';
 
 const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 	const { __ } = useI18n();
-	const page = Number( useQuery().get( 'page' ) ) || 1;
-	const search = useQuery().get( 'search' ) || '';
+	const urlQueryParams = useQuery();
+	const page = Number( urlQueryParams.get( 'page' ) ) || 1;
+	const search = urlQueryParams.get( 'search' ) || '';
 	const status =
-		( useQuery().get( 'status' ) as GroupableSiteLaunchStatuses ) ||
+		( urlQueryParams.get( 'status' ) as GroupableSiteLaunchStatuses ) ||
 		DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE;
+	const sourceSiteSlug = urlQueryParams.get( 'from' ) || '';
+	const [ destinationSite, setDestinationSite ] = useState< SiteExcerptData >();
+	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 
 	const onQueryParamChange = ( params: Partial< SitesDashboardQueryParams > ) => {
 		recordTracksEvent( 'calypso_import_site_picker_query_param_change', params );
@@ -42,6 +48,36 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 		navigation.submit?.( { action: 'select-site', site } );
 	};
 
+	const onSelectSite = ( site: SiteExcerptData ) => {
+		setDestinationSite( site );
+		setShowConfirmModal( true );
+	};
+
+	const renderConfirmModal = () => (
+		<ConfirmModal
+			onClose={ () => {
+				setDestinationSite( undefined );
+				setShowConfirmModal( false );
+			} }
+			onConfirm={ () => {
+				destinationSite && selectSite( destinationSite );
+			} }
+		>
+			<p>
+				{ sprintf(
+					/* translators: the `sourceSite` and `targetSite` fields could be any site URL (eg: "yourname.com") */
+					__(
+						'Your site %(sourceSite)s will be migrated to %(targetSite)s, overriding all the content in your destination site. '
+					),
+					{
+						sourceSite: sourceSiteSlug,
+						targetSite: destinationSite?.slug,
+					}
+				) }
+			</p>
+		</ConfirmModal>
+	);
+
 	return (
 		<>
 			<DocumentHead title={ __( 'Pick your destination' ) } />
@@ -57,12 +93,13 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 						search={ search }
 						status={ status }
 						onCreateSite={ createNewSite }
-						onSelectSite={ selectSite }
+						onSelectSite={ onSelectSite }
 						onQueryParamChange={ onQueryParamChange }
 					/>
 				}
 				recordTracksEvent={ recordTracksEvent }
 			/>
+			{ showConfirmModal && renderConfirmModal() }
 		</>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77374

## Proposed Changes

* Created reusable/adaptable Confirm modal component
* Introduced confirmation modal into Site picker step

## Testing Instructions

* Go to `/setup/import-focused/sitePicker?from={JN_SITE}`
* Select one of the presented sites by pressing the "Select this site" button
* Check if the Confirm modal shows

**NOTE:** In the next PRs, we are going to handle conditional showing of confirm modal on the ready screen.

## Screenshot
<img width="618" alt="Screenshot 2023-05-29 at 15 46 11" src="https://github.com/Automattic/wp-calypso/assets/1241413/3cb62a4d-c61d-4a93-a214-adcc2bc10963">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
