### PR TITLE
Adds Blaze Dashboard App build in Team City

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -32,6 +32,7 @@ object WPComPlugins : Project({
 	buildType(WpcomBlockEditor)
 	buildType(Notifications)
 	buildType(OdysseyStats)
+	buildType(BlazeDashboard)
 	buildType(O2Blocks)
 	buildType(HappyBlocks)
 	buildType(Happychat)
@@ -49,6 +50,7 @@ object WPComPlugins : Project({
 				withTags = anyOf(
 					"notifications-release-build",
 					"odyssey-stats-release-build",
+					"blaze-dashboard-release-build",
 					"etk-release-build",
 					"wpcom-block-editor-release-build",
 					"o2-blocks-release-build",
@@ -258,7 +260,27 @@ private object OdysseyStats : WPComPluginBuild(
 				yarn test:size
 			"""
 		}
-		
+
+	}
+)
+
+private object BlazeDashboard : WPComPluginBuild(
+	buildId = "WPComPlugins_BlazeDashboard",
+	buildName = "Blaze Dashboard",
+	pluginSlug = "blaze-dashboard",
+	archiveDir = "./dist/",
+	withPRNotify = "false",
+	docsLink = "TODO",
+	buildSteps = {
+		bashNodeScript {
+			name = "Translate Blaze Dashboard"
+			scriptContent = """
+				cd apps/blaze-dashboard
+
+				# generate language files
+				yarn translate
+			"""
+		}
 	}
 )
 

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -270,6 +270,7 @@ private object BlazeDashboard : WPComPluginBuild(
 	pluginSlug = "blaze-dashboard",
 	archiveDir = "./dist/",
 	withPRNotify = "false",
+	// TODO: Update doc link when the doc is released
 	docsLink = "TODO",
 	buildSteps = {
 		bashNodeScript {


### PR DESCRIPTION
Related to #SELFSERVE-413

## Proposed Changes

This PR adds the building step of the new Blaze Dashboard app inside Team City. The changes are based on the Odyssey Stats app.

The Blaze App is located here: https://github.com/Automattic/wp-calypso/tree/trunk/apps/blaze-dashboard

## Testing Instructions

Following [this PR comment](https://github.com/Automattic/wp-calypso/pull/70353#issuecomment-1338192868), the change needs to be merged to be tested.

Code review should be enough; please check if I make any obvious mistake 🙂

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
