### PR TITLE
Email stats: Set max height of country list

### DIFF
--- a/client/my-sites/stats/stats-email-detail/style.scss
+++ b/client/my-sites/stats/stats-email-detail/style.scss
@@ -89,6 +89,10 @@ $break-large-stats-countries: 1280px;
 		.stats-card--header-and-body {
 			grid-area: list;
 		}
+		.stats-card--body {
+			max-height: 400px;
+			overflow: auto;
+		}
 		.stats-card--footer {
 			grid-area: more;
 		}


### PR DESCRIPTION
Closes [#77665](https://github.com/Automattic/wp-calypso/issues/77665)

## Proposed Changes

This PR limits the max height of the country list in the email stats.

## Testing Instructions

1. Apply this PR
2. Visit the email stats page of a very popular blog post
3. Ensure that the country list isn't as tall as the Eiffel Tower

| Before | After |
|-|-|
| ![CleanShot 2023-06-01 at 13 22 25@2x](https://github.com/Automattic/wp-calypso/assets/528287/895c0627-3951-4b7e-8a68-f05403825b55) | ![CleanShot 2023-06-01 at 16 32 58@2x](https://github.com/Automattic/wp-calypso/assets/528287/5e6f1d1e-205a-4bbe-890e-686d2f14eaf9) | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
