### PR TITLE
Showing only free themes and default variation for design-first flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -129,7 +129,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			allDesigns.designs = allDesigns.designs.filter( ( design ) => design.is_premium === false );
 
 			allDesigns.designs = allDesigns.designs.map( ( design ) => {
-				design.style_variations = design.style_variations.filter(
+				design.style_variations = design.style_variations?.filter(
 					( variation ) => variation.slug === 'default'
 				);
 				return design;
@@ -186,7 +186,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	} );
 
 	if ( isDesignFirstFlow && selectedDesignDetails?.style_variations ) {
-		selectedDesignDetails.style_variations = selectedDesignDetails?.style_variations[ 0 ];
+		selectedDesignDetails.style_variations = [];
 	}
 
 	const selectedStyleVariation = useSelect(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -58,6 +58,7 @@ const SiteIntent = Onboard.SiteIntent;
 const SITE_ASSEMBLER_AVAILABLE_INTENTS: string[] = [ SiteIntent.Build, SiteIntent.Write ];
 
 const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
+	const queryParams = useQuery();
 	const { goBack, submit, exitFlow } = navigation;
 
 	const reduxDispatch = useReduxDispatch();
@@ -80,6 +81,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const siteTitle = site?.name;
 	const siteDescription = site?.description;
 	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles( site?.ID );
+	const isDesignFirstFlow = queryParams.get( 'flowToReturnTo' ) === 'design-first';
 
 	const { goToCheckout } = useCheckout();
 
@@ -121,6 +123,17 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			) {
 				allDesigns.designs.push( ...blankCanvasDesign );
 			}
+		}
+
+		if ( isDesignFirstFlow ) {
+			allDesigns.designs = allDesigns.designs.filter( ( design ) => design.is_premium === false );
+
+			allDesigns.designs = allDesigns.designs.map( ( design ) => {
+				design.style_variations = design.style_variations.filter(
+					( variation ) => variation.slug === 'default'
+				);
+				return design;
+			} );
 		}
 
 		return allDesigns;
@@ -172,6 +185,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		enabled: isPreviewingDesign && selectedDesignHasStyleVariations,
 	} );
 
+	if ( isDesignFirstFlow && selectedDesignDetails?.style_variations ) {
+		selectedDesignDetails.style_variations = selectedDesignDetails?.style_variations[ 0 ];
+	}
+
 	const selectedStyleVariation = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedStyleVariation(),
 		[]
@@ -187,7 +204,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	// When the theme or style query strings parameters are present,
 	// automatically switch to previewing that theme (if it's a valid theme)
 	// and that style variation (if it's a valid style variation).
-	const queryParams = useQuery();
 	const themeFromQueryString = queryParams.get( 'theme' );
 	const styleFromQueryString = queryParams.get( 'style' );
 	const hideBackFromQueryString = queryParams.get( 'hideBack' );
@@ -704,6 +720,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	);
 
 	const currentPlanFeatures = site?.plan?.features.active ?? [];
+
+	if ( isDesignFirstFlow ) {
+		categorization.categories = [];
+		categorization.selection = 'blog';
+	}
 
 	const stepContent = (
 		<UnifiedDesignPicker


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2583-gh-Automattic/dotcom-forge

## Proposed Changes

* User can't see paid themes while in the design-first flow
* User can't see paid custom styles while in the design-first flow
* Paid themes and custom styles should still be available for other flows

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the new /setup/design-first flow
* On Theme selection, ensure you only see free themes and no more than the default variation (which won't show since we're hiding the siblings variations)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?