### PR TITLE
Reader search link - add equal margin above

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -146,6 +146,8 @@ export class ReaderSidebar extends Component {
 				<QueryReaderTeams />
 				<QueryReaderOrganizations />
 
+				<SidebarSeparator />
+
 				<SidebarItem
 					label={ translate( 'Search' ) }
 					onNavigate={ this.handleReaderSidebarSearchClicked }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Related to - pe7F0s-Rz-p2

> Search link padding – In the left nav, the search link is positioned right up next to the adminbar. I might be nice to experiment with adding a little padding above the search link. We could try adding the same amount of padding above that we have below.

Here we add the suggested padding to the top of the search link as well. This 'padding' is actually the result of the separator component, so I added it above the search link section. This makes more sense than adding padding to the css styles of the search link itself, as it preserves the symmetry in padding of the actual element and would make it easier to add/move items between sections in the future if needed.

AFTER 
<img width="374" alt="Screenshot 2023-06-01 at 1 51 25 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/e58df31a-a94d-4043-8b49-4324dc409c09">
AFTER - hover state
<img width="331" alt="Screenshot 2023-06-01 at 1 52 03 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/54d71274-6c9d-477d-b7e1-3716c6d810f1">

BEFORE
<img width="271" alt="Screenshot 2023-06-01 at 1 52 43 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/c2acf135-adce-406a-8ffe-959178dcb6b6">
BEFORE - hover state
<img width="271" alt="Screenshot 2023-06-01 at 1 53 12 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/65dc4bfd-0f10-42ed-a71b-e1a6d862b603">


## Testing Instructions

* run this calypso build
* go to the reader
* see what you think about the new padding 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?