### PR TITLE
Subscription Management: Fix unsubscribe button not left aligned on settings popover.

### DIFF
--- a/client/landing/subscriptions/components/settings/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings/settings-popover/styles.scss
@@ -4,8 +4,8 @@
 	outline: none;
 	min-width: 305px;
 
-	.popover {
-		&__inner {
+	&.popover {
+		.popover__inner {
 			border: none;
 			box-shadow: 0 3px 8px rgba($studio-black, 0.12), 0 3px 1px rgba($studio-black, 0.04);
 			padding: 21px;


### PR DESCRIPTION
Fixes #77424

## Proposed Changes

* Increase CSS specificity to ensure our popover CSS overrides are applied on the settings popover dropdown.

See context in this comment: https://github.com/Automattic/wp-calypso/issues/77424#issuecomment-1569972700

## Testing Instructions

* Not sure if there is a way to test this on development or calypso live, but the increase of specificity should fix this issue on production.


| Before | After | 
| --- | --- |
| <img width="358" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/2a4a74b5-36e9-4c56-bff5-7b27b172e134"> | <img width="418" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/be4672a3-3699-441a-971a-b48e7bee798e"> |
| <img width="379" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/d42d7b66-e9b7-4068-99c9-a940c734a520"> | <img width="382" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/7466f575-ee3f-42f6-93f9-6d3447afd9f6"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
