### PR TITLE
`useFollowerQuery`: fix `queryKey` eslint violations

### DIFF
--- a/client/data/followers/use-follower-query.js
+++ b/client/data/followers/use-follower-query.js
@@ -16,7 +16,7 @@ const useFollowerQuery = ( siteId, subscriberId, type ) => {
 	}
 
 	return useQuery( {
-		queryKey: [ 'subscriber', subscriberId, type ],
+		queryKey: [ 'subscriber', siteId, subscriberId, type ],
 		queryFn: () =>
 			wpcom.req.get( {
 				path: `/sites/${ siteId }/followers/${ subscriberId }?type=${ type }&http_envelope=1`,


### PR DESCRIPTION
Related to #77214

## Proposed Changes

PR fixes a vialotion for the `@tanstack/query/exhaustive-deps` rule in `useFollowerQuery`.

## Testing Instructions

Go to `/people/subscribers/:siteSlug` on a site which has subscribers. Open the detail page for one of the subscribers and verify they're displayed correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
