### PR TITLE
Reader: Add suggested follows modal to search sites results

### DIFF
--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -1,10 +1,12 @@
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose, isEmpty, get } from 'lodash';
+import { useState } from 'react';
 import { connect } from 'react-redux';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
 import ReaderSubscriptionListItemPlaceholder from 'calypso/blocks/reader-subscription-list-item/placeholder';
+import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import ExternalLink from 'calypso/components/external-link';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import FollowButton from 'calypso/reader/follow-button';
@@ -49,10 +51,19 @@ function ReaderSubscriptionListItem( {
 	const siteUrl = getSiteUrl( { feed, site } );
 	const isMultiAuthor = get( site, 'is_multi_author', false );
 	const preferGravatar = ! isMultiAuthor;
+	const [ isSuggestedFollowsModalOpen, setIsSuggestedFollowsModalOpen ] = useState( false );
 
 	if ( ! site && ! feed ) {
 		return <ReaderSubscriptionListItemPlaceholder />;
 	}
+
+	const openSuggestedFollowsModal = ( followClicked ) => {
+		setIsSuggestedFollowsModalOpen( followClicked );
+	};
+
+	const onCloseSuggestedFollowModal = () => {
+		setIsSuggestedFollowsModalOpen( false );
+	};
 
 	function recordEvent( name ) {
 		const props = {
@@ -162,11 +173,19 @@ function ReaderSubscriptionListItem( {
 					feedId={ feedId }
 					siteId={ siteId }
 					railcar={ railcar }
+					onFollowToggle={ openSuggestedFollowsModal }
 				/>
 				{ isFollowing && showNotificationSettings && (
 					<ReaderSiteNotificationSettings siteId={ siteId } />
 				) }
 			</div>
+			{ siteId && (
+				<ReaderSuggestedFollowsDialog
+					onClose={ onCloseSuggestedFollowModal }
+					siteId={ siteId }
+					isVisible={ isSuggestedFollowsModalOpen }
+				/>
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/77300

This adds the suggested follows modal to the Reader search page site results.

When a user clicks on the follow button, they should get a modal showing a list of related/suggested sites to follow;

### Example

https://github.com/Automattic/wp-calypso/assets/5560595/65f652a9-ac45-4c70-bf09-b5cab9d597b9



### Testing
* Apply PR
* Go to Reader full post page like - http://calypso.localhost:3000/read/search
* Search something and click the follow button under the list of search sites results
* You should see modal like in example above

