### PR TITLE
New hosted site: display site options for non-Atomic sites

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
@@ -168,6 +168,12 @@ body:has(.new-hosted-site.options) {
 		}
 	}
 
+	.site-options__form-fieldset {
+		&.no-site-picker {
+			margin-bottom: 0;
+		}
+	}
+
 	.data-center-picker {
 		color: var(--studio-gray-60);
 	}

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -1,4 +1,3 @@
-import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
 import { NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -159,32 +158,27 @@ const hosting: Flow = {
 
 					// User picked the Free plan
 					if ( ! productSlug ) {
-						return navigate( 'siteCreationStep' );
+						return navigate( 'options' );
 					}
 
 					setPlanCartItem( {
 						product_slug: productSlug,
-						extra: { geo_affinity: siteGeoAffinity },
 					} );
 
-					const mustPickDataCenter =
-						isBusinessPlan( productSlug ) || isEcommercePlan( productSlug );
-
-					if ( mustPickDataCenter ) {
-						return navigate( 'options' );
-					}
-
-					return navigate( 'siteCreationStep' );
+					return navigate( 'options' );
 				}
 
 				case 'options': {
 					setSiteTitle( providedDependencies.siteTitle );
-					setSiteGeoAffinity( providedDependencies.siteGeoAffinity );
 
-					setPlanCartItem( {
-						product_slug: planCartItem?.product_slug,
-						extra: { geo_affinity: providedDependencies.siteGeoAffinity },
-					} );
+					if ( providedDependencies.siteGeoAffinity ) {
+						setPlanCartItem( {
+							product_slug: planCartItem?.product_slug,
+							extra: { geo_affinity: providedDependencies.siteGeoAffinity },
+						} );
+
+						setSiteGeoAffinity( providedDependencies.siteGeoAffinity );
+					}
 
 					return navigate( 'siteCreationStep' );
 				}


### PR DESCRIPTION
## Proposed Changes

@wojtekn found it weird that they're getting a `<username><unique-id>.wordpress.com` site and that doesn't make sense indeed.

I think we should offer the site options step for 

## Testing Instructions

1. Open `/setup/new-hosted-site` and select Free, Personal or Premium plan;
2. Check that you're redirected to the options step and there's a suggestion name;
3. Go to checkout (or home in case of free) and see that the site slug is related to the site title.

In the case of a non-Atomic plan, you should not see the data center picker. Picking Business or Commerce should display the data center picker.

Check that `/setup/new-hosted-site?hosting-flow` is unaffected and the first step is `siteOptions` with the data center picker available.
