### PR TITLE
Email stats: Change pane placement

### DIFF
--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -165,8 +165,8 @@ $grid-vertical-gutters: 32px;
 		"posts posts posts posts posts posts posts referrers referrers referrers referrers referrers"
 		"country country country country country country country country country country country country"
 		"authors authors authors authors search search search search clicks clicks clicks clicks"
-		"videos videos videos videos videos videos downloads downloads downloads downloads downloads downloads"
-		"emails emails emails emails emails emails emails emails emails emails emails emails",
+		"videos videos videos videos videos videos emails emails emails emails emails emails"
+		"downloads downloads downloads downloads downloads downloads x x x x x x",
 		6
 	);
 
@@ -175,8 +175,8 @@ $grid-vertical-gutters: 32px;
 		"country country country country country country country country"
 		"authors authors authors authors search search search search"
 		"clicks clicks clicks clicks videos videos videos videos"
-		"downloads downloads downloads downloads downloads downloads downloads downloads"
-		"emails emails emails emails emails emails emails emails",
+		"emails emails emails emails emails emails emails emails"
+		"downloads downloads downloads downloads downloads downloads downloads downloads",
 		7
 	);
 
@@ -188,8 +188,8 @@ $grid-vertical-gutters: 32px;
 		"search search search search"
 		"clicks clicks clicks clicks"
 		"videos videos videos videos"
-		"downloads downloads downloads downloads"
-		"emails emails emails emails",
+		"emails emails emails emails"
+		"downloads downloads downloads downloads",
 		10
 	);
 


### PR DESCRIPTION
## Proposed Changes

This changes the pane placement. On Atomic sites there's no Downloads pane, so we were left with a blank hole:

| Before | After |
|-|-|
| ![CleanShot 2023-05-31 at 08 36 04@2x](https://github.com/Automattic/wp-calypso/assets/528287/ee465662-6133-49cd-a9ac-46e4ec694fcc) | <img width="1454" alt="CleanShot 2023-05-31 at 10 40 56@2x" src="https://github.com/Automattic/wp-calypso/assets/528287/a24b678f-bc82-4df2-a0a2-8d2031ff5e2f"> |

I had to add a fake grid column name called `x`, otherwise it didn't want to render the grid 🤷‍♂️

## Testing Instructions

1. Apply this PR
2. Verify that the stats look like the After screenshot, and verify that all breakpoints work as intended

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
