### PR TITLE
Assembler: Survey Modal

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -74,6 +74,7 @@ export class Banner extends Component {
 		customerType: PropTypes.string,
 		isSiteWPForTeams: PropTypes.bool,
 		displayAsLink: PropTypes.bool,
+		showLinkIcon: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -278,6 +279,7 @@ export class Banner extends Component {
 			isAtomic,
 			plan,
 			displayAsLink,
+			showLinkIcon,
 		} = this.props;
 
 		// For P2 sites, only show banners if they have the 'p2-banner' class.
@@ -325,6 +327,7 @@ export class Banner extends Component {
 				href={ ( disableHref || callToAction ) && ! forceHref ? null : this.getHref() }
 				onClick={ callToAction && ! forceHref ? null : this.handleClick }
 				displayAsLink={ displayAsLink }
+				showLinkIcon={ showLinkIcon }
 			>
 				{ dismissWithoutSavingPreference && (
 					<Gridicon icon="cross" className="banner__close-icon" onClick={ this.handleDismiss } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -67,7 +67,7 @@ const PatternAssembler = ( {
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const [ activePosition, setActivePosition ] = useState( -1 );
 	const [ isPatternPanelListOpen, setIsPatternPanelListOpen ] = useState( false );
-	const [ userHasEngaged, setUserHasEngaged ] = useState( false );
+	const [ surveyDismissed, setSurveyDismissed ] = useState( false );
 	const { goBack, goNext, submit } = navigation;
 	const { applyThemeWithPatterns, assembleSite } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
@@ -478,8 +478,6 @@ const PatternAssembler = ( {
 	};
 
 	const onMainItemSelect = ( name: string ) => {
-		setUserHasEngaged( true );
-
 		if ( PATTERN_TYPES.includes( name ) ) {
 			trackEventPatternAdd( name );
 		}
@@ -564,7 +562,8 @@ const PatternAssembler = ( {
 						onSelect={ onMainItemSelect }
 						onContinueClick={ onContinueClick }
 						recordTracksEvent={ recordTracksEvent }
-						userHasEngaged={ userHasEngaged }
+						surveyDismissed={ surveyDismissed }
+						setSurveyDismissed={ setSurveyDismissed }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -67,6 +67,7 @@ const PatternAssembler = ( {
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const [ activePosition, setActivePosition ] = useState( -1 );
 	const [ isPatternPanelListOpen, setIsPatternPanelListOpen ] = useState( false );
+	const [ userHasEngaged, setUserHasEngaged ] = useState( false );
 	const { goBack, goNext, submit } = navigation;
 	const { applyThemeWithPatterns, assembleSite } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
@@ -477,6 +478,8 @@ const PatternAssembler = ( {
 	};
 
 	const onMainItemSelect = ( name: string ) => {
+		setUserHasEngaged( true );
+
 		if ( PATTERN_TYPES.includes( name ) ) {
 			trackEventPatternAdd( name );
 		}
@@ -561,6 +564,7 @@ const PatternAssembler = ( {
 						onSelect={ onMainItemSelect }
 						onContinueClick={ onContinueClick }
 						recordTracksEvent={ recordTracksEvent }
+						userHasEngaged={ userHasEngaged }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -21,9 +21,10 @@ interface Props {
 	onSelect: ( name: string ) => void;
 	onContinueClick: ( callback?: () => void ) => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
+	userHasEngaged: boolean;
 }
 
-const ScreenMain = ( { onSelect, onContinueClick, recordTracksEvent }: Props ) => {
+const ScreenMain = ( { onSelect, onContinueClick, recordTracksEvent, userHasEngaged }: Props ) => {
 	const translate = useTranslate();
 	const [ disabled, setDisabled ] = useState( true );
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
@@ -134,7 +135,7 @@ const ScreenMain = ( { onSelect, onContinueClick, recordTracksEvent }: Props ) =
 						</>
 					</NavigatorItemGroup>
 				</HStack>
-				<Survey />
+				<Survey userHasEngaged={ userHasEngaged } />
 			</div>
 			<div className="screen-container__footer">
 				<span className="screen-container__description">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -13,7 +13,7 @@ import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { NavigationButtonAsItem } from './navigator-buttons';
 import NavigatorHeader from './navigator-header';
 import { NavigatorItemGroup } from './navigator-item-group';
-import Survey from './survey/survey';
+import Survey from './survey';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { MouseEvent } from 'react';
 
@@ -21,10 +21,17 @@ interface Props {
 	onSelect: ( name: string ) => void;
 	onContinueClick: ( callback?: () => void ) => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
-	userHasEngaged: boolean;
+	surveyDismissed: boolean;
+	setSurveyDismissed: ( dismissed: boolean ) => void;
 }
 
-const ScreenMain = ( { onSelect, onContinueClick, recordTracksEvent, userHasEngaged }: Props ) => {
+const ScreenMain = ( {
+	onSelect,
+	onContinueClick,
+	recordTracksEvent,
+	surveyDismissed,
+	setSurveyDismissed,
+}: Props ) => {
 	const translate = useTranslate();
 	const [ disabled, setDisabled ] = useState( true );
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
@@ -135,7 +142,7 @@ const ScreenMain = ( { onSelect, onContinueClick, recordTracksEvent, userHasEnga
 						</>
 					</NavigatorItemGroup>
 				</HStack>
-				<Survey userHasEngaged={ userHasEngaged } />
+				{ ! surveyDismissed && <Survey setSurveyDismissed={ setSurveyDismissed } /> }
 			</div>
 			<div className="screen-container__footer">
 				<span className="screen-container__description">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -13,6 +13,7 @@ import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { NavigationButtonAsItem } from './navigator-buttons';
 import NavigatorHeader from './navigator-header';
 import { NavigatorItemGroup } from './navigator-item-group';
+import Survey from './survey/survey';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { MouseEvent } from 'react';
 
@@ -133,6 +134,7 @@ const ScreenMain = ( { onSelect, onContinueClick, recordTracksEvent }: Props ) =
 						</>
 					</NavigatorItemGroup>
 				</HStack>
+				<Survey />
 			</div>
 			<div className="screen-container__footer">
 				<span className="screen-container__description">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -262,7 +262,6 @@ $font-family: "SF Pro Text", $sans;
 		margin: 0 -16px 32px;
 		margin-bottom: 32px;
 		overflow-y: auto;
-		flex-grow: 1;
 		// Reserve space for the scrollbar to prevent unwanted layout change
 		scrollbar-gutter: stable;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
@@ -9,6 +9,7 @@ interface Props {
 const Survey = ( { setSurveyDismissed }: Props ) => {
 	const locale = useLocale();
 
+	// We only target English locale variations
 	if ( ! locale.includes( 'en' ) ) {
 		return null;
 	}
@@ -16,6 +17,7 @@ const Survey = ( { setSurveyDismissed }: Props ) => {
 	return (
 		<Banner
 			className="pattern-assembler__survey"
+			// Translation to other locales is not required
 			title={
 				<>
 					<a href="https://lucasmdo.survey.fm/assembler-survey-modal" target="blank">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
@@ -9,7 +9,7 @@ interface Props {
 const Survey = ( { setSurveyDismissed }: Props ) => {
 	const locale = useLocale();
 
-	if ( 'en' !== locale ) {
+	if ( ! locale.includes( 'en' ) ) {
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
@@ -31,6 +31,7 @@ const Survey = ( { setSurveyDismissed }: Props ) => {
 			} }
 			dismissTemporary
 			showIcon={ false }
+			showLinkIcon={ false }
 			dismissWithoutSavingPreference
 			tracksImpressionName="calypso_onboarding_survey_impression"
 			tracksClickName="calypso_onboarding_survey_click"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
@@ -1,13 +1,15 @@
 import { useLocale } from '@automattic/i18n-utils';
-import { useState } from 'react';
 import Banner from 'calypso/components/banner';
 import './survey.scss';
 
-const Survey = ( { userHasEngaged }: { userHasEngaged: boolean } ) => {
-	const locale = useLocale();
-	const [ dismissed, setDismissed ] = useState( false );
+interface Props {
+	setSurveyDismissed: ( dismissed: boolean ) => void;
+}
 
-	if ( 'en' !== locale || dismissed || ! userHasEngaged ) {
+const Survey = ( { setSurveyDismissed }: Props ) => {
+	const locale = useLocale();
+
+	if ( 'en' !== locale ) {
 		return null;
 	}
 
@@ -25,7 +27,7 @@ const Survey = ( { userHasEngaged }: { userHasEngaged: boolean } ) => {
 			event="assembler-june-2023"
 			onDismiss={ ( e: Event ) => {
 				e.stopPropagation();
-				setDismissed( true );
+				setSurveyDismissed( true );
 			} }
 			dismissTemporary
 			showIcon={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
@@ -32,6 +32,7 @@ const Survey = ( { setSurveyDismissed }: Props ) => {
 				setSurveyDismissed( true );
 			} }
 			dismissTemporary
+			disableHref
 			showIcon={ false }
 			showLinkIcon={ false }
 			dismissWithoutSavingPreference

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.scss
@@ -1,0 +1,36 @@
+.pattern-assembler__survey {
+	min-height: 76px;
+	border-radius: 4px;
+	background: #f0f7fc;
+	margin: 16px 0;
+
+	&.banner.card {
+		cursor: default;
+		border: 0;
+		box-shadow: none;
+		padding-right: 52px;
+	}
+
+	.banner__info .banner__title {
+		font-weight: 400;
+		line-height: 20px;
+		color: var(--studio-gray-70);
+		font-size: $font-body-extra-small;
+		font-family: "SF Pro Text", $sans;
+
+		a,
+		a:visited {
+			font-weight: 600;
+			color: var(--studio-gray-90);
+			text-decoration: underline;
+		}
+	}
+
+	.banner__close-icon {
+		fill: var(--studio-gray-60);
+		top: auto;
+		right: 18px;
+		height: 15.4px;
+		width: 15.4px;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.tsx
@@ -1,0 +1,41 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useState } from 'react';
+import Banner from 'calypso/components/banner';
+import './survey.scss';
+
+const Survey = () => {
+	const locale = useLocale();
+	const [ dismissed, setDismissed ] = useState( false );
+
+	if ( 'en' !== locale || dismissed ) {
+		return null;
+	}
+
+	return (
+		<Banner
+			className="pattern-assembler__survey"
+			// href="https://lucasmdo.survey.fm/assembler-survey-modal"
+			title={
+				<>
+					<a href="https://lucasmdo.survey.fm/assembler-survey-modal" target="blank">
+						Fill out this quick survey
+					</a>{ ' ' }
+					and help us to improve our product.
+				</>
+			}
+			event="assembler-june-2023"
+			onDismiss={ ( e: Event ) => {
+				e.stopPropagation();
+				setDismissed( true );
+			} }
+			dismissTemporary
+			showIcon={ false }
+			dismissWithoutSavingPreference
+			tracksImpressionName="calypso_onboarding_survey_impression"
+			tracksClickName="calypso_onboarding_survey_click"
+			tracksDismissName="calypso_onboarding_survey_dismiss"
+		/>
+	);
+};
+
+export default Survey;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.tsx
@@ -3,18 +3,17 @@ import { useState } from 'react';
 import Banner from 'calypso/components/banner';
 import './survey.scss';
 
-const Survey = () => {
+const Survey = ( { userHasEngaged }: { userHasEngaged: boolean } ) => {
 	const locale = useLocale();
 	const [ dismissed, setDismissed ] = useState( false );
 
-	if ( 'en' !== locale || dismissed ) {
+	if ( 'en' !== locale || dismissed || ! userHasEngaged ) {
 		return null;
 	}
 
 	return (
 		<Banner
 			className="pattern-assembler__survey"
-			// href="https://lucasmdo.survey.fm/assembler-survey-modal"
 			title={
 				<>
 					<a href="https://lucasmdo.survey.fm/assembler-survey-modal" target="blank">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #76653
Pattern Assembler Survey pbxlJb-3T9-p2
Figma Tv3pYqA3EcRfiXC31IxrXE-fi-314_8143

## Proposed Changes

https://github.com/Automattic/wp-calypso/assets/1881481/916b2729-c3df-49e3-8778-c7ce6a3dab46

Note that I recorded that video before adding the feature to show the survey only to engaged users, so you will have to click on any item from the nav bar before you can see it.


https://github.com/Automattic/wp-calypso/assets/1881481/30be8c0c-151e-4782-bc10-ad6d1545801a





* Add survey CTA in the assembler main screen
* Show only for en locale after users click on an item from the side nav
* Allow dismissing it only for the session
* Link to the survey and open in a new tab
* Add reusable Tracks events with the prop `cta_name: assembler-june-2023`:
  * `calypso_onboarding_survey_impression` triggered when it's visible
  * `calypso_onboarding_survey_click` triggered when it's clicked (not dismissed)
  * `calypso_onboarding_survey_dismiss` triggered when it's dismissed
 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a new site 
- Continue until the design picker
- Scroll down to click `Start Designing`
- Verify that you don't see the Survey CTA when your interface language is not English
- Verify that you can click the `X` button to dismiss the survey CTA
- Verify the link `Fill out this quick survey` opens the survey in a new tab
- Verify the tracks events for each action are sent with the prop `cta_name: assembler-june-2023`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?