### PR TITLE
Hosting onboarding i2: Gate /setup/new-hosted-site behind feature flag

### DIFF
--- a/client/lib/paths/use-add-new-site-url.tsx
+++ b/client/lib/paths/use-add-new-site-url.tsx
@@ -13,7 +13,7 @@ export const useAddNewSiteUrl = ( queryParameters: Record< string, Primitive > )
 		// eslint-disable-next-line no-nested-ternary
 		isJetpackCloud()
 			? config( 'jetpack_connect_url' )
-			: isDevAccount
+			: isDevAccount && config.isEnabled( 'hosting-onboarding-i2' )
 			? '/setup/new-hosted-site'
 			: config( 'signup_url' )
 	);


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/77691, we're changing the onboarding flow for developer accounts, but that path should still be gated behind `hosting-onboarding-i2` since we're not done yet with the project and some parts of the flow might be inconsistent.

## Testing Instructions

Check that Sites > Add new site points to `/start` if `hosting-onboarding-i2` is disabled, even if `is_dev_account` is enabled.
