### PR TITLE
Newsletters: Add skip button to subscribers form

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -32,7 +32,7 @@ const Subscribers: Step = function ( { navigation } ) {
 
 	const submitButtonText = isImportValid
 		? translate( 'Add and continue' )
-		: translate( 'Skip for now' );
+		: translate( 'Add subscribers' );
 
 	return (
 		<StepContainer
@@ -51,14 +51,17 @@ const Subscribers: Step = function ( { navigation } ) {
 							flowName="onboarding_subscribers"
 							submitBtnName={ submitButtonText }
 							onImportFinished={ handleSubmit }
+							onSkipBtnClick={ handleSubmit }
 							onChangeIsImportValid={ ( isValid ) => setIsImportValid( isValid ) }
-							allowEmptyFormSubmit={ true }
+							allowEmptyFormSubmit={ false }
 							manualListEmailInviting={ ! isUserEligibleForSubscriberImporter }
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 							recordTracksEvent={ recordTracksEvent }
 							titleText={ translate( 'Ready to add your first subscribers?' ) }
 							subtitleText={ subtitleText }
 							showSubtitle={ true }
+							showSkipLink={ true }
+							submitBtnAlwaysEnable={ false }
 						/>
 					) }
 				</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
@@ -44,6 +44,16 @@
 			display: block;
 			width: 100%;
 			margin: 2rem 0;
+			&:disabled {
+				color: var(--studio-white);
+			}
+		}
+
+		.add-subscriber__form-skip-link-wrapper {
+			justify-content: center;
+			.add-subscriber__form-skip-link {
+				color: var(--studio-blue-50);
+			}
 		}
 
 		.add-subscriber__form--container .form-input-validation.is-error.is-file-validation {

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -69,6 +69,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		onChangeIsImportValid,
 		titleText,
 		subtitleText,
+		showSkipLink,
 	} = props;
 
 	const {
@@ -510,7 +511,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					>
 						{ submitBtnName }
 					</NextButton>
-					{ props.showSkipLink && (
+					{ showSkipLink && (
 						<div className="add-subscriber__form-skip-link-wrapper">
 							<button className="add-subscriber__form-skip-link" onClick={ props.onSkipBtnClick }>
 								{ translate( 'Skip for now' ) }

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -43,6 +43,7 @@ interface Props {
 	onChangeIsImportValid?: ( isValid: boolean ) => void;
 	titleText?: string;
 	subtitleText?: string;
+	showSkipLink?: boolean;
 }
 
 export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
@@ -96,7 +97,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const [ isDirtyEmails, setIsDirtyEmails ] = useState< boolean[] >( [] );
 	const [ emailFormControls, setEmailFormControls ] = useState( emailControlPlaceholder );
 	const [ submitAttemptCount, setSubmitAttemptCount ] = useState( 0 );
-	const [ submitBtnReady, setIsSubmitBtnReady ] = useState( isSubmitButtonReady() );
+
 	const importSelector = useSelect(
 		( select ) => select( Subscriber.store ).getImportSubscribersSelector(),
 		[]
@@ -112,6 +113,12 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const getValidEmails = useCallback( () => {
 		return isValidEmails.map( ( x, i ) => x && emails[ i ] ).filter( ( x ) => !! x ) as string[];
 	}, [ isValidEmails, emails ] );
+
+	// This useState call has been moved below getValidEmails() to resolve
+	// an error with calling getValidEmails() before it is initialized.
+	// The next line calls isSubmitButtonReady() which invokes getValidEmails()
+	// if submitBtnAlwaysEnable and allowEmptyFormSubmit are both false.
+	const [ submitBtnReady, setIsSubmitBtnReady ] = useState( isSubmitButtonReady() );
 
 	/**
 	 * ↓ Effects
@@ -503,6 +510,13 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					>
 						{ submitBtnName }
 					</NextButton>
+					{ props.showSkipLink && (
+						<div className="add-subscriber__form-skip-link-wrapper">
+							<button className="add-subscriber__form-skip-link" onClick={ props.onSkipBtnClick }>
+								{ translate( 'Skip for now' ) }
+							</button>
+						</div>
+					) }
 					{ showCsvUpload && ! includesHandledError() && renderImportCsvDisclaimerMsg() }
 				</form>
 			</div>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -67,6 +67,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		recordTracksEvent,
 		onImportFinished,
 		onChangeIsImportValid,
+		onSkipBtnClick,
 		titleText,
 		subtitleText,
 		showSkipLink,
@@ -513,7 +514,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					</NextButton>
 					{ showSkipLink && (
 						<div className="add-subscriber__form-skip-link-wrapper">
-							<button className="add-subscriber__form-skip-link" onClick={ props.onSkipBtnClick }>
+							<button className="add-subscriber__form-skip-link" onClick={ onSkipBtnClick }>
 								{ translate( 'Skip for now' ) }
 							</button>
 						</div>

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -59,7 +59,7 @@
 	.add-subscriber__form-skip-link-wrapper {
 		display: flex;
 		justify-content: flex-start;
-		padding: 16px 0;
+		padding: 1rem 0;
 		.add-subscriber__form-skip-link {
 			color: var(--color-primary);
 			font-weight: 500;

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -55,6 +55,17 @@
 	.components-notice.is-info {
 		background: var(--studio-gray-0);
 	}
+
+	.add-subscriber__form-skip-link-wrapper {
+		display: flex;
+		justify-content: flex-start;
+		padding: 16px 0;
+		.add-subscriber__form-skip-link {
+			color: var(--color-primary);
+			font-weight: 500;
+			cursor: pointer;
+		}
+	}
 }
 
 .add-subscriber .add-subscriber__title-container {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/77247

## Proposed Changes

* Adds an optional skip link to the AddSubcribersForm component, via a prop and conditional mark up. 
* Display the new skip link on the Subscribers screen during the Newsletter onboarding flow.
* Disable the Add and Continue button until subscribers have been added (now that skip link is separate).
* These changes also revealed a small issue where AddSubcribersForm component was invoking a method before initialization when given a specific set of prop values.  

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Check out this branch and run yarn and yarn start if needed. 
2) Start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro and proceed to Subscribers screen.
3) Confirm the main button is disabled. Add a valid email to one field, and confirm the button is now enabled. 
4) Confirm the Skip for now link shows as expected and, when clicks, takes you to Launchpad.
5) Test to confirm no regressive breakage in other places where the AddSubscriberForm is used. You can test this by going to http://calypso.localhost:3000/people/add-subscribers/YOURDOMAIN. You should see the Add Subscribers form on this page, but the Skip for now link should not show.
