### PR TITLE
Import onboarding flow: Mark the return type of the `getUrlData` selector as nullable

### DIFF
--- a/client/blocks/importer/components/importer-drag/index.tsx
+++ b/client/blocks/importer/components/importer-drag/index.tsx
@@ -37,7 +37,7 @@ interface Props {
 	importerStatus: ImportJob;
 	importerData: ImporterConfig;
 	site: SiteDetails | null | undefined;
-	urlData: UrlData;
+	urlData?: UrlData;
 	startImport: ( siteId: number, type: string ) => void;
 }
 const ImporterDrag: React.FunctionComponent< Props > = ( props ) => {

--- a/client/blocks/importer/components/importing-pane/importing-pane.tsx
+++ b/client/blocks/importer/components/importing-pane/importing-pane.tsx
@@ -32,7 +32,7 @@ class ImportingPane extends ImportingPaneBase {
 		// Add the site favicon as author's icon
 		if ( importerStatus?.customData?.sourceAuthors ) {
 			for ( const author of importerStatus.customData.sourceAuthors ) {
-				author.icon = ( urlData as UrlData )?.meta?.favicon;
+				author.icon = ( urlData as UrlData | undefined )?.meta?.favicon;
 			}
 		}
 

--- a/client/blocks/importer/components/importing-pane/importing-pane.tsx
+++ b/client/blocks/importer/components/importing-pane/importing-pane.tsx
@@ -32,7 +32,11 @@ class ImportingPane extends ImportingPaneBase {
 		// Add the site favicon as author's icon
 		if ( importerStatus?.customData?.sourceAuthors ) {
 			for ( const author of importerStatus.customData.sourceAuthors ) {
-				author.icon = ( urlData as UrlData | undefined )?.meta?.favicon;
+				const authorIcon = ( urlData as UrlData | undefined )?.meta?.favicon;
+
+				if ( authorIcon ) {
+					author.icon = authorIcon;
+				}
 			}
 		}
 

--- a/client/blocks/importer/types.ts
+++ b/client/blocks/importer/types.ts
@@ -62,7 +62,7 @@ export interface ImporterBaseProps {
 	site: SiteDetails;
 	siteSlug: string;
 	fromSite: string;
-	urlData: UrlData;
+	urlData?: UrlData;
 	importSite: ( params: ImportJobParams ) => void;
 	startImport: ( siteId: number, type: string ) => void;
 	resetImport: ( siteId: number, importerId: string ) => void;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
@@ -43,6 +43,10 @@ const ImportReadyPreview: Step = function ImportStep( props ) {
 	 ↓ Methods
 	 */
 	function goToImporterPage() {
+		if ( ! urlData ) {
+			return;
+		}
+
 		const url = getFinalImporterUrl(
 			siteSlug as string,
 			urlData.url,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
@@ -29,7 +29,7 @@ const ImportReady: Step = function ImportStep( props ) {
 	/**
 	 ↓ Methods
 	 */
-	function goToImporterPage() {
+	const goToImporterPage = () => {
 		const url = getFinalImporterUrl(
 			siteSlug as string,
 			urlData.url,
@@ -39,7 +39,7 @@ const ImportReady: Step = function ImportStep( props ) {
 		);
 
 		navigation.submit?.( { url, platform: urlData.platform } );
-	}
+	};
 
 	function goToHomeStep() {
 		navigation.goToStep?.( BASE_ROUTE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -89,7 +89,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		useEffect( checkFromSiteData, [ fromSiteData?.url ] );
 		useEffect( () => onComponentUnmount, [] );
 
-		if ( ! importer ) {
+		if ( ! importer || ! fromSiteData ) {
 			stepNavigator.goToImportCapturePage?.();
 			return null;
 		}
@@ -161,7 +161,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		/**
 	 	↓ Renders
 		 */
-		function renderStepContent() {
+		const renderStepContent = () => {
 			if ( isLoading() ) {
 				return <LoadingEllipsis />;
 			} else if ( ! siteSlug || ! site || ! siteId ) {
@@ -188,7 +188,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 					showConfirmDialog={ ! isMigrateFromWp }
 				/>
 			);
-		}
+		};
 
 		return (
 			<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -89,7 +89,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		useEffect( checkFromSiteData, [ fromSiteData?.url ] );
 		useEffect( () => onComponentUnmount, [] );
 
-		if ( ! importer || ! fromSiteData ) {
+		if ( ! importer ) {
 			stepNavigator.goToImportCapturePage?.();
 			return null;
 		}
@@ -183,7 +183,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 					site={ site }
 					siteSlug={ siteSlug }
 					fromSite={ fromSite }
-					urlData={ fromSiteData }
+					urlData={ fromSiteData ?? undefined }
 					stepNavigator={ stepNavigator }
 					showConfirmDialog={ ! isMigrateFromWp }
 				/>

--- a/client/state/imports/url-analyzer/selectors.ts
+++ b/client/state/imports/url-analyzer/selectors.ts
@@ -6,8 +6,8 @@ export const isAnalyzing = ( state: State ): boolean => {
 	return state.imports.urlAnalyzer.isAnalyzing;
 };
 
-export const getUrlData = ( state: State ): UrlData => {
-	return state.imports.urlAnalyzer.urlData;
+export const getUrlData = ( state: State ): UrlData | null => {
+	return state.imports.urlAnalyzer.urlData ?? null;
 };
 
 export const getAnalyzerError = ( state: State ): Error => {


### PR DESCRIPTION
Follow up for https://github.com/Automattic/wp-calypso/pull/77770.

## Proposed Changes

We're unsafely accessing the `urlData` through the `getUrlData` selector. There is a chance that the data doesn't exist, so we need to type it as `UrlData | null`.

This PR does that and fixes the type errors by either null coalescing where this data is optional, or short-circuiting if the data is mandatory.

## Testing Instructions

The import flows should work normally, as should every other onboarding flow that uses `siteCreationStep`. There are no wrong usages left, we're just making sure that this won't happen again.