### PR TITLE
Sites: put created site at the top of the list

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -212,7 +212,7 @@ export function SitesDashboard( {
 				<SitesDashboardSitesList
 					sites={ allSites }
 					filtering={ { search } }
-					sorting={ sitesSorting }
+					sorting={ { ...sitesSorting, newSiteID } }
 					grouping={ { status, showHidden: true } }
 				>
 					{ ( { sites, statuses } ) => {

--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -29,7 +29,9 @@ export const parseSitesSorting = ( serializedSorting: SitesSorting | 'none' ) =>
 	return sorting;
 };
 
-export const stringifySitesSorting = ( sorting: Required< SitesSortOptions > ): SitesSorting => {
+export const stringifySitesSorting = (
+	sorting: Required< Pick< SitesSortOptions, 'sortKey' | 'sortOrder' > >
+): SitesSorting => {
 	return `${ sorting.sortKey }${ SEPARATOR }${ sorting.sortOrder }`;
 };
 

--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -38,24 +38,35 @@ export const isValidSorting = ( input: {
 export interface SitesSortOptions {
 	sortKey?: SitesSortKey;
 	sortOrder?: SitesSortOrder;
+	newSiteID?: number;
 }
 
 export function useSitesListSorting< T extends SiteDetailsForSorting >(
 	allSites: T[],
-	{ sortKey, sortOrder = 'asc' }: SitesSortOptions
+	{ sortKey, sortOrder = 'asc', newSiteID }: SitesSortOptions
 ) {
-	return useMemo( () => {
+	const newSite = allSites.find( ( site ) => site.ID === newSiteID );
+
+	const allSitesExceptNew = allSites.filter( ( site ) => site !== newSite );
+
+	const sortedSites = useMemo( () => {
 		switch ( sortKey ) {
 			case 'lastInteractedWith':
-				return sortSitesByStaging( sortSitesByLastInteractedWith( allSites, sortOrder ) );
+				return sortSitesByStaging( sortSitesByLastInteractedWith( allSitesExceptNew, sortOrder ) );
 			case 'alphabetically':
-				return sortSitesAlphabetically( allSites, sortOrder );
+				return sortSitesAlphabetically( allSitesExceptNew, sortOrder );
 			case 'updatedAt':
-				return sortSitesByLastPublish( allSites, sortOrder );
+				return sortSitesByLastPublish( allSitesExceptNew, sortOrder );
 			default:
-				return allSites;
+				return allSitesExceptNew;
 		}
-	}, [ allSites, sortKey, sortOrder ] );
+	}, [ allSitesExceptNew, sortKey, sortOrder ] );
+
+	if ( newSite ) {
+		return [ newSite, ...sortedSites ];
+	}
+
+	return sortedSites;
 }
 
 const subtractDays = ( date: string, days: number ) => {


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/2616.

## Proposed Changes

It's difficult to find the created site if the user has multiple entries. Especially because the sites list gets ordered.

This PR makes sure that the `?new-site` is always on top, making it impossible for the user to miss t.

## Testing Instructions

1. Browse `/setup/new-hosted-site`;
2. Pick the free plan;
3. Verify that you have been redirected to `/sites` and that your newly created site shows up as the first site on the list.