### PR TITLE
Add `canUseTheme` selector

### DIFF
--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -17,12 +17,12 @@ import { getThemeType } from 'calypso/state/themes/selectors';
 import 'calypso/state/themes/init';
 
 /**
- * Get the theme type.
+ * Checks whether the given theme is included in the current plan of the site.
  *
  * @param  {Object}  state   Global state tree
  * @param  {number}  siteId  Site ID
  * @param  {string}  themeId Theme ID
- * @returns {boolean}         theme type
+ * @returns {boolean}         Whether the theme is included in the site plan.
  */
 export function canUseTheme( state, siteId, themeId ) {
 	const type = getThemeType( state, themeId );

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -12,7 +12,7 @@ import {
 	MARKETPLACE_THEME,
 } from '@automattic/design-picker';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { getThemeType } from 'calypso/state/themes/selectors/get-theme-type';
+import { getThemeType } from 'calypso/state/themes/selectors';
 
 import 'calypso/state/themes/init';
 

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -20,7 +20,7 @@ import 'calypso/state/themes/init';
  * Get the theme type.
  *
  * @param  {Object}  state   Global state tree
- * @param  {string}  siteId  Site ID
+ * @param  {number}  siteId  Site ID
  * @param  {string}  themeId Theme ID
  * @returns {boolean}         theme type
  */

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -1,0 +1,58 @@
+import {
+	FEATURE_WOOP,
+	WPCOM_FEATURES_ATOMIC,
+	WPCOM_FEATURES_PREMIUM_THEMES,
+	FEATURE_INSTALL_THEMES,
+} from '@automattic/calypso-products';
+import {
+	FREE_THEME,
+	PREMIUM_THEME,
+	DOT_ORG_THEME,
+	WOOCOMMERCE_THEME,
+	MARKETPLACE_THEME,
+} from '@automattic/design-picker';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getThemeType } from 'calypso/state/themes/selectors/get-theme-type';
+
+import 'calypso/state/themes/init';
+
+/**
+ * Get the theme type.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {string}  siteId  Site ID
+ * @param  {string}  themeId Theme ID
+ * @returns {boolean}         theme type
+ */
+export function canUseTheme( state, siteId, themeId ) {
+	const type = getThemeType( state, themeId );
+
+	if ( type === FREE_THEME ) {
+		return true;
+	}
+
+	if ( type === PREMIUM_THEME ) {
+		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES );
+	}
+
+	if ( type === DOT_ORG_THEME ) {
+		return siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES );
+	}
+
+	if ( type === WOOCOMMERCE_THEME ) {
+		return (
+			siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ) &&
+			siteHasFeature( state, siteId, FEATURE_WOOP ) &&
+			siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC )
+		);
+	}
+
+	if ( type === MARKETPLACE_THEME ) {
+		return (
+			siteHasFeature( state, siteId, FEATURE_WOOP ) &&
+			siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC )
+		);
+	}
+
+	return false;
+}

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -1,6 +1,7 @@
 export { arePremiumThemesEnabled } from 'calypso/state/themes/selectors/are-premium-themes-enabled';
 export { areRecommendedThemesLoading } from 'calypso/state/themes/selectors/are-recommended-themes-loading';
 export { areTrendingThemesLoading } from 'calypso/state/themes/selectors/are-trending-themes-loading';
+export { canUseTheme } from 'calypso/state/themes/selectors/can-use-theme';
 export { doesThemeBundleSoftwareSet } from 'calypso/state/themes/selectors/does-theme-bundle-software-set';
 export { doesThemeBundleUsableSoftwareSet } from 'calypso/state/themes/selectors/does-theme-bundle-usable-software-set';
 export { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-filter-term';


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2438

## Proposed Changes

In order to reuse the same component for rendering the theme type badges in the design picker and in the theme showcase (https://github.com/Automattic/dotcom-forge/issues/2438) we need a single way to infer whether the site has needed plan to activate a certain theme type.

This PR introduces a new `canUseTheme` selector to centralize that logic rather than duplicating it across the codebase. The new selector will be used a by a follow-up PR which will refactor how the theme type badges are rendered.

## Testing Instructions

N/A. The new selector is still unused, but you can manually test it in this follow-up PR: https://github.com/Automattic/wp-calypso/pull/77555
