### PR TITLE
Subscription Management: Add "Paid" label to comments list.

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -56,7 +56,9 @@ const CommentRow = ( {
 								{ site_title }
 								{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
 								{ !! is_paid_subscription && (
-									<span className="paid-label">{ translate( 'Paid' ) }</span>
+									<span className="paid-label">
+										{ translate( 'Paid', { context: 'Label for a paid subscription plan' } ) }
+									</span>
 								) }
 							</span>
 							<span className="url">{ hostname }</span>

--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -25,6 +25,7 @@ const CommentRow = ( {
 	forwardedRef,
 	style,
 	is_wpforteams_site,
+	is_paid_subscription,
 }: CommentRowProps ) => {
 	const translate = useTranslate();
 	const hostname = useMemo( () => new URL( site_url ).hostname, [ site_url ] );
@@ -54,6 +55,9 @@ const CommentRow = ( {
 							<span className="name">
 								{ site_title }
 								{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
+								{ !! is_paid_subscription && (
+									<span className="paid-label">{ translate( 'Paid' ) }</span>
+								) }
 							</span>
 							<span className="url">{ hostname }</span>
 						</span>

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -86,7 +86,7 @@ export default function SiteRow( {
 							{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
 							{ !! is_paid_subscription && (
 								<span className="paid-label">
-									{ translate( 'Paid', { context: 'verb: past participle' } ) }
+									{ translate( 'Paid', { context: 'Label for a paid subscription plan' } ) }
 								</span>
 							) }
 						</span>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/77220

☢️☢️☢️ Alert: don't merge this PR until this patch is in production: D112430-code ☢️☢️☢️

## Proposed Changes

This PR adds the `Paid` label to the comment subscription list in the new Subscription Manager like this:

<img width="1305" alt="Screenshot 2023-05-31 at 10 55 51" src="https://github.com/Automattic/wp-calypso/assets/3832570/b883cb1e-bd70-4ba3-b6cc-d058e0bc2671">

## Testing Instructions

1. Apply this patch in your sandbox: D112430-code.
2. Sandbox `public-api.wordpress.com`.
3. Apply this PR.
4. Add `return next();` right after the line `app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res, next ) {` in the file `client/server/pages/index.js`.
5. Run Calypso with `yarn start`.
6. You need to have an internal user with a paid subscription. Follow these instructions to get it: pdDOJh-1SM-p2
7. With that user, go to `http://calypso.localhost:3000/subscriptions/comments`. You should see the green `Paid` label beside the site name where it corresponds.