### PR TITLE
Sharing Preview Pane | Fix WSOD when Mastodon is not enabled

### DIFF
--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -58,17 +58,20 @@ class SharingPreviewPane extends PureComponent {
 	constructor( props ) {
 		super( props );
 
-		if ( ! props.isMastodonEligible ) {
-			const { mastodon, ...rest } = props.services;
-			props.services = rest;
-		}
-
 		const connectedServices = map( props.connections, 'service' );
-		const firstConnectedService = find( props.services, ( service ) => {
+		const firstConnectedService = find( this.getAvailableServices(), ( service ) => {
 			return find( connectedServices, ( connectedService ) => service === connectedService );
 		} );
 		const selectedService = props.selectedService || firstConnectedService;
 		this.state = { selectedService };
+	}
+
+	getAvailableServices() {
+		const { isMastodonEligible, services } = this.props;
+		if ( ! isMastodonEligible ) {
+			return services.filter( ( service ) => service !== 'mastodon' );
+		}
+		return services;
 	}
 
 	selectPreview = ( selectedService ) => {
@@ -171,7 +174,8 @@ class SharingPreviewPane extends PureComponent {
 	}
 
 	render() {
-		const { translate, services } = this.props;
+		const { translate } = this.props;
+		const services = this.getAvailableServices();
 		const initialMenuItemIndex = services.indexOf( this.state.selectedService );
 
 		return (


### PR DESCRIPTION
🐛 Steps to reproduce:

- Goto `https://wordpress.com/posts/:site` for a site which doesn't have Mastodon enabled
- Click on the 3 dots for any post and Click "Share"
- Click on "Preview"
- There is White Screen of Death (WSOD), with the below error in console
<img width="884" alt="Screenshot 2023-06-02 at 2 14 34 PM" src="https://github.com/Automattic/wp-calypso/assets/18226415/5d69fcfd-1f44-4f20-9ba8-88275acda4d2">
- In Calpso development environment, the error is a different one
<img width="780" alt="Screenshot 2023-06-02 at 12 43 01 PM" src="https://github.com/Automattic/wp-calypso/assets/18226415/6dacaf3a-5dbd-46fa-8c1a-89e0c2acf9ab">
<br><br>

This is what results in those errors:

1. In `client/blocks/sharing-preview-pane/index.jsx`, props are being mutated, which can result in unpredictable behavior.
2. `propTypes` mention `services` as an array but in the constructor, it's assigned to an object.
3. `props.services` is being used as an array in the component.

Fixes https://github.com/Automattic/wp-calypso/pull/77178#discussion_r1214009290
See p1685690128561139-slack-C055TKELKK6

## Proposed Changes

* Remove mutation of the props
* Use `props.services` as an array instead of an object
* Create `getAvailableServices` method to filter out the disabled services

## Testing Instructions

* Checkout this PR or use the Calypso Live link below
* Follow the steps given above an confirm that there is no WSOD
* Confirm that there is no regression with the  Mastodon preview

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?