### PR TITLE
Jetpack Pro Dashboard: refactor the NotificationSettings component into multiple smaller components

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/email-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/email-notification.tsx
@@ -1,0 +1,77 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import ConfigureEmailNotification from '../../configure-email-notification';
+import type { StateMonitorSettingsEmail } from '../../../sites-overview/types';
+
+interface Props {
+	recordEvent: ( action: string, params?: object ) => void;
+	verifiedItem?: { [ key: string ]: string };
+	enableEmailNotification: boolean;
+	setEnableEmailNotification: ( isEnabled: boolean ) => void;
+	defaultUserEmailAddresses: string[];
+	toggleAddEmailModal: () => void;
+	allEmailItems: StateMonitorSettingsEmail[];
+}
+
+export default function EmailNotification( {
+	recordEvent,
+	verifiedItem,
+	enableEmailNotification,
+	setEnableEmailNotification,
+	defaultUserEmailAddresses,
+	toggleAddEmailModal,
+	allEmailItems,
+}: Props ) {
+	const translate = useTranslate();
+
+	const isMultipleEmailEnabled: boolean = isEnabled(
+		'jetpack/pro-dashboard-monitor-multiple-email-recipients'
+	);
+
+	return (
+		<>
+			<div className="notification-settings__toggle-container">
+				<div className="notification-settings__toggle">
+					<ToggleControl
+						onChange={ ( isEnabled ) => {
+							recordEvent( isEnabled ? 'email_notification_enable' : 'email_notification_disable' );
+							setEnableEmailNotification( isEnabled );
+						} }
+						checked={ enableEmailNotification }
+					/>
+				</div>
+				<div className="notification-settings__toggle-content">
+					<div className="notification-settings__content-heading-with-beta">
+						<div className="notification-settings__content-heading">{ translate( 'Email' ) }</div>
+						{ isMultipleEmailEnabled && (
+							<div className="notification-settings__beta-tag">{ translate( 'BETA' ) }</div>
+						) }
+					</div>
+					{ isMultipleEmailEnabled ? (
+						<>
+							<div className="notification-settings__content-sub-heading">
+								{ translate( 'Receive email notifications with one or more recipients.' ) }
+							</div>
+						</>
+					) : (
+						<div className="notification-settings__content-sub-heading">
+							{ translate( 'Receive email notifications with your account email address %s.', {
+								args: defaultUserEmailAddresses,
+							} ) }
+						</div>
+					) }
+				</div>
+			</div>
+
+			{ enableEmailNotification && isMultipleEmailEnabled && (
+				<ConfigureEmailNotification
+					toggleModal={ toggleAddEmailModal }
+					allEmailItems={ allEmailItems }
+					recordEvent={ recordEvent }
+					verifiedEmail={ verifiedItem?.email }
+				/>
+			) }
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/footer.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/footer.tsx
@@ -1,0 +1,53 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+
+interface Props {
+	isLoading: boolean;
+	validationError?: string;
+	isBulkUpdate: boolean;
+	handleOnClose: () => void;
+	hasUnsavedChanges: boolean;
+	unsavedChangesExist: boolean;
+}
+
+export default function NotificationSettingsFormFooter( {
+	isLoading,
+	validationError,
+	isBulkUpdate,
+	handleOnClose,
+	hasUnsavedChanges,
+	unsavedChangesExist,
+}: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="notification-settings__footer">
+			{ ( validationError || hasUnsavedChanges ) && (
+				<div className="notification-settings__footer-validation-error" role="alert">
+					{ hasUnsavedChanges
+						? translate( 'You have unsaved changes. Are you sure you want to close?' )
+						: validationError }
+				</div>
+			) }
+			<div className="notification-settings__footer-buttons">
+				<Button
+					onClick={ handleOnClose }
+					aria-label={ translate( 'Cancel and close notification settings popup' ) }
+				>
+					{ translate( 'Cancel' ) }
+				</Button>
+				<Button
+					disabled={
+						// Disable save button if there is no change and not bulk update
+						!! validationError || isLoading || ( ! isBulkUpdate && ! unsavedChangesExist )
+					}
+					type="submit"
+					primary
+					aria-label={ translate( 'Save notification settings' ) }
+				>
+					{ isLoading ? translate( 'Saving Changes' ) : translate( 'Save' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/mobile-push-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/mobile-push-notification.tsx
@@ -1,0 +1,48 @@
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { mobileAppLink } from '../../../sites-overview/utils';
+
+interface Props {
+	recordEvent: ( action: string, params?: object ) => void;
+	enableMobileNotification: boolean;
+	setEnableMobileNotification: ( isEnabled: boolean ) => void;
+}
+
+export default function MobilePushNotification( {
+	recordEvent,
+	enableMobileNotification,
+	setEnableMobileNotification,
+}: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="notification-settings__toggle-container">
+			<div className="notification-settings__toggle">
+				<ToggleControl
+					onChange={ ( isEnabled ) => {
+						recordEvent( isEnabled ? 'mobile_notification_enable' : 'mobile_notification_disable' );
+						setEnableMobileNotification( isEnabled );
+					} }
+					checked={ enableMobileNotification }
+				/>
+			</div>
+			<div className="notification-settings__toggle-content">
+				<div className="notification-settings__content-heading">{ translate( 'Mobile' ) }</div>
+				<div className="notification-settings__content-sub-heading">
+					{ translate( 'Receive notifications via the {{a}}Jetpack App{{/a}}.', {
+						components: {
+							a: (
+								<a
+									className="notification-settings__link"
+									target="_blank"
+									rel="noreferrer"
+									href={ mobileAppLink }
+								/>
+							),
+						},
+					} ) }
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
@@ -1,0 +1,52 @@
+import { useTranslate } from 'i18n-calypso';
+import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
+import SelectDropdown from 'calypso/components/select-dropdown';
+import { availableNotificationDurations as durations } from '../../../sites-overview/utils';
+import type { MonitorDuration } from '../../../sites-overview/types';
+
+interface Props {
+	selectedDuration?: MonitorDuration;
+	selectDuration: ( duration: MonitorDuration ) => void;
+	recordEvent: ( action: string, params?: object ) => void;
+}
+
+export default function NotificationDuration( {
+	selectedDuration,
+	selectDuration,
+	recordEvent,
+}: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="notification-settings__content-block">
+			<div className="notification-settings__content-heading">
+				{ translate( 'Notify me about downtime:' ) }
+			</div>
+			<SelectDropdown
+				onToggle={ ( { open: isOpen }: { open: boolean } ) => {
+					if ( isOpen ) {
+						recordEvent( 'notification_duration_toggle' );
+					}
+				} }
+				selectedIcon={
+					<img
+						className="notification-settings__duration-icon"
+						src={ clockIcon }
+						alt={ translate( 'Schedules' ) }
+					/>
+				}
+				selectedText={ selectedDuration?.label }
+			>
+				{ durations.map( ( duration ) => (
+					<SelectDropdown.Item
+						key={ duration.time }
+						selected={ duration.time === selectedDuration?.time }
+						onClick={ () => selectDuration( duration ) }
+					>
+						{ duration.label }
+					</SelectDropdown.Item>
+				) ) }
+			</SelectDropdown>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -1,12 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button } from '@automattic/components';
-import { Modal, ToggleControl } from '@wordpress/components';
+import { Modal } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState, useContext } from 'react';
-import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
 import AlertBanner from 'calypso/components/jetpack/alert-banner';
-import SelectDropdown from 'calypso/components/select-dropdown';
 import {
 	useUpdateMonitorSettings,
 	useJetpackAgencyDashboardRecordTrackEvent,
@@ -16,10 +13,12 @@ import DashboardDataContext from '../../sites-overview/dashboard-data-context';
 import {
 	availableNotificationDurations as durations,
 	getSiteCountText,
-	mobileAppLink,
 } from '../../sites-overview/utils';
-import ConfigureEmailNotification from '../configure-email-notification';
 import EmailAddressEditor from '../configure-email-notification/email-address-editor';
+import EmailNotification from './form-content/email-notification';
+import NotificationSettingsFormFooter from './form-content/footer';
+import MobilePushNotification from './form-content/mobile-push-notification';
+import NotificationDuration from './form-content/notification-duration';
 import type {
 	MonitorSettings,
 	Site,
@@ -295,7 +294,6 @@ export default function NotificationSettings( {
 			className="notification-settings__modal"
 		>
 			<div className="notification-settings__sub-title">{ getSiteCountText( sites ) }</div>
-
 			<form onSubmit={ onSave }>
 				{ isBulkUpdate && (
 					<AlertBanner type="warning">
@@ -303,143 +301,34 @@ export default function NotificationSettings( {
 					</AlertBanner>
 				) }
 				<div className={ classNames( { 'notification-settings__content': ! isBulkUpdate } ) }>
-					<div className="notification-settings__content-block">
-						<div className="notification-settings__content-heading">
-							{ translate( 'Notify me about downtime:' ) }
-						</div>
-						<SelectDropdown
-							onToggle={ ( { open: isOpen }: { open: boolean } ) => {
-								if ( isOpen ) {
-									recordEvent( 'notification_duration_toggle' );
-								}
-							} }
-							selectedIcon={
-								<img
-									className="notification-settings__duration-icon"
-									src={ clockIcon }
-									alt={ translate( 'Schedules' ) }
-								/>
-							}
-							selectedText={ selectedDuration?.label }
-						>
-							{ durations.map( ( duration ) => (
-								<SelectDropdown.Item
-									key={ duration.time }
-									selected={ duration.time === selectedDuration?.time }
-									onClick={ () => selectDuration( duration ) }
-								>
-									{ duration.label }
-								</SelectDropdown.Item>
-							) ) }
-						</SelectDropdown>
-					</div>
-					<div className="notification-settings__toggle-container">
-						<div className="notification-settings__toggle">
-							<ToggleControl
-								onChange={ ( isEnabled ) => {
-									recordEvent(
-										isEnabled ? 'mobile_notification_enable' : 'mobile_notification_disable'
-									);
-									setEnableMobileNotification( isEnabled );
-								} }
-								checked={ enableMobileNotification }
-							/>
-						</div>
-						<div className="notification-settings__toggle-content">
-							<div className="notification-settings__content-heading">
-								{ translate( 'Mobile' ) }
-							</div>
-							<div className="notification-settings__content-sub-heading">
-								{ translate( 'Receive notifications via the {{a}}Jetpack App{{/a}}.', {
-									components: {
-										a: (
-											<a
-												className="notification-settings__link"
-												target="_blank"
-												rel="noreferrer"
-												href={ mobileAppLink }
-											/>
-										),
-									},
-								} ) }
-							</div>
-						</div>
-					</div>
-					<div className="notification-settings__toggle-container">
-						<div className="notification-settings__toggle">
-							<ToggleControl
-								onChange={ ( isEnabled ) => {
-									recordEvent(
-										isEnabled ? 'email_notification_enable' : 'email_notification_disable'
-									);
-									setEnableEmailNotification( isEnabled );
-								} }
-								checked={ enableEmailNotification }
-							/>
-						</div>
-						<div className="notification-settings__toggle-content">
-							<div className="notification-settings__content-heading-with-beta">
-								<div className="notification-settings__content-heading">
-									{ translate( 'Email' ) }
-								</div>
-								{ isMultipleEmailEnabled && (
-									<div className="notification-settings__beta-tag">{ translate( 'BETA' ) }</div>
-								) }
-							</div>
-							{ isMultipleEmailEnabled ? (
-								<>
-									<div className="notification-settings__content-sub-heading">
-										{ translate( 'Receive email notifications with one or more recipients.' ) }
-									</div>
-								</>
-							) : (
-								<div className="notification-settings__content-sub-heading">
-									{ translate( 'Receive email notifications with your account email address %s.', {
-										args: defaultUserEmailAddresses,
-									} ) }
-								</div>
-							) }
-						</div>
-					</div>
-
-					{ enableEmailNotification && isMultipleEmailEnabled && (
-						<ConfigureEmailNotification
-							toggleModal={ toggleAddEmailModal }
-							allEmailItems={ allEmailItems }
-							recordEvent={ recordEvent }
-							verifiedEmail={ verifiedItem?.email }
-						/>
-					) }
+					<NotificationDuration
+						recordEvent={ recordEvent }
+						selectedDuration={ selectedDuration }
+						selectDuration={ selectDuration }
+					/>
+					<MobilePushNotification
+						recordEvent={ recordEvent }
+						enableMobileNotification={ enableMobileNotification }
+						setEnableMobileNotification={ setEnableMobileNotification }
+					/>
+					<EmailNotification
+						recordEvent={ recordEvent }
+						verifiedItem={ verifiedItem }
+						enableEmailNotification={ enableEmailNotification }
+						setEnableEmailNotification={ setEnableEmailNotification }
+						defaultUserEmailAddresses={ defaultUserEmailAddresses }
+						toggleAddEmailModal={ toggleAddEmailModal }
+						allEmailItems={ allEmailItems }
+					/>
 				</div>
-
-				<div className="notification-settings__footer">
-					{ ( validationError || hasUnsavedChanges ) && (
-						<div className="notification-settings__footer-validation-error" role="alert">
-							{ hasUnsavedChanges
-								? translate( 'You have unsaved changes. Are you sure you want to close?' )
-								: validationError }
-						</div>
-					) }
-					<div className="notification-settings__footer-buttons">
-						<Button
-							onClick={ handleOnClose }
-							aria-label={ translate( 'Cancel and close notification settings popup' ) }
-						>
-							{ translate( 'Cancel' ) }
-						</Button>
-						<Button
-							disabled={
-								// Disable save button if there is no change and not bulk update
-								!! validationError || isLoading || ( ! isBulkUpdate && ! unsavedChangesExist )
-							}
-							type="submit"
-							primary
-							aria-label={ translate( 'Save notification settings' ) }
-						>
-							{ isLoading ? translate( 'Saving Changes' ) : translate( 'Save' ) }
-						</Button>
-					</div>
-				</div>
+				<NotificationSettingsFormFooter
+					isLoading={ isLoading }
+					validationError={ validationError }
+					isBulkUpdate={ isBulkUpdate }
+					handleOnClose={ handleOnClose }
+					hasUnsavedChanges={ hasUnsavedChanges }
+					unsavedChangesExist={ unsavedChangesExist }
+				/>
 			</form>
 		</Modal>
 	);


### PR DESCRIPTION
Related to 1204408201748644-as-1204740928923023

## Proposed Changes

This PR refactors the `NotificationSettings` component to have multiple smaller components.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Apply this D111846-code and sandbox the public API.
2. Run `git checkout update/refactor-notification-settings-component` and `yarn start-jetpack-cloud`.
3. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
4. Enable monitor if not enabled already.
5. Click on the clock icon next to the monitor toggle.
6. Verify everything works as expected. Since no change is done to the logic and only code refactoring, we just need to make sure the code changes looks good and a basic testing is good enough. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?