### PR TITLE
Subscription manager: Make action bar behave better on mobile

### DIFF
--- a/client/landing/subscriptions/components/tab-views/comments/comments.tsx
+++ b/client/landing/subscriptions/components/tab-views/comments/comments.tsx
@@ -62,9 +62,9 @@ const Comments = () => {
 					onSelect={ ( selectedOption: Option ) =>
 						setFilterOption( selectedOption.value as Reader.SiteSubscriptionsFilterBy )
 					}
-					selectedText={
-						translate( 'View: ' ) + getFilterLabel( availableFilterOptions, filterOption )
-					}
+					selectedText={ translate( 'View: %s', {
+						args: getFilterLabel( availableFilterOptions, filterOption ) || '',
+					} ) }
 				/>
 
 				<SortControls options={ sortOptions } value={ sortTerm } onChange={ setSortTerm } />

--- a/client/landing/subscriptions/components/tab-views/comments/comments.tsx
+++ b/client/landing/subscriptions/components/tab-views/comments/comments.tsx
@@ -57,7 +57,7 @@ const Comments = () => {
 				/>
 
 				<SelectDropdown
-					className="subscriptions-manager__filter-control"
+					className="subscriptions-manager__filter-control subscriptions-manager__list-actions-bar-spacer"
 					options={ availableFilterOptions }
 					onSelect={ ( selectedOption: Option ) =>
 						setFilterOption( selectedOption.value as Reader.SiteSubscriptionsFilterBy )

--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -62,7 +62,7 @@ const Sites = () => {
 						onSearch={ handleSearch }
 					/>
 					<SelectDropdown
-						className="subscriptions-manager__filter-control"
+						className="subscriptions-manager__filter-control subscriptions-manager__list-actions-bar-spacer"
 						options={ availableFilterOptions }
 						onSelect={ ( selectedOption: Option ) =>
 							setFilterOption( selectedOption.value as SiteSubscriptionsFilterBy )

--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -61,7 +61,6 @@ const Sites = () => {
 						searchIcon={ <SearchIcon size={ 18 } /> }
 						onSearch={ handleSearch }
 					/>
-
 					<SelectDropdown
 						className="subscriptions-manager__filter-control"
 						options={ availableFilterOptions }
@@ -72,7 +71,7 @@ const Sites = () => {
 							args: getFilterLabel( availableFilterOptions, filterOption ) || '',
 						} ) }
 					/>
-
+					<div className="subscriptions-manager__list-actions-bar-spacer"></div>
 					<SortControls options={ sortOptions } value={ sortTerm } onChange={ setSortTerm } />
 				</div>
 			) }

--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -61,6 +61,7 @@ const Sites = () => {
 						searchIcon={ <SearchIcon size={ 18 } /> }
 						onSearch={ handleSearch }
 					/>
+
 					<SelectDropdown
 						className="subscriptions-manager__filter-control subscriptions-manager__list-actions-bar-spacer"
 						options={ availableFilterOptions }
@@ -71,7 +72,7 @@ const Sites = () => {
 							args: getFilterLabel( availableFilterOptions, filterOption ) || '',
 						} ) }
 					/>
-					<div className="subscriptions-manager__list-actions-bar-spacer"></div>
+
 					<SortControls options={ sortOptions } value={ sortTerm } onChange={ setSortTerm } />
 				</div>
 			) }

--- a/client/landing/subscriptions/styles/styles.scss
+++ b/client/landing/subscriptions/styles/styles.scss
@@ -47,16 +47,22 @@ body {
 		&__list-actions-bar {
 			margin-bottom: 57px;
 			display: flex;
-			justify-content: space-between;
+			justify-content: flex-start;
 			align-items: center;
 			gap: 8px;
+			flex-wrap: wrap;
 
-			.subscription-manager__sort-controls {
-				margin-left: auto;
+			.search-component {
+				min-width: 300px;
+				flex: 1;
+			}
+
+			&-spacer {
+				flex: 1;
 			}
 
 			.subscriptions-manager__filter-control {
-				flex-grow: 1;
+				min-width: 115px;
 
 				&.select-dropdown,
 				.select-dropdown__header {
@@ -67,20 +73,21 @@ body {
 					background-color: var(--color-primary);
 				}
 			}
-		}
 
-		@media (max-width: $break-small) {
-			&__list-actions-bar {
-				margin-bottom: 38.5px;
-				flex-direction: column;
-				align-items: stretch;
-				gap: 0;
+			.subscription-manager-sort-controls {
+				flex-grow: 0;
+			}
 
+			@media (max-width: $break-small) {
+				.subscriptions-manager__filter-control,
 				.subscription-manager-sort-controls {
-					margin-top: 30.5px;
-
 					&__button {
 						padding: 0;
+					}
+				}
+				.subscription-manager-sort-controls {
+					&__button {
+						margin-top: -6px;
 					}
 				}
 			}

--- a/client/landing/subscriptions/styles/styles.scss
+++ b/client/landing/subscriptions/styles/styles.scss
@@ -53,7 +53,7 @@ body {
 			flex-wrap: wrap;
 
 			.search-component {
-				min-width: 300px;
+				min-width: min(400px, 100%);
 				flex: 1;
 			}
 


### PR DESCRIPTION
Closes #77229

## Proposed Changes

* Adds better mobile styling for the action bar (search + filter + sort) in the new subscription manager

### Before
https://github.com/Automattic/wp-calypso/assets/528287/9d145856-e10e-47dd-8d60-e0b3a6589bec 

### After 
https://github.com/Automattic/wp-calypso/assets/528287/fcf663d6-e75a-467f-8a3b-11bfa1f5c592

The code does away with most of the media queries, and instead just uses standard flexbox styling together with `flex-wrap`

## Testing Instructions

- Apply this PR
- Add `return next();` on line 833 of `client/server/pages/index.js`
- Restart Calypso
- Visit `http://calypso.localhost:3000/subscriptions/comments` & `http://calypso.localhost:3000/subscriptions/sites` and ensure the styles render fine on all screen sizes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
