### PR TITLE
Domains: Improve "invalid domain" message in "Use a domain I own" component

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-domain-name-validation-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-domain-name-validation-error-message.js
@@ -1,9 +1,16 @@
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
+const isIdnDomain = ( domainName ) =>
+	/^(?!-)(?:[\p{L}0-9-]{0,61}[\p{L}0-9]\.)+[\p{L}]{2,}$/u.test( domainName );
+
 export function getDomainNameValidationErrorMessage( domainName ) {
 	if ( ! domainName ) {
 		return __( 'Please enter your domain before continuing.' );
+	}
+
+	if ( isIdnDomain( domainName ) ) {
+		return __( 'Internationalized Domain Names (IDNs) are currently not supported.' );
 	}
 
 	if (


### PR DESCRIPTION
This PR improves the error message used if we try to map IDN domains in the "Use a domain I own" component.

## Testing Instructions

- Go to `calypso.localhost:3000/domains/add/use-my-domain/:your_site`;
- Input any IDN domain and ensure the error message looks correct - as in the **"after"** screenshot below.

### Before
![image](https://github.com/Automattic/wp-calypso/assets/18705930/f0e6a1a6-0de1-434a-a457-6a4cd853b236)

### After
![image](https://github.com/Automattic/wp-calypso/assets/18705930/f68eee14-ba11-4cf3-b13a-c761baf388e3)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
