### PR TITLE
Checkout: Add required fields to Google Workspace contact form

### DIFF
--- a/client/components/domains/contact-details-form-fields/g-suite-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/g-suite-fields.tsx
@@ -1,0 +1,26 @@
+import { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
+import TaxFields from 'calypso/my-sites/checkout/composite-checkout/components/tax-fields';
+
+export function GSuiteFields( {
+	taxInfo,
+	countriesList,
+	onChange,
+	isDisabled,
+}: {
+	taxInfo: ManagedContactDetails;
+	countriesList: CountryListItem[];
+	onChange: ( taxInfo: ManagedContactDetails ) => void;
+	isDisabled?: boolean;
+} ) {
+	return (
+		<div className="contact-details-form-fields__row g-apps-fieldset">
+			<TaxFields
+				section="gsuite-contact-step"
+				taxInfo={ taxInfo }
+				countriesList={ countriesList }
+				onChange={ onChange }
+				isDisabled={ isDisabled }
+			/>
+		</div>
+	);
+}

--- a/client/components/domains/contact-details-form-fields/g-suite-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/g-suite-fields.tsx
@@ -13,7 +13,7 @@ export function GSuiteFields( {
 	isDisabled?: boolean;
 } ) {
 	return (
-		<div className="contact-details-form-fields__row g-apps-fieldset">
+		<div className="g-apps-fieldset">
 			<TaxFields
 				section="gsuite-contact-step"
 				taxInfo={ taxInfo }

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -425,7 +425,8 @@ export class ManagedContactDetailsFormFields extends Component {
 		// ManagedContactDetails, originally changed by
 		// `prepareDomainContactDetails()` back up in ContactDetailsContainer.
 		const managedContactInfo = convertDomainContactDetailsToManagedContactDetails(
-			this.props.contactDetails
+			this.props.contactDetails,
+			this.props.contactDetailsErrors
 		);
 
 		// Convert the ManagedContactDetails back to DomainContactDetails for the update.

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -1,3 +1,7 @@
+.g-apps-fieldset {
+	margin-top: 15px;
+}
+
 .form-fieldset.contact-details-form-fields {
 	margin-bottom: 0;
 	display: flex;

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -63,7 +63,10 @@ export default function TaxFields( {
 		countriesList.length && countryCode?.value
 			? getCountryPostalCodeSupport( countriesList, countryCode.value )
 			: false;
-	const taxRequirements = getCountryTaxRequirements( countriesList, countryCode?.value );
+	const taxRequirements =
+		countriesList.length && countryCode?.value
+			? getCountryTaxRequirements( countriesList, countryCode?.value )
+			: {};
 	const isVatSupported = config.isEnabled( 'checkout/vat-form' ) && allowVat;
 
 	const fields: JSX.Element[] = [

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -87,7 +87,7 @@ export default function TaxFields( {
 			} }
 			isError={ countryCode?.isTouched && ! isValid( countryCode ) }
 			isDisabled={ isDisabled }
-			errorMessage={ countryCode?.errors[ 0 ] ?? translate( 'This field is required.' ) }
+			errorMessage={ countryCode?.errors?.[ 0 ] ?? translate( 'This field is required.' ) }
 			currentValue={ countryCode?.value }
 			countriesList={ countriesList }
 		/>,
@@ -122,7 +122,9 @@ export default function TaxFields( {
 				} }
 				autoComplete={ section + ' postal-code' }
 				isError={ postalCode?.isTouched && ! isValid( postalCode ) }
-				errorMessage={ postalCode?.errors[ 0 ] ?? String( translate( 'This field is required.' ) ) }
+				errorMessage={
+					postalCode?.errors?.[ 0 ] ?? String( translate( 'This field is required.' ) )
+				}
 			/>
 		);
 	}
@@ -152,7 +154,7 @@ export default function TaxFields( {
 				} }
 				autoComplete={ section + ' city' }
 				isError={ city?.isTouched && ! isValid( city ) }
-				errorMessage={ city?.errors[ 0 ] ?? String( translate( 'This field is required.' ) ) }
+				errorMessage={ city?.errors?.[ 0 ] ?? String( translate( 'This field is required.' ) ) }
 			/>
 		);
 	}

--- a/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
@@ -49,6 +49,8 @@ jest.mock( 'calypso/lib/navigate' );
 // we are increasing this to 12 seconds.
 jest.setTimeout( 12000 );
 
+type TestProductType = 'google workspace' | 'plan' | 'plan with domain';
+
 describe( 'Checkout contact step extra tax fields', () => {
 	const mainCartKey: CartKey = 'foo.com' as CartKey;
 	const initialCart = getBasicCart();
@@ -170,14 +172,14 @@ describe( 'Checkout contact step extra tax fields', () => {
 			labels?: Record< string, string >;
 			product: string;
 		} ) => {
-			const getPostalCodeLabel = ( productType: string ): string => {
-				if ( productType === 'plan' ) {
+			const getPostalCodeLabel = ( productType: TestProductType ): string => {
+				if ( productType === 'plan' || productType === 'google workspace' ) {
 					return 'Postal code';
 				}
 				return 'Postal Code';
 			};
 			const getContactValidationEndpointType = (
-				productType: string
+				productType: TestProductType
 			): Exclude< ContactDetailsType, 'none' > => {
 				if ( productType === 'plan' ) {
 					return 'tax';
@@ -190,7 +192,7 @@ describe( 'Checkout contact step extra tax fields', () => {
 				}
 				throw new Error( `Unknown product type '${ productType }'` );
 			};
-			const getCartProducts = ( productType: string ): ResponseCartProduct[] => {
+			const getCartProducts = ( productType: TestProductType ): ResponseCartProduct[] => {
 				if ( productType === 'plan' ) {
 					return [ planWithoutDomain ];
 				}
@@ -208,16 +210,19 @@ describe( 'Checkout contact step extra tax fields', () => {
 				city: 'City',
 				subdivision_code: 'State',
 				organization: 'Organization',
-				postal_code: getPostalCodeLabel( product ),
+				postal_code: getPostalCodeLabel( product as TestProductType ),
 				country_code: 'Country',
 				address: 'Address',
 				...labels,
 			};
-			mockContactDetailsValidationEndpoint( getContactValidationEndpointType( product ), {
-				success: true,
-			} );
+			mockContactDetailsValidationEndpoint(
+				getContactValidationEndpointType( product as TestProductType ),
+				{
+					success: true,
+				}
+			);
 			const user = userEvent.setup();
-			const cartChanges = { products: getCartProducts( product ) };
+			const cartChanges = { products: getCartProducts( product as TestProductType ) };
 
 			const setCart = jest.fn().mockImplementation( mockSetCartEndpoint );
 

--- a/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
@@ -27,9 +27,11 @@ import {
 	mockGetPaymentMethodsEndpoint,
 	mockLogStashEndpoint,
 	mockGetSupportedCountriesEndpoint,
+	gSuiteProduct,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
-import type { CartKey } from '@automattic/shopping-cart';
+import type { CartKey, ResponseCartProduct } from '@automattic/shopping-cart';
+import type { ContactDetailsType } from '@automattic/wpcom-checkout';
 
 jest.mock( 'calypso/state/sites/selectors' );
 jest.mock( 'calypso/state/sites/domains/selectors' );
@@ -54,7 +56,7 @@ describe( 'Checkout contact step extra tax fields', () => {
 		initialCart,
 	};
 
-	getPlansBySiteId.mockImplementation( () => ( {
+	( getPlansBySiteId as jest.Mock ).mockImplementation( () => ( {
 		data: getActivePersonalPlanDataForType( 'yearly' ),
 	} ) );
 	hasLoadedSiteDomains.mockImplementation( () => true );
@@ -79,6 +81,17 @@ describe( 'Checkout contact step extra tax fields', () => {
 	} );
 
 	it.each( [
+		{
+			tax: {
+				country_code: 'CA',
+				city: 'Montreal',
+				subdivision_code: 'QC',
+				postal_code: 'A1A 1A1',
+			},
+			labels: { subdivision_code: 'Province' },
+			product: 'google workspace',
+			expect: 'city and province',
+		},
 		{
 			tax: {
 				country_code: 'CA',
@@ -157,24 +170,54 @@ describe( 'Checkout contact step extra tax fields', () => {
 			labels?: Record< string, string >;
 			product: string;
 		} ) => {
+			const getPostalCodeLabel = ( productType: string ): string => {
+				if ( productType === 'plan' ) {
+					return 'Postal code';
+				}
+				return 'Postal Code';
+			};
+			const getContactValidationEndpointType = (
+				productType: string
+			): Exclude< ContactDetailsType, 'none' > => {
+				if ( productType === 'plan' ) {
+					return 'tax';
+				}
+				if ( productType === 'plan with domain' ) {
+					return 'domain';
+				}
+				if ( productType === 'google workspace' ) {
+					return 'gsuite';
+				}
+				throw new Error( `Unknown product type '${ productType }'` );
+			};
+			const getCartProducts = ( productType: string ): ResponseCartProduct[] => {
+				if ( productType === 'plan' ) {
+					return [ planWithoutDomain ];
+				}
+				if ( productType === 'plan with domain' ) {
+					return [ planWithBundledDomain, domainProduct ];
+				}
+				if ( productType === 'google workspace' ) {
+					return [ gSuiteProduct ];
+				}
+				throw new Error( `Unknown product type '${ productType }'` );
+			};
+
 			const selects = { country_code: true, subdivision_code: true };
 			labels = {
 				city: 'City',
 				subdivision_code: 'State',
 				organization: 'Organization',
-				postal_code: product === 'plan' ? 'Postal code' : 'Postal Code',
+				postal_code: getPostalCodeLabel( product ),
 				country_code: 'Country',
 				address: 'Address',
 				...labels,
 			};
-			mockContactDetailsValidationEndpoint( product === 'plan' ? 'tax' : 'domain', {
+			mockContactDetailsValidationEndpoint( getContactValidationEndpointType( product ), {
 				success: true,
 			} );
 			const user = userEvent.setup();
-			const cartChanges =
-				product === 'plan'
-					? { products: [ planWithoutDomain ] }
-					: { products: [ planWithBundledDomain, domainProduct ] };
+			const cartChanges = { products: getCartProducts( product ) };
 
 			const setCart = jest.fn().mockImplementation( mockSetCartEndpoint );
 

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -22,6 +22,7 @@ import type {
 import type {
 	CountryListItem,
 	PossiblyCompleteDomainContactDetails,
+	ContactDetailsType,
 } from '@automattic/wpcom-checkout';
 
 export const normalAllowedPaymentMethods = [
@@ -1648,7 +1649,7 @@ export function mockCachedContactDetailsEndpoint( responseData ): void {
 }
 
 export function mockContactDetailsValidationEndpoint(
-	type: 'domain' | 'gsuite' | 'tax',
+	type: Exclude< ContactDetailsType, 'none' >,
 	responseData,
 	conditionCallback?: ( body ) => boolean
 ): void {

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -339,6 +339,26 @@ export function prepareDomainContactDetails(
 	};
 }
 
+export function convertDomainContactDetailsToManagedContactDetails(
+	details: DomainContactDetails
+): ManagedContactDetails {
+	return {
+		firstName: getInitialManagedValue( { value: details.firstName ?? '' } ),
+		lastName: getInitialManagedValue( { value: details.lastName ?? '' } ),
+		organization: getInitialManagedValue( { value: details.organization ?? '' } ),
+		email: getInitialManagedValue( { value: details.email ?? '' } ),
+		phone: getInitialManagedValue( { value: details.phone ?? '' } ),
+		address1: getInitialManagedValue( { value: details.address1 ?? '' } ),
+		address2: getInitialManagedValue( { value: details.address2 ?? '' } ),
+		city: getInitialManagedValue( { value: details.city ?? '' } ),
+		state: getInitialManagedValue( { value: details.state ?? '' } ),
+		postalCode: getInitialManagedValue( { value: details.postalCode ?? '' } ),
+		countryCode: getInitialManagedValue( { value: details.countryCode ?? '' } ),
+		fax: getInitialManagedValue( { value: details.fax ?? '' } ),
+		// TODO: handle extra
+	};
+}
+
 export function prepareDomainContactDetailsForTransaction(
 	details: ManagedContactDetails
 ): DomainContactDetails {

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -322,6 +322,12 @@ function setManagedContactDetailsErrors(
 export function prepareDomainContactDetails(
 	details: ManagedContactDetails
 ): DomainContactDetails {
+	return convertManagedContactDetailsToDomainContactDetails( details );
+}
+
+export function convertManagedContactDetailsToDomainContactDetails(
+	details: ManagedContactDetails
+): DomainContactDetails {
 	return {
 		firstName: details.firstName?.value,
 		lastName: details.lastName?.value,
@@ -340,21 +346,70 @@ export function prepareDomainContactDetails(
 }
 
 export function convertDomainContactDetailsToManagedContactDetails(
-	details: DomainContactDetails
+	details: DomainContactDetails,
+	errors: DomainContactDetailsErrors
 ): ManagedContactDetails {
 	return {
-		firstName: getInitialManagedValue( { value: details.firstName ?? '' } ),
-		lastName: getInitialManagedValue( { value: details.lastName ?? '' } ),
-		organization: getInitialManagedValue( { value: details.organization ?? '' } ),
-		email: getInitialManagedValue( { value: details.email ?? '' } ),
-		phone: getInitialManagedValue( { value: details.phone ?? '' } ),
-		address1: getInitialManagedValue( { value: details.address1 ?? '' } ),
-		address2: getInitialManagedValue( { value: details.address2 ?? '' } ),
-		city: getInitialManagedValue( { value: details.city ?? '' } ),
-		state: getInitialManagedValue( { value: details.state ?? '' } ),
-		postalCode: getInitialManagedValue( { value: details.postalCode ?? '' } ),
-		countryCode: getInitialManagedValue( { value: details.countryCode ?? '' } ),
-		fax: getInitialManagedValue( { value: details.fax ?? '' } ),
+		firstName: getInitialManagedValue( {
+			value: details.firstName ?? '',
+			errors: [ String( errors.firstName ) ],
+			isTouched: Boolean( errors.firstName ),
+		} ),
+		lastName: getInitialManagedValue( {
+			value: details.lastName ?? '',
+			errors: [ String( errors.lastName ) ],
+			isTouched: Boolean( errors.lastName ),
+		} ),
+		organization: getInitialManagedValue( {
+			value: details.organization ?? '',
+			errors: [ String( errors.organization ) ],
+			isTouched: Boolean( errors.organization ),
+		} ),
+		email: getInitialManagedValue( {
+			value: details.email ?? '',
+			errors: [ String( errors.email ) ],
+			isTouched: Boolean( errors.email ),
+		} ),
+		phone: getInitialManagedValue( {
+			value: details.phone ?? '',
+			errors: [ String( errors.phone ) ],
+			isTouched: Boolean( errors.phone ),
+		} ),
+		address1: getInitialManagedValue( {
+			value: details.address1 ?? '',
+			errors: [ String( errors.address1 ) ],
+			isTouched: Boolean( errors.address1 ),
+		} ),
+		address2: getInitialManagedValue( {
+			value: details.address2 ?? '',
+			errors: [ String( errors.address2 ) ],
+			isTouched: Boolean( errors.address2 ),
+		} ),
+		city: getInitialManagedValue( {
+			value: details.city ?? '',
+			errors: [ String( errors.city ) ],
+			isTouched: Boolean( errors.city ),
+		} ),
+		state: getInitialManagedValue( {
+			value: details.state ?? '',
+			errors: [ String( errors.state ) ],
+			isTouched: Boolean( errors.state ),
+		} ),
+		postalCode: getInitialManagedValue( {
+			value: details.postalCode ?? '',
+			errors: [ String( errors.postalCode ) ],
+			isTouched: Boolean( errors.postalCode ),
+		} ),
+		countryCode: getInitialManagedValue( {
+			value: details.countryCode ?? '',
+			errors: [ String( errors.countryCode ) ],
+			isTouched: Boolean( errors.countryCode ),
+		} ),
+		fax: getInitialManagedValue( {
+			value: details.fax ?? '',
+			errors: [ String( errors.fax ) ],
+			isTouched: Boolean( errors.fax ),
+		} ),
 		// TODO: handle extra
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -541,26 +541,29 @@ export function prepareDomainContactValidationRequest(
 	}
 
 	return {
-		contact_information: {
-			first_name: details.firstName?.value,
-			last_name: details.lastName?.value,
-			organization: details.organization?.value,
-			email: details.email?.value,
-			phone: details.phone?.value,
-			phone_number_country: details.phoneNumberCountry?.value,
-			address_1: details.address1?.value,
-			address_2: details.address2?.value,
-			city: details.city?.value,
-			state: details.state?.value,
-			postal_code: tryToGuessPostalCodeFormat(
-				details.postalCode?.value ?? '',
-				details.countryCode?.value
-			),
-			country_code: details.countryCode?.value,
-			fax: details.fax?.value,
-			vat_id: details.vatId?.value,
-			extra,
-		},
+		contact_information: { ...prepareValidationRequestContactSection( details ), extra },
+	};
+}
+
+function prepareValidationRequestContactSection( details: ManagedContactDetails ) {
+	return {
+		address_1: details.address1?.value,
+		address_2: details.address2?.value,
+		city: details.city?.value,
+		country_code: details.countryCode?.value ?? '',
+		email: details.email?.value ?? '',
+		fax: details.fax?.value,
+		first_name: details.firstName?.value ?? '',
+		last_name: details.lastName?.value ?? '',
+		organization: details.organization?.value,
+		phone: details.phone?.value,
+		phone_number_country: details.phoneNumberCountry?.value,
+		postal_code: tryToGuessPostalCodeFormat(
+			details.postalCode?.value ?? '',
+			details.countryCode?.value
+		),
+		state: details.state?.value,
+		vat_id: details.vatId?.value,
 	};
 }
 
@@ -568,16 +571,7 @@ export function prepareGSuiteContactValidationRequest(
 	details: ManagedContactDetails
 ): GSuiteContactValidationRequest {
 	return {
-		contact_information: {
-			first_name: details.firstName?.value ?? '',
-			last_name: details.lastName?.value ?? '',
-			email: details.email?.value ?? '',
-			postal_code: tryToGuessPostalCodeFormat(
-				details.postalCode?.value ?? '',
-				details.countryCode?.value
-			),
-			country_code: details.countryCode?.value ?? '',
-		},
+		contact_information: prepareValidationRequestContactSection( details ),
 	};
 }
 

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -428,21 +428,21 @@ export type SignupValidationResponse = {
  * @see WPCOM_JSON_API_Domains_Validate_Contact_Information_Endpoint
  */
 export type ContactValidationRequestContactInformation = {
-	first_name?: string;
-	last_name?: string;
-	organization?: string;
-	email?: string;
-	phone?: string;
-	phone_number_country?: string;
 	address_1?: string;
 	address_2?: string;
 	city?: string;
-	state?: string;
-	postal_code?: string;
 	country_code?: string;
-	fax?: string;
-	vat_id?: string;
+	email?: string;
 	extra?: DomainContactValidationRequestExtraFields;
+	fax?: string;
+	first_name?: string;
+	last_name?: string;
+	organization?: string;
+	phone?: string;
+	phone_number_country?: string;
+	postal_code?: string;
+	state?: string;
+	vat_id?: string;
 };
 
 export type DomainContactValidationRequest = {
@@ -451,11 +451,20 @@ export type DomainContactValidationRequest = {
 
 export type GSuiteContactValidationRequest = {
 	contact_information: {
+		country_code: string;
+		email: string;
 		first_name: string;
 		last_name: string;
-		email: string;
 		postal_code: string;
-		country_code: string;
+		address_1?: string;
+		address_2?: string;
+		city?: string;
+		fax?: string;
+		organization?: string;
+		phone?: string;
+		phone_number_country?: string;
+		state?: string;
+		vat_id?: string;
 	};
 };
 


### PR DESCRIPTION
## Proposed Changes

The contact info/billing info step of checkout automatically shows fields that are required for taxes by the selected country. There are three versions of the contact step: "tax" (the default), "domain" (for domain products), and "gsuite" (for Google Workspace products).

When required contact form fields were added in https://github.com/Automattic/wp-calypso/pull/73121, we forgot to add those same fields to the Google Workspace contact form.

This PR adds support for those fields.

Partially takes care of https://github.com/Automattic/wp-calypso/issues/77759

**NOTE**: the Google Workspace validation endpoint (`/me/google-apps/validate`) does not currently return an error if required fields are missing. This also needs to be fixed! Otherwise it's possible to complete the contact step with (for example) and empty required City field. However, since the transactions endpoint _does_ perform the correct validation, this PR will at least let users get through checkout successfully if they fill in the required fields.

Before: 

<img width="642" alt="Screenshot 2023-06-02 at 6 15 38 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/d8ea7f85-e1fe-4104-ac88-2802618e0ef6">

After:

<img width="642" alt="Screenshot 2023-06-02 at 7 31 50 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/8649df94-4c63-45ac-a00b-99f189b1260f">

## Testing Instructions

Automated tests are included.

This only happens when Google Workspace is the only product in the cart, so to test this we'll need to have a site that already owns a domain registration.

- Visit `/email` and select the site you want to use.
- Click the Google Workspace upsell at the bottom of the page.
- Fill in the new account form (address, name, password) with any data and click "Purchase" to continue to Checkout.
- Edit the contact info step if it is not already active.
- Select a country that has required tax fields (eg: Canada).
- Verify that the additional tax fields become visible (eg: City and Province).
- Fill in the required fields with invalid data (bad postal code) and press "Continue".
- Verify that you see an error message and that the required fields are highlighted.
- Fill in the required fields with valid data and press "Continue".
- Verify that the step completes.

You can also try submitting checkout itself, but to avoid actually making a purchase I recommend selecting PayPal as the payment method (that way you'll be redirected to PayPal on success but no payment will be made). Before this PR, you'll get an error message when you try to submit the form; after this PR you'll be redirected to PayPal.