### PR TITLE
Fix scroll on tags page. 

### DIFF
--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -83,7 +83,7 @@ const scrollToLetter = ( letter: string ) => {
 		// setTimeout so that the focus is set after the scrollIntoViewport has completed.
 		setTimeout( () => {
 			element.focus();
-		}, 500 );
+		}, 1500 );
 	}
 };
 

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -78,7 +78,8 @@ const scrollToLetter = ( letter: string ) => {
 	if ( element ) {
 		scrollIntoViewport( element, {
 			behavior: 'smooth',
-			scrollMode: 'if-needed',
+			block: 'center',
+			scrollMode: 'always',
 		} );
 		// setTimeout so that the focus is set after the scrollIntoViewport has completed.
 		setTimeout( () => {

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { debounce } from 'lodash';
 import { createRef } from 'react';
 import titlecase from 'to-title-case';
 import StickyPanel from 'calypso/components/sticky-panel';
@@ -81,10 +82,12 @@ const scrollToLetter = ( letter: string ) => {
 			block: 'center',
 			scrollMode: 'always',
 		} );
-		// setTimeout so that the focus is set after the scrollIntoViewport has completed.
-		setTimeout( () => {
+		// set focus after scrollIntoViewport has completed.
+		const focusElement = debounce( () => {
 			element.focus();
-		}, 1500 );
+			window.removeEventListener( 'scroll', focusElement );
+		}, 50 );
+		window.addEventListener( 'scroll', focusElement );
 	}
 };
 


### PR DESCRIPTION
Fixes issues reported here p7DVsv-hf4-p2#comment-46057

Used a debounced scroll function so that focus doesn't prematurely cancel scroll.

I also changed to use the "center" option of the underlying scrollIntoView function to avoid the top of the element being cut off https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView. I couldn't find another way to do this with our `scrollIntoViewport` library (or `element.scrollIntoView`) because neither support taking an offset from the element. 


## Testing Instructions

go to /tags page and click on the letters to scroll down, scroll should complete every time.
When logged in, the section you scroll to should be centered vertically and not cut off