### PR TITLE
Stats: simplify subscribers overview card index and display calculations

### DIFF
--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -2,15 +2,14 @@ import { CountComparisonCard } from '@automattic/components';
 import { UseQueryResult, useQueries } from '@tanstack/react-query';
 import { translate } from 'i18n-calypso';
 import React from 'react';
+import card from 'calypso/../packages/components/src/card';
 import {
 	querySubscribers,
 	selectSubscribers,
 } from 'calypso/my-sites/stats/hooks/use-subscribers-query';
 
-const indexFirstCard = 0; // 0 for today
-const indexSecondCard = 30; // 30 days out
-const indexThirdCard = 60; // 60 days out
-const indexFourthCard = 90; // 90 days out
+// array of indices to use to calculate the dates to query for
+const cardIndices = [ 0, 30, 60, 90 ];
 
 interface SubscribersData {
 	period: string;
@@ -27,12 +26,6 @@ interface SubscribersDataResult {
 interface SubscribersOverviewProps {
 	siteId: number | null;
 }
-
-// calculate the dates to query for
-const dateToday = calculateQueryDate( indexFirstCard );
-const date30DaysAgo = calculateQueryDate( indexSecondCard );
-const date60DaysAgo = calculateQueryDate( indexThirdCard );
-const date90DaysAgo = calculateQueryDate( indexFourthCard );
 
 // calculate the date to query for based on the number of days to subtract
 function calculateQueryDate( daysToSubtract: number ) {
@@ -73,7 +66,7 @@ function SubscribersOverviewCardStats( subscribersData: SubscribersData[][] ) {
 const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } ) => {
 	const period = 'day';
 	const quantity = 1;
-	const dates: string[] = [ dateToday, date30DaysAgo, date60DaysAgo, date90DaysAgo ];
+	const dates = cardIndices.map( calculateQueryDate );
 	const subscribersQueries = useQueries( {
 		queries: dates.map( ( date ) => ( {
 			queryKey: [ 'stats', 'subscribers', siteId, period, quantity, date ],

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -2,7 +2,6 @@ import { CountComparisonCard } from '@automattic/components';
 import { UseQueryResult, useQueries } from '@tanstack/react-query';
 import { translate } from 'i18n-calypso';
 import React from 'react';
-import card from 'calypso/../packages/components/src/card';
 import {
 	querySubscribers,
 	selectSubscribers,


### PR DESCRIPTION
Related to #77513

## Proposed Changes

* This small PR simplifies subscribers' overview card index and display calculations by converting `const indexFirstCard = 0; // 0 for today` etc. into an array.

## Testing Instructions

* Open the live branch for this PR.
* Navigate to `/stats/day/:siteSlug`
* Add `?flags=stats/subscribers-section` to the URL to enable the subscriber stats page.
* Scroll down to locate the overview cards (immediately under the chart)
* Check that they load data correctly, still behave acceptably on resize etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
