### PR TITLE
`read/subscriptions`: Fix styles of site row labels

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-list.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-list.tsx
@@ -1,8 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
 import { VirtualizedList } from '../virtualized-list';
 import CommentRow from './comment-row';
-import './styles.scss';
 import type { PostSubscription } from '@automattic/data-stores/src/reader/types';
+import './styles.scss';
 
 type CommentListProps = {
 	posts?: PostSubscription[];

--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -1,6 +1,7 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
+@import "client/landing/subscriptions/styles/row-title-label";
 
 %ellipsis {
 	white-space: nowrap;
@@ -107,6 +108,14 @@
 
 					&:hover {
 						text-decoration: underline;
+					}
+
+					.p2-label {
+						@extend %p2-label;
+					}
+
+					.paid-label {
+						@extend %paid-label;
 					}
 				}
 

--- a/client/landing/subscriptions/components/site-list/styles.scss
+++ b/client/landing/subscriptions/components/site-list/styles.scss
@@ -2,6 +2,7 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 @import "client/assets/stylesheets/p2-vars";
+@import "landing/subscriptions/styles/row-title-label";
 
 .subscription-manager__site-list {
 
@@ -67,6 +68,14 @@
 
 					&:hover {
 						text-decoration: underline;
+					}
+
+					.p2-label {
+						@extend %p2-label;
+					}
+
+					.paid-label {
+						@extend %paid-label;
 					}
 				}
 

--- a/client/landing/subscriptions/components/site-list/styles.scss
+++ b/client/landing/subscriptions/components/site-list/styles.scss
@@ -2,7 +2,7 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 @import "client/assets/stylesheets/p2-vars";
-@import "landing/subscriptions/styles/row-title-label";
+@import "client/landing/subscriptions/styles/row-title-label";
 
 .subscription-manager__site-list {
 

--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -31,8 +31,9 @@ const Sites = () => {
 	} );
 	const { subscriptions, totalCount } = data ?? {};
 	const sortOptions = useSortOptions( translate );
-	// todo: translate when we have agreed on the error message
-	const errorMessage = error ? 'An error occurred while fetching your subscriptions.' : '';
+	const errorMessage = error
+		? translate( "Oops! The subscription couldn't be found or doesn't exist." )
+		: '';
 	const isListControlsEnabled = config.isEnabled( 'subscription-management/sites-list-controls' );
 
 	if ( ! isLoading && ! totalCount ) {

--- a/client/landing/subscriptions/styles/row-title-label.scss
+++ b/client/landing/subscriptions/styles/row-title-label.scss
@@ -1,0 +1,39 @@
+
+%row-title-label {
+	display: inline-block;
+	text-align: center;
+	height: 20px;
+	color: $studio-green-0;
+	font-size: $font-body-extra-small;
+	border-radius: 4px;
+	margin-left: 8px;
+	line-height: 20px;
+
+	&__p2 {
+		background: var(--p2-color-link);
+		width: 36px;
+	}
+
+	&__paid {
+		background: $studio-green-50;
+		padding-left: 5px;
+		padding-right: 5px;
+		min-width: 35px;
+	}
+}
+
+%p2-label {
+	@extend %row-title-label;
+
+	background: var(--p2-color-link);
+	width: 36px;
+}
+
+%paid-label {
+	@extend %row-title-label;
+
+	background: $studio-green-50;
+	padding-left: 5px;
+	padding-right: 5px;
+	min-width: 35px;
+}

--- a/client/landing/subscriptions/styles/styles.scss
+++ b/client/landing/subscriptions/styles/styles.scss
@@ -113,28 +113,4 @@ body {
 		border: none;
 		border-top: 1px solid $studio-gray-5;
 	}
-
-	.p2-label,
-	.paid-label {
-		display: inline-block;
-		text-align: center;
-		height: 20px;
-		color: $studio-green-0;
-		font-size: $font-body-extra-small;
-		border-radius: 4px;
-		margin-left: 8px;
-		line-height: 20px;
-	}
-
-	.p2-label {
-		background: var(--p2-color-link);
-		width: 36px;
-	}
-
-	.paid-label {
-		background: $studio-green-50;
-		padding-left: 5px;
-		padding-right: 5px;
-		min-width: 35px;
-	}
 }

--- a/client/reader/subscriptions/site-subscriptions-list/site-subscriptions-list.tsx
+++ b/client/reader/subscriptions/site-subscriptions-list/site-subscriptions-list.tsx
@@ -11,7 +11,6 @@ const SiteSubscriptionsList = () => {
 	const { subscriptions, totalCount } = data ?? {};
 
 	if ( error ) {
-		// todo: translate when we have agreed on the error message
 		return (
 			<Notice type={ NoticeType.Error }>
 				{ translate( "Oops! The subscription couldn't be found or doesn't exist." ) }

--- a/client/reader/subscriptions/site-subscriptions-list/site-subscriptions-list.tsx
+++ b/client/reader/subscriptions/site-subscriptions-list/site-subscriptions-list.tsx
@@ -14,7 +14,7 @@ const SiteSubscriptionsList = () => {
 		// todo: translate when we have agreed on the error message
 		return (
 			<Notice type={ NoticeType.Error }>
-				An error occurred while fetching your subscriptions.
+				{ translate( "Oops! The subscription couldn't be found or doesn't exist." ) }
 			</Notice>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

| Before | After |
|:---:|:---:|
| <img src="https://github.com/Automattic/wp-calypso/assets/2019970/8328f1cf-6f9f-4ff8-a4be-62999b0e63eb" width="400"> | <img src="https://github.com/Automattic/wp-calypso/assets/2019970/563ab0ce-8cc3-498d-bb1d-32a38e4e689c" width="400"> |

Fixes https://github.com/Automattic/wp-calypso/issues/77533

## Proposed Changes

* Make sure the label styles are imported together with the `SitesList` component's styles

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/read/subscriptions
* Ensure the P2, or Paid labels are displayed with the correct labels applied

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
