### PR TITLE
Reader: Fix suggested follows - no related sites found

### DIFF
--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -13,7 +13,7 @@ const ReaderSuggestedFollowsDialog = ( { onClose, siteId, postId, isVisible } ) 
 		<Dialog
 			additionalClassNames="reader-recommended-follows-dialog"
 			isBackdropVisible={ true }
-			isVisible={ isVisible }
+			isVisible={ isVisible && ( isLoading || ( ! isLoading && data ) ) }
 			onClose={ onClose }
 			showCloseIcon={ true }
 			label={ translate( 'Suggested follows' ) }


### PR DESCRIPTION
This PR fixes an issue where the related sites endpoint return no sites. In this case the dialog/modal was being display with no sites listed.

This PR will handle this case by not displaying a modal if no sites are found.

### Example


https://github.com/Automattic/wp-calypso/assets/5560595/d9d7165a-8aba-4e08-a326-0687bbb2a755


