### PR TITLE
Add option to jetpack cancellation survey

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
@@ -46,6 +46,10 @@ export default function JetpackCancellationSurvey( {
 			answerText: translate( 'I no longer need a website.' ),
 		},
 		{
+			id: 'could-not-get-support',
+			answerText: translate( 'I couldn’t get the support I needed.' ),
+		},
+		{
 			id: 'another-reason',
 			answerText: translate( 'Other' ),
 		},

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
@@ -31,11 +31,11 @@ export default function JetpackCancellationSurvey( {
 		},
 		{
 			id: 'want-to-downgrade',
-			answerText: translate( "I'd like to downgrade to another plan." ),
+			answerText: translate( 'I’d like to downgrade to another plan.' ),
 		},
 		{
 			id: 'upgrade-by-mistake',
-			answerText: translate( "This upgrade didn't include what I needed." ),
+			answerText: translate( 'This upgrade didn’t include what I needed.' ),
 		},
 		{
 			id: 'could-not-activate',


### PR DESCRIPTION
## Proposed Changes

* Add new option "I couldn’t get the support I needed" to the jetpack cancellation survey

P2: p1HpG7-ml4-p2#comment-63091

## Testing Instructions

1. Checkout these changes
2. Purchase a Jetpack product
3. In your local environment (or the calypso live link), go to `/me/purchases` and select the product
4. Click cancel subscription twice. The cancellation survey should pop up
5. Confirm that the new option shows up
![image](https://github.com/Automattic/wp-calypso/assets/65001528/8a300ac2-a923-4131-b698-7e9a2fa25a95)
6. Select it and make sure you can submit the survey with no errors or console errors

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?