### PR TITLE
data/emails: fix `@tanstack/query/prefer-query-object-syntax`

### DIFF
--- a/client/data/emails/use-add-email-forward-mutation.tsx
+++ b/client/data/emails/use-add-email-forward-mutation.tsx
@@ -177,12 +177,12 @@ export default function useAddEmailForwardMutation(
 		dispatch( errorNotice( errorMessage ) );
 	};
 
-	return useMutation< any, unknown, AddMailboxFormData, Context >(
-		( { mailbox, destination } ) =>
+	return useMutation< any, unknown, AddMailboxFormData, Context >( {
+		mutationFn: ( { mailbox, destination } ) =>
 			wp.req.post( `/domains/${ encodeURIComponent( domainName ) }/email/new`, {
 				mailbox,
 				destination,
 			} ),
-		mutationOptions
-	);
+		...mutationOptions,
+	} );
 }

--- a/client/data/emails/use-remove-email-forward-mutation.tsx
+++ b/client/data/emails/use-remove-email-forward-mutation.tsx
@@ -141,13 +141,13 @@ export default function useRemoveEmailForwardMutation(
 		dispatch( errorMessage );
 	};
 
-	return useMutation< any, unknown, EmailAccountEmail, Context >(
-		( { mailbox } ) =>
+	return useMutation< any, unknown, EmailAccountEmail, Context >( {
+		mutationFn: ( { mailbox } ) =>
 			wp.req.post(
 				`/domains/${ encodeURIComponent( domainName ) }/email/${ encodeURIComponent(
 					mailbox
 				) }/delete`
 			),
-		mutationOptions
-	);
+		...mutationOptions,
+	} );
 }

--- a/client/data/emails/use-remove-titan-mailbox-mutation.ts
+++ b/client/data/emails/use-remove-titan-mailbox-mutation.ts
@@ -73,8 +73,8 @@ export function useRemoveTitanMailboxMutation(
 		} );
 	};
 
-	return useMutation(
-		() =>
+	return useMutation( {
+		mutationFn: () =>
 			wp.req.get( {
 				path: `/emails/titan/${ encodeURIComponent( domainName ) }/mailbox/${ encodeURIComponent(
 					mailboxName
@@ -82,6 +82,6 @@ export function useRemoveTitanMailboxMutation(
 				method: 'DELETE',
 				apiNamespace: 'wpcom/v2',
 			} ),
-		mutationOptions
-	);
+		...mutationOptions,
+	} );
 }

--- a/client/data/emails/use-remove-titan-mailbox-mutation.ts
+++ b/client/data/emails/use-remove-titan-mailbox-mutation.ts
@@ -32,7 +32,10 @@ type MutationContext = {
 export function useRemoveTitanMailboxMutation(
 	domainName: string,
 	mailboxName: string,
-	mutationOptions: UseMutationOptions< unknown, unknown, void, MutationContext > = {}
+	mutationOptions: Omit<
+		UseMutationOptions< unknown, unknown, void, MutationContext >,
+		'mutationFn'
+	> = {}
 ): UseMutationResult< unknown, unknown, void, unknown > {
 	const queryClient = useQueryClient();
 

--- a/client/data/emails/use-resend-verify-email-forward-mutation.tsx
+++ b/client/data/emails/use-resend-verify-email-forward-mutation.tsx
@@ -70,13 +70,13 @@ export default function useResendVerifyEmailForwardMutation(
 		dispatch( errorNotice( failureMessage ) );
 	};
 
-	return useMutation< any, unknown, EmailAccountEmail >(
-		( { mailbox } ) =>
+	return useMutation< any, unknown, EmailAccountEmail >( {
+		mutationFn: ( { mailbox } ) =>
 			wp.req.post(
 				`/domains/${ encodeURIComponent( domainName ) }/email/${ encodeURIComponent(
 					mailbox
 				) }/resend-verification`
 			),
-		mutationOptions
-	);
+		...mutationOptions,
+	} );
 }


### PR DESCRIPTION
Related to #77214 

## Proposed Changes

PR fixes `@tanstack/query/prefer-query-object-syntax` violations in `client/data/emails`.

It's worth noting that the object syntax will be the only available option in a future major version (see [docs](https://tanstack.com/query/v4/docs/react/eslint/prefer-query-object-syntax)).

## Testing Instructions

Verify the following actions still perform as expected.

* Email Forwarding
  * Go to `/email/:siteSlug/forwarding/add/:siteSlug and add a new email forward
  * On the next page hit "Resend verification email" (make sure you get another email)
  * Remove that email forward you just added

* Remove Titan Mailbox:
  * Create a new titan mailbox in case you don't have one for testing
  * Attempt to remove that mailbox

Also verify all checks are green.
