### PR TITLE
Stats: Add static highlight card settings tooltip

### DIFF
--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -294,6 +294,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	font-weight: 500;
 	line-height: 20px;
 	font-family: $highlight-card-tooltip-font;
+	letter-spacing: -0.24px;
 
 	&.comparing-info {
 		display: block;
@@ -332,6 +333,29 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		fill: var(--studio-white);
 		display: flex;
 		padding-right: 8px;
+	}
+}
+
+.highlight-card__settings-tooltip {
+	.highlight-card-tooltip-content {
+		flex-direction: column;
+		align-items: flex-end;
+
+		p {
+			margin-bottom: 24px;
+		}
+
+		button {
+			font-family: $font-sf-pro-text;
+			font-weight: 600;
+			font-size: $font-body-extra-small;
+			line-height: 20px;
+			color: var(--studio-black);
+			padding: 4px 8px;
+			background-color: var(--studio-white);
+			border-radius: 4px;
+			cursor: pointer;
+		}
 	}
 }
 

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -64,7 +64,7 @@ const HighlightCardsSettings = function ( {
 	const [ isSettingsTooltipVisible, setSettingsTooltipVisible ] = useState( showSettingsTooltip );
 	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
 
-	// @TODO: Update the state when users dismiss the settings tooltip.
+	// @TODO: Update the state to the API endpoint when users dismiss the settings tooltip.
 	const dismissSettingsTooltip = useCallback( () => {
 		sessionStorage.setItem( 'jp-stats-settings-tooltip', '1' );
 		setSettingsTooltipVisible( false );

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -69,18 +69,19 @@ export default function WeeklyHighlightCards( {
 	const [ isSettingsTooltipVisible, setSettingsTooltipVisible ] = useState( showSettingsTooltip );
 	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
 
-	// @TODO: Set the popover to disappear when the users click outside of the popover.
-	const togglePopoverMenu = useCallback( () => {
-		setPopoverVisible( ( isVisible ) => {
-			return ! isVisible;
-		} );
-	}, [] );
-
 	// @TODO: Update the state when users dismiss the settings tooltip.
 	const dismissSettingsTooltip = useCallback( () => {
 		sessionStorage.setItem( 'jp-stats-settings-tooltip', '1' );
 		setSettingsTooltipVisible( false );
 	}, [] );
+
+	// @TODO: Set the popover to disappear when the users click outside of the popover.
+	const togglePopoverMenu = useCallback( () => {
+		dismissSettingsTooltip();
+		setPopoverVisible( ( isVisible ) => {
+			return ! isVisible;
+		} );
+	}, [ dismissSettingsTooltip ] );
 
 	const isHighlightsSettingsEnabled = config.isEnabled( 'stats/highlights-settings' );
 

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -59,17 +59,27 @@ export default function WeeklyHighlightCards( {
 }: WeeklyHighlightCardsProps ) {
 	const translate = useTranslate();
 
+	// @TODO: Fetch the state from API to determine whether showing the settings tooltip.
+	const showSettingsTooltip =
+		sessionStorage.getItem( 'jp-stats-settings-tooltip' ) === '1' ? false : true;
+
 	const textRef = useRef( null );
 	const settingsActionRef = useRef( null );
 	const [ isTooltipVisible, setTooltipVisible ] = useState( true );
-	const [ isSettingsTooltipVisible, setSettingsTooltipVisible ] = useState( true );
+	const [ isSettingsTooltipVisible, setSettingsTooltipVisible ] = useState( showSettingsTooltip );
 	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
 
-	// @TODO: Set the popover to disappear when the user clicks outside of the popover.
+	// @TODO: Set the popover to disappear when the users click outside of the popover.
 	const togglePopoverMenu = useCallback( () => {
 		setPopoverVisible( ( isVisible ) => {
 			return ! isVisible;
 		} );
+	}, [] );
+
+	// @TODO: Update the state when users dismiss the settings tooltip.
+	const dismissSettingsTooltip = useCallback( () => {
+		sessionStorage.setItem( 'jp-stats-settings-tooltip', '1' );
+		setSettingsTooltipVisible( false );
 	}, [] );
 
 	const isHighlightsSettingsEnabled = config.isEnabled( 'stats/highlights-settings' );
@@ -157,7 +167,11 @@ export default function WeeklyHighlightCards( {
 										'You can now tailor your site highlights by adjusting the time range.'
 									) }
 								</p>
-								<button onClick={ () => setSettingsTooltipVisible( false ) }>
+								<button
+									onClick={ () => {
+										dismissSettingsTooltip();
+									} }
+								>
 									{ translate( 'Got it' ) }
 								</button>
 							</div>

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -61,7 +61,8 @@ export default function WeeklyHighlightCards( {
 
 	const textRef = useRef( null );
 	const settingsActionRef = useRef( null );
-	const [ isTooltipVisible, setTooltipVisible ] = useState( false );
+	const [ isTooltipVisible, setTooltipVisible ] = useState( true );
+	const [ isSettingsTooltipVisible, setSettingsTooltipVisible ] = useState( true );
 	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
 
 	// @TODO: Set the popover to disappear when the user clicks outside of the popover.
@@ -144,6 +145,23 @@ export default function WeeklyHighlightCards( {
 						>
 							<Icon className="gridicon" icon={ moreVertical } />
 						</button>
+						<Popover
+							className="tooltip tooltip--darker highlight-card-tooltip highlight-card__settings-tooltip"
+							isVisible={ isSettingsTooltipVisible }
+							position="bottom left"
+							context={ settingsActionRef.current }
+						>
+							<div className="highlight-card-tooltip-content">
+								<p>
+									{ translate(
+										'You can now tailor your site highlights by adjusting the time range.'
+									) }
+								</p>
+								<button onClick={ () => setSettingsTooltipVisible( false ) }>
+									{ translate( 'Got it' ) }
+								</button>
+							</div>
+						</Popover>
 						<Popover
 							className="tooltip highlight-card-popover"
 							isVisible={ isPopoverVisible }

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -149,7 +149,7 @@ export default function WeeklyHighlightCards( {
 	const translate = useTranslate();
 
 	const textRef = useRef( null );
-	const [ isTooltipVisible, setTooltipVisible ] = useState( true );
+	const [ isTooltipVisible, setTooltipVisible ] = useState( false );
 
 	const isHighlightsSettingsEnabled = config.isEnabled( 'stats/highlights-settings' );
 

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -40,32 +40,27 @@ type WeeklyHighlightCardsProps = {
 	currentPeriod: string;
 };
 
+type HighlightCardsSettingsProps = {
+	onTogglePeriod: ( period: string ) => void;
+	currentPeriod: string;
+};
+
 export const PAST_SEVEN_DAYS = 'past_seven_days';
 export const PAST_THIRTY_DAYS = 'past_thirty_days';
 export const BETWEEN_PAST_EIGHT_AND_FIFTEEN_DAYS = 'between_past_eight_and_fifteen_days';
 export const BETWEEN_PAST_THIRTY_ONE_AND_SIXTY_DAYS = 'between_past_thirty_one_and_sixty_days';
 
-export default function WeeklyHighlightCards( {
-	className,
-	counts,
-	onClickComments,
-	onClickLikes,
-	onClickViews,
-	onClickVisitors,
-	onTogglePeriod,
-	previousCounts,
-	showValueTooltip,
+const HighlightCardsSettings = function ( {
 	currentPeriod,
-}: WeeklyHighlightCardsProps ) {
+	onTogglePeriod,
+}: HighlightCardsSettingsProps ) {
 	const translate = useTranslate();
 
 	// @TODO: Fetch the state from API to determine whether showing the settings tooltip.
 	const showSettingsTooltip =
 		sessionStorage.getItem( 'jp-stats-settings-tooltip' ) === '1' ? false : true;
 
-	const textRef = useRef( null );
 	const settingsActionRef = useRef( null );
-	const [ isTooltipVisible, setTooltipVisible ] = useState( true );
 	const [ isSettingsTooltipVisible, setSettingsTooltipVisible ] = useState( showSettingsTooltip );
 	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
 
@@ -82,6 +77,79 @@ export default function WeeklyHighlightCards( {
 			return ! isVisible;
 		} );
 	}, [ dismissSettingsTooltip ] );
+
+	return (
+		<div className="highlight-cards-heading__settings">
+			<button
+				className="highlight-cards-heading__settings-action"
+				ref={ settingsActionRef }
+				onClick={ togglePopoverMenu }
+			>
+				<Icon className="gridicon" icon={ moreVertical } />
+			</button>
+			<Popover
+				className="tooltip tooltip--darker highlight-card-tooltip highlight-card__settings-tooltip"
+				isVisible={ isSettingsTooltipVisible }
+				position="bottom left"
+				context={ settingsActionRef.current }
+			>
+				<div className="highlight-card-tooltip-content">
+					<p>
+						{ translate( 'You can now tailor your site highlights by adjusting the time range.' ) }
+					</p>
+					<button
+						onClick={ () => {
+							dismissSettingsTooltip();
+						} }
+					>
+						{ translate( 'Got it' ) }
+					</button>
+				</div>
+			</Popover>
+			<Popover
+				className="tooltip highlight-card-popover"
+				isVisible={ isPopoverVisible }
+				position="bottom left"
+				context={ settingsActionRef.current }
+				focusOnShow={ false }
+			>
+				<button
+					onClick={ () => {
+						onTogglePeriod( PAST_SEVEN_DAYS );
+					} }
+				>
+					{ translate( '7-day highlights' ) }
+					{ currentPeriod === PAST_SEVEN_DAYS && <Icon className="gridicon" icon={ check } /> }
+				</button>
+				<button
+					onClick={ () => {
+						onTogglePeriod( PAST_THIRTY_DAYS );
+					} }
+				>
+					{ translate( '30-day highlights' ) }
+					{ currentPeriod === PAST_THIRTY_DAYS && <Icon className="gridicon" icon={ check } /> }
+				</button>
+			</Popover>
+		</div>
+	);
+};
+
+export default function WeeklyHighlightCards( {
+	className,
+	counts,
+	onClickComments,
+	onClickLikes,
+	onClickViews,
+	onClickVisitors,
+	onTogglePeriod,
+	previousCounts,
+	showValueTooltip,
+	currentPeriod,
+}: WeeklyHighlightCardsProps ) {
+	const translate = useTranslate();
+
+	const textRef = useRef( null );
+	const [ isTooltipVisible, setTooltipVisible ] = useState( true );
 
 	const isHighlightsSettingsEnabled = config.isEnabled( 'stats/highlights-settings' );
 
@@ -148,64 +216,10 @@ export default function WeeklyHighlightCards( {
 				) }
 
 				{ isHighlightsSettingsEnabled && (
-					<div className="highlight-cards-heading__settings">
-						<button
-							className="highlight-cards-heading__settings-action"
-							ref={ settingsActionRef }
-							onClick={ togglePopoverMenu }
-						>
-							<Icon className="gridicon" icon={ moreVertical } />
-						</button>
-						<Popover
-							className="tooltip tooltip--darker highlight-card-tooltip highlight-card__settings-tooltip"
-							isVisible={ isSettingsTooltipVisible }
-							position="bottom left"
-							context={ settingsActionRef.current }
-						>
-							<div className="highlight-card-tooltip-content">
-								<p>
-									{ translate(
-										'You can now tailor your site highlights by adjusting the time range.'
-									) }
-								</p>
-								<button
-									onClick={ () => {
-										dismissSettingsTooltip();
-									} }
-								>
-									{ translate( 'Got it' ) }
-								</button>
-							</div>
-						</Popover>
-						<Popover
-							className="tooltip highlight-card-popover"
-							isVisible={ isPopoverVisible }
-							position="bottom left"
-							context={ settingsActionRef.current }
-							focusOnShow={ false }
-						>
-							<button
-								onClick={ () => {
-									onTogglePeriod( PAST_SEVEN_DAYS );
-								} }
-							>
-								{ translate( '7-day highlights' ) }
-								{ currentPeriod === PAST_SEVEN_DAYS && (
-									<Icon className="gridicon" icon={ check } />
-								) }
-							</button>
-							<button
-								onClick={ () => {
-									onTogglePeriod( PAST_THIRTY_DAYS );
-								} }
-							>
-								{ translate( '30-day highlights' ) }
-								{ currentPeriod === PAST_THIRTY_DAYS && (
-									<Icon className="gridicon" icon={ check } />
-								) }
-							</button>
-						</Popover>
-					</div>
+					<HighlightCardsSettings
+						currentPeriod={ currentPeriod }
+						onTogglePeriod={ onTogglePeriod }
+					/>
 				) }
 			</h3>
 

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -58,7 +58,7 @@ const HighlightCardsSettings = function ( {
 
 	// @TODO: Fetch the state from API to determine whether showing the settings tooltip.
 	const showSettingsTooltip =
-		sessionStorage.getItem( 'jp-stats-settings-tooltip' ) === '1' ? false : true;
+		sessionStorage.getItem( 'jp-stats-hide-traffic-highlights-tooltip' ) === '1' ? false : true;
 
 	const settingsActionRef = useRef( null );
 	const [ isSettingsTooltipVisible, setSettingsTooltipVisible ] = useState( showSettingsTooltip );
@@ -66,7 +66,7 @@ const HighlightCardsSettings = function ( {
 
 	// @TODO: Update the state to the API endpoint when users dismiss the settings tooltip.
 	const dismissSettingsTooltip = useCallback( () => {
-		sessionStorage.setItem( 'jp-stats-settings-tooltip', '1' );
+		sessionStorage.setItem( 'jp-stats-hide-traffic-highlights-tooltip', '1' );
 		setSettingsTooltipVisible( false );
 	}, [] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #77548 

## Proposed Changes

* Add a highlight card settings tooltip that is temporarily determined displaying by `sessionStorage`.

<img width="1310" alt="截圖 2023-06-02 上午12 59 02" src="https://github.com/Automattic/wp-calypso/assets/6869813/9e225e14-b664-4e8a-b661-3517507d2be3">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the live branch link.
* Navigate to Stats > `Traffic` page.
* Ensure the highlights section settings tooltip shows in line with the design.
* Click the `Got it` or settings popover toggle button.
* Ensure the settings tooltip disappears and do not show after refreshing the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
