### PR TITLE
URL Search component: Fix browser hard refreshing on search param update

### DIFF
--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -6,12 +6,12 @@ const debug = debugFactory( 'calypso:url-search' );
 
 /**
  * Function for constructing the url to page to. Here are some examples:
- * 1. { uri: 'google.com', search:'hello' } --> 'google.com?s=hello'
+ * 1. { uri: 'google.com', search:'hello' } --> 'https://google.com/?s=hello'
  * 2. {
  *     uri: 'wordpress.com/read/search?q=reader+is+awesome',
  *     search: 'reader is super awesome'
  *     queryKey: 'q',
- *    } --> 'wordpress.com/read/search?q=reader+is+super+awesome'
+ *    } --> result.searchParams.get( 'q' ) === 'reader is super awesome'
  *
  * @param {Object} options the options object
  * @param {string} options.uri the base uri to modify and add a query to

--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -30,7 +30,6 @@ export const buildSearchUrl = ( { uri, search, queryKey = 's' } ) => {
 	} else {
 		parsedUrl.searchParams.delete( queryKey );
 	}
-
 	return parsedUrl;
 };
 
@@ -60,14 +59,15 @@ const UrlSearch = ( Component ) =>
 				search: query,
 				queryKey: this.props.queryKey,
 			} );
+			const pathSearch = searchURL.pathname + searchURL.search;
 
 			debug( 'search for: %s', query );
 			if ( this.props.search && query ) {
-				debug( 'replacing URL: %s', searchURL );
-				page.replace( searchURL.pathname + searchURL.search );
+				debug( 'replacing URL: %s', pathSearch );
+				page.replace( pathSearch );
 			} else {
-				debug( 'setting URL: %s', searchURL );
-				page( searchURL );
+				debug( 'setting URL: %s', pathSearch );
+				page( pathSearch );
 			}
 		};
 

--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -31,8 +31,8 @@ export const buildSearchUrl = ( { uri, search, queryKey = 's' } ) => {
 		parsedUrl.searchParams.delete( queryKey );
 	}
 
-	// Remove the origin from the url, get only pathName with query params
-	return parsedUrl.toString().replace( parsedUrl.origin, '' );
+	// Remove the protocol from the URL so that page doesn't redirect.
+	return parsedUrl.toString().replace( parsedUrl.protocol + '//', '' );
 };
 
 const UrlSearch = ( Component ) =>

--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -17,7 +17,7 @@ const debug = debugFactory( 'calypso:url-search' );
  * @param {string} options.uri the base uri to modify and add a query to
  * @param {string} options.search the search term
  * @param {string} [options.queryKey = s] the key to place in the url.  defaults to s
- * @returns {string} The built search url
+ * @returns {URL} The built search url
  */
 export const buildSearchUrl = ( { uri, search, queryKey = 's' } ) => {
 	if ( ! uri.startsWith( 'http' ) ) {
@@ -31,8 +31,7 @@ export const buildSearchUrl = ( { uri, search, queryKey = 's' } ) => {
 		parsedUrl.searchParams.delete( queryKey );
 	}
 
-	// Remove the protocol from the URL so that page doesn't redirect.
-	return parsedUrl.toString().replace( parsedUrl.protocol + '//', '' );
+	return parsedUrl;
 };
 
 const UrlSearch = ( Component ) =>
@@ -65,7 +64,7 @@ const UrlSearch = ( Component ) =>
 			debug( 'search for: %s', query );
 			if ( this.props.search && query ) {
 				debug( 'replacing URL: %s', searchURL );
-				page.replace( searchURL );
+				page.replace( searchURL.pathname + searchURL.search );
 			} else {
 				debug( 'setting URL: %s', searchURL );
 				page( searchURL );

--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -65,10 +65,10 @@ const UrlSearch = ( Component ) =>
 			debug( 'search for: %s', query );
 			if ( this.props.search && query ) {
 				debug( 'replacing URL: %s', searchURL );
-				page.replace( searchURL, null, false );
+				page.replace( searchURL );
 			} else {
 				debug( 'setting URL: %s', searchURL );
-				page( searchURL, null, false );
+				page( searchURL );
 			}
 		};
 

--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -31,7 +31,8 @@ export const buildSearchUrl = ( { uri, search, queryKey = 's' } ) => {
 		parsedUrl.searchParams.delete( queryKey );
 	}
 
-	return parsedUrl.toString();
+	// Remove the origin from the url, get only pathName with query params
+	return parsedUrl.toString().replace( parsedUrl.origin, '' );
 };
 
 const UrlSearch = ( Component ) =>
@@ -64,10 +65,10 @@ const UrlSearch = ( Component ) =>
 			debug( 'search for: %s', query );
 			if ( this.props.search && query ) {
 				debug( 'replacing URL: %s', searchURL );
-				page.replace( searchURL );
+				page.replace( searchURL, null, false );
 			} else {
 				debug( 'setting URL: %s', searchURL );
-				page( searchURL );
+				page( searchURL, null, false );
 			}
 		};
 

