### PR TITLE
Import flow: Improve logic of showing loading screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -115,7 +115,6 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		}
 
 		function resetImportJob( job: ImportJob | undefined ): void {
-			dispatch( resetImportReceived() );
 			if ( ! job ) {
 				return;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -87,6 +87,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		useAtomicTransferQueryParamUpdate( siteId );
 		useEffect( fetchImporters, [ siteId ] );
 		useEffect( checkFromSiteData, [ fromSiteData?.url ] );
+		useEffect( () => onComponentUnmount, [] );
 
 		if ( ! importer ) {
 			stepNavigator.goToImportCapturePage?.();
@@ -99,6 +100,10 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		function onGoBack() {
 			resetImportJob( getImportJob( importer ) );
 			navigation.goBack?.();
+		}
+
+		function onComponentUnmount() {
+			dispatch( resetImportReceived() );
 		}
 
 		function fetchImporters() {


### PR DESCRIPTION
Related to #77719

## Proposed Changes

* Improved logic of showing loading screen fixing a moment of showing "NotFound" component

## Testing Instructions


https://github.com/Automattic/wp-calypso/assets/4074459/b89e22c6-8013-4841-84f7-4f06d943160c

See the demo video above. To reproduce this issue:
- Go to the site picker step and pick a site.
- Click the browser go back button, and pick another site.
- You'll see the Page not found component first, then wait a few seconds the page shows
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
