### PR TITLE
Site Assembler - Fix category description margin bottom 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
@@ -29,6 +29,7 @@
 		letter-spacing: -0.1px;
 		color: var(--color-neutral-60);
 		padding-bottom: 16px;
+		margin: 0;
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -49,10 +49,6 @@ $font-family: "SF Pro Text", $sans;
 		overflow-x: visible;
 	}
 
-	p {
-		margin: 0;
-	}
-
 	/**
 	 * Pattern Layout
 	 */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77447 #77087


## Proposed Changes

|BEFORE|AFTER|
|------|-----|
|<img width="696" alt="Screenshot 2566-05-30 at 17 18 45" src="https://github.com/Automattic/wp-calypso/assets/1881481/fd85a939-13a4-4e77-baa1-9676990b7fb7">|<img width="697" alt="Screenshot 2566-05-30 at 17 18 23" src="https://github.com/Automattic/wp-calypso/assets/1881481/0468d871-e7bb-464d-b8c7-591359a7318b">|


* Fix the category description margin by removing the paragraphs style introduced in https://github.com/Automattic/wp-calypso/pull/77447

Let's fix the paragraphs style in storybook using a more specific CSS selector. See https://github.com/Automattic/wp-calypso/pull/77447#discussion_r1209936210

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a new site with any plan
- Continue until the Design Picker
- Scroll down and click `Start designing`
- Click `Homepage` > `Add patterns` and click on the first category
- Verify that the category description has a margin bottom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
