### PR TITLE
happy-blocks: Fix translations relative path for RTL locales

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -67,6 +67,10 @@ function happyblocks_normalize_translations_relative_path( $relative, $src ) {
 	if ( preg_match( '#/wp-content/a8c-plugins/happy-blocks/(.*\.js)#', $src, $m ) ) {
 		// Fix the path to support `yarn dev --sync`.
 		$relative = str_replace( 'build/', '', $m[1] );
+
+		// Remove rtl segment from the relative path to prevent encoding incorrect $md5_filename for the script translations.
+		$relative = str_replace( '/rtl/../', '/', $m[1] );
+
 		return $relative;
 	}
 	return $relative;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 626-gh-Automattic/i18n-issues

## Proposed Changes

* Remove the redundant `rtl/../` segment from the relative path in `load_script_textdomain_relative_path` filter to prevent encoding incorrect md5 file name when loading the script translations for RTL locales.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Follow test instructions in D112577-code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
