### PR TITLE
Blog onboarding: Fix tracks event for plan step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-submit-step.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-submit-step.ts
@@ -31,6 +31,10 @@ export function recordSubmitStep(
 				propValue = ( propValue as { product_slug: string } ).product_slug;
 			}
 
+			if ( propName === 'plan' ) {
+				propValue = ( propValue as { product_slug: string } ).product_slug;
+			}
+
 			return {
 				...props,
 				[ propName ]: propValue,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2609

## Proposed Changes

* We flatten the nested plans property as mentioned in the issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/start-writing or /setup/design-first with a new account or account with 0 sites
* Go through the flow and check in the console when selecting the plan, there are no track event errors (as seen in the issue)

Example of the error
![image](https://github.com/Automattic/wp-calypso/assets/6586048/76948949-54c8-41d5-92ee-c9b35235cb96)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
