### PR TITLE
Jetpack Cloud: Make skip-link on pricing page scroll to main content

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -24,7 +24,7 @@ import useUserMenu from './use-user-menu';
 
 import './style.scss';
 
-export const MAIN_CONTENT_ID = 'content';
+export const MAIN_CONTENT_ID = 'pricing-content';
 
 const JETPACK_COM_BASE_URL = 'https://jetpack.com';
 


### PR DESCRIPTION
This PR seeks to fix the "Skip to main content" accessibility skip-link on the pricing page, which currently doesn't work because the ID it looks for (`#content`) is not unique on the page.

Resolves #77562.

## Proposed Changes

* Rename the ID for the pricing page's main content anchor, so that browsers can scroll to it.

## Testing Instructions

1. Verify the issue: follow the instructions in #77562 to see the bug in action.
2. Visit the same pricing page using the code in this pull request (either via Calypso Live or in a local testing environment).
3. Follow the same instructions as in step 1. The page should correctly scroll to the main content of the page, and pressing the Tab key should start its navigation sequence at the top of the main content.