### PR TITLE
Updates the Blaze App route to /advertising

### DIFF
--- a/apps/blaze-dashboard/src/app.jsx
+++ b/apps/blaze-dashboard/src/app.jsx
@@ -48,7 +48,7 @@ async function AppBoot() {
 	setupContextMiddleware( store, queryClient );
 
 	if ( window.location?.hash ) {
-		// The URL could already gets broken by page.js by the appended `?page=jetpack-blaze`.
+		// The URL could already gets broken by page.js by the appended `?page=advertising`.
 		window.location.hash = fixPath( window.location.hash );
 	}
 

--- a/apps/blaze-dashboard/src/load-config.js
+++ b/apps/blaze-dashboard/src/load-config.js
@@ -16,6 +16,6 @@ productionConfig.dsp_widget_js_src = 'https://widgets.wp.com/promote-v2/widget.j
 // Note: configData is hydrated in Jetpack: projects/packages/blaze/src/class-dashboard-config-data.php - method `get_data`
 // TODO: link to Github when code in Jetpack is merged
 window.configData.features = productionConfig.features;
-window.configData.advertising_dashboard_path_prefix = '/jetpack-blaze';
+window.configData.advertising_dashboard_path_prefix = '/advertising';
 window.configData.dsp_stripe_pub_key = productionConfig.dsp_stripe_pub_key;
 window.configData.dsp_widget_js_src = productionConfig.dsp_widget_js_src;


### PR DESCRIPTION
Related to #SELFSERVE-412

## Proposed Changes

We are changing the URL prefix for the Blaze App inside Jetpack, from `page=jetpack-blaze` to `page=advertising`.
This PR changes the `advertising_dashboard_path_prefix` config option for the Blaze app to the new route.

## Testing Instructions

Code review should be enough, the App is not being used at the moment.

You can test this locally by following these steps:
1. Checkout Jetpack branch [add/blaze-dashboard-menu](https://github.com/Automattic/jetpack/pull/30103) and start the Jetpack dev environment with those changes.
2. Checkout this PR branch and execute yarn install in the root
3. On the console in the Calypso repo, go to `apps/blaze-dashboard`
4. Execute: `BLAZE_DASHBOARD_PACKAGE_PATH=/path/to/jetpack/projects/packages/blaze yarn dev`, change `/path/to/jetpack` to the correct path to the Jetpack branch.
5. Go to the Jetpack repo directory and build the blaze package: `pnpm jetpack build packages/blaze`
6. Start the Jurrasic Tube tunnel (to have Jetpack enable in your local). 
7. Open the browser and go to your Jurrasic Tube URL, and then enter wp-admin site
8. Click on Tools->Advertising and check that the app is loaded and that you can navigate through the tabs (Posts & Campaigns).


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
