### PR TITLE
Handle Jetpack sites in the site store

### DIFF
--- a/packages/data-stores/src/queries/use-wpcom-site.ts
+++ b/packages/data-stores/src/queries/use-wpcom-site.ts
@@ -9,6 +9,7 @@ export function useWpcomSite( siteId: number | string | undefined, enabled = tru
 			wpcomRequest< SiteDetails >( {
 				path: '/sites/' + encodeURIComponent( siteId as string ),
 				apiVersion: '1.1',
+				query: '?force=wpcom',
 			} ),
 		refetchOnWindowFocus: false,
 		staleTime: Infinity,

--- a/packages/data-stores/src/queries/use-wpcom-site.ts
+++ b/packages/data-stores/src/queries/use-wpcom-site.ts
@@ -9,7 +9,7 @@ export function useWpcomSite( siteId: number | string | undefined, enabled = tru
 			wpcomRequest< SiteDetails >( {
 				path: '/sites/' + encodeURIComponent( siteId as string ),
 				apiVersion: '1.1',
-				query: '?force=wpcom',
+				query: 'force=wpcom',
 			} ),
 		refetchOnWindowFocus: false,
 		staleTime: Infinity,

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -101,15 +101,6 @@ export const sites: Reducer< { [ key: number | string ]: SiteDetails | undefined
 ) => {
 	if ( action.type === 'RECEIVE_SITE' ) {
 		if ( action.response ) {
-			// Sometimes, the siteId in the request is not the same as the ID in the response in Jetpack sites.
-			// Save both ids in the look up table so the site is accessible by both ids.
-			if ( action.siteId !== action.response.ID ) {
-				return {
-					...state,
-					[ action.response.ID ]: action.response,
-					[ action.siteId ]: action.response,
-				};
-			}
 			return { ...state, [ action.response.ID ]: action.response };
 		}
 		return state;

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -101,6 +101,15 @@ export const sites: Reducer< { [ key: number | string ]: SiteDetails | undefined
 ) => {
 	if ( action.type === 'RECEIVE_SITE' ) {
 		if ( action.response ) {
+			// Sometimes, the siteId in the request is not the same as the ID in the response in Jetpack sites.
+			// Save both ids in the look up table so the site is accessible by both ids.
+			if ( action.siteId !== action.response.ID ) {
+				return {
+					...state,
+					[ action.response.ID ]: action.response,
+					[ action.siteId ]: action.response,
+				};
+			}
 			return { ...state, [ action.response.ID ]: action.response };
 		}
 		return state;

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -25,6 +25,7 @@ export const getSite =
 			const existingSite: SiteDetails | undefined = await wpcomRequest( {
 				path: '/sites/' + encodeURIComponent( siteId ),
 				apiVersion: '1.1',
+				query: '?force=wpcom',
 			} );
 			dispatch.receiveSite( siteId, existingSite );
 		} catch ( err ) {

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -25,7 +25,7 @@ export const getSite =
 			const existingSite: SiteDetails | undefined = await wpcomRequest( {
 				path: '/sites/' + encodeURIComponent( siteId ),
 				apiVersion: '1.1',
-				query: '?force=wpcom',
+				query: 'force=wpcom',
 			} );
 			dispatch.receiveSite( siteId, existingSite );
 		} catch ( err ) {

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -140,7 +140,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 		[ siteId || primarySiteId ]
 	);
 
-	const usedSite = site || backendProvidedSite;
+	const usedSite = backendProvidedSite || site;
 
 	useEffect( () => {
 		setSite( usedSite );

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -129,12 +129,15 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	useSelect( ( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(), [] );
 
 	const currentSite = window?.helpCenterData?.currentSite;
+
 	const site = useSelect(
 		( select ) => ( select( SITE_STORE ) as SiteSelect ).getSite( siteId || primarySiteId ),
 		[ siteId || primarySiteId ]
 	);
 
-	setSite( currentSite ? currentSite : site );
+	useEffect( () => {
+		setSite( currentSite ? currentSite : site );
+	}, [ currentSite, site, setSite ] );
 
 	useStillNeedHelpURL();
 

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -128,16 +128,23 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 
 	useSelect( ( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(), [] );
 
-	const currentSite = window?.helpCenterData?.currentSite;
+	/**
+	 * This site is provided by the backed in Editing Toolkit.
+	 * It's difficult to get the site information on the client side in Atomic sites. So we moved this challenge to the backend,
+	 * and forwarded the data using `localize_script` to the client side.
+	 */
+	const backendProvidedSite = window?.helpCenterData?.currentSite;
 
 	const site = useSelect(
 		( select ) => ( select( SITE_STORE ) as SiteSelect ).getSite( siteId || primarySiteId ),
 		[ siteId || primarySiteId ]
 	);
 
+	const usedSite = site || backendProvidedSite;
+
 	useEffect( () => {
-		setSite( currentSite ? currentSite : site );
-	}, [ currentSite, site, setSite ] );
+		setSite( usedSite );
+	}, [ usedSite, setSite ] );
 
 	useStillNeedHelpURL();
 


### PR DESCRIPTION

## Proposed Changes

The site endpoint returns a different site ID in the response from the ID in the request. This confuses the site store because it uses the site ID as the key for the sites it stores.

This fix sends `force=wpcom` query parameter to guarantee a wpcom site.

## Testing Instructions

1. Login to a user who only owns a Jetpack site.
2. Open wordpress.com.
3. Open the Help Center.
4. Go to Live Chat.
5. "Continue" button should be active.
