### PR TITLE
Analytics: Add prop to GA4 purchase event if purchasing yearly or higher WPcom plan

### DIFF
--- a/client/lib/analytics/utils/cart-to-ga-purchase.ts
+++ b/client/lib/analytics/utils/cart-to-ga-purchase.ts
@@ -62,6 +62,8 @@ export function cartToGaPurchase(
 		currency: 'USD', // we track all prices in USD
 		value,
 		items: items.map( ( product ) => productToGaItem( product, cart.currency ) ),
-		contains_yearly_or_higher_wpcom_plan: containsYearlyOrHigherWPcomPlan,
+		...( 'wpcom' === cartInfoType
+			? { contains_yearly_or_higher_wpcom_plan: containsYearlyOrHigherWPcomPlan }
+			: {} ),
 	};
 }

--- a/client/lib/analytics/utils/cart-to-ga-purchase.ts
+++ b/client/lib/analytics/utils/cart-to-ga-purchase.ts
@@ -9,6 +9,7 @@ export type GaPurchase = {
 	transaction_id: string;
 	coupon: string;
 	items: GaItem[];
+	contains_yearly_or_higher_wpcom_plan?: boolean;
 };
 
 const parseCartInfo = ( cartInfo: WpcomJetpackCartInfo ) => ( {
@@ -45,6 +46,15 @@ export function cartToGaPurchase(
 ): GaPurchase {
 	const cartInfoType = getCartInfoType( cartInfo );
 
+	// When using gtag.js, we can't access the `items` array to make custom events in GA4.
+	// To get around this limitation, we need to set this property on the top level purcahse object.
+	const containsYearlyOrHigherWPcomPlan = cartInfo.wpcomProducts?.some( ( product ) => {
+		if ( ! product.months_per_bill_period ) {
+			return false;
+		}
+		return product.months_per_bill_period >= 12;
+	} );
+
 	const { value, items } = parseCartInfo( cartInfo )[ cartInfoType ];
 	return {
 		transaction_id: orderId,
@@ -52,5 +62,6 @@ export function cartToGaPurchase(
 		currency: 'USD', // we track all prices in USD
 		value,
 		items: items.map( ( product ) => productToGaItem( product, cart.currency ) ),
+		contains_yearly_or_higher_wpcom_plan: containsYearlyOrHigherWPcomPlan,
 	};
 }


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/Martech#1754

## Proposed Changes

* When implementing GA4 via Gtag, we are not able to use custom conversions based on the `items` array, only the top-level cart. This is a limitation in Gtag (ref: https://support.google.com/analytics/answer/10085872?hl=en)
* There are two ways around this: we can either implement the whole conversion tracking in GTM, or we can add this prop to the top level of the cart.
* @robertsreberski  -- what do you think of this? It seems a bit hacky, e.g. if we want to add other conditions, and it's WPcom specific, and does not make sense for Akismet or Jetpack -- but it's important for a conversion test we're doing.

![Screenshot 2023-06-05 at 13 28 37](https://github.com/Automattic/wp-calypso/assets/52675688/9da2247b-9865-4931-ba90-8cc95ba1e6fc)

## Testing Instructions
* Ensure ad-tracking is enabled, either via a flag `?flags=ad-tracking` or by changing the values in your local `development.json` file.
* Store sandbox
* Either via the Google Analytics 4 debug view, or by setting a breakpoint before `recordOrderInWPcomGA4` returns, confirm that:
    * After purchasing a plan, the new prop `contains_yearly_or_higher_wpcom_plan` is visible, and it will return `false` for a monthly plan, and `true` for a yearly or higher (e.g. 2 or 3 year) plan. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
