### PR TITLE
data/reader: fix `tanstack/query` eslint violations

### DIFF
--- a/client/data/reader/use-related-meta-by-tag.ts
+++ b/client/data/reader/use-related-meta-by-tag.ts
@@ -108,7 +108,7 @@ export const useRelatedMetaByTag = ( tag: string ): UseQueryResult< RelatedMetaB
 	const tag_recs_per_card = 10;
 	const site_recs_per_card = 5;
 	return useQuery( {
-		queryKey: [ 'related-meta-by-tag-' + tag_recs_per_card + '-' + site_recs_per_card, tag ],
+		queryKey: [ 'related-meta-by-tag', tag_recs_per_card, site_recs_per_card, tag ],
 		queryFn: () =>
 			wp.req.get( {
 				path: `/read/tags/${ encodeURIComponent(

--- a/client/data/reader/use-related-sites.ts
+++ b/client/data/reader/use-related-sites.ts
@@ -59,17 +59,22 @@ export const useRelatedSites = (
 	postId?: number
 ): UseQueryResult< RelatedSite[] | null > => {
 	const SITE_RECOMMENDATIONS_COUNT = 5;
-	let path = `/read/site/${ siteId }/sites/related?size_global=${ SITE_RECOMMENDATIONS_COUNT }&http_envelope=1`;
-	if ( postId && postId > 0 ) {
-		path += `&post_id=${ postId }`;
-	}
-	return useQuery(
-		[ `related-sites-${ SITE_RECOMMENDATIONS_COUNT }`, siteId ],
-		() => wpcom.req.get( { path: path, apiNamespace: 'rest/v1.2' } ),
-		{
-			enabled: !! siteId,
-			staleTime: 3600000, // 1 hour
-			select: selectRelatedSites,
-		}
-	);
+	return useQuery( {
+		queryKey: [ `related-sites`, SITE_RECOMMENDATIONS_COUNT, siteId, postId ],
+		queryFn: () =>
+			wpcom.req.get(
+				{
+					path: `/read/site/${ siteId }/sites/related`,
+					apiNamespace: 'rest/v1.2',
+				},
+				{
+					size_global: SITE_RECOMMENDATIONS_COUNT,
+					post_id: postId,
+					http_envelope: 1,
+				}
+			),
+		enabled: !! siteId,
+		staleTime: 3600000, // 1 hour
+		select: selectRelatedSites,
+	} );
 };


### PR DESCRIPTION
Related to #77214

## Proposed Changes

PR fixes violations of `@tanstack/eslint-plugin-query` in `client/data/reader`

## Testing Instructions

1. Open up a post on `/reader` and verify related posts are shown correctly (bottom of the post)
2. In the sidebar choose a tag and verify related tags are shown correctly (on the right side of the content)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
