### PR TITLE
Enable updating already set plan and site name in the launchpad start writing flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -110,7 +110,7 @@ export function getEnhancedTasks(
 								} )
 							);
 						},
-						disabled: task.completed && ! isStartWritingFlow( flow ),
+						disabled: task.completed && ! isBlogOnboardingFlow( flow ),
 					};
 					break;
 				case 'setup_newsletter':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -170,7 +170,8 @@ export function getEnhancedTasks(
 							window.location.assign( plansUrl );
 						},
 						badge_text: ! task.completed ? null : translatedPlanName,
-						disabled: ( task.completed || ! domainUpsellCompleted ) && ! isBlogOnboardingFlow( flow ),
+						disabled:
+							( task.completed || ! domainUpsellCompleted ) && ! isBlogOnboardingFlow( flow ),
 					};
 					break;
 				case 'subscribers_added':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -170,7 +170,7 @@ export function getEnhancedTasks(
 							window.location.assign( plansUrl );
 						},
 						badge_text: ! task.completed ? null : translatedPlanName,
-						disabled: ( task.completed || ! domainUpsellCompleted ) && ! isStartWritingFlow( flow ),
+						disabled: ( task.completed || ! domainUpsellCompleted ) && ! isBlogOnboardingFlow( flow ),
 					};
 					break;
 				case 'subscribers_added':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -110,7 +110,7 @@ export function getEnhancedTasks(
 								} )
 							);
 						},
-						disabled: task.completed,
+						disabled: task.completed && ! isStartWritingFlow( flow ),
 					};
 					break;
 				case 'setup_newsletter':
@@ -170,7 +170,7 @@ export function getEnhancedTasks(
 							window.location.assign( plansUrl );
 						},
 						badge_text: ! task.completed ? null : translatedPlanName,
-						disabled: task.completed || ! domainUpsellCompleted,
+						disabled: ( task.completed || ! domainUpsellCompleted ) && ! isStartWritingFlow( flow ),
 					};
 					break;
 				case 'subscribers_added':


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2588

## Proposed Changes

* Enables updating site name and changing plans after already completing those steps in the launchpad "start writing" flow.

Before

![Screenshot 2023-06-01 at 13-55-06 Almost ready to launch — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/549fae50-08ea-4e5b-bfb4-1a467947ca5f)


After (plan now enabled regardless of completing the domain step)

![Screenshot 2023-06-01 at 13-55-25 Almost ready to launch — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/da46f82e-bafa-4913-95cf-a3d3a2291b13)

Also now able to click these links a second time after completing the step:

https://github.com/Automattic/wp-calypso/assets/811776/98ab9703-65f3-4276-8302-71712d99faaf


## Testing Instructions

* With an account with no sites
* http://calypso.localhost:3000/setup/start-writing
* Publish your first post
* Complete launchpad steps in any order
* Update answers in any order
* Launching should still work
* No flows should be broken
* No other flows should be broken (ie test /start launchpad flow as well)

https://github.com/Automattic/wp-calypso/assets/811776/158067c8-adfe-4f02-93aa-6a60b2030856


Notes:
* The plan and domain screens are missing page variations depending on whether a domain or plan is already selected. I'm not sure whether that is a blocker for merging this PR as is or not. We can probably do those in another PR or two.
* We can enable the "Write first post" link but there are two issues: 1, it creates a new post, 2 returning on subsequent post publishing the url fails to update in the launchpad step and launching then fails with a browser error (mal site warning). If we can fix that url we can probably just enable users to write more than one first post or edit the one they created.
![Screenshot(22)](https://github.com/Automattic/wp-calypso/assets/811776/5b741a15-4f6e-42be-aa2c-ac9b44c16cc7)



