### PR TITLE
Hide credits balance when. 0.00

### DIFF
--- a/client/my-sites/promote-post/components/credit-balance/index.tsx
+++ b/client/my-sites/promote-post/components/credit-balance/index.tsx
@@ -10,7 +10,7 @@ const CreditBalance = () => {
 	const creditBalance = useCreditBalanceQuery();
 	const { data: balance } = creditBalance;
 
-	if ( ! balance ) {
+	if ( ! balance || balance === '0.00' ) {
 		return null;
 	}
 

--- a/client/my-sites/promote-post/test/credit-balance.test.tsx
+++ b/client/my-sites/promote-post/test/credit-balance.test.tsx
@@ -17,8 +17,17 @@ describe( 'CreditBalance component', () => {
 		expect( screen.queryByText( /Credits: \$.+/ ) ).toBeNull();
 	} );
 
+	test( 'displays null when balance is 0.00', () => {
+		const mockBalance = '0.00';
+		useCreditBalanceQuery.mockReturnValue( { data: mockBalance } );
+
+		render( <CreditBalance /> );
+
+		expect( screen.queryByText( /Credits: \$.+/ ) ).toBeNull();
+	} );
+
 	test( 'displays "Credits: $10" when balance is set to 10', () => {
-		const mockBalance = 10;
+		const mockBalance = '10.00';
 		useCreditBalanceQuery.mockReturnValue( { data: mockBalance } );
 
 		render( <CreditBalance /> );


### PR DESCRIPTION
## Proposed Changes

* Hide the credit balance when it is "0.00"

## Testing Instructions

* visit /advertising using the[  links below ](https://calypso.live/?image=registry.a8c.com/calypso/app:commit-61e8455a5ce639ee828bb3593c7286bf8898b7eb)I f you have no credits you should not see the balance

**New behaviour:**
![Screenshot 2023-05-30 at 12 42 00](https://github.com/Automattic/wp-calypso/assets/6440498/134f5f4d-de7e-4d93-a80d-4aa89ff38ac6)

**Old behaviour**
![Screenshot 2023-05-30 at 12 42 51](https://github.com/Automattic/wp-calypso/assets/6440498/04c22020-fad9-491e-aca2-cf22ce3e9b26)




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
