### PR TITLE
Components: Allow Intl.NumberFormat to degrade gracefully

### DIFF
--- a/packages/components/src/number-formatters/formatted-number.tsx
+++ b/packages/components/src/number-formatters/formatted-number.tsx
@@ -1,4 +1,5 @@
-const FORMATTER = new Intl.NumberFormat();
+import formatNumber, { DEFAULT_LOCALE } from './lib/format-number';
+
 export default function formattedNumber( number: number | null ) {
-	return Number.isFinite( number ) ? FORMATTER.format( number as number ) : '-';
+	return formatNumber( number, DEFAULT_LOCALE, {} );
 }

--- a/packages/components/src/number-formatters/index.tsx
+++ b/packages/components/src/number-formatters/index.tsx
@@ -1,17 +1,8 @@
+import formatNumber from './lib/format-number';
+
 export type ShortenedNumberProps = {
 	value: number | null;
 };
-
-const LOCALE = ( typeof window === 'undefined' ? null : window.navigator?.language ) ?? 'en-US';
-const FORMATTER = new Intl.NumberFormat( LOCALE, {
-	notation: 'compact',
-	compactDisplay: 'short',
-	maximumFractionDigits: 1,
-} );
-
-function formatNumber( value: number | null ) {
-	return Number.isFinite( value ) ? FORMATTER.format( value as number ) : '-';
-}
 
 export default function ShortenedNumber( { value }: ShortenedNumberProps ) {
 	return (

--- a/packages/components/src/number-formatters/lib/format-number.ts
+++ b/packages/components/src/number-formatters/lib/format-number.ts
@@ -1,0 +1,63 @@
+import { memoize } from 'lodash';
+
+const warnOnce = memoize( console.warn ); // eslint-disable-line no-console
+
+export const DEFAULT_LOCALE =
+	( typeof window === 'undefined' ? null : window.navigator?.language ) ?? 'en-US';
+export const DEFAULT_OPTIONS = {
+	compactDisplay: 'short',
+	maximumFractionDigits: 1,
+	notation: 'compact',
+} as Intl.NumberFormatOptions;
+
+export default function formatNumber(
+	number: number | null,
+	locale = DEFAULT_LOCALE,
+	options = DEFAULT_OPTIONS
+) {
+	if ( number === null || ! Number.isFinite( number ) ) {
+		return '-';
+	}
+
+	// Certain versions of Safari (14.1) on macOS Mojave (10.14) have encountered problems with specific parameters in formatOptions.
+	// In the event of an error, problematic parameters are removed from the formatOptions object, and no formatting is applied as a fallback.
+	// This approach ensures a smooth user experience by avoiding disruption for unaffected users.
+	// Refer to https://github.com/Automattic/wp-calypso/issues/77635 for more details.
+	try {
+		new Intl.NumberFormat( locale, options ).format( number as number );
+	} catch ( error: unknown ) {
+		warnOnce(
+			`formatted-number numberFormat error: Intl.NumberFormat().format( ${ typeof number } )`,
+			error
+		);
+	}
+
+	// Remove these key/values from formatOptions.
+	const optionsToRemove: Record< string, string > = {
+		currencyDisplay: 'narrow',
+		currencySign: 'accounting',
+		style: 'unit',
+	};
+
+	// Remove these keys from formatOptions irrespective of value.
+	const optionNamesToRemove = [ 'signDisplay', 'compactDisplay' ];
+
+	// Create new format options object with problematic parameters removed.
+	const reducedFormatOptions: Record< string, string > = {};
+	for ( const [ key, value ] of Object.entries( options ) ) {
+		if ( optionsToRemove[ key ] && value === optionsToRemove[ key ] ) {
+			continue;
+		}
+		if ( optionNamesToRemove.includes( key ) ) {
+			continue;
+		}
+		reducedFormatOptions[ key ] = value;
+	}
+
+	try {
+		return new Intl.NumberFormat( locale, reducedFormatOptions ).format( number );
+	} catch {
+		// If the reduced format option still throws an error, try without format options as a fallback.
+		return new Intl.NumberFormat( locale ).format( number );
+	}
+}

--- a/packages/components/src/number-formatters/lib/test/format-number.ts
+++ b/packages/components/src/number-formatters/lib/test/format-number.ts
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+
+import formatNumber from '../format-number';
+
+describe( 'formatNumber', () => {
+	it( 'formats numbers correctly according to the locale provided', () => {
+		expect( formatNumber( 123.87, 'en-US', {} ) ).toStrictEqual( '123.87' );
+		expect( formatNumber( 1234.87, 'en-US', {} ) ).toStrictEqual( '1,234.87' );
+		expect( formatNumber( 12345.87, 'en-US', {} ) ).toStrictEqual( '12,345.87' );
+		expect( formatNumber( 123456.87, 'en-US', {} ) ).toStrictEqual( '123,456.87' );
+		expect( formatNumber( 1234567.87, 'en-US', {} ) ).toStrictEqual( '1,234,567.87' );
+		expect( formatNumber( 12345678.87, 'en-US', {} ) ).toStrictEqual( '12,345,678.87' );
+		expect( formatNumber( 123456789.87, 'en-US', {} ) ).toStrictEqual( '123,456,789.87' );
+		expect( formatNumber( 123.87, 'de-DE', {} ) ).toStrictEqual( '123,87' );
+		expect( formatNumber( 1234.87, 'de-DE', {} ) ).toStrictEqual( '1.234,87' );
+		expect( formatNumber( 12345.87, 'de-DE', {} ) ).toStrictEqual( '12.345,87' );
+		expect( formatNumber( 123456.87, 'de-DE', {} ) ).toStrictEqual( '123.456,87' );
+		expect( formatNumber( 1234567.87, 'de-DE', {} ) ).toStrictEqual( '1.234.567,87' );
+		expect( formatNumber( 12345678.87, 'de-DE', {} ) ).toStrictEqual( '12.345.678,87' );
+		expect( formatNumber( 123456789.87, 'de-DE', {} ) ).toStrictEqual( '123.456.789,87' );
+	} );
+
+	const locales: [ string, number, string ][] = [
+		[ 'de-DE', 123.87, '123,87' ],
+		[ 'de-CH', 123.87, '123.87' ],
+		[ 'pt-PT', 123.87, '123,87' ],
+	];
+
+	it.each( locales )( 'formats numbers correctly with locale %s', ( locale, value, expected ) => {
+		expect( formatNumber( value, locale, {} ) ).toStrictEqual( expected );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #77635.

## Proposed Changes

* Modularizes use of `Intl.NumberFormat` into a new, tested library module (`format-number`) while preserving backward compatibility.
* Adds try/catch handling for the expected ICU error from Safari 10.14.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the live branch for this PR and ensure that the Stats dashboard (where this component is most frequently used) works as expected. Specifically:
    * Weekly highlight cards and horizontal bar charts on the traffic page.
    * Annual highlight cards on the insights page.
    * Post stats card on the post stats page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
