### PR TITLE
Stats: Toggle highlight section with periods data

### DIFF
--- a/client/my-sites/stats/highlights-section/index.tsx
+++ b/client/my-sites/stats/highlights-section/index.tsx
@@ -1,5 +1,11 @@
-import { WeeklyHighlightCards } from '@automattic/components';
-import { useEffect, useMemo } from 'react';
+import {
+	WeeklyHighlightCards,
+	PAST_SEVEN_DAYS,
+	PAST_THIRTY_DAYS,
+	BETWEEN_PAST_EIGHT_AND_FIFTEEN_DAYS,
+	BETWEEN_PAST_THIRTY_ONE_AND_SIXTY_DAYS,
+} from '@automattic/components';
+import { useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { requestHighlights } from 'calypso/state/stats/highlights/actions';
 import { getHighlights } from 'calypso/state/stats/highlights/selectors';
@@ -12,25 +18,30 @@ export default function HighlightsSection( { siteId }: { siteId: number } ) {
 		dispatch( requestHighlights( siteId ) );
 	}, [ dispatch, siteId ] );
 
+	const [ currentPeriod, setCurrentPeriod ] = useState( PAST_SEVEN_DAYS );
+
 	const highlights = useSelector( ( state ) => getHighlights( state, siteId ) );
 	const counts = useMemo(
 		() => ( {
-			comments: highlights?.past_seven_days?.comments ?? null,
-			likes: highlights?.past_seven_days?.likes ?? null,
-			views: highlights?.past_seven_days?.views ?? null,
-			visitors: highlights?.past_seven_days?.visitors ?? null,
+			comments: highlights[ currentPeriod ]?.comments ?? null,
+			likes: highlights[ currentPeriod ]?.likes ?? null,
+			views: highlights[ currentPeriod ]?.views ?? null,
+			visitors: highlights[ currentPeriod ]?.visitors ?? null,
 		} ),
-		[ highlights ]
+		[ highlights, currentPeriod ]
 	);
-	const previousCounts = useMemo(
-		() => ( {
-			comments: highlights?.between_past_eight_and_fifteen_days?.comments ?? null,
-			likes: highlights?.between_past_eight_and_fifteen_days?.likes ?? null,
-			views: highlights?.between_past_eight_and_fifteen_days?.views ?? null,
-			visitors: highlights?.between_past_eight_and_fifteen_days?.visitors ?? null,
-		} ),
-		[ highlights ]
-	);
+	const previousCounts = useMemo( () => {
+		const comparePeriod =
+			currentPeriod === PAST_THIRTY_DAYS
+				? BETWEEN_PAST_THIRTY_ONE_AND_SIXTY_DAYS
+				: BETWEEN_PAST_EIGHT_AND_FIFTEEN_DAYS;
+		return {
+			comments: highlights[ comparePeriod ]?.comments ?? null,
+			likes: highlights[ comparePeriod ]?.likes ?? null,
+			views: highlights[ comparePeriod ]?.views ?? null,
+			visitors: highlights[ comparePeriod ]?.visitors ?? null,
+		};
+	}, [ highlights, currentPeriod ] );
 
 	return (
 		<WeeklyHighlightCards
@@ -42,6 +53,8 @@ export default function HighlightsSection( { siteId }: { siteId: number } ) {
 			onClickLikes={ () => null }
 			onClickViews={ () => null }
 			onClickVisitors={ () => null }
+			onTogglePeriod={ setCurrentPeriod }
+			currentPeriod={ currentPeriod }
 		/>
 	);
 }

--- a/config/development.json
+++ b/config/development.json
@@ -181,7 +181,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": false,
-		"stats/highlights-settings": false,
+		"stats/highlights-settings": true,
 		"stats/new-video-summary": true,
 		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -56,6 +56,19 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	display: flex;
 	align-items: center;
 
+	.highlight-cards-heading__description {
+		display: flex;
+		align-items: flex-end;
+		height: 31px;
+		margin-left: 12px;
+		font-family: $font-sf-pro-text;
+		font-weight: 400;
+		font-size: $font-body-small;
+		color: var(--studio-gray-60);
+		line-height: 20px;
+		letter-spacing: -0.15px;
+	}
+
 	.highlight-cards-heading__tooltip {
 		margin-left: 6px;
 	}

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -1,4 +1,5 @@
 @use "sass:math";
+@import "@wordpress/base-styles/colors";
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/typography/styles/variables";
 @import "@automattic/components/src/styles/typography";
@@ -81,6 +82,15 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		width: 24px;
 		height: 24px;
 		cursor: pointer;
