### PR TITLE
Reader views: update check to expect a string for views value

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -180,7 +180,7 @@ class ReaderPostCard extends Component {
 				fullPost={ false }
 				onCommentClick={ onCommentClick }
 				showEdit={ false }
-				showViews={ ( post.views || 0 ) > 0 }
+				showViews={ !! post.views }
 				className="ignore-click"
 				iconSize={ 20 }
 			/>


### PR DESCRIPTION
## Proposed Changes

Small follow-up to https://github.com/Automattic/wp-calypso/pull/76803

I've changed the `views` property to return a string, rather than a raw count. This updates the `showViews` check to account for that.

## Testing Instructions

Combine with D110502-code and see that views show up in the Reader post card, as described in the original PR.
