### PR TITLE
Site Transfers: Fix font style and font size for site transfers

### DIFF
--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
@@ -71,6 +71,7 @@ const SiteOwnerTransfer = () => {
 	return (
 		<Main>
 			<FormattedHeader
+				brandFont
 				headerText={ translate( 'Site Transfer' ) }
 				subHeaderText={ translate(
 					'Transfer your site to another WordPress.com user. {{a}}Learn more.{{/a}}',

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -17,7 +17,7 @@ const TextControlContainer = styled.div( {
 	marginBottom: '2em',
 	label: {
 		textTransform: 'none',
-		fontSize: '100%',
+		fontSize: '14px',
 		color: 'black',
 	},
 } );


### PR DESCRIPTION
Closes:  https://github.com/Automattic/dotcom-forge/issues/2624

## Proposed Changes

### Change 1: 

This PR changes the font size of the `Username and email address` field on https://wpcalypso.wordpress.com/settings/start-site-transfer to be consistent with the Figma design. 

**Before**:

<img width="800" alt="Screenshot 2023-06-02 at 10 28 56 AM" src="https://github.com/Automattic/wp-calypso/assets/25575134/d78d3ed7-9c7b-47fe-af3d-eaf1388f3511">

**After**:

<img width="771" alt="Screenshot 2023-06-02 at 10 29 49 AM" src="https://github.com/Automattic/wp-calypso/assets/25575134/6c867347-d13e-4120-bca4-adfcece1db2e">

* [Link to Figma design](1U910ArebC7gbLF1RtxUxE-fi-1_2)

### Change 2: 

This PR changes the font style of the `Site Transfer` heading to be consistent with other headings and the Figma design.

**Before**:

<img width="902" alt="Screenshot 2023-06-02 at 10 33 00 AM" src="https://github.com/Automattic/wp-calypso/assets/25575134/ba4083c1-8bf9-43aa-abf6-439f5f1d734f">

**After**: 

<img width="566" alt="Screenshot 2023-06-02 at 10 33 43 AM" src="https://github.com/Automattic/wp-calypso/assets/25575134/33a04783-652d-4083-be7a-7fdf2a685e08">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you have a Simple site
* Navigate to `Settings > General > Transfer your site`: https://wpcalypso.wordpress.com/settings/start-site-transfer/{yoursite}
* Confirm that the `Site Transfer` heading is consistent with [Figma design](1U910ArebC7gbLF1RtxUxE-fi-102_9511) and has a class `wp-brand-font` set on it
* Confirm that the font size on `Username and email address` is set to 14px

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?