+
+		&:focus {
+			outline: 2px solid #3057dc;
+			border-radius: 2px;
+		}
+
+		svg {
+			fill: $gray-900;
+		}
 	}
 
 	small {
@@ -96,7 +106,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	}
 
 	svg {
-		fill: var(--studio-gray-50);
+		fill: var(--studio-gray-30);
 	}
 }
 

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { eye } from '../icons';
 import Popover from '../popover';
 import { comparingInfoBarsChart, comparingInfoRangeChart } from './charts';
@@ -64,9 +64,11 @@ export default function WeeklyHighlightCards( {
 	const [ isTooltipVisible, setTooltipVisible ] = useState( false );
 	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
 
-	const togglePopoverMenu = () => {
-		setPopoverVisible( ! isPopoverVisible );
-	};
+	const togglePopoverMenu = useCallback( () => {
+		setPopoverVisible( ( isVisible ) => {
+			return ! isVisible;
+		} );
+	}, [] );
 
 	const isHighlightsSettingsEnabled = config.isEnabled( 'stats/highlights-settings' );
 
@@ -146,6 +148,7 @@ export default function WeeklyHighlightCards( {
 							isVisible={ isPopoverVisible }
 							position="bottom left"
 							context={ settingsActionRef.current }
+							focusOnShow={ false }
 						>
 							<button
 								onClick={ () => {

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -78,48 +78,60 @@ export default function WeeklyHighlightCards( {
 						? translate( '30-day highlights' )
 						: translate( '7-day highlights' ) }
 				</span>
-				<div className="highlight-cards-heading__tooltip">
-					<span
-						className="highlight-cards-heading-icon"
-						ref={ textRef }
-						onMouseEnter={ () => setTooltipVisible( true ) }
-						onMouseLeave={ () => setTooltipVisible( false ) }
-					>
-						<Icon className="gridicon" icon={ info } />
-					</span>
-					<Popover
-						className="tooltip tooltip--darker highlight-card-tooltip"
-						isVisible={ isTooltipVisible }
-						position="bottom right"
-						context={ textRef.current }
-					>
-						<div className="highlight-card-tooltip-content comparing-info">
-							<p>
-								{ translate( 'Highlights displayed are for the last 7 days, excluding today.' ) }
-							</p>
-							<p>
-								{ translate(
-									'Trends shown are in comparison to the previous 7 days before that.'
-								) }
-							</p>
-							<div className="comparing-info-chart">
-								<small>
-									{ translate( '%(fourteen)d days {{vs/}} %(seven)d days', {
-										components: {
-											vs: <span>vs</span>,
-										},
-										args: {
-											fourteen: 14,
-											seven: 7,
-										},
-									} ) }
-								</small>
-								{ comparingInfoRangeChart }
-								{ comparingInfoBarsChart }
+
+				{ isHighlightsSettingsEnabled && (
+					<small className="highlight-cards-heading__description">
+						{ currentPeriod === PAST_THIRTY_DAYS
+							? translate( 'Compared to previous 30 days' )
+							: translate( 'Compared to previous 7 days' ) }
+					</small>
+				) }
+
+				{ ! isHighlightsSettingsEnabled && (
+					<div className="highlight-cards-heading__tooltip">
+						<span
+							className="highlight-cards-heading-icon"
+							ref={ textRef }
+							onMouseEnter={ () => setTooltipVisible( true ) }
+							onMouseLeave={ () => setTooltipVisible( false ) }
+						>
+							<Icon className="gridicon" icon={ info } />
+						</span>
+						<Popover
+							className="tooltip tooltip--darker highlight-card-tooltip"
+							isVisible={ isTooltipVisible }
+							position="bottom right"
+							context={ textRef.current }
+						>
+							<div className="highlight-card-tooltip-content comparing-info">
+								<p>
+									{ translate( 'Highlights displayed are for the last 7 days, excluding today.' ) }
+								</p>
+								<p>
+									{ translate(
+										'Trends shown are in comparison to the previous 7 days before that.'
+									) }
+								</p>
+								<div className="comparing-info-chart">
+									<small>
+										{ translate( '%(fourteen)d days {{vs/}} %(seven)d days', {
+											components: {
+												vs: <span>vs</span>,
+											},
+											args: {
+												fourteen: 14,
+												seven: 7,
+											},
+										} ) }
+									</small>
+									{ comparingInfoRangeChart }
+									{ comparingInfoBarsChart }
+								</div>
 							</div>
-						</div>
-					</Popover>
-				</div>
+						</Popover>
+					</div>
+				) }
+
 				{ isHighlightsSettingsEnabled && (
 					<div className="highlight-cards-heading__settings">
 						<button

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -36,7 +36,14 @@ type WeeklyHighlightCardsProps = {
 	onClickLikes: ( event: MouseEvent ) => void;
 	onClickViews: ( event: MouseEvent ) => void;
 	onClickVisitors: ( event: MouseEvent ) => void;
+	onTogglePeriod: ( period: string ) => void;
+	currentPeriod: string;
 };
+
+export const PAST_SEVEN_DAYS = 'past_seven_days';
+export const PAST_THIRTY_DAYS = 'past_thirty_days';
+export const BETWEEN_PAST_EIGHT_AND_FIFTEEN_DAYS = 'between_past_eight_and_fifteen_days';
+export const BETWEEN_PAST_THIRTY_ONE_AND_SIXTY_DAYS = 'between_past_thirty_one_and_sixty_days';
 
 export default function WeeklyHighlightCards( {
 	className,
@@ -45,8 +52,10 @@ export default function WeeklyHighlightCards( {
 	onClickLikes,
 	onClickViews,
 	onClickVisitors,
+	onTogglePeriod,
 	previousCounts,
 	showValueTooltip,
+	currentPeriod,
 }: WeeklyHighlightCardsProps ) {
 	const translate = useTranslate();
 
@@ -64,7 +73,11 @@ export default function WeeklyHighlightCards( {
 	return (
 		<div className={ classNames( 'highlight-cards', className ?? null ) }>
 			<h3 className="highlight-cards-heading">
-				<span>{ translate( '7-day highlights' ) }</span>
+				<span>
+					{ currentPeriod === PAST_THIRTY_DAYS
+						? translate( '30-day highlights' )
+						: translate( '7-day highlights' ) }
+				</span>
 				<div className="highlight-cards-heading__tooltip">
 					<span
 						className="highlight-cards-heading-icon"
@@ -122,13 +135,25 @@ export default function WeeklyHighlightCards( {
 							position="bottom left"
 							context={ settingsActionRef.current }
 						>
-							<button>
+							<button
+								onClick={ () => {
+									onTogglePeriod( PAST_SEVEN_DAYS );
+								} }
+							>
 								{ translate( '7-day highlights' ) }
-								<Icon className="gridicon" icon={ check } />
+								{ currentPeriod === PAST_SEVEN_DAYS && (
+									<Icon className="gridicon" icon={ check } />
+								) }
 							</button>
-							<button>
+							<button
+								onClick={ () => {
+									onTogglePeriod( PAST_THIRTY_DAYS );
+								} }
+							>
 								{ translate( '30-day highlights' ) }
-								{ false && <Icon className="gridicon" icon={ check } /> }
+								{ currentPeriod === PAST_THIRTY_DAYS && (
+									<Icon className="gridicon" icon={ check } />
+								) }
 							</button>
 						</Popover>
 					</div>

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -64,6 +64,7 @@ export default function WeeklyHighlightCards( {
 	const [ isTooltipVisible, setTooltipVisible ] = useState( false );
 	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
 
+	// @TODO: Set the popover to disappear when the user clicks outside of the popover.
 	const togglePopoverMenu = useCallback( () => {
 		setPopoverVisible( ( isVisible ) => {
 			return ! isVisible;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -37,7 +37,13 @@ export {
 	percentCalculator,
 } from './highlight-cards/count-comparison-card';
 export { default as AnnualHighlightCards } from './highlight-cards/annual-highlight-cards';
-export { default as WeeklyHighlightCards } from './highlight-cards/weekly-highlight-cards';
+export {
+	default as WeeklyHighlightCards,
+	PAST_SEVEN_DAYS,
+	PAST_THIRTY_DAYS,
+	BETWEEN_PAST_EIGHT_AND_FIFTEEN_DAYS,
+	BETWEEN_PAST_THIRTY_ONE_AND_SIXTY_DAYS,
+} from './highlight-cards/weekly-highlight-cards';
 export { default as AppPromoCard } from './app-promo-card';
 export { default as ShortenedNumber } from './number-formatters';
 export { default as formattedNumber } from './number-formatters/formatted-number';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77425 

## Proposed Changes

* Toggle the `7-day` highlights section data period by operating `past_thirty_days` and `between_past_thirty_one_and_sixty_days` API data generated from `D112152-code`.
* Replace the highlights section tooltip with the heading description.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox API with the diff `D112152-code`.
* Spin the local site with this change.
* Navigate to the Stats > `Traffic` page.
* Ensure the `7-day` highlights section works as previously and aligns with the design.
* Toggle the highlights period to 30 days.
* Ensure the `30-day` highlights section works in line with the design.

|7 days|30 days|
|-|-|
|<img width="1294" alt="截圖 2023-05-30 上午11 20 01" src="https://github.com/Automattic/wp-calypso/assets/6869813/cf29d7d4-735d-4a98-8e8f-cfc6f5165e73">|<img width="1268" alt="截圖 2023-05-30 上午11 20 10" src="https://github.com/Automattic/wp-calypso/assets/6869813/20e5f249-9b58-481c-899c-a2576d9cd74a">|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?