### PR TITLE
Update font of plans header

### DIFF
--- a/client/my-sites/plans/components/plans-header/index.tsx
+++ b/client/my-sites/plans/components/plans-header/index.tsx
@@ -72,7 +72,6 @@ const PlansHeader: React.FunctionComponent< {
 	return (
 		<FormattedHeader
 			className="plans__formatted-header plans__section-header modernized-header"
-			brandFont
 			headerText={ translate( 'Plans' ) }
 			subHeaderText={ plansDescription }
 			align="left"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1526

## Proposed Changes

* Resets the font of the "Plans" header on the `/plans` page.
<img width="1215" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/74ce5680-3f96-4f79-bae6-2266e1aa5c59">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/<site slug>` and confirm that the Plans header matches the design: xkhhUlDowF13dRoXJqlRDM-fi-1704:19742

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?