### PR TITLE
Blog onboarding: Redirect users with sites to theme selection on design-first flow

### DIFF
--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -18,7 +18,10 @@ import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { freeSiteAddressType } from 'calypso/lib/domains/constants';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { requestSiteAddressChange } from 'calypso/state/site-address-change/actions';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import type { AppState } from 'calypso/types';
 
 const designFirst: Flow = {
 	name: DESIGN_FIRST_FLOW,
@@ -214,6 +217,11 @@ const designFirst: Flow = {
 			currentPath.includes( 'setup/design-first/site-creation-step' );
 		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
 
+		const primaryDomain = useSelector( ( state: AppState ) => {
+			const primarySiteId = getPrimarySiteId( state );
+			return getSiteSlug( state, primarySiteId );
+		} );
+
 		const logInUrl =
 			locale && locale !== 'en'
 				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Pick%20a%20design&redirect_to=/setup/${ flowName }`
@@ -230,7 +238,8 @@ const designFirst: Flow = {
 		} else if ( userAlreadyHasSites && isSiteCreationStep ) {
 			// Redirect users with existing sites out of the flow as we create a new site as the first step in this flow.
 			// This prevents a bunch of sites being created accidentally.
-			redirect( `/post?${ DESIGN_FIRST_FLOW }=true` );
+			redirect( `/themes/${ primaryDomain }` );
+
 			result = {
 				state: AssertConditionState.CHECKING,
 				message: `${ flowName } requires no preexisting sites`,

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -18,10 +18,7 @@ import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { freeSiteAddressType } from 'calypso/lib/domains/constants';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { requestSiteAddressChange } from 'calypso/state/site-address-change/actions';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
-import type { AppState } from 'calypso/types';
 
 const designFirst: Flow = {
 	name: DESIGN_FIRST_FLOW,
@@ -217,11 +214,6 @@ const designFirst: Flow = {
 			currentPath.includes( 'setup/design-first/site-creation-step' );
 		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
 
-		const primaryDomain = useSelector( ( state: AppState ) => {
-			const primarySiteId = getPrimarySiteId( state );
-			return getSiteSlug( state, primarySiteId );
-		} );
-
 		const logInUrl =
 			locale && locale !== 'en'
 				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Pick%20a%20design&redirect_to=/setup/${ flowName }`
@@ -238,7 +230,7 @@ const designFirst: Flow = {
 		} else if ( userAlreadyHasSites && isSiteCreationStep ) {
 			// Redirect users with existing sites out of the flow as we create a new site as the first step in this flow.
 			// This prevents a bunch of sites being created accidentally.
-			redirect( `/themes/${ primaryDomain }` );
+			redirect( `/themes` );
 
 			result = {
 				state: AssertConditionState.CHECKING,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2619-gh-Automattic/dotcom-forge

## Proposed Changes

* Changed the destination path to design selection on users who already have a site created and used the primary site as the selected one

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With an account having at least one site created, access http://calypso.localhost:3000/setup/design-first and ensure you'll be redirected at http://calypso.localhost:3000/themes/{primaryDomain}

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?