### PR TITLE
Reader: Add Suggested Follows to Search Post Results Stream

### DIFF
--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -1,11 +1,13 @@
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 import CommentButton from 'calypso/blocks/comment-button';
 import { shouldShowComments } from 'calypso/blocks/comments/helper';
 import PostEditButton from 'calypso/blocks/post-edit-button';
 import ShareButton from 'calypso/blocks/reader-share';
 import { shouldShowShare } from 'calypso/blocks/reader-share/helper';
+import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import ReaderViews from 'calypso/blocks/reader-views';
 import ReaderVisitLink from 'calypso/blocks/reader-visit-link';
 import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
@@ -25,12 +27,23 @@ const ReaderPostActions = ( props ) => {
 		showEdit,
 		showViews,
 		showVisit,
+		showSuggestedFollows,
 		iconSize,
 		className,
 		visitUrl,
 		fullPost,
 		translate,
 	} = props;
+
+	const [ isSuggestedFollowsModalOpen, setIsSuggestedFollowsModalOpen ] = useState( false );
+
+	const openSuggestedFollowsModal = ( followClicked ) => {
+		setIsSuggestedFollowsModalOpen( followClicked );
+	};
+
+	const onCloseSuggestedFollowModal = () => {
+		setIsSuggestedFollowsModalOpen( false );
+	};
 
 	const onEditClick = () => {
 		stats.recordAction( 'edit_post' );
@@ -76,9 +89,21 @@ const ReaderPostActions = ( props ) => {
 					/>
 				</li>
 			) }
