### PR TITLE
Remove feature flag for newsletter stats

### DIFF
--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -88,13 +88,8 @@ export default function () {
 	page( '/stats/ads/(.*)', redirectToDefaultWordAdsPeriod );
 
 	// Email stats Pages
-	if ( config.isEnabled( 'newsletter/stats' ) ) {
-		statsPage(
-			`/stats/email/:statType/:period(${ validEmailPeriods })/:email_id/:site`,
-			emailStats
-		);
-		statsPage( `/stats/day/emails/:site`, emailSummary );
-	}
+	statsPage( `/stats/email/:statType/:period(${ validEmailPeriods })/:email_id/:site`, emailStats );
+	statsPage( `/stats/day/emails/:site`, emailSummary );
 
 	// Anything else should redirect to default stats page
 	page( '/stats/(.*)', redirectToDefaultSitePage );

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Card, PostStatsCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
@@ -67,7 +66,7 @@ export default function PostDetailHighlightsSection( {
 
 	// postId > 0: Show the tabs for posts except for the Home Page (postId = 0).
 	// isWPcomSite: The Newsletter Stats is only covering `WPCOM sites` for now.
-	const isEmailTabsAvailable = config.isEnabled( 'newsletter/stats' ) && postId > 0 && isWPcomSite;
+	const isEmailTabsAvailable = postId > 0 && isWPcomSite;
 
 	return (
 		<div className="stats__post-detail-highlights-section">

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -285,7 +285,7 @@ class StatsSite extends Component {
 							statType="statsVideoPlays"
 							showSummaryLink
 						/>
-						{ config.isEnabled( 'newsletter/stats' ) && ! isOdysseyStats && (
+						{ ! isOdysseyStats && (
 							<StatsModuleEmails period={ this.props.period } query={ query } />
 						) }
 						{


### PR DESCRIPTION
Closes #77585

## Proposed Changes

* Removes the feature flag check in the stats overview page & post detail highlights (to render the tab bar)
* Keeps the feature flag check for subscriber stats

## Testing Instructions

* Visit the Calypso live URL below and verify that email stats is live

![CleanShot 2023-05-31 at 08 36 04@2x](https://github.com/Automattic/wp-calypso/assets/528287/e80bb393-1133-4530-9775-8aa8fbcf0337)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
