### PR TITLE
Fix the logic to decide if a migration can proceed

### DIFF
--- a/client/blocks/importer/hooks/use-site-can-migrate.ts
+++ b/client/blocks/importer/hooks/use-site-can-migrate.ts
@@ -30,9 +30,10 @@ export function useSiteMigrateInfo(
 		}
 		const { jetpack_activated, jetpack_compatible, migration_activated, migration_compatible } =
 			data as MigrationEnabledResponse;
-		return isMigrateFromWp
-			? migration_activated && migration_compatible
-			: jetpack_activated && jetpack_compatible;
+
+		return (
+			( migration_activated && migration_compatible ) || ( jetpack_activated && jetpack_compatible )
+		);
 	};
 
 	const onMigrationEnabledSuccess = ( data: MigrationEnabledResponse ) => {


### PR DESCRIPTION
Related to #77536

## Proposed Changes

Check if the source site either has a valid and active Jetpack installation OR a compatible Move to WordPress.com plugin installed.

Previously, if you were going through the migration flow that started from the Move to WordPress.com plugin, a compatible version of that plugin was required even if you have Jetpack set up already. Since having a valid Jetpack plugin + connection is enough to do a migration, there is no need to ask the user to upgrade the plugin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See D112563-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?