### PR TITLE
Stats: Subscribers overview rename subscribersData to subscribersDataArrays

### DIFF
--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -37,7 +37,7 @@ function calculateQueryDate( daysToSubtract: number ) {
 // calculate the stats to display in the cards
 function SubscribersOverviewCardStats( subscribersDataArrays: SubscribersData[][] ) {
 	const getCount = ( index: number ) => {
-		return SubscribersDataArrays[ index ]?.[ 0 ]?.subscribers || 0;
+		return subscribersDataArrays[ index ]?.[ 0 ]?.subscribers || 0;
 	};
 
 	const overviewCardStats = [

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -10,14 +10,14 @@ import {
 // array of indices to use to calculate the dates to query for
 const cardIndices = [ 0, 30, 60, 90 ];
 
-interface SubscribersData {
+interface subscribersDataArrays {
 	period: string;
 	subscribers: number;
 	subscribers_change: number;
 }
 
-interface SubscribersDataResult {
-	data: SubscribersData[];
+interface subscribersDataArraysResult {
+	data: subscribersDataArrays[];
 	unit: string;
 	date: string;
 }
@@ -35,9 +35,9 @@ function calculateQueryDate( daysToSubtract: number ) {
 }
 
 // calculate the stats to display in the cards
-function SubscribersOverviewCardStats( subscribersData: SubscribersData[][] ) {
+function SubscribersOverviewCardStats( subscribersDataArrays: subscribersDataArrays[][] ) {
 	const getCount = ( index: number ) => {
-		return subscribersData[ index ]?.[ 0 ]?.subscribers || 0;
+		return subscribersDataArrays[ index ]?.[ 0 ]?.subscribers || 0;
 	};
 
 	const overviewCardStats = [
@@ -73,13 +73,13 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 			select: selectSubscribers,
 			staleTime: 1000 * 60 * 5, // 5 minutes
 		} ) ),
-	} ) as UseQueryResult< SubscribersDataResult >[];
+	} ) as UseQueryResult< subscribersDataArraysResult >[];
 
 	const isLoading = subscribersQueries.some( ( result ) => result.isLoading );
 	const isError = subscribersQueries.some( ( result ) => result.isError );
-	const subscribersData = subscribersQueries.map( ( result ) => result.data?.data || [] );
+	const subscribersDataArrays = subscribersQueries.map( ( result ) => result.data?.data || [] );
 
-	const overviewCardStats = SubscribersOverviewCardStats( subscribersData );
+	const overviewCardStats = SubscribersOverviewCardStats( subscribersDataArrays );
 
 	return (
 		<div className="subscribers-overview highlight-cards">

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -79,7 +79,7 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 	const isError = subscribersQueries.some( ( result ) => result.isError );
 	const subscribersData = subscribersQueries.map( ( result ) => result.data?.data || [] );
 
-	const overviewCardStats = SubscribersOverviewCardStats( SubscribersData );
+	const overviewCardStats = SubscribersOverviewCardStats( subscribersData );
 
 	return (
 		<div className="subscribers-overview highlight-cards">

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -35,7 +35,7 @@ function calculateQueryDate( daysToSubtract: number ) {
 }
 
 // calculate the stats to display in the cards
-function SubscribersOverviewCardStats( SubscribersDataArrays: SubscribersData[][] ) {
+function SubscribersOverviewCardStats( subscribersDataArrays: SubscribersData[][] ) {
 	const getCount = ( index: number ) => {
 		return SubscribersDataArrays[ index ]?.[ 0 ]?.subscribers || 0;
 	};

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -10,14 +10,14 @@ import {
 // array of indices to use to calculate the dates to query for
 const cardIndices = [ 0, 30, 60, 90 ];
 
-interface subscribersDataArrays {
+interface SubscribersData {
 	period: string;
 	subscribers: number;
 	subscribers_change: number;
 }
 
-interface subscribersDataArraysResult {
-	data: subscribersDataArrays[];
+interface SubscribersDataResult {
+	data: SubscribersData[];
 	unit: string;
 	date: string;
 }
@@ -35,9 +35,9 @@ function calculateQueryDate( daysToSubtract: number ) {
 }
 
 // calculate the stats to display in the cards
-function SubscribersOverviewCardStats( subscribersDataArrays: subscribersDataArrays[][] ) {
+function SubscribersOverviewCardStats( SubscribersDataArrays: SubscribersData[][] ) {
 	const getCount = ( index: number ) => {
-		return subscribersDataArrays[ index ]?.[ 0 ]?.subscribers || 0;
+		return SubscribersDataArrays[ index ]?.[ 0 ]?.subscribers || 0;
 	};
 
 	const overviewCardStats = [
@@ -73,13 +73,13 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 			select: selectSubscribers,
 			staleTime: 1000 * 60 * 5, // 5 minutes
 		} ) ),
-	} ) as UseQueryResult< subscribersDataArraysResult >[];
+	} ) as UseQueryResult< SubscribersDataResult >[];
 
 	const isLoading = subscribersQueries.some( ( result ) => result.isLoading );
 	const isError = subscribersQueries.some( ( result ) => result.isError );
-	const subscribersDataArrays = subscribersQueries.map( ( result ) => result.data?.data || [] );
+	const SubscribersData = subscribersQueries.map( ( result ) => result.data?.data || [] );
 
-	const overviewCardStats = SubscribersOverviewCardStats( subscribersDataArrays );
+	const overviewCardStats = SubscribersOverviewCardStats( SubscribersData );
 
 	return (
 		<div className="subscribers-overview highlight-cards">

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -77,7 +77,7 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 
 	const isLoading = subscribersQueries.some( ( result ) => result.isLoading );
 	const isError = subscribersQueries.some( ( result ) => result.isError );
-	const SubscribersData = subscribersQueries.map( ( result ) => result.data?.data || [] );
+	const subscribersData = subscribersQueries.map( ( result ) => result.data?.data || [] );
 
 	const overviewCardStats = SubscribersOverviewCardStats( SubscribersData );
 


### PR DESCRIPTION
Related to #77513

## Proposed Changes

* This PR renames `subscribersData` to `subscribersDataArrays` as it is actually a two-dimensional array of SubscribersData and reflects this better. 

## Testing Instructions

* Open the live branch for this PR.
* Navigate to `/stats/day/:siteSlug`
* Add `?flags=stats/subscribers-section` to the URL to enable the subscriber stats page.
* Scroll down to locate the overview cards (immediately under the chart)
* Check that they load data correctly, still behave acceptably on resize etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
