### PR TITLE
Blog Onboarding: Add loading state on plans selection

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -43,6 +43,7 @@ type PlanFeaturesActionsButtonProps = {
 	isWooExpressPlusPlan?: boolean;
 	selectedSiteSlug: string | null;
 	planActionOverrides?: PlanActionOverrides;
+	selectedPlan?: string;
 };
 
 const DummyDisabledButton = styled.div`
@@ -61,14 +62,18 @@ const SignupFlowPlanFeatureActionButton = ( {
 	freePlan,
 	isPlaceholder,
 	planName,
+	planType,
 	classes,
 	handleUpgradeButtonClick,
+	selectedPlan,
 }: {
 	freePlan: boolean;
 	isPlaceholder: boolean;
 	planName: TranslateResult;
+	planType: string;
 	classes: string;
 	handleUpgradeButtonClick: () => void;
+	selectedPlan?: string;
 } ) => {
 	const translate = useTranslate();
 	let btnText;
@@ -83,8 +88,16 @@ const SignupFlowPlanFeatureActionButton = ( {
 		} );
 	}
 
+	const isDisabled = selectedPlan ? isPlaceholder || selectedPlan !== planType : isPlaceholder;
+	const isBusy = selectedPlan === planType;
+
 	return (
-		<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+		<Button
+			className={ classes }
+			onClick={ handleUpgradeButtonClick }
+			disabled={ isDisabled }
+			busy={ isBusy }
+		>
 			{ btnText }
 		</Button>
 	);
@@ -316,6 +329,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	isWooExpressPlusPlan = false,
 	selectedSiteSlug,
 	planActionOverrides,
+	selectedPlan,
 } ) => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
@@ -396,8 +410,10 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 				freePlan={ freePlan }
 				isPlaceholder={ isPlaceholder }
 				planName={ planName }
+				planType={ planType }
 				classes={ classes }
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
+				selectedPlan={ selectedPlan }
 			/>
 		);
 	}

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -148,6 +148,7 @@ type PlanFeatures2023GridType = PlanFeatures2023GridProps &
 
 type PlanFeatures2023GridState = {
 	showPlansComparisonGrid: boolean;
+	isSelectedPlan?: string;
 };
 
 const PlanLogo: React.FunctionComponent< {
@@ -252,6 +253,7 @@ export class PlanFeatures2023Grid extends Component<
 > {
 	state = {
 		showPlansComparisonGrid: false,
+		isSelectedPlan: '',
 	};
 
 	plansComparisonGridContainerRef = createRef< HTMLDivElement >();
@@ -265,6 +267,10 @@ export class PlanFeatures2023Grid extends Component<
 		this.setState( ( { showPlansComparisonGrid } ) => ( {
 			showPlansComparisonGrid: ! showPlansComparisonGrid,
 		} ) );
+	};
+
+	setSelectedPlan = ( planName: string ) => {
+		this.setState( { isSelectedPlan: planName } );
 	};
 
 	componentDidUpdate(
@@ -645,6 +651,7 @@ export class PlanFeatures2023Grid extends Component<
 		const { onUpgradeClick: ownPropsOnUpgradeClick } = this.props;
 		const { cartItemForPlan, planName } = singlePlanProperties;
 
+		this.setSelectedPlan( planName );
 		if ( ownPropsOnUpgradeClick && cartItemForPlan ) {
 			ownPropsOnUpgradeClick( cartItemForPlan );
 			return;
@@ -705,6 +712,7 @@ export class PlanFeatures2023Grid extends Component<
 							isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planName ) }
 							isWooExpressPlusPlan={ isWooExpressPlusPlan( planName ) }
 							isPlaceholder={ isPlaceholder ?? false }
+							selectedPlan={ this.state.isSelectedPlan }
 							isInSignup={ isInSignup }
 							isLaunchPage={ isLaunchPage }
 							onUpgradeClick={ () => this.handleUpgradeClick( properties ) }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -148,7 +148,7 @@ type PlanFeatures2023GridType = PlanFeatures2023GridProps &
 
 type PlanFeatures2023GridState = {
 	showPlansComparisonGrid: boolean;
-	isSelectedPlan?: string;
+	selectedPlan?: string;
 };
 
 const PlanLogo: React.FunctionComponent< {
@@ -253,7 +253,7 @@ export class PlanFeatures2023Grid extends Component<
 > {
 	state = {
 		showPlansComparisonGrid: false,
-		isSelectedPlan: '',
+		selectedPlan: '',
 	};
 
 	plansComparisonGridContainerRef = createRef< HTMLDivElement >();
@@ -270,7 +270,7 @@ export class PlanFeatures2023Grid extends Component<
 	};
 
 	setSelectedPlan = ( planName: string ) => {
-		this.setState( { isSelectedPlan: planName } );
+		this.setState( { selectedPlan: planName } );
 	};
 
 	componentDidUpdate(
@@ -712,7 +712,7 @@ export class PlanFeatures2023Grid extends Component<
 							isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planName ) }
 							isWooExpressPlusPlan={ isWooExpressPlusPlan( planName ) }
 							isPlaceholder={ isPlaceholder ?? false }
-							selectedPlan={ this.state.isSelectedPlan }
+							selectedPlan={ this.state.selectedPlan }
 							isInSignup={ isInSignup }
 							isLaunchPage={ isLaunchPage }
 							onUpgradeClick={ () => this.handleUpgradeClick( properties ) }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2443

## Proposed Changes

Add loading state when selecting a plan and while the async process of adding the plan to the cart is loading.

https://github.com/Automattic/wp-calypso/assets/402286/2c1412b7-8d1f-4dd1-9b13-d57bf8cfe931

## Testing Instructions

* Using a new user OR a user without any site, start the flow with [/setup/start-writing](http://calypso.localhost:3000/setup/start-writing).
* On the plans page, choose a plan, and all buttons should show a loading state.
* Check other flows and all plan's pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
