### PR TITLE
Subscription Management: Add payment info to individual site subscription page.

### DIFF
--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -47,6 +47,7 @@ const SiteSubscriptionPage = () => {
 							siteIcon={ data.site_icon }
 							deliveryMethods={ data.delivery_methods }
 							url={ data.URL }
+							paymentDetails={ data.payment_details }
 						/>
 					) }
 				</div>

--- a/client/landing/subscriptions/components/site-subscription-page/styles.scss
+++ b/client/landing/subscriptions/components/site-subscription-page/styles.scss
@@ -102,6 +102,7 @@
 
 		&__list {
 			margin: 0;
+			padding: 10px 0;
 
 			dt,
 			dd {
@@ -122,7 +123,7 @@
 				margin: 0;
 
 				+ dt {
-					margin-top: 24px;
+					margin-top: 8px;
 				}
 			}
 		}

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -144,6 +144,20 @@ export type SiteSubscriptionDetails = {
 	date_subscribed: Date;
 	subscriber_count: number;
 	delivery_methods: SiteSubscriptionDeliveryMethods;
+	payment_details: SiteSubscriptionPaymentDetails;
+};
+
+export type SiteSubscriptionPaymentDetails = {
+	ID: string;
+	site_id: string;
+	status: string;
+	start_date: string;
+	end_date: string;
+	renew_interval: string;
+	renewal_price: string;
+	currency: string;
+	product_id: string;
+	title: string;
 };
 
 export type ErrorResponse< Errors = unknown, ErrorData = unknown > = {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/77233

## Proposed Changes

These changes add payment information to the Individual Subscription page. This info can be for non, one, or more subscriptions.

![image](https://github.com/Automattic/wp-calypso/assets/3832570/7f262f2c-1939-4313-a257-714b93c6ccc3)

Several notes about the design and this implementation:
- the "Manage purchase" button is added in a different PR.
- the Payment details field still needs to be implemented in the endpoint so that it will be implemented in the front end later.

## Testing Instructions

1. You need to have an account with purchases. You can follow these instructions: pdDOJh-1SM-p2
2. Apply this PR and run the application.
3. Go to the Individual Subscription page of the blog you have paid subscriptions to, with this URL: `http://calypso.localhost:3000/subscriptions/site/[id-of-the-blog]`.
4. Check that your paid subscriptions info is shown like in the screenshot.

