### PR TITLE
Plugins: Specify selector types when TypeScript cannot infer

### DIFF
--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -15,7 +15,6 @@ import type {
 	PluginSites,
 	PluginStatus,
 } from './types';
-import type { SiteDetails } from '@automattic/data-stores';
 import type { AppState } from 'calypso/types';
 
 import 'calypso/state/plugins/init';
@@ -61,7 +60,7 @@ const getSiteIdsThatHavePlugins = createSelector(
 		return Object.keys( state.plugins.installed.plugins ).map( ( siteId ) => Number( siteId ) );
 	},
 	( state: AppState ) => [ state.plugins.installed.plugins ]
-) as ( state: AppState ) => number[];
+);
 
 /**
  * The server returns plugins store at state.plugins.installed.plugins are indexed by site, which means
@@ -176,7 +175,7 @@ export const getAllPluginsIndexedBySiteId = createSelector(
 		getAllPluginsIndexedByPluginSlug( state ),
 		getSiteIdsThatHavePlugins( state ),
 	]
-) as { ( state: AppState ): { [ siteId: number ]: { [ pluginSlug: string ]: Plugin } } };
+);
 
 export const getFilteredAndSortedPlugins = createSelector(
 	( state: AppState, siteIds: number[], pluginFilter?: PluginFilter ) => {
@@ -228,7 +227,7 @@ export const getFilteredAndSortedPlugins = createSelector(
 	( state: AppState, siteIds: number[], pluginFilter?: PluginFilter ) => {
 		return [ siteIds, pluginFilter ].flat().join( '-' );
 	}
-) as ( state: AppState, siteIds: number[], pluginFilter?: PluginFilter ) => Plugin[];
+);
 
 export function getPluginsWithUpdates( state: AppState, siteIds: number[] ) {
 	return getFilteredAndSortedPlugins( state, siteIds, 'updates' ).map( ( plugin ) => ( {
@@ -313,7 +312,7 @@ export const getSitesWithPlugin = createSelector(
 	},
 	( state: AppState ) => [ getAllPluginsIndexedByPluginSlug( state ), getSitesItems( state ) ],
 	( state: AppState, siteIds: number[], pluginSlug: string ) => [ pluginSlug, ...siteIds ].join()
-) as ( state: AppState, siteIds: number[], pluginSlug: string ) => number[];
+);
 
 export const getSiteObjectsWithPlugin = createSelector(
 	( state: AppState, siteIds: number[], pluginSlug: string ) => {
@@ -322,7 +321,7 @@ export const getSiteObjectsWithPlugin = createSelector(
 	},
 	( state: AppState ) => [ getAllPluginsIndexedByPluginSlug( state ), getSitesItems( state ) ],
 	( state: AppState, siteIds: number[], pluginSlug: string ) => [ pluginSlug, ...siteIds ].join()
-) as ( state: AppState, siteIds: number[], pluginSlug: string ) => SiteDetails[];
+);
 
 export const getSitesWithoutPlugin = createSelector(
 	( state: AppState, siteIds: number[], pluginSlug: string ) => {
@@ -344,7 +343,7 @@ export const getSitesWithoutPlugin = createSelector(
 	},
 	( state: AppState ) => [ getAllPluginsIndexedByPluginSlug( state ), getSitesItems( state ) ],
 	( state: AppState, siteIds: number[], pluginSlug: string ) => [ pluginSlug, ...siteIds ].join()
-) as ( state: AppState, siteIds: number[], pluginSlug: string ) => number[];
+);
 
 export const getSiteObjectsWithoutPlugin = createSelector(
 	( state: AppState, siteIds: number[], pluginSlug: string ) => {
@@ -353,7 +352,7 @@ export const getSiteObjectsWithoutPlugin = createSelector(
 	},
 	( state: AppState ) => [ getAllPluginsIndexedByPluginSlug( state ), getSitesItems( state ) ],
 	( state: AppState, siteIds: number[], pluginSlug: string ) => [ pluginSlug, ...siteIds ].join()
-) as ( state: AppState, siteIds: number[], pluginSlug: string ) => SiteDetails[];
+);
 
 export function getStatusForPlugin(
 	state: AppState,

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -358,7 +358,7 @@ export function getStatusForPlugin(
 	state: AppState,
 	siteId: number,
 	pluginId: string
-): { [ key: string ]: string } | undefined {
+): PluginStatus | undefined {
 	if ( typeof state.plugins.installed.status[ siteId ]?.[ pluginId ] === 'undefined' ) {
 		return undefined;
 	}

--- a/client/state/plugins/installed/types.ts
+++ b/client/state/plugins/installed/types.ts
@@ -36,13 +36,15 @@ export type Plugin = {
 	wporg?: boolean;
 };
 
+export type PluginSite = {
+	active: boolean;
+	autoupdate: boolean;
+	update?: PluginUpdate;
+	version: string;
+};
+
 export type PluginSites = {
-	[ siteId: string ]: {
-		active: boolean;
-		autoupdate: boolean;
-		update?: PluginUpdate;
-		version: string;
-	};
+	[ siteId: string ]: PluginSite;
 };
 
 export type PluginUpdate = {

--- a/client/state/plugins/installed/types.ts
+++ b/client/state/plugins/installed/types.ts
@@ -6,10 +6,8 @@ export type InstalledPlugins = {
 };
 
 export type InstalledPluginData = {
-	active: boolean;
 	author: string;
 	author_url: string;
-	autoupdate: boolean;
 	description: string;
 	id: string;
 	name: string;
@@ -17,9 +15,7 @@ export type InstalledPluginData = {
 	plugin_url: string;
 	slug: string;
 	uninstallable: boolean;
-	update?: PluginUpdate;
-	version: string;
-};
+} & PluginSite;
 
 // This is the plugin as it is exposed by the selectors
 export type Plugin = {

--- a/client/state/plugins/installed/types.ts
+++ b/client/state/plugins/installed/types.ts
@@ -60,4 +60,5 @@ export type PluginStatus = {
 	pluginId: string;
 	siteId: number;
 	status: string;
+	error: string;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR addresses a few issues noted in this recent incident report: p58i-eyE-p2

* The types of the selectors are specified when TypeScript cannot infer them. This would have avoided the fatal error which led to the incident report.
* An error in `getPluginOnSite` where the `sites` property could be accessed before checking for its existence is resolved.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Use the TypeScript tools in your favorite IDE to ensure that all selectors have return types which are either correctly specified or inferred. (`requestPluginsError` is an exception. It is used only as a truthy/falsey but I suspect it is actually an object and I do not know its type.)

Verify that the unit tests pass and Calypso has no type errors. There is no functional testing to do as the altered functions are not in use yet.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?