### PR TITLE
Jetpack Pro Dashboard: implement monitor notification email resend code

### DIFF
--- a/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
@@ -24,8 +24,6 @@ const useFetchMonitorVerfiedContacts = ( isPartnerOAuthTokenLoaded: boolean ) =>
 				};
 			},
 			enabled: isPartnerOAuthTokenLoaded && isMultipleEmailEnabled,
-			refetchOnWindowFocus: false,
-			staleTime: 1000 * 60 * 5,
 		}
 	);
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -86,7 +86,8 @@ export default function EmailAddressEditor( {
 		setResendCodeClicked( true );
 		recordEvent( 'downtime_monitoring_resend_email_verification_code' );
 		handleResendCode();
-	}, [ handleResendCode, recordEvent ] );
+		setEmailItem( { ...emailItem, code: undefined } );
+	}, [ emailItem, handleResendCode, recordEvent ] );
 
 	const translationArgs = useMemo(
 		() => ( {
@@ -387,7 +388,7 @@ export default function EmailAddressEditor( {
 								<FormTextInput
 									id="code"
 									name="code"
-									value={ emailItem.code }
+									value={ emailItem.code || '' }
 									onChange={ handleChange( 'code' ) }
 								/>
 								{ validationError?.code && (
@@ -397,10 +398,12 @@ export default function EmailAddressEditor( {
 								) }
 								<div className="configure-email-notification__help-text" id="code-help-text">
 									{ helpText ??
-										translate(
-											'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
-											translationArgs
-										) }
+										( resendCodeClicked && resendCode.isLoading
+											? translate( 'Sending code' )
+											: translate(
+													'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
+													translationArgs
+											  ) ) }
 								</div>
 							</FormFieldset>
 						) }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -1,13 +1,18 @@
 import { Button } from '@automattic/components';
 import { Modal } from '@wordpress/components';
+import classNames from 'classnames';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { ReactChild, useCallback, useContext, useEffect, useState, useMemo } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import DashboardDataContext from '../../sites-overview/dashboard-data-context';
-import { useRequestVerificationCode, useValidateVerificationCode } from '../hooks';
+import {
+	useRequestVerificationCode,
+	useValidateVerificationCode,
+	useResendVerificationCode,
+} from '../hooks';
 import EmailItemContent from './email-item-content';
 import type {
 	AllowedMonitorContactActions,
@@ -52,6 +57,8 @@ export default function EmailAddressEditor( {
 		email: '',
 		id: '',
 	} );
+	const [ resendCodeClicked, setResendCodeClicked ] = useState< boolean >( false );
+	const [ helpText, setHelpText ] = useState< ReactChild | undefined >( undefined );
 
 	const { verifiedContacts } = useContext( DashboardDataContext );
 
@@ -61,13 +68,43 @@ export default function EmailAddressEditor( {
 
 	const requestVerificationCode = useRequestVerificationCode();
 	const verifyEmail = useValidateVerificationCode();
+	const resendCode = useResendVerificationCode();
 
 	// Function to handle resending verification code
 	const handleResendCode = useCallback( () => {
-		setValidationError( undefined );
+		if ( emailItem.email ) {
+			setValidationError( undefined );
+			resendCode.mutate( { type: 'email', value: emailItem.email } );
+		}
+		// Disabled because we don't want to re-run this effect when resendCode changes
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ emailItem.email ] );
+
+	// Function to handle resend code button click
+	const handleResendCodeClick = useCallback( () => {
+		setHelpText( undefined );
+		setResendCodeClicked( true );
 		recordEvent( 'downtime_monitoring_resend_email_verification_code' );
-		// TODO: implement resending verification code
-	}, [ recordEvent ] );
+		handleResendCode();
+	}, [ handleResendCode, recordEvent ] );
+
+	const translationArgs = useMemo(
+		() => ( {
+			components: {
+				button: (
+					<Button
+						className={ classNames( 'configure-email-notification__resend-code-button', {
+							'is-loading': resendCode.isLoading,
+						} ) }
+						borderless
+						onClick={ handleResendCodeClick }
+						disabled={ resendCode.isLoading }
+					/>
+				),
+			},
+		} ),
+		[ handleResendCodeClick, resendCode.isLoading ]
+	);
 
 	const handleSetEmailItems = useCallback(
 		( isVerified = true ) => {
@@ -128,6 +165,44 @@ export default function EmailAddressEditor( {
 		}
 	}, [ translate, verifyEmail.errorMessage ] );
 
+	// Set help text when email verification fails
+	useEffect( () => {
+		if ( verifyEmail.isError ) {
+			setHelpText(
+				translate(
+					'Please try again or we can {{button}}resend a new code{{/button}}.',
+					translationArgs
+				)
+			);
+		}
+	}, [ translate, translationArgs, verifyEmail.isError ] );
+
+	// Set help text when resend code is successful and resend button is clicked
+	useEffect( () => {
+		if ( resendCodeClicked && resendCode.isSuccess ) {
+			setHelpText(
+				<>
+					<div>{ translate( 'We just sent you a new code. Please wait for a minute.' ) }</div>
+					<div>
+						{ translate(
+							'Click to {{button}}resend{{/button}} if you didn’t receive it. If you still experience issues, please reach out to our support.',
+							translationArgs
+						) }
+					</div>
+				</>
+			);
+		}
+	}, [ resendCodeClicked, resendCode.isSuccess, translate, translationArgs ] );
+
+	// Show error message when resend code fails
+	useEffect( () => {
+		if ( resendCode.isError ) {
+			setValidationError( {
+				code: translate( 'Something went wrong. Please try again by clicking the resend button.' ),
+			} );
+		}
+	}, [ resendCode.isError, translate ] );
+
 	// Set email item when selectedEmail changes
 	useEffect( () => {
 		if ( selectedEmail ) {
@@ -170,6 +245,7 @@ export default function EmailAddressEditor( {
 
 	// Verify email when user clicks on Verify button
 	const handleVerifyEmail = () => {
+		setHelpText( undefined );
 		recordEvent( 'downtime_monitoring_verify_email' );
 		if ( emailItem?.code ) {
 			verifyEmail.mutate( {
@@ -250,18 +326,6 @@ export default function EmailAddressEditor( {
 		? translate( 'Verifying…' )
 		: translate( 'Verify' );
 
-	const translationArgs = {
-		components: {
-			button: (
-				<Button
-					className="configure-email-notification__resend-code-button"
-					borderless
-					onClick={ handleResendCode }
-				/>
-			),
-		},
-	};
-
 	return (
 		<Modal
 			open={ true }
@@ -332,15 +396,11 @@ export default function EmailAddressEditor( {
 									</div>
 								) }
 								<div className="configure-email-notification__help-text" id="code-help-text">
-									{ verifyEmail.isError
-										? translate(
-												'Please try again or we can {{button}}resend a new code{{/button}}',
-												translationArgs
-										  )
-										: translate(
-												'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
-												translationArgs
-										  ) }
+									{ helpText ??
+										translate(
+											'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
+											translationArgs
+										) }
 								</div>
 							</FormFieldset>
 						) }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-item-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-item-content.tsx
@@ -56,7 +56,7 @@ export default function EmailItemContent( {
 		}
 	};
 
-	const isVerified = verifiedContacts.emails.includes( item.email ) || item.verified;
+	const isVerified = item.verified || verifiedContacts.emails.includes( item.email );
 
 	return (
 		<Card className="configure-email-address__card" key={ item.email } compact>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-item-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-item-content.tsx
@@ -1,10 +1,11 @@
 import { Card, Button } from '@automattic/components';
 import { Icon, moreHorizontal } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef } from 'react';
+import { useState, useRef, useContext } from 'react';
 import Badge from 'calypso/components/badge';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import DashboardDataContext from '../../sites-overview/dashboard-data-context';
 import type {
 	StateMonitorSettingsEmail,
 	AllowedMonitorContactActions,
@@ -37,6 +38,8 @@ export default function EmailItemContent( {
 
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
 
+	const { verifiedContacts } = useContext( DashboardDataContext );
+
 	const showActions = () => {
 		setIsOpen( true );
 	};
@@ -53,6 +56,8 @@ export default function EmailItemContent( {
 		}
 	};
 
+	const isVerified = verifiedContacts.emails.includes( item.email ) || item.verified;
+
 	return (
 		<Card className="configure-email-address__card" key={ item.email } compact>
 			<div className="configure-email-address__card-content-container">
@@ -65,7 +70,7 @@ export default function EmailItemContent( {
 				 }
 				{ ! item.isDefault && ! isRemoveAction && (
 					<>
-						{ ! item.verified && (
+						{ ! isVerified && (
 							<span
 								role="button"
 								tabIndex={ 0 }
@@ -76,7 +81,7 @@ export default function EmailItemContent( {
 								<Badge type="warning">{ translate( 'Pending' ) }</Badge>
 							</span>
 						) }
-						{ showVerifiedBadge && item.verified && (
+						{ showVerifiedBadge && isVerified && (
 							<span className="configure-email-address__verification-status">
 								<Badge type="success">{ translate( 'Verified' ) }</Badge>
 							</span>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
@@ -2,10 +2,12 @@ import { useQueryClient } from '@tanstack/react-query';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
 import useRequestContactVerificationCode from 'calypso/state/jetpack-agency-dashboard/hooks/use-request-contact-verification-code';
+import useResendVerificationCodeMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-resend-contact-verification-code';
 import useValidateVerificationCodeMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-validate-contact-verification-code';
 import {
 	RequestVerificationCodeParams,
 	ValidateVerificationCodeParams,
+	ResendVerificationCodeParams,
 } from '../sites-overview/types';
 
 export function useRequestVerificationCode(): {
@@ -92,4 +94,17 @@ export function useValidateVerificationCode(): {
 		}
 	}
 	return { ...data, errorMessage, isVerified: data.isSuccess || isAlreadyVerifed };
+}
+
+export function useResendVerificationCode(): {
+	mutate: ( params: ResendVerificationCodeParams ) => void;
+	isLoading: boolean;
+	isSuccess: boolean;
+	isError: boolean;
+} {
+	return useResendVerificationCodeMutation( {
+		retry: () => {
+			return false;
+		},
+	} );
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -142,7 +142,7 @@ export default function NotificationSettings( {
 			const extraEmails = allEmailItems.filter( ( item ) => ! item.isDefault );
 			params.contacts = {
 				emails: extraEmails.map( ( item ) => {
-					const isVerified = verifiedContacts.emails.includes( item.email ) || item.verified;
+					const isVerified = item.verified || verifiedContacts.emails.includes( item.email );
 					return {
 						name: item.name,
 						email_address: item.email,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -455,3 +455,8 @@
 .cursor-pointer {
 	cursor: pointer;
 }
+
+.is-loading {
+	opacity: 0.5;
+	pointer-events: none;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -458,5 +458,4 @@
 
 .is-loading {
 	opacity: 0.5;
-	pointer-events: none;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -314,3 +314,7 @@ export interface InitialMonitorSettings {
 	selectedDuration: MonitorDuration | undefined;
 	emailContacts?: MonitorSettingsEmail[] | [];
 }
+export interface ResendVerificationCodeParams {
+	type: 'email';
+	value: string;
+}

--- a/client/state/jetpack-agency-dashboard/hooks/use-resend-contact-verification-code.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-resend-contact-verification-code.ts
@@ -1,0 +1,29 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import type {
+	APIError,
+	ResendVerificationCodeParams,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+interface APIResponse {
+	success: boolean;
+}
+
+function mutationResendVerificationCode(
+	params: ResendVerificationCodeParams
+): Promise< APIResponse > {
+	return wpcomJpl.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: '/jetpack-agency/contacts/resend-verification',
+		body: params,
+	} );
+}
+
+export default function useResendVerificationCodeMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, ResendVerificationCodeParams, TContext >
+): UseMutationResult< APIResponse, APIError, ResendVerificationCodeParams, TContext > {
+	return useMutation< APIResponse, APIError, ResendVerificationCodeParams, TContext >(
+		mutationResendVerificationCode,
+		options
+	);
+}


### PR DESCRIPTION
Related to 1204408201748644-as-1204666762460286

## Proposed Changes

This PR implements resend code for the monitor notification email.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Apply this D111846-code and sandbox the public API.
2. Run `git checkout add/implement-monitor-resend-code` and `yarn start-jetpack-cloud`
3. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
4. Enable monitor if not enabled already.
5. Click on the clock icon next to the monitor toggle.
6. Click the `+ Add email address` button -> Enter the name and email `testemail@email.com` -> Click `Verify`.
7.  Enter a random(wrong) verification code and verify the below error is shown.

<img width="472" alt="Screenshot 2023-06-02 at 3 21 25 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/af0f6a83-91df-4e7e-9c2a-49430222935f">

8. Click on `resend` and verify the button is disabled when the request is being made.

<img width="473" alt="Screenshot 2023-06-02 at 3 22 27 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/9a35a9dc-6fe5-4b18-8909-df1934e1df51">

<img width="474" alt="Screenshot 2023-06-06 at 5 06 00 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8006bc44-2428-4baf-81e3-abc40f9bca2f">


9. Verify the help text looks like the below once the resend request is successful. 

<img width="470" alt="Screenshot 2023-06-02 at 2 53 44 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/502971e2-c062-4bb6-b224-9311639684f4">

10. Follow the instruction - D111846-code on how to get the verification code, enter the verification code and click `Verify` and make sure the email address is verified. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?