### PR TITLE
Import: turn on new migration plugin / import flow feature flag on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -111,6 +111,7 @@
 		"onboarding/import-light": false,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
+		"onboarding/import-redesign": true,
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/all-patterns-category": true,

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -14,7 +14,7 @@ const selectors = {
 	// The "content only" "continue" button of '/start/from/importing/wordpress'
 	wpContentOnlyContinueButton:
 		'.content-chooser .import-layout__column:nth-child(2) > div > div:last-child button:text("Continue")',
-
+	wpPreMigrationContentOnlyOptionButton: 'button:has-text("Use the content-only import option")',
 	// ImporterDrag page
 	importerDrag: ( text: string ) => `div.importer-wrapper__${ text }`,
 
@@ -126,6 +126,13 @@ export class StartImportFlow {
 	 */
 	async contentOnlyWordPressPage(): Promise< void > {
 		await this.page.click( selectors.wpContentOnlyContinueButton );
+	}
+
+	/**
+	 * Continue 'content only' WordPress migration on pre-migration page.
+	 */
+	async clickPremigrationOptionButton(): Promise< void > {
+		await this.page.locator( selectors.wpPreMigrationContentOnlyOptionButton ).click();
 	}
 
 	/**

--- a/test/e2e/specs/onboarding/setup__importer.ts
+++ b/test/e2e/specs/onboarding/setup__importer.ts
@@ -10,6 +10,8 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
 
+	// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
+	let redesignImporterFeature = false;
 	let page: Page;
 	let startImportFlow: StartImportFlow;
 
@@ -19,6 +21,11 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
+
+		// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
+		redesignImporterFeature = await page.evaluate(
+			`configData.features['onboarding/import-redesign']`
+		);
 	} );
 
 	/**
@@ -41,8 +48,14 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
-			await startImportFlow.validateWordPressPage();
-			await startImportFlow.contentOnlyWordPressPage();
+			// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
+			if ( redesignImporterFeature ) {
+				await startImportFlow.clickPremigrationOptionButton();
+			} else {
+				await startImportFlow.validateWordPressPage();
+				await startImportFlow.contentOnlyWordPressPage();
+			}
+
 			await startImportFlow.validateImporterDragPage( 'wordpress' );
 		} );
 	} );

--- a/test/e2e/specs/onboarding/setup__importer.ts
+++ b/test/e2e/specs/onboarding/setup__importer.ts
@@ -10,8 +10,6 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
 
-	// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
-	let redesignImporterFeature = false;
 	let page: Page;
 	let startImportFlow: StartImportFlow;
 
@@ -21,11 +19,6 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
-
-		// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
-		redesignImporterFeature = await page.evaluate(
-			`configData.features['onboarding/import-redesign']`
-		);
 	} );
 
 	/**
@@ -48,13 +41,13 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
-			// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
-			if ( redesignImporterFeature ) {
-				await startImportFlow.clickPremigrationOptionButton();
-			} else {
-				await startImportFlow.validateWordPressPage();
-				await startImportFlow.contentOnlyWordPressPage();
-			}
+			await Promise.any( [
+				startImportFlow.clickPremigrationOptionButton(),
+				Promise.all( [
+					startImportFlow.validateWordPressPage(),
+					startImportFlow.contentOnlyWordPressPage(),
+				] ),
+			] );
 
 			await startImportFlow.validateImporterDragPage( 'wordpress' );
 		} );

--- a/test/e2e/specs/onboarding/start__importer.ts
+++ b/test/e2e/specs/onboarding/start__importer.ts
@@ -10,6 +10,8 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
 
+	// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
+	let redesignImporterFeature = false;
 	let page: Page;
 	let startImportFlow: StartImportFlow;
 
@@ -19,6 +21,10 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
+		// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
+		redesignImporterFeature = await page.evaluate(
+			`configData.features['onboarding/import-redesign']`
+		);
 	} );
 
 	/**
@@ -41,8 +47,13 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
-			await startImportFlow.validateWordPressPage();
-			await startImportFlow.contentOnlyWordPressPage();
+			// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
+			if ( redesignImporterFeature ) {
+				await startImportFlow.clickPremigrationOptionButton();
+			} else {
+				await startImportFlow.validateWordPressPage();
+				await startImportFlow.contentOnlyWordPressPage();
+			}
 			await startImportFlow.validateImporterDragPage( 'wordpress' );
 		} );
 	} );

--- a/test/e2e/specs/onboarding/start__importer.ts
+++ b/test/e2e/specs/onboarding/start__importer.ts
@@ -10,8 +10,6 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
 
-	// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
-	let redesignImporterFeature = false;
 	let page: Page;
 	let startImportFlow: StartImportFlow;
 
@@ -21,10 +19,6 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
-		// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
-		redesignImporterFeature = await page.evaluate(
-			`configData.features['onboarding/import-redesign']`
-		);
 	} );
 
 	/**
@@ -47,13 +41,13 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
 			await startImportFlow.validateImportPage();
 			await startImportFlow.clickButton( 'Import your content' );
-			// TODO: remove redesignImporterFeature once project: pcmemI-1YX-p2 goes live.
-			if ( redesignImporterFeature ) {
-				await startImportFlow.clickPremigrationOptionButton();
-			} else {
-				await startImportFlow.validateWordPressPage();
-				await startImportFlow.contentOnlyWordPressPage();
-			}
+			await Promise.any( [
+				startImportFlow.clickPremigrationOptionButton(),
+				Promise.all( [
+					startImportFlow.validateWordPressPage(),
+					startImportFlow.contentOnlyWordPressPage(),
+				] ),
+			] );
 			await startImportFlow.validateImporterDragPage( 'wordpress' );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77478, #77642

## Proposed Changes

* This is a follow up from the issue mentioned above, for some reason the Team City is still picking up the condition from the old flow, see error below:

```
page.waitForSelector: Timeout 10000ms exceeded.
=========================== logs ===========================
waiting for locator('.content-chooser .import-layout__column:nth-child(2) > div > div:last-child button:text("Continue")') to be visible
============================================================
at StartImportFlow.validateWordPressPage (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/flows/start-import-flow.ts:114:19)
    at Object.<anonymous> (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/onboarding/setup__importer.ts:44:26)
```

This doesn't makes sense because if the feature flag is on it should always looking for the new page, or is the way we read config feature flag wrong? Is it possible if user's PR is not up to date so it triggers the error here?

The investigation reported here: https://github.com/Automattic/wp-calypso/issues/77642#issuecomment-1572169910
This error was triggered because testing branches didn't have the latest feature flag included when trigger the testing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TeamCity test run against the live link of this PR



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
