### PR TITLE
Blog Onboarding: Add loading state for domains selections

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -38,6 +38,7 @@ class DomainRegistrationSuggestion extends Component {
 	static propTypes = {
 		isDomainOnly: PropTypes.bool,
 		isCartPendingUpdate: PropTypes.bool,
+		isCartPendingUpdateDomain: PropTypes.object,
 		isSignupStep: PropTypes.bool,
 		showStrikedOutPrice: PropTypes.bool,
 		isFeatured: PropTypes.bool,
@@ -132,6 +133,7 @@ class DomainRegistrationSuggestion extends Component {
 			translate,
 			pendingCheckSuggestion,
 			premiumDomain,
+			isCartPendingUpdateDomain,
 		} = this.props;
 		const { domain_name: domain } = suggestion;
 		const isAdded = hasDomainInCart( cart, domain );
@@ -168,9 +170,15 @@ class DomainRegistrationSuggestion extends Component {
 			buttonContent = translate( 'Unavailable', {
 				context: 'Domain suggestion is not available for registration',
 			} );
-		} else if ( pendingCheckSuggestion?.domain_name === domain ) {
+		} else if (
+			pendingCheckSuggestion?.domain_name === domain ||
+			( this.props.isCartPendingUpdate && isCartPendingUpdateDomain?.domain_name === domain )
+		) {
 			buttonStyles = { ...buttonStyles, busy: true, disabled: true };
-		} else if ( pendingCheckSuggestion || this.props.isCartPendingUpdate ) {
+		} else if (
+			pendingCheckSuggestion ||
+			( this.props.isCartPendingUpdate && isCartPendingUpdateDomain?.domain_name !== domain )
+		) {
 			buttonStyles = { ...buttonStyles, disabled: true };
 		}
 		return {

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -29,6 +29,7 @@ class DomainSearchResults extends Component {
 		lastDomainSearched: PropTypes.string,
 		cart: PropTypes.object,
 		isCartPendingUpdate: PropTypes.bool,
+		isCartPendingUpdateDomain: PropTypes.object,
 		premiumDomains: PropTypes.object,
 		products: PropTypes.object,
 		selectedSite: PropTypes.object,
@@ -282,6 +283,7 @@ class DomainSearchResults extends Component {
 					isReskinned={ this.props.isReskinned }
 					domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
 					products={ this.props.useProvidedProductsList ? this.props.products : undefined }
+					isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }
 				/>
 			);
 
@@ -312,6 +314,7 @@ class DomainSearchResults extends Component {
 						isReskinned={ this.props.isReskinned }
 						domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
 						products={ this.props.useProvidedProductsList ? this.props.products : undefined }
+						isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }
 					/>
 				);
 			} );

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -21,6 +21,7 @@ export class FeaturedDomainSuggestions extends Component {
 		unavailableDomains: PropTypes.array,
 		domainAndPlanUpsellFlow: PropTypes.bool,
 		products: PropTypes.object,
+		isCartPendingUpdateDomain: PropTypes.object,
 	};
 
 	getChildProps() {
@@ -119,6 +120,7 @@ export class FeaturedDomainSuggestions extends Component {
 						buttonStyles={ { primary: true } }
 						isReskinned={ this.props.isReskinned }
 						products={ this.props.products ?? undefined }
+						isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }
 						{ ...childProps }
 					/>
 				) ) }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -102,6 +102,7 @@ class RegisterDomainStep extends Component {
 	static propTypes = {
 		cart: PropTypes.object,
 		isCartPendingUpdate: PropTypes.bool,
+		isCartPendingUpdateDomain: PropTypes.object,
 		isDomainOnly: PropTypes.bool,
 		onDomainsAvailabilityChange: PropTypes.func,
 		products: PropTypes.object,
@@ -1456,6 +1457,7 @@ class RegisterDomainStep extends Component {
 				isReskinned={ this.props.isReskinned }
 				domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
 				useProvidedProductsList={ this.props.useProvidedProductsList }
+				isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }
 			>
 				{ ! this.props.isReskinned &&
 					hasResults &&

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -8,6 +8,7 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import { useState } from 'react';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
@@ -35,6 +36,9 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		} ),
 		[]
 	);
+	const [ isCartPendingUpdate, setIsCartPendingUpdate ] = useState( false );
+	const [ isCartPendingUpdateDomain, setIsCartPendingUpdateDomain ] =
+		useState< DomainSuggestion >();
 	const siteSlug = getQueryArg( window.location.search, 'siteSlug' );
 
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
@@ -77,6 +81,9 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	};
 
 	const submitWithDomain = async ( suggestion: DomainSuggestion | undefined ) => {
+		setIsCartPendingUpdate( true );
+		setIsCartPendingUpdateDomain( suggestion );
+
 		setDomain( suggestion );
 
 		if ( suggestion?.is_free ) {
@@ -114,6 +121,8 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 						flowName: flow || undefined,
 					} ) }
 					handleClickUseYourDomain={ onClickUseYourDomain }
+					isCartPendingUpdate={ isCartPendingUpdate }
+					isCartPendingUpdateDomain={ isCartPendingUpdateDomain }
 				/>
 			</CalypsoShoppingCartProvider>
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2561

## Proposed Changes

Add loading state when selecting a free domain and while the async process of adding the domain to cart is working.

https://github.com/Automattic/wp-calypso/assets/402286/ca7de6ae-d2ab-455a-8a1d-7f4c4b3134c9

## Testing Instructions

* Using a new user OR a user without any site, start the flow with [/setup/start-writing](http://calypso.localhost:3000/setup/start-writing).
* On the domains page, choose a free domain, all buttons should show with a loading state.
* Same for paid domains

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
