### PR TITLE
Fix - Plan upgrade credit information on the checkout page

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -776,13 +776,8 @@ function isCouponApplied( { coupon_savings_integer = 0 }: ResponseCartProduct ) 
 	return coupon_savings_integer > 0;
 }
 
-function planUpgradeCreditInformation( {
-	product,
-	translate,
-}: {
-	product: ResponseCartProduct;
-	translate: ReturnType< typeof useTranslate >;
-} ) {
+function UpgradeCreditInformation( { product }: { product: ResponseCartProduct } ) {
+	const translate = useTranslate();
 	const origCost = product.item_original_subtotal_integer;
 	const finalCost = product.item_subtotal_integer;
 	const upgradeCredit = origCost - finalCost;
@@ -804,45 +799,57 @@ function planUpgradeCreditInformation( {
 		return null;
 	}
 	if ( isMonthlyProduct( product ) ) {
-		return translate( 'Upgrade Credit: %(upgradeCredit)s applied in first month only', {
-			comment:
-				'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
-				'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
-			args: {
-				upgradeCredit: formatCurrency( upgradeCredit, product.currency, {
-					isSmallestUnit: true,
-					stripZeros: true,
-				} ),
-			},
-		} );
+		return (
+			<>
+				{ translate( 'Upgrade Credit: %(upgradeCredit)s applied in first month only', {
+					comment:
+						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
+						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
+					args: {
+						upgradeCredit: formatCurrency( upgradeCredit, product.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+					},
+				} ) }
+			</>
+		);
 	}
 
 	if ( isYearly( product ) ) {
-		return translate( 'Upgrade Credit: %(upgradeCredit)s applied in first year only', {
-			comment:
-				'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
-				'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
-			args: {
-				discount: formatCurrency( upgradeCredit, product.currency, {
-					isSmallestUnit: true,
-					stripZeros: true,
-				} ),
-			},
-		} );
+		return (
+			<>
+				{ translate( 'Upgrade Credit: %(upgradeCredit)s applied in first year only', {
+					comment:
+						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
+						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
+					args: {
+						discount: formatCurrency( upgradeCredit, product.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+					},
+				} ) }
+			</>
+		);
 	}
 
 	if ( isBiennially( product ) || isTriennially( product ) ) {
-		return translate( 'Upgrade Credit: %(discount)s applied in first term only', {
-			comment:
-				'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
-				'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
-			args: {
-				discount: formatCurrency( upgradeCredit, product.currency, {
-					isSmallestUnit: true,
-					stripZeros: true,
-				} ),
-			},
-		} );
+		return (
+			<>
+				{ translate( 'Upgrade Credit: %(discount)s applied in first term only', {
+					comment:
+						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
+						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
+					args: {
+						discount: formatCurrency( upgradeCredit, product.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+					},
+				} ) }
+			</>
+		);
 	}
 	return null;
 }
@@ -1029,7 +1036,9 @@ function WPLineItem( {
 
 			{ product && ! containsPartnerCoupon && (
 				<>
-					<LineItemMeta>{ planUpgradeCreditInformation( { product, translate } ) }</LineItemMeta>
+					<LineItemMeta>
+						<UpgradeCreditInformation product={ product } />
+					</LineItemMeta>
 					<LineItemMeta>
 						<LineItemSublabelAndPrice product={ product } />
 						<DomainDiscountCallout product={ product } />

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -898,7 +898,7 @@ function DomainDiscountCallout( { product }: { product: ResponseCartProduct } ) 
 		return <DiscountCallout>{ translate( 'Free with your plan' ) }</DiscountCallout>;
 	}
 
-	return <></>;
+	return null;
 }
 
 function CouponDiscountCallout( { product }: { product: ResponseCartProduct } ) {
@@ -921,7 +921,7 @@ function GSuiteDiscountCallout( { product }: { product: ResponseCartProduct } ) 
 	) {
 		return <DiscountCallout>{ translate( 'Discount for first year' ) }</DiscountCallout>;
 	}
-	return <></>;
+	return null;
 }
 
 function WPLineItem( {


### PR DESCRIPTION
Related to :  Automattic/martech#1665
Additional Context : pdgrnI-2nz-p2
## Proposed Changes
* Increase clarity about the plan upgrade credit in the checkout page by including an additional line of explanation as shown below.

| Existing      | Proposed |
| ----------- | ----------- |
| Yearly plan : <img width="603" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/7fddd321-33ed-47de-8b60-7ee962ca4bf9">         |   ![image](https://github.com/Automattic/wp-calypso/assets/3422709/2688f542-a1b9-4ea8-8271-bff5411c42cc)  |
| Monthly Plan :  <img width="572" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/5cce793e-2954-4c3b-8fdc-54d23e312dbd">  |     <img width="630" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/52f767cd-0009-43bf-b988-03213da28b19">     |






## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a plan under Ecommerce in a site
* Go to the `/plans` page
* Click on `Upgrade` on any plan
* The above changes should be visible at checkout.
* Make sure the above changes work in different terms like monthly and annual.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?