### PR TITLE
Use `ThemeTypeBadge` in Design Picker

### DIFF
--- a/client/components/data/query-site-features/index.jsx
+++ b/client/components/data/query-site-features/index.jsx
@@ -15,18 +15,22 @@ const siteIdsHash = ( siteIds ) => {
 	return siteIds.join( '_' );
 };
 
+export function useQuerySiteFeatures( siteIds ) {
+	const dispatch = useDispatch();
+	const hashedSiteIds = siteIdsHash( siteIds );
+
+	useEffect( () => {
+		siteIds.forEach( ( siteId ) => dispatch( request( siteId ) ) );
+	}, [ dispatch, hashedSiteIds ] );
+}
+
 /**
  * Makes an API request to fetch the features for the given array of siteIds.
  * This will make one request per site, so if you have a large number of sites
  * then consider using QueryJetpackSitesFeatures or something similar.
  */
 export default function QuerySiteFeatures( { siteIds } ) {
-	const dispatch = useDispatch();
-
-	useEffect( () => {
-		siteIds.forEach( ( siteId ) => dispatch( request( siteId ) ) );
-	}, [ dispatch, siteIdsHash( siteIds ) ] );
-
+	useQuerySiteFeatures( siteIds );
 	return null;
 }
 

--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -1,60 +1,44 @@
-import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
 import { requestThemes } from 'calypso/state/themes/actions';
 import { getThemesForQuery, isRequestingThemesForQuery } from 'calypso/state/themes/selectors';
 
