### PR TITLE
PA in LiTS: Go to the editor on the small screen

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -60,8 +60,8 @@ export const ThemesList = ( props ) => {
 	}, [ updateShowSecondUpsellNudge ] );
 
 	const selectedSite = useSelector( getSelectedSite );
-
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const siteEditorUrl = useSelector( ( state ) => getSiteEditorUrl( state, selectedSite?.ID ) );
 
 	const isPatternAssemblerCTAEnabled =
 		! isLoggedIn || isEnabled( 'pattern-assembler/logged-in-showcase' );
@@ -78,17 +78,27 @@ export const ThemesList = ( props ) => {
 			goes_to_assembler_step: shouldGoToAssemblerStep,
 		} );
 
-		const basePathname = isLoggedIn ? '/setup' : '/start';
-		const params = new URLSearchParams( {
-			ref: 'calypshowcase',
-			theme: BLANK_CANVAS_DESIGN.slug,
-		} );
+		let destinationUrl;
 
-		if ( selectedSite?.slug ) {
-			params.set( 'siteSlug', selectedSite.slug );
+		// We have to redirect the user to the site editor directly if the user has logged in but
+		// they're on the small screen because the Assembler doesn't support the small screen yet.
+		if ( ! isLoggedIn || shouldGoToAssemblerStep ) {
+			const basePathname = isLoggedIn ? '/setup' : '/start';
+			const params = new URLSearchParams( {
+				ref: 'calypshowcase',
+				theme: BLANK_CANVAS_DESIGN.slug,
+			} );
+
+			if ( selectedSite?.slug ) {
+				params.set( 'siteSlug', selectedSite.slug );
+			}
+
+			destinationUrl = `${ basePathname }/${ WITH_THEME_ASSEMBLER_FLOW }?${ params }`;
+		} else {
+			destinationUrl = siteEditorUrl;
 		}
 
-		window.location.assign( `${ basePathname }/${ WITH_THEME_ASSEMBLER_FLOW }?${ params }` );
+		window.location.assign( destinationUrl );
 	};
 
 	const matchingWpOrgThemes = useMemo( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* On the small screen (viewport width < 960px), the BCPA CTA should open the editor instead of going to the `with-theme-assembler` flow.
* Maybe we have to switch the theme to the blank canvas and create a blank home template before redirecting the user to the editor. But now I want to simply align the “Open the editor” behavior when you're not able to find a suitable theme.
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/03dd7e9d-eabe-4500-9315-0fb86c8acd38)

Any thoughts?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Themes on the small screen
* Scroll down, and you have to see the BCPA CTA and the copy should “Open the editor”
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/46adbecb-d2e9-429d-b300-f2b79bdf2b0d)
* Click on it, and you have to land on the site editor directly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
