### PR TITLE
Site Assembler: Create an empty home template if no layout is selected

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -547,10 +547,11 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			siteSetupOption,
 		}: AssembleSiteOptions = {}
 	) {
-		const templates: RequestTemplate[] = [
+		const templates = [
 			{
 				type: 'wp_template' as const,
 				slug: 'home',
+				title: __( 'Home' ),
 				content: createCustomHomeTemplateContent(
 					stylesheet,
 					!! headerHtml,
@@ -559,17 +560,19 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 					homeHtml
 				),
 			},
-			{
+			headerHtml && {
 				type: 'wp_template_part' as const,
 				slug: 'header',
+				title: __( 'Header' ),
 				content: headerHtml,
 			},
-			{
+			footerHtml && {
 				type: 'wp_template_part' as const,
 				slug: 'footer',
+				title: __( 'Footer' ),
 				content: footerHtml,
 			},
-		].filter( ( template: RequestTemplate ) => !! template.content );
+		].filter( Boolean ) as RequestTemplate[];
 
 		yield wpcomRequest( {
 			path: `/sites/${ encodeURIComponent( siteSlug ) }/site-assembler`,

--- a/packages/data-stores/src/site/utils.ts
+++ b/packages/data-stores/src/site/utils.ts
@@ -27,5 +27,11 @@ export const createCustomHomeTemplateContent = (
 		);
 	}
 
-	return content.join( '\n' );
+	if ( content.length ) {
+		return content.join( '\n' );
+	}
+
+	// If no layout is selected, return the paragraph block to start with blank content to avoid the StartModal showing.
+	// See https://github.com/WordPress/gutenberg/blob/343fd27a51ae549c013bc30f51f13aad235d0d4a/packages/edit-site/src/components/start-template-options/index.js#L162
+	return '<!-- wp:paragraph --><p></p><!-- /wp:paragraph -->';
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1685497341615639-slack-CRWCHQGUB

## Proposed Changes

* Keep the home template without the content so that we're able to create a blank homepage when no layout is selected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D112421-code to your sandbox
* Creating a new site
* When you are in the onboarding flow, continue until you land on the Design Picker
* Scroll down to the bottom and select BCPA CTA
* On the PA screen, continue directly
* When you land on the editor, you have to see the blank homepage

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?