-class QueryThemes extends Component {
-	static propTypes = {
-		siteId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.oneOf( [ 'wpcom', 'wporg' ] ) ] )
-			.isRequired,
-		// A theme query. Note that on Jetpack sites, only the `search` argument is supported.
-		query: PropTypes.shape( {
-			// The search string
-			search: PropTypes.string,
-			// The tier to look for -- 'free', 'premium', 'marketplace', or '' (for all themes)
-			tier: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
-			// Comma-separated list of filters; see my-sites/themes/theme-filters
-			filter: PropTypes.string,
-			// Which page of the results list to display
-			page: PropTypes.number,
-			// How many results per page
-			number: PropTypes.number,
-		} ),
-		// Connected props
-		hasThemes: PropTypes.bool.isRequired,
-		isRequesting: PropTypes.bool.isRequired,
-		requestThemes: PropTypes.func.isRequired,
-	};
+export function useQueryThemes( siteId, query ) {
+	const dispatch = useDispatch();
+	const isRequesting = useSelector( ( state ) =>
+		isRequestingThemesForQuery( state, siteId, query )
+	);
+	const hasThemes = useSelector( ( state ) => getThemesForQuery( state, siteId, query ) !== null );
 
-	componentDidMount() {
-		this.request();
-	}
-
-	shouldComponentUpdate( nextProps ) {
-		return this.props.siteId !== nextProps.siteId || ! isEqual( this.props.query, nextProps.query );
-	}
-
-	componentDidUpdate() {
-		this.request();
-	}
-
-	request() {
-		if ( ! this.props.isRequesting && ! this.props.hasThemes ) {
-			this.props.requestThemes( this.props.siteId, this.props.query );
+	useEffect( () => {
+		if ( ! isRequesting && ! hasThemes ) {
+			dispatch( requestThemes( siteId, query ) );
 		}
-	}
-
-	render() {
-		return null;
-	}
+	}, [ dispatch, siteId, query, isRequesting, hasThemes ] );
 }
 
-export default connect(
-	( state, { query, siteId } ) => ( {
-		hasThemes: getThemesForQuery( state, siteId, query ) !== null,
-		isRequesting: isRequestingThemesForQuery( state, siteId, query ),
+function QueryThemes( { siteId, query } ) {
+	useQueryThemes( siteId, query );
+	return null;
+}
+
+QueryThemes.propTypes = {
+	siteId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.oneOf( [ 'wpcom', 'wporg' ] ) ] )
+		.isRequired,
+	// A theme query. Note that on Jetpack sites, only the `search` argument is supported.
+	query: PropTypes.shape( {
+		// The search string
+		search: PropTypes.string,
+		// The tier to look for -- 'free', 'premium', 'marketplace', or '' (for all themes)
+		tier: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
+		// Comma-separated list of filters; see my-sites/themes/theme-filters
+		filter: PropTypes.string,
+		// Which page of the results list to display
+		page: PropTypes.number,
+		// How many results per page
+		number: PropTypes.number,
 	} ),
-	{ requestThemes }
-)( QueryThemes );
+};
+
+export default QueryThemes;

--- a/client/components/theme-type-badge/index.tsx
+++ b/client/components/theme-type-badge/index.tsx
@@ -23,6 +23,7 @@ interface Props {
 	siteId: number | null;
 	siteSlug: string | null;
 	themeId: string;
+	tooltipHeader?: string;
 	tooltipMessage?: string;
 }
 
@@ -32,6 +33,7 @@ const ThemeTypeBadge = ( {
 	siteId,
 	siteSlug,
 	themeId,
+	tooltipHeader,
 	tooltipMessage,
 }: Props ) => {
 	const translate = useTranslate();
@@ -58,6 +60,7 @@ const ThemeTypeBadge = ( {
 				siteId={ siteId }
 				siteSlug={ siteSlug }
 				themeId={ themeId }
+				tooltipHeader={ tooltipHeader }
 				tooltipMessage={ tooltipMessage }
 			/>
 		),

--- a/client/components/theme-type-badge/index.tsx
+++ b/client/components/theme-type-badge/index.tsx
@@ -18,12 +18,25 @@ import ThemeTypeBadgeTooltip from './tooltip';
 import './style.scss';
 
 interface Props {
+	canGoToCheckout?: boolean;
+	forcePremium?: boolean;
+	siteId: number | null;
+	siteSlug: string | null;
 	themeId: string;
+	tooltipMessage?: string;
 }
 
-const ThemeTypeBadge = ( { themeId }: Props ) => {
+const ThemeTypeBadge = ( {
+	canGoToCheckout,
+	forcePremium,
+	siteId,
+	siteSlug,
+	themeId,
+	tooltipMessage,
+}: Props ) => {
 	const translate = useTranslate();
-	const type = useSelector( ( state ) => getThemeType( state, themeId ) );
+	const _type = useSelector( ( state ) => getThemeType( state, themeId ) );
+	const type = forcePremium ? PREMIUM_THEME : _type;
 
 	useEffect( () => {
 		if ( type === FREE_THEME ) {
@@ -38,7 +51,16 @@ const ThemeTypeBadge = ( { themeId }: Props ) => {
 	const badgeContentProps = {
 		className: 'theme-type-badge__content',
 		tooltipClassName: 'theme-type-badge-tooltip',
-		tooltipContent: <ThemeTypeBadgeTooltip themeId={ themeId } />,
+		tooltipContent: (
+			<ThemeTypeBadgeTooltip
+				canGoToCheckout={ canGoToCheckout }
+				forcePremium={ forcePremium }
+				siteId={ siteId }
+				siteSlug={ siteSlug }
+				themeId={ themeId }
+				tooltipMessage={ tooltipMessage }
+			/>
+		),
 		tooltipPosition: 'top',
 	};
 

--- a/client/components/theme-type-badge/test/index.jsx
+++ b/client/components/theme-type-badge/test/index.jsx
@@ -43,7 +43,9 @@ describe( 'ThemeTypeBadge', () => {
 
 	describe( 'Premium theme popover', () => {
 		test( 'Free site', async () => {
-			const { container } = renderWithState( <ThemeTypeBadge themeId="premium/test" /> );
+			const { container } = renderWithState(
+				<ThemeTypeBadge siteId={ 123 } siteSlug="example.com" themeId="premium/test" />
+			);
 			const popoverTrigger = container.getElementsByClassName( 'theme-type-badge__content' )[ 0 ];
 			await userEvent.hover( popoverTrigger );
 
@@ -55,9 +57,12 @@ describe( 'ThemeTypeBadge', () => {
 		} );
 
 		test( 'Premium site', async () => {
-			const { container } = renderWithState( <ThemeTypeBadge themeId="premium/test" />, {
-				hasPremiumPlan: true,
-			} );
+			const { container } = renderWithState(
+				<ThemeTypeBadge siteId={ 123 } siteSlug="example.com" themeId="premium/test" />,
+				{
+					hasPremiumPlan: true,
+				}
+			);
 			const popoverTrigger = container.getElementsByClassName( 'theme-type-badge__content' )[ 0 ];
 			await userEvent.hover( popoverTrigger );
 
@@ -69,9 +74,12 @@ describe( 'ThemeTypeBadge', () => {
 		} );
 
 		test( 'Purchased a premium theme', async () => {
-			const { container } = renderWithState( <ThemeTypeBadge themeId="premium/test" />, {
-				hasPurchasedTheme: true,
-			} );
+			const { container } = renderWithState(
+				<ThemeTypeBadge siteId={ 123 } siteSlug="example.com" themeId="premium/test" />,
+				{
+					hasPurchasedTheme: true,
+				}
+			);
 			const popoverTrigger = container.getElementsByClassName( 'theme-type-badge__content' )[ 0 ];
 			await userEvent.hover( popoverTrigger );
 

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -19,11 +19,12 @@ import {
 } from 'calypso/state/themes/selectors';
 
 interface Props {
-	canGoToCheckout: boolean;
+	canGoToCheckout?: boolean;
 	forcePremium?: boolean;
 	siteId: number | null;
 	siteSlug: string | null;
 	themeId: string;
+	tooltipHeader?: string;
 	tooltipMessage?: string;
 }
 
@@ -33,6 +34,7 @@ const ThemeTypeBadgeTooltip = ( {
 	siteId,
 	siteSlug,
 	themeId,
+	tooltipHeader,
 	tooltipMessage,
 }: Props ) => {
 	const translate = useTranslate();
@@ -68,6 +70,10 @@ const ThemeTypeBadgeTooltip = ( {
 	}, [ themeId ] );
 
 	const getHeader = (): string | null => {
+		if ( tooltipHeader ) {
+			return tooltipHeader;
+		}
+
 		const headers = {
 			[ PREMIUM_THEME ]: translate( 'Premium theme' ),
 			[ DOT_ORG_THEME ]: translate( 'Community theme', {

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -17,18 +17,27 @@ import {
 	isMarketplaceThemeSubscribed,
 	getMarketplaceThemeSubscriptionPrices,
 } from 'calypso/state/themes/selectors';
-import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
-import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 
 interface Props {
+	canGoToCheckout: boolean;
+	forcePremium?: boolean;
+	siteId: number | null;
+	siteSlug: string | null;
 	themeId: string;
+	tooltipMessage?: string;
 }
 
-const ThemeTypeBadgeTooltip = ( { themeId }: Props ) => {
+const ThemeTypeBadgeTooltip = ( {
+	canGoToCheckout = true,
+	forcePremium,
+	siteId,
+	siteSlug,
+	themeId,
+	tooltipMessage,
+}: Props ) => {
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
-	const type = useSelector( ( state ) => getThemeType( state, themeId ) );
+	const _type = useSelector( ( state ) => getThemeType( state, themeId ) );
+	const type = forcePremium ? PREMIUM_THEME : _type;
 	const isIncludedCurrentPlan = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
@@ -89,8 +98,19 @@ const ThemeTypeBadgeTooltip = ( { themeId }: Props ) => {
 		}
 	};
 
+	const Link = ( { children, onClick }: { children?: React.ReactNode[]; onClick: () => void } ) =>
+		canGoToCheckout && siteSlug ? (
+			<LinkButton isLink onClick={ onClick }>
+				{ children }
+			</LinkButton>
+		) : (
+			<>{ children }</>
+		);
+
 	let message;
-	if ( type === PREMIUM_THEME ) {
+	if ( tooltipMessage ) {
+		message = tooltipMessage;
+	} else if ( type === PREMIUM_THEME ) {
 		if ( isPurchased ) {
 			message = translate( 'You have purchased this theme.' );
 		} else if ( isIncludedCurrentPlan ) {
@@ -99,7 +119,7 @@ const ThemeTypeBadgeTooltip = ( { themeId }: Props ) => {
 			message = createInterpolateElement(
 				translate( 'This premium theme is included in the <Link>Premium plan</Link>.' ),
 				{
-					Link: <LinkButton isLink onClick={ () => goToCheckout( 'premium' ) } />,
+					Link: <Link onClick={ () => goToCheckout( 'premium' ) } />,
 				}
 			);
 		}
@@ -111,7 +131,7 @@ const ThemeTypeBadgeTooltip = ( { themeId }: Props ) => {
 						'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
 					),
 					{
-						Link: <LinkButton isLink onClick={ () => goToCheckout( 'business' ) } />,
+						Link: <Link onClick={ () => goToCheckout( 'business' ) } />,
 					}
 			  );
 	} else if ( type === WOOCOMMERCE_THEME ) {
@@ -120,7 +140,7 @@ const ThemeTypeBadgeTooltip = ( { themeId }: Props ) => {
 			: createInterpolateElement(
 					translate( 'This WooCommerce theme is included in the <Link>Business plan</Link>.' ),
 					{
-						Link: <LinkButton isLink onClick={ () => goToCheckout( 'business' ) } />,
+						Link: <Link onClick={ () => goToCheckout( 'business' ) } />,
 					}
 			  );
 	} else if ( type === MARKETPLACE_THEME ) {
@@ -134,7 +154,7 @@ const ThemeTypeBadgeTooltip = ( { themeId }: Props ) => {
 					'You have a subscription for this theme, but it will only be usable if you have the <link>Business plan</link> on your site.'
 				),
 				{
-					link: <LinkButton isLink onClick={ () => goToCheckout( 'business' ) } />,
+					link: <Link onClick={ () => goToCheckout( 'business' ) } />,
 				}
 			);
 		} else if ( ! isPurchased && isIncludedCurrentPlan ) {
@@ -161,7 +181,7 @@ const ThemeTypeBadgeTooltip = ( { themeId }: Props ) => {
 					}
 				) as string,
 				{
-					Link: <LinkButton isLink onClick={ () => goToCheckout( 'business' ) } />,
+					Link: <Link onClick={ () => goToCheckout( 'business' ) } />,
 				}
 			);
 		}

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -28,6 +28,39 @@ interface Props {
 	tooltipMessage?: string;
 }
 
+const ThemeTypeBadgeTooltipUpgradeLink = ( {
+	canGoToCheckout,
+	children,
+	plan,
+	siteSlug,
+}: {
+	canGoToCheckout: boolean;
+	children?: React.ReactNode[];
+	plan: string;
+	siteSlug: string | null;
+} ) => {
+	if ( ! canGoToCheckout || ! siteSlug ) {
+		return <>{ children }</>;
+	}
+
+	const goToCheckout = () => {
+		recordTracksEvent( 'calypso_theme_tooltip_upgrade_nudge_click', { plan } );
+
+		const params = new URLSearchParams();
+		params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
+
+		window.location.href = `/checkout/${ encodeURIComponent(
+			siteSlug
+		) }/${ plan }?${ params.toString() }`;
+	};
+
+	return (
+		<LinkButton isLink onClick={ () => goToCheckout() }>
+			{ children }
+		</LinkButton>
+	);
+};
+
 const ThemeTypeBadgeTooltip = ( {
 	canGoToCheckout = true,
 	forcePremium,
@@ -91,28 +124,6 @@ const ThemeTypeBadgeTooltip = ( {
 		return headers[ type ];
 	};
 
-	const goToCheckout = ( plan: string ) => {
-		recordTracksEvent( 'calypso_theme_tooltip_upgrade_nudge_click', { plan } );
-
-		if ( siteSlug ) {
-			const params = new URLSearchParams();
-			params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
-
-			window.location.href = `/checkout/${ encodeURIComponent(
-				siteSlug
-			) }/${ plan }?${ params.toString() }`;
-		}
-	};
-
-	const Link = ( { children, onClick }: { children?: React.ReactNode[]; onClick: () => void } ) =>
-		canGoToCheckout && siteSlug ? (
-			<LinkButton isLink onClick={ onClick }>
-				{ children }
-			</LinkButton>
-		) : (
-			<>{ children }</>
-		);
-
 	let message;
 	if ( tooltipMessage ) {
 		message = tooltipMessage;
@@ -125,7 +136,13 @@ const ThemeTypeBadgeTooltip = ( {
 			message = createInterpolateElement(
 				translate( 'This premium theme is included in the <Link>Premium plan</Link>.' ),
 				{
-					Link: <Link onClick={ () => goToCheckout( 'premium' ) } />,
+					Link: (
+						<ThemeTypeBadgeTooltipUpgradeLink
+							canGoToCheckout={ canGoToCheckout }
+							plan="premium"
+							siteSlug={ siteSlug }
+						/>
+					),
 				}
 			);
 		}
@@ -137,7 +154,13 @@ const ThemeTypeBadgeTooltip = ( {
 						'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
 					),
 					{
-						Link: <Link onClick={ () => goToCheckout( 'business' ) } />,
+						Link: (
+							<ThemeTypeBadgeTooltipUpgradeLink
+								canGoToCheckout={ canGoToCheckout }
+								plan="business"
+								siteSlug={ siteSlug }
+							/>
+						),
 					}
 			  );
 	} else if ( type === WOOCOMMERCE_THEME ) {
@@ -146,7 +169,13 @@ const ThemeTypeBadgeTooltip = ( {
 			: createInterpolateElement(
 					translate( 'This WooCommerce theme is included in the <Link>Business plan</Link>.' ),
 					{
-						Link: <Link onClick={ () => goToCheckout( 'business' ) } />,
+						Link: (
+							<ThemeTypeBadgeTooltipUpgradeLink
+								canGoToCheckout={ canGoToCheckout }
+								plan="business"
+								siteSlug={ siteSlug }
+							/>
+						),
 					}
 			  );
 	} else if ( type === MARKETPLACE_THEME ) {
@@ -160,7 +189,13 @@ const ThemeTypeBadgeTooltip = ( {
 					'You have a subscription for this theme, but it will only be usable if you have the <link>Business plan</link> on your site.'
 				),
 				{
-					link: <Link onClick={ () => goToCheckout( 'business' ) } />,
+					link: (
+						<ThemeTypeBadgeTooltipUpgradeLink
+							canGoToCheckout={ canGoToCheckout }
+							plan="business"
+							siteSlug={ siteSlug }
+						/>
+					),
 				}
 			);
 		} else if ( ! isPurchased && isIncludedCurrentPlan ) {
@@ -187,7 +222,13 @@ const ThemeTypeBadgeTooltip = ( {
 					}
 				) as string,
 				{
-					Link: <Link onClick={ () => goToCheckout( 'business' ) } />,
+					Link: (
+						<ThemeTypeBadgeTooltipUpgradeLink
+							canGoToCheckout={ canGoToCheckout }
+							plan="business"
+							siteSlug={ siteSlug }
+						/>
+					),
 				}
 			);
 		}

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import ThemeTypeBadge from 'calypso/components/theme-type-badge';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { updateThemes } from 'calypso/state/themes/actions/theme-update';
 import { isExternallyManagedTheme as getIsExternallyManagedTheme } from 'calypso/state/themes/selectors';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
@@ -274,7 +275,13 @@ export class Theme extends Component {
 	};
 
 	renderBadge = () => {
-		return <ThemeTypeBadge themeId={ this.props.theme.id } />;
+		return (
+			<ThemeTypeBadge
+				siteId={ this.props.siteId }
+				siteSlug={ this.props.siteSlug }
+				themeId={ this.props.theme.id }
+			/>
+		);
 	};
 
 	render() {
@@ -313,7 +320,7 @@ export class Theme extends Component {
 }
 
 export default connect(
-	( state, { theme } ) => {
+	( state, { theme, siteId } ) => {
 		const {
 			themes: { themesUpdate },
 		} = state;
@@ -325,6 +332,7 @@ export default connect(
 			isUpdating: themesUpdating && themesUpdating.indexOf( theme.id ) > -1,
 			isUpdated: themesUpdated && themesUpdated.indexOf( theme.id ) > -1,
 			isExternallyManagedTheme,
+			siteSlug: getSiteSlug( state, siteId ),
 		};
 	},
 	{ recordTracksEvent, setThemesBookmark, updateThemes }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -47,6 +47,18 @@ jest.mock( 'calypso/lib/explat', () => ( {
 	useExperiment: () => [ false, null ],
 } ) );
 
+jest.mock( 'calypso/components/data/query-site-features', () => ( {
+	useQuerySiteFeatures: () => {
+		return;
+	},
+} ) );
+
+jest.mock( 'calypso/components/data/query-themes', () => ( {
+	useQueryThemes: () => {
+		return;
+	},
+} ) );
+
 /**
  * Mock wpcom-proxy-request so that we could use wpcom-xhr-request to call the endpoint
  * and get the response from nock

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -16,9 +16,12 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState, useEffect } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
+import { useQuerySiteFeatures } from 'calypso/components/data/query-site-features';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
+import { useQueryThemes } from 'calypso/components/data/query-themes';
 import FormattedHeader from 'calypso/components/formatted-header';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
+import ThemeTypeBadge from 'calypso/components/theme-type-badge';
 import WebPreview from 'calypso/components/web-preview/content';
 import { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -26,7 +29,6 @@ import { urlToSlug } from 'calypso/lib/url';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import { setActiveTheme } from 'calypso/state/themes/actions';
-import { getPurchasedThemes } from 'calypso/state/themes/selectors/get-purchased-themes';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import useCheckout from '../../../../hooks/use-checkout';
 import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
@@ -302,11 +304,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	// ********** Logic for unlocking a selected premium design
 
+	useQueryThemes( 'wpcom', { tier: '-marketplace', number: 1000 } );
 	useQuerySitePurchases( site ? site.ID : -1 );
+	useQuerySiteFeatures( [ site?.ID ] );
 
-	const purchasedThemes = useSelector( ( state ) =>
-		site ? getPurchasedThemes( state, site.ID ) : []
-	);
 	const selectedDesignThemeId = selectedDesign ? getThemeIdFromDesign( selectedDesign ) : null;
 	const didPurchaseSelectedTheme = useSelector( ( state ) =>
 		site && selectedDesignThemeId
@@ -326,6 +327,17 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const isEligibleForProPlan = useSelect(
 		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isEligibleForProPlan( site.ID ),
 		[ site ]
+	);
+
+	const getBadge = ( themeId: string, forcePremium: boolean, tooltipMessage: string ) => (
+		<ThemeTypeBadge
+			canGoToCheckout={ false }
+			forcePremium={ forcePremium }
+			siteId={ site?.ID ?? null }
+			siteSlug={ siteSlug }
+			themeId={ themeId }
+			tooltipMessage={ tooltipMessage }
+		/>
 	);
 
 	function upgradePlan() {
@@ -724,8 +736,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		/>
 	);
 
-	const currentPlanFeatures = site?.plan?.features.active ?? [];
-
 	if ( isDesignFirstFlow ) {
 		categorization.categories = [];
 		categorization.selection = 'blog';
@@ -742,9 +752,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			heading={ heading }
 			categorization={ categorization }
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }
-			purchasedThemes={ purchasedThemes }
-			currentPlanFeatures={ currentPlanFeatures }
 			shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
+			getBadge={ getBadge }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -329,13 +329,19 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		[ site ]
 	);
 
-	const getBadge = ( themeId: string, forcePremium: boolean, tooltipMessage: string ) => (
+	const getBadge = (
+		themeId: string,
+		forcePremium: boolean,
+		tooltipHeader: string,
+		tooltipMessage: string
+	) => (
 		<ThemeTypeBadge
 			canGoToCheckout={ false }
 			forcePremium={ forcePremium }
 			siteId={ site?.ID ?? null }
 			siteSlug={ siteSlug }
 			themeId={ themeId }
+			tooltipHeader={ tooltipHeader }
 			tooltipMessage={ tooltipMessage }
 		/>
 	);

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -21,10 +21,9 @@ jest.mock( 'calypso/lib/analytics/page-view-tracker', () =>
 jest.mock( 'calypso/my-sites/themes/theme-preview', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'react-redux', () => ( {
-	...jest.requireActual( 'react-redux' ),
-	useSelector: () => false,
-} ) );
+jest.mock( 'calypso/components/data/query-themes', () =>
+	require( 'calypso/components/empty-component' )
+);
 
 window.IntersectionObserver = jest.fn( () => ( { observe: jest.fn(), disconnect: jest.fn() } ) );
 

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -271,37 +271,6 @@ $theme-card-info-margin-top: 16px;
 	width: 0;
 }
 
-.theme-card__info-pricing {
-	display: flex;
-	flex-basis: 100%;
-	font-size: 0;
-	gap: 10px;
-	line-height: 20px;
-	padding: 0;
-
-	> span {
-		color: var(--color-neutral-60);
-		font-size: $font-body-small;
-		line-height: 20px;
-	}
-
-	.premium-badge,
-	.woocommerce-bundled-badge {
-		margin: 0;
-		vertical-align: middle;
-
-		svg {
-			padding: 0;
-			transform: none;
-			width: auto;
-		}
-	}
-
-	.premium-badge svg {
-		height: auto;
-	}
-}
-
 .theme-card__info-style-variations {
 	align-items: center;
 	display: flex;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -136,7 +136,12 @@ interface DesignCardProps {
 	shouldLimitGlobalStyles?: boolean;
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
-	getBadge: ( themeId: string, forcePremium: boolean, tooltipMessage: string ) => React.ReactNode;
+	getBadge: (
+		themeId: string,
+		forcePremium: boolean,
+		tooltipHeader: string,
+		tooltipMessage: string
+	) => React.ReactNode;
 }
 
 const DesignCard: React.FC< DesignCardProps > = ( {
@@ -158,6 +163,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 
 	const isPremiumStyleVariation =
 		( ! design.is_premium && shouldLimitGlobalStyles && ! isDefaultVariation ) ?? false;
+	const badgeTooltipHeader = isPremiumStyleVariation ? __( 'Premium style' ) : '';
 	const badgeTooltipMessage = isPremiumStyleVariation
 		? __( 'Unlock this style, and tons of other features, by upgrading to a Premium plan.' )
 		: '';
@@ -176,7 +182,12 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 					styleVariation={ selectedStyleVariation }
 				/>
 			}
-			badge={ getBadge( design.slug, isPremiumStyleVariation, badgeTooltipMessage ) }
+			badge={ getBadge(
+				design.slug,
+				isPremiumStyleVariation,
+				badgeTooltipHeader,
+				badgeTooltipMessage
+			) }
 			styleVariations={ style_variations }
 			selectedStyleVariation={ selectedStyleVariation }
 			onImageClick={ () => onPreview( design, selectedStyleVariation ) }
@@ -198,7 +209,12 @@ interface DesignPickerProps {
 	categorization?: Categorization;
 	isPremiumThemeAvailable?: boolean;
 	shouldLimitGlobalStyles?: boolean;
-	getBadge: ( themeId: string, forcePremium: boolean, tooltipMessage: string ) => React.ReactNode;
+	getBadge: (
+		themeId: string,
+		forcePremium: boolean,
+		tooltipHeader: string,
+		tooltipMessage: string
+	) => React.ReactNode;
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -273,7 +289,12 @@ export interface UnifiedDesignPickerProps {
 	heading?: React.ReactNode;
 	isPremiumThemeAvailable?: boolean;
 	shouldLimitGlobalStyles?: boolean;
-	getBadge: ( themeId: string, forcePremium: boolean, tooltipMessage: string ) => React.ReactNode;
+	getBadge: (
+		themeId: string,
+		forcePremium: boolean,
+		tooltipHeader: string,
+		tooltipMessage: string
+	) => React.ReactNode;
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2438

## Proposed Changes


Refactors the Design Picker to use the `ThemeTypeBadge` component introduced in https://github.com/Automattic/wp-calypso/pull/77554 to display the theme type badges, so we no longer need to duplicate logic from the Theme Showcase.

**Premium style variations**
Before | After
--- | ---
<img width="406" alt="Screenshot 2023-06-01 at 15 04 11" src="https://github.com/Automattic/wp-calypso/assets/1233880/abf1eb9b-0dfe-48d6-b4ee-8378df005556"> | <img width="406" alt="Screenshot 2023-06-01 at 15 12 10" src="https://github.com/Automattic/wp-calypso/assets/1233880/85bcefe3-6538-46f2-890f-a7549944166f">


**Premium themes**

Eligible plan | One-off purchase | Before | After
--- | --- | --- | ---
❌ | ❌ | <img width="395" alt="Screenshot 2023-06-01 at 14 56 04" src="https://github.com/Automattic/wp-calypso/assets/1233880/c81fc805-e820-4728-b026-87e2c85b53ea"> | <img width="504" alt="Screenshot 2023-06-01 at 14 56 42" src="https://github.com/Automattic/wp-calypso/assets/1233880/b21d402b-4172-4906-b95f-a20364634c7a">
✅ | ❌ | <img width="397" alt="Screenshot 2023-06-01 at 14 58 58" src="https://github.com/Automattic/wp-calypso/assets/1233880/127c7c4e-cf95-48e2-910f-d0f0c2aea927"> | <img width="507" alt="Screenshot 2023-06-01 at 15 01 48" src="https://github.com/Automattic/wp-calypso/assets/1233880/ab722cb3-3779-4b24-93b2-eec4cd0389cf">
❌ | ✅ | <img width="399" alt="Screenshot 2023-06-01 at 15 02 38" src="https://github.com/Automattic/wp-calypso/assets/1233880/d340690b-fbb4-4c80-b5c0-5f4854709596"> | <img width="399" alt="Screenshot 2023-06-01 at 15 02 53" src="https://github.com/Automattic/wp-calypso/assets/1233880/80278320-f7b1-4946-b2e4-55b479591bf3">


**WooCommerce themes**

Eligible plan | Before | After
--- | --- | ---
❌ | <img width="398" alt="Screenshot 2023-06-01 at 15 13 04" src="https://github.com/Automattic/wp-calypso/assets/1233880/ca0709b3-a583-4846-bdb6-3f61fff4e3b4"> | <img width="480" alt="Screenshot 2023-06-01 at 15 13 15" src="https://github.com/Automattic/wp-calypso/assets/1233880/37f96ae9-bfd3-433c-bf4f-e5d54e2b5055">
✅ | <img width="403" alt="Screenshot 2023-06-01 at 15 14 08" src="https://github.com/Automattic/wp-calypso/assets/1233880/1cd4ce16-52c0-40b7-80d9-2519cd487f97"> | <img width="408" alt="Screenshot 2023-06-01 at 15 14 24" src="https://github.com/Automattic/wp-calypso/assets/1233880/3f38f4cc-5b65-4317-b7a5-c50a36a964e4">

## Testing Instructions

- Use the Calypso live link below.
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`.
- Test all the different scenarios listed in the screenshots above.
- Make sure the theme type badge is rendered correctly.