### PR TITLE
Import flow: Implement conditional confirm modal on ready screen

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/confirm-modal.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/confirm-modal.tsx
@@ -1,0 +1,34 @@
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import * as React from 'react';
+import ConfirmModal from 'calypso/blocks/importer/components/confirm-modal';
+
+interface Props {
+	sourceSiteSlug: string;
+	targetSiteSlug: string;
+	onClose: () => void;
+	onConfirm: () => void;
+}
+const ConfirmModalPrompt: React.FunctionComponent< Props > = ( props ) => {
+	const { __ } = useI18n();
+	const { sourceSiteSlug, targetSiteSlug, onClose, onConfirm } = props;
+
+	return (
+		<ConfirmModal onClose={ () => onClose() } onConfirm={ () => onConfirm() }>
+			<p>
+				{ sprintf(
+					/* translators: the `sourceSite` and `targetSite` fields could be any site URL (eg: "yourname.com") */
+					__(
+						'Your site %(sourceSite)s will be migrated to %(targetSite)s, overriding all the content in your destination site. '
+					),
+					{
+						sourceSite: sourceSiteSlug,
+						targetSite: targetSiteSlug,
+					}
+				) }
+			</p>
+		</ConfirmModal>
+	);
+};
+
+export default ConfirmModalPrompt;

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -50,7 +50,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 
 	const [ showCredentials, setShowCredentials ] = useState( false );
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
-	const [ migrationConfirmed ] = useMigrationConfirmation();
+	const [ migrationConfirmed, setMigrationConfirmed ] = useMigrationConfirmation();
 	const [ selectedHost, setSelectedHost ] = useState( 'generic' );
 	const [ selectedProtocol, setSelectedProtocol ] = useState< 'ftp' | 'ssh' >( 'ftp' );
 	const [ hasLoaded, setHasLoaded ] = useState( false );
@@ -185,7 +185,11 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 						sourceSiteSlug={ sourceSiteSlug }
 						targetSiteSlug={ targetSite.slug }
 						onClose={ () => setShowConfirmModal( false ) }
-						onConfirm={ () => startImport( { type: 'without-credentials' } ) }
+						onConfirm={ () => {
+							// reset migration confirmation to initial state
+							setMigrationConfirmed( false );
+							startImport( { type: 'without-credentials' } );
+						} }
 					/>
 				) }
 				<div

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -13,12 +13,14 @@ import { UpdatePluginInfo } from 'calypso/blocks/importer/wordpress/import-every
 import { PreMigrationUpgradePlan } from 'calypso/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan';
 import { FormState } from 'calypso/components/advanced-credentials/form';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import useMigrationConfirmation from 'calypso/landing/stepper/hooks/use-migration-confirmation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCredentials } from 'calypso/state/jetpack/credentials/actions';
 import getJetpackCredentials from 'calypso/state/selectors/get-jetpack-credentials';
 import isRequestingSiteCredentials from 'calypso/state/selectors/is-requesting-site-credentials';
+import ConfirmModal from './confirm-modal';
 import { CredentialsHelper } from './credentials-helper';
 import { StartImportTrackingProps } from './types';
 
@@ -47,6 +49,8 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	const dispatch = useDispatch();
 
 	const [ showCredentials, setShowCredentials ] = useState( false );
+	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
+	const [ migrationConfirmed ] = useMigrationConfirmation();
 	const [ selectedHost, setSelectedHost ] = useState( 'generic' );
 	const [ selectedProtocol, setSelectedProtocol ] = useState< 'ftp' | 'ssh' >( 'ftp' );
 	const [ hasLoaded, setHasLoaded ] = useState( false );
