### PR TITLE
New hosted site: do not go to cart if picking the free plan

### DIFF
--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -80,14 +80,18 @@ const hosting: Flow = {
 				setSignupCompleteSlug( providedDependencies?.siteSlug );
 				setSignupCompleteFlowName( flowName );
 
-				return window.location.assign(
-					addQueryArgs(
-						`/checkout/${ encodeURIComponent(
-							( providedDependencies?.siteSlug as string ) ?? ''
-						) }`,
-						{ redirect_to: destination }
-					)
-				);
+				if ( providedDependencies.goToCheckout ) {
+					return window.location.assign(
+						addQueryArgs(
+							`/checkout/${ encodeURIComponent(
+								( providedDependencies?.siteSlug as string ) ?? ''
+							) }`,
+							{ redirect_to: destination }
+						)
+					);
+				}
+
+				return window.location.assign( destination );
 			}
 
 			return providedDependencies;
@@ -152,6 +156,11 @@ const hosting: Flow = {
 				case 'plans': {
 					const productSlug =
 						( providedDependencies?.plan as MinimalRequestCartProduct | null )?.product_slug ?? '';
+
+					// User picked the Free plan
+					if ( ! productSlug ) {
+						return navigate( 'siteCreationStep' );
+					}
 
 					setPlanCartItem( {
 						product_slug: productSlug,


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/2614.

## Proposed Changes

The user should not go to checkout if they don't have a paid cart item.

## Testing Instructions

1. Browse `/setup/new-hosted-site`;
2. Pick the free plan;
3. Check that you're immediately redirected to `/sites` with your free site created successfully.

1. Browse `/setup/new-hosted-site`;
2. Pick any paid plan;
3. Check that you're sent to checkout and redirected to `/sites` after paying for the site.
