### PR TITLE
Virtual Page: Use isInitialLoading to avoid showing placeholder all the time

### DIFF
--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -114,7 +114,9 @@ const VirtualPage = ( {
 		? addQueryArgs( { templateId: id, templateType: type }, defaultEditorUrl )
 		: defaultEditorUrl;
 
-	const { data: template, isLoading } = useTemplate( site.ID, id, { enabled: isAdmin && !! id } );
+	const { data: template, isInitialLoading } = useTemplate( site.ID, id, {
+		enabled: isAdmin && !! id,
+	} );
 
 	const recordGoogleEvent = ( action: string ) => {
 		props.recordGoogleEvent( 'Pages', action );
@@ -178,7 +180,7 @@ const VirtualPage = ( {
 		props.recordGoogleEvent( 'Pages', 'Clicked Copy Page Link' );
 	};
 
-	if ( isAdmin && isLoading ) {
+	if ( isAdmin && isInitialLoading ) {
 		return <Placeholder.Page key={ id } multisite={ ! site } />;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* If the homepage is a template, the virtual pages will keep loading due to the side effect of the react-query upgrade.

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/d80936bd-60bf-4a4b-819e-8db1bf7b9649) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/40126ecb-10a4-429d-a0a2-c7677d929c5b) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to your atomic site
* Go to Settings
  * Configure the “Homepage displays” to “Default” to use the template as a homepage
  * Configure the “Privacy” to “Private”
* Go to Pages
* Ensure you're able to see the Homepage instead of the loading placeholder forever

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
