### PR TITLE
Fix regression: fix selector for applying color palette

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -2,8 +2,7 @@
 
 $colophon-height: 50px; // wpcomColophon element at the bottom
 
-.jetpack-connect__main:not(.is-woocommerce),
-.jetpack-connect__main:not(.is-wpcom-migration),
+.jetpack-connect__main:not(.is-woocommerce):not(.is-wpcom-migration),
 .layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow):not(.is-jetpack-woocommerce-flow):not(.is-jetpack-woo-dna-flow):not(.is-wpcom-migration) {
 	@include jetpack-connect-colors();
 }


### PR DESCRIPTION
Related to: https://github.com/Automattic/wp-calypso/pull/76688

## Proposed Changes

* Fixed selector for applying a color palette

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a JN site with Woo Commerce and Woo Payments plugins
* Select Payments from the left side-bar
* Press "Finish setup" button
* Replace  domain`wordpress.com` with `calypso.localhost:3000` or PR live link domain
* Check if there is WOO button color

## Screenshots
<table>
  <tr>
    <td width=50%>
      <img src="https://github.com/Automattic/wp-calypso/assets/1241413/cf89ede8-cb79-4bc1-a75a-4fab6e3630c7"/>
    <td width=50%>
      <img src="https://github.com/Automattic/wp-calypso/assets/1241413/34340f56-07a3-4032-a631-372c8f4baac2" />
</table>
      

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
