### PR TITLE
Stats: Fix <small> tag position for the HighlightCards heading text

### DIFF
--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -61,7 +61,6 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		display: flex;
 		align-items: flex-end;
 		height: 31px;
-		margin-left: 12px;
 		font-family: $font-sf-pro-text;
 		font-weight: 400;
 		font-size: $font-body-small;
@@ -99,6 +98,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		line-height: 1.5;
 		color: var(--studio-gray-50);
 		font-weight: 400;
+		margin-left: 12px;
 
 		@media ( max-width: $break-mobile ) {
 			display: block;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Make `<small>` tag `margin-left: 12px` to the heading text of the highlight cards.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the live branch link.
* Navigate to Stats > `Insights` page.
* Ensure the subtitle next to the `.highlight-cards-heading` is positioned well.
* Navigate to Stats > `Subscribers` page by appending the feature flag: `?flags=stats/subscribers-section`.
* Ensure the subtitle next to the `.highlight-cards-heading` is positioned well.

### Insights page
|Before|After|
|-|-|
|<img width="425" alt="截圖 2023-06-01 上午12 56 29" src="https://github.com/Automattic/wp-calypso/assets/6869813/bb91067f-37ee-4115-bbba-a61d4b294ecf">|<img width="418" alt="截圖 2023-06-01 上午12 59 18" src="https://github.com/Automattic/wp-calypso/assets/6869813/198d0c72-29dc-4b3c-b84e-18fb45a487d0">|

### Subscribers page
|Before|After|
|-|-|
|<img width="439" alt="截圖 2023-06-01 上午12 57 38" src="https://github.com/Automattic/wp-calypso/assets/6869813/b2afcd7c-5b58-424b-aff8-bcf171f90476">|<img width="458" alt="截圖 2023-06-01 上午12 57 49" src="https://github.com/Automattic/wp-calypso/assets/6869813/29f53f8d-8187-4e76-88e5-f729b6776511">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
