### PR TITLE
Post-Likes Popover - Fix styles for the has display names state.

### DIFF
--- a/client/blocks/post-likes/style.scss
+++ b/client/blocks/post-likes/style.scss
@@ -19,7 +19,9 @@
 		overflow-y: auto;
 
 		.post-likes__item {
-			display: block;
+			display: flex;
+			align-items: center;
+			justify-content: start;
 			position: relative;
 			padding: 4px 8px;
 			border-bottom: 1px solid var(--color-neutral-0);
@@ -27,16 +29,12 @@
 			&:last-child {
 				border-bottom-width: 0;
 			}
-
-			.gravatar {
-				position: absolute;
-			}
 		}
 
 		.post-likes__display-name {
 			display: block;
 			line-height: 24px;
-			padding-left: 32px;
+			padding-left: 4px;
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pe7F0s-Rz-p2

## Proposed Changes

* Adjusts styles on the post-likes component when has-display-names is set. 
* This converts the item element to a flex container and balance its contents layout naturally. 
* Adds a small (4px) padding between the gravatar and the display name.


BEFORE:
<img width="267" alt="Screenshot 2023-06-02 at 9 30 15 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/04b6996e-a25b-4802-a00e-49aefe91a8ab">

AFTER:
<img width="286" alt="Screenshot 2023-06-02 at 9 29 31 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/09e58aac-529c-4637-9cab-b8896d4f1956">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of calypso
* test post-likes popover in the reader and calypso posts view.
* verify no regressions in areas where postLikes are rendered without display names, such as stats pages for specific posts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?