### PR TITLE
Add busy state when user selects a plan

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -14,6 +14,7 @@ import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import i18n, { localize, TranslateResult, useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -70,7 +71,18 @@ const SignupFlowPlanFeatureActionButton = ( {
 	classes: string;
 	handleUpgradeButtonClick: () => void;
 } ) => {
+	const [ busy, setBusy ] = useState( false );
 	const translate = useTranslate();
+
+	const handleClick = () => {
+		if ( handleUpgradeButtonClick ) {
+			handleUpgradeButtonClick();
+			// sets the button to busy state so that the user knows their request is being processed
+			// the upgrade button usually takes user to the next step so we don't set it back to false
+			setBusy( true );
+		}
+	};
+
 	let btnText;
 
 	if ( freePlan ) {
@@ -84,7 +96,7 @@ const SignupFlowPlanFeatureActionButton = ( {
 	}
 
 	return (
-		<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+		<Button className={ classes } onClick={ handleClick } disabled={ isPlaceholder } busy={ busy }>
 			{ btnText }
 		</Button>
 	);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2443

## Proposed Changes

* When the user selects the "Get `<plan>`" button, set the button to busy state

The buttons:
![get plan](https://github.com/Automattic/wp-calypso/assets/6586048/53f4200c-d752-4966-8994-813b16f96946)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout to this branch
* Go to `/setup/start-writing` with a new account or 0 sites on the account
* Follow the flow
* Check when you click on a plan, it will show the loading (busy) state
* Test other signup flows

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
