### PR TITLE
Reader: Revert passing post ID to related sites in post stream

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -208,7 +208,7 @@ class FeedHeader extends Component {
 				{ siteId && (
 					<ReaderSuggestedFollowsDialog
 						onClose={ this.onCloseSuggestedFollowModal }
-						siteId={ siteId }
+						siteId={ +siteId }
 						isVisible={ this.state.isSuggestedFollowsModalOpen }
 					/>
 				) }

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -92,8 +92,7 @@ const ReaderPostActions = ( props ) => {
 			{ showSuggestedFollows && post.site_ID && (
 				<ReaderSuggestedFollowsDialog
 					onClose={ onCloseSuggestedFollowModal }
-					siteId={ post.site_ID }
-					postId={ post.ID }
+					siteId={ +post.site_ID }
 					isVisible={ isSuggestedFollowsModalOpen }
 				/>
 			) }

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -93,6 +93,7 @@ const ReaderPostActions = ( props ) => {
 				<ReaderSuggestedFollowsDialog
 					onClose={ onCloseSuggestedFollowModal }
 					siteId={ +post.site_ID }
+					postId={ +post.ID }
 					isVisible={ isSuggestedFollowsModalOpen }
 				/>
 			) }

--- a/client/blocks/reader-related-card/index.jsx
+++ b/client/blocks/reader-related-card/index.jsx
@@ -177,7 +177,7 @@ export function RelatedPostCard( {
 			{ post.site_ID && (
 				<ReaderSuggestedFollowsDialog
 					onClose={ onCloseSuggestedFollowModal }
-					siteId={ post.site_ID }
+					siteId={ +post.site_ID }
 					isVisible={ isSuggestedFollowsModalOpen }
 				/>
 			) }

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -182,7 +182,7 @@ function ReaderSubscriptionListItem( {
 			{ siteId && (
 				<ReaderSuggestedFollowsDialog
 					onClose={ onCloseSuggestedFollowModal }
-					siteId={ siteId }
+					siteId={ +siteId }
 					isVisible={ isSuggestedFollowsModalOpen }
 				/>
 			) }

--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -9,7 +9,7 @@ import './style.scss';
 const ReaderSuggestedFollowsDialog = ( { onClose, siteId, postId, isVisible } ) => {
 	const translate = useTranslate();
 	const { data, isLoading } = useRelatedSites( siteId, postId );
-	// If we are no longer loading and still have no data, don't show the dialog
+	// If we are no longer loading and no data available, don't show the dialog
 	if ( ! isLoading && ! data ) {
 		return null;
 	}

--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -9,11 +9,15 @@ import './style.scss';
 const ReaderSuggestedFollowsDialog = ( { onClose, siteId, postId, isVisible } ) => {
 	const translate = useTranslate();
 	const { data, isLoading } = useRelatedSites( siteId, postId );
+	// If we are no longer loading and still have no data, don't show the dialog
+	if ( ! isLoading && ! data ) {
+		return null;
+	}
 	return (
 		<Dialog
 			additionalClassNames="reader-recommended-follows-dialog"
 			isBackdropVisible={ true }
-			isVisible={ isVisible && ( isLoading || ( ! isLoading && data ) ) }
+			isVisible={ isVisible }
 			onClose={ onClose }
 			showCloseIcon={ true }
 			label={ translate( 'Suggested follows' ) }

--- a/client/data/reader/use-related-sites.ts
+++ b/client/data/reader/use-related-sites.ts
@@ -63,13 +63,8 @@ export const useRelatedSites = (
 	if ( postId && postId > 0 ) {
 		path += `&post_id=${ postId }`;
 	}
-	const queryKeyParts: ( string | number | undefined )[] = [
-		`related-sites-${ SITE_RECOMMENDATIONS_COUNT }`,
-		siteId,
-		postId,
-	].filter( Boolean );
 	return useQuery(
-		queryKeyParts,
+		[ `related-sites-${ SITE_RECOMMENDATIONS_COUNT }`, siteId ],
 		() => wpcom.req.get( { path: path, apiNamespace: 'rest/v1.2' } ),
 		{
 			enabled: !! siteId,


### PR DESCRIPTION
The call to get related sites (suggested follows) is slow. I'm seeing an issue on the Reader search page, where there are too many calls to the related sites endpoint that are taking too long and its causing a broken experience as the suggested follows modal won't show.

![Screenshot 2023-06-01 at 22 21 42](https://github.com/Automattic/wp-calypso/assets/5560595/dc38f8f2-3111-41dc-ac43-0453506da2c0)

This PR removes the post ID when caching the query - it should mean less calls.

Other change of note is using the unary to make sure the site ID/post ID is an integer.
