### PR TITLE
Marketplace Thank You: Add support for SaaS products to redirect to the Thank You page

### DIFF
--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -544,7 +544,10 @@ function getFallbackDestination( {
 		cart?.products?.filter( ( product ) => product?.extra?.is_marketplace_product ) || [];
 
 	const marketplacePluginSlugs = marketplaceProducts
-		.filter( ( { extra } ) => extra.product_type === 'marketplace_plugin' )
+		.filter(
+			( { extra } ) =>
+				extra.product_type === 'marketplace_plugin' || extra.product_type === 'saas_plugin'
+		)
 		.map( ( { extra } ) => extra.product_slug );
 
 	const marketplaceThemeSlugs = marketplaceProducts

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -569,7 +569,7 @@ export interface ResponseCartProductExtra {
 	 */
 	is_marketplace_product?: boolean;
 	product_slug?: string;
-	product_type?: 'marketplace_plugin' | 'marketplace_theme';
+	product_type?: 'marketplace_plugin' | 'marketplace_theme' | 'saas_plugin';
 }
 
 export interface ResponseCartGiftDetails {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2247

## Proposed Changes

Redirect to the default Marketplace Thank You page when the purchased SaaS product doesn't have a return_url set.

This PR allows the correct mounting of the Thank You page URL by adding the `saas_plugin` product_type.

## Testing Instructions
* Apply the diff D112730-code and follow its test instructions
* When no `return_url` is passed, you should be redirected to the default Marketplace Thank You page

<img width="1224" alt="CleanShot 2023-06-02 at 10 09 03@2x" src="https://github.com/Automattic/wp-calypso/assets/5039531/a9e9c4f9-80a4-4aba-833d-c4a16b74bddf">


**Regression test**
* Create an intent with a `return_url`
* Make sure after the purchase you are redirected to the specified URL


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?