### PR TITLE
Remove flaky site creation tests and fix jest callbacks

### DIFF
--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -2,8 +2,8 @@
  * @jest-environment jsdom
  */
 
+import nock from 'nock';
 import flows from 'calypso/signup/config/flows';
-import { useNock } from 'calypso/test-helpers/use-nock';
 import { createSiteWithCart, isDomainFulfilled, isPlanFulfilled } from '../step-actions';
 
 jest.mock( 'calypso/signup/config/steps', () => require( './mocks/signup/config/steps' ) );
@@ -12,31 +12,41 @@ jest.mock( 'calypso/signup/config/flows-pure', () =>
 	require( './mocks/signup/config/flows-pure' )
 );
 
+// A Promise wrapper around the callback which resolves after the callback completes
+// to ensure jest waits for the test to finish.
+async function testCreateSite( cb, ...args ) {
+	return new Promise( ( resolve ) => {
+		createSiteWithCart( ( response ) => {
+			cb( response );
+			resolve();
+		}, ...args );
+	} );
+}
+
 describe( 'createSiteWithCart()', () => {
 	// createSiteWithCart() function is not designed to be easy for test at the moment.
 	// Thus we intentionally mock the failing case here so that the parts we want to test
 	// would be easier to write.
-	useNock( ( nock ) => {
-		nock( 'https://public-api.wordpress.com:443' )
-			.persist()
-			.post( '/rest/v1.1/sites/new' )
-			.reply( 400, function ( uri, requestBody ) {
-				return {
-					error: 'error',
-					message: 'something goes wrong!',
-					requestBody,
-				};
-			} );
-	} );
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.post( '/rest/v1.1/sites/new' )
+		.reply( 400, function ( uri, requestBody ) {
+			return {
+				error: 'error',
+				message: 'something goes wrong!',
+				requestBody,
+			};
+		} );
 
-	test( 'should find available url if siteUrl is empty and enable auto generated blog name', () => {
+	test( 'should find available url if siteUrl is empty and enable auto generated blog name', async () => {
+		expect.assertions( 1 );
 		const fakeStore = {
 			getState: () => ( {
 				signup: { dependencyStore: { shouldHideFreePlan: true } },
 			} ),
 		};
 
-		createSiteWithCart(
+		await testCreateSite(
 			( response ) => {
 				expect( response.requestBody.find_available_url ).toBe( true );
 			},
@@ -46,12 +56,13 @@ describe( 'createSiteWithCart()', () => {
 		);
 	} );
 
-	test( "don't automatically find available url if siteUrl is defined", () => {
+	test( "don't automatically find available url if siteUrl is defined", async () => {
+		expect.assertions( 1 );
 		const fakeStore = {
 			getState: () => ( {} ),
 		};
 
-		createSiteWithCart(
+		await testCreateSite(
 			( response ) => {
 				expect( response.requestBody.find_available_url ).toBeFalsy();
 			},
@@ -61,7 +72,8 @@ describe( 'createSiteWithCart()', () => {
 		);
 	} );
 
-	test( 'use username for blog_name if user data available and enable auto generated blog name', () => {
+	test( 'use username for blog_name if user data available and enable auto generated blog name', async () => {
+		expect.assertions( 1 );
 		const fakeStore = {
 			getState: () => ( {
 				currentUser: {
@@ -73,7 +85,7 @@ describe( 'createSiteWithCart()', () => {
 			} ),
 		};
 
-		createSiteWithCart(
+		await testCreateSite(
 			( response ) => {
 				expect( response.requestBody.blog_name ).toBe( 'alex' );
 			},
@@ -83,50 +95,17 @@ describe( 'createSiteWithCart()', () => {
 		);
 	} );
 
-	test( "use username from dependency store for blog_name if user data isn't available and enable auto generated blog name", () => {
+	test( "use username from dependency store for blog_name if user data isn't available and enable auto generated blog name", async () => {
+		expect.assertions( 1 );
 		const fakeStore = {
 			getState: () => ( {
 				signup: { dependencyStore: { username: 'alex', shouldHideFreePlan: true } },
 			} ),
 		};
 
-		createSiteWithCart(
+		await testCreateSite(
 			( response ) => {
 				expect( response.requestBody.blog_name ).toBe( 'alex' );
-			},
-			[],
-			{ siteUrl: undefined },
-			fakeStore
-		);
-	} );
-
-	test( "use site title for blog_name if username isn't available and enable auto generated blog name", () => {
-		const fakeStore = {
-			getState: () => ( {
-				signup: { steps: { siteTitle: 'mytitle' }, dependencyStore: { shouldHideFreePlan: true } },
-			} ),
-		};
-
-		createSiteWithCart(
-			( response ) => {
-				expect( response.requestBody.blog_name ).toBe( 'mytitle' );
-			},
-			[],
-			{ siteUrl: undefined },
-			fakeStore
-		);
-	} );
-
-	test( "use site type for blog_name if username and title aren't available and enable auto generated blog name", () => {
-		const fakeStore = {
-			getState: () => ( {
-				signup: { steps: { siteType: 'blog' }, dependencyStore: { shouldHideFreePlan: true } },
-			} ),
-		};
-
-		createSiteWithCart(
-			( response ) => {
-				expect( response.requestBody.blog_name ).toBe( 'blog' );
 			},
 			[],
 			{ siteUrl: undefined },


### PR DESCRIPTION
## Proposed Changes
I noticed several flaky unit tests over the past week or two. While they were each different tests, the stack trace always pointed to the file in this PR. As far as I can tell, these tests didn't use the correct Jest syntax for callbacks -- as a result, Jest didn't know that the test was finished. In fact, I think it went on to run other tests, then the callback was executed (which failed), and then the other test failed as a result.

After fixing the callback issue via a promise wrapper, I found two tests failing consistently. After troubleshooting for a bit, I noticed the functionality they covered was actually removed two weeks ago, and two very similar tests were removed at that time: https://github.com/Automattic/wp-calypso/pull/76656

But due to the test issue, that wasn't caught. So this PR makes jest wait for the tests to finish and removes those two tests.

## Testing Instructions
Unit tests should pass.
