### PR TITLE
Subscription Management: Add Manage Purchase button on individual site subscription page.

### DIFF
--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
@@ -1,61 +1,21 @@
 import { SubscriptionManager, Reader } from '@automattic/data-stores';
-import { getCurrencyObject } from '@automattic/format-currency';
 import { useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useTranslate, numberFormat } from 'i18n-calypso';
-import moment from 'moment';
 import { useEffect, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import TimeSince from 'calypso/components/time-since';
 import { Notice, NoticeState, NoticeType } from 'calypso/landing/subscriptions/components/notice';
 import { SiteIcon } from 'calypso/landing/subscriptions/components/site-icon';
+import {
+	PaymentPlan,
+	SiteSubscriptionDetailsProps,
+	formatRenewalDate,
+	formatRenewalPrice,
+	getPaymentInterval,
+} from './site-subscription-helpers';
 import SiteSubscriptionSettings from './site-subscription-settings';
 import './styles.scss';
-
-type SiteSubscriptionDetailsProps = {
-	subscriberCount: number;
-	dateSubscribed: Date;
-	siteIcon: string;
-	name: string;
-	blogId: string;
-	deliveryMethods: Reader.SiteSubscriptionDeliveryMethods;
-	url: string;
-	paymentDetails: Reader.SiteSubscriptionPaymentDetails[];
-};
-
-type PaymentPlan = {
-	id: string;
-	renewalPrice: string;
-	renewalDate: string;
-};
-
-const getPaymentInterval = ( renew_interval: string ) => {
-	if ( renew_interval === null ) {
-		return 'one time';
-	} else if ( renew_interval === '1 month' ) {
-		return 'per month';
-	} else if ( renew_interval === '1 year' ) {
-		return 'per year';
-	}
-};
-
-function formatRenewalPrice( renewalPrice: string, currency: string ) {
-	if ( ! renewalPrice ) {
-		return '';
-	}
-
-	const money = getCurrencyObject( parseFloat( renewalPrice ), currency );
-	return money.integer !== '0' ? `${ money.symbol }${ money.integer } /` : '';
-}
-
-function formatRenewalDate( renewalDate: string, localeSlug: string ) {
-	if ( ! renewalDate ) {
-		return '';
-	}
-
-	const date = moment( renewalDate );
-	return date.locale( localeSlug ).format( 'LL' );
-}
 
 const SiteSubscriptionDetails = ( {
 	subscriberCount,
@@ -83,6 +43,18 @@ const SiteSubscriptionDetails = ( {
 		isSuccess: unsubscribed,
 		error: unsubscribeError,
 	} = SubscriptionManager.useSiteUnsubscribeMutation( blogId );
+
+	const confirmUnsubscribe = ( { blogId, url }: { blogId: string; url: string } ) => {
+		if (
+			confirm(
+				translate(
+					'You currently have paid subscriptions with this site. Paid subscriptions must be cancelled separately by clicking the Manage Subscriptions button or going to https://wordpress.com/me/purchases. Press OK to proceed with unsubscribing from the site. Press Cancel to go back.'
+				)
+			)
+		) {
+			unsubscribe( { blog_id: blogId, url } );
+		}
+	};
 
 	const [ paymentPlans, setPaymentPlans ] = useState< PaymentPlan[] >( [] );
 
@@ -250,14 +222,23 @@ const SiteSubscriptionDetails = ( {
 							) ) }
 					</div>
 
-					<Button
-						className="site-subscription-page__unsubscribe-button"
-						isSecondary
-						onClick={ () => unsubscribe( { blog_id: blogId, url } ) }
-						disabled={ unsubscribing }
-					>
-						{ translate( 'Cancel subscription' ) }
-					</Button>
+					<div className="site-subscription-page__button-container">
+						<Button
+							className="site-subscription-page__manage-button"
+							isPrimary
+							href="/me/purchases"
+							disabled={ unsubscribing }
+						>
+							{ translate( 'Manage purchases' ) }
+						</Button>
+						<Button
+							className="site-subscription-page__unsubscribe-button"
+							onClick={ () => confirmUnsubscribe( { blogId, url } ) }
+							disabled={ unsubscribing }
+						>
+							{ translate( 'Cancel subscription' ) }
+						</Button>
+					</div>
 				</>
 			) }
 		</>

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
@@ -47,9 +47,7 @@ const SiteSubscriptionDetails = ( {
 	const confirmUnsubscribe = ( { blogId, url }: { blogId: string; url: string } ) => {
 		if (
 			confirm(
-				translate(
-					'You currently have paid subscriptions with this site. Paid subscriptions must be cancelled separately by clicking the Manage Subscriptions button or going to https://wordpress.com/me/purchases. Press OK to proceed with unsubscribing from the site. Press Cancel to go back.'
-				)
+				'You currently have paid subscriptions with this site. Paid subscriptions must be cancelled separately by clicking the Manage Subscriptions button or going to https://wordpress.com/me/purchases.\n\nPress OK to proceed with unsubscribing from the site.\nPress Cancel to go back.'
 			)
 		) {
 			unsubscribe( { blog_id: blogId, url } );

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-helpers.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-helpers.tsx
@@ -1,0 +1,48 @@
+import { Reader } from '@automattic/data-stores';
+import { getCurrencyObject } from '@automattic/format-currency';
+import moment from 'moment';
+
+export type SiteSubscriptionDetailsProps = {
+	subscriberCount: number;
+	dateSubscribed: Date;
+	siteIcon: string;
+	name: string;
+	blogId: string;
+	deliveryMethods: Reader.SiteSubscriptionDeliveryMethods;
+	url: string;
+	paymentDetails: Reader.SiteSubscriptionPaymentDetails[];
+};
+
+export type PaymentPlan = {
+	id: string;
+	renewalPrice: string;
+	renewalDate: string;
+};
+
+export const getPaymentInterval = ( renew_interval: string ) => {
+	if ( renew_interval === null ) {
+		return 'one time';
+	} else if ( renew_interval === '1 month' ) {
+		return 'per month';
+	} else if ( renew_interval === '1 year' ) {
+		return 'per year';
+	}
+};
+
+export function formatRenewalPrice( renewalPrice: string, currency: string ) {
+	if ( ! renewalPrice ) {
+		return '';
+	}
+
+	const money = getCurrencyObject( parseFloat( renewalPrice ), currency );
+	return money.integer !== '0' ? `${ money.symbol }${ money.integer } /` : '';
+}
+
+export function formatRenewalDate( renewalDate: string, localeSlug: string ) {
+	if ( ! renewalDate ) {
+		return '';
+	}
+
+	const date = moment( renewalDate );
+	return date.locale( localeSlug ).format( 'LL' );
+}

--- a/client/landing/subscriptions/components/site-subscription-page/styles.scss
+++ b/client/landing/subscriptions/components/site-subscription-page/styles.scss
@@ -136,6 +136,11 @@
 	&__fetch-details-error {
 		margin: 64px 0 32px;
 	}
+
+	.site-subscription-page__unsubscribe-button {
+		border: 1px solid $studio-gray-20;
+		margin-left: 10px;
+	}
 }
 
 // Mobile screens


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/77335

## Proposed Changes

This PR adds the "Manage purchases" button to the Individual subscription page. It also adds a confirmation popup to the "Cancel subscription" button.
![image](https://github.com/Automattic/wp-calypso/assets/3832570/9d817802-611a-46d9-9c8c-241ff021af0b)


## Testing Instructions

1. You need to have an account with purchases. You can follow these instructions: pdDOJh-1SM-p2
2. Apply this PR and run the application.
3. Go to the Individual Subscription page of the blog you have paid subscriptions to, with this URL: `http://calypso.localhost:3000/subscriptions/site/[id-of-the-blog]`.
4. Click on "Manage purchases". You should end up in `http://calypso.localhost:3000/me/purchases`.
5. Click on "Cancel subscription". You should see a confirmation popup warning you about your subscriptions. If you click "Cancel", nothing should happen. If you click "Ok" you should see a message about you being unsubscribed. You can resubscribe again if you want on that same screen.
