### PR TITLE
ETK - update site intent hook to use existing data on window object

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-intent/use-site-intent.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-intent/use-site-intent.js
@@ -1,8 +1,9 @@
 // FIXME: We can use `useSiteIntent` from `@automattic/data-stores` and remove this.
 // https://github.com/Automattic/wp-calypso/pull/73565#discussion_r1113839120
 const useSiteIntent = () => {
-	// We can skip the request altogether since this information is already added to the window. We
-	// could update this to use the launchpad endpoint in jetpack-mu-wpcom, but that may require
+	// We can skip the request altogether since this information is already added to the window in
+	// https://github.com/Automattic/jetpack/blob/e135711f9a130946dae1bca6c9c0967350331067/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/launchpad-save-modal.php#LL31C8-L31C34
+	// We could update this to use the launchpad endpoint in jetpack-mu-wpcom, but that may require
 	// permissions changes as it requires 'manage_options' to read
 	// https://github.com/Automattic/jetpack/blob/e135711f9a130946dae1bca6c9c0967350331067/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php#L121.
 	return {

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-intent/use-site-intent.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-intent/use-site-intent.js
@@ -1,27 +1,13 @@
-import apiFetch from '@wordpress/api-fetch';
-import { useState, useEffect, useCallback } from '@wordpress/element';
-
 // FIXME: We can use `useSiteIntent` from `@automattic/data-stores` and remove this.
 // https://github.com/Automattic/wp-calypso/pull/73565#discussion_r1113839120
 const useSiteIntent = () => {
-	const [ siteIntent, setSiteIntent ] = useState( undefined );
-	const [ siteIntentFetched, setSiteIntentFetched ] = useState( false );
-
-	const fetchSiteIntent = useCallback( () => {
-		apiFetch( { path: '/wpcom/v2/site-intent' } )
-			.then( ( result ) => {
-				setSiteIntent( result.site_intent );
-				setSiteIntentFetched( true );
-			} )
-			.catch( () => {
-				setSiteIntent( undefined );
-				setSiteIntentFetched( true );
-			} );
-	}, [] );
-
-	useEffect( () => {
-		fetchSiteIntent();
-	}, [ fetchSiteIntent ] );
-	return { siteIntent, siteIntentFetched };
+	// We can skip the request altogether since this information is already added to the window. We
+	// could update this to use the launchpad endpoint in jetpack-mu-wpcom, but that may require
+	// permissions changes as it requires 'manage_options' to read
+	// https://github.com/Automattic/jetpack/blob/e135711f9a130946dae1bca6c9c0967350331067/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php#L121.
+	return {
+		siteIntent: window.Jetpack_LaunchpadSaveModal?.siteIntentOption,
+		siteIntentFetched: true,
+	};
 };
 export default useSiteIntent;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
Replaces the api request used here with data that is already [added to the window via jetpack](https://github.com/Automattic/jetpack/blob/e135711f9a130946dae1bca6c9c0967350331067/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/launchpad-save-modal.php#LL31C8-L31C34).

Use of this previous endpoint was causing many 404 errors on atomic sites, and triggering other rate limitation and breaking features as a result. p1685550995632009-slack-C03N25JPCE4

We could update to using a different endpoint that works for both simple and atomic (such as https://github.com/Automattic/wp-calypso/pull/77627). However, it looks like the permissions check on the read end for that is not what we want and may need to be updated to suit our needs. 

Reading the window for this data should work for what we want, at least until we can get the above endpoint updated.
*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
SIMPLE
* Patch this ETK build on your sandbox.
* smoke test features using this hook, such as the domain upsell callout, nav sidebar, etc.  Similarly you can log the result and verify it is the same as before.  Verify this data is present on the first render.


ATOMIC
* patch this ETK build to an atomic site (find the editing-toolkit build under the tests and checks below, click on that, in teamcity click the 'artificats' tab, and download the zip for the plugin. upload this to an atomic site)
* Load the editor and verify there are no longer 7 404s requests for 'site-intent'
* smoke test features using this hook noted above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
