### PR TITLE
Load GTM at the beginning of session for Akismet checkout

### DIFF
--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -1,8 +1,9 @@
 import { getCurrentUser } from '@automattic/calypso-analytics';
 import { loadScript } from '@automattic/load-script';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { mayWeTrackByTracker } from '../tracker-buckets';
+import { mayWeInitTracker, mayWeTrackByTracker } from '../tracker-buckets';
 import { getGaGtag } from '../utils/get-ga-gtag';
 import {
 	debug,
@@ -16,6 +17,7 @@ import {
 	QUORA_SCRIPT_URL,
 	OUTBRAIN_SCRIPT_URL,
 	PINTEREST_SCRIPT_URL,
+	GOOGLE_GTM_SCRIPT_URL,
 } from './constants';
 
 // Ensure setup has run.
@@ -96,6 +98,10 @@ function getTrackingScriptsToLoad() {
 
 	if ( mayWeTrackByTracker( 'pinterest' ) ) {
 		scripts.push( PINTEREST_SCRIPT_URL );
+	}
+
+	if ( mayWeInitTracker( 'googleTagManager' ) && isAkismetCheckout() ) {
+		scripts.push( GOOGLE_GTM_SCRIPT_URL + TRACKING_IDS.akismetGoogleTagManagerId );
 	}
 
 	return scripts;

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -1,3 +1,4 @@
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { mayWeInitTracker, mayWeTrackByTracker } from '../tracker-buckets';
@@ -73,6 +74,11 @@ if ( typeof window !== 'undefined' ) {
 	// AdRoll
 	if ( mayWeInitTracker( 'adroll' ) ) {
 		setupAdRollGlobal();
+	}
+
+	// GTM
+	if ( mayWeInitTracker( 'googleTagManager' ) ) {
+		setupGtmGtag();
 	}
 }
 
@@ -221,5 +227,12 @@ function setupWpcomFloodlightGtag() {
 
 	if ( mayWeTrackByTracker( 'floodlight' ) ) {
 		window.gtag( 'config', TRACKING_IDS.wpcomFloodlightGtag );
+	}
+}
+
+function setupGtmGtag() {
+	if ( isAkismetCheckout() ) {
+		window.dataLayer = window.dataLayer || [];
+		window.dataLayer.push( { 'gtm.start': new Date().getTime(), event: 'gtm.js' } );
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76034

## Proposed Changes

We want to ensure the GTM linker properly links cross-domain ads conversion data. Thus, we want to fire it at the beginning of the session instead of just on `recordOrder` side effect. 

## Testing Instructions

* Use store sandbox on your sandbox
* Checkout this PR and go to `http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_1?flags=ad-tracking`
* If in GDPR/CCPA zone - be sure to accept cookie banner
* Enable debug logs for analytics `localStorage.setItem( 'debug', 'calypso:analytics:*' );`
* Refresh the page
* You should find in DOM `https://www.googletagmanager.com/gtm.js?id=GTM-NLFBXG5` being loaded
* Purchase the product
* You should see events `recordOrderInAkismetGTM: Record Akismet GTM purchase` and `recordOrderInAkismetGA: Record Akismet Purchase` in console log, with appropriate properties assigned

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
