### PR TITLE
Fix issue with incorrect siteSlug show for newly created sites on `/sites` page

### DIFF
--- a/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosting-site-creation-flow.ts
@@ -71,7 +71,7 @@ const hosting: Flow = {
 
 				case 'processing': {
 					const destination = addQueryArgs( '/sites', {
-						'new-site': providedDependencies.siteSlug,
+						'new-site': providedDependencies?.siteId,
 					} );
 					persistSignupDestination( destination );
 					setSignupCompleteSlug( providedDependencies?.siteSlug );

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -188,8 +188,8 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 	return `/home/${ siteSlug }`;
 }
 
-function getSitesDestination( { siteSlug } ) {
-	return addQueryArgs( { 'new-site': siteSlug }, '/sites' );
+function getSitesDestination( { siteId } ) {
+	return addQueryArgs( { 'new-site': siteId }, '/sites' );
 }
 
 const flows = generateFlows( {

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -18,7 +18,7 @@ export interface SitesDashboardQueryParams {
 	search?: string;
 	showHidden?: boolean;
 	status?: GroupableSiteLaunchStatuses;
-	newSiteSlug?: string;
+	newSiteID?: number;
 }
 
 const FilterBar = styled.div( {

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -143,7 +143,7 @@ const ScrollButton = styled( Button, { shouldForwardProp: ( prop ) => prop !== '
 const SitesDashboardSitesList = createSitesListComponent();
 
 export function SitesDashboard( {
-	queryParams: { page = 1, perPage = 96, search, status = 'all', newSiteSlug },
+	queryParams: { page = 1, perPage = 96, search, status = 'all', newSiteID },
 }: SitesDashboardProps ) {
 	const { __, _n } = useI18n();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
@@ -164,7 +164,7 @@ export function SitesDashboard( {
 		smoothScrolling: true,
 	} );
 
-	useShowSiteCreationNotice( allSites, newSiteSlug );
+	useShowSiteCreationNotice( allSites, newSiteID );
 
 	return (
 		<main>
@@ -315,17 +315,17 @@ export function SitesDashboard( {
 	);
 }
 
-function useShowSiteCreationNotice( allSites: SiteExcerptData[], newSiteSlug: string | undefined ) {
+function useShowSiteCreationNotice( allSites: SiteExcerptData[], newSiteID: number | undefined ) {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const shownSiteCreationNotice = useRef( false );
 
 	useEffect( () => {
-		if ( shownSiteCreationNotice.current || ! newSiteSlug ) {
+		if ( shownSiteCreationNotice.current || ! newSiteID ) {
 			return;
 		}
 
-		const site = allSites.find( ( { slug } ) => slug === newSiteSlug );
+		const site = allSites.find( ( { ID } ) => ID === newSiteID );
 		if ( ! site ) {
 			return;
 		}
@@ -349,5 +349,5 @@ function useShowSiteCreationNotice( allSites: SiteExcerptData[], newSiteSlug: st
 		const newUrl = new URL( window.location.href );
 		newUrl.searchParams.delete( 'new-site' );
 		window.history.replaceState( null, '', newUrl.toString() );
-	}, [ __, allSites, dispatch, newSiteSlug ] );
+	}, [ __, allSites, dispatch, newSiteID ] );
 }

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -125,7 +125,7 @@ function sitesDashboard( context: PageJSContext, next: () => void ) {
 						: undefined,
 					search: context.query.search,
 					status: context.query.status,
-					newSiteSlug: context.query[ 'new-site' ] || undefined,
+					newSiteID: parseInt( context.query[ 'new-site' ] ) || undefined,
 				} }
 			/>
 		</>


### PR DESCRIPTION
There is a notice that is shown when a site is created on `/sites` page, at the moment the notice is showing incorrect `siteSlug` because we use a query param `new-site` and pass the siteSlug of the created site. However with the new hosting flow sites goes atomic automatically and so the siteSlug changes to wpcomstaging domain while the notice shows simple sites slug.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/2567

## Proposed Changes

* pass `siteId` in the `new-site` query param instead of the `siteSlug`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to` /setup/new-hosted-site`
* complete the process and you will be redirected to `/sites`
* verify the notice that is shown has the correct siteSlug for the created site

![image](https://github.com/Automattic/wp-calypso/assets/47489215/fba4117e-a556-4a0f-b8e5-39e33debf049)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
