### PR TITLE
Hide tab bar for email stats for posts that have not been backfilled yet

### DIFF
--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -66,7 +66,9 @@ export default function PostDetailHighlightsSection( {
 
 	// postId > 0: Show the tabs for posts except for the Home Page (postId = 0).
 	// isWPcomSite: The Newsletter Stats is only covering `WPCOM sites` for now.
-	const isEmailTabsAvailable = postId > 0 && isWPcomSite;
+	// TODO: remove the (post?.date && new Date(post?.date) >= new Date("2023-05-30")) check when the Newsletter Stats data is backfilled.
+	const isEmailTabsAvailable =
+		postId > 0 && isWPcomSite && post?.date && new Date( post?.date ) >= new Date( '2023-05-30' );
 
 	return (
 		<div className="stats__post-detail-highlights-section">


### PR DESCRIPTION
## Proposed Changes

Only shows the tab bar for posts that were published after the livefilling of email stats data started.

## Testing Instructions

1. Apply this patch
2. View the stats of a post that was published before 2023-05-30:

![CleanShot 2023-06-01 at 16 24 09@2x](https://github.com/Automattic/wp-calypso/assets/528287/5d4a0519-7e82-44dd-9369-e6fd65bd07d0)

3. View the stats of a post that was published on or after 2023-05-30:

![CleanShot 2023-06-01 at 16 24 51@2x](https://github.com/Automattic/wp-calypso/assets/528287/daa62f1b-de56-4172-bfa9-9a9acc855bb7)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
