### PR TITLE
Marketplace Thank You: Remove param key for empty product types

### DIFF
--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -554,7 +554,10 @@ function getFallbackDestination( {
 	if ( marketplaceProducts.length > 0 ) {
 		debug( 'site with marketplace products' );
 		return addQueryArgs(
-			{ plugins: marketplacePluginSlugs.join( ',' ), themes: marketplaceThemeSlugs.join( ',' ) },
+			{
+				...( marketplacePluginSlugs.length ? { plugins: marketplacePluginSlugs.join( ',' ) } : {} ),
+				...( marketplaceThemeSlugs.length ? { themes: marketplaceThemeSlugs.join( ',' ) } : {} ),
+			},
 			`/marketplace/thank-you/${ siteSlug }`
 		);
 	}


### PR DESCRIPTION
## Proposed Changes

When mounting the URL for Marketplace products, add param keys only for existent product types.

## Testing Instructions
**Prod version**
* Purchase a Marketplace Plugin and check the Marketplace Thank You page URL is mounted as `/marketplace/thank-you/:site?plugins=:plugin_slug&themes=`
* Purchase a Marketplace Theme and check the Marketplace Thank You page URL is mounted as `/marketplace/thank-you/:site?plugins=&themes=:theme_slug`


**This branch version**
* Purchase a Marketplace Plugin and check the Marketplace Thank You page URL is mounted as `/marketplace/thank-you/:site?plugins=:plugin_slug`
* Purchase a Marketplace Theme and check the Marketplace Thank You page URL is mounted as `/marketplace/thank-you/:site?themes=:theme_slug`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
