### PR TITLE
Dev accounts: use consistent new site url in site selector, sidebar and sites dashboard

### DIFF
--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -2,8 +2,7 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback } from 'react';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { onboardingUrl } from 'calypso/lib/paths';
-import { addQueryArgs } from 'calypso/lib/url';
+import { useSitesDashboardCreateSiteUrl } from 'calypso/sites-dashboard/hooks/use-sites-dashboard-create-site-url';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -21,19 +20,14 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 		dispatch( recordTracksEvent( event ) );
 	}, [ dispatch ] );
 
+	const addNewSiteUrl = useSitesDashboardCreateSiteUrl( {
+		ref: 'calypso-selector',
+		source: 'my-home',
+		siteSlug,
+	} );
+
 	return (
-		<Button
-			primary
-			href={ addQueryArgs(
-				{
-					ref: 'calypso-selector',
-					source: 'my-home',
-					siteSlug,
-				},
-				onboardingUrl()
-			) }
-			onClick={ recordAddNewSite }
-		>
+		<Button primary href={ addNewSiteUrl } onClick={ recordAddNewSite }>
 			{ translate( 'Add new site' ) }
 		</Button>
 	);

--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -21,7 +21,7 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 	}, [ dispatch ] );
 
 	const addNewSiteUrl = useAddNewSiteUrl( {
-		ref: 'calypso-selector',
+		ref: isJetpackCloud() ? 'jetpack-cloud-selector' : 'calypso-selector',
 		source: 'my-home',
 		siteSlug,
 	} );

--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback } from 'react';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { useSitesDashboardCreateSiteUrl } from 'calypso/sites-dashboard/hooks/use-sites-dashboard-create-site-url';
+import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -20,7 +20,7 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 		dispatch( recordTracksEvent( event ) );
 	}, [ dispatch ] );
 
