### PR TITLE
DRAFT: Earn: Hide dashboard menu during newsletter onboarding

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -654,6 +654,18 @@ export function redirectToPrimary( context, primarySiteSlug ) {
 }
 
 export function navigation( context, next ) {
+	// Hide the dashboard navigation during onboarding for Newsletters.
+	// This code is still experimental to spark conversation.
+	const store = context.store;
+	const selectedSite = getSelectedSite( store.getState() );
+	if (
+		selectedSite?.options?.launchpad_screen === 'full' &&
+		selectedSite?.options?.site_intent === 'newsletter' &&
+		context?.page.current.includes( '/earn/' )
+	) {
+		context.hideLeftNavigation = true;
+	}
+
 	// Render the My Sites navigation in #secondary
 	if ( ! context.hideLeftNavigation ) {
 		context.secondary = createNavigation( context );

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -153,7 +153,17 @@ class EarningsMain extends Component {
 	 *
 	 * @returns {string} Path to Earn home. Has site slug append if it exists.
 	 */
-	goBack = () => ( this.props.siteSlug ? '/earn/' + this.props.siteSlug : '' );
+	goBack = () => {
+		const isLaunchpadEnabled = this.props.site.options.launchpad_screen === 'full';
+		const siteIntent = this.props.site.options.site_intent;
+		const isNewsletter = siteIntent === 'newsletter';
+
+		if ( isLaunchpadEnabled && isNewsletter && this.props.siteSlug ) {
+			return `/setup/${ siteIntent }/launchpad?siteSlug=${ this.props.siteSlug }`;
+		}
+
+		return this.props.siteSlug ? '/earn/' + this.props.siteSlug : '';
+	};
 
 	getHeaderCake = () => {
 		const headerText = this.getHeaderText();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

**Still experimental. Do not merge.**

During newsletter onboarding for paid newsletters, if a user clicks to connect stripe or set up a plan on the Launchpad screen, they end up on the Earn page with no easy way to return to Launchpad. 

This PR improves on the experience by hiding the dashboard menu, and updating the exiting 'Back' link on earn pages to redirect to Launchpad instead of Earn > Home.

Notes: 
   - This is a sensitive change in that it touches the Calypso client controller. I don't know the code there well, and would welcome feedback on where to put the conditional code here. I don't think putting it in the navigation() method is best. 
   - There is an alternative solution to the same issue above here. That solution adds an extra section to Earn pages with a link back to Launchpad. 

## Testing Instructions

1. Checkout this branch and run yarn and yarn start. 
2. Start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro. Be sure to click the paid newsletter option. 
3. Proceed to Launchpad. 
4. Click the `Set up payments` and/or `Create paid newsletter` tasks. When you arrive on Earn page, confirm that the Dashboard menu is hidden, and that the Back link takes you back to Launchpad. 
