### PR TITLE
Theme Showcase: Remove Mention of Individual Premium Theme Purchase

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -8,7 +8,6 @@ import {
 } from '@automattic/design-picker';
 import { Button as LinkButton } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { isEmpty, isEqual } from 'lodash';
@@ -293,34 +292,12 @@ export class Theme extends Component {
 		}
 	};
 
-	parseThemePrice = ( price ) => {
-		/*
-		theme.price on "Recommended" themes tab
-		Premium theme: "$50"
-		Free theme:    undefined
-
-		theme.price on Trending themes tab
-		Premium theme: { value: 50, currency: "USD", display: "<abbr title=\"United States Dollars\">US$</abbr>50" }
-		Free theme:    { value: 0, currency: "USD", display: "Free" }
-
-		Try to correctly parse the price for both cases.
-		*/
-		if ( typeof price === 'object' && 'display' in price ) {
-			let parsedThemePrice = price.display;
-			// Remove all html tags from the price string
-			parsedThemePrice = parsedThemePrice.replace( /(<([^>]+)>)/gi, '' );
-			return parsedThemePrice;
-		}
-		return price;
-	};
-
 	getUpsellMessage = () => {
 		const {
 			didPurchaseTheme,
 			doesThemeBundleSoftwareSet,
 			hasMarketplaceThemeSubscription,
 			hasPremiumThemesFeature,
-			theme,
 			translate,
 			isSiteEligibleForBundledSoftware,
 			isExternallyManagedTheme,
@@ -408,15 +385,7 @@ export class Theme extends Component {
 		}
 
 		return createInterpolateElement(
-			sprintf(
-				/* translators: the "price" is the price of the theme, example: US$50; */
-				translate(
-					'This premium theme is included in the <Link>Premium plan</Link>, or you can purchase individually for %(price)s.'
-				),
-				{
-					price: this.parseThemePrice( theme.price ),
-				}
-			),
+			translate( 'This premium theme is included in the <Link>Premium plan</Link>.' ),
 			{
 				Link: <LinkButton isLink onClick={ () => this.goToCheckout( 'premium' ) } />,
 			}


### PR DESCRIPTION
## Proposed Changes

* Remove mention of individual premium theme purchase from the Theme Showcase label.

| Before | After |
|--------|--------|
| <img width="319" alt="Screenshot 2023-06-02 at 17 36 45" src="https://github.com/Automattic/wp-calypso/assets/2070010/663371b0-3e0d-48d2-ba22-cd5b7e3f4f2f"> | <img width="323" alt="Screenshot 2023-06-02 at 17 36 38" src="https://github.com/Automattic/wp-calypso/assets/2070010/24f14319-18c0-46b8-aba6-90ec144a5ae1"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a free site, navigate to the Theme Showcase (`/themes/premium`).
* Hover on a Premium label.
* Check that it doesn't mention the individual purchase anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
