### PR TITLE
Change /built-by links to /website-design-service across Calypso

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -24,7 +24,7 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 				<?php esc_html_e( 'Our professional website-building service can create the site of your dreams, no matter the scope of your project - from small websites and personal blogs to large-scale custom development and migrations.', 'happy-blocks' ); ?>
 			</p>
 			<div class="resource-link">
-				<a href="<?php echo esc_url( 'https://wordpress.com/built-by/?ref=banner-learn' ); ?>">
+				<a href="<?php echo esc_url( 'https://wordpress.com/website-design-service/?ref=banner-learn' ); ?>">
 					<?php esc_html_e( 'Get Started', 'happy-blocks' ); ?>
 				</a>
 			</div>

--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -20,7 +20,7 @@ class UpworkBanner extends PureComponent {
 	render() {
 		const { translate, location, refURLParam, currentPlan } = this.props;
 		const plan = currentPlan?.productSlug;
-		const builtByWpUrl = new URL( 'https://wordpress.com/built-by/' );
+		const builtByWpUrl = new URL( 'https://wordpress.com/website-design-service/' );
 		builtByWpUrl.search = new URLSearchParams( {
 			ref: refURLParam,
 		} );

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -114,7 +114,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 	const numberOfPluginsThemes = numberFormat( 50000, 0 );
 	const discountRate = 25;
 	const couponCode = 'BIZWPC25';
-	const builtByURL = 'https://wordpress.com/built-by/?ref=wpcom-cancel-flow';
+	const builtByURL = 'https://wordpress.com/website-design-service/?ref=wpcom-cancel-flow';
 	const { refundAmount } = props;
 
 	switch ( upsell ) {

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -298,9 +298,9 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 				site_plan: sitePlan,
 				search_term: searchTerm,
 			} );
-			window.location.replace( 'https://wordpress.com/built-by/?ref=no-themes' );
+			window.location.replace( 'https://wordpress.com/website-design-service/?ref=no-themes' );
 		},
-		url: 'https://wordpress.com/built-by/?ref=no-themes',
+		url: 'https://wordpress.com/website-design-service/?ref=no-themes',
 		buttonText: translate( 'Hire an expert' ),
 	} );
 

