### PR TITLE
Site Transfers: Enable ownerhsip transfers for Atomic sites

### DIFF
--- a/client/state/selectors/can-current-user-start-site-owner-transfer.ts
+++ b/client/state/selectors/can-current-user-start-site-owner-transfer.ts
@@ -24,13 +24,15 @@ export default function canCurrentUserStartSiteOwnerTransfer(
 		return false;
 	}
 
+	const isNonAtomicJetpackSite =
+		isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId );
+
 	// These sites can't be transferred.
 	if (
-		isJetpackSite( state, siteId ) ||
+		isNonAtomicJetpackSite ||
 		isSiteP2Hub( state, siteId ) ||
 		isSiteWPForTeams( state, siteId ) ||
-		isVipSite( state, siteId ) ||
-		isSiteAutomatedTransfer( state, siteId )
+		isVipSite( state, siteId )
 	) {
 		return false;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2563

## Proposed Changes

In this diff, I propose to show site ownership transfer UI to Atomic site owners.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to the Atomic site's General Settings
2. Confirm that "Transfer your site" block is displayed
3. Confirm that the UI is still not displayed for P2 or the external Jetpack site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
