### PR TITLE
Theme Showcase: Add plans page link to the theme card pricing badge

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -1,4 +1,8 @@
-import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
+import {
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	WPCOM_FEATURES_PREMIUM_THEMES,
+} from '@automattic/calypso-products';
 import { Card, Button, Gridicon } from '@automattic/components';
 import {
 	DesignPreviewImage,
@@ -293,6 +297,19 @@ export class Theme extends Component {
 		}
 	};
 
+	getThemePriceUrl = ( plan = '' ) => {
+		const { siteSlug } = this.props;
+		const base = siteSlug ? `/plans/${ encodeURIComponent( siteSlug ) }` : '/pricing';
+
+		const params = new URLSearchParams();
+		if ( siteSlug && plan.length > 0 ) {
+			params.append( 'plan', plan );
+		}
+
+		const paramsString = params.toString().length ? `?${ params.toString() }` : '';
+		return `${ base }${ paramsString }`;
+	};
+
 	parseThemePrice = ( price ) => {
 		/*
 		theme.price on "Recommended" themes tab
@@ -510,7 +527,8 @@ export class Theme extends Component {
 	};
 
 	renderUpsell = () => {
-		const { theme } = this.props;
+		const { doesThemeBundleSoftwareSet, theme } = this.props;
+		const themePlan = doesThemeBundleSoftwareSet ? PLAN_ECOMMERCE : PLAN_BUSINESS;
 
 		return (
 			<>
@@ -518,7 +536,7 @@ export class Theme extends Component {
 					eventName="calypso_upgrade_nudge_impression"
 					eventProperties={ { cta_name: 'theme-upsell', theme: theme.id } }
 				/>
-				{ this.getPremiumThemeBadge() }
+				<a href={ this.getThemePriceUrl( themePlan ) }>{ this.getPremiumThemeBadge() }</a>
 			</>
 		);
 	};
@@ -534,7 +552,11 @@ export class Theme extends Component {
 			return this.renderUpsell();
 		}
 
-		return <span>{ translate( 'Free' ) }</span>;
+		return (
+			<a href={ this.getThemePriceUrl() }>
+				<span>{ translate( 'Free' ) }</span>
+			</a>
+		);
 	};
 
 	renderMoreButton = () => {

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -55,6 +55,10 @@ $theme-info-height: 54px;
 
 	&.premium-badge.theme__marketplace-theme {
 		background: var(--color-primary);
+
+		svg:hover {
+			background: var(--color-primary);
+		}
 	}
 
 	&.popover.info-popover__tooltip {

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -41,9 +41,13 @@ exports[`Theme rendering with default display buttonContents should match snapsh
       <div
         class="theme-card__info-pricing"
       >
-        <span>
-          Free
-        </span>
+        <a
+          href="/pricing"
+        >
+          <span>
+            Free
+          </span>
+        </a>
       </div>
       <div
         class="theme-card__info-options"

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -279,10 +279,15 @@ $theme-card-info-margin-top: 16px;
 	line-height: 20px;
 	padding: 0;
 
+	> a,
 	> span {
 		color: var(--color-neutral-60);
 		font-size: $font-body-small;
 		line-height: 20px;
+	}
+
+	> a:focus-visible {
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2), 0 0 0 2px var(--color-primary-light);
 	}
 
 	.premium-badge,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75444

## Proposed Changes

This PR is an accessibility improvement to the theme card pricing badges in the Theme Showcase. By adding links to these badges, they become keyboard accessible and screen-reader readable.

![Screenshot 2023-05-31 at 2 31 46 PM](https://github.com/Automattic/wp-calypso/assets/797888/50d735fc-f149-4b72-aa58-95054d8d9cc5)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/themes`.
* Ensure that the pricing badges are accessible in the way as described above.
* Also check the logged-out Theme Showcase, which will link users to `/pricing` instead of `/plans`.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
