### PR TITLE
Stepper: Add disabled button logic to Setup form

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
@@ -58,6 +58,7 @@ const SetupForm = ( {
 }: SetupFormProps ) => {
 	const { __ } = useI18n();
 	const usesSite = !! useSiteSlugParam();
+	const isTitleEmpty = siteTitle.trim().length === 0;
 
 	const imageFileToBase64 = ( file: Blob ) => {
 		const reader = new FileReader();
@@ -121,7 +122,11 @@ const SetupForm = ( {
 				/>
 			</FormFieldset>
 			{ children }
-			<Button className="setup-form__submit" disabled={ isLoading } type="submit">
+			<Button
+				className={ `setup-form__submit ${ isTitleEmpty && 'disabled' }` }
+				disabled={ isLoading }
+				type="submit"
+			>
 				{ isLoading ? __( 'Loading' ) : translatedText?.buttonText ?? __( 'Continue' ) }
 			</Button>
 			{ isSubmitError && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
@@ -91,13 +91,20 @@
 		// adds +2 px of padding to the button to match the input field height
 		padding: 10px 14px;
 		margin-top: 16px;
+		&.disabled,
+		&.disabled:focus,
+		&.disabled:hover,
+		&:disabled {
+			background: var(--studio-blue-20);
+			cursor: default;
+		}
 		&:focus {
 			box-shadow: none;
 			outline: 2px solid var(--studio-blue-60);
 			outline-offset: 1px;
 			background: var(--studio-blue-60);
 		}
-		&:hover:not([disabled]) {
+		&:hover {
 			background-color: var(--wp-admin-theme-color-darker-10);
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/77223

## Proposed Changes

* Adds a disabled class and styling to the Newsletter setup screen button when the site title is empty.
* This change will affect all onboarding flows that use the setup form. 
* Adding a class vs disabling the button entirely allows users to still click the button, which will show the existing validation notice by the site title, so users can get clarity on what they need to do. 

**Video of new button behavior**

https://github.com/Automattic/wp-calypso/assets/21228350/2e81f161-58c1-4361-aeec-370c1be9b0a2

## Testing Instructions

1. Check out this branch and run yarn and yarn start if needed
2. Go to http://calypso.localhost:3000/setup/newsletter/intro to start a newsletter site. Confirm the button behaves like the video above. 
3. Continue to Launchpad and click Personalize your newsletter to go to post-setup screen. Again confirm button behaves as expected. 
4. Re-test this using at least one of the following flows.
   - http://calypso.localhost:3000/setup/free/intro
   - http://calypso.localhost:3000/setup/link-in-bio/intro
   - http://calypso.localhost:3000/setup/videopress

