### PR TITLE
Email stats: Change breadcrumbs title

### DIFF
--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -15,6 +15,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import memoizeLast from 'calypso/lib/memoize-last';
 import StatsEmailModule from 'calypso/my-sites/stats/stats-email-module';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -126,6 +127,24 @@ class StatsEmailDetail extends Component {
 
 	getTitle = ( statType ) => pageTitles[ statType ];
 
+	getNavigationTitle = () => {
+		const { isPostHomepage, post, postFallback } = this.props;
+
+		if ( isPostHomepage ) {
+			return translate( 'Home page / Archives' );
+		}
+
+		if ( typeof post?.title === 'string' && post.title.length ) {
+			return decodeEntities( stripHTML( post.title ) );
+		}
+
+		if ( typeof postFallback?.post_title === 'string' && postFallback.post_title.length ) {
+			return decodeEntities( stripHTML( postFallback.post_title ) );
+		}
+
+		return null;
+	};
+
 	onChangeLegend = ( activeLegend ) => this.setState( { activeLegend } );
 
 	onChangeMaxBars = ( maxBars ) => this.setState( { maxBars } );
@@ -193,7 +212,7 @@ class StatsEmailDetail extends Component {
 					/>
 
 					<FixedNavigationHeader
-						navigationItems={ this.getNavigationItemsWithTitle( this.getTitle( statType ) ) }
+						navigationItems={ this.getNavigationItemsWithTitle( this.getNavigationTitle() ) }
 					></FixedNavigationHeader>
 
 					{ ! isRequestingStats && ! countViews && post && (


### PR DESCRIPTION
Closes #77590

## Proposed Changes

* This PR changes the breadcrumbs to show the email title, instead of the page title (Email opens, ...). This is done to be consistent with the other tab (Highlights).

![CleanShot 2023-05-31 at 09 27 25@2x](https://github.com/Automattic/wp-calypso/assets/528287/8c7ddb06-ee57-4b9c-9102-25498c2ef6ac)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply this PR
2. Verify breadcrumb title

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
