### PR TITLE
Blog onboarding: Avoid page refresh after focusing on input field

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-blog/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-blog/index.tsx
@@ -68,6 +68,10 @@ const SetupBlog: Step = ( { navigation, flow } ) => {
 		}
 	};
 
+	if ( ! site ) {
+		return null;
+	}
+
 	return (
 		<StepContainer
 			stepName="setup-blog"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/77457

## Proposed Changes

* While creating an e2e test, [we want to avoid waiting for network idle state](https://github.com/Automattic/wp-calypso/pull/77457#discussion_r1209300530), so we can avoid the whole refresh on that page which is the root problem for that issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the page doesn't refresh once is loaded:


**Before**

https://github.com/Automattic/wp-calypso/assets/1044309/34ef69c2-3b4c-4673-aa80-f2b6b45c5a6a

**After**

https://github.com/Automattic/wp-calypso/assets/1044309/f275b861-80db-4ed5-ac32-f5e43f77f166




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
