### PR TITLE
Site creation step: check for the existence of `urlData` before accessing it

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -141,7 +141,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			isPaidDomainItem,
 			theme,
 			siteVisibility,
-			urlData.meta.title ?? selectedSiteTitle,
+			urlData?.meta.title ?? selectedSiteTitle,
 			siteAccentColor,
 			useThemeHeadstart,
 			username,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/77588 and fixes p1685743300003049-slack-C04U5A26MJB.

## Proposed Changes

We need to check if `urlData` is defined before accessing it. It gets filled whenever there is import information, but when creating a site through any other onboarding flow that doesn't involve importing, there is none.

Too bad, because `getUrlData` assures that the information exists. There is an error in the typings. I'm submitting a PR to fix the immediate problem, and a follow-up to fix the other places where this selector is being used.

## Testing Instructions

Create a site through the `/setup/free` flow. It should not crash in `siteCreationStep` and your site should be created successfully.