### PR TITLE
Site Assembler: Fix site editor with edit mode and assembler welcome tour again

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -281,7 +281,7 @@ export const redirectSiteEditor = async ( context ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteEditorUrl = getSiteEditorUrl( state, siteId );
 	// Calling replace to avoid adding an entry to the browser history upon redirect.
-	return location.replace( siteEditorUrl );
+	return window.location.replace( addQueryArgs( context.query, siteEditorUrl ) );
 };
 /**
  * Redirect the logged user to the permalink of the post, page, custom post type if the post is published.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/76072, https://github.com/Automattic/wp-calypso/pull/76371/files#r1209973202

## Proposed Changes

The query parameter is removed after redirecting to the site editor. So, this PR is focusing on keeping the query parameter. 

See https://github.com/Automattic/wp-calypso/pull/76072 for more details.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/site-setup?siteSlug=<your_free_site>
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select any layout and styles
  * Continue
* When you land on the site editor
  * Verify it's in the edit mode directly
  * Verify the first slide of the Welcome Tour is for the assembler.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
