### PR TITLE
Backup: add defaultProps and propTypes to ActionButtons component

### DIFF
--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -94,8 +94,8 @@ const ActionButtons = ( {
 	rewindId,
 	disabled,
 	isMultiSite,
-	hasWarnings = false,
-	availableActions = [ 'rewind', 'download' ],
+	hasWarnings,
+	availableActions,
 	onClickClone,
 } ) => (
 	<>
@@ -127,6 +127,19 @@ const ActionButtons = ( {
 ActionButtons.propTypes = {
 	rewindId: PropTypes.string,
 	disabled: PropTypes.bool,
+	isMultiSite: PropTypes.bool,
+	hasWarnings: PropTypes.bool,
+	availableActions: PropTypes.arrayOf( PropTypes.string ),
+	onClickClone: PropTypes.func,
+};
+
+ActionButtons.defaultProps = {
+	rewindId: null,
+	disabled: false,
+	isMultiSite: false,
+	hasWarnings: false,
+	availableActions: [ 'rewind', 'download' ],
+	onClickClone: () => {},
 };
 
 export default ActionButtons;

--- a/client/components/jetpack/daily-backup-status/test/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/test/action-buttons.jsx
@@ -87,6 +87,7 @@ describe( 'ActionButtons', () => {
 		const rewindId = 'test';
 		render( <ActionButtons rewindId={ rewindId } /> );
 		const downloadButton = screen.getByRole( 'link', { name: /download/i } );
+		downloadButton.onclick = jest.fn( ( event ) => event.preventDefault() );
 
 		await user.click( downloadButton );
 
@@ -103,6 +104,8 @@ describe( 'ActionButtons', () => {
 		render( <ActionButtons rewindId={ rewindId } /> );
 
 		const restoreButton = screen.getByRole( 'link', { name: /restore/i } );
+		restoreButton.onclick = jest.fn( ( event ) => event.preventDefault() );
+
 		await user.click( restoreButton );
 
 		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_jetpack_backup_restore', {


### PR DESCRIPTION
## Proposed Changes

* Add propTypes and defaultProps to ActionButtons component. This way we don't require to send default properties to comply with Typescript. [More info here](https://github.com/Automattic/wp-calypso/pull/77767/files#r1214888896).
* Fix `ActionButtons` unit tests. It were failing due to a navigation event being triggered while validating if an action button triggers a Tracks event when clicked, which is not supported in JSDOM. Mocking the `onclick` handler does the trick.

This is the error that have been thrown when executing unit tests before:
```
➜  packages git:(fix/action-buttons-optional-prop) ✗ yarn run test-client client/components/jetpack/daily-backup-status/test/action-buttons.jsx
 PASS  client/components/jetpack/daily-backup-status/test/action-buttons.jsx

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        4.869 s, estimated 6 s
Ran all test suites matching /client\/components\/jetpack\/daily-backup-status\/test\/action-buttons.jsx/i.
➜  packages git:(fix/action-buttons-optional-prop) ✗ yarn run test-client client/components/jetpack/daily-backup-status/test/action-buttons.jsx
 PASS  client/components/jetpack/daily-backup-status/test/action-buttons.jsx (5.278 s)
  ● Console

    console.error
      Error: Not implemented: navigation (except hash changes)
          at module.exports (/Users/rafaelagostini/Workspace/wp-calypso/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
          at navigateFetch (/Users/rafaelagostini/Workspace/wp-calypso/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/window/navigation.js:76:3)
          at exports.navigate (/Users/rafaelagostini/Workspace/wp-calypso/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/window/navigation.js:54:3)
          at Timeout._onTimeout (/Users/rafaelagostini/Workspace/wp-calypso/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/nodes/HTMLHyperlinkElementUtils-impl.js:81:7)
          at listOnTimeout (node:internal/timers:564:17)
          at processTimers (node:internal/timers:507:7) undefined

      at console.error (../node_modules/@testing-library/react-hooks/lib/core/console.js:19:7)
      at console.error (../node_modules/@testing-library/react/dist/act-compat.js:55:34)
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure unit tests are still passing by executing:
  * `yarn run test-client client/components/jetpack/daily-backup-status/test`.
* Explore backup page and clone flow to ensure everything still working as usual and no errors related to propTypes are thrown in the developer console.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
