### PR TITLE
Editor modals: align border radius

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/style.scss
@@ -2,11 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 
 .wpcom-block-editor-post-published-sharing-modal {
-	border-radius: 4px;
-	@media only screen and (max-width: 600px) {
-		border-radius: 0;
-	}
-
 	.components-modal__content {
 		margin-top: 0;
 		padding-bottom: 0;
@@ -131,7 +126,7 @@
 	margin: 8px 8px 0 0;
 	border-radius: 50%;
 	color: var(--color-neutral-80);
-	background: #fff;
+	background: var(--studio-white);
 	padding: 7px;
 
 	&:hover {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/style.scss
@@ -2,6 +2,9 @@
 @import "@wordpress/base-styles/mixins";
 
 .wpcom-block-editor-post-published-sharing-modal {
+	@media only screen and (max-width: 600px) {
+		border-radius: 0;
+	}
 	.components-modal__content {
 		margin-top: 0;
 		padding-bottom: 0;

--- a/packages/whats-new/src/style.scss
+++ b/packages/whats-new/src/style.scss
@@ -18,7 +18,6 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-content-spacing * 2 );
 
 	&.components-modal__frame {
 		top: calc(17.5vh - #{$wpcom-modal-footer-height * 0.5});
-		border-radius: 4px;
 		overflow: auto;
 		max-height: 80vh;
 


### PR DESCRIPTION
Modals using `@wordpress/components` [Modal component](https://wordpress.github.io/gutenberg/?path=/story/components-modal--default) (i.e. not Calypso modal) were some using component's original border radius, and some had 4px override. This caused things to look inconsistent inside the editor.

We still have a separate modal component in Calypso, which again creates inconsistencies but at least they're on different views, not within the same (editor) view.

Core modal:

<img width="1064" alt="Screenshot 2023-06-05 at 09 01 15" src="https://github.com/Automattic/wp-calypso/assets/87168/1ae5c095-478b-4d1e-94db-94af68a3dad5">

One of WP.com modals with correct radius — most of the [modals listed here are fine](https://github.com/Automattic/wp-calypso/tree/b8062d6f337ba951807da5cbe44e8196e3ecb340/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src):

<img width="870" alt="Screenshot 2023-06-05 at 09 02 38" src="https://github.com/Automattic/wp-calypso/assets/87168/00acf35e-bae9-414d-b029-c81e69371a95">


## Proposed Changes

#### Remove "Post publish sharing" modal's border-radius override (+ use CSS var instead of fixed colour)

**Before**

<img width="1150" alt="Screenshot 2023-06-05 at 09 28 36" src="https://github.com/Automattic/wp-calypso/assets/87168/197ff4a3-76b9-442e-ad31-490c2e74f4ac">

**After**

<img width="1137" alt="Screenshot 2023-06-05 at 09 28 57" src="https://github.com/Automattic/wp-calypso/assets/87168/905671b2-9391-43f5-912a-0511b19b2e7c">

No changes to mobile version radius as that seems to have more overrides:

<img width="437" alt="Screenshot 2023-06-05 at 09 26 34" src="https://github.com/Automattic/wp-calypso/assets/87168/78d6c508-e90a-4a55-aaf1-77685959e47c">

Reported visual bugs: https://github.com/Automattic/wp-calypso/issues/77786

#### Remove "What's new" modal's border-radius override 

**Before**

<img width="797" alt="Screenshot 2023-06-05 at 09 29 10" src="https://github.com/Automattic/wp-calypso/assets/87168/c6272e94-ddf6-43e2-903f-f6ab3431ae7f">


**After**

<img width="808" alt="Screenshot 2023-06-05 at 09 29 48" src="https://github.com/Automattic/wp-calypso/assets/87168/5a521180-ca67-4c60-a4e4-049ecfce6a01">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* [Build and sync](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/README.md#build-system) changes in editing toolkit to your sandbox
* From 3 dots menu in editor, pick "What's new?" modal and see the radius. 
* Publish a post on some site, note the sharing modal. See the radius.
* Test mobile screens!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
