### PR TITLE
data/site-migration: fix `@tanstack/eslint-plugin-query` violations

### DIFF
--- a/client/data/site-migration/migrate-provision-mutation.ts
+++ b/client/data/site-migration/migrate-provision-mutation.ts
@@ -10,8 +10,12 @@ interface MigrateProvisionMutationOptions {
 }
 
 export const useMigrateProvisionMutation = ( onSuccessCallback: () => void ) => {
-	const mutation = useMutation(
-		( { targetBlogId, sourceBlogId, checkMigrationPlugin }: MigrateProvisionMutationOptions ) => {
+	const mutation = useMutation( {
+		mutationFn: ( {
+			targetBlogId,
+			sourceBlogId,
+			checkMigrationPlugin,
+		}: MigrateProvisionMutationOptions ) => {
 			const path =
 				`/sites/${ targetBlogId }/migrate-provision/${ sourceBlogId }` +
 				( checkMigrationPlugin ? '?check_migration_plugin=true' : '' );
@@ -20,10 +24,8 @@ export const useMigrateProvisionMutation = ( onSuccessCallback: () => void ) => 
 				apiNamespace: 'wpcom/v2',
 			} );
 		},
-		{
-			onSuccess: onSuccessCallback,
-		}
-	);
+		onSuccess: onSuccessCallback,
+	} );
 
 	const { mutate } = mutation;
 	const migrateProvision = useCallback(

--- a/client/data/site-migration/use-migration-enabled.ts
+++ b/client/data/site-migration/use-migration-enabled.ts
@@ -26,25 +26,23 @@ export const useMigrationEnabledInfoQuery = (
 		},
 	];
 
-	return useQuery(
+	return useQuery( {
 		queryKey,
-		(): Promise< MigrationEnabledResponse > =>
+		queryFn: (): Promise< MigrationEnabledResponse > =>
 			wpcom.req.get( {
 				apiNamespace: 'wpcom/v2/',
 				path: `sites/${ targetSiteId }/migration-enabled/${ encodeURIComponent( sourcSite ) }`,
 			} ),
-		{
-			meta: {
-				persist: false,
-			},
-			enabled: !! ( enabled && targetSiteId && sourcSite ),
-			retry: false,
-			onSuccess: onSuccessCallback,
-			onError: () => {
-				// Clear data on error
-				queryClient.setQueryData( queryKey, null );
-				onErrorCallback && onErrorCallback();
-			},
-		}
-	);
+		meta: {
+			persist: false,
+		},
+		enabled: !! ( enabled && targetSiteId && sourcSite ),
+		retry: false,
+		onSuccess: onSuccessCallback,
+		onError: () => {
+			// Clear data on error
+			queryClient.setQueryData( queryKey, null );
+			onErrorCallback && onErrorCallback();
+		},
+	} );
 };


### PR DESCRIPTION
Related to #77214

## Proposed Changes

PR fixes violations of `@tanstack/eslint-plugin-query` recommended rules in `client/data/site-migrations` (see related issue mentioned above).

## Testing Instructions

Follow the testing instructions in https://github.com/Automattic/wp-calypso/pull/77019 and verify they work as described.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
