### PR TITLE
Email stats: Remove the bar below the chart

### DIFF
--- a/client/my-sites/stats/stats-email-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-email-chart-tabs/index.jsx
@@ -12,7 +12,6 @@ import { getSiteOption } from 'calypso/state/sites/selectors';
 import { isLoadingTabs, getCountRecords } from 'calypso/state/stats/email-chart-tabs/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StatsModulePlaceholder from '../stats-module/placeholder';
-import StatTabs from '../stats-tabs';
 import { buildChartData, getQueryDate } from './utility';
 
 import './style.scss';
@@ -99,14 +98,6 @@ class StatModuleChartTabs extends Component {
 					minBarWidth={ 35 }
 					sliceFromBeginning={ false }
 					onChangeMaxBars={ onChangeMaxBars }
-				/>
-				<StatTabs
-					data={ this.props.counts }
-					tabs={ this.props.charts }
-					switchTab={ this.props.switchTab }
-					selectedTab={ this.props.chartTab }
-					activeIndex={ this.props.queryDate }
-					activeKey="period"
 				/>
 			</div>
 		);


### PR DESCRIPTION
Closes [#77745](https://github.com/Automattic/wp-calypso/issues/77745)

## Proposed Changes

This PR removes the horizontal bar below the chart

| Before | After |
|-|-|
| <img width="1278" alt="CleanShot 2023-06-02 at 16 58 28@2x" src="https://github.com/Automattic/wp-calypso/assets/528287/9f5c7ae7-926f-4492-bc52-5be038f12f80"> | <img width="1251" alt="CleanShot 2023-06-02 at 16 58 36@2x" src="https://github.com/Automattic/wp-calypso/assets/528287/acfb76c0-e8a1-4601-babe-de11e2a031be"> |

## Testing Instructions

1. Apply this PR
2. Make sure the bar is gone on both email opens & email clicks stats
3. Make sure there are no regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
