### PR TITLE
Import: Add un-authorized screen in migration handler

### DIFF
--- a/client/blocks/importer/components/not-authorized/index.tsx
+++ b/client/blocks/importer/components/not-authorized/index.tsx
@@ -8,11 +8,14 @@ import React, { useEffect } from 'react';
 interface Props {
 	onBackToStart?: () => void;
 	onStartBuilding?: () => void;
+	onStartBuildingText?: string;
 }
 
 const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { onBackToStart, onStartBuilding } = props;
+	const { onBackToStart, onStartBuilding, onStartBuildingText } = props;
+
+	const startBuildingText = onStartBuildingText ?? __( 'Start building' );
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_site_importer_unauthorized' );
@@ -27,7 +30,7 @@ const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 
 					<div className="import__buttons-group">
 						{ onStartBuilding && (
-							<NextButton onClick={ onStartBuilding }>{ __( 'Start building' ) }</NextButton>
+							<NextButton onClick={ onStartBuilding }>{ startBuildingText }</NextButton>
 						) }
 						{ onBackToStart && (
 							<div>

--- a/client/blocks/importer/components/not-authorized/index.tsx
+++ b/client/blocks/importer/components/not-authorized/index.tsx
@@ -1,6 +1,7 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { BackButton, NextButton, SubTitle, Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -12,6 +13,10 @@ interface Props {
 const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
 	const { onBackToStart, onStartBuilding } = props;
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_site_importer_unauthorized' );
+	}, [] );
 
 	return (
 		<div className="import-layout__center">

--- a/client/data/site-migration/use-source-migration-status-query.ts
+++ b/client/data/site-migration/use-source-migration-status-query.ts
@@ -3,8 +3,14 @@ import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 import type { SiteId, SiteSlug } from 'calypso/types';
 
+export interface MigrationStatusError {
+	status: number;
+	message: string;
+}
+
 export const useSourceMigrationStatusQuery = (
-	sourceIdOrSlug: SiteId | SiteSlug | null | undefined
+	sourceIdOrSlug: SiteId | SiteSlug | null | undefined,
+	onErrorCallback?: ( error: MigrationStatusError ) => void
 ) => {
 	return useQuery( {
 		queryKey: [ 'source-migration-status', sourceIdOrSlug ],
@@ -17,5 +23,9 @@ export const useSourceMigrationStatusQuery = (
 			persist: false,
 		},
 		enabled: !! sourceIdOrSlug,
+		retry: false,
+		onError: ( error: MigrationStatusError ) => {
+			onErrorCallback && onErrorCallback( error );
+		},
 	} );
 };

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -95,10 +95,6 @@ const importFlow: Flow = {
 		const handleMigrationRedirects = ( providedDependencies: ProvidedDependencies = {} ) => {
 			const userHasSite = sites && sites.length > 0;
 
-			// If there's any errors, we redirect them to the select/create a new site for a clean start
-			if ( providedDependencies?.hasError ) {
-				return userHasSite ? navigate( 'sitePicker' ) : navigate( 'siteCreationStep' );
-			}
 			if ( providedDependencies?.status === 'inactive' ) {
 				// This means they haven't kick off the migration before, so we send them to select/create a new site
 				if ( ! providedDependencies?.targetBlogId ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -9,6 +9,7 @@ import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-s
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { redirect } from '../import/util';
 import type { Step } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import './styles.scss';
@@ -58,9 +59,19 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 		return __( 'Scanning your site' );
 	};
 
+	const skipToDashboard = () => {
+		recordTracksEvent( 'calypso_importer_migration_skip_to_dashboard' );
+		return redirect( '/' );
+	};
+
 	const renderContent = () => {
 		if ( isUnAuthorized ) {
-			return <NotAuthorized />;
+			return (
+				<NotAuthorized
+					onStartBuilding={ skipToDashboard }
+					onStartBuildingText={ __( 'Skip to dashboard' ) }
+				/>
+			);
 		}
 		return (
 			<div className="import-layout__center">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -1,7 +1,8 @@
 import { StepContainer, Title } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import NotAuthorized from 'calypso/blocks/importer/components/not-authorized';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
@@ -20,14 +21,14 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 		[]
 	);
 	const { setIsMigrateFromWp } = useDispatch( ONBOARD_STORE );
+	const [ isUnAuthorized, setIsUnAuthorized ] = useState( false );
 	const urlQueryParams = useQuery();
 	const sourceSiteSlug = urlQueryParams.get( 'from' ) || '';
-	const { data: sourceSiteMigrationStatus, isError: isErrorSourceSiteMigrationStatus } =
-		useSourceMigrationStatusQuery( sourceSiteSlug );
-	const errorDependency = {
-		isFromMigrationPlugin: true,
-		hasError: true,
+	const onSourceMigrationStatusError = () => {
+		setIsUnAuthorized( true );
 	};
+	const { data: sourceSiteMigrationStatus, isError: isErrorSourceSiteMigrationStatus } =
+		useSourceMigrationStatusQuery( sourceSiteSlug, onSourceMigrationStatusError );
 
 	useEffect( () => {
 		setIsMigrateFromWp( true );
@@ -37,7 +38,7 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 	useEffect( () => {
 		if ( submit ) {
 			if ( isErrorSourceSiteMigrationStatus ) {
-				return submit( errorDependency );
+				return;
 			}
 			if ( sourceSiteMigrationStatus ) {
 				submit( {
@@ -57,23 +58,33 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 		return __( 'Scanning your site' );
 	};
 
+	const renderContent = () => {
+		if ( isUnAuthorized ) {
+			return <NotAuthorized />;
+		}
+		return (
+			<div className="import-layout__center">
+				<div className="import__header import__loading">
+					<Title>{ getCurrentMessage() }</Title>
+					<LoadingEllipsis />
+				</div>
+			</div>
+		);
+	};
+
 	return (
 		<>
 			<DocumentHead title={ getCurrentMessage() } />
 			<StepContainer
 				shouldHideNavButtons={ true }
 				hideFormattedHeader={ true }
+				isWideLayout={ true }
 				stepName="migration-handler"
-				isHorizontalLayout={ true }
 				recordTracksEvent={ recordTracksEvent }
-				stepContent={
-					<>
-						<Title>{ getCurrentMessage() }</Title>
-						<LoadingEllipsis />
-					</>
-				}
+				stepContent={ renderContent() }
 				stepProgress={ stepProgress }
 				showFooterWooCommercePowered={ false }
+				className="import__onboarding-page"
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/styles.scss
@@ -1,16 +1,4 @@
-@import "../style";
-
-.migration-handler {
-	max-width: 540px;
-	text-align: center;
-	margin: 16vh auto 0;
-
-	.step-container__content {
-		.onboarding-title {
-			font-size: 1.625rem; /* stylelint-disable-line scales/font-sizes */
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			line-height: 1em;
-			margin-bottom: 1.5rem;
-		}
-	}
+.import__loading {
+	display: flex;
+	flex-direction: column;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77474

## Proposed Changes

* When users from the migration plugin land on the `migrationHandler` step, they should already have their user account connected. If for some reason they don't have fully connected yet, we'll need to block them from going any further.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a JN site, don't connect it, or connect to some other accounts.
* Navigate to `http://calypso.localhost:3000/setup/import-focused/migrationHandler?from=${source_site}`
* See if you can see the un-authorized screen shows up
* See if event `calypso_site_importer_unauthorized` gets recorded
* Clicks on Skip to dashboard and see if it brings you to the homepage
* See if event `calypso_importer_migration_skip_to_dashboard` gets recorded

![Screen Shot 2023-05-30 at 7 55 07 PM](https://github.com/Automattic/wp-calypso/assets/4074459/66e0d162-6837-420a-9e10-34d7cd172bfe)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
