### PR TITLE
Site Assembler - Sections Pattern Inserter, Categories, and Large Preview UX

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
+import classnames from 'classnames';
 import { useState, useRef, useMemo } from 'react';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import { createRecordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -66,6 +67,7 @@ const PatternAssembler = ( {
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const [ activePosition, setActivePosition ] = useState( -1 );
 	const [ surveyDismissed, setSurveyDismissed ] = useState( false );
+	const [ isPatternPanelListOpen, setIsPatternPanelListOpen ] = useState( false );
 	const { goBack, goNext, submit } = navigation;
 	const { applyThemeWithPatterns, assembleSite } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
@@ -546,7 +548,13 @@ const PatternAssembler = ( {
 	}
 
 	const stepContent = (
-		<div className="pattern-assembler__wrapper" ref={ wrapperRef } tabIndex={ -1 }>
+		<div
+			className={ classnames( 'pattern-assembler__wrapper', {
+				'pattern-assembler__pattern-panel-list--is-open': isPatternPanelListOpen,
+			} ) }
+			ref={ wrapperRef }
+			tabIndex={ -1 }
+		>
 			<Notices noticeList={ noticeList } noticeOperations={ noticeOperations } />
 			<div className="pattern-assembler__sidebar">
 				<NavigatorScreen path={ NAVIGATOR_PATHS.MAIN }>
@@ -601,6 +609,7 @@ const PatternAssembler = ( {
 						selectedPattern={ sectionPosition !== null ? sections[ sectionPosition ] : null }
 						onSelect={ onSelect }
 						recordTracksEvent={ recordTracksEvent }
+						onTogglePatternPanelList={ setIsPatternPanelListOpen }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -556,6 +556,7 @@ const PatternAssembler = ( {
 						recordTracksEvent={ recordTracksEvent }
 						surveyDismissed={ surveyDismissed }
 						setSurveyDismissed={ setSurveyDismissed }
+						patterns={ sections }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -564,7 +564,7 @@ const PatternAssembler = ( {
 						recordTracksEvent={ recordTracksEvent }
 						surveyDismissed={ surveyDismissed }
 						setSurveyDismissed={ setSurveyDismissed }
-						hasSections={ sections.length }
+						hasSections={ !! sections.length }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -564,7 +564,7 @@ const PatternAssembler = ( {
 						recordTracksEvent={ recordTracksEvent }
 						surveyDismissed={ surveyDismissed }
 						setSurveyDismissed={ setSurveyDismissed }
-						patterns={ sections }
+						hasSections={ sections.length }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -10,7 +10,6 @@ import {
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
-import classnames from 'classnames';
 import { useState, useRef, useMemo } from 'react';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import { createRecordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -66,7 +65,6 @@ const PatternAssembler = ( {
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const [ activePosition, setActivePosition ] = useState( -1 );
-	const [ isPatternPanelListOpen, setIsPatternPanelListOpen ] = useState( false );
 	const [ surveyDismissed, setSurveyDismissed ] = useState( false );
 	const { goBack, goNext, submit } = navigation;
 	const { applyThemeWithPatterns, assembleSite } = useDispatch( SITE_STORE );
@@ -548,13 +546,7 @@ const PatternAssembler = ( {
 	}
 
 	const stepContent = (
-		<div
-			className={ classnames( 'pattern-assembler__wrapper', {
-				'pattern-assembler__pattern-panel-list--is-open': isPatternPanelListOpen,
-			} ) }
-			ref={ wrapperRef }
-			tabIndex={ -1 }
-		>
+		<div className="pattern-assembler__wrapper" ref={ wrapperRef } tabIndex={ -1 }>
 			<Notices noticeList={ noticeList } noticeOperations={ noticeOperations } />
 			<div className="pattern-assembler__sidebar">
 				<NavigatorScreen path={ NAVIGATOR_PATHS.MAIN }>
@@ -607,8 +599,6 @@ const PatternAssembler = ( {
 						replacePatternMode={ sectionPosition !== null }
 						selectedPattern={ sectionPosition !== null ? sections[ sectionPosition ] : null }
 						onSelect={ onSelect }
-						wrapperRef={ wrapperRef }
-						onTogglePatternPanelList={ setIsPatternPanelListOpen }
 						recordTracksEvent={ recordTracksEvent }
 					/>
 				</NavigatorScreen>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -9,6 +9,15 @@
 	margin-inline-start: 10px;
 	box-sizing: border-box;
 	z-index: 1;
+	transition: margin-inline-start 0.1s ease-out;
+
+	&.device-switcher__container--frame-bordered .device-switcher__frame {
+		box-shadow: none;
+	}
+
+	.pattern-assembler__pattern-panel-list--is-open & {
+		margin-inline-start: 365px;
+	}
 }
 
 .pattern-large-preview__patterns {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -16,20 +16,20 @@
 		position: relative;
 	}
 
-	&.device-switcher__container--is-computer .pattern-large-preview__patterns {
-		--pattern-large-preview-device-computer-scale: 0.52;
-		--pattern-large-preview-device-computer-width: 1024;
-		position: absolute;
-		left: 0;
-		top: 0;
-		transform: scale(var(--pattern-large-preview-device-computer-scale));
-		transform-origin: left top;
-		width: calc(var(--pattern-large-preview-device-computer-width) * 1px);
-		max-height: calc(100% / var(--pattern-large-preview-device-computer-scale));
-	}
-
 	.pattern-assembler__pattern-panel-list--is-open & {
 		margin-inline-start: 365px;
+
+		&.device-switcher__container--is-computer .pattern-large-preview__patterns {
+			--pattern-large-preview-device-computer-scale: 0.52;
+			--pattern-large-preview-device-computer-width: 1024;
+			position: absolute;
+			left: 0;
+			top: 0;
+			transform: scale(var(--pattern-large-preview-device-computer-scale));
+			transform-origin: left top;
+			width: calc(var(--pattern-large-preview-device-computer-width) * 1px);
+			max-height: calc(100% / var(--pattern-large-preview-device-computer-scale));
+		}
 	}
 }
 
@@ -86,10 +86,6 @@
 				bottom: -6px;
 			}
 		}
-	}
-
-	.block-renderer * {
-		transition: all 0.1s ease-out;
 	}
 
 	&::after {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -18,18 +18,6 @@
 
 	.pattern-assembler__pattern-panel-list--is-open & {
 		margin-inline-start: 365px;
-
-		&.device-switcher__container--is-computer .pattern-large-preview__patterns {
-			--pattern-large-preview-device-computer-scale: 0.52;
-			--pattern-large-preview-device-computer-width: 1024;
-			position: absolute;
-			left: 0;
-			top: 0;
-			transform: scale(var(--pattern-large-preview-device-computer-scale));
-			transform-origin: left top;
-			width: calc(var(--pattern-large-preview-device-computer-width) * 1px);
-			max-height: calc(100% / var(--pattern-large-preview-device-computer-scale));
-		}
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -64,11 +64,6 @@
 				bottom: -6px;
 			}
 		}
-
-		.pattern-assembler__pattern-panel-list--is-open & {
-			left: unset;
-			right: 16px;
-		}
 	}
 
 	&::after {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -13,6 +13,19 @@
 
 	&.device-switcher__container--frame-bordered .device-switcher__frame {
 		box-shadow: none;
+		position: relative;
+	}
+
+	&.device-switcher__container--is-computer .pattern-large-preview__patterns {
+		--pattern-large-preview-device-computer-scale: 0.52;
+		--pattern-large-preview-device-computer-width: 1024;
+		position: absolute;
+		left: 0;
+		top: 0;
+		transform: scale(var(--pattern-large-preview-device-computer-scale));
+		transform-origin: left top;
+		width: calc(var(--pattern-large-preview-device-computer-width) * 1px);
+		max-height: calc(100% / var(--pattern-large-preview-device-computer-scale));
 	}
 
 	.pattern-assembler__pattern-panel-list--is-open & {
@@ -73,6 +86,10 @@
 				bottom: -6px;
 			}
 		}
+	}
+
+	.block-renderer * {
+		transition: all 0.1s ease-out;
 	}
 
 	&::after {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -29,8 +29,6 @@ interface Props {
 
 // The pattern renderer element has 1px min height before the pattern is loaded
 const PATTERN_RENDERER_MIN_HEIGHT = 1;
-// Desktop viewport width in pixels
-const DEVICE_COMPUTER_VIEWPORT_WIDTH = 1280;
 
 const PatternLargePreview = ( {
 	header,
@@ -137,61 +135,10 @@ const PatternLargePreview = ( {
 		);
 	};
 
-	const deviceComputerViewportScale = () =>
-		frameRef.current!.clientWidth / DEVICE_COMPUTER_VIEWPORT_WIDTH;
-
-	const setLargePreviewStyleForViewport = () => {
-		if ( NAVIGATOR_PATHS.SECTION_PATTERNS === navigator.location.path ) {
-			// Extend state with viewport styles
-			setPatternLargePreviewStyle(
-				( state ) =>
-					( {
-						...state,
-						'--pattern-large-preview-device-computer-width': DEVICE_COMPUTER_VIEWPORT_WIDTH,
-						'--pattern-large-preview-device-computer-scale': deviceComputerViewportScale(),
-					} as CSSProperties )
-			);
-		}
-	};
-
 	const updateViewportHeight = () => {
-		let height = frameRef.current?.clientHeight as number;
-		if ( 'computer' === device ) {
-			// Scale up for patterns with 100vh
-			height = height / deviceComputerViewportScale();
-		}
-		setViewportHeight( height );
+		setViewportHeight( frameRef.current?.clientHeight );
 	};
 
-	// Scale down the computer device viewport
-	useEffect( () => {
-		if ( NAVIGATOR_PATHS.SECTION_PATTERNS === navigator.location.path ) {
-			setTimeout(
-				() => {
-					updateViewportHeight();
-					setLargePreviewStyleForViewport();
-				},
-				// Wait for .pattern-large-preview transition
-				205
-			);
-		}
-	}, [ navigator.location ] );
-
-	// Update viewport height on device switch
-	useEffect( () => {
-		setTimeout(
-			updateViewportHeight,
-			// Wait for device switch transition
-			205
-		);
-	}, [ device ] );
-
-	// Update viewport styles after window resize
-	useEffect( () => {
-		setLargePreviewStyleForViewport();
-	}, [ viewportHeight ] );
-
-	// Scroll to newly added patterns
 	useEffect( () => {
 		let timerId: number;
 		const scrollIntoView = () => {
@@ -248,6 +195,11 @@ const PatternLargePreview = ( {
 			onDeviceChange={ ( device ) => {
 				recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PREVIEW_DEVICE_CLICK, { device } );
 				setDevice( device );
+				// Wait for the animation to end in 200ms
+				// The animation is triggered by the setDevice above
+				window.setTimeout( () => {
+					updateViewportHeight();
+				}, 205 );
 			} }
 		>
 			{ hasSelectedPattern ? (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -8,7 +8,6 @@
 	width: 348px;
 	background: var(--studio-gray-0);
 	border-left: 1px solid rgba(0, 0, 0, 0.03);
-	box-shadow: 183px 0 110px rgb(0 0 0 / 2%), 81px 0 81px rgb(0 0 0 / 3%), 20px 0 45px rgb(0 0 0 / 3%), 0 0 0 rgb(0 0 0 / 3%);
 	padding: 24px;
 	max-height: 100vh;
 	min-height: 100vh;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
@@ -32,7 +32,7 @@ const PatternListPanel = ( {
 	return (
 		<div key="pattern-list-panel" className="pattern-list-panel__wrapper">
 			<div className="pattern-list-panel__title">{ category?.label }</div>
-			<p className="pattern-list-panel__description">{ category?.description }</p>
+			<div className="pattern-list-panel__description">{ category?.description }</div>
 			<PatternSelector
 				patterns={ categoryPatterns }
 				onSelect={ onSelect }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -8,7 +8,7 @@ import {
 import { Icon, chevronRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import useCategoriesOrder from './hooks/use-categories-order';
 import NavigatorHeader from './navigator-header';
@@ -28,8 +28,6 @@ interface Props {
 	) => void;
 	replacePatternMode: boolean;
 	selectedPattern: Pattern | null;
-	wrapperRef: React.RefObject< HTMLDivElement > | null;
-	onTogglePatternPanelList?: ( isOpen: boolean ) => void;
 	recordTracksEvent: ( name: string, eventProperties: any ) => void;
 }
 
@@ -40,47 +38,21 @@ const ScreenCategoryList = ( {
 	replacePatternMode,
 	onSelect,
 	selectedPattern,
-	wrapperRef,
-	onTogglePatternPanelList,
 	recordTracksEvent,
 }: Props ) => {
 	const translate = useTranslate();
-	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
+	const firstCategory = categories[ 0 ];
+	const [ selectedCategory, setSelectedCategory ] = useState< string | null >(
+		firstCategory?.name ?? null
+	);
 	const categoriesInOrder = useCategoriesOrder( categories );
 	const composite = useCompositeState( { orientation: 'vertical' } );
-
-	const handleFocusOutside = ( event: Event ) => {
-		// Click outside the sidebar or action bar to close Pattern List
-		const target = event.target as HTMLElement;
-		if (
-			! (
-				target.closest( '.pattern-action-bar' ) || target.closest( '.pattern-assembler__sidebar' )
-			)
-		) {
-			setSelectedCategory( null );
-			onTogglePatternPanelList?.( false );
-		}
-	};
 
 	const trackEventCategoryClick = ( name: string ) => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_CATEGORY_LIST_CATEGORY_CLICK, {
 			pattern_category: replaceCategoryAllName( name ),
 		} );
 	};
-
-	useEffect( () => {
-		wrapperRef?.current?.addEventListener( 'click', handleFocusOutside );
-		return () => {
-			wrapperRef?.current?.removeEventListener( 'click', handleFocusOutside );
-		};
-	}, [] );
-
-	useEffect( () => {
-		// Notify the pattern panel list is going to close when umount
-		return () => {
-			onTogglePatternPanelList?.( false );
-		};
-	}, [] );
 
 	return (
 		<div className="screen-container">
@@ -125,12 +97,8 @@ const ScreenCategoryList = ( {
 							aria-describedby={ description }
 							aria-current={ isOpen }
 							onClick={ () => {
-								if ( isOpen ) {
-									setSelectedCategory( null );
-									onTogglePatternPanelList?.( false );
-								} else {
+								if ( ! isOpen ) {
 									setSelectedCategory( name );
-									onTogglePatternPanelList?.( true );
 									trackEventCategoryClick( name );
 								}
 							} }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -8,7 +8,7 @@ import {
 import { Icon, chevronRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import useCategoriesOrder from './hooks/use-categories-order';
 import NavigatorHeader from './navigator-header';
@@ -29,6 +29,7 @@ interface Props {
 	replacePatternMode: boolean;
 	selectedPattern: Pattern | null;
 	recordTracksEvent: ( name: string, eventProperties: any ) => void;
+	onTogglePatternPanelList?: ( isOpen: boolean ) => void;
 }
 
 const ScreenCategoryList = ( {
@@ -39,12 +40,11 @@ const ScreenCategoryList = ( {
 	onSelect,
 	selectedPattern,
 	recordTracksEvent,
+	onTogglePatternPanelList,
 }: Props ) => {
 	const translate = useTranslate();
 	const firstCategory = categories[ 0 ];
-	const [ selectedCategory, setSelectedCategory ] = useState< string | null >(
-		firstCategory?.name ?? null
-	);
+	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
 	const categoriesInOrder = useCategoriesOrder( categories );
 	const composite = useCompositeState( { orientation: 'vertical' } );
 
@@ -53,6 +53,17 @@ const ScreenCategoryList = ( {
 			pattern_category: replaceCategoryAllName( name ),
 		} );
 	};
+
+	useEffect( () => {
+		// Open first category with a delay to avoid the top position flickering
+		setTimeout( () => setSelectedCategory( firstCategory?.name ?? null ), 200 );
+
+		// Notify the pattern panel list is open and closed
+		onTogglePatternPanelList?.( true );
+		return () => {
+			onTogglePatternPanelList?.( false );
+		};
+	}, [] );
 
 	return (
 		<div className="screen-container">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -108,7 +108,11 @@ const ScreenCategoryList = ( {
 							aria-describedby={ description }
 							aria-current={ isOpen }
 							onClick={ () => {
-								if ( ! isOpen ) {
+								if ( isOpen ) {
+									onTogglePatternPanelList?.( false );
+									setSelectedCategory( null );
+								} else {
+									onTogglePatternPanelList?.( true );
 									setSelectedCategory( name );
 									trackEventCategoryClick( name );
 								}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -9,11 +9,13 @@ import { header, footer, layout, color, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef } from 'react';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { NAVIGATOR_PATHS } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { NavigationButtonAsItem } from './navigator-buttons';
 import NavigatorHeader from './navigator-header';
 import { NavigatorItemGroup } from './navigator-item-group';
 import Survey from './survey';
+import type { Pattern } from './types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { MouseEvent } from 'react';
 
@@ -23,6 +25,7 @@ interface Props {
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 	surveyDismissed: boolean;
 	setSurveyDismissed: ( dismissed: boolean ) => void;
+	patterns: Pattern[];
 }
 
 const ScreenMain = ( {
@@ -31,6 +34,7 @@ const ScreenMain = ( {
 	recordTracksEvent,
 	surveyDismissed,
 	setSurveyDismissed,
+	patterns,
 }: Props ) => {
 	const translate = useTranslate();
 	const [ disabled, setDisabled ] = useState( true );
@@ -97,7 +101,7 @@ const ScreenMain = ( {
 				<HStack direction="column" alignment="top" spacing="4">
 					<NavigatorItemGroup title={ translate( 'Layout' ) }>
 						<NavigationButtonAsItem
-							path="/header"
+							path={ NAVIGATOR_PATHS.HEADER }
 							icon={ header }
 							aria-label={ translate( 'Header' ) }
 							onClick={ () => onSelect( 'header' ) }
@@ -105,7 +109,7 @@ const ScreenMain = ( {
 							<span className="pattern-layout__list-item-text">{ translate( 'Header' ) }</span>
 						</NavigationButtonAsItem>
 						<NavigationButtonAsItem
-							path="/section"
+							path={ patterns.length ? NAVIGATOR_PATHS.SECTION : NAVIGATOR_PATHS.SECTION_PATTERNS }
 							icon={ layout }
 							aria-label={ translate( 'Homepage' ) }
 							onClick={ () => onSelect( 'section' ) }
@@ -113,7 +117,7 @@ const ScreenMain = ( {
 							<span className="pattern-layout__list-item-text">{ translate( 'Homepage' ) }</span>
 						</NavigationButtonAsItem>
 						<NavigationButtonAsItem
-							path="/footer"
+							path={ NAVIGATOR_PATHS.FOOTER }
 							icon={ footer }
 							aria-label={ translate( 'Footer' ) }
 							onClick={ () => onSelect( 'footer' ) }
@@ -124,7 +128,7 @@ const ScreenMain = ( {
 					<NavigatorItemGroup title={ translate( 'Style' ) }>
 						<>
 							<NavigationButtonAsItem
-								path="/color-palettes"
+								path={ NAVIGATOR_PATHS.COLOR_PALETTES }
 								icon={ color }
 								aria-label={ translate( 'Colors' ) }
 								onClick={ () => onSelect( 'color-palettes' ) }
@@ -132,7 +136,7 @@ const ScreenMain = ( {
 								<span className="pattern-layout__list-item-text">{ translate( 'Colors' ) }</span>
 							</NavigationButtonAsItem>
 							<NavigationButtonAsItem
-								path="/font-pairings"
+								path={ NAVIGATOR_PATHS.FONT_PAIRINGS }
 								icon={ typography }
 								aria-label={ translate( 'Fonts' ) }
 								onClick={ () => onSelect( 'font-pairings' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -15,7 +15,6 @@ import { NavigationButtonAsItem } from './navigator-buttons';
 import NavigatorHeader from './navigator-header';
 import { NavigatorItemGroup } from './navigator-item-group';
 import Survey from './survey';
-import type { Pattern } from './types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { MouseEvent } from 'react';
 
@@ -25,7 +24,7 @@ interface Props {
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 	surveyDismissed: boolean;
 	setSurveyDismissed: ( dismissed: boolean ) => void;
-	patterns: Pattern[];
+	hasSections: boolean;
 }
 
 const ScreenMain = ( {
@@ -34,7 +33,7 @@ const ScreenMain = ( {
 	recordTracksEvent,
 	surveyDismissed,
 	setSurveyDismissed,
-	patterns,
+	hasSections,
 }: Props ) => {
 	const translate = useTranslate();
 	const [ disabled, setDisabled ] = useState( true );
@@ -109,7 +108,7 @@ const ScreenMain = ( {
 							<span className="pattern-layout__list-item-text">{ translate( 'Header' ) }</span>
 						</NavigationButtonAsItem>
 						<NavigationButtonAsItem
-							path={ patterns.length ? NAVIGATOR_PATHS.SECTION : NAVIGATOR_PATHS.SECTION_PATTERNS }
+							path={ hasSections ? NAVIGATOR_PATHS.SECTION : NAVIGATOR_PATHS.SECTION_PATTERNS }
 							icon={ layout }
 							aria-label={ translate( 'Homepage' ) }
 							onClick={ () => onSelect( 'section' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75327

## Proposed Changes

- The "Homepage" screen won't show if there aren't patterns added. The user goes directly to the "Add patterns" screen
- The "Add patterns" screen has the first category open by default
- Allow toggling the category to hide the patterns panel
- The large preview is fully visible and the patterns panel doesn't float over it

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Click on the Calypso Live link in the first comment
- Create a new site with any plan
- Continue until the Design Picker
- Scroll down and click `Start designing`
- Click `Homepage` and verify
  - The  `Homepage` screen only shows when there are patterns selected
  - The `Back` and `Save` buttons go to the previous screen
- Verify that the large preview is fully visible
- Verify you can switch devices and scroll the large preview
- Verify you can click on a category to toggle the patterns panel
- Test patterns from the "Link in bio" category to test that they use the 100% viewport height 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
