### PR TITLE
ETK - use jetpack launchpad endpoint for site intent hook.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-intent/use-site-intent.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-intent/use-site-intent.js
@@ -8,7 +8,7 @@ const useSiteIntent = () => {
 	const [ siteIntentFetched, setSiteIntentFetched ] = useState( false );
 
 	const fetchSiteIntent = useCallback( () => {
-		apiFetch( { path: '/wpcom/v2/site-intent' } )
+		apiFetch( { path: '/wpcom/v2/launchpad' } )
 			.then( ( result ) => {
 				setSiteIntent( result.site_intent );
 				setSiteIntentFetched( true );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes


Replaces the endpoint used for the site intent hook with an endpoint that is available in both simple and atomic context.

HOLD ON - permissions for the endpoint used in this seem to be for 'manage_options' which may be too restrictive for what we want. We probably want to change the permissions on that endpoint and still use it here, but we may need another solution in the meantime.

Use of this previous endpoint was causing many 404 errors on atomic sites, and triggering other rate limitation as a result. p1685550995632009-slack-C03N25JPCE4

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this build of ETK on your sandbox and ensure the use-site-intent hook continues to work as expected.
* You can smoke test places it is used such as the domain-upsell-callout or sidebar, as well as log responses from this request and verify they are the same as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?