### PR TITLE
Hosting onboarding i2: enable it in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -55,7 +55,7 @@
 		"help": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,
-		"hosting-onboarding-i2": false,
+		"hosting-onboarding-i2": true,
 		"hosting/datacenter-picker": true,
 		"i18n/translation-scanner": true,
 		"importers/substack": true,


### PR DESCRIPTION
## Proposed Changes

Let's enable `hosting-onboarding-i2` in wpcalypso so folks can easily test it during the CfT period.