@@ -175,30 +179,40 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		}
 
 		return (
-			<div
-				className={ classnames( 'import__pre-migration import__import-everything', {
-					'import__import-everything--redesign': isEnabled( 'onboarding/import-redesign' ),
-				} ) }
-			>
-				<div className="import__heading-title">
-					<Title>{ translate( 'You are ready to migrate' ) }</Title>
-				</div>
-				{ renderCredentialsFormSection() }
-				{ ! showCredentials && (
-					<div className="import__footer-button-container pre-migration__proceed">
-						<NextButton
-							type="button"
-							onClick={ () =>
-								startImport( {
-									type: 'without-credentials',
-								} )
-							}
-						>
-							{ translate( 'Start migration' ) }
-						</NextButton>
-					</div>
+			<>
+				{ showConfirmModal && (
+					<ConfirmModal
+						sourceSiteSlug={ sourceSiteSlug }
+						targetSiteSlug={ targetSite.slug }
+						onClose={ () => setShowConfirmModal( false ) }
+						onConfirm={ () => startImport( { type: 'without-credentials' } ) }
+					/>
 				) }
-			</div>
+				<div
+					className={ classnames( 'import__pre-migration import__import-everything', {
+						'import__import-everything--redesign': isEnabled( 'onboarding/import-redesign' ),
+					} ) }
+				>
+					<div className="import__heading-title">
+						<Title>{ translate( 'You are ready to migrate' ) }</Title>
+					</div>
+					{ renderCredentialsFormSection() }
+					{ ! showCredentials && (
+						<div className="import__footer-button-container pre-migration__proceed">
+							<NextButton
+								type="button"
+								onClick={ () => {
+									migrationConfirmed
+										? startImport( { type: 'without-credentials' } )
+										: setShowConfirmModal( true );
+								} }
+							>
+								{ translate( 'Start migration' ) }
+							</NextButton>
+						</div>
+					) }
+				</div>
+			</>
 		);
 	}
 

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
@@ -48,12 +48,8 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 	const isFormSubmissionPending = formSubmissionStatus === 'pending';
 	const formHasErrors = formErrors && Object.keys( formErrors ).length > 0;
 
-	useEffect( () => {
-		// Clear the hasMissingFields flag when there are no more errors.
-		if ( ! formHasErrors ) {
-			setHasMissingFields( false );
-		}
-	}, [ formErrors ] );
+	// Clear the hasMissingFields flag when there are no more errors.
+	useEffect( () => setHasMissingFields( formHasErrors ), [ formErrors ] );
 
 	// validate changes to the credentials form
 	useEffect( () => {
@@ -155,9 +151,8 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 	);
 
 	useEffect( () => {
-		if ( updateError ) {
+		updateError &&
 			dispatch( recordTracksEvent( 'calypso_site_migration_credentials_update_error' ) );
-		}
 	}, [ updateError ] );
 
 	return (

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
@@ -83,10 +83,10 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 
 	const startImportCallback = useCallback(
 		( args ) => {
-			startImport( args );
-			setShowConfirmModal( false );
 			// reset migration confirmation to initial state
 			setMigrationConfirmed( false );
+			setShowConfirmModal( false );
+			startImport( args );
 		},
 		[ startImport ]
 	);

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
@@ -47,35 +47,9 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 
 	const isFormSubmissionPending = formSubmissionStatus === 'pending';
 	const formHasErrors = formErrors && Object.keys( formErrors ).length > 0;
-
-	// Clear the hasMissingFields flag when there are no more errors.
-	useEffect( () => setHasMissingFields( formHasErrors ), [ formErrors ] );
-
-	// validate changes to the credentials form
-	useEffect( () => {
-		const errors = validate( formState, formMode );
-
-		// Shorten the root user error message as the original message used in the form is too long.
-		if ( formState.user === 'root' ) {
-			errors.user = {
-				message: translate( "We can't accept credentials for the root user." ),
-				waitForInteraction: true,
-			};
-		}
-
-		if ( typeof formState.port === 'string' ) {
-			errors.port = {
-				message: translate( 'Invalid port.' ),
-				waitForInteraction: true,
-			};
-		}
-
-		setFormErrors( errors );
-	}, [ formState, formMode ] );
-
-	useEffect( () => {
-		props.onChangeProtocol( formState.protocol as CredentialsProtocol );
-	}, [ formState.protocol ] );
+	const updateError = useSelector( ( state ) =>
+		getJetpackCredentialsUpdateError( state, sourceSite.ID )
+	);
 
 	const startImportCallback = useCallback(
 		( args ) => {
@@ -86,14 +60,6 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 		},
 		[ startImport ]
 	);
-
-	useEffect( () => {
-		switch ( formSubmissionStatus ) {
-			case 'success':
-				startImportCallback( { type: 'with-credentials' } );
-				break;
-		}
-	}, [ formSubmissionStatus, startImportCallback ] );
 
 	const handleUpdateCredentials = () => {
 		if ( formHasErrors ) {
@@ -146,9 +112,44 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 		]
 	);
 
-	const updateError = useSelector( ( state ) =>
-		getJetpackCredentialsUpdateError( state, sourceSite.ID )
-	);
+	// Clear the hasMissingFields flag when there are no more errors.
+	useEffect( () => {
+		! formHasErrors && setHasMissingFields( false );
+	}, [ formErrors ] );
+
+	// validate changes to the credentials form
+	useEffect( () => {
+		const errors = validate( formState, formMode );
+
+		// Shorten the root user error message as the original message used in the form is too long.
+		if ( formState.user === 'root' ) {
+			errors.user = {
+				message: translate( "We can't accept credentials for the root user." ),
+				waitForInteraction: true,
+			};
+		}
+
+		if ( typeof formState.port === 'string' ) {
+			errors.port = {
+				message: translate( 'Invalid port.' ),
+				waitForInteraction: true,
+			};
+		}
+
+		setFormErrors( errors );
+	}, [ formState, formMode ] );
+
+	useEffect( () => {
+		props.onChangeProtocol( formState.protocol as CredentialsProtocol );
+	}, [ formState.protocol ] );
+
+	useEffect( () => {
+		switch ( formSubmissionStatus ) {
+			case 'success':
+				startImportCallback( { type: 'with-credentials' } );
+				break;
+		}
+	}, [ formSubmissionStatus, startImportCallback ] );
 
 	useEffect( () => {
 		updateError &&

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
@@ -16,14 +16,14 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { updateCredentials } from 'calypso/state/jetpack/credentials/actions';
 import getJetpackCredentialsUpdateError from 'calypso/state/selectors/get-jetpack-credentials-update-error';
 import getJetpackCredentialsUpdateStatus from 'calypso/state/selectors/get-jetpack-credentials-update-status';
-import { StartImportTrackingProps } from './types';
+import type { CredentialsProtocol, CredentialsStatus, StartImportTrackingProps } from './types';
 
 interface Props {
 	sourceSite: SiteDetails;
 	targetSite: SiteDetails;
 	startImport: ( props?: StartImportTrackingProps ) => void;
 	selectedHost: string;
-	onChangeProtocol: ( protocol: 'ftp' | 'ssh' ) => void;
+	onChangeProtocol: ( protocol: CredentialsProtocol ) => void;
 }
 
 export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( props ) => {
@@ -36,13 +36,9 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 	const [ formMode, setFormMode ] = useState( FormMode.Password );
 	const [ hasMissingFields, setHasMissingFields ] = useState( false );
 
-	const formSubmissionStatus = useSelector(
+	const formSubmissionStatus: CredentialsStatus = useSelector(
 		( state ) =>
-			getJetpackCredentialsUpdateStatus( state, sourceSite.ID ) as
-				| 'unsubmitted'
-				| 'pending'
-				| 'success'
-				| 'failed'
+			getJetpackCredentialsUpdateStatus( state, sourceSite.ID )
 	);
 
 	const isFormSubmissionPending = formSubmissionStatus === 'pending';
@@ -78,7 +74,7 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 	}, [ formState, formMode ] );
 
 	useEffect( () => {
-		props.onChangeProtocol( formState.protocol as 'ftp' | 'ssh' );
+		props.onChangeProtocol( formState.protocol as CredentialsProtocol );
 	}, [ formState.protocol ] );
 
 	useEffect( () => {

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
@@ -92,15 +92,12 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 	);
 
 	useEffect( () => {
-		if ( formSubmissionStatus === 'success' ) {
-			if ( ! migrationConfirmed ) {
-				setShowConfirmModal( true );
-				setConfirmCallback( () => startImportCallback.bind( null, { type: 'with-credentials' } ) );
-			} else {
+		switch ( formSubmissionStatus ) {
+			case 'success':
 				startImportCallback( { type: 'with-credentials' } );
-			}
+				break;
 		}
-	}, [ formSubmissionStatus ] );
+	}, [ formSubmissionStatus, startImportCallback ] );
 
 	const handleUpdateCredentials = () => {
 		if ( formHasErrors ) {
@@ -124,17 +121,33 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 
 	const submitCredentials = useCallback(
 		( e ) => {
-			e.preventDefault();
-			setHasMissingFields( false );
-			// If the form is submitted with errors, prevent the submission and show the errors.
-			if ( formHasErrors ) {
-				setHasMissingFields( true );
-				return;
-			}
+			const _confirmCallback = () => {
+				setShowConfirmModal( false );
+				setMigrationConfirmed( true );
+				setHasMissingFields( false );
+				// If the form is submitted with errors, prevent the submission and show the errors.
+				if ( formHasErrors ) {
+					setHasMissingFields( true );
+					return;
+				}
 
-			migrateProvision( targetSite.ID, sourceSite.ID, true );
+				migrateProvision( targetSite.ID, sourceSite.ID, true );
+			};
+
+			e.preventDefault();
+			setConfirmCallback( () => _confirmCallback );
+			migrationConfirmed ? _confirmCallback?.() : setShowConfirmModal( true );
 		},
-		[ formHasErrors, dispatch, sourceSite.ID, formState, formMode ]
+		[
+			formHasErrors,
+			migrationConfirmed,
+			migrateProvision,
+			targetSite,
+			sourceSite,
+			setShowConfirmModal,
+			setMigrationConfirmed,
+			setHasMissingFields,
+		]
 	);
 
 	const updateError = useSelector( ( state ) =>

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/types.ts
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/types.ts
@@ -1,3 +1,7 @@
 export interface StartImportTrackingProps {
 	type: string;
 }
+
+export type CredentialsStatus = 'unsubmitted' | 'pending' | 'success' | 'failed';
+
+export type CredentialsProtocol = 'ftp' | 'ssh';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -1,12 +1,12 @@
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer, IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 import CaptureStep from 'calypso/blocks/import/capture';
 import CaptureStepRetired from 'calypso/blocks/import/capture-retired';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useCurrentRoute } from 'calypso/landing/stepper/hooks/use-current-route';
+import useMigrationConfirmation from 'calypso/landing/stepper/hooks/use-migration-confirmation';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { BASE_ROUTE } from './config';
 import { generateStepPath } from './helper';
@@ -19,9 +19,12 @@ export const ImportWrapper: Step = function ( props ) {
 	const { __ } = useI18n();
 	const { navigation, children, stepName, flow } = props;
 	const currentRoute = useCurrentRoute();
+	const [ , setMigrationConfirmed ] = useMigrationConfirmation();
 	const shouldHideBackBtn = currentRoute === `${ IMPORT_FOCUSED_FLOW }/${ BASE_ROUTE }`;
 	const skipLabelText =
 		flow === IMPORT_FOCUSED_FLOW ? __( 'Skip to dashboard' ) : __( "I don't have a site address" );
+
+	useEffect( () => setMigrationConfirmed( false ), [] );
 
 	const shouldHideSkipBtn = () => {
 		switch ( flow ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -5,9 +5,11 @@ import {
 } from '@automattic/sites';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useState } from 'react';
+import { defer } from 'lodash';
+import React, { useState, useEffect } from 'react';
 import ConfirmModal from 'calypso/blocks/importer/components/confirm-modal';
 import DocumentHead from 'calypso/components/data/document-head';
+import useMigrationConfirmation from 'calypso/landing/stepper/hooks/use-migration-confirmation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { SitesDashboardQueryParams } from 'calypso/sites-dashboard/components/sites-content-controls';
@@ -28,6 +30,9 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 	const sourceSiteSlug = urlQueryParams.get( 'from' ) || '';
 	const [ destinationSite, setDestinationSite ] = useState< SiteExcerptData >();
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
+	const [ , setMigrationConfirmed ] = useMigrationConfirmation();
+
+	useEffect( () => setMigrationConfirmed( false ), [] );
 
 	const onQueryParamChange = ( params: Partial< SitesDashboardQueryParams > ) => {
 		recordTracksEvent( 'calypso_import_site_picker_query_param_change', params );
@@ -60,7 +65,8 @@ const SitePickerStep: Step = function SitePickerStep( { navigation } ) {
 				setShowConfirmModal( false );
 			} }
 			onConfirm={ () => {
-				destinationSite && selectSite( destinationSite );
+				setMigrationConfirmed( true );
+				defer( () => destinationSite && selectSite( destinationSite ) );
 			} }
 		>
 			<p>

--- a/client/landing/stepper/hooks/use-migration-confirmation.ts
+++ b/client/landing/stepper/hooks/use-migration-confirmation.ts
@@ -1,6 +1,12 @@
 import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useEffect, useState } from 'react';
 
+/**
+ * Hook to store the migration confirmation in session storage.
+ * It returns an array with the current value and a setter.
+ * It allows us to know if the user has confirmed the migration prompt,
+ * so we don't show it multiple times.
+ */
 export default function useMigrationConfirmation(): [ boolean, ( value: boolean ) => void ] {
 	const KEY = `${ IMPORT_FOCUSED_FLOW }_prompt-confirmed`;
 

--- a/client/landing/stepper/hooks/use-migration-confirmation.ts
+++ b/client/landing/stepper/hooks/use-migration-confirmation.ts
@@ -1,0 +1,16 @@
+import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
+import { useEffect, useState } from 'react';
+
+export default function useMigrationConfirmation(): [ boolean, ( value: boolean ) => void ] {
+	const KEY = `${ IMPORT_FOCUSED_FLOW }_prompt-confirmed`;
+
+	const [ migrationConfirmed, setMigrationConfirmed ] = useState(
+		sessionStorage.getItem( KEY ) === 'true'
+	);
+
+	useEffect( () => {
+		sessionStorage.setItem( KEY, migrationConfirmed.toString() );
+	}, [ migrationConfirmed ] );
+
+	return [ migrationConfirmed, setMigrationConfirmed ];
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/77374

## Proposed Changes

* Created common Confirm modal wrapper component
* Introduced `useMigrationConfirmation` hook for storing flag for users who confirmed the migration process
* Integrated `useMigrationConfirmation` into the `import-focused` flow

## Testing Instructions

**Test scenario 1**
* Go to `setup/import-focused/importerWordpress?from={JURASSIC_NINJA_SITE}&siteSlug={DESTINATION_SITE_SLUG}&option=everything`
* Press "Start migration"
* Check if Confirm modal appears
* * The same for the `Skip credentials (slower setup)` option

**Test scenario 2**
* Start the flow from the "sitePicker" step: `/setup/import-focused/sitePicker?from={JURASSIC_NINJA_SITE}`
* Select a migration destination site
* Check if Confirm modal appears
* Confirm it by clicking on the `Continue` button
* Ready screen will be presented with the `Start migration` button
* Press the button and check if migration starts without the Confirm modal prompt
* * The same for the `Skip credentials (slower setup)` option

## Screenshot
<img width="743" alt="Screenshot 2023-05-31 at 11 01 03" src="https://github.com/Automattic/wp-calypso/assets/1241413/e8a936b8-b4d4-4f11-8285-af1110e44300">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
