### PR TITLE
Fix conflicting interval toggle styles in plans pages

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -125,48 +125,6 @@
 			text-decoration: underline;
 		}
 
-		.plans-features-main {
-			ul.segmented-control {
-				background-color: #f2f2f2;
-				border-radius: 6px;  /* stylelint-disable-line scales/radii */
-				border-color: var(--studio-gray-5);
-
-				li.segmented-control__item {
-					border: 6px;
-					padding: 2px;
-					&:first-child {
-						margin-right: 5px;
-					}
-					&.is-selected {
-						a.segmented-control__link {
-							padding-top: 6px;
-							padding-bottom: 6px;
-							border: 0.5px solid #0000000a;
-							background-color: var(--studio-white);
-							color: var(--color-text);
-							border-radius: 5px;  /* stylelint-disable-line scales/radii */
-							box-shadow: 0 3px 8px #0000001f, 0 3px 1px #0000000a;
-						}
-					}
-					a.segmented-control__link {
-						border: solid 1px #f2f2f2;
-						border-radius: 5px;  /* stylelint-disable-line scales/radii */
-					}
-				}
-				li.segmented-control__item:not(.is-selected) {
-					a.segmented-control__link {
-						border: solid 1px #f2f2f2;
-						border-radius: 5px;  /* stylelint-disable-line scales/radii */
-						&:hover {
-							background-color: unset !important;
-							border: 1px solid var(--studio-gray-10);
-							border-radius: 5px;  /* stylelint-disable-line scales/radii */
-						}
-					}
-				}
-			}
-		}
-
 		.plans__loading {
 			width: 100%;
 			display: flex;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -728,58 +728,6 @@ body.is-section-signup.is-white-signup,
 	}
 }
 
