### PR TITLE
Reader: Tidy up Search sites sidebar styles

### DIFF
--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -21,6 +21,7 @@ const ReaderAvatar = ( {
 	preferBlavatar = false,
 	showPlaceholder = false,
 	onClick,
+	iconSize = null,
 } ) => {
 	let fakeSite;
 
@@ -77,6 +78,11 @@ const ReaderAvatar = ( {
 		gravatarSize = hasBothIcons ? 32 : 96;
 	}
 
+	if ( iconSize > 0 ) {
+		siteIconSize = iconSize;
+		gravatarSize = iconSize;
+	}
+
 	const classes = classnames( 'reader-avatar', {
 		'is-compact': isCompact,
 		'has-site-and-author-icon': hasBothIcons,
@@ -111,6 +117,7 @@ ReaderAvatar.propTypes = {
 	showPlaceholder: PropTypes.bool,
 	isCompact: PropTypes.bool,
 	onClick: PropTypes.func,
+	iconSize: PropTypes.number,
 };
 
 ReaderAvatar.defaultProps = {

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -95,6 +95,7 @@ function ReaderSubscriptionListItem( {
 					siteUrl={ streamUrl }
 					isCompact={ true }
 					onClick={ recordAvatarClick }
+					iconSize={ 32 }
 				/>
 			</div>
 			<div className="reader-subscription-list-item__byline">

--- a/client/blocks/reader-subscription-list-item/placeholder.jsx
+++ b/client/blocks/reader-subscription-list-item/placeholder.jsx
@@ -4,7 +4,7 @@ const ReaderSubscriptionListItemPlaceholder = () => {
 	return (
 		<div className="reader-subscription-list-item reader-subscription-list-item__placeholder">
 			<div>
-				<ReaderAvatar showPlaceholder={ true } isCompact={ true } />
+				<ReaderAvatar showPlaceholder={ true } isCompact={ true } iconSize={ 32 } />
 			</div>
 			<div className="reader-subscription-list-item__byline">
 				<span className="reader-subscription-list-item__site-title is-placeholder">Site title</span>

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -1,6 +1,6 @@
 .reader-subscription-list-item__byline {
 	color: var(--color-text);
-	margin: 0 16px;
+	margin: 0 12px;
 	flex: 1 1 0;
 }
 

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -52,7 +52,6 @@
 
 .reader-subscription-list-item .gravatar {
 	float: left;
-	margin: 4px 12px 0 0;
 	height: 32px;
 	min-height: 32px;
 	min-width: 32px;

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -1,6 +1,6 @@
 .reader-subscription-list-item__byline {
 	color: var(--color-text);
-	margin-right: 16px;
+	margin: 0 16px;
 	flex: 1 1 0;
 }
 
@@ -31,15 +31,23 @@
 
 .reader-subscription-list-item__link,
 .reader-subscription-list-item__link:visited {
-	color: var(--color-primary);
+	color: var(--color-neutral-100);
 
 	&:hover {
-		color: var(--color-primary-light);
+		color: var(--color-text-subtle);
 	}
 }
 
-.reader-subscription-list-item__by-text .reader-subscription-list-item__link {
-	color: var(--color-text);
+.reader-subscription-list-item__site-excerpt {
+	display: -webkit-box;
+	color: var(--color-neutral-70);
+	font-weight: 600;
+	font-size: $font-body-extra-small;
+	line-height: 18px;
+	overflow: hidden;
+	width: auto;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
 }
 
 .reader-subscription-list-item .gravatar {
@@ -52,6 +60,10 @@
 
 .reader-subscription-list-item .site-icon {
 	margin-top: 5px;
+
+	img {
+		border-radius: 100%;
+	}
 }
 
 .reader-subscription-list-item {
@@ -76,9 +88,26 @@
 	margin-right: 8px;
 }
 
-.reader-subscription-list-item__site-title,
+.reader-subscription-list-item__site-title {
+	color: var(--color-neutral-100);
+	font-weight: 600;
+	font-size: $font-body-small;
+
+	&:hover {
+		color: var(--color-text-subtle);
+	}
+
+	.reader-sidebar-site_nameurl,
+	.reader-sidebar-site_updated {
+		display: block;
+		display: -webkit-box;
+		overflow: hidden;
+		-webkit-line-clamp: 1;
+		-webkit-box-orient: vertical;
+	}
+}
+
 .reader-subscription-list-item__by-text,
-.reader-subscription-list-item__site-excerpt,
 .reader-subscription-list-item__site-url-timestamp {
 	display: block;
 	max-height: 16px * 3;
@@ -88,27 +117,13 @@
 	width: 100%;
 	overflow-wrap: break-word;
 	word-wrap: break-word;
-	word-break: break-word;
+	word-break: break-all;
 
 	&:not(.is-placeholder)::after {
 		@include long-content-fade( $size: 20% );
 		height: 16px * 1.3;
 		top: auto;
 	}
-}
-
-.reader-subscription-list-item__by-text,
-.reader-subscription-list-item__site-url-timestamp {
-	word-break: break-all;
-}
-
-.reader-subscription-list-item__site-excerpt {
-	max-height: 16px * 2.8;
-}
-
-.reader-subscription-list-item__site-title {
-	font-size: $font-body;
-	font-weight: 600;
 }
 
 .reader-subscription-list-item__site-url-timestamp {
@@ -146,6 +161,9 @@
 		justify-content: space-between;
 		list-style-type: disc;
 		color: var(--color-text-subtle);
+		font-weight: 400;
+		font-size: 0.75rem;
+		line-height: 18px;
 		margin: 0;
 		gap: 8px;
 		li {
@@ -224,5 +242,5 @@
 }
 
 .reader-subscription-list-item__avatar {
-	min-width: 52px;
+	min-width: 32px;
 }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -88,6 +88,12 @@
 }
 
 .reader-subscription-list-item__site-title {
+	display: -webkit-box;
+	line-height: 18px;
+	overflow: hidden;
+	width: auto;
+	-webkit-line-clamp: 1;
+	-webkit-box-orient: vertical;
 	color: var(--color-neutral-100);
 	font-weight: 600;
 	font-size: $font-body-small;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -287,8 +287,8 @@
 }
 
 .search-stream__results.is-two-columns .reader-subscription-list-item__byline {
-	min-width: 177px;
-	max-width: 177px;
+	min-width: 185px;
+	max-width: 185px;
 }
 
 .search-stream__single-column-results .reader-subscription-list-item__options {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -320,7 +320,7 @@
 
 .search-stream__results.is-two-columns .search-stream__post-results {
 	max-width: 660px;
-	width: calc(100% - 300px);
+	width: calc(100% - 304px);
 
 	.reader-post-card__post {
 		@include breakpoint-deprecated( "<960px" ) {


### PR DESCRIPTION
This PR intends to fix some style issues with the Reader search site results in the sidebar. One of the main issues is that the newest styles in Search for Popular Sites is different to the older Site results sidebar styling. This will try to make them more alike;

### Popular Sites
<img width="947" alt="Screenshot 2023-05-30 at 14 30 13" src="https://github.com/Automattic/wp-calypso/assets/5560595/29d89e9b-e7ff-433b-81b2-6ee086c07de4">

### Search Sites Sidebar - Before
<img width="937" alt="Screenshot 2023-05-30 at 14 24 14" src="https://github.com/Automattic/wp-calypso/assets/5560595/81ad028c-1b74-41c9-92fd-18df2f3ebda5">

1 - Updates square to circular site icons as used elsewhere on Reader
2 - Updated site title styling to match Popular Sites styling
3 - Updated site description to match Popular Sites styling

### Search Sites Sidebar - After
<img width="941" alt="Screenshot 2023-05-30 at 11 48 29" src="https://github.com/Automattic/wp-calypso/assets/5560595/8602a2f0-036f-4fe0-b07d-01f7ee733401">
