### PR TITLE
Hosting onboarding i2: After creating a hosted site, wait in the stepper until the atomic transfer is complete

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -2,6 +2,7 @@ import { ProgressBar } from '@automattic/components';
 import {
 	CONNECT_DOMAIN_FLOW,
 	isNewHostedSiteCreationFlow,
+	isTransferringHostedSiteCreationFlow,
 	SITE_SETUP_FLOW,
 } from '@automattic/onboarding';
 import classnames from 'classnames';
@@ -32,7 +33,8 @@ const StepRoute = ( {
 		// See https://github.com/Automattic/wp-calypso/pull/73653
 		if (
 			[ SITE_SETUP_FLOW, CONNECT_DOMAIN_FLOW ].includes( flow.name ) ||
-			isNewHostedSiteCreationFlow( flow.name )
+			isNewHostedSiteCreationFlow( flow.name ) ||
+			isTransferringHostedSiteCreationFlow( flow.name )
 		) {
 			return null;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -5,6 +5,7 @@ import {
 	isUpdateDesignFlow,
 	ECOMMERCE_FLOW,
 	isWooExpressFlow,
+	isTransferringHostedSiteCreationFlow,
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -133,7 +134,9 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 					<>
 						<div className="processing-step">
 							<h1 className="processing-step__progress-step">{ getCurrentMessage() }</h1>
-							{ progress >= 0 || isWooExpressFlow( flow ) ? (
+							{ progress >= 0 ||
+							isWooExpressFlow( flow ) ||
+							isTransferringHostedSiteCreationFlow( flow ) ? (
 								<LoadingBar
 									progress={ progress }
 									className="processing-step__content woocommerce-install__content"

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -72,9 +72,25 @@ const hosting: Flow = {
 			}
 
 			if ( _currentStepSlug === 'processing' ) {
-				const destination = addQueryArgs( '/sites', {
-					'new-site': providedDependencies.siteId,
-				} );
+				// Purchasing these plans will trigger an atomic transfer, so go to stepper flow where we wait for it to complete.
+				const goingAtomic =
+					providedDependencies.goToCheckout &&
+					planCartItem?.product_slug &&
+					[
+						'business-bundle',
+						'business-bundle-monthly',
+						'ecommerce-bundle',
+						'ecommerce-bundle-monthly',
+					].includes( planCartItem.product_slug );
+
+				const destination = goingAtomic
+					? addQueryArgs( '/setup/transferring-hosted-site', {
+							siteId: providedDependencies.siteId,
+					  } )
+					: addQueryArgs( '/sites', {
+							'new-site': providedDependencies.siteId,
+					  } );
+
 				persistSignupDestination( destination );
 				setSignupCompleteSlug( providedDependencies?.siteSlug );
 				setSignupCompleteFlowName( flowName );

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -87,9 +87,7 @@ const hosting: Flow = {
 					? addQueryArgs( '/setup/transferring-hosted-site', {
 							siteId: providedDependencies.siteId,
 					  } )
-					: addQueryArgs( '/sites', {
-							'new-site': providedDependencies.siteId,
-					  } );
+					: '/home/' + providedDependencies.siteSlug;
 
 				persistSignupDestination( destination );
 				setSignupCompleteSlug( providedDependencies?.siteSlug );

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -4,6 +4,7 @@ import {
 	CONNECT_DOMAIN_FLOW,
 	NEW_HOSTED_SITE_FLOW,
 	DESIGN_FIRST_FLOW,
+	TRANSFERRING_HOSTED_SITE_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -89,6 +90,11 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	[ NEW_HOSTED_SITE_FLOW ]: () =>
 		import( /* webpackChunkName: "new-hosted-site-flow" */ './new-hosted-site-flow' ),
+
+	[ TRANSFERRING_HOSTED_SITE_FLOW ]: () =>
+		import(
+			/* webpackChunkName: "transferring-hosted-site-flow" */ './transferring-hosted-site-flow'
+		),
 };
 
 availableFlows[ 'plugin-bundle' ] = () =>

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -1,6 +1,5 @@
 import { TRANSFERRING_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
 import { ONBOARD_STORE } from '../stores';
@@ -48,17 +47,11 @@ const transferringHostedSite: Flow = {
 						return navigate( 'error' );
 					}
 
-					return exitFlow(
-						addQueryArgs( '/sites', {
-							'new-site': siteId,
-						} )
-					);
+					return exitFlow( '/home/' + siteId );
 				}
 
 				case 'waitForAtomic': {
-					return navigate( 'processing', {
-						currentStep,
-					} );
+					return navigate( 'processing' );
 				}
 			}
 		}

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -1,0 +1,70 @@
+import { TRANSFERRING_HOSTED_SITE_FLOW } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
+import { useSiteIdParam } from '../hooks/use-site-id-param';
+import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
+import { ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import ErrorStep from './internals/steps-repository/error-step';
+import ProcessingStep from './internals/steps-repository/processing-step';
+import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
+import WaitForAtomic from './internals/steps-repository/wait-for-atomic';
+import type { Flow, ProvidedDependencies } from './internals/types';
+
+const transferringHostedSite: Flow = {
+	name: TRANSFERRING_HOSTED_SITE_FLOW,
+
+	useSteps() {
+		return [
+			{ slug: 'waitForAtomic', component: WaitForAtomic },
+			{ slug: 'processing', component: ProcessingStep },
+			{ slug: 'error', component: ErrorStep },
+		];
+	},
+	useSideEffect() {
+		const { setProgress } = useDispatch( ONBOARD_STORE );
+		setProgress( 0 );
+	},
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
+		const siteId = useSiteIdParam();
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+
+		const flowProgress = useSiteSetupFlowProgress( currentStep, '' );
+		setStepProgress( flowProgress );
+
+		const exitFlow = ( to: string ) => {
+			window.location.assign( to );
+		};
+
+		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
+			recordSubmitStep( providedDependencies, '', flowName, currentStep );
+
+			switch ( currentStep ) {
+				case 'processing': {
+					const processingResult = params[ 0 ] as ProcessingResult;
+
+					if ( processingResult === ProcessingResult.FAILURE ) {
+						return navigate( 'error' );
+					}
+
+					return exitFlow(
+						addQueryArgs( '/sites', {
+							'new-site': siteId,
+						} )
+					);
+				}
+
+				case 'waitForAtomic': {
+					return navigate( 'processing', {
+						currentStep,
+					} );
+				}
+			}
+		}
+
+		return { submit, exitFlow };
+	},
+};
+
+export default transferringHostedSite;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -2,6 +2,7 @@ export const NEWSLETTER_FLOW = 'newsletter';
 export const NEWSLETTER_POST_SETUP_FLOW = 'newsletter-post-setup';
 export const HOSTING_LP_FLOW = 'hosting';
 export const NEW_HOSTED_SITE_FLOW = 'new-hosted-site';
+export const TRANSFERRING_HOSTED_SITE_FLOW = 'transferring-hosted-site';
 export const LINK_IN_BIO_FLOW = 'link-in-bio';
 export const LINK_IN_BIO_DOMAIN_FLOW = 'link-in-bio-domain';
 export const LINK_IN_BIO_TLD_FLOW = 'link-in-bio-tld';
@@ -72,6 +73,10 @@ export const isHostingFlow = ( flowName: string | null ) => {
 
 export const isNewHostedSiteCreationFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && NEW_HOSTED_SITE_FLOW === flowName );
+};
+
+export const isTransferringHostedSiteCreationFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && TRANSFERRING_HOSTED_SITE_FLOW === flowName );
 };
 
 export const isMigrationFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/2616.

## Proposed Changes

* Creates a new `/setup/transferring-hosted-site`
* Creating a new site in `/setup/new-hosted-site`, which we know will be transferred to Atomic, will be taken to `transferring-hosted-site` before the ultimate destination.

The logic for whether a site will automatically be taken Atomic is on the backend, and unfortunately we need to replicate that same logic on the front end. Here's where it is if it needs changing: https://github.com/Automattic/wp-calypso/pull/77723/files#diff-cc59aa46143159b6a6ca515435b7e71073c365342162deb1a2de7f43f1dee0fdR76-R84

This is where the text that renders above the progress bar comes from: https://github.com/Automattic/wp-calypso/blob/05b86d44dfde2057d3dd08860ea7ab483d8d450e/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx#L158-L169

Note @zaguiini that I haven't tested the `error` path yet. I copied it from the `wooexpress` flow, so I don't actually know what it looks like.

I've noticed that a new "finalising your purchase" message appears quickly after the checkout completes before getting to the `/setup/transferring-hosted-site` flow. I'm not sure whether that's something I've inadvertently added or whether it was already there.

The final commit changes the ultimate destination to `/home` b2e12c3c3a15246b669f7f63fb9db61534d71058. Feel free to delete it if you want to do that in another PR. Note that I'm still navigating to `/home/:siteId` rather than `/home/:siteSlug` (using the new `.wpcomstaging.com` slug) which we'd traditionally use. We should be able to do that, but I don't know quite how yet. Maybe we have to make a request for the new site slug. The AT polling API doesn't return the new slug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* **Create a site at `/setup/new-hosted-site`**
* Choose a business or commerce plan
* Go through checkout
* Confirm the progress bar works and automatically goes to the ultimate location
* **Create a site at `/setup/new-hosted-site`**
* Choose a plan that doesn't get transferred to Atomic
* Go through checkout
* Confirm you automatically go to the ultimate location

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
