### PR TITLE
Update search input to prevent overflow

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/header.scss
+++ b/apps/happy-blocks/block-library/universal-header/header.scss
@@ -93,7 +93,7 @@ body.archive {
 	// This applies to all search bars
 	.happy-blocks-search__inside-wrapper {
 		// width is 1/3 of the grid width minus 30px * 2 / 3 for the grid gap (gap is 30px, we need 2/3 of it)
-		width: calc(var(--wp--style--global--wide-size, 1224px) / 3 - 30px * 2 / 3);
+		width: 300px;
 		max-width: 100%;
 		position: relative;
 		border-radius: 4px;
@@ -126,6 +126,9 @@ body.archive {
 
 			font-size: 1rem;
 			color: var(--color-neutral-50);
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			overflow: hidden;
 		}
 
 		&::before {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to (https://github.com/Automattic/wpsupport3/issues/458)

## Proposed Changes

* Update Happy-Block search input to prevent it from overflow/overlapping the page header text.

Before:
![image](https://github.com/Automattic/wp-calypso/assets/10482592/52645f99-d74a-4703-b474-bf9059cb53f8)


After:
![CleanShot 2023-05-31 at 14 10 37@2x](https://github.com/Automattic/wp-calypso/assets/10482592/d0ea9bc2-dd96-490c-9905-4c8284d441b2)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Checkout this branch and sync `apps/happy-blocks` to your sandbox `yarn dev --sync`
* Sandbox the wpsupport3 theme staging sites (https://github.com/Automattic/wpsupport3) and run the app
* Verify the search input field does not overflow / overlap the page header text (https://wordpress.com/support/seo/). 
* Navigate to different pages and verify the search input field is still visually correct (no other issues such as overflow)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


Fixes https://github.com/Automattic/wpsupport3/issues/458