### PR TITLE
Stats: subscribers overview cards data - move subscribers payload to interface declaration

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -47,6 +47,7 @@ export function selectSubscribers( payload: SubscriberPayload ) {
 		unit: payload.unit,
 		data: payload.data.map( ( dataSet ) => {
 			return {
+				// For `week` period replace `W` separator to match the format.
 				[ payload.fields[ 0 ] ]:
 					payload.unit !== 'week' ? dataSet[ 0 ] : dataSet[ 0 ].replaceAll( 'W', '-' ),
 				[ payload.fields[ 1 ] ]: dataSet[ 1 ],

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -62,7 +62,7 @@ export default function useSubscribersQuery(
 	quantity: number,
 	date?: Date
 ) {
-	const queryDate = date.toISOString();
+	const queryDate = date ? date.toISOString() : new Date().toISOString();
 
 	// TODO: Account for other query parameters before release.
 	return useQuery( {

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -1,6 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
+interface SubscriberPayload {
+	date: string;
+	unit: string;
+	data: any[]; // TODO: add type
+	fields: string[];
+}
+
 export function querySubscribers(
 	siteId: number | null,
 	period: string,
@@ -30,13 +37,7 @@ export function querySubscribers(
 	);
 }
 
-export function selectSubscribers( payload: {
-	date: string;
-	unit: string;
-	// todo: add type
-	data: any[];
-	fields: string[];
-} ) {
+export function selectSubscribers( payload: SubscriberPayload ) {
 	if ( ! payload || ! payload.data ) {
 		return [];
 	}
@@ -46,7 +47,6 @@ export function selectSubscribers( payload: {
 		unit: payload.unit,
 		data: payload.data.map( ( dataSet ) => {
 			return {
-				// For `week` period replace `W` separator to match the format.
 				[ payload.fields[ 0 ] ]:
 					payload.unit !== 'week' ? dataSet[ 0 ] : dataSet[ 0 ].replaceAll( 'W', '-' ),
 				[ payload.fields[ 1 ] ]: dataSet[ 1 ],
@@ -62,7 +62,7 @@ export default function useSubscribersQuery(
 	quantity: number,
 	date?: Date
 ) {
-	const queryDate = date ? date.toISOString() : new Date().toISOString();
+	const queryDate = date.toISOString();
 
 	// TODO: Account for other query parameters before release.
 	return useQuery( {


### PR DESCRIPTION
Related to #77513

## Proposed Changes

* This PR adds a subscriber payload interface declaration to the react-query hook in order to improve the clarity and type safety of this file. 

## Testing Instructions

* Open the live branch for this PR.
* Navigate to `/stats/day/:siteSlug`
* Add `?flags=stats/subscribers-section` to the URL to enable the subscriber stats page.
* Scroll down to locate the overview cards (immediately under the chart)
* Check that they load data correctly, still behave acceptably on resize etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
