### PR TITLE
Subscription Management: Don't redirect back to subscriptions landing page on non-production environment.

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -830,7 +830,7 @@ function wpcomPages( app ) {
 	} );
 
 	app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res, next ) {
-		if ( req.cookies.subkey || req.context.isLoggedIn ) {
+		if ( req.cookies.subkey || req.context.isLoggedIn || calypsoEnv !== 'production' ) {
 			// If the user is logged in, or has a subkey cookie, they are authorized to view the page
 			return next();
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/77230

## Proposed Changes

On non production environment, don't redirect back to subscriptions landing page when the user does not have a subkey or is not logged in.

## Testing Instructions

On your browser that is already logged in to wordpress.com:
* Go to `calypso.localhost:3000/subscriptions`, it should just load the page.
* Go to the calypso live link in this PR generated by the bot below, it should just load the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
