### PR TITLE
Add /setup/blog binary selection screen for blog onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -1,5 +1,13 @@
+import { useLocale } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
-import { Flow } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
+import {
+	AssertConditionResult,
+	AssertConditionState,
+	Flow,
+} from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const Blog: Flow = {
 	name: 'blog',
@@ -15,8 +23,52 @@ const Blog: Flow = {
 		];
 	},
 
-	useStepNavigation() {
-		return {};
+	useStepNavigation( navigate ) {
+		const goBack = () => {
+			return;
+		};
+
+		const goNext = () => {
+			return;
+		};
+
+		const goToStep = ( step: string ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep };
+	},
+
+	useAssertConditions(): AssertConditionResult {
+		const flowName = this.name;
+		const isLoggedIn = useSelector( isUserLoggedIn );
+		const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
+		const locale = useLocale();
+		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
+
+		const logInUrl =
+			locale && locale !== 'en'
+				? `/start/account/user/${ locale }?redirect_to=/setup/blog`
+				: `/start/account/user?redirect_to=/setup/blog`;
+
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+
+		if ( ! isLoggedIn ) {
+			redirect( logInUrl );
+			result = {
+				state: AssertConditionState.CHECKING,
+				message: `${ flowName } requires a logged in user`,
+			};
+		} else if ( userAlreadyHasSites ) {
+			// This prevents a bunch of sites being created accidentally.
+			redirect( `/` );
+			result = {
+				state: AssertConditionState.CHECKING,
+				message: `${ flowName } requires no preexisting sites`,
+			};
+		}
+
+		return result;
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -1,13 +1,5 @@
-import { useLocale } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
-import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
-import {
-	AssertConditionResult,
-	AssertConditionState,
-	Flow,
-} from 'calypso/landing/stepper/declarative-flow/internals/types';
-import { useSelector } from 'calypso/state';
-import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { Flow } from 'calypso/landing/stepper/declarative-flow/internals/types';
 
 const Blog: Flow = {
 	name: 'blog',
@@ -23,52 +15,8 @@ const Blog: Flow = {
 		];
 	},
 
-	useStepNavigation( navigate ) {
-		const goBack = () => {
-			return;
-		};
-
-		const goNext = () => {
-			return;
-		};
-
-		const goToStep = ( step: string ) => {
-			navigate( step );
-		};
-
-		return { goNext, goBack, goToStep };
-	},
-
-	useAssertConditions(): AssertConditionResult {
-		const flowName = this.name;
-		const isLoggedIn = useSelector( isUserLoggedIn );
-		const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
-		const locale = useLocale();
-		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
-
-		const logInUrl =
-			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?redirect_to=/setup/blog`
-				: `/start/account/user?redirect_to=/setup/blog`;
-
-		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
-
-		if ( ! isLoggedIn ) {
-			redirect( logInUrl );
-			result = {
-				state: AssertConditionState.CHECKING,
-				message: `${ flowName } requires a logged in user`,
-			};
-		} else if ( userAlreadyHasSites ) {
-			// This prevents a bunch of sites being created accidentally.
-			redirect( `/` );
-			result = {
-				state: AssertConditionState.CHECKING,
-				message: `${ flowName } requires no preexisting sites`,
-			};
-		}
-
-		return result;
+	useStepNavigation() {
+		return {};
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -1,0 +1,75 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { translate } from 'i18n-calypso';
+import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
+import {
+	AssertConditionResult,
+	AssertConditionState,
+	Flow,
+} from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+
+const Blog: Flow = {
+	name: 'blog',
+	get title() {
+		return translate( 'Blog' );
+	},
+	useSteps() {
+		return [
+			{
+				slug: 'blogger-intent',
+				asyncComponent: () => import( './internals/steps-repository/blogger-intent' ),
+			},
+		];
+	},
+
+	useStepNavigation( navigate ) {
+		const goBack = () => {
+			return;
+		};
+
+		const goNext = () => {
+			return;
+		};
+
+		const goToStep = ( step: string ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep };
+	},
+
+	useAssertConditions(): AssertConditionResult {
+		const flowName = this.name;
+		const isLoggedIn = useSelector( isUserLoggedIn );
+		const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
+		const locale = useLocale();
+		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
+
+		const logInUrl =
+			locale && locale !== 'en'
+				? `/start/account/user/${ locale }?redirect_to=/setup/blog`
+				: `/start/account/user?redirect_to=/setup/blog`;
+
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+
+		if ( ! isLoggedIn ) {
+			redirect( logInUrl );
+			result = {
+				state: AssertConditionState.CHECKING,
+				message: `${ flowName } requires a logged in user`,
+			};
+		} else if ( userAlreadyHasSites ) {
+			// This prevents a bunch of sites being created accidentally.
+			redirect( `/` );
+			result = {
+				state: AssertConditionState.CHECKING,
+				message: `${ flowName } requires no preexisting sites`,
+			};
+		}
+
+		return result;
+	},
+};
+
+export default Blog;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/icons.jsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/icons.jsx
@@ -1,0 +1,66 @@
+export const FeatherIcon = () => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="24"
+		height="24"
+		fill="none"
+		viewBox="0 0 24 24"
+		className="blogger-intent__icon"
+	>
+		<path
+			stroke="#8C8F94"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			strokeWidth="1.6"
+			d="M20.24 12.24a6.003 6.003 0 00-8.49-8.49L5 10.5V19h8.5l6.74-6.76z"
+		></path>
+		<path stroke="#8C8F94" strokeLinecap="square" strokeWidth="1.6" d="M16 8L2 22"></path>
+		<path
+			stroke="#8C8F94"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			strokeWidth="1.6"
+			d="M17.5 15H9"
+		></path>
+	</svg>
+);
+
+export const DesignIcon = () => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="24"
+		height="24"
+		fill="none"
+		viewBox="0 0 24 24"
+		className="blogger-intent__icon"
+	>
+		<mask id="path-1-inside-1_1831_60163" fill="#fff">
+			<rect width="22" height="18" x="1" y="3.5" rx="1"></rect>
+		</mask>
+		<rect
+			width="22"
+			height="18"
+			x="1"
+			y="3.5"
+			stroke="#8C8F94"
+			strokeWidth="3.2"
+			mask="url(#path-1-inside-1_1831_60163)"
+			rx="1"
+		></rect>
+		<mask id="path-2-inside-2_1831_60163" fill="#fff">
+			<rect width="13" height="11" x="10" y="3.5" rx="1"></rect>
+		</mask>
+		<rect
+			width="13"
+			height="11"
+			x="10"
+			y="3.5"
+			stroke="#8C8F94"
+			strokeWidth="3.2"
+			mask="url(#path-2-inside-2_1831_60163)"
+			rx="1"
+		></rect>
+		<path fill="#8C8F94" d="M5 2H8V3.5H5z"></path>
+		<path fill="#8C8F94" d="M16 2h3v1.5h-3V2z"></path>
+	</svg>
+);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
@@ -1,30 +1,60 @@
+import { Button, Gridicon } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
+import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
+import type { UserSelect } from '@automattic/data-stores';
 
 import './style.scss';
 
 const BlogIntent: Step = function BlogIntent() {
 	const translate = useTranslate();
+
+	const currentUser = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+		[]
+	);
+
 	return (
 		<>
 			<DocumentHead title={ translate( 'Create your blog' ) } />
 			<StepContainer
 				stepName="intent"
-				isFullLayout
-				hideFormattedHeader
 				hideBack={ true }
 				hideSkip={ true }
 				hideNext={ true }
-				skipButtonAlign="top"
 				showJetpackPowered={ true }
 				stepContent={
-					<div>
-						<h1>Let's start your blog</h1>
-						<a href="/setup/start-writing">Start Writing</a>
-						<a href="/setup/design-first">View designs</a>
+					<div className="blogger-intent__container">
+						<h1 className="blogger-intent__heading">
+							{ translate( "Let's start your blog, %(username)s", {
+								args: { username: currentUser?.display_name || currentUser?.username },
+							} ) }
+						</h1>
+						<div className="blogger-intent__content">
+							<div className="blogger-intent__row">
+								<div className="blogger-intent__row-text">
+									<Gridicon icon="pencil" />
+									{ translate( 'Write your first post' ) }
+								</div>
+								<Button primary href="/setup/start-writing">
+									{ translate( 'Start Writing' ) }
+								</Button>
+							</div>
+							<hr />
+							<div className="blogger-intent__row">
+								<div className="blogger-intent__row-text">
+									<Gridicon icon="layout" />
+									{ translate( 'Pick a design first' ) }
+								</div>
+								<Button primary href="/setup/design-first">
+									{ translate( 'View designs' ) }
+								</Button>
+							</div>
+						</div>
 					</div>
 				}
 				recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
@@ -1,14 +1,22 @@
 import { Button, Gridicon } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
+import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
+import type { UserSelect } from '@automattic/data-stores';
 
 import './style.scss';
 
 const BlogIntent: Step = function BlogIntent() {
 	const translate = useTranslate();
+
+	const currentUser = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+		[]
+	);
 
 	return (
 		<>
@@ -21,14 +29,18 @@ const BlogIntent: Step = function BlogIntent() {
 				showJetpackPowered={ true }
 				stepContent={
 					<div className="blogger-intent__container">
-						<h1 className="blogger-intent__heading">{ translate( "Let's start your blog!" ) }</h1>
+						<h1 className="blogger-intent__heading">
+							{ translate( "Let's start your blog, %(username)s", {
+								args: { username: currentUser?.display_name || currentUser?.username },
+							} ) }
+						</h1>
 						<div className="blogger-intent__content">
 							<div className="blogger-intent__row">
 								<div className="blogger-intent__row-text">
 									<Gridicon icon="pencil" />
 									{ translate( 'Write your first post' ) }
 								</div>
-								<Button primary className="blogger-intent__button" href="/setup/start-writing">
+								<Button primary href="/setup/start-writing">
 									{ translate( 'Start Writing' ) }
 								</Button>
 							</div>
@@ -38,7 +50,7 @@ const BlogIntent: Step = function BlogIntent() {
 									<Gridicon icon="layout" />
 									{ translate( 'Pick a design first' ) }
 								</div>
-								<Button primary className="blogger-intent__button" href="/setup/design-first">
+								<Button primary href="/setup/design-first">
 									{ translate( 'View designs' ) }
 								</Button>
 							</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
@@ -1,22 +1,14 @@
 import { Button, Gridicon } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
-import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
-import type { UserSelect } from '@automattic/data-stores';
 
 import './style.scss';
 
 const BlogIntent: Step = function BlogIntent() {
 	const translate = useTranslate();
-
-	const currentUser = useSelect(
-		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
-		[]
-	);
 
 	return (
 		<>
@@ -29,18 +21,14 @@ const BlogIntent: Step = function BlogIntent() {
 				showJetpackPowered={ true }
 				stepContent={
 					<div className="blogger-intent__container">
-						<h1 className="blogger-intent__heading">
-							{ translate( "Let's start your blog, %(username)s", {
-								args: { username: currentUser?.display_name || currentUser?.username },
-							} ) }
-						</h1>
+						<h1 className="blogger-intent__heading">{ translate( "Let's start your blog!" ) }</h1>
 						<div className="blogger-intent__content">
 							<div className="blogger-intent__row">
 								<div className="blogger-intent__row-text">
 									<Gridicon icon="pencil" />
 									{ translate( 'Write your first post' ) }
 								</div>
-								<Button primary href="/setup/start-writing">
+								<Button primary className="blogger-intent__button" href="/setup/start-writing">
 									{ translate( 'Start Writing' ) }
 								</Button>
 							</div>
@@ -50,7 +38,7 @@ const BlogIntent: Step = function BlogIntent() {
 									<Gridicon icon="layout" />
 									{ translate( 'Pick a design first' ) }
 								</div>
-								<Button primary href="/setup/design-first">
+								<Button primary className="blogger-intent__button" href="/setup/design-first">
 									{ translate( 'View designs' ) }
 								</Button>
 							</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
@@ -1,10 +1,11 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { DesignIcon, FeatherIcon } from './icons';
 import type { Step } from '../../types';
 import type { UserSelect } from '@automattic/data-stores';
 
@@ -37,7 +38,7 @@ const BlogIntent: Step = function BlogIntent() {
 						<div className="blogger-intent__content">
 							<div className="blogger-intent__row">
 								<div className="blogger-intent__row-text">
-									<Gridicon icon="pencil" />
+									<FeatherIcon />
 									{ translate( 'Write your first post' ) }
 								</div>
 								<Button primary href="/setup/start-writing">
@@ -47,7 +48,7 @@ const BlogIntent: Step = function BlogIntent() {
 							<hr />
 							<div className="blogger-intent__row">
 								<div className="blogger-intent__row-text">
-									<Gridicon icon="layout" />
+									<DesignIcon />
 									{ translate( 'Pick a design first' ) }
 								</div>
 								<Button primary href="/setup/design-first">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
@@ -30,18 +30,18 @@ const BlogIntent: Step = function BlogIntent() {
 				showJetpackPowered={ true }
 				stepContent={
 					<div className="blogger-intent__container">
-						<h1 className="blogger-intent__heading">
+						<h2 className="blogger-intent__heading">
 							{ translate( "Let's start your blog, %(username)s!", {
 								args: { username: currentUser?.display_name || currentUser?.username },
 							} ) }
-						</h1>
+						</h2>
 						<div className="blogger-intent__content">
 							<div className="blogger-intent__row">
 								<div className="blogger-intent__row-text">
 									<FeatherIcon />
 									{ translate( 'Write your first post' ) }
 								</div>
-								<Button primary href="/setup/start-writing">
+								<Button className="blogger-intent__button" primary href="/setup/start-writing">
 									{ translate( 'Start Writing' ) }
 								</Button>
 							</div>
@@ -51,7 +51,7 @@ const BlogIntent: Step = function BlogIntent() {
 									<DesignIcon />
 									{ translate( 'Pick a design first' ) }
 								</div>
-								<Button primary href="/setup/design-first">
+								<Button className="blogger-intent__button" primary href="/setup/design-first">
 									{ translate( 'View designs' ) }
 								</Button>
 							</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
@@ -30,7 +30,7 @@ const BlogIntent: Step = function BlogIntent() {
 				stepContent={
 					<div className="blogger-intent__container">
 						<h1 className="blogger-intent__heading">
-							{ translate( "Let's start your blog, %(username)s", {
+							{ translate( "Let's start your blog, %(username)s!", {
 								args: { username: currentUser?.display_name || currentUser?.username },
 							} ) }
 						</h1>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
@@ -1,0 +1,36 @@
+import { StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+import './style.scss';
+
+const BlogIntent: Step = function BlogIntent() {
+	const translate = useTranslate();
+	return (
+		<>
+			<DocumentHead title={ translate( 'Create your blog' ) } />
+			<StepContainer
+				stepName="intent"
+				isFullLayout
+				hideFormattedHeader
+				hideBack={ true }
+				hideSkip={ true }
+				hideNext={ true }
+				skipButtonAlign="top"
+				showJetpackPowered={ true }
+				stepContent={
+					<div>
+						<h1>Let's start your blog</h1>
+						<a href="/setup/start-writing">Start Writing</a>
+						<a href="/setup/design-first">View designs</a>
+					</div>
+				}
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
+	);
+};
+
+export default BlogIntent;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
@@ -19,9 +19,6 @@
 	.blogger-intent__heading {
 		@include onboarding-font-recoleta;
 		text-align: left;
-		font-size: 2rem;
-		max-width: 377px;
-		line-height: 40px;
 		color: var(--color-neutral-100);
 	}
 
@@ -45,21 +42,21 @@
 		justify-content: space-between;
 		margin-bottom: 20px;
 		width: 100%;
+		flex-wrap: wrap;
 
 		.blogger-intent__row-text {
 			display: flex;
 			align-items: center;
 			color: var(--color-neutral-100);
 
-			.gridicon {
-				margin-right: 10px;
-
-				fill: var(--color-neutral-30);
+			.blogger-intent__icon {
+				margin-right: 26px; // mobile 22
 			}
 		}
 
 		.blogger-intent__button {
-			margin-left: 10px;
+			margin-top: 24px; // mobile
+			margin-left: 64px; // mobile, desktop = 100+
 			background-color: var(--studio-blue-50);
 			border-color: var(--studio-blue-50);
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
@@ -59,8 +59,7 @@
 		}
 
 		.blogger-intent__button {
-			padding: 10px 20px;
-			margin-left: auto;
+			margin-left: 10px;
 			background-color: var(--studio-blue-50);
 			border-color: var(--studio-blue-50);
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
@@ -1,9 +1,17 @@
-@import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 @import "@automattic/onboarding/styles/mixins";
 @import "jetpack-connect/colors.scss";
 
 .blog.blogger-intent {
+	.wordpress-logo {
+		position: absolute;
+		inset-block-start: 20px;
+		inset-inline-start: 24px;
+		fill: var(--color-text);
+		transform-origin: 0 0;
+	}
+
 	.flow-progress {
 		display: none;
 	}
@@ -14,10 +22,14 @@
 		align-items: center;
 		justify-content: center;
 		min-height: 80vh;
+		margin-left: 20px;
+		margin-right: 20px;
+		margin-top: 104px;
 	}
 
 	.blogger-intent__heading {
 		@include onboarding-font-recoleta;
+		font-size: $font-title-large;
 		text-align: left;
 		color: var(--color-neutral-100);
 	}
@@ -27,12 +39,13 @@
 		flex-direction: column;
 		align-items: flex-start;
 		justify-content: center;
-		margin: 20px;
+		margin: 32px 0 0 0;
 		min-width: 20vw;
 
 		hr {
 			color: var(--color-neutral-10);
 			width: 100%;
+			margin-bottom: 6px; // 32 - 26
 		}
 	}
 
@@ -48,14 +61,18 @@
 			display: flex;
 			align-items: center;
 			color: var(--color-neutral-100);
+			margin-top: 24px; // mobile gap
 
 			.blogger-intent__icon {
-				margin-right: 26px; // mobile 22
+				margin-right: 26px;
+				@include break-mobile {
+					margin-right: 22px;
+				}
 			}
 		}
 
 		.blogger-intent__button {
-			margin-top: 24px; // mobile
+			margin-top: 24px; // mobile gap
 			margin-left: 64px; // mobile, desktop = 100+
 			background-color: var(--studio-blue-50);
 			border-color: var(--studio-blue-50);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
@@ -3,10 +3,6 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "jetpack-connect/colors.scss";
 
-body.is-section-stepper.theme-default.color-scheme {
-	--color-surface-backdrop: var(--studio-white);
-}
-
 .blog.blogger-intent {
 	.flow-progress {
 		display: none;
@@ -20,6 +16,15 @@ body.is-section-stepper.theme-default.color-scheme {
 		min-height: 80vh;
 	}
 
+	.blogger-intent__heading {
+		@include onboarding-font-recoleta;
+		text-align: left;
+		font-size: 2rem;
+		max-width: 377px;
+		line-height: 40px;
+		color: var(--color-neutral-100);
+	}
+
 	.blogger-intent__content {
 		display: flex;
 		flex-direction: column;
@@ -28,18 +33,9 @@ body.is-section-stepper.theme-default.color-scheme {
 		margin: 20px;
 		min-width: 20vw;
 
-		.blogger-intent__heading {
-			@include onboarding-font-recoleta;
-			text-align: left;
-			font-size: 2rem;
-			max-width: 377px;
-			line-height: 40px;
-			color: var(--color-neutral-100);
-		}
-
 		hr {
-			border: none;
-			color: var(--color-neutral-50);
+			color: var(--color-neutral-10);
+			width: 100%;
 		}
 	}
 
@@ -65,6 +61,8 @@ body.is-section-stepper.theme-default.color-scheme {
 		.blogger-intent__button {
 			padding: 10px 20px;
 			margin-left: auto;
+			background-color: var(--studio-blue-50);
+			border-color: var(--studio-blue-50);
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
@@ -1,0 +1,11 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
+
+.blog.blogger-intent {
+	.flow-progress {
+		display: none;
+	}
+	.step-container.intent {
+		display: block;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
@@ -1,11 +1,70 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
+@import "@automattic/onboarding/styles/mixins";
+@import "jetpack-connect/colors.scss";
+
+body.is-section-stepper.theme-default.color-scheme {
+	--color-surface-backdrop: var(--studio-white);
+}
 
 .blog.blogger-intent {
 	.flow-progress {
 		display: none;
 	}
-	.step-container.intent {
-		display: block;
+
+	.blogger-intent__container {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		min-height: 80vh;
+	}
+
+	.blogger-intent__content {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: center;
+		margin: 20px;
+		min-width: 20vw;
+
+		.blogger-intent__heading {
+			@include onboarding-font-recoleta;
+			text-align: left;
+			font-size: 2rem;
+			max-width: 377px;
+			line-height: 40px;
+			color: var(--color-neutral-100);
+		}
+
+		hr {
+			border: none;
+			color: var(--color-neutral-50);
+		}
+	}
+
+	.blogger-intent__row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 20px;
+		width: 100%;
+
+		.blogger-intent__row-text {
+			display: flex;
+			align-items: center;
+			color: var(--color-neutral-100);
+
+			.gridicon {
+				margin-right: 10px;
+
+				fill: var(--color-neutral-30);
+			}
+		}
+
+		.blogger-intent__button {
+			padding: 10px 20px;
+			margin-left: auto;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -80,6 +80,8 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	sensei: () => import( /* webpackChunkName: "sensei-flow" */ '../declarative-flow/sensei' ),
 
+	blog: () => import( /* webpackChunkName: "blog" */ '../declarative-flow/blog' ),
+
 	[ START_WRITING_FLOW ]: () =>
 		import( /* webpackChunkName: "start-writing-flow" */ './start-writing' ),
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2141

## Proposed Changes

* Adds binary selection page for blog onboarding 

## Testing Instructions

* http://calypso.localhost:3000/setup/blog
* ~Logged out should force a login or user creation before loading the page, both flows should return back to this screen~
* Clicking on one of the buttons should move you to the editor, design picker, or login screen before hand as required.

Screenshot

![Screenshot 2023-06-05 at 18-01-00 Create your blog — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/37a12c34-d8a0-41fc-b04a-e24bf4e63486)

- [ ] Mobile/small screen breakpoints need work
- [x] Wordpress logo missing?
- [x] Figma icons needed

