### PR TITLE
When the atomic transfer completes, reload the site.

### DIFF
--- a/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
+++ b/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
@@ -68,15 +68,13 @@ export const useCheckSiteTransferStatus = ( {
 	useEffect( () => {
 		if ( ! isTransferring && wasTransferring && isTransferCompleted ) {
 			const dismissTransferNoticeTimeout = setTimeout( () => {
+				dispatch( requestSite( siteId ) );
 				setWasTransferring( false );
 			}, 3000 );
 
 			return () => {
 				clearTimeout( dismissTransferNoticeTimeout );
 			};
-			// eslint-disable-next-line no-else-return
-		} else if ( wasTransferring && isTransferCompleted ) {
-			dispatch( requestSite( siteId ) );
 		}
 	}, [ isTransferring, wasTransferring, isTransferCompleted ] );
 

--- a/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
+++ b/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { requestLatestAtomicTransfer } from 'calypso/state/atomic/transfers/actions';
 import { transferStates } from 'calypso/state/atomic/transfers/constants';
 import { getLatestAtomicTransfer } from 'calypso/state/atomic/transfers/selectors';
+import { requestSite } from 'calypso/state/sites/actions';
 
 interface SiteTransferStatusProps {
 	siteId: number;
@@ -73,6 +74,9 @@ export const useCheckSiteTransferStatus = ( {
 			return () => {
 				clearTimeout( dismissTransferNoticeTimeout );
 			};
+			// eslint-disable-next-line no-else-return
+		} else {
+			dispatch( requestSite( siteId ) );
 		}
 	}, [ isTransferring, wasTransferring, isTransferCompleted ] );
 

--- a/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
+++ b/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
@@ -75,7 +75,7 @@ export const useCheckSiteTransferStatus = ( {
 				clearTimeout( dismissTransferNoticeTimeout );
 			};
 			// eslint-disable-next-line no-else-return
-		} else {
+		} else if ( wasTransferring && isTransferCompleted ) {
 			dispatch( requestSite( siteId ) );
 		}
 	}, [ isTransferring, wasTransferring, isTransferCompleted ] );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/2568

## Proposed Changes

* After the automatic Atomic transfer completes, reload the site to get the new state. This avoid issues with stale state, like showing the "Activate" banner on the `/hosting-config` page. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<img width="522" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6851384/167c2dff-9f85-468d-9901-8adefe4201c8">

* You need an account with no sites and then use to new "Create a site" button
* Create a site, buy Business, checkout and then you'll be sent back to `/sites`
* Watch the transfer status in the site tile/row until it changes to 'Activated!'
* Use the overflow menu to go to the `Hosting configurations` > `SFTP/SSH credentials`
* On trunk, you will see the "Activate" banner. On this branch, you will see the hosting configuration page has already been activated. 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
