### PR TITLE
Import: update progress bar style and unify the progress bar

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -211,41 +211,17 @@ export class ImportEverything extends SectionMigrate {
 
 	renderMigrationProgressSimple() {
 		const { translate } = this.props;
-		const statusSteps: string[] = [
-			translate( 'Preparing your files' ),
-			translate( 'Gathering your data' ),
-			translate( 'Preparing your files' ),
-		];
-		const statusStep =
-			statusSteps[ Math.floor( this.state.percent / ( 100 / statusSteps.length ) ) ];
 
 		return (
 			<Progress className="onboarding-progress-simple">
 				<Interval onTick={ this.updateFromAPI } period={ EVERY_TEN_SECONDS } />
-				<Title>{ translate( 'We’re safely gathering all your data.' ) }</Title>
-				<SubTitle tagName="h2">
-					{ translate( 'This can take from a few minutes to a few hours.' ) }
-				</SubTitle>
+				<Title>{ translate( 'We’re safely migrating all your data' ) }</Title>
 				<ProgressBar compact={ false } value={ this.state.percent ? this.state.percent : 0 } />
 				<SubTitle tagName="h3">
-					{ statusStep ? statusStep : statusSteps[ statusSteps.length - 1 ] }...
+					{ translate(
+						'Feel free to close this window. We’ll email you when your new site is ready.'
+					) }
 				</SubTitle>
-
-				<div className="progress-status">{ translate( 'Site migration in progress' ) }...</div>
-
-				<p className="support-block">
-					{ translate( 'Do you need help? {{a}}Contact us{{/a}}.', {
-						components: {
-							a: (
-								<a
-									href="https://wordpress.com/help/contact"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					} ) }
-				</p>
 			</Progress>
 		);
 	}
@@ -339,8 +315,6 @@ export class ImportEverything extends SectionMigrate {
 	}
 
 	render() {
-		const { isMigrateFromWp } = this.props;
-
 		switch ( this.state.migrationStatus ) {
 			case MigrationStatus.UNKNOWN:
 				return this.renderLoading();
@@ -351,9 +325,7 @@ export class ImportEverything extends SectionMigrate {
 			case MigrationStatus.NEW:
 			case MigrationStatus.BACKING_UP:
 			case MigrationStatus.RESTORING:
-				return isMigrateFromWp
-					? this.renderMigrationProgressSimple()
-					: this.renderMigrationProgress();
+				return this.renderMigrationProgressSimple();
 
 			case MigrationStatus.DONE:
 				return this.renderMigrationComplete();

--- a/client/blocks/importer/wordpress/import-everything/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/style.scss
@@ -114,28 +114,8 @@
 
 		.progress-bar {
 			max-width: 385px;
-			margin-bottom: rem(14px);
-		}
-
-		.progress-status {
-			display: inline-block;
-			font-size: rem(14px);
-			font-weight: 500;
-			color: var(--studio-gray-60);
-			border: solid 1px var(--studio-gray-10);
-			border-radius: 4px;
 			margin-bottom: rem(24px);
-			padding: rem(10px) rem(24px);
-		}
-
-		.support-block {
-			font-size: rem(14px);
-			color: var(--studio-gray-50);
-
-			a {
-				color: var(--studio-gray-50);
-				text-decoration: underline;
-			}
+			height: 4px;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77600

## Proposed Changes

* Previously the progress bar shows different styles when user comes from different path, we only show one progress bar for all cases now.
* Update the screen based on the design.

![Screen Shot 2023-06-01 at 2 16 48 PM](https://github.com/Automattic/wp-calypso/assets/4074459/4377db99-59dd-4a31-a193-de7b25035b50)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**Test case 1:**
* Start a migration from the normal flow by navigating to `calypso.localhost:3000/setup/import-focused/import?siteSlug=${site_slug}`
* See if the progress screen shows like the screenshot above.

**Test case 2:**
* Start a migration from the plugin flow
* See if the progress screen shows like the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
