### PR TITLE
Design Picker: Skip flagged virtual themes from going to SA

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -252,9 +252,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	}
 
 	function previewDesign( design: Design, styleVariation?: StyleVariation ) {
-		// Virtual designs don't need to be previewed and can go directly to the site assembler.
-		const shouldGoToAssembler =
-			design.is_virtual && design.slug === BLANK_CANVAS_DESIGN.slug && isDesktop;
+		// Redirect to Site Assembler if the design_type is set to "assembler".
+		const shouldGoToAssembler = isDesktop && design.design_type === 'assembler';
 
 		if ( shouldGoToAssembler ) {
 			design = {

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -9,6 +9,7 @@ import type {
 	SoftwareSet,
 	StyleVariation,
 	PreviewData,
+	DesignType,
 } from '@automattic/design-picker/src/types';
 
 interface StarterDesignsQueryParams {
@@ -37,6 +38,7 @@ interface StarterDesign {
 	software_sets?: SoftwareSet[];
 	is_virtual: boolean;
 	preview_data: PreviewData | null;
+	design_type?: DesignType;
 }
 
 export function useStarterDesignsQuery(
@@ -83,6 +85,7 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		style_variations,
 		software_sets,
 		preview_data,
+		design_type,
 	} = design;
 	const is_premium =
 		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) || false;
@@ -101,7 +104,7 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		is_bundled_with_woo_commerce,
 		price,
 		software_sets,
-		design_type: is_premium ? 'premium' : 'standard',
+		design_type: design_type ?? ( is_premium ? 'premium' : 'standard' ),
 		style_variations,
 		is_virtual: design.is_virtual && !! design.recipe?.pattern_ids?.length,
 		...( preview_data && { preview_data } ),


### PR DESCRIPTION
When the design_type property is set on the design and equals "assembler", then we should point the user to the Site Assembler.

This is needed so that we can exclude some Virtual themes from being sent to the Site Assembler. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/77321

## Proposed Changes

* Send the user to Site Assembler only when the `design_type` is set to `assembler`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox your site and apply D112585-code
* Use the live link and go to `setup/site-setup/designSetup?siteSlug=your-site`
* Click on the Link in Bio category
* Click on the `Link in Bio: Anime` virtual theme
* Make sure that you're sent to the preview page of the theme (not the Site Assembler)
* Click on another virtual theme and notice that you're sent to the SIte Assembler (only the Anime theme is flagged in the back-end for now - all LiB will be flagged this way once this PR lands).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
