### PR TITLE
Revert "ESLint: Enable `@tanstack/eslint-plugin-query` (#77214)"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,6 @@ module.exports = {
 		'plugin:prettier/recommended',
 		'plugin:md/prettier',
 		'plugin:@wordpress/eslint-plugin/i18n',
-		'plugin:@tanstack/eslint-plugin-query/recommended',
 	],
 	overrides: [
 		{
@@ -282,7 +281,7 @@ module.exports = {
 		// this is when Webpack last built the bundle
 		BUILD_TIMESTAMP: true,
 	},
-	plugins: [ 'import', 'you-dont-need-lodash-underscore', '@tanstack/query' ],
+	plugins: [ 'import', 'you-dont-need-lodash-underscore' ],
 	settings: {
 		react: {
 			version: reactVersion,
@@ -534,10 +533,5 @@ module.exports = {
 		'you-dont-need-lodash-underscore/to-pairs': 'error',
 		'you-dont-need-lodash-underscore/to-upper': 'error',
 		'you-dont-need-lodash-underscore/uniq': 'error',
-
-		// @TODO remove these lines once we fixed the warnings so
-		// they'll become errors for new code added to the codebase
-		'@tanstack/query/exhaustive-deps': 'warn',
-		'@tanstack/query/prefer-query-object-syntax': 'warn',
 	},
 };

--- a/package.json
+++ b/package.json
@@ -220,7 +220,6 @@
 		"@signal-noise/stylelint-scales": "^2.0.3",
 		"@storybook/cli": "^7.0.18",
 		"@storybook/react": "^7.0.18",
-		"@tanstack/eslint-plugin-query": "^4.29.8",
 		"@testing-library/jest-dom": "^5.16.2",
 		"@types/gtag.js": "^0.0.10",
 		"@types/superagent": "^4.1.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6067,13 +6067,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/eslint-plugin-query@npm:^4.29.8":
-  version: 4.29.8
-  resolution: "@tanstack/eslint-plugin-query@npm:4.29.8"
-  checksum: 073913fa080a22446f9639bc232639be8728d9d4df7658cbbfaf3eec274146902d23f68cd7d7102712424b8c308d72efa8d726cf02683998143527343c9f55e5
-  languageName: node
-  linkType: hard
-
 "@tanstack/match-sorter-utils@npm:^8.7.0":
   version: 8.7.6
   resolution: "@tanstack/match-sorter-utils@npm:8.7.6"
@@ -31574,7 +31567,6 @@ __metadata:
     "@signal-noise/stylelint-scales": ^2.0.3
     "@storybook/cli": ^7.0.18
     "@storybook/react": ^7.0.18
-    "@tanstack/eslint-plugin-query": ^4.29.8
     "@testing-library/jest-dom": ^5.16.2
     "@types/cookie": ^0.4.1
     "@types/debug": ^4.1.7


### PR DESCRIPTION
see p1685923446140549-slack-C7YPUHBB2

It appears that the update to the linter works on local machines but causes linting of the newspack-blocks project to fail in CI which was responsible for replacing the translation text domains. See example diff generated D112800-code