### PR TITLE
Update commission fees copy and link to plans for upgrade

### DIFF
--- a/client/my-sites/earn/components/commission-fees.tsx
+++ b/client/my-sites/earn/components/commission-fees.tsx
@@ -25,10 +25,10 @@ const CommissionFees = ( {
 	const StripeFeesLink = (
 		<ExternalLink href="https://stripe.com/pricing" icon={ true } iconSize={ iconSize } />
 	);
-	const plansLink = `/plans/${ siteSlug }`;
+	const plansLink = siteSlug ? `/plans/${ siteSlug }` : '/plans';
 	let commissionFeesText;
 
-	if ( commission === 0 || ! siteSlug ) {
+	if ( commission === 0 ) {
 		commissionFeesText = translate(
 			'With your current plan, the transaction fee for payments is %(commissionFee)d% (+ <StripeFeesLink>Stripe fees</StripeFeesLink>).',
 			{

--- a/client/my-sites/earn/components/commission-fees.tsx
+++ b/client/my-sites/earn/components/commission-fees.tsx
@@ -1,4 +1,3 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import ExternalLink from 'calypso/components/external-link';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -12,34 +11,45 @@ type CommissionFeesProps = {
 const CommissionFees = ( { className, commission, iconSize = 16 }: CommissionFeesProps ) => {
 	const translate = useTranslate();
 
-	return commission !== null ? (
-		<span className={ className }>
-			{ preventWidows(
-				translate(
-					'On your current plan, WordPress.com charges {{em}}%(commission)s{{/em}}.{{br/}} Additionally, Stripe charges are typically %(stripe)s. {{a}}Learn more{{/a}}',
-					{
-						args: {
-							commission: '' + parseFloat( String( commission ) ) * 100 + '%',
-							stripe: '2.9%+30c',
-						},
-						components: {
-							em: <em />,
-							br: <br />,
-							a: (
-								<ExternalLink
-									href={ localizeUrl(
-										'https://wordpress.com/support/wordpress-editor/blocks/payments/#related-fees'
-									) }
-									icon={ true }
-									iconSize={ iconSize }
-								/>
-							),
-						},
-					}
-				)
-			) }
-		</span>
-	) : null;
+	if ( commission === null ) {
+		return null;
+	}
+
+	const commissionFee = commission * 100;
+	const StripeFeesLink = (
+		<ExternalLink href="https://stripe.com/pricing" icon={ true } iconSize={ iconSize } />
+	);
+	const plansLink = '/plans';
+	let commissionFeesText;
+
+	if ( commission === 0 ) {
+		commissionFeesText = translate(
+			'With your current plan, the transaction fee for payments is %(commissionFee)d% (+ <StripeFeesLink>Stripe fees</StripeFeesLink>).',
+			{
+				args: {
+					commissionFee,
+				},
+				components: {
+					StripeFeesLink,
+				},
+			}
+		);
+	} else {
+		commissionFeesText = translate(
+			'With your current plan, the transaction fee for payments is %(commissionFee)d% (+ <StripeFeesLink>Stripe fees</StripeFeesLink>). <UpgradeLink>Upgrade to lower it.</UpgradeLink>',
+			{
+				args: {
+					commissionFee,
+				},
+				components: {
+					StripeFeesLink,
+					UpgradeLink: <a href={ plansLink } />,
+				},
+			}
+		);
+	}
+
+	return <span className={ className }>{ preventWidows( commissionFeesText ) }</span>;
 };
 
 export default CommissionFees;

--- a/client/my-sites/earn/components/commission-fees.tsx
+++ b/client/my-sites/earn/components/commission-fees.tsx
@@ -6,9 +6,15 @@ type CommissionFeesProps = {
 	className?: string;
 	commission: number | null;
 	iconSize?: number;
+	siteSlug?: string | null;
 };
 
-const CommissionFees = ( { className, commission, iconSize = 16 }: CommissionFeesProps ) => {
+const CommissionFees = ( {
+	className,
+	commission,
+	iconSize = 16,
+	siteSlug,
+}: CommissionFeesProps ) => {
 	const translate = useTranslate();
 
 	if ( commission === null ) {
@@ -19,10 +25,10 @@ const CommissionFees = ( { className, commission, iconSize = 16 }: CommissionFee
 	const StripeFeesLink = (
 		<ExternalLink href="https://stripe.com/pricing" icon={ true } iconSize={ iconSize } />
 	);
-	const plansLink = '/plans';
+	const plansLink = `/plans/${ siteSlug }`;
 	let commissionFeesText;
 
-	if ( commission === 0 ) {
+	if ( commission === 0 || ! siteSlug ) {
 		commissionFeesText = translate(
 			'With your current plan, the transaction fee for payments is %(commissionFee)d% (+ <StripeFeesLink>Stripe fees</StripeFeesLink>).',
 			{

--- a/client/my-sites/earn/components/commission-fees.tsx
+++ b/client/my-sites/earn/components/commission-fees.tsx
@@ -38,9 +38,8 @@ const CommissionFees = ( {
 				<>
 					{ ' ' }
 					<a href={ siteSlug ? `/plans/${ siteSlug }` : '/plans' }>
-						{ translate( 'Upgrade to lower it.', {
-							context: 'Upgrade to a paid plan to lower transaction fee % for payment features.',
-						} ) }
+						{ /* translators: 'Upgrade to a paid plan to lower transaction fee % for payment features. */ }
+						{ translate( 'Upgrade to lower it.' ) }
 					</a>
 				</>
 			);

--- a/client/my-sites/earn/components/commission-fees.tsx
+++ b/client/my-sites/earn/components/commission-fees.tsx
@@ -1,5 +1,3 @@
-import { englishLocales, localizeUrl, useLocale } from '@automattic/i18n-utils';
-import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import ExternalLink from 'calypso/components/external-link';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -18,86 +16,45 @@ const CommissionFees = ( {
 	siteSlug,
 }: CommissionFeesProps ) => {
 	const translate = useTranslate();
-	const { hasTranslation } = useI18n();
-	const locale = useLocale();
 
 	if ( commission === null ) {
 		return null;
 	}
 
-	const useNewStrings =
-		englishLocales.includes( locale ) ||
-		( hasTranslation(
-			'With your current plan, the transaction fee for payments is %(commissionFee)d% (+ {{link}}Stripe fees{{/link}}).'
-		) &&
-			hasTranslation( 'Upgrade to lower it.' ) );
-
-	if ( useNewStrings ) {
-		const upgradeLink =
-			commission === 0 ? null : (
-				<>
-					{ ' ' }
-					<a href={ siteSlug ? `/plans/${ siteSlug }` : '/plans' }>
-						{ /* translators: 'Upgrade to a paid plan to lower transaction fee % for payment features. */ }
-						{ translate( 'Upgrade to lower it.' ) }
-					</a>
-				</>
-			);
-
-		return (
-			<span className={ className }>
-				{ preventWidows(
-					<>
-						{ translate(
-							'With your current plan, the transaction fee for payments is %(commissionFee)d% (+ {{link}}Stripe fees{{/link}}).',
-							{
-								args: {
-									commissionFee: commission * 100,
-								},
-								components: {
-									link: (
-										<ExternalLink
-											href="https://stripe.com/pricing"
-											icon={ true }
-											iconSize={ iconSize }
-										/>
-									),
-								},
-							}
-						) }
-						{ upgradeLink }
-					</>
-				) }
-			</span>
+	const upgradeLink =
+		commission === 0 ? null : (
+			<>
+				{ ' ' }
+				<a href={ siteSlug ? `/plans/${ siteSlug }` : '/plans' }>
+					{ /* translators: 'Upgrade to a paid plan to lower transaction fee % for payment features. */ }
+					{ translate( 'Upgrade to lower it.' ) }
+				</a>
+			</>
 		);
-	}
 
-	// Old strings, remove once above has been translated
 	return (
 		<span className={ className }>
 			{ preventWidows(
-				translate(
-					'On your current plan, WordPress.com charges {{em}}%(commission)s{{/em}}.{{br/}} Additionally, Stripe charges are typically %(stripe)s. {{a}}Learn more{{/a}}',
-					{
-						args: {
-							commission: '' + parseFloat( commission ) * 100 + '%',
-							stripe: '2.9%+30c',
-						},
-						components: {
-							em: <em />,
-							br: <br />,
-							a: (
-								<ExternalLink
-									href={ localizeUrl(
-										'https://wordpress.com/support/wordpress-editor/blocks/payments/#related-fees'
-									) }
-									icon={ true }
-									iconSize={ iconSize }
-								/>
-							),
-						},
-					}
-				)
+				<>
+					{ translate(
+						'With your current plan, the transaction fee for payments is %(commissionFee)d% (+ {{link}}Stripe fees{{/link}}).',
+						{
+							args: {
+								commissionFee: commission * 100,
+							},
+							components: {
+								link: (
+									<ExternalLink
+										href="https://stripe.com/pricing"
+										icon={ true }
+										iconSize={ iconSize }
+									/>
+								),
+							},
+						}
+					) }
+					{ upgradeLink }
+				</>
 			) }
 		</span>
 	);

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -481,7 +481,12 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 				) }
 				<br />
 				<br />
-				<CommissionFees commission={ commission } iconSize={ 14 } className="earn__notes" />
+				<CommissionFees
+					className="earn__notes"
+					commission={ commission }
+					iconSize={ 14 }
+					siteSlug={ selectedSiteSlug }
+				/>
 			</>
 		),
 	} );

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -597,11 +597,11 @@ class MembershipsSection extends Component {
 						) }
 					</div>
 					<div>
-						<h3>{ translate( 'No membership fees' ) }</h3>
-						<p>{ preventWidows( translate( 'No monthly or annual fees charged.' ) ) }</p>
+						<h3>{ translate( 'Simple fees structure' ) }</h3>
 						<p>
 							<CommissionFees commission={ commission } siteSlug={ siteSlug } />
 						</p>
+						<p>{ preventWidows( translate( 'No fixed monthly or annual fees charged.' ) ) }</p>
 					</div>
 					<div>
 						<h3>{ translate( 'Join thousands of others' ) }</h3>

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -7,7 +7,7 @@ import { Card, Button, Dialog, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { englishLocales, localizeUrl } from '@automattic/i18n-utils';
 import { saveAs } from 'browser-filesaver';
-import { hasTranslation, localize, getLocaleSlug } from 'i18n-calypso';
+import i18n, { localize, getLocaleSlug } from 'i18n-calypso';
 import { orderBy } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -599,7 +599,7 @@ class MembershipsSection extends Component {
 					<div>
 						<h3>
 							{ englishLocales.includes( getLocaleSlug() ) ||
-							hasTranslation( 'Simple fees structure' )
+							i18n.hasTranslation( 'Simple fees structure' )
 								? translate( 'Simple fees structure' )
 								: translate( 'No membership fees' ) }
 						</h3>
@@ -609,7 +609,7 @@ class MembershipsSection extends Component {
 						<p>
 							{ preventWidows(
 								englishLocales.includes( getLocaleSlug() ) ||
-									hasTranslation( 'No fixed monthly or annual fees charged.' )
+									i18n.hasTranslation( 'No fixed monthly or annual fees charged.' )
 									? translate( 'No fixed monthly or annual fees charged.' )
 									: translate( 'No monthly or annual fees charged.' )
 							) }

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -73,7 +73,8 @@ class MembershipsSection extends Component {
 		}
 	}
 	renderEarnings() {
-		const { commission, currency, forecast, lastMonth, siteId, total, translate } = this.props;
+		const { commission, currency, forecast, lastMonth, siteId, siteSlug, total, translate } =
+			this.props;
 		return (
 			<div>
 				<SectionHeader label={ translate( 'Earnings' ) } />
@@ -112,6 +113,7 @@ class MembershipsSection extends Component {
 					<CommissionFees
 						commission={ commission }
 						iconSize={ 12 }
+						siteSlug={ siteSlug }
 						className="memberships__earnings-breakdown-notes"
 					/>
 				</Card>
@@ -531,7 +533,7 @@ class MembershipsSection extends Component {
 	}
 
 	renderOnboarding( cta, intro ) {
-		const { commission, translate } = this.props;
+		const { commission, translate, siteSlug } = this.props;
 
 		return (
 			<Card>
@@ -598,7 +600,7 @@ class MembershipsSection extends Component {
 						<h3>{ translate( 'No membership fees' ) }</h3>
 						<p>{ preventWidows( translate( 'No monthly or annual fees charged.' ) ) }</p>
 						<p>
-							<CommissionFees commission={ commission } />
+							<CommissionFees commission={ commission } siteSlug={ siteSlug } />
 						</p>
 					</div>
 					<div>

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -5,9 +5,9 @@ import {
 } from '@automattic/calypso-products';
 import { Card, Button, Dialog, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { englishLocales, localizeUrl } from '@automattic/i18n-utils';
 import { saveAs } from 'browser-filesaver';
-import { localize } from 'i18n-calypso';
+import { hasTranslation, localize, getLocaleSlug } from 'i18n-calypso';
 import { orderBy } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -597,11 +597,23 @@ class MembershipsSection extends Component {
 						) }
 					</div>
 					<div>
-						<h3>{ translate( 'Simple fees structure' ) }</h3>
+						<h3>
+							{ englishLocales.includes( getLocaleSlug() ) ||
+							hasTranslation( 'Simple fees structure' )
+								? translate( 'Simple fees structure' )
+								: translate( 'No membership fees' ) }
+						</h3>
 						<p>
 							<CommissionFees commission={ commission } siteSlug={ siteSlug } />
 						</p>
-						<p>{ preventWidows( translate( 'No fixed monthly or annual fees charged.' ) ) }</p>
+						<p>
+							{ preventWidows(
+								englishLocales.includes( getLocaleSlug() ) ||
+									hasTranslation( 'No fixed monthly or annual fees charged.' )
+									? translate( 'No fixed monthly or annual fees charged.' )
+									: translate( 'No monthly or annual fees charged.' )
+							) }
+						</p>
 					</div>
 					<div>
 						<h3>{ translate( 'Join thousands of others' ) }</h3>


### PR DESCRIPTION

<img width="1070" alt="Screenshot 2023-06-05 at 23 00 30" src="https://github.com/Automattic/wp-calypso/assets/87168/4887ca71-0398-40e0-8953-f70d1b1e4222">
<img width="1122" alt="Screenshot 2023-06-05 at 22 59 59" src="https://github.com/Automattic/wp-calypso/assets/87168/d18257a8-fa0d-4ba4-83c0-2a9779e953d6">
<img width="1105" alt="Screenshot 2023-06-05 at 22 59 53" src="https://github.com/Automattic/wp-calypso/assets/87168/8ba64874-1b48-4689-a351-bcda20565b9a">

## Proposed Changes

* Link to plans for upgrade instead of documentation. Pending adding the fees directly in plans grid first.

## Testing Instructions

* Open /earn and note the copy added in https://github.com/Automattic/wp-calypso/pull/77552

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
