### PR TITLE
ESLint: Enable `@tanstack/eslint-plugin-query` (#77214)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
 		'plugin:jsx-a11y/recommended',
 		'plugin:jest/recommended',
 		'plugin:prettier/recommended',
+		'plugin:@tanstack/eslint-plugin-query/recommended',
 		'plugin:md/prettier',
 		'plugin:@wordpress/eslint-plugin/i18n',
 	],
@@ -281,7 +282,7 @@ module.exports = {
 		// this is when Webpack last built the bundle
 		BUILD_TIMESTAMP: true,
 	},
-	plugins: [ 'import', 'you-dont-need-lodash-underscore' ],
+	plugins: [ 'import', 'you-dont-need-lodash-underscore', '@tanstack/query' ],
 	settings: {
 		react: {
 			version: reactVersion,
@@ -534,5 +535,10 @@ module.exports = {
 		'you-dont-need-lodash-underscore/to-pairs': 'error',
 		'you-dont-need-lodash-underscore/to-upper': 'error',
 		'you-dont-need-lodash-underscore/uniq': 'error',
+
+		// @TODO remove these lines once we fixed the warnings so
+		// they'll become errors for new code added to the codebase
+		'@tanstack/query/exhaustive-deps': 'warn',
+		'@tanstack/query/prefer-query-object-syntax': 'warn',
 	},
 };

--- a/apps/editing-toolkit/bin/sync-newspack-blocks.sh
+++ b/apps/editing-toolkit/bin/sync-newspack-blocks.sh
@@ -135,7 +135,7 @@ sed "${sedi[@]}" -e "s| function| Function|g" "$TARGET/types/index.d.ts"
 
 echo "Fixing the text domains…"
 echo -n "eslint --fix: "
-npx eslint . --fix > /dev/null 2>&1
+DEBUG=eslint:* npx eslint . --fix > /dev/null 2>&1
 echo "done"
 echo -n "phpcbf: "
 ../../vendor/bin/phpcbf -q $TARGET | grep "A TOTAL OF" || PHPCBF_ERRORED=1

--- a/apps/editing-toolkit/bin/sync-newspack-blocks.sh
+++ b/apps/editing-toolkit/bin/sync-newspack-blocks.sh
@@ -135,7 +135,7 @@ sed "${sedi[@]}" -e "s| function| Function|g" "$TARGET/types/index.d.ts"
 
 echo "Fixing the text domains…"
 echo -n "eslint --fix: "
-DEBUG=eslint:* npx eslint . --fix > /dev/null 2>&1
+npx eslint . --fix > /dev/null 2>&1
 echo "done"
 echo -n "phpcbf: "
 ../../vendor/bin/phpcbf -q $TARGET | grep "A TOTAL OF" || PHPCBF_ERRORED=1

--- a/apps/editing-toolkit/bin/sync-newspack-blocks.sh
+++ b/apps/editing-toolkit/bin/sync-newspack-blocks.sh
@@ -135,7 +135,7 @@ sed "${sedi[@]}" -e "s| function| Function|g" "$TARGET/types/index.d.ts"
 
 echo "Fixing the text domains…"
 echo -n "eslint --fix: "
-DEBUG=eslint:* npx eslint . --fix > /dev/null 2>&1
+DEBUG=eslint:* npx eslint . --fix
 echo "done"
 echo -n "phpcbf: "
 ../../vendor/bin/phpcbf -q $TARGET | grep "A TOTAL OF" || PHPCBF_ERRORED=1

--- a/apps/editing-toolkit/bin/sync-newspack-blocks.sh
+++ b/apps/editing-toolkit/bin/sync-newspack-blocks.sh
@@ -135,7 +135,7 @@ sed "${sedi[@]}" -e "s| function| Function|g" "$TARGET/types/index.d.ts"
 
 echo "Fixing the text domains…"
 echo -n "eslint --fix: "
-DEBUG=eslint:* npx eslint . --fix
+DEBUG=eslint:* npx eslint . --fix > /dev/null 2>&1
 echo "done"
 echo -n "phpcbf: "
 ../../vendor/bin/phpcbf -q $TARGET | grep "A TOTAL OF" || PHPCBF_ERRORED=1

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -124,6 +124,7 @@
 		"@automattic/calypso-apps-builder": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-jest": "workspace:^",
+		"@tanstack/eslint-plugin-query": "^4.29.8",
 		"@testing-library/jest-dom": "^5.16.2",
 		"@testing-library/react": "^12.1.3",
 		"@types/node": "^18.11.18",

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
 		"@signal-noise/stylelint-scales": "^2.0.3",
 		"@storybook/cli": "^7.0.18",
 		"@storybook/react": "^7.0.18",
+		"@tanstack/eslint-plugin-query": "^4.29.8",
 		"@testing-library/jest-dom": "^5.16.2",
 		"@types/gtag.js": "^0.0.10",
 		"@types/superagent": "^4.1.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6080,6 +6080,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/eslint-plugin-query@npm:^4.29.8":
+  version: 4.29.8
+  resolution: "@tanstack/eslint-plugin-query@npm:4.29.8"
+  checksum: 073913fa080a22446f9639bc232639be8728d9d4df7658cbbfaf3eec274146902d23f68cd7d7102712424b8c308d72efa8d726cf02683998143527343c9f55e5
+  languageName: node
+  linkType: hard
+
 "@tanstack/match-sorter-utils@npm:^8.7.0":
   version: 8.7.6
   resolution: "@tanstack/match-sorter-utils@npm:8.7.6"
@@ -31580,6 +31587,7 @@ __metadata:
     "@signal-noise/stylelint-scales": ^2.0.3
     "@storybook/cli": ^7.0.18
     "@storybook/react": ^7.0.18
+    "@tanstack/eslint-plugin-query": ^4.29.8
     "@testing-library/jest-dom": ^5.16.2
     "@types/cookie": ^0.4.1
     "@types/debug": ^4.1.7

--- a/yarn.lock
+++ b/yarn.lock
@@ -1826,6 +1826,7 @@ __metadata:
     "@babel/core": ^7.17.5
     "@popperjs/core": ^2.10.2
     "@sentry/browser": ^7.54.0
+    "@tanstack/eslint-plugin-query": ^4.29.8
     "@tanstack/react-query": ^4.29.1
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3


### PR DESCRIPTION
The original PR (#77214) was reverted due to some unforeseen complications with the synchronisation of newspack blocks in the editing toolkit (see #77779). Opening this PR to reintroduce our original changes alongside with a fix (currently being worked on).

⚠️ PR is blocked until the aforementioned issues with newspack blocks are resolved.

## Proposed Changes

Enable the `@tanstack/eslint-plugin-query` ESLint plugin with its recommended rules but make them non-blocking warnings for now.

Adding `@tanstack/eslint-plugin-query` as a dev dependency to ETK since it has its own build pipeline that runs an isolated `eslint --fix` command.

## Testing Instructions

1. Run ESLint locally and verify you're seeing **warnings** related to these rules:

- `@tanstack/query/prefer-query-object-syntax`
- `@tanstack/query/exhaustive-deps`

2. Verify that in TeamCity, in the ETK check artifacts, the textdomain used when localizing strings inside ETK's `newspack-blocks/synced-newspack-blocks` directory is properly changed to "full-site-editing".