### PR TITLE
[E2E][AT][GB] Add nightly builds for AT GB edge nightly E2E testing

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -45,7 +45,9 @@ object WPComTests : Project({
 	// Gutenberg Atomic Edge
 	buildType(gutenbergPlaywrightBuildType("desktop", "4c66d90d-99c6-4ecb-9507-18bc2f44b551" , atomic=true, edge=true));
 	buildType(gutenbergPlaywrightBuildType("mobile", "ba0f925b-497b-4156-977e-5bfbe94f5744", atomic=true, edge=true));
-
+	// Gutenberg Atomic Nightly
+	buildType(gutenbergPlaywrightBuildType("desktop", "a3f58555-56bb-42c6-8543-ab27213d3085" , atomic=true, nightly=true));
+	buildType(gutenbergPlaywrightBuildType("mobile", "8191e677-0682-4709-9201-66a7788980f0", atomic=true, nightly=true));
 	// Editor Tracking
 	buildType(editorTrackingBuildType("desktop", "bd15ed14-e77d-11ec-8fea-0242ac120002", atomic=false, edge=false));
 	// Editor Tracking Edge
@@ -67,14 +69,18 @@ object WPComTests : Project({
 	buildType(P2E2ETests)
 })
 
-fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomic: Boolean = false, edge: Boolean = false ): E2EBuildType {
+fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomic: Boolean = false, edge: Boolean = false, nightly: Boolean = false): E2EBuildType {
 	var siteType = if (atomic) "atomic" else "simple";
-	var edgeType = if (edge) "edge" else "production";
+	var releaseType = when {
+		nightly -> "nightly"
+		edge -> "edge"
+		else -> "production"
+	}
 
-    return E2EBuildType (
-		buildId = "WPComTests_gutenberg_${siteType}_${edgeType}_$targetDevice",
+	return E2EBuildType (
+		buildId = "WPComTests_gutenberg_${siteType}_${releaseType}_$targetDevice",
 		buildUuid = buildUuid,
-		buildName = "Gutenberg $siteType E2E tests $edgeType ($targetDevice)",
+		buildName = "Gutenberg $siteType E2E tests $releaseType ($targetDevice)",
 		buildDescription = "Runs Gutenberg $siteType E2E tests on $targetDevice size",
 		testGroup = "gutenberg",
 		buildParams = {
@@ -102,6 +108,15 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 				// more than one test runs in parallel. Remove or set it to 16 after the issue is solved.
 				param("JEST_E2E_WORKERS", "1")
 			}
+
+			// Nightlies only make sense in the AT context for now, but we leave it here to make it easier
+			// to setup a new nightly build for simple in the future. Nightly+edge doesn't make sense,
+			// but I don't think guarding against that here is worth the additional logic, as this is
+			// a factory function and a mistake like that should be clear by checking the arguments.
+			if (nightly) {
+				param("env.GUTENBERG_NIGHTLY", "true");
+			}
+
 			if (edge) {
 				param("env.GUTENBERG_EDGE", "true")
 			}


### PR DESCRIPTION
## Proposed Changes

What the title says :)

Follow-up to: https://github.com/Automattic/wp-calypso/pull/77639

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Merge and 🤞🏻

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
