### PR TITLE
New hosted site: Go to site home if the user has more than one site

### DIFF
--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -9,6 +9,7 @@ import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
+import getSites from 'calypso/state/selectors/get-sites';
 import { useQuery } from '../hooks/use-query';
 import { ONBOARD_STORE } from '../stores';
 import { isInHostingFlow } from '../utils/is-in-hosting-flow';
@@ -55,6 +56,7 @@ const hosting: Flow = {
 		];
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {
+		const siteCount = useSelector( getSites ).length;
 		const hostingFlow = useSelector( isInHostingFlow );
 		const { setSiteTitle, setPlanCartItem, setSiteGeoAffinity } = useDispatch( ONBOARD_STORE );
 		const { siteGeoAffinity, planCartItem } = useSelect(
@@ -73,9 +75,13 @@ const hosting: Flow = {
 			}
 
 			if ( _currentStepSlug === 'processing' ) {
-				const destination = addQueryArgs( '/sites', {
-					'new-site': providedDependencies.siteId,
-				} );
+				const destination =
+					siteCount === 0
+						? addQueryArgs( '/sites', {
+								'new-site': providedDependencies.siteId as number,
+						  } )
+						: `/home/${ providedDependencies.siteSlug }`;
+
 				persistSignupDestination( destination );
 				setSignupCompleteSlug( providedDependencies?.siteSlug );
 				setSignupCompleteFlowName( flowName );


### PR DESCRIPTION
Supersedes https://github.com/Automattic/wp-calypso/pull/77674. Closes https://github.com/Automattic/dotcom-forge/issues/2616.

## Proposed Changes

In the onboarding flow, it makes sense to redirect the user to `/sites` after they purchase the site because we want them to be aware of our dashboard.

But this behavior might not be wanted in subsequent purchases because most of the time, after a site is created, it makes sense to modify it immediately. So why send them to `/sites`? They are already aware of the dashboard, and know how it works, so let's send them to `/home/%s`.

See more in p1685625431206379-slack-C0347E545HR.

## Testing Instructions

- Login to an account with zero sites and create a site through `/setup/new-hosted-site`. You should be redirected to `/sites`;
- Create a new site with the same account and flow. You should be redirected to `/home/%s`.