### PR TITLE
data/marketplace: fix `tanstack/query` eslint violations

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -48,13 +48,13 @@ export const getWPCOMPluginsQueryParams = (
 	type: Type,
 	searchTerm?: string,
 	tag?: string
-): [ QueryKey, QueryFunction< any[] > ] => {
-	const cacheKey = getCacheKey( type + searchTerm + tag + '-normalized' );
-	const fetchFn = () =>
+): { queryKey: QueryKey; queryFn: QueryFunction< any[] > } => {
+	const queryKey = getCacheKey( type + searchTerm + tag + '-normalized' );
+	const queryFn = () =>
 		fetchWPCOMPlugins( type, searchTerm, tag ).then( ( data: { results: any[] } ) =>
 			normalizePluginsList( data.results )
 		);
-	return [ cacheKey, fetchFn ];
+	return { queryKey, queryFn };
 };
 
 /**
@@ -76,7 +76,8 @@ export const useWPCOMPluginsList = (
 		refetchOnMount = true,
 	}: UseQueryOptions< any > = {}
 ): UseQueryResult => {
-	return useQuery( ...getWPCOMPluginsQueryParams( type, searchTerm, tag ), {
+	return useQuery( {
+		...getWPCOMPluginsQueryParams( type, searchTerm, tag ),
 		enabled: enabled,
 		staleTime: staleTime,
 		refetchOnMount: refetchOnMount,
@@ -89,14 +90,16 @@ const fetchWPCOMPlugin = ( slug: string ) =>
 		apiNamespace: pluginsApiNamespace,
 	} );
 
-export const getWPCOMPluginQueryParams = ( slug: string ): [ QueryKey, QueryFunction ] => {
-	const cacheKey = getCacheKey( slug + '-normalized' );
-	const fetchFn = () =>
+export const getWPCOMPluginQueryParams = (
+	slug: string
+): { queryKey: QueryKey; queryFn: QueryFunction } => {
+	const queryKey = getCacheKey( slug + '-normalized' );
+	const queryFn = () =>
 		fetchWPCOMPlugin( slug ).then( ( data: any ) =>
 			normalizePluginData( { detailsFetched: Date.now() }, data )
 		);
 
-	return [ cacheKey, fetchFn ];
+	return { queryKey, queryFn };
 };
 
 /**
@@ -110,7 +113,8 @@ export const useWPCOMPlugin = (
 	slug: string,
 	{ enabled = true, staleTime = BASE_STALE_TIME, refetchOnMount = true }: UseQueryOptions = {}
 ): UseQueryResult< any > => {
-	return useQuery( ...getWPCOMPluginQueryParams( slug ), {
+	return useQuery( {
+		...getWPCOMPluginQueryParams( slug ),
 		enabled: enabled,
 		staleTime: staleTime,
 		refetchOnMount: refetchOnMount,
@@ -120,26 +124,24 @@ export const useWPCOMPlugin = (
 export const useWPCOMPlugins = ( slugs: Array< string > ): Array< UseQueryResult< any > > => {
 	return useQueries( {
 		queries: slugs.map( ( slug ) => {
-			const [ cacheKey, fetchFn ] = getWPCOMPluginQueryParams( slug );
-
-			return {
-				queryKey: cacheKey,
-				queryFn: fetchFn,
-			};
+			return getWPCOMPluginQueryParams( slug );
 		} ),
 	} );
 };
 
-export const getWPCOMFeaturedPluginsQueryParams = (): [ QueryKey, QueryFunction ] => {
-	const cacheKey = [ 'plugins-featured-list-normalized' ];
-	const fetchFn = () =>
+export const getWPCOMFeaturedPluginsQueryParams = (): {
+	queryKey: QueryKey;
+	queryFn: QueryFunction;
+} => {
+	const queryKey = [ 'plugins-featured-list-normalized' ];
+	const queryFn = () =>
 		wpcom.req
 			.get( {
 				path: featuredPluginsApiBase,
 				apiNamespace: pluginsApiNamespace,
 			} )
 			.then( normalizePluginsList );
-	return [ cacheKey, fetchFn ];
+	return { queryKey, queryFn };
 };
 
 /**
@@ -153,7 +155,8 @@ export const useWPCOMFeaturedPlugins = ( {
 	staleTime = BASE_STALE_TIME,
 	refetchOnMount = true,
 }: UseQueryOptions = {} ): UseQueryResult => {
-	return useQuery( ...getWPCOMFeaturedPluginsQueryParams(), {
+	return useQuery( {
+		...getWPCOMFeaturedPluginsQueryParams(),
 		enabled,
 		staleTime,
 		refetchOnMount,

--- a/client/data/marketplace/use-wporg-plugin-query.ts
+++ b/client/data/marketplace/use-wporg-plugin-query.ts
@@ -24,9 +24,12 @@ import { getPluginsListKey } from './utils';
 export const getWPORGPluginsQueryParams = (
 	options: PluginQueryOptions,
 	locale: string
-): [ QueryKey, QueryFunction< { plugins: any[]; pagination: { page: number } }, QueryKey > ] => {
-	const cacheKey = getPluginsListKey( [ WPORG_CACHE_KEY, 'normalized' ], options );
-	const fetchFn = () => {
+): {
+	queryKey: QueryKey;
+	queryFn: QueryFunction< { plugins: any[]; pagination: { page: number } }, QueryKey >;
+} => {
+	const queryKey = getPluginsListKey( [ WPORG_CACHE_KEY, 'normalized' ], options );
+	const queryFn = () => {
 		const [ search, author ] = extractSearchInformation( options.searchTerm );
 		return fetchPluginsList( {
 			pageSize: options.pageSize,
@@ -41,7 +44,7 @@ export const getWPORGPluginsQueryParams = (
 			pagination: info,
 		} ) );
 	};
-	return [ cacheKey, fetchFn ];
+	return { queryKey, queryFn };
 };
 
 export const useWPORGPlugins = (
@@ -54,7 +57,8 @@ export const useWPORGPlugins = (
 ): UseQueryResult => {
 	const locale = useSelector( getCurrentUserLocale );
 
-	return useQuery( ...getWPORGPluginsQueryParams( options, locale ), {
+	return useQuery( {
+		...getWPORGPluginsQueryParams( options, locale ),
 		enabled: enabled,
 		staleTime: staleTime,
 		refetchOnMount: refetchOnMount,
@@ -78,9 +82,9 @@ export const useWPORGInfinitePlugins = (
 	const [ search, author ] = extractSearchInformation( options.searchTerm );
 	const locale = useSelector( getCurrentUserLocale );
 
-	return useInfiniteQuery(
-		getPluginsListKey( [ WPORG_CACHE_KEY ], options, true ),
-		( { pageParam = 1 } ) =>
+	return useInfiniteQuery( {
+		queryKey: getPluginsListKey( [ WPORG_CACHE_KEY ], options, true ),
+		queryFn: ( { pageParam = 1 } ) =>
 			fetchPluginsList( {
 				pageSize: options.pageSize,
 				page: pageParam,
@@ -90,28 +94,26 @@ export const useWPORGInfinitePlugins = (
 				tag: options.tag && ! search ? options.tag : null,
 				author,
 			} ),
-		{
-			select: (
-				data: InfiniteData< { plugins: Plugin[]; info: { page: number; pages: number } } >
-			) => {
-				return {
-					...data,
-					plugins: extractPages( data.pages ),
-					pagination: extractPagination( data.pages ),
-				};
-			},
-			getNextPageParam: ( lastPage: { info: { page: number; pages: number } } ) => {
-				// When on last page, the next page is undefined, according to docs.
-				// @see: https://tanstack.com/query/v4/docs/reference/useInfiniteQuery
-				if ( lastPage.info.pages <= lastPage.info.page ) {
-					return undefined;
-				}
+		select: (
+			data: InfiniteData< { plugins: Plugin[]; info: { page: number; pages: number } } >
+		) => {
+			return {
+				...data,
+				plugins: extractPages( data.pages ),
+				pagination: extractPagination( data.pages ),
+			};
+		},
+		getNextPageParam: ( lastPage: { info: { page: number; pages: number } } ) => {
+			// When on last page, the next page is undefined, according to docs.
+			// @see: https://tanstack.com/query/v4/docs/reference/useInfiniteQuery
+			if ( lastPage.info.pages <= lastPage.info.page ) {
+				return undefined;
+			}
 
-				return ( lastPage.info.page || 0 ) + 1;
-			},
-			enabled: enabled,
-			staleTime: staleTime,
-			refetchOnMount: refetchOnMount,
-		}
-	);
+			return ( lastPage.info.page || 0 ) + 1;
+		},
+		enabled: enabled,
+		staleTime: staleTime,
+		refetchOnMount: refetchOnMount,
+	} );
 };

--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -30,7 +30,7 @@ function getQueryOptions( { path, lang } ) {
 function prefetchPluginsData( queryClient, fetchParams, infinite ) {
 	const queryType = infinite ? 'prefetchInfiniteQuery' : 'prefetchQuery';
 
-	return queryClient[ queryType ]( ...fetchParams );
+	return queryClient[ queryType ]( fetchParams );
 }
 
 const prefetchPaidPlugins = ( queryClient, options ) =>


### PR DESCRIPTION
Related to #77214

## Proposed Changes

PR fixes violations of `@tanstack/eslint-plugin-query` in `client/data/marketplace`

## Testing Instructions

* Smoke test plugins marketplace on simple and atomic sites. Everything should look normal and behave as on prod.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
