### PR TITLE
Hosting onboarding: display the empty state on top of the Sites page

### DIFF
--- a/client/sites-dashboard/components/empty-sites-dashboard.tsx
+++ b/client/sites-dashboard/components/empty-sites-dashboard.tsx
@@ -39,15 +39,26 @@ const EmptySitesCTAs = () => {
 				css={ {
 					width: '85%',
 					display: 'flex',
-					gap: '48px',
+					gap: '32px',
 					flexDirection: 'column',
 					[ MEDIA_QUERIES.small ]: {
 						width: '100%',
-						gap: '32px',
+						gap: '24px',
 					},
 				} }
 			>
 				<CreateSiteCTA />
+				<div
+					css={ {
+						'&:before': {
+							content: '""',
+							display: 'block',
+							height: '1px',
+							opacity: 0.64,
+							background: '#DCDCDE',
+						},
+					} }
+				/>
 				<MigrateSiteCTA />
 			</div>
 		</EmptyContent>
@@ -59,6 +70,9 @@ export const EmptySitesDashboard = () => {
 		<div
 			css={ {
 				paddingTop: '20vh',
+				[ MEDIA_QUERIES.small ]: {
+					paddingTop: '60px',
+				},
 				zIndex: 9999,
 				position: 'relative',
 				display: 'flex',

--- a/client/sites-dashboard/components/empty-sites-dashboard.tsx
+++ b/client/sites-dashboard/components/empty-sites-dashboard.tsx
@@ -3,7 +3,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import { MEDIA_QUERIES } from '../utils';
 import { CreateSiteCTA, MigrateSiteCTA } from './sites-dashboard-ctas';
 
-export const EmptySitesDashboard = () => {
+const EmptySitesCTAs = () => {
 	const { __ } = useI18n();
 
 	return (
@@ -39,31 +39,33 @@ export const EmptySitesDashboard = () => {
 				css={ {
 					width: '85%',
 					display: 'flex',
+					gap: '48px',
 					flexDirection: 'column',
 					[ MEDIA_QUERIES.small ]: {
 						width: '100%',
+						gap: '32px',
 					},
 				} }
 			>
 				<CreateSiteCTA />
-				<div
-					css={ {
-						margin: '32px 0',
-						[ MEDIA_QUERIES.small ]: {
-							margin: '24px 0',
-						},
-
-						'&:before': {
-							content: '""',
-							display: 'block',
-							height: '1px',
-							opacity: 0.64,
-							background: '#DCDCDE',
-						},
-					} }
-				/>
 				<MigrateSiteCTA />
 			</div>
 		</EmptyContent>
+	);
+};
+
+export const EmptySitesDashboard = () => {
+	return (
+		<div
+			css={ {
+				paddingTop: '20vh',
+				zIndex: 9999,
+				position: 'relative',
+				display: 'flex',
+				justifyContent: 'center',
+			} }
+		>
+			<EmptySitesCTAs />
+		</div>
 	);
 };

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -142,6 +142,16 @@ const ScrollButton = styled( Button, { shouldForwardProp: ( prop ) => prop !== '
 	}
 `;
 
+const DisabledGradient = styled.div( {
+	position: 'absolute',
+	top: 0,
+	right: 0,
+	bottom: 0,
+	left: 0,
+	background:
+		'linear-gradient(to bottom, rgba(var(--color-surface-backdrop-rgb), 0.4), rgba(var(--color-surface-backdrop-rgb), 1))',
+} );
+
 const SitesDashboardSitesList = createSitesListComponent();
 
 export function SitesDashboard( {
@@ -213,24 +223,24 @@ export function SitesDashboard( {
 				</HeaderControls>
 			</PageHeader>
 			<PageBodyWrapper>
-				{ hasSites ? (
-					<>
-						<SitesDashboardOptInBanner sites={ allSites } />
-						<SitesDashboardSitesList
-							sites={ allSites }
-							filtering={ { search } }
-							sorting={ sitesSorting }
-							grouping={ { status, showHidden: true } }
-						>
-							{ ( { sites, statuses } ) => {
-								const paginatedSites = sites.slice( ( page - 1 ) * perPage, page * perPage );
+				<SitesDashboardOptInBanner sites={ allSites } />
+				<SitesDashboardSitesList
+					sites={ allSites }
+					filtering={ { search } }
+					sorting={ sitesSorting }
+					grouping={ { status, showHidden: true } }
+				>
+					{ ( { sites, statuses } ) => {
+						const paginatedSites = sites.slice( ( page - 1 ) * perPage, page * perPage );
 
-								const selectedStatus =
-									statuses.find( ( { name } ) => name === status ) || statuses[ 0 ];
+						const selectedStatus =
+							statuses.find( ( { name } ) => name === status ) || statuses[ 0 ];
 
-								return (
-									<>
-										{ ( allSites.length > 0 || isLoading ) && (
+						if ( ! hasSites ) {
+							return (
+								<>
+									<div css={ { opacity: 0.2, position: 'relative' } }>
+										<div css={ { width: '100%', position: 'absolute' } }>
 											<SitesContentControls
 												initialSearch={ search }
 												statuses={ statuses }
@@ -241,78 +251,96 @@ export function SitesDashboard( {
 												onSitesSortingChange={ onSitesSortingChange }
 												hasSitesSortingPreferenceLoaded={ hasSitesSortingPreferenceLoaded }
 											/>
-										) }
-										{ userPreferencesLoaded && (
+											<SitesTable isLoading sites={ [] } delayAnimation={ false } hideLinkInBio />
+											<DisabledGradient />
+										</div>
+									</div>
+									<EmptySitesDashboard />
+								</>
+							);
+						}
+
+						return (
+							<>
+								{ ( allSites.length > 0 || isLoading ) && (
+									<SitesContentControls
+										initialSearch={ search }
+										statuses={ statuses }
+										selectedStatus={ selectedStatus }
+										displayMode={ displayMode }
+										onDisplayModeChange={ setDisplayMode }
+										sitesSorting={ sitesSorting }
+										onSitesSortingChange={ onSitesSortingChange }
+										hasSitesSortingPreferenceLoaded={ hasSitesSortingPreferenceLoaded }
+									/>
+								) }
+								{ userPreferencesLoaded && (
+									<>
+										{ paginatedSites.length > 0 || isLoading ? (
 											<>
-												{ paginatedSites.length > 0 || isLoading ? (
-													<>
-														{ displayMode === 'list' && (
-															<SitesTable
-																isLoading={ isLoading }
-																sites={ paginatedSites }
-																className={ sitesMargin }
-															/>
-														) }
-														{ displayMode === 'tile' && (
-															<SitesGrid
-																isLoading={ isLoading }
-																sites={ paginatedSites }
-																className={ sitesMargin }
-															/>
-														) }
-														{ ( selectedStatus.hiddenCount > 0 || sites.length > perPage ) && (
-															<PageBodyBottomContainer>
-																<Pagination
-																	page={ page }
-																	perPage={ perPage }
-																	total={ sites.length }
-																	pageClick={ ( newPage: number ) => {
-																		handleQueryParamChange( { page: newPage } );
-																	} }
-																/>
-																{ selectedStatus.hiddenCount > 0 && (
-																	<HiddenSitesMessageContainer>
-																		<HiddenSitesMessage>
-																			{ sprintf(
-																				/* translators: the `hiddenSitesCount` field will be a number greater than 0 */
-																				_n(
-																					'%(hiddenSitesCount)d site is hidden from the list. Use search to access it.',
-																					'%(hiddenSitesCount)d sites are hidden from the list. Use search to access them.',
-																					selectedStatus.hiddenCount
-																				),
-																				{
-																					hiddenSitesCount: selectedStatus.hiddenCount,
-																				}
-																			) }
-																		</HiddenSitesMessage>
-																		<Button
-																			href={ addQueryArgs( window.location.href, {
-																				'show-hidden': 'true',
-																			} ) }
-																		>
-																			{ __( 'Show all' ) }
-																		</Button>
-																	</HiddenSitesMessageContainer>
-																) }
-															</PageBodyBottomContainer>
-														) }
-													</>
-												) : (
-													<NoSitesMessage
-														status={ selectedStatus.name }
-														statusSiteCount={ selectedStatus.count }
+												{ displayMode === 'list' && (
+													<SitesTable
+														isLoading={ isLoading }
+														sites={ paginatedSites }
+														className={ sitesMargin }
 													/>
 												) }
+												{ displayMode === 'tile' && (
+													<SitesGrid
+														isLoading={ isLoading }
+														sites={ paginatedSites }
+														className={ sitesMargin }
+													/>
+												) }
+												{ ( selectedStatus.hiddenCount > 0 || sites.length > perPage ) && (
+													<PageBodyBottomContainer>
+														<Pagination
+															page={ page }
+															perPage={ perPage }
+															total={ sites.length }
+															pageClick={ ( newPage: number ) => {
+																handleQueryParamChange( { page: newPage } );
+															} }
+														/>
+														{ selectedStatus.hiddenCount > 0 && (
+															<HiddenSitesMessageContainer>
+																<HiddenSitesMessage>
+																	{ sprintf(
+																		/* translators: the `hiddenSitesCount` field will be a number greater than 0 */
+																		_n(
+																			'%(hiddenSitesCount)d site is hidden from the list. Use search to access it.',
+																			'%(hiddenSitesCount)d sites are hidden from the list. Use search to access them.',
+																			selectedStatus.hiddenCount
+																		),
+																		{
+																			hiddenSitesCount: selectedStatus.hiddenCount,
+																		}
+																	) }
+																</HiddenSitesMessage>
+																<Button
+																	href={ addQueryArgs( window.location.href, {
+																		'show-hidden': 'true',
+																	} ) }
+																>
+																	{ __( 'Show all' ) }
+																</Button>
+															</HiddenSitesMessageContainer>
+														) }
+													</PageBodyBottomContainer>
+												) }
 											</>
+										) : (
+											<NoSitesMessage
+												status={ selectedStatus.name }
+												statusSiteCount={ selectedStatus.count }
+											/>
 										) }
 									</>
-								);
-							} }
-						</SitesDashboardSitesList>
-					</>
-				) : (
-					<EmptySitesDashboard />
-				) }
+								) }
+							</>
+						);
+					} }
+				</SitesDashboardSitesList>
 			</PageBodyWrapper>
 			<ScrollButton
 				onClick={ scrollToTop }

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -8,13 +8,14 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useCallback, useEffect, useRef } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import Pagination from 'calypso/components/pagination';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import { withoutHttp } from 'calypso/lib/url';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
 import { MEDIA_QUERIES } from '../utils';
@@ -32,7 +33,6 @@ import { SitesTable } from './sites-table';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 interface SitesDashboardProps {
-	hasSites: boolean;
 	queryParams: SitesDashboardQueryParams;
 }
 
@@ -156,7 +156,6 @@ const SitesDashboardSitesList = createSitesListComponent();
 
 export function SitesDashboard( {
 	queryParams: { page = 1, perPage = 96, search, status = 'all', newSiteSlug },
-	hasSites,
 }: SitesDashboardProps ) {
 	const { __, _n } = useI18n();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
@@ -164,6 +163,7 @@ export function SitesDashboard( {
 	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();
 	const userPreferencesLoaded = hasSitesSortingPreferenceLoaded && 'none' !== displayMode;
 	const elementRef = useRef( window );
+	const hasSites = useSelector( ( state ) => ( getCurrentUserSiteCount( state ) ?? 0 ) > 0 );
 
 	const isBelowThreshold = useCallback( ( containerNode: Window ) => {
 		const SCROLL_THRESHOLD = containerNode.innerHeight;

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -245,7 +245,7 @@ export function SitesDashboard( {
 												initialSearch={ search }
 												statuses={ statuses }
 												selectedStatus={ selectedStatus }
-												displayMode={ displayMode }
+												displayMode="list" // We're always showing <SitesTable> when there are no sites
 												onDisplayModeChange={ setDisplayMode }
 												sitesSorting={ sitesSorting }
 												onSitesSortingChange={ onSitesSortingChange }

--- a/client/sites-dashboard/components/sites-table-row-loading.tsx
+++ b/client/sites-dashboard/components/sites-table-row-loading.tsx
@@ -13,7 +13,7 @@ interface LoadingLogoProps {
 interface SitesTableRowLoadingProps {
 	columns?: number;
 	logoProps?: LoadingLogoProps;
-	delayMS?: number;
+	delayMS?: number | null;
 }
 
 const Row = styled.tr`

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -14,6 +14,8 @@ interface SitesTableProps {
 	className?: string;
 	sites: SiteExcerptData[];
 	isLoading?: boolean;
+	delayAnimation?: boolean;
+	hideLinkInBio?: boolean;
 }
 
 const Table = styled.table`
@@ -80,7 +82,13 @@ const StatsThInner = styled.div( {
 	gap: '6px',
 } );
 
-export function SitesTable( { className, sites, isLoading = false }: SitesTableProps ) {
+export function SitesTable( {
+	className,
+	sites,
+	isLoading = false,
+	delayAnimation = true,
+	hideLinkInBio,
+}: SitesTableProps ) {
 	const { __ } = useI18n();
 
 	const headerRef = useRef< HTMLTableSectionElement >( null );
@@ -170,7 +178,7 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 								<SitesTableRowLoading
 									key={ i }
 									columns={ 6 }
-									delayMS={ i * 150 }
+									delayMS={ delayAnimation ? i * 150 : null }
 									logoProps={ { width: 108, height: 78 } }
 								/>
 							) ) }
@@ -179,7 +187,7 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 					) ) }
 				</tbody>
 			</Table>
-			<LinkInBioBanner displayMode="row" />
+			{ ! hideLinkInBio && <LinkInBioBanner displayMode="row" /> }
 		</>
 	);
 }

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -6,6 +6,7 @@ import { Global, css } from '@emotion/react';
 import { removeQueryArgs } from '@wordpress/url';
 import AsyncLoad from 'calypso/components/async-load';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { removeNotice } from 'calypso/state/notices/actions';
 import { SitesDashboard } from './components/sites-dashboard';
 import { MEDIA_QUERIES } from './utils';
@@ -44,6 +45,8 @@ export function sanitizeQueryParameters( context: PageJSContext, next: () => voi
 }
 
 export function sitesDashboard( context: PageJSContext, next: () => void ) {
+	const siteCount = getCurrentUser( context.store.getState() )?.site_count ?? 0;
+
 	const sitesDashboardGlobalStyles = css`
 		body.is-group-sites-dashboard {
 			background: #fdfdfd;
@@ -70,6 +73,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 			<PageViewTracker path="/sites" title="Sites Management Page" delay={ 500 } />
 			<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
 			<SitesDashboard
+				hasSites={ siteCount > 0 }
 				queryParams={ {
 					page: context.query.page ? parseInt( context.query.page ) : undefined,
 					perPage: context.query[ 'per-page' ]

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -6,7 +6,6 @@ import { Global, css } from '@emotion/react';
 import { removeQueryArgs } from '@wordpress/url';
 import AsyncLoad from 'calypso/components/async-load';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { removeNotice } from 'calypso/state/notices/actions';
 import { SitesDashboard } from './components/sites-dashboard';
 import { MEDIA_QUERIES } from './utils';
@@ -45,8 +44,6 @@ export function sanitizeQueryParameters( context: PageJSContext, next: () => voi
 }
 
 export function sitesDashboard( context: PageJSContext, next: () => void ) {
-	const siteCount = getCurrentUser( context.store.getState() )?.site_count ?? 0;
-
 	const sitesDashboardGlobalStyles = css`
 		body.is-group-sites-dashboard {
 			background: #fdfdfd;
@@ -73,7 +70,6 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 			<PageViewTracker path="/sites" title="Sites Management Page" delay={ 500 } />
 			<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
 			<SitesDashboard
-				hasSites={ siteCount > 0 }
 				queryParams={ {
 					page: context.query.page ? parseInt( context.query.page ) : undefined,
 					perPage: context.query[ 'per-page' ]

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -6,9 +6,7 @@ import { Global, css } from '@emotion/react';
 import { removeQueryArgs } from '@wordpress/url';
 import AsyncLoad from 'calypso/components/async-load';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { removeNotice } from 'calypso/state/notices/actions';
-import { EmptySitesDashboard } from './components/empty-sites-dashboard';
 import { SitesDashboard } from './components/sites-dashboard';
 import { MEDIA_QUERIES } from './utils';
 import type { Context as PageJSContext } from 'page';
@@ -45,53 +43,7 @@ export function sanitizeQueryParameters( context: PageJSContext, next: () => voi
 	next();
 }
 
-export function maybeSitesDashboard( context: PageJSContext, next: () => void ) {
-	const siteCount = getCurrentUser( context.store.getState() )?.site_count;
-
-	if ( ! context.query[ 'new-site' ] && siteCount === 0 ) {
-		return emptySites( context, next );
-	}
-
-	return sitesDashboard( context, next );
-}
-
-function emptySites( context: PageJSContext, next: () => void ) {
-	const emptySitesDashboardGlobalStyles = css`
-		body.is-group-sites-dashboard {
-			background: #fff;
-
-			.layout__primary {
-				margin: 100px 24px;
-			}
-
-			.layout__content {
-				padding: 0 !important; /* this is overriden by other styles being injected on the page */
-				min-height: auto; /* browsing a different page might inject this style on the page */
-			}
-
-			${ MEDIA_QUERIES.mediumOrLarger } {
-				height: 100vh;
-
-				.wpcom-site {
-					display: flex;
-					align-items: center;
-					justify-content: center;
-				}
-			}
-		}
-	`;
-
-	context.primary = (
-		<>
-			<Global styles={ emptySitesDashboardGlobalStyles } />
-			<EmptySitesDashboard />
-		</>
-	);
-
-	return next();
-}
-
-function sitesDashboard( context: PageJSContext, next: () => void ) {
+export function sitesDashboard( context: PageJSContext, next: () => void ) {
 	const sitesDashboardGlobalStyles = css`
 		body.is-group-sites-dashboard {
 			background: #fdfdfd;

--- a/client/sites-dashboard/index.ts
+++ b/client/sites-dashboard/index.ts
@@ -4,7 +4,7 @@ import { getSiteBySlug, getSiteHomeUrl } from 'calypso/state/sites/selectors';
 import {
 	maybeRemoveCheckoutSuccessNotice,
 	sanitizeQueryParameters,
-	maybeSitesDashboard,
+	sitesDashboard,
 } from './controller';
 
 export default function () {
@@ -21,7 +21,7 @@ export default function () {
 		'/sites',
 		maybeRemoveCheckoutSuccessNotice,
 		sanitizeQueryParameters,
-		maybeSitesDashboard,
+		sitesDashboard,
 		makeLayout,
 		clientRender
 	);

--- a/packages/components/src/loading-placeholder/loading-placeholder.tsx
+++ b/packages/components/src/loading-placeholder/loading-placeholder.tsx
@@ -2,7 +2,7 @@ import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
 interface LoadingPlaceholderProps {
-	delayMS?: number;
+	delayMS?: number | null;
 }
 
 const pulseLightKeyframes = keyframes`
@@ -11,11 +11,14 @@ const pulseLightKeyframes = keyframes`
 	}`;
 
 const LoadingPlaceholder = styled.div< LoadingPlaceholderProps >`
-	animation: ${ pulseLightKeyframes } 1.8s ease-in-out infinite;
 	background-color: var( --color-neutral-10 );
 	min-height: 18px;
 	width: 100%;
-	animation-delay: ${ ( { delayMS = 0 } ) => delayMS }ms;
+	${ ( props ) =>
+		props.delayMS !== null && {
+			animation: `${ pulseLightKeyframes } 1.8s ease-in-out infinite`,
+			animationDelay: `${ props.delayMS ?? 0 }ms`,
+		} }
 `;
 
 export default LoadingPlaceholder;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Changes the empty state for the Sites page so that the CTAs appear over top of a faded out placeholder of the dashboard. This gives the users a hint about where they are in Calypso (a sites manager sort of place), while also making it very clear what the next action to take is.

![desktop](https://github.com/Automattic/wp-calypso/assets/1500769/369eab53-7af9-44ce-b272-037a7942016f)

<img src="https://user-images.githubusercontent.com/1500769/241893761-688ac92a-fe45-4d40-b7ce-d0c8ba34bda8.png" alt="mobile" style="max-width: 100%;" width="50%">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The updated style of the empty sites page has already shipped so there's no feature flag needed to test this change.

* Create a new user
* Before creating a site head to `/sites`
* The URLs for the two CTAs should be no different from what's there in production.
* The page should work good for desktop/mobile, RTL, and other themes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
