### PR TITLE
Update selectors used to select goal checkboxes in e2e tests

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -80,7 +80,7 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 				{ hasBuiltByExpressGoal && isBuiltByExpressExperimentLoading
 					? goalOptions.map( ( { key } ) => (
 							<div
-								className="select-card__container"
+								className="select-card-checkbox__container"
 								role="progressbar"
 								key={ `goal-${ key }-placeholder` }
 								style={ { cursor: 'default' } }

--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -21,8 +21,10 @@ const selectors = {
 	individualThemeContainer: ( name: string ) => `.design-button-container:has-text("${ name }")`,
 
 	// Goals
-	goalButton: ( goal: string ) => `.select-card__container:has-text("${ goal.toLowerCase() }")`,
-	selectedGoalButton: ( goal: string ) => `.select-card__container.selected:has-text("${ goal }")`,
+	goalButton: ( goal: string ) =>
+		`.select-card-checkbox__container:has-text("${ goal.toLowerCase() }")`,
+	selectedGoalButton: ( goal: string ) =>
+		`.select-card-checkbox__container.is-checked:has-text("${ goal }")`,
 
 	// Step containers
 	contentAgnosticContainer: '.step-container',


### PR DESCRIPTION
The checkbox component used by the goal step was refactored in #77482. The refactor changed the CSS class names, however those class names were used to select elements in the E2E tests. This broke the E2E tests but for some reason that issue didn't show up in the test run for #77482.

This PR updates the selectors used by the E2E tests.
