### PR TITLE
Design first flow: Turn off launchpad for sites that has launched.

### DIFF
--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -103,8 +103,15 @@ const designFirst: Flow = {
 
 					// If the user's site has just been launched.
 					if ( providedDependencies?.blogLaunched && siteSlug ) {
-						// Remove the site_intent.
-						setIntentOnSite( siteSlug, '' );
+						await Promise.all( [
+							// We set launchpad_screen to off because users can choose to
+							// complete the first_post_published checklist task or not.
+							saveSiteSettings( providedDependencies?.siteSlug, {
+								launchpad_screen: 'off',
+							} ),
+							// Remove the site_intent.
+							setIntentOnSite( providedDependencies?.siteSlug, '' ),
+						] );
 
 						// If the user launched their site with a plan or domain in their cart, redirect them to
 						// checkout before sending them home.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2552

## Proposed Changes

* Set `launchpad_screen` to `off` when a user launches their site through `design-first` flow

Context: the `launchpad_screen` will automatically be set to `off` from the back end when user finishes all checklist task. But for the `design-first` flow, Writing a first post task is **optional**, so the user can still launch the site without completing **all** tasks. Therefore, the user gets redirected to the Blog hero flow (check the video in https://github.com/Automattic/dotcom-forge/issues/2552)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout to this branch
* Go to `/setup/design-first` with either an account with 0 sites or create a new account
* Go through the steps and launch the site without "Writing first post"
* Should not be redirected

https://github.com/Automattic/wp-calypso/assets/6586048/f66de7fa-b632-4cb5-8349-de96cd5a5f9b

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