--- a/client/lib/url-search/test/index.js
+++ b/client/lib/url-search/test/index.js
@@ -3,7 +3,7 @@ import { buildSearchUrl } from '../';
 describe( '#buildSearchUrl', () => {
 	test( 'should return original url if there is no search', () => {
 		const params = { uri: 'chicken.com' };
-		expect( buildSearchUrl( params ) ).toEqual( 'https://chicken.com/' );
+		expect( buildSearchUrl( params ) ).toEqual( 'chicken.com/' );
 	} );
 
 	test( 'should add add the default params of s to built query', () => {
@@ -12,7 +12,7 @@ describe( '#buildSearchUrl', () => {
 			search: 'hello',
 		};
 		const url = buildSearchUrl( params );
-		expect( url ).toEqual( 'https://google.com/?s=hello' );
+		expect( url ).toEqual( 'google.com/?s=hello' );
 	} );
 
 	test( 'should replace current query with new one even when using custom query key', () => {
@@ -22,7 +22,7 @@ describe( '#buildSearchUrl', () => {
 			queryKey: 'q',
 		};
 		const url = buildSearchUrl( params );
-		expect( url ).toEqual( 'https://wordpress.com/read/search?q=reader+is+super+awesome' );
+		expect( url ).toEqual( 'wordpress.com/read/search?q=reader+is+super+awesome' );
 	} );
 
 	test( 'should remove the query if search is empty', () => {
@@ -31,6 +31,6 @@ describe( '#buildSearchUrl', () => {
 			queryKey: 'q',
 		};
 		const url = buildSearchUrl( params );
-		expect( url ).toEqual( 'https://wordpress.com/read/search' );
+		expect( url ).toEqual( 'wordpress.com/read/search' );
 	} );
 } );

--- a/client/lib/url-search/test/index.js
+++ b/client/lib/url-search/test/index.js
@@ -3,7 +3,7 @@ import { buildSearchUrl } from '../';
 describe( '#buildSearchUrl', () => {
 	test( 'should return original url if there is no search', () => {
 		const params = { uri: 'chicken.com' };
-		expect( buildSearchUrl( params ) ).toEqual( 'chicken.com/' );
+		expect( buildSearchUrl( params ).toString() ).toEqual( 'https://chicken.com/' );
 	} );
 
 	test( 'should add add the default params of s to built query', () => {
@@ -12,7 +12,7 @@ describe( '#buildSearchUrl', () => {
 			search: 'hello',
 		};
 		const url = buildSearchUrl( params );
-		expect( url ).toEqual( 'google.com/?s=hello' );
+		expect( url.searchParams.get( 's' ) ).toEqual( 'hello' );
 	} );
 
 	test( 'should replace current query with new one even when using custom query key', () => {
@@ -22,7 +22,7 @@ describe( '#buildSearchUrl', () => {
 			queryKey: 'q',
 		};
 		const url = buildSearchUrl( params );
-		expect( url ).toEqual( 'wordpress.com/read/search?q=reader+is+super+awesome' );
+		expect( url.searchParams.get( 'q' ) ).toEqual( 'reader is super awesome' );
 	} );
 
 	test( 'should remove the query if search is empty', () => {
@@ -31,6 +31,6 @@ describe( '#buildSearchUrl', () => {
 			queryKey: 'q',
 		};
 		const url = buildSearchUrl( params );
-		expect( url ).toEqual( 'wordpress.com/read/search' );
+		expect( url.searchParams.get( 'q' ) ).toEqual( null );
 	} );
 } );

--- a/client/lib/url-search/test/index.js
+++ b/client/lib/url-search/test/index.js
@@ -25,6 +25,16 @@ describe( '#buildSearchUrl', () => {
 		expect( url.searchParams.get( 'q' ) ).toEqual( 'reader is super awesome' );
 	} );
 
+	test( 'should stringify to convert spaces to +', () => {
+		const params = {
+			uri: 'wordpress.com/read/search?q=reader+is+awesome',
+			search: 'hello there',
+			queryKey: 'q',
+		};
+		const url = buildSearchUrl( params );
+		expect( url.search ).toEqual( '?q=hello+there' );
+	} );
+
 	test( 'should remove the query if search is empty', () => {
 		const params = {
 			uri: 'wordpress.com/read/search?q=reader+is+awesome',


### PR DESCRIPTION
## Proposed Changes

After [Update packages to versions which include React 18 as peer dependencies](https://github.com/Automattic/wp-calypso/commit/8d1be7918a1c79edfba76eea679a234f0b2bb11c) changes, URL Search component doesn't work as before; after each keyboard typing, the browser hard-refresh happens instead of only updating the query param.

`page.replace` method expects pathName.
Before this fix, it was full URL, ex: `https://calypso.localhost:3000/people/subscribers/{SLUG}`

It is fixed by providing only pathName + query params.

![Screen Capture on 2023-06-01 at 22-30-32](https://github.com/Automattic/wp-calypso/assets/1241413/f1fc200c-fd27-4e5c-a75c-7e4aa9afa635)



## Testing Instructions

* Go to `/people/team/{SLUG}`
* Search by any term
* Check if there is no browser refreshing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
