### PR TITLE
Revert "Site creation step: check for the existence of `urlData` before accessing it"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -141,7 +141,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			isPaidDomainItem,
 			theme,
 			siteVisibility,
-			urlData?.meta.title ?? selectedSiteTitle,
+			urlData.meta.title ?? selectedSiteTitle,
 			siteAccentColor,
 			useThemeHeadstart,
 			username,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#77770