### PR TITLE
Subscribers Page: Create the page scaffolding

### DIFF
--- a/client/my-sites/subscribers/controller.js
+++ b/client/my-sites/subscribers/controller.js
@@ -1,0 +1,7 @@
+import { createElement } from 'react';
+import { Subscribers } from './main';
+
+export function subscribers( context, next ) {
+	context.primary = createElement( Subscribers );
+	next();
+}

--- a/client/my-sites/subscribers/index.js
+++ b/client/my-sites/subscribers/index.js
@@ -1,0 +1,10 @@
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import { subscribers } from './controller';
+
+export default function () {
+	page( '/subscribers', siteSelection, sites, navigation, makeLayout, clientRender );
+
+	page( '/subscribers/:domain', siteSelection, navigation, subscribers, makeLayout, clientRender );
+}

--- a/client/my-sites/subscribers/index.js
+++ b/client/my-sites/subscribers/index.js
@@ -5,6 +5,5 @@ import { subscribers } from './controller';
 
 export default function () {
 	page( '/subscribers', siteSelection, sites, navigation, makeLayout, clientRender );
-
 	page( '/subscribers/:domain', siteSelection, navigation, subscribers, makeLayout, clientRender );
 }

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -11,7 +11,7 @@ export const Subscribers = () => {
 	}
 
 	return (
-		<Main className="subscribers">
+		<Main>
 			<DocumentHead title={ translate( 'Subscribers' ) } />
 			Subscribers
 		</Main>

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,0 +1,18 @@
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+
+export const Subscribers = () => {
+	return (
+		<Main className="subscribers">
+			<DocumentHead title="Subscribers" />
+			<FormattedHeader
+				brandFont
+				className="subscribers__page-heading"
+				headerText="Subscribers page"
+				subHeaderText="Test"
+				align="left"
+			/>
+		</Main>
+	);
+};

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,8 +1,15 @@
+import config from '@automattic/calypso-config';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 
 export const Subscribers = () => {
+	const isSubscribersPageEnabled = config.isEnabled( 'subscribers-page' );
+
+	if ( ! isSubscribersPageEnabled ) {
+		return null;
+	}
+
 	return (
 		<Main className="subscribers">
 			<DocumentHead title="Subscribers" />

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
+import { translate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 
 export const Subscribers = () => {
@@ -12,14 +12,8 @@ export const Subscribers = () => {
 
 	return (
 		<Main className="subscribers">
-			<DocumentHead title="Subscribers" />
-			<FormattedHeader
-				brandFont
-				className="subscribers__page-heading"
-				headerText="Subscribers page"
-				subHeaderText="Test"
-				align="left"
-			/>
+			<DocumentHead title={ translate( 'Subscribers' ) } />
+			Subscribers
 		</Main>
 	);
 };

--- a/client/sections.js
+++ b/client/sections.js
@@ -180,6 +180,12 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'subscribers',
+		paths: [ '/subscribers' ],
+		module: 'calypso/my-sites/subscribers',
+		group: 'sites',
+	},
+	{
 		name: 'jetpack-connect',
 		paths: [ '/jetpack' ],
 		module: 'calypso/jetpack-connect',


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/77527.

## Proposed Changes

* add `/subscribers` section to the Calypso client
* render the basic `<Main />` component - only if the `subscribers-page` feature flag is enabled 
* make sure "Site selector" is rendered when the user doesn't specify the site address when entering `/subscribers`

![Markup on 2023-05-31 at 14:26:02](https://github.com/Automattic/wp-calypso/assets/25105483/4c4f5ed2-e59a-4503-933a-eeb2d839bf8c)

ℹ️ Please note this PR does not bring in the sidebar menu item. This will be addressed in a separate PR.

TODOs:

- [x] add feature flag check
- [ ] ~~add styles~~ - at the end I decided to leave the styles out from this PR

## Testing Instructions

1. Check out and build this PR.
2. Make sure the `subscribers-page` feature flag is enabled in your local environment
3. Navigate to `/subscribers/[site-address]` (example URL with the feature flag enabled: `http://calypso.localhost:3000/subscribers/[site-address]?flags=subscribers-page`).
4. Simple "Subscribers" text should render.
5. Navigate to `/subscribers/` (without the site address).
6. The "Site selector" should be rendered. Once you select one of your sites, again, the "Subscribers" text should render.
7. When the `subscribers-page` feature flag is disabled (e.g. by navigating to `http://calypso.localhost:3000/subscribers/[site-address]?flags=-subscribers-page`), only empty page with navigation on the side should render.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