-	const addNewSiteUrl = useSitesDashboardCreateSiteUrl( {
+	const addNewSiteUrl = useAddNewSiteUrl( {
 		ref: 'calypso-selector',
 		source: 'my-home',
 		siteSlug,

--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -21,8 +21,8 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 	}, [ dispatch ] );
 
 	const addNewSiteUrl = useAddNewSiteUrl( {
-		ref: isJetpackCloud() ? 'jetpack-cloud-selector' : 'calypso-selector',
-		source: 'my-home',
+		ref: 'site-selector',
+		source: isJetpackCloud() ? 'jetpack-cloud' : 'my-home',
 		siteSlug,
 	} );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sidebar/test/sidebar.jsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sidebar/test/sidebar.jsx
@@ -10,6 +10,11 @@ import Sidebar from '../index';
 describe( '<Sitebar>', () => {
 	test( 'should render correctly', () => {
 		const initialState = {
+			userSettings: {
+				settings: {
+					is_dev_account: false,
+				},
+			},
 			currentUser: {
 				capabilities: {},
 				user: {

--- a/client/lib/paths/use-add-new-site-url.tsx
+++ b/client/lib/paths/use-add-new-site-url.tsx
@@ -3,22 +3,13 @@ import { useSelector } from 'react-redux';
 import { Primitive } from 'utility-types';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { addQueryArgs } from 'calypso/lib/url';
-import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
-import { TRACK_SOURCE_NAME } from '../utils';
 
-export const useSitesDashboardCreateSiteUrl = (
-	additionalParams: Record< string, Primitive > = {}
-) => {
+export const useAddNewSiteUrl = ( queryParameters: Record< string, Primitive > ) => {
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
-	const siteCount = useSelector( getCurrentUserSiteCount );
 
 	return addQueryArgs(
-		{
-			source: TRACK_SOURCE_NAME,
-			ref: siteCount === 0 ? 'calypso-nosites' : null,
-			...additionalParams,
-		},
+		queryParameters,
 		// eslint-disable-next-line no-nested-ternary
 		isJetpackCloud()
 			? config( 'jetpack_connect_url' )

--- a/client/my-sites/sidebar/add-new-site.jsx
+++ b/client/my-sites/sidebar/add-new-site.jsx
@@ -1,13 +1,18 @@
 import { Button } from '@automattic/components';
 import { useSelector, useDispatch } from 'react-redux';
 import TranslatableString from 'calypso/components/translatable/proptype';
-import { onboardingUrl } from 'calypso/lib/paths';
+import { useSitesDashboardCreateSiteUrl } from 'calypso/sites-dashboard/hooks/use-sites-dashboard-create-site-url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 
 export const AddNewSite = ( { title } ) => {
 	const reduxDispatch = useDispatch();
+
+	const addNewSiteUrl = useSitesDashboardCreateSiteUrl( {
+		ref: 'calypso-sidebar',
+		source: 'my-home',
+	} );
 
 	const visibleSiteCount = useSelector( getCurrentUser ).visible_site_count;
 	if ( visibleSiteCount > 1 ) {
@@ -21,7 +26,7 @@ export const AddNewSite = ( { title } ) => {
 
 	return (
 		<li className="sidebar__actions">
-			<Button transparent href={ `${ onboardingUrl() }?ref=calypso-sidebar` } onClick={ onClick }>
+			<Button transparent href={ addNewSiteUrl } onClick={ onClick }>
 				<span className="sidebar__action--collapsed dashicons dashicons-plus-alt"></span>
 				<span>{ title }</span>
 			</Button>

--- a/client/my-sites/sidebar/add-new-site.jsx
+++ b/client/my-sites/sidebar/add-new-site.jsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { useSelector, useDispatch } from 'react-redux';
 import TranslatableString from 'calypso/components/translatable/proptype';
-import { useSitesDashboardCreateSiteUrl } from 'calypso/sites-dashboard/hooks/use-sites-dashboard-create-site-url';
+import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
@@ -9,7 +9,7 @@ import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 export const AddNewSite = ( { title } ) => {
 	const reduxDispatch = useDispatch();
 
-	const addNewSiteUrl = useSitesDashboardCreateSiteUrl( {
+	const addNewSiteUrl = useAddNewSiteUrl( {
 		ref: 'calypso-sidebar',
 		source: 'my-home',
 	} );

--- a/client/my-sites/sidebar/add-new-site.jsx
+++ b/client/my-sites/sidebar/add-new-site.jsx
@@ -11,7 +11,7 @@ export const AddNewSite = ( { title } ) => {
 
 	const addNewSiteUrl = useAddNewSiteUrl( {
 		ref: 'calypso-sidebar',
-		source: 'my-home',
+		source: 'calypso-static',
 	} );
 
 	const visibleSiteCount = useSelector( getCurrentUser ).visible_site_count;

--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -1,18 +1,22 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
+import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import { useSitesDashboardCreateSiteUrl } from '../hooks/use-sites-dashboard-create-site-url';
+import { AppState } from 'calypso/types';
 import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
+import { TRACK_SOURCE_NAME } from '../utils';
 import { EmptyStateCTA } from './empty-state-cta';
 
 export const CreateSiteCTA = () => {
 	const { __ } = useI18n();
 
 	const isHostingFlow = useSelector(
-		( state ) => getCurrentQueryArguments( state )?.[ 'hosting-flow' ] === 'true'
+		( state: AppState ) => getCurrentQueryArguments( state )?.[ 'hosting-flow' ] === 'true'
 	);
 
-	const createSiteUrl = useSitesDashboardCreateSiteUrl( {
+	const createSiteUrl = useAddNewSiteUrl( {
+		source: TRACK_SOURCE_NAME,
+		ref: 'calypso-nosites',
 		'hosting-flow': isHostingFlow ? true : null,
 	} );
 
@@ -27,7 +31,9 @@ export const CreateSiteCTA = () => {
 
 export const MigrateSiteCTA = () => {
 	const { __ } = useI18n();
-	const importSiteUrl = useSitesDashboardImportSiteUrl();
+	const importSiteUrl = useSitesDashboardImportSiteUrl( {
+		ref: 'calypso-nosites',
+	} );
 
 	return (
 		<EmptyStateCTA

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -13,11 +13,11 @@ import Pagination from 'calypso/components/pagination';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
+import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import { withoutHttp } from 'calypso/lib/url';
 import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
-import { useSitesDashboardCreateSiteUrl } from '../hooks/use-sites-dashboard-create-site-url';
 import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
 import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from '../utils';
 import { NoSitesMessage } from './no-sites-message';
@@ -145,8 +145,13 @@ const SitesDashboardSitesList = createSitesListComponent();
 export function SitesDashboard( {
 	queryParams: { page = 1, perPage = 96, search, status = 'all', newSiteID },
 }: SitesDashboardProps ) {
-	const createSiteUrl = useSitesDashboardCreateSiteUrl();
-	const importSiteUrl = useSitesDashboardImportSiteUrl();
+	const createSiteUrl = useAddNewSiteUrl( {
+		source: TRACK_SOURCE_NAME,
+		ref: 'topbar-cta',
+	} );
+	const importSiteUrl = useSitesDashboardImportSiteUrl( {
+		ref: 'topbar-cta',
+	} );
 	const { __, _n } = useI18n();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -147,10 +147,10 @@ export function SitesDashboard( {
 }: SitesDashboardProps ) {
 	const createSiteUrl = useAddNewSiteUrl( {
 		source: TRACK_SOURCE_NAME,
-		ref: 'topbar-cta',
+		ref: 'topbar',
 	} );
 	const importSiteUrl = useSitesDashboardImportSiteUrl( {
-		ref: 'topbar-cta',
+		ref: 'topbar',
 	} );
 	const { __, _n } = useI18n();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();

--- a/client/sites-dashboard/hooks/use-sites-dashboard-create-site-url.ts
+++ b/client/sites-dashboard/hooks/use-sites-dashboard-create-site-url.ts
@@ -1,5 +1,7 @@
+import config from '@automattic/calypso-config';
 import { useSelector } from 'react-redux';
 import { Primitive } from 'utility-types';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { addQueryArgs } from 'calypso/lib/url';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
@@ -17,6 +19,11 @@ export const useSitesDashboardCreateSiteUrl = (
 			ref: siteCount === 0 ? 'calypso-nosites' : null,
 			...additionalParams,
 		},
-		isDevAccount ? '/setup/new-hosted-site' : '/start'
+		// eslint-disable-next-line no-nested-ternary
+		isJetpackCloud()
+			? config( 'jetpack_connect_url' )
+			: isDevAccount
+			? '/setup/new-hosted-site'
+			: config( 'signup_url' )
 	);
 };

--- a/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
+++ b/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
@@ -1,15 +1,13 @@
-import { useSelector } from 'react-redux';
 import { addQueryArgs } from 'calypso/lib/url';
-import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { TRACK_SOURCE_NAME } from '../utils';
 
-export const useSitesDashboardImportSiteUrl = () => {
-	const siteCount = useSelector( getCurrentUserSiteCount );
-
+export const useSitesDashboardImportSiteUrl = (
+	additionalParameters: Record< string, string >
+) => {
 	return addQueryArgs(
 		{
 			source: TRACK_SOURCE_NAME,
-			ref: siteCount === 0 ? 'calypso-nosites' : null,
+			...additionalParameters,
 		},
 		'/start/import'
 	);


### PR DESCRIPTION
## Proposed Changes

@wojtekn highlighted (p1685624234557559/1685607458.219219-slack-C04H4NY6STW) that we're having diverging new site URLs in the sidebar and site selector. The experience for developer accounts should be consistent: always see `/setup/new-hosted-site`. 

## Testing Instructions

### Developer account

- Empty `/sites` page "Create site" CTA should point to `/setup/new-hosted-site?source=sites-dashboard&ref=calypso-nosites`, with `hosting-flow=true` if thee `?hosting-flow=true` query parameter is present in the URL;
- `/sites` page with a site should make "Add new site" point to `/setup/new-hosted-site?source=sites-dashboard&ref=topbar`;
- Calypso Sidebar's "Add new site" should point to /setup/new-hosted-site?ref=site-selector&source=my-home&siteSlug=%s`;
- Calypso static sidebar (e.g. `/posts`) "Add new site" button at the bottom of the page (you should have zero sites to test this scenario) should point to `/setup/new-hosted-site?ref=calypso-sidebar&source=calypso-static`.

### Non-developer account

All of the above CTAs should point to `/start` instead of `/setup-new-hosted-site`.

### Jetpack Cloud

1. Click "Switch Site";
2. The sidebar's "Add new site" button should point to `/jetpack/connect?ref=site-selector&source=jetpack-cloud`.