### PR TITLE
Help Center: Reduce the amount of AI search requests

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -186,8 +186,8 @@ export const HelpCenterContactForm = () => {
 		supportSite = currentSite as HelpCenterSite;
 	}
 
-	const [ debouncedMessage ] = useDebounce( message || '', 500 );
-	const [ debouncedSubject ] = useDebounce( subject || '', 500 );
+	const [ debouncedMessage ] = useDebounce( message || '', 1000 );
+	const [ debouncedSubject ] = useDebounce( subject || '', 1000 );
 
 	const enableGPTResponse =
 		config.isEnabled( 'help/gpt-response' ) && ! ( params.get( 'disable-gpt' ) === 'true' );

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -479,29 +479,15 @@ export const HelpCenterContactForm = () => {
 	}
 
 	const {
-		isFetching: isFetchingGPTUrls,
-		isError: isGPTLinksError,
-		data: links,
-	} = useJetpackSearchAIQuery( {
-		siteId: '9619154',
-		query: jpSearchAiQueryText,
-		stopAt: 'urls',
-		enabled: enableGPTResponse,
-	} );
-
-	const {
-		isFetching: isFetchingGPTAnswer,
-		isError: isGPTResponseError,
+		isFetching: isFetchingGPTResponse,
+		isError: isGPTError,
 		data: gptResponse,
 	} = useJetpackSearchAIQuery( {
 		siteId: '9619154',
 		query: jpSearchAiQueryText,
 		stopAt: 'response',
-		enabled: !! links?.urls,
+		enabled: enableGPTResponse,
 	} );
-
-	const isFetchingGPTResponse = isFetchingGPTUrls || isFetchingGPTAnswer;
-	const isGPTError = isGPTLinksError || isGPTResponseError;
 
 	const getCTALabel = () => {
 		const showingHelpOrGPTResults = showingSearchResults || showingGPTResponse;

--- a/packages/help-center/src/components/help-center-gpt.tsx
+++ b/packages/help-center/src/components/help-center-gpt.tsx
@@ -69,25 +69,15 @@ export function HelpCenterGPT() {
 
 	const query = message ?? '';
 
-	// First fetch the links
-	const { data: links, isError: isLinksError } = useJetpackSearchAIQuery( {
-		siteId: '9619154',
-		query: query,
-		stopAt: 'urls',
-		enabled: true,
-	} );
-
 	// Then fetch the response
-	const { data, isError: isResponseError } = useJetpackSearchAIQuery( {
+	const { data, isError: isGPTError } = useJetpackSearchAIQuery( {
 		siteId: '9619154',
 		query: query,
 		stopAt: 'response',
-		enabled: !! links?.urls,
+		enabled: true,
 	} );
 
 	const allowedTags = [ 'a', 'p', 'ol', 'ul', 'li', 'br', 'b', 'strong', 'i', 'em' ];
-
-	const isGPTError = isLinksError || isResponseError;
 
 	useEffect( () => {
 		if ( data?.response ) {

--- a/packages/help-center/src/components/help-center-gpt.tsx
+++ b/packages/help-center/src/components/help-center-gpt.tsx
@@ -69,7 +69,6 @@ export function HelpCenterGPT() {
 
 	const query = message ?? '';
 
-	// Then fetch the response
 	const { data, isError: isGPTError } = useJetpackSearchAIQuery( {
 		siteId: '9619154',
 		query: query,


### PR DESCRIPTION
## Proposed Changes

* Increase the delay to 1000 from 500 ms. This should help reduce the unnecessary requests that we make. 
* Switch to making just one request for AI search.  Since we're not showing the interim results (urls), we can simplify the code and reduce the number of outgoing requests.

## Testing Instructions
* Open the help center
* Click on "Still need help"
* Choose one of the options
* In the form, start typing your message.
* Notice how many requests go out to the jetpack-search/ai endpoint
* Make sure the response is shown as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
