### PR TITLE
Checkout: Do not save VAT info at checkout when logged-out

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -402,6 +402,7 @@ export default function WPCheckout( {
 							// When the contact details change, update the VAT details on the server.
 							try {
 								if (
+									! isLoggedOutCart &&
 									vatDetailsInForm.id &&
 									! areVatDetailsSame( vatDetailsInForm, vatDetailsFromServer )
 								) {

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -1485,6 +1485,18 @@ export function mockSetVatInfoEndpoint() {
 	return endpoint;
 }
 
+export function mockUserSignupValidationEndpoint( endpointResponse ) {
+	const endpoint = jest.fn();
+	endpoint.mockReturnValue( true );
+
+	nock( 'https://public-api.wordpress.com' )
+		.post( '/rest/v1.1/signups/validation/user/', ( body ) => {
+			return endpoint( body );
+		} )
+		.reply( endpointResponse );
+	return endpoint;
+}
+
 export function mockPayPalEndpoint( endpointResponse ) {
 	const endpoint = jest.fn();
 	endpoint.mockReturnValue( true );
@@ -1650,8 +1662,6 @@ export function mockContactDetailsValidationEndpoint(
 				return '/rest/v1.1/me/google-apps/validate';
 		}
 	} )();
-	const endpoint = jest.fn();
-	endpoint.mockReturnValue( true );
 	const mockResponse = () => [ 200, responseData ];
 	nock( 'https://public-api.wordpress.com' )
 		.post( endpointPath, conditionCallback )


### PR DESCRIPTION
## Proposed Changes

When using checkout, it's possible to enter VAT details. The VAT validation endpoint works with logged-out users, so this is fine. However, when validation completes, checkout attempts to _save_ the VAT details, which will never work for a logged-out user.

This PR changes the code to avoid trying to save the VAT details during checkout if the user is logged-out.

Screenshot of the error before this PR:

<img width="1088" alt="Screenshot 2023-05-30 at 2 23 48 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/de39bdb9-23f3-4038-a916-956772177f6b">

Screenshot after this PR:

<img width="927" alt="Screenshot 2023-05-30 at 2 29 44 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/79749149-811d-4d95-b56a-98051a43a21e">


## Testing Instructions

An automated test is included but you can test this manually as well:

- Visit checkout logged-out (eg: using an incognito window, visit `/checkout/jetpack/jetpack_security_t1_yearly`).
- In the contact step, select a country that allows VAT (eg: "United Kingdom") and a valid postal code (eg: `M1 1AE`).
- Check the box to add VAT details.
- Enter valid VAT details (eg: if you are sandboxed you can use the number `553557881` and any other info).
- Click "Continue".
- Verify that the step completes successfully.