### PR TITLE
Enable search page for logged out users

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -76,6 +76,8 @@ const LayoutLoggedOut = ( {
 
 	const isReaderTagPage =
 		sectionName === 'reader' && window.location.pathname.startsWith( '/tag/' );
+	const isReaderSearchPage =
+		sectionName === 'reader' && window.location.pathname.startsWith( '/read/search' );
 
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
@@ -124,7 +126,8 @@ const LayoutLoggedOut = ( {
 		masterbar = null;
 	} else if (
 		[ 'plugins', 'themes', 'theme', 'reader', 'subscriptions' ].includes( sectionName ) &&
-		! isReaderTagPage
+		! isReaderTagPage &&
+		! isReaderSearchPage
 	) {
 		masterbar = (
 			<UniversalNavbarHeader

--- a/client/reader/lib/header-section/index.tsx
+++ b/client/reader/lib/header-section/index.tsx
@@ -1,0 +1,16 @@
+import { translate } from 'i18n-calypso';
+import React from 'react';
+
+const renderHeaderSection = () => (
+	<div className="tag-stream__page-header">
+		<h2>
+			{
+				// translators: The title of the reader tag page
+				translate( 'WordPress Reader' )
+			}
+		</h2>
+		<h1>{ translate( 'Enjoy millions of blogs at your fingertips.' ) }</h1>
+	</div>
+);
+
+export default renderHeaderSection;

--- a/client/reader/lib/header-section/index.tsx
+++ b/client/reader/lib/header-section/index.tsx
@@ -2,7 +2,7 @@ import { translate } from 'i18n-calypso';
 import React from 'react';
 
 const renderHeaderSection = () => (
-	<div className="tag-stream__page-header">
+	<div className="logged-out-reader-header">
 		<h2>
 			{
 				// translators: The title of the reader tag page

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -16,6 +16,7 @@ import ReaderMain from 'calypso/reader/components/reader-main';
 import { getSearchPlaceholderText } from 'calypso/reader/search/utils';
 import SearchFollowButton from 'calypso/reader/search-stream/search-follow-button';
 import { recordAction } from 'calypso/reader/stats';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import {
 	SORT_BY_RELEVANCE,
@@ -107,7 +108,7 @@ class SearchStream extends React.Component {
 	handleSearchTypeSelection = ( searchType ) => updateQueryArg( { show: searchType } );
 
 	render() {
-		const { query, translate, searchType, suggestions } = this.props;
+		const { query, translate, searchType, suggestions, isLoggedIn } = this.props;
 		const sortOrder = this.props.sort;
 		const wideDisplay = this.props.width > WIDE_DISPLAY_CUTOFF;
 		const segmentedControlClass = wideDisplay
@@ -201,7 +202,7 @@ class SearchStream extends React.Component {
 						/>
 					) }
 				</div>
-				<SpacerDiv domTarget={ this.fixedAreaRef } />
+				{ isLoggedIn && <SpacerDiv domTarget={ this.fixedAreaRef } /> }
 				{ ! hidePostsAndSites && wideDisplay && (
 					<div className={ searchStreamResultsClasses }>
 						<div className="search-stream__post-results">
@@ -253,6 +254,7 @@ export default connect(
 	( state, ownProps ) => ( {
 		readerAliasedFollowFeedUrl:
 			ownProps.query && getReaderAliasedFollowFeedUrl( state, ownProps.query ),
+		isLoggedIn: isUserLoggedIn( state ),
 	} ),
 	{
 		recordReaderTracksEvent,

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -50,6 +50,8 @@
 
 .layout.has-header-section .search-stream__fixed-area {
 	position: static;
+	padding-top: 0;
+	margin-top: 0;
 }
 
 .search-stream__fixed-area .section-nav-tabs.is-dropdown {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -48,6 +48,10 @@
 	}
 }
 
+.layout.has-header-section .search-stream__fixed-area {
+	position: static;
+}
+
 .search-stream__fixed-area .section-nav-tabs.is-dropdown {
 	margin: 0;
 }

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -80,6 +80,7 @@ const exported = {
 				onQueryChange={ reportQueryChange }
 				onSortChange={ reportSortChange }
 				searchType={ show }
+				trendingTags={ context.params.trendingTags }
 			/>
 		);
 		next();

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -8,6 +8,7 @@ import {
 } from 'calypso/reader/controller-helper';
 import { SEARCH_TYPES } from 'calypso/reader/search-stream/search-stream-header';
 import { recordTrack } from 'calypso/reader/stats';
+import renderHeaderSection from '../lib/header-section';
 
 const analyticsPageTitle = 'Reader';
 
@@ -55,6 +56,7 @@ const exported = {
 		function reportSortChange( newSort ) {
 			replaceSearchUrl( searchSlug, newSort !== 'relevance' ? newSort : undefined );
 		}
+		context.headerSection = renderHeaderSection();
 
 		context.primary = (
 			<AsyncLoad

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -1,11 +1,28 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { fetchTrendingTags } from '../tags/controller';
 import { search } from './controller';
+
+const fetchTrendingTagsIfLoggedOut = ( context, next ) => {
+	if ( ! isUserLoggedIn( context.store.getState() ) ) {
+		return fetchTrendingTags( context, next );
+	}
+	next();
+};
 
 export default function () {
 	// Old recommendations page
 	page( '/recommendations', '/read/search' );
 
-	page( '/read/search', updateLastRoute, sidebar, search, makeLayout, clientRender );
+	page(
+		'/read/search',
+		fetchTrendingTagsIfLoggedOut,
+		updateLastRoute,
+		sidebar,
+		search,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -420,3 +420,19 @@
 		}
 	}
 }
+
+// specific rule to override existing rules
+.layout.has-header-section.is-section-reader .layout__header-section-content .logged-out-reader-header {
+	text-align: center;
+
+	h2 {
+		font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-weight: 500;
+		margin-bottom: 10px;
+	}
+
+	h1 {
+		font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-weight: 500;
+	}
+}

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -1,4 +1,3 @@
-import { translate } from 'i18n-calypso';
 import { trim } from 'lodash';
 import AsyncLoad from 'calypso/components/async-load';
 import {
@@ -9,20 +8,9 @@ import {
 } from 'calypso/reader/controller-helper';
 import { recordTrack } from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import renderHeaderSection from '../lib/header-section';
 
 const analyticsPageTitle = 'Reader';
-
-const renderHeaderSection = () => (
-	<div className="tag-stream__page-header">
-		<h2>
-			{
-				// translators: The title of the reader tag page
-				translate( 'WordPress Reader' )
-			}
-		</h2>
-		<h1>{ translate( 'Enjoy millions of blogs at your fingertips.' ) }</h1>
-	</div>
-);
 
 export const tagListing = ( context, next ) => {
 	const basePath = '/tag/:slug';

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -58,22 +58,6 @@
 	margin-top: 15px;
 }
 
-// specific rule to override existing rules
-.layout.has-header-section.is-section-reader .layout__header-section-content .tag-stream__page-header {
-	text-align: center;
-
-	h2 {
-		font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		font-weight: 500;
-		margin-bottom: 10px;
-	}
-
-	h1 {
-		font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		font-weight: 500;
-	}
-}
-
 // Tag page only shows site titles in the sidebar, so spacing needs to be tighter
 .tag-stream__main {
 	.stream__two-column .reader__content::before {

--- a/client/sections.js
+++ b/client/sections.js
@@ -369,6 +369,7 @@ const sections = [
 		paths: [ '/read/search', '/recommendations' ],
 		module: 'calypso/reader/search',
 		group: 'reader',
+		enableLoggedOut: true,
 		trackLoadPerformance: true,
 	},
 	{


### PR DESCRIPTION
see pe7F0s-Ti-p2

* Makes the `/read/search` page public
* Updates its style and header to match the `/tag/$tag` pages
* Uses trending tags rather than subscribed tags to generate recommendations.
* By applying D112875-code, the default search results will be available to logged out users

### Blank state
<img width="992" alt="Screen Shot 2023-06-06 at 2 49 18 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/651e16f8-191f-4e40-bab6-5cefb97fcc5c">

### After search
<img width="994" alt="Screen Shot 2023-06-06 at 2 49 35 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/34d0d543-012b-4111-bafc-4c4f62f129f6">


### Testing instructions
The public version of the page will not be publicly available until we update nginx config for wordpress.com
Therefore it is most important to test that the logged in search has not been affected.
Ensure design, search and suggestions still work as before in the logged in`/read/search` page.