+			{ showSuggestedFollows && post.site_ID && (
+				<ReaderSuggestedFollowsDialog
+					onClose={ onCloseSuggestedFollowModal }
+					siteId={ post.site_ID }
+					postId={ post.ID }
+					isVisible={ isSuggestedFollowsModalOpen }
+				/>
+			) }
 			{ shouldShowLikes( post ) && (
 				<li className="reader-post-actions__item">
-					<ReaderFollowButton siteUrl={ post.feed_URL || post.site_URL } iconSize={ iconSize } />
+					<ReaderFollowButton
+						siteUrl={ post.feed_URL || post.site_URL }
+						iconSize={ iconSize }
+						onFollowToggle={ openSuggestedFollowsModal }
+					/>
 				</li>
 			) }
 			{ shouldShowShare( post ) && (
@@ -125,6 +150,7 @@ ReaderPostActions.propTypes = {
 	onCommentClick: PropTypes.func,
 	showEdit: PropTypes.bool,
 	showViews: PropTypes.bool,
+	showSuggestedFollows: PropTypes.bool,
 	iconSize: PropTypes.number,
 	visitUrl: PropTypes.string,
 	fullPost: PropTypes.bool,
@@ -134,6 +160,7 @@ ReaderPostActions.defaultProps = {
 	showEdit: true,
 	showViews: false,
 	showVisit: false,
+	showSuggestedFollows: false,
 	iconSize: 20,
 };
 

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -100,6 +100,11 @@ class ReaderPostCard extends Component {
 			return;
 		}
 
+		// ignore clicks to close a dialog backdrop
+		if ( closest( event.target, '.dialog__backdrop', rootNode ) ) {
+			return;
+		}
+
 		// ignore clicks when highlighting text
 		if ( selection && selection.toString() ) {
 			return;
@@ -146,6 +151,7 @@ class ReaderPostCard extends Component {
 		const isDiscover = post.is_discover;
 		const title = truncate( post.title, { length: 140, separator: /,? +/ } );
 		const isReaderTagPage = currentRoute.startsWith( '/tag/' );
+		const isReaderSearchPage = currentRoute.startsWith( '/read/search' );
 		const classes = classnames( 'reader-post-card', {
 			'has-thumbnail': !! post.canonical_media,
 			'is-photo': isPhotoPost,
@@ -181,6 +187,7 @@ class ReaderPostCard extends Component {
 				onCommentClick={ onCommentClick }
 				showEdit={ false }
 				showViews={ !! post.views }
+				showSuggestedFollows={ isReaderSearchPage }
 				className="ignore-click"
 				iconSize={ 20 }
 			/>

--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -6,9 +6,9 @@ import { READER_SUGGESTED_FOLLOWS_DIALOG } from 'calypso/reader/follow-sources';
 
 import './style.scss';
 
-const ReaderSuggestedFollowsDialog = ( { onClose, siteId, isVisible } ) => {
+const ReaderSuggestedFollowsDialog = ( { onClose, siteId, postId, isVisible } ) => {
 	const translate = useTranslate();
-	const { data, isLoading } = useRelatedSites( siteId );
+	const { data, isLoading } = useRelatedSites( siteId, postId );
 	return (
 		<Dialog
 			additionalClassNames="reader-recommended-follows-dialog"
@@ -17,6 +17,7 @@ const ReaderSuggestedFollowsDialog = ( { onClose, siteId, isVisible } ) => {
 			onClose={ onClose }
 			showCloseIcon={ true }
 			label={ translate( 'Suggested follows' ) }
+			shouldCloseOnEsc={ true }
 		>
 			<div className="reader-recommended-follows-dialog__content">
 				<div className="reader-recommended-follows-dialog__header">

--- a/client/data/reader/use-related-sites.ts
+++ b/client/data/reader/use-related-sites.ts
@@ -48,10 +48,16 @@ const selectRelatedSites = ( response: { sites: Site[] } ): RelatedSite[] | null
 	return relatedSites.length > 0 ? relatedSites : null;
 };
 
-export const useRelatedSites = ( siteId: number ): UseQueryResult< RelatedSite[] | null > => {
+export const useRelatedSites = (
+	siteId: number,
+	postId?: number
+): UseQueryResult< RelatedSite[] | null > => {
 	const site_recs = 5;
-	const path =
+	let path =
 		'/read/site/' + siteId + '/sites/related?size_global=' + site_recs + '&http_envelope=1';
+	if ( postId && postId > 0 ) {
+		path += '&post_id=' + postId;
+	}
 	return useQuery(
 		[ 'related-sites-' + site_recs, siteId ],
 		() => wpcom.req.get( { path: path, apiNamespace: 'rest/v1.2' } ),

--- a/client/data/reader/use-related-sites.ts
+++ b/client/data/reader/use-related-sites.ts
@@ -59,7 +59,7 @@ export const useRelatedSites = (
 		path += '&post_id=' + postId;
 	}
 	return useQuery(
-		[ 'related-sites-' + site_recs, siteId ],
+		[ 'related-sites-' + site_recs, siteId, postId ],
 		() => wpcom.req.get( { path: path, apiNamespace: 'rest/v1.2' } ),
 		{
 			enabled: !! siteId,


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/77300

This adds the suggested follows modal to the Reader search page post results.

When a user clicks on the follow button, they should get a modal showing a list of related/suggested sites to follow;

### Example

https://github.com/Automattic/wp-calypso/assets/5560595/711ccb2a-34cd-4b08-affd-faf3f4ab61dc

### Highlights

This PR will pass the post ID that the follow click was for. The thinking here is that this is the content that encouraged the user to follow this site, we should use the content from this post to find related sites... rather than lookup the most viewed post on that site as is happening now.

I works with change to the related sites endpoint to pass the `post_id` arg when known - code-D112470.

Another things is the post stream is also shown in the `Following` page - we don't want this popup there (yet?) so I have added a prop to only show this on the search page for now.

Lastly... I had to add an exception to the click redirect that normally redirects the users to the Reader full post page when it detects a click event. Since the modal relies on a click event to close the modal dialog, we need an exception to avoid this redirect.

### Testing
* Apply PR and code-D112470
* Go to Reader full post page like - http://calypso.localhost:3000/read/search
* Search something and click the follow button under the list of search posts results
* You should see modal like in example above

