### PR TITLE
Domains: Redirect user to "Use a domain I own" flow in domain search results page

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -11,6 +11,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import EmptyContent from 'calypso/components/empty-content';
@@ -30,8 +31,8 @@ import DomainAndPlanPackageNavigation from 'calypso/my-sites/domains/components/
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 import {
 	domainAddEmailUpsell,
-	domainMapping,
 	domainManagementList,
+	domainUseMyDomain,
 } from 'calypso/my-sites/domains/paths';
 import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
@@ -96,7 +97,11 @@ class DomainSearch extends Component {
 	};
 
 	handleAddMapping = ( domain ) => {
-		const domainMappingUrl = domainMapping( this.props.selectedSiteSlug, domain );
+		const domainMappingUrl = domainUseMyDomain(
+			this.props.selectedSiteSlug,
+			domain,
+			useMyDomainInputMode.transferOrConnect
+		);
 		this.isMounted && page( domainMappingUrl );
 	};
 


### PR DESCRIPTION
If we try to search for a domain that can't be registered - but can be connected - in the domain search component, we get a notice with a quick link to connect it. If we click this link, we get redirected to the old mapping page.
This PR fixes it.

## Testing Instructions
 - Go to `calypso.localhost:3000/domains/add/:your_site`;
 - Try searching for any mappable domain;
 - Ensure the "connect it" link redirects you to the "Use a domain I own" component/page.
 
### Before
https://github.com/Automattic/wp-calypso/assets/18705930/898dcbfc-77eb-498c-ba17-f8930b08f5ca

### After
https://github.com/Automattic/wp-calypso/assets/18705930/cbaf602e-ad3a-4ec7-b33d-e66d7529120e

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
