### PR TITLE
Change wording from upgrade to update for Move to WordPress.com screen

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -9,8 +9,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useSiteMigrateInfo } from 'calypso/blocks/importer/hooks/use-site-can-migrate';
 import { formatSlugToURL } from 'calypso/blocks/importer/util';
 import MigrationCredentialsForm from 'calypso/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form';
+import { UpdatePluginInfo } from 'calypso/blocks/importer/wordpress/import-everything/pre-migration/update-plugins';
 import { PreMigrationUpgradePlan } from 'calypso/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan';
-import { UpgradePluginInfo } from 'calypso/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plugins';
 import { FormState } from 'calypso/components/advanced-credentials/form';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -50,7 +50,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	const [ selectedHost, setSelectedHost ] = useState( 'generic' );
 	const [ selectedProtocol, setSelectedProtocol ] = useState< 'ftp' | 'ssh' >( 'ftp' );
 	const [ hasLoaded, setHasLoaded ] = useState( false );
-	const [ showUpgradePluginInfo, setShowUpgradePluginInfo ] = useState( false );
+	const [ showUpdatePluginInfo, setShowUpdatePluginInfo ] = useState( false );
 	const fetchMigrationEnabledOnMount = isTargetSitePlanCompatible ? true : false;
 	const [ continueImport, setContinueImport ] = useState( false );
 	const urlQueryParams = useQuery();
@@ -64,9 +64,9 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 
 	const onfetchCallback = ( siteCanMigrate: boolean ) => {
 		if ( ! siteCanMigrate ) {
-			setShowUpgradePluginInfo( true );
+			setShowUpdatePluginInfo( true );
 		} else {
-			setShowUpgradePluginInfo( false );
+			setShowUpdatePluginInfo( false );
 		}
 	};
 
@@ -111,13 +111,13 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 
 	useEffect( () => {
 		// If we are blocked by plugin upgrade check or has continueImport set to false, we do not start the migration
-		if ( showUpgradePluginInfo || ! continueImport ) {
+		if ( showUpdatePluginInfo || ! continueImport ) {
 			return;
 		}
 		if ( sourceSite ) {
 			startImport();
 		}
-	}, [ continueImport, sourceSite, startImport, showUpgradePluginInfo ] );
+	}, [ continueImport, sourceSite, startImport, showUpdatePluginInfo ] );
 
 	function renderCredentialsFormSection() {
 		// We do not show the credentials form if we already have credentials
@@ -202,10 +202,10 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		);
 	}
 
-	function renderUpgradePluginInfo() {
+	function renderUpdatePluginInfo() {
 		return (
 			<>
-				<UpgradePluginInfo isMigrateFromWp={ isMigrateFromWp } sourceSiteUrl={ sourceSiteUrl } />
+				<UpdatePluginInfo isMigrateFromWp={ isMigrateFromWp } sourceSiteUrl={ sourceSiteUrl } />
 				<Interval onTick={ fetchMigrationEnabledStatus } period={ EVERY_FIVE_SECONDS } />
 			</>
 		);
@@ -213,8 +213,8 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 
 	function render() {
 		// If the source site is not capable of being migrated, we show the update info screen
-		if ( showUpgradePluginInfo ) {
-			return renderUpgradePluginInfo();
+		if ( showUpdatePluginInfo ) {
+			return renderUpdatePluginInfo();
 		}
 
 		// If the target site is plan compatible, we show the pre-migration screen

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/update-plugins.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/update-plugins.tsx
@@ -14,19 +14,19 @@ interface Props {
 	sourceSiteUrl: URL;
 }
 
-export const UpgradePluginInfo: React.FunctionComponent< Props > = ( props: Props ) => {
+export const UpdatePluginInfo: React.FunctionComponent< Props > = ( props: Props ) => {
 	const translate = useTranslate();
 	const { isMigrateFromWp, sourceSiteUrl } = props;
 
 	useEffect( () => {
-		recordTracksEvent( 'calypso_site_importer_show_upgrade_info', {
+		recordTracksEvent( 'calypso_site_importer_show_update_info', {
 			plugins_info: isMigrateFromWp ? 'wpcom_migration_plugin' : 'jetpack',
 		} );
 	}, [] );
 
 	function renderTitle() {
 		return isMigrateFromWp
-			? translate( `Upgrade ‘Move to WordPress.com’` )
+			? translate( `Update ‘Move to WordPress.com’` )
 			: translate( `Install Jetpack` );
 	}
 
@@ -62,7 +62,7 @@ export const UpgradePluginInfo: React.FunctionComponent< Props > = ( props: Prop
 				</p>
 			),
 			icon: <Gridicon icon="plugins" />,
-			actionText: translate( 'Upgrade plugin' ),
+			actionText: translate( 'Update plugin' ),
 			value: '',
 		};
 		return isMigrateFromWp ? wpcomMigrationContentObj : jetpackContentObj;
@@ -74,13 +74,13 @@ export const UpgradePluginInfo: React.FunctionComponent< Props > = ( props: Prop
 		window.open( `/jetpack/connect/?url=${ sourceSiteUrl }&source=${ source }`, '_blank' );
 	}
 
-	function onMigrationPluginUpgrade() {
-		recordTracksEvent( 'calypso_site_importer_upgrade_wp_migration_plugin' );
+	function onMigrationPluginUpdate() {
+		recordTracksEvent( 'calypso_site_importer_update_wp_migration_plugin' );
 		window.open( `${ sourceSiteUrl }/wp-admin/plugins.php`, '_blank' );
 	}
 
 	function onActionClick() {
-		return isMigrateFromWp ? onMigrationPluginUpgrade() : installJetpack();
+		return isMigrateFromWp ? onMigrationPluginUpdate() : installJetpack();
 	}
 
 	function onIntallJetpackManuallyClick() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77607

## Proposed Changes

* This PR changes the wording of Upgrade Move to WordPress.com to "Update", along with variable names and file names. more context here: p1685529607921929-slack-C01A60HCGUA
* No functionality changes in this PR

![Screen Shot 2023-05-31 at 8 09 55 PM](https://github.com/Automattic/wp-calypso/assets/4074459/bff2ed5b-425a-47f9-a0b3-89e1d898d0ff)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a JN site and go to Plugins page
* Search for Move to WordPress.com and download the plugin
* Click Get started button on the plugin homepage and go through the flow
* You'll see the update information screen once you are on migrate ready page
* Make sure you see "Update" and not "Upgrade" anymore


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?