--- a/client/my-sites/customer-home/cards/tasks/use-built-by/index.js
+++ b/client/my-sites/customer-home/cards/tasks/use-built-by/index.js
@@ -8,7 +8,7 @@ const UseBuiltBy = () => {
 			title="Get expert help for your website"
 			description="Whether you want to create an online store, redesign your website, migrate your site or simply showcase your work — we are happy to help."
 			actionText="Get Started"
-			actionUrl="https://wordpress.com/built-by/?ref=my-home-card"
+			actionUrl="https://wordpress.com/website-design-service/?ref=my-home-card"
 			illustration={ announcementImage }
 			taskId={ TASK_USE_BUILT_BY }
 		/>

--- a/client/my-sites/marketing/index.js
+++ b/client/my-sites/marketing/index.js
@@ -16,7 +16,7 @@ import {
 
 export default function () {
 	page( '/marketing/do-it-for-me*', function redirectToDIFMLandingPage() {
-		window.location.replace( 'https://wordpress.com/built-by/' );
+		window.location.replace( 'https://wordpress.com/website-design-service/' );
 	} );
 
 	page( '/marketing/ultimate-traffic-guide*', function redirectToWPCoursesPage() {

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -107,7 +107,7 @@ export const MarketingTools: FunctionComponent = () => {
 				>
 					<Button
 						onClick={ handleBuiltByWpClick }
-						href="https://wordpress.com/built-by/?ref=tools-banner"
+						href="https://wordpress.com/website-design-service/?ref=tools-banner"
 						target="_blank"
 					>
 						{ translate( 'Get started' ) }

--- a/client/my-sites/plans-features-main/components/plan-faq.jsx
+++ b/client/my-sites/plans-features-main/components/plan-faq.jsx
@@ -188,7 +188,7 @@ const PlanFAQ = ( { titanMonthlyRenewalCost } ) => {
 							ExternalLinkWithTracking: (
 								<ExternalLinkWithTracking
 									icon={ true }
-									href="https://wordpress.com/built-by/"
+									href="https://wordpress.com/website-design-service/"
 									tracksEventName="calypso_signup_step_plans_faq_difm_lp"
 								/>
 							),

--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -131,7 +131,9 @@ export const PureUniversalNavbarFooter = ( {
 								</li>
 								<li>
 									<a
-										href={ localizeUrl( 'https://wordpress.com/built-by/?ref=footer_pricing' ) }
+										href={ localizeUrl(
+											'https://wordpress.com/website-design-service/?ref=footer_pricing'
+										) }
 										title="WordPress Website Building Service"
 										target="_self"
 									>

--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -137,7 +137,7 @@ export const PureUniversalNavbarFooter = ( {
 										title="WordPress Website Building Service"
 										target="_self"
 									>
-										{ __( 'Built by WordPress.com', __i18n_text_domain__ ) }
+										{ __( 'Website Design Services', __i18n_text_domain__ ) }
 									</a>
 								</li>
 							</ul>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -115,7 +115,7 @@ const UniversalNavbarHeader = ( {
 																titleValue={ __( 'Website Design Services', __i18n_text_domain__ ) }
 																content={ __( 'Website Design Services', __i18n_text_domain__ ) }
 																urlValue={ localizeUrl(
-																	'//wordpress.com/built-by/?ref=main-menu'
+																	'//wordpress.com/website-design-service/?ref=main-menu'
 																) }
 																type="dropdown"
 																target="_self"
@@ -454,7 +454,9 @@ const UniversalNavbarHeader = ( {
 												<ClickableItem
 													titleValue={ __( 'Website Design Services', __i18n_text_domain__ ) }
 													content={ __( 'Website Design Services', __i18n_text_domain__ ) }
-													urlValue={ localizeUrl( '//wordpress.com/built-by/?ref=main-menu' ) }
+													urlValue={ localizeUrl(
+														'//wordpress.com/website-design-service/?ref=main-menu'
+													) }
 													type="menu"
 													target="_self"
 												/>


### PR DESCRIPTION
## Proposed Changes

We've changed the slug of the Built-By page from `/built-by` to `/website-design-service`.
This updates those links across Calypso.
This also changes the link text in the footer of the logged-out /plugins and /themes pages to be "Website Design Services" instead of "Built by WordPress.com".


## Testing Instructions

* Marketing card in Calypso
	* Visit `http://calypso.localhost:3000/marketing/tools/[SITE]`
	* ![Aw3mCj.png](https://user-images.githubusercontent.com/690843/230681835-8395f38f-d0f3-4686-a3fd-9475b2eaed75.png)
	* Should go to https://wordpress.com/website-design-service/?ref=tools-banner
* Cancelation flow
	* Start plan cancellation, for the feedback select:
		* “Why would you like to cancel?” = **Couldn’t finish my site**
		* “Why is that?” = **Need professional help to build my site.**
	* Click “Get help building my site”
	* ![A77aki.png](https://user-images.githubusercontent.com/690843/230681837-71886a75-2a89-4186-b7c6-be470e3b0e0f.png)
	* Should go to https://wordpress.com/website-design-service/?ref=wpcom-cancel-flow
* My Home card
	* With a user with less than 8 total sites, choose a site and has been launched (public).
	* Visit `http://calypso.localhost:3000/home/[SITE]`
	* Scroll through the cards until you find the “Built By” card
	* ![XDYeAp.png](https://user-images.githubusercontent.com/690843/230681836-3da85d97-f229-440e-9542-e6f7a1aa96f6.png)
	* Click “Get Started
	* Should go to https://wordpress.com/website-design-service/?ref=my-home-card
* CTA on Themes page
	* Visit  `http://calypso.localhost:3000/themes/[SITE]`
	* Click the “Find your expert” button in the banner.
	* <img width="1424" alt="Screenshot 2023-04-07 at 2 41 20 PM" src="https://user-images.githubusercontent.com/690843/230682663-e26f3e70-2c91-483f-b978-d58408c5d18c.png">
	* Should go to https://wordpress.com/website-design-service/?ref=themes
* CTA on Themes page (No themes found)
	* Same page, but do a search that won’t return any results
	* Click the “Hire an expert” button
	* <img width="1424" alt="Screenshot 2023-04-07 at 2 09 46 PM" src="https://user-images.githubusercontent.com/690843/230682719-1bba3492-a52a-4c23-a493-a2af52d521d0.png">
	* Should go to https://wordpress.com/website-design-service/?ref=no-themes
* Try to visit `/marketing/do-it-for-me`
	* It should redirect you to https://wordpress.com/website-design-service/
* Header and footer on logged-out /plugins and /themes
	* Visit http://calypso.localhost:3000/themes and http://calypso.localhost:3000/plugins
	* Check the "Website Design Services" link in the header and footer nav.
	* <img width="785" alt="Screenshot 2023-06-01 at 11 58 28 AM" src="https://github.com/Automattic/wp-calypso/assets/690843/880b8602-aab7-4d6f-8331-6c6ec02d17ac">
	* <img width="560" alt="Screenshot 2023-06-01 at 2 00 28 PM" src="https://github.com/Automattic/wp-calypso/assets/690843/16f99388-8074-46ac-992f-ff8e8e51bc94">

	* Should go to:
		* https://wordpress.com/website-design-service/?ref=main-menu (header)
		* https://wordpress.com/website-design-service/?ref=footer_pricing (footer)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
