### PR TITLE
Domain-upsell-callout - remove site intent hook.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/src/domain-upsell-callout.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/src/domain-upsell-callout.jsx
@@ -3,7 +3,6 @@ import { dispatch, select, subscribe } from '@wordpress/data';
 import { render } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { close, globe, Icon } from '@wordpress/icons';
-import useSiteIntent from '../../dotcom-fse/lib/site-intent/use-site-intent';
 
 import './domain-upsell-callout.scss';
 
@@ -35,12 +34,6 @@ const shouldShowDomainUpsell = () => {
 };
 
 const DomainUpsellCallout = () => {
-	const { siteIntent: intent, siteIntentFetched: intentFetched } = useSiteIntent();
-
-	if ( ! intentFetched || intent ) {
-		return;
-	}
-
 	const siteSlug = window.location.hostname;
 	const target = '_parent';
 	const trackEventView = 'calypso_block_editor_domain_upsell_callout_view';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove site intent hook from domain-upsell-callout

Im not sure if there is a regression in the domain-upsell-callout or not (it seems there may be a regression after https://github.com/Automattic/wp-calypso/pull/77629), but looking into the code it seems like:
1. domain-upsell-callout seems to be [returning early if the site has any site-intent set](https://github.com/Automattic/wp-calypso/blob/e91d4e096a730c28f11a39cde298140b0d262c25/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/src/domain-upsell-callout.jsx#L40).
2. the domain-upsell-callout uses a hook for and waits for the site-intent, but never uses the site-intent.

With 2 in mind, it seems like we could just remove this hook from the component? Im assuming maybe we used intent in the past and removed it at some point? Or is there a reason we are returning early if there is any site intent set?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* patch this ETK build to your sandbox.
* sandbox the public-api and test site
* load into the editor and test the domain-upsell-callout appears when expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