-.plans-features-main.is-pricing-grid-2023-plans-features-main  ul.segmented-control.price-toggle,
-body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup__step .segmented-control.price-toggle,
-#primary .is-pricing-grid-2023-plans-features-main .segmented-control.price-toggle {
-	background-color: #f2f2f2;
-	width: 100%;
-	margin: 0 auto;
-
-	@include plans-2023-break-small {
-		max-width: fit-content;
-		width: auto;
-	}
-
-	.segmented-control__link {
-		padding: 6px 11px;
-	}
-
-	li.segmented-control__item:not(.is-selected) {
-		border: 6px;
-		padding: 2px;
-		font-weight: 500;
-
-		& a.segmented-control__link {
-			border: 1px solid #f2f2f2;
-			border-radius: 5px; /* stylelint-disable-line scales/radii */
-
-			&:hover {
-				border-color: rgba(0, 0, 0, 0.04);
-				background: rgba(255, 255, 255, 0.3) !important;
-			}
-			&:focus {
-				box-shadow: 0 0 0 1px var(--studio-gray-90);
-				outline: none;
-			}
-		}
-
-		&.is-selected .segmented-control__link {
-			border: 0.5px solid rgba(0, 0, 0, 0.04);
-			box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
-
-			background-color: #fff;
-
-			&:hover {
-				background-color: #fff;
-				border-color: rgba(0, 0, 0, 0.04);
-			}
-		}
-
-		.segmented-control__text {
-			color: var(--studio-gray-90);
-		}
-	}
-}
 
 .plan-comparison-grid {
 	.plan-features-2023-gridrison__actions-buttons {

--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -303,59 +303,6 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
-.notouch .signup__step .segmented-control.price-toggle,
-.notouch .plans .segmented-control.price-toggle {
-	background-color: var(--studio-gray-5);
-	border-color: var(--studio-gray-5);
-	border-radius: 6px; /* stylelint-disable-line scales/radii */
-	color: var(--color-text);
-	margin-top: 16px;
-
-	.segmented-control__item {
-		border: 1px solid;
-		border-radius: 6px; /* stylelint-disable-line scales/radii */
-		border-color: var(--studio-gray-5);
-
-		&.is-selected {
-			padding: 1px 0 0 1px;
-		}
-
-		&:hover:not(.is-selected) {
-			border-color: var(--studio-gray-30);
-		}
-
-		&:first-child {
-			margin-right: 5px;
-		}
-
-		& .segmented-control__link {
-			color: var(--color-text);
-			padding: 10px 20px;
-
-			&:hover {
-				background-color: unset;
-			}
-		}
-
-		&.is-selected .segmented-control__link {
-			border-radius: 5px; /* stylelint-disable-line scales/radii */
-			background-color: var(--studio-white);
-			border-color: var(--studio-white);
-			box-shadow:
-				0 4px 4px rgba(0, 0, 0, 0.25),
-				0 3px 8px rgba(0, 0, 0, 0.12),
-				inset 0 0 0 rgba(0, 0, 0, 0.2);
-			border: 0.5px solid rgba(0, 0, 0, 0.07);
-			padding: 11px 20px;
-			color: var(--color-text);
-
-			&:hover {
-				background-color: var(--studio-white);
-			}
-		}
-	}
-}
-
 .plan-features__actions-button {
 	border-radius: 4px;
 }
@@ -431,41 +378,6 @@ body.is-section-signup.is-white-signup {
 		.plan-features-comparison__item-annual-plan-container
 		.plan-features-comparison__item-annual-plan {
 			color: var(--studio-orange-40);
-		}
-	}
-}
-
-.notouch body.is-section-signup.is-white-signup .signup__step .segmented-control.price-toggle,
-.notouch body.is-section-plans.is-section-plans .plans .segmented-control.price-toggle {
-	background-color: #f2f2f2;
-	margin-top: 0;
-
-	.segmented-control__link {
-		padding: 6px 11px;
-	}
-
-	.segmented-control__item {
-		border: 6px;
-		padding: 2px;
-
-		& .segmented-control__link {
-			border: 1px solid #f2f2f2;
-			&:hover {
-				border: 1px solid var(--studio-gray-10);
-				background-color: unset;
-				border-radius: 5px; /* stylelint-disable-line scales/radii */
-			}
-		}
-
-		&.is-selected .segmented-control__link {
-			border: 0.5px solid rgba(0, 0, 0, 0.04);
-			box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
-			border-radius: 5px; /* stylelint-disable-line scales/radii */
-
-			&:hover {
-				background-color: #fff;
-				border-color: rgba(0, 0, 0, 0.04);
-			}
 		}
 	}
 }

--- a/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
@@ -29,6 +29,7 @@ import {
 import { getSitePlanSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { IAppState } from 'calypso/state/types';
+import './style.scss';
 
 export type PlanTypeSelectorProps = {
 	kind: 'interval' | 'customer';
@@ -333,67 +334,6 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 	align-content: space-between;
 	justify-content: center;
 	margin: 0 20px 24px;
-
-	> .segmented-control.is-compact:not( .is-signup ) {
-		margin: 8px auto 16px;
-		max-width: 480px;
-
-		.segmented-control__link {
-			padding: 8px 12px;
-		}
-	}
-
-	> .segmented-control.is-signup {
-		margin: 0 auto;
-		border: solid 1px var( --color-neutral-10 );
-
-		@media screen and ( max-width: 960px ) {
-			margin-bottom: ${ ( { showingMonthly } ) => ( showingMonthly ? '65px' : 0 ) };
-		}
-
-		.segmented-control__item {
-			--color-primary: var( --color-neutral-100 );
-			--color-text-inverted: var( --color-neutral-0 );
-			--color-primary-light: var( --color-neutral-80 );
-			--color-primary-dark: var( --color-neutral-80 );
-			--item-padding: 3px;
-
-			padding: var( --item-padding ) 0;
-
-			&:first-of-type {
-				padding-left: var( --item-padding );
-
-				.rtl & {
-					padding-right: var( --item-padding );
-				}
-			}
-
-			&:last-of-type {
-				padding-right: var( --item-padding );
-
-				.rtl & {
-					padding-left: var( --item-padding );
-				}
-			}
-
-			&:last-of-type .segmented-control__link {
-				border-right: none;
-			}
-		}
-
-		.segmented-control__link {
-			border: none;
-			padding-top: 6px;
-			padding-bottom: 6px;
-			color: var( --color-neutral-80 );
-		}
-
-		.segmented-control__item:not( .is-selected ) {
-			.segmented-control__link:hover {
-				background-color: var( --color-neutral-5 );
-			}
-		}
-	}
 `;
 
 const StyledPopover = styled( Popover )`

--- a/client/my-sites/plans-features-main/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-features-main/components/plan-type-selector/style.scss
@@ -1,0 +1,51 @@
+
+.notouch body.is-section-signup.is-white-signup .signup__step .segmented-control.price-toggle,
+.notouch body.is-section-plans.is-section-plans .plans .segmented-control.price-toggle {
+	background-color: #f2f2f2;
+	border-radius: 6px; /* stylelint-disable-line scales/radii */
+	margin-top: 16px;
+	margin-top: 0;
+
+	.segmented-control__item {
+		border: 6px;
+		padding: 2px;
+		.segmented-control__link {
+			color: var(--studio-gray-90);
+			font-weight: 500;
+			padding: 6px 11px;
+			border: 1px solid #f2f2f2;
+			border-radius: 5px; /* stylelint-disable-line scales/radii */
+			&:hover {
+				border: 1px solid var(--studio-gray-10);
+				background-color: unset;
+				border-radius: 5px; /* stylelint-disable-line scales/radii */
+			}
+			&:focus {
+				box-shadow: 0 0 0 1px var(--studio-gray-90);
+				outline: none;
+			}
+		}
+
+		&.is-selected .segmented-control__link {
+			color: var(--studio-gray-80);
+			font-weight: 400;
+			border: 0.5px solid rgba(0, 0, 0, 0.04);
+			box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
+			border-radius: 5px; /* stylelint-disable-line scales/radii */
+			background-color: var(--studio-white);
+			&:hover {
+				background-color: var(--studio-white);
+				border-color: rgba(0, 0, 0, 0.04);
+			}
+		}
+	}
+}
+
+.notouch body.is-section-signup.is-white-signup .signup__step .segmented-control.price-toggle {
+	border: solid 1px var(--studio-gray-5);
+}
+
+.notouch body.is-section-plans.is-section-plans .plans .segmented-control.price-toggle {
+	margin: 8px auto 16px;
+	max-width: fit-content;
+}

--- a/client/my-sites/plans-features-main/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-features-main/components/plan-type-selector/style.scss
@@ -1,6 +1,7 @@
 
-.notouch body.is-section-signup.is-white-signup .signup__step .segmented-control.price-toggle,
-.notouch body.is-section-plans.is-section-plans .plans .segmented-control.price-toggle {
+body.is-section-signup.is-white-signup .signup__step .segmented-control.price-toggle,
+body.is-section-plans.is-section-plans .plans .segmented-control.price-toggle,
+body.is-group-stepper .plans .segmented-control.price-toggle {
 	background-color: #f2f2f2;
 	border-radius: 6px; /* stylelint-disable-line scales/radii */
 	margin-top: 16px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/martech#1522
## Proposed Changes

- Moves styled component related styles for the segment control component into sass
- Cleans up any other plans related segment control sass dead code 

## Additional Context

TLDR; accessing the same element (.segment-control) via multiple approaches (SCSS, Emotion) can lead to a nasty, intermittently visible bug, which is hard to diagnose and solve. It happens when both approaches match the same specificity.

---

This bug used to appear intermittently. It appeared because of two conflicting css transpilations fighting for the same specificity. For example, if one is consuming any component, if that said component has implemented its styles using a `.scss` file and then if we use `Styled Component child selectors` to modify the said component's styles, this can lead to said bug. For example ...

https://github.com/Automattic/wp-calypso/blob/7d5a48bbeb604774bb6c2d0b4fa6df7c840268a2/client/my-sites/plans-features-main/components/plan-type-selector.tsx#L337-L396

And in general styled components and sass approaches when mixed to apply styles to the same elements. Can lead to this bug. The bug that we faced with this issue was intermittent, it appeared and disappeared at times. It was incredibly hard to diagnose and solve. The reason for this is `SASS` and `Styled Component` both have a compile step which renders **_internal css_** onto the page. If by chance they both end up targeting the same specificity of styles for a given element, then the order of precedence for the `<style />`  tag is what will decide which rule wins. And the transpilation order of the <style /> tag cannot be guaranteed.

### So how do we solve this?

There are three approaches 
1 - Move all the `child selectors` shown above to sass. ( This PR )
2 - Move the Segment Control sass styles to `styled components` ( Ignored since would lead to refactors effecting many other components )
3 - Leave everything as it is and get a higher specificity in the Style Component selector (Will fix the issue short term but has the potential to reintroduce the bug)

I think we should be careful when mixing these approaches. Generally there wont be any issues but problems can arise if we are targeting the same element with both approaches and specificity becomes equal. And those bugs are build order dependent and therefore extremely hard to investigate. I think generally its a good practice to avoid targeting the same element with these two different approaches.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to each of the following and confirm the interval toggle matches the one from Figma (xkhhUlDowF13dRoXJqlRDM-fi-1_95):
    - `/setup/link-in-bio/plans` to test a Stepper flow with plans
    - `/start/plans` to test Signup flow with plans
    - `/plans[free]` to test Admin with plans

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?