### PR TITLE
Plans 2023: Fix interval toggle

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -125,48 +125,6 @@
 			text-decoration: underline;
 		}
 
-		.plans-features-main {
-			ul.segmented-control {
-				background-color: #f2f2f2;
-				border-radius: 6px;  /* stylelint-disable-line scales/radii */
-				border-color: var(--studio-gray-5);
-
-				li.segmented-control__item {
-					border: 6px;
-					padding: 2px;
-					&:first-child {
-						margin-right: 5px;
-					}
-					&.is-selected {
-						a.segmented-control__link {
-							padding-top: 6px;
-							padding-bottom: 6px;
-							border: 0.5px solid #0000000a;
-							background-color: var(--studio-white);
-							color: var(--color-text);
-							border-radius: 5px;  /* stylelint-disable-line scales/radii */
-							box-shadow: 0 3px 8px #0000001f, 0 3px 1px #0000000a;
-						}
-					}
-					a.segmented-control__link {
-						border: solid 1px #f2f2f2;
-						border-radius: 5px;  /* stylelint-disable-line scales/radii */
-					}
-				}
-				li.segmented-control__item:not(.is-selected) {
-					a.segmented-control__link {
-						border: solid 1px #f2f2f2;
-						border-radius: 5px;  /* stylelint-disable-line scales/radii */
-						&:hover {
-							background-color: unset !important;
-							border: 1px solid var(--studio-gray-10);
-							border-radius: 5px;  /* stylelint-disable-line scales/radii */
-						}
-					}
-				}
-			}
-		}
-
 		.plans__loading {
 			width: 100%;
 			display: flex;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -717,8 +717,43 @@ body.is-section-signup.is-white-signup,
 }
 
 .plans-features-main.is-pricing-grid-2023-plans-features-main  ul.segmented-control.price-toggle,
-body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup__step .segmented-control.price-toggle,
-#primary .is-pricing-grid-2023-plans-features-main .segmented-control.price-toggle {
+body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup__step ul.segmented-control.price-toggle,
+#primary .is-pricing-grid-2023-plans-features-main ul.segmented-control.price-toggle {
+	background-color: #f2f2f2;
+	border-radius: 6px;  /* stylelint-disable-line scales/radii */
+
+	@include plans-2023-break-small {
+		max-width: fit-content;
+		width: auto;
+	}
+
+	li.segmented-control__item {
+		&.is-selected {
+			a.segmented-control__link {
+				padding-top: 6px;
+				padding-bottom: 6px;
+				border: 0.5px solid #0000000a;
+				background-color: var(--studio-white);
+				color: var(--color-text);
+				border-radius: 5px;  /* stylelint-disable-line scales/radii */
+				box-shadow: 0 3px 8px #0000001f, 0 3px 1px #0000000a;
+			}
+		}
+		a.segmented-control__link {
+			border: solid 1px #f2f2f2;
+			border-radius: 5px;  /* stylelint-disable-line scales/radii */
+
+			&:focus {
+				outline: none;
+			}
+		}
+	}
+}
+
+// .plans-features-main.is-pricing-grid-2023-plans-features-main  ul.segmented-control.price-toggle,
+// body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup__step .segmented-control.price-toggle,
+// #primary .is-pricing-grid-2023-plans-features-main .segmented-control.price-toggle
+.foo {
 	background-color: #f2f2f2;
 	width: 100%;
 	margin: 0 auto;

--- a/client/my-sites/plans-features-main/components/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/components/plan-type-selector.tsx
@@ -326,23 +326,22 @@ function useMaxDiscount( plans: string[] ): number {
 export default PlanTypeSelector;
 
 const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSignup: boolean } >`
-	display: ${ ( { isInSignup } ) => ( isInSignup ? 'flex' : 'block' ) };
+	display: 'flex';
 	align-content: space-between;
 	justify-content: center;
 	margin: 0 20px 24px;
 
-	> .segmented-control.is-compact:not( .is-signup ) {
+	> .segmented-control.is-compact {
 		margin: 8px auto 16px;
 		max-width: 480px;
 
 		.segmented-control__link {
-			padding: 8px 12px;
+			padding: 6px 11px;
 		}
 	}
 
-	> .segmented-control.is-signup {
+	> .segmented-control {
 		margin: 0 auto;
-		border: solid 1px var( --color-neutral-10 );
 
 		@media screen and ( max-width: 960px ) {
 			margin-bottom: ${ ( { showingMonthly } ) => ( showingMonthly ? '65px' : 0 ) };
@@ -355,10 +354,11 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 			--color-primary-dark: var( --color-neutral-80 );
 			--item-padding: 3px;
 
-			padding: var( --item-padding ) 0;
-
+			padding: var( --item-padding );
+			border: 5px;
 			&:first-of-type {
 				padding-left: var( --item-padding );
+				margin-right: 3px;
 
 				.rtl & {
 					padding-right: var( --item-padding );
@@ -386,10 +386,21 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 		}
 
 		.segmented-control__item:not( .is-selected ) {
-			.segmented-control__link:hover {
-				background-color: var( --color-neutral-5 );
+			a.segmented-control__link {
+				border: solid 1px #f2f2f2;
+				border-radius: 5px;
+
+				&:hover {
+					background-color: var( --color-neutral-5 );
+					border: 1px solid var( --studio-gray-10 );
+					border-radius: 5px;
+				}
 			}
 		}
+	}
+
+	.segmented-control__text {
+		color: var( --studio-gray-90 );
 	}
 `;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1522

## Proposed Changes

Updates the interval toggle to have consistent styles across usages in Stepper/Signup/Admin.

### TODO

- [ ] remove sensei flow styles.
- [ ] migrate the few remaining SASS styles to the styled component
- [ ] some cleanup

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to each of the following and confirm the interval toggle matches the one from Figma (xkhhUlDowF13dRoXJqlRDM-fi-1_95):
    - `/setup/link-in-bio/plans`
    - `/start/plans`
    - `/plans[free]`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?