### PR TITLE
media: fix `@tanstack/query/prefer-query-object-syntax`

### DIFF
--- a/client/data/media/use-delete-media-mutation.js
+++ b/client/data/media/use-delete-media-mutation.js
@@ -2,8 +2,9 @@ import { useMutation } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 export const useDeleteMediaMutation = ( queryOptions = {} ) => {
-	return useMutation(
-		( { siteId, mediaId } ) => wp.req.post( `/sites/${ siteId }/media/${ mediaId }/delete` ),
-		queryOptions
-	);
+	return useMutation( {
+		mutationFn: ( { siteId, mediaId } ) =>
+			wp.req.post( `/sites/${ siteId }/media/${ mediaId }/delete` ),
+		...queryOptions,
+	} );
 };

--- a/client/data/media/use-delete-media-mutation.js
+++ b/client/data/media/use-delete-media-mutation.js
@@ -3,8 +3,8 @@ import wp from 'calypso/lib/wp';
 
 export const useDeleteMediaMutation = ( queryOptions = {} ) => {
 	return useMutation( {
+		...queryOptions,
 		mutationFn: ( { siteId, mediaId } ) =>
 			wp.req.post( `/sites/${ siteId }/media/${ mediaId }/delete` ),
-		...queryOptions,
 	} );
 };

--- a/client/data/media/use-edit-media-mutation.js
+++ b/client/data/media/use-edit-media-mutation.js
@@ -33,14 +33,14 @@ const startEditMediaItem = ( siteId, item ) => ( dispatch, getState ) => {
 export function useEditMediaMutation( queryOptions ) {
 	const dispatch = useDispatch();
 
-	const mutation = useMutation(
-		( { siteId, mediaId, payload } ) =>
+	const mutation = useMutation( {
+		mutationFn: ( { siteId, mediaId, payload } ) =>
 			wp.req.post( {
 				path: `/sites/${ siteId }/media/${ mediaId }/edit`,
 				formData: Object.entries( payload ),
 			} ),
-		queryOptions
-	);
+		...queryOptions,
+	} );
 
 	const { mutate } = mutation;
 

--- a/client/data/media/use-edit-media-mutation.js
+++ b/client/data/media/use-edit-media-mutation.js
@@ -34,12 +34,12 @@ export function useEditMediaMutation( queryOptions ) {
 	const dispatch = useDispatch();
 
 	const mutation = useMutation( {
+		...queryOptions,
 		mutationFn: ( { siteId, mediaId, payload } ) =>
 			wp.req.post( {
 				path: `/sites/${ siteId }/media/${ mediaId }/edit`,
 				formData: Object.entries( payload ),
 			} ),
-		...queryOptions,
 	} );
 
 	const { mutate } = mutation;

--- a/client/data/media/use-update-media-mutation.js
+++ b/client/data/media/use-update-media-mutation.js
@@ -4,9 +4,9 @@ import wp from 'calypso/lib/wp';
 
 export const useUpdateMediaMutation = ( queryOptions = {} ) => {
 	const mutation = useMutation( {
+		...queryOptions,
 		mutationFn: ( { siteId, mediaId, updates } ) =>
 			wp.req.post( `/sites/${ siteId }/media/${ mediaId }`, updates ),
-		...queryOptions,
 	} );
 
 	const { mutate } = mutation;

--- a/client/data/media/use-update-media-mutation.js
+++ b/client/data/media/use-update-media-mutation.js
@@ -3,11 +3,11 @@ import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
 
 export const useUpdateMediaMutation = ( queryOptions = {} ) => {
-	const mutation = useMutation(
-		( { siteId, mediaId, updates } ) =>
+	const mutation = useMutation( {
+		mutationFn: ( { siteId, mediaId, updates } ) =>
 			wp.req.post( `/sites/${ siteId }/media/${ mediaId }`, updates ),
-		queryOptions
-	);
+		...queryOptions,
+	} );
 
 	const { mutate } = mutation;
 


### PR DESCRIPTION
Related to #77214 

## Proposed Changes

PR fixes `@tanstack/query/prefer-query-object-syntax` violations in `client/data/media`.

It's worth noting that the object syntax will be the only available option in a future major version (see [docs](https://tanstack.com/query/v4/docs/react/eslint/prefer-query-object-syntax)).

## Testing Instructions

* Verify the following actions related to media files are still working:
  * update meta information like title, caption, alt text, etc
  * edit an image (flip, rotate, etc)
  * delete a media file
* Verify checks are green
