### PR TITLE
Reader: Update full post page to pass post ID to suggested follows

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -107,7 +107,6 @@ export class FullPostView extends Component {
 	openSuggestedFollowsModal = ( followClicked ) => {
 		this.setState( { isSuggestedFollowsModalOpen: followClicked } );
 	};
-
 	onCloseSuggestedFollowModal = () => {
 		this.setState( { isSuggestedFollowsModalOpen: false } );
 	};
@@ -132,7 +131,6 @@ export class FullPostView extends Component {
 
 		document.addEventListener( 'keydown', this.handleKeydown, true );
 	}
-
 	componentDidUpdate( prevProps ) {
 		// Send page view if applicable
 		if (
@@ -662,6 +660,7 @@ export class FullPostView extends Component {
 					<ReaderSuggestedFollowsDialog
 						onClose={ this.onCloseSuggestedFollowModal }
 						siteId={ +post.site_ID }
+						postId={ +post.ID }
 						isVisible={ this.state.isSuggestedFollowsModalOpen }
 					/>
 				) }


### PR DESCRIPTION
This is a follow up to https://github.com/Automattic/wp-calypso/pull/77620.

This passes the the post ID value when requesting related sites for a site. This will mean the endpoint will use this post as reference when finding related posts and in turn related sites.