### PR TITLE
Hosting signup: display "Creating your account" in the progress bar

### DIFF
--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -1,3 +1,4 @@
+import { HOSTING_LP_FLOW } from '@automattic/onboarding';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -33,6 +34,9 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 				{ title: __( 'Making you cookies' ) },
 				{ title: __( 'Planning the next chess move' ) },
 			];
+			break;
+		case HOSTING_LP_FLOW:
+			steps = [ { title: __( 'Creating your account' ) } ];
 			break;
 		default:
 			steps = [


### PR DESCRIPTION
Related to p1685587184411499-slack-C04H4NY6STW.

## Proposed Changes

I tried not doing anything because the endpoint itself is pretty quick, but it does take 2~3 seconds to complete. Besides that, the components noticeably re-render and for some reason the UI jumps quickly, making it quirky.

It's easier to keep the progress bar but say "Creating your account" instead of "Building your site". That's what this PR does.

## Testing Instructions

In order for social accounts to work we have to setup local environment with production build.

- Run `bin/calypso-secrets .config/secrets.php` in your WordPress.com sandbox;
- Copy the output of the script to `config/secrets.json` in your wp-calypso checkout;
- Build this branch with `NODE_ENV=production CALYPSO_ENV=production BUILD_TRANSLATION_CHUNKS=true yarn run build`;
- Run these commands in the Calypso root folder so you can SSL the local version you just built:

```sh
openssl req \
    -newkey rsa:2048 \
    -x509 \
    -nodes \
    -keyout ./config/server/key.pem \
    -new \
    -out ./config/server/certificate.pem \
    -subj /CN=wordpress.com \
    -reqexts SAN \
    -extensions SAN \
    -config <(cat /System/Library/OpenSSL/openssl.cnf \
     <(printf '[SAN]\nsubjectAltName=DNS:wpcalypso.wordpress.com')) \
    -sha256 \
    -days 365
 
# Add it to the trusted certificates
sudo security add-trusted-cert -d -k $(security list-keychains | grep System | cut -d '"' -f 2 ) ./config/server/certificate.pem
```

- Kick off the server with `NODE_ENV=production HOST=wpcalypso.wordpress.com PORT=443 PROTOCOL=https CALYPSO_ENV=wpcalypso BUILD_TRANSLATION_CHUNKS=true node build/server.js`;
- Proxy `wpcalypso.wordpress.com` to `127.0.0.1`;
- go to `/start/hosting?flags=hosting-onboarding-i2` and social login;
- if it takes enough time, it will show the progress bar saying "Creating your account" above it.