### PR TITLE
Growth: Minimal stepper onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -1,7 +1,7 @@
 import {
 	DOMAIN_UPSELL_FLOW,
 	LINK_IN_BIO_TLD_FLOW,
-	ONBOARDING_PM_LOW,
+	ONBOARDING_PM_FLOW,
 } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isEmpty } from 'lodash';
@@ -200,7 +200,7 @@ export function DomainFormControl( {
 			return false;
 		}
 
-		return [ DOMAIN_UPSELL_FLOW, ONBOARDING_PM_LOW ].includes( flow );
+		return [ DOMAIN_UPSELL_FLOW, ONBOARDING_PM_FLOW ].includes( flow );
 	};
 
 	const renderDomainForm = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -1,4 +1,4 @@
-import { DOMAIN_UPSELL_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
+import { DOMAIN_UPSELL_FLOW, LINK_IN_BIO_TLD_FLOW, ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isEmpty } from 'lodash';
 import { useState } from 'react';
@@ -196,7 +196,7 @@ export function DomainFormControl( {
 			return false;
 		}
 
-		return [ DOMAIN_UPSELL_FLOW ].includes( flow );
+		return [ DOMAIN_UPSELL_FLOW, ONBOARDING_FLOW ].includes( flow );
 	};
 
 	const renderDomainForm = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -1,4 +1,8 @@
-import { DOMAIN_UPSELL_FLOW, LINK_IN_BIO_TLD_FLOW, ONBOARDING_FLOW } from '@automattic/onboarding';
+import {
+	DOMAIN_UPSELL_FLOW,
+	LINK_IN_BIO_TLD_FLOW,
+	ONBOARDING_PM_LOW,
+} from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isEmpty } from 'lodash';
 import { useState } from 'react';
@@ -196,7 +200,7 @@ export function DomainFormControl( {
 			return false;
 		}
 
-		return [ DOMAIN_UPSELL_FLOW, ONBOARDING_FLOW ].includes( flow );
+		return [ DOMAIN_UPSELL_FLOW, ONBOARDING_PM_LOW ].includes( flow );
 	};
 
 	const renderDomainForm = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -7,7 +7,7 @@ import {
 	isCopySiteFlow,
 	NEWSLETTER_FLOW,
 	DOMAIN_UPSELL_FLOW,
-	ONBOARDING_PM_LOW,
+	ONBOARDING_PM_FLOW,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -157,7 +157,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			case COPY_SITE_FLOW:
 				return __( 'Make your copied site unique with a custom domain all of its own.' );
 			case DOMAIN_UPSELL_FLOW:
-			case ONBOARDING_PM_LOW:
+			case ONBOARDING_PM_FLOW:
 				return __( 'Enter some descriptive keywords to get started' );
 			default:
 				return createInterpolateElement(
@@ -256,7 +256,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 	};
 
 	const shouldHideBackButton = () => {
-		if ( [ DOMAIN_UPSELL_FLOW, ONBOARDING_PM_LOW ].includes( flow ) ) {
+		if ( [ DOMAIN_UPSELL_FLOW, ONBOARDING_PM_FLOW ].includes( flow ) ) {
 			return false;
 		}
 		return ! isCopySiteFlow( flow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -7,7 +7,7 @@ import {
 	isCopySiteFlow,
 	NEWSLETTER_FLOW,
 	DOMAIN_UPSELL_FLOW,
-	ONBOARDING_FLOW,
+	ONBOARDING_PM_LOW,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -157,7 +157,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			case COPY_SITE_FLOW:
 				return __( 'Make your copied site unique with a custom domain all of its own.' );
 			case DOMAIN_UPSELL_FLOW:
-			case ONBOARDING_FLOW:
+			case ONBOARDING_PM_LOW:
 				return __( 'Enter some descriptive keywords to get started' );
 			default:
 				return createInterpolateElement(
@@ -256,7 +256,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 	};
 
 	const shouldHideBackButton = () => {
-		if ( [ DOMAIN_UPSELL_FLOW, ONBOARDING_FLOW ].includes( flow ) ) {
+		if ( [ DOMAIN_UPSELL_FLOW, ONBOARDING_PM_LOW ].includes( flow ) ) {
 			return false;
 		}
 		return ! isCopySiteFlow( flow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -7,6 +7,7 @@ import {
 	isCopySiteFlow,
 	NEWSLETTER_FLOW,
 	DOMAIN_UPSELL_FLOW,
+	ONBOARDING_FLOW,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -156,6 +157,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			case COPY_SITE_FLOW:
 				return __( 'Make your copied site unique with a custom domain all of its own.' );
 			case DOMAIN_UPSELL_FLOW:
+			case ONBOARDING_FLOW:
 				return __( 'Enter some descriptive keywords to get started' );
 			default:
 				return createInterpolateElement(
@@ -240,21 +242,21 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			return setShowUseYourDomain( false );
 		}
 
-		if ( flow === DOMAIN_UPSELL_FLOW ) {
+		if ( [ DOMAIN_UPSELL_FLOW, ONBOARDING_FLOW ].includes( flow ) ) {
 			return goBack?.();
 		}
 		return exitFlow?.( '/sites' );
 	};
 
 	const getBackLabelText = () => {
-		if ( flow === DOMAIN_UPSELL_FLOW ) {
+		if ( [ DOMAIN_UPSELL_FLOW, ONBOARDING_FLOW ].includes( flow ) ) {
 			return __( 'Back' );
 		}
 		return __( 'Back to sites' );
 	};
 
 	const shouldHideBackButton = () => {
-		if ( flow === DOMAIN_UPSELL_FLOW ) {
+		if ( [ DOMAIN_UPSELL_FLOW, ONBOARDING_FLOW ].includes( flow ) ) {
 			return false;
 		}
 		return ! isCopySiteFlow( flow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -242,14 +242,14 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			return setShowUseYourDomain( false );
 		}
 
-		if ( [ DOMAIN_UPSELL_FLOW, ONBOARDING_FLOW ].includes( flow ) ) {
+		if ( [ DOMAIN_UPSELL_FLOW ].includes( flow ) ) {
 			return goBack?.();
 		}
 		return exitFlow?.( '/sites' );
 	};
 
 	const getBackLabelText = () => {
-		if ( [ DOMAIN_UPSELL_FLOW, ONBOARDING_FLOW ].includes( flow ) ) {
+		if ( [ DOMAIN_UPSELL_FLOW ].includes( flow ) ) {
 			return __( 'Back' );
 		}
 		return __( 'Back to sites' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -244,7 +244,7 @@
 // Domain upsell flow
 
 .domain-upsell.domains,
-.onboarding-pm-dev.domains {
+.onboarding-media.domains {
 
 	$domain-stepper-component-width: 1040px;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -244,7 +244,7 @@
 // Domain upsell flow
 
 .domain-upsell.domains,
-.onboarding-pm.domains {
+.onboarding-pm-dev.domains {
 
 	$domain-stepper-component-width: 1040px;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -244,7 +244,7 @@
 // Domain upsell flow
 
 .domain-upsell.domains,
-.onboarding.domains {
+.onboarding-pm.domains {
 
 	$domain-stepper-component-width: 1040px;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -243,7 +243,8 @@
 
 // Domain upsell flow
 
-.domain-upsell.domains {
+.domain-upsell.domains,
+.onboarding.domains {
 
 	$domain-stepper-component-width: 1040px;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -2,7 +2,7 @@ import {
 	isBlogOnboardingFlow,
 	isDomainUpsellFlow,
 	isNewHostedSiteCreationFlow,
-	isOnboardingFlow,
+	isOnboardingPMFlow,
 	StepContainer,
 } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -18,14 +18,19 @@ const plans: Step = function Plans( { navigation, flow } ) {
 			plan,
 		};
 
-		if ( isDomainUpsellFlow( flow ) || isBlogOnboardingFlow( flow ) || isOnboardingFlow( flow ) ) {
+		if (
+			isDomainUpsellFlow( flow ) ||
+			isBlogOnboardingFlow( flow ) ||
+			isOnboardingPMFlow( flow )
+		) {
 			providedDependencies.goToCheckout = true;
 		}
 
 		submit?.( providedDependencies );
 	};
 
-	const isAllowedToGoBack = isDomainUpsellFlow( flow ) || isNewHostedSiteCreationFlow( flow );
+	const isAllowedToGoBack =
+		isOnboardingPMFlow( flow ) || isDomainUpsellFlow( flow ) || isNewHostedSiteCreationFlow( flow );
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -2,6 +2,7 @@ import {
 	isBlogOnboardingFlow,
 	isDomainUpsellFlow,
 	isNewHostedSiteCreationFlow,
+	isOnboardingFlow,
 	StepContainer,
 } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -17,7 +18,7 @@ const plans: Step = function Plans( { navigation, flow } ) {
 			plan,
 		};
 
-		if ( isDomainUpsellFlow( flow ) || isBlogOnboardingFlow( flow ) ) {
+		if ( isDomainUpsellFlow( flow ) || isBlogOnboardingFlow( flow ) || isOnboardingFlow( flow ) ) {
 			providedDependencies.goToCheckout = true;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -22,7 +22,7 @@ import {
 	isDomainUpsellFlow,
 	DESIGN_FIRST_FLOW,
 	isBlogOnboardingFlow,
-	isOnboardingFlow,
+	isOnboardingPMFlow,
 } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
@@ -188,7 +188,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		if (
 			flowName === DOMAIN_UPSELL_FLOW ||
 			isNewHostedSiteCreationFlow( flowName ) ||
-			isOnboardingFlow( flowName )
+			isOnboardingPMFlow( flowName )
 		) {
 			return __( 'Choose your flavor of WordPress' );
 		}
@@ -220,7 +220,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			isNewsletterFlow( flowName ) ||
 			isLinkInBioFlow( flowName ) ||
 			isDomainUpsellFlow( flowName ) ||
-			isOnboardingFlow( flowName )
+			isOnboardingPMFlow( flowName )
 		) {
 			return;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -22,6 +22,7 @@ import {
 	isDomainUpsellFlow,
 	DESIGN_FIRST_FLOW,
 	isBlogOnboardingFlow,
+	isOnboardingFlow,
 } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
@@ -184,7 +185,11 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 
 	const getHeaderText = () => {
 		const { flowName } = props;
-		if ( flowName === DOMAIN_UPSELL_FLOW || isNewHostedSiteCreationFlow( flowName ) ) {
+		if (
+			flowName === DOMAIN_UPSELL_FLOW ||
+			isNewHostedSiteCreationFlow( flowName ) ||
+			isOnboardingFlow( flowName )
+		) {
 			return __( 'Choose your flavor of WordPress' );
 		}
 
@@ -214,7 +219,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			isBlogOnboardingFlow( flowName ) ||
 			isNewsletterFlow( flowName ) ||
 			isLinkInBioFlow( flowName ) ||
-			isDomainUpsellFlow( flowName )
+			isDomainUpsellFlow( flowName ) ||
+			isOnboardingFlow( flowName )
 		) {
 			return;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -137,7 +137,7 @@
 
 // Onboarding flow
 
-.onboarding-pm.plans {
+.onboarding-media.plans {
 	.signup-header h1 {
 		display: none;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -135,6 +135,24 @@
 	}
 }
 
+// Onboarding flow
+
+.onboarding.plans {
+	.signup-header h1 {
+		display: none;
+	}
+
+	button.button.navigation-link.is-borderless {
+		background: none;
+		border: none;
+		color: var(--studio-gray-100);
+		font-size: 0.875rem;
+		font-weight: 600;
+		padding: 0;
+		text-decoration: none;
+	}
+}
+
 // Domain upsell flow
 
 .domain-upsell.plans {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -137,7 +137,7 @@
 
 // Onboarding flow
 
-.onboarding.plans {
+.onboarding-pm.plans {
 	.signup-header h1 {
 		display: none;
 	}

--- a/client/landing/stepper/declarative-flow/onboarding-pm.ts
+++ b/client/landing/stepper/declarative-flow/onboarding-pm.ts
@@ -1,6 +1,6 @@
 import { UserSelect } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
-import { ONBOARDING_PM_LOW, useFlowProgress } from '@automattic/onboarding';
+import { ONBOARDING_PM_FLOW, useFlowProgress } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import wpcom from 'calypso/lib/wp';
@@ -16,7 +16,7 @@ import { AssertConditionState, ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
 
 const onboarding: Flow = {
-	name: ONBOARDING_PM_LOW,
+	name: ONBOARDING_PM_FLOW,
 	useSteps() {
 		return [
 			{
@@ -38,7 +38,7 @@ const onboarding: Flow = {
 		];
 	},
 	useStepNavigation( currentStep, navigate ) {
-		const flowName = ONBOARDING_PM_LOW;
+		const flowName = ONBOARDING_PM_FLOW;
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: currentStep, flowName } );
 		const { domain, provider } = useDomainParams();
@@ -125,7 +125,7 @@ const onboarding: Flow = {
 		};
 	},
 	useAssertConditions() {
-		const flowName = ONBOARDING_PM_LOW;
+		const flowName = ONBOARDING_PM_FLOW;
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]

--- a/client/landing/stepper/declarative-flow/onboarding-pm.ts
+++ b/client/landing/stepper/declarative-flow/onboarding-pm.ts
@@ -1,5 +1,5 @@
 import { UserSelect } from '@automattic/data-stores';
-import { useLocale } from '@automattic/i18n-utils';
+import { useLocale, useLocalizeUrl } from '@automattic/i18n-utils';
 import { ONBOARDING_PM_FLOW, useFlowProgress } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -11,6 +11,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useDomainParams } from '../hooks/use-domain-params';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
+import { getLoginPath } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { AssertConditionState, ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
@@ -131,10 +132,13 @@ const onboarding: Flow = {
 			[]
 		);
 		const locale = useLocale();
-		const logInUrl =
-			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?redirect_to=/setup/${ flowName }`
-				: `/start/account/user?redirect_to=/setup/${ flowName }`;
+		const localizeUrl = useLocalizeUrl();
+
+		const logInUrl = localizeUrl(
+			getLoginPath( `/setup/${ flowName }/`, 'Onboarding', flowName, `/start/${ flowName }` ),
+			locale,
+			userIsLoggedIn
+		);
 
 		if ( ! userIsLoggedIn ) {
 			window.location.assign( logInUrl );

--- a/client/landing/stepper/declarative-flow/onboarding-pm.ts
+++ b/client/landing/stepper/declarative-flow/onboarding-pm.ts
@@ -2,7 +2,6 @@ import { UserSelect } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { ONBOARDING_PM_LOW, useFlowProgress } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import {
 	persistSignupDestination,
@@ -17,9 +16,6 @@ import type { Flow } from './internals/types';
 
 const onboarding: Flow = {
 	name: ONBOARDING_PM_LOW,
-	get title() {
-		return translate( 'Onboarding' );
-	},
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/onboarding-pm.ts
+++ b/client/landing/stepper/declarative-flow/onboarding-pm.ts
@@ -1,6 +1,6 @@
 import { UserSelect } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
-import { ONBOARDING_FLOW, useFlowProgress } from '@automattic/onboarding';
+import { ONBOARDING_PM_LOW, useFlowProgress } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
@@ -17,7 +17,7 @@ import { AssertConditionState, ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
 
 const onboarding: Flow = {
-	name: ONBOARDING_FLOW,
+	name: ONBOARDING_PM_LOW,
 	get title() {
 		return translate( 'Onboarding' );
 	},
@@ -42,7 +42,7 @@ const onboarding: Flow = {
 		];
 	},
 	useStepNavigation( currentStep, navigate ) {
-		const flowName = ONBOARDING_FLOW;
+		const flowName = ONBOARDING_PM_LOW;
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: currentStep, flowName } );
 		const { domain, provider } = useDomainParams();
@@ -122,7 +122,7 @@ const onboarding: Flow = {
 		};
 	},
 	useAssertConditions() {
-		const flowName = ONBOARDING_FLOW;
+		const flowName = ONBOARDING_PM_LOW;
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]

--- a/client/landing/stepper/declarative-flow/onboarding-pm.ts
+++ b/client/landing/stepper/declarative-flow/onboarding-pm.ts
@@ -134,6 +134,7 @@ const onboarding: Flow = {
 			flowName,
 			redirectTo: `/setup/${ flowName }`,
 			pageTitle: 'Onboarding',
+			loginPath: `/start/${ flowName }/`,
 		} );
 
 		if ( ! userIsLoggedIn ) {

--- a/client/landing/stepper/declarative-flow/onboarding-pm.ts
+++ b/client/landing/stepper/declarative-flow/onboarding-pm.ts
@@ -5,7 +5,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import {
-	clearSignupDestinationCookie,
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 	setSignupCompleteSlug,

--- a/client/landing/stepper/declarative-flow/onboarding-pm.ts
+++ b/client/landing/stepper/declarative-flow/onboarding-pm.ts
@@ -2,6 +2,7 @@ import { UserSelect } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { ONBOARDING_PM_LOW, useFlowProgress } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import wpcom from 'calypso/lib/wp';
 import {
 	persistSignupDestination,
@@ -87,27 +88,29 @@ const onboarding: Flow = {
 					return;
 				case 'processing': {
 					// clearSignupDestinationCookie();
-					if ( providedDependencies?.goToCheckout ) {
-						const destination = `/setup/site-setup/goals?siteSlug=${ providedDependencies.siteSlug }&notice=purchase-success`;
-						const returnUrl = encodeURIComponent( destination );
+					const destination = addQueryArgs( '/setup/site-setup/goals', {
+						siteSlug: providedDependencies.siteSlug,
+					} );
 
-						persistSignupDestination( destination ); // not sure if this is needed
-						setSignupCompleteSlug( providedDependencies?.siteSlug );
-						setSignupCompleteFlowName( flowName );
+					persistSignupDestination( destination ); // not sure if this is needed
+					setSignupCompleteSlug( providedDependencies.siteSlug );
+					setSignupCompleteFlowName( flowName );
+
+					if ( providedDependencies.goToCheckout ) {
+						const returnUrl = addQueryArgs( destination, { notice: 'purchase-success' } );
 
 						window.location.assign(
-							`/checkout/${ encodeURIComponent(
-								( providedDependencies?.siteSlug as string ) ?? ''
-							) }?redirect_to=${ returnUrl }&signup=1`
+							addQueryArgs(
+								`/checkout/${ encodeURIComponent(
+									( providedDependencies.siteSlug as string ) ?? ''
+								) }`,
+								{ redirect_to: returnUrl, signup: 1 }
+							)
 						);
 						return;
 					}
 
-					window.location.assign(
-						`/setup/site-setup/goals?siteSlug=${
-							encodeURIComponent( providedDependencies?.siteSlug as string ) ?? ''
-						}`
-					);
+					window.location.assign( destination );
 					return;
 				}
 			}

--- a/client/landing/stepper/declarative-flow/onboarding-pm.ts
+++ b/client/landing/stepper/declarative-flow/onboarding-pm.ts
@@ -1,5 +1,4 @@
 import { UserSelect } from '@automattic/data-stores';
-import { useLocale, useLocalizeUrl } from '@automattic/i18n-utils';
 import { ONBOARDING_PM_FLOW, useFlowProgress } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -11,7 +10,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useDomainParams } from '../hooks/use-domain-params';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
-import { getLoginPath } from '../utils/path';
+import { useLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { AssertConditionState, ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
@@ -131,14 +130,11 @@ const onboarding: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
-		const locale = useLocale();
-		const localizeUrl = useLocalizeUrl();
-
-		const logInUrl = localizeUrl(
-			getLoginPath( `/setup/${ flowName }/`, 'Onboarding', flowName, `/start/${ flowName }` ),
-			locale,
-			userIsLoggedIn
-		);
+		const logInUrl = useLoginUrl( {
+			flowName,
+			redirectTo: `/setup/${ flowName }`,
+			pageTitle: 'Onboarding',
+		} );
 
 		if ( ! userIsLoggedIn ) {
 			window.location.assign( logInUrl );

--- a/client/landing/stepper/declarative-flow/onboarding-pm.ts
+++ b/client/landing/stepper/declarative-flow/onboarding-pm.ts
@@ -80,12 +80,15 @@ const onboarding: Flow = {
 
 			switch ( currentStep ) {
 				case 'domains':
-					return navigate( 'plans' );
+					navigate( 'plans' );
+					return;
 				case 'plans':
-					return navigate( 'siteCreationStep' );
+					navigate( 'siteCreationStep' );
+					return;
 				case 'siteCreationStep':
 					// clearSignupDestinationCookie(); // not sure if this is needed and if it is, where it should go
-					return navigate( 'processing' );
+					navigate( 'processing' );
+					return;
 				case 'processing': {
 					// clearSignupDestinationCookie();
 					if ( providedDependencies?.goToCheckout ) {
@@ -96,18 +99,20 @@ const onboarding: Flow = {
 						setSignupCompleteSlug( providedDependencies?.siteSlug );
 						setSignupCompleteFlowName( flowName );
 
-						return window.location.assign(
+						window.location.assign(
 							`/checkout/${ encodeURIComponent(
 								( providedDependencies?.siteSlug as string ) ?? ''
 							) }?redirect_to=${ returnUrl }&signup=1`
 						);
+						return;
 					}
 
-					return window.location.assign(
+					window.location.assign(
 						`/setup/site-setup/goals?siteSlug=${
 							encodeURIComponent( providedDependencies?.siteSlug as string ) ?? ''
 						}`
 					);
+					return;
 				}
 			}
 

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -2,7 +2,6 @@ import { UserSelect } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { ONBOARDING_FLOW, useFlowProgress } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import {
 	clearSignupDestinationCookie,
@@ -19,9 +18,6 @@ import type { Flow } from './internals/types';
 
 const onboarding: Flow = {
 	name: ONBOARDING_FLOW,
-	get title() {
-		return translate( 'Onboarding' );
-	},
 	useSteps() {
 		return [
 			{
@@ -90,7 +86,7 @@ const onboarding: Flow = {
 					return navigate( 'processing' );
 				case 'processing': {
 					clearSignupDestinationCookie();
-					const destination = `/domains/mapping/${ providedDependencies.siteSlug }/setup/${ domain }?firstVisit=true`;
+					const destination = `/setup/site-setup/goals?siteSlug=${ providedDependencies.siteSlug }&notice=purchase-success`;
 					const returnUrl = encodeURIComponent( destination );
 
 					persistSignupDestination( destination ); // not sure if this is needed

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,0 +1,142 @@
+import { UserSelect } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
+import { ONBOARDING_FLOW, useFlowProgress } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
+import wpcom from 'calypso/lib/wp';
+import {
+	clearSignupDestinationCookie,
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+	setSignupCompleteSlug,
+} from 'calypso/signup/storageUtils';
+import { useDomainParams } from '../hooks/use-domain-params';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { ONBOARD_STORE, USER_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { AssertConditionState, ProvidedDependencies } from './internals/types';
+import type { Flow } from './internals/types';
+
+const onboarding: Flow = {
+	name: ONBOARDING_FLOW,
+	get title() {
+		return translate( 'Onboarding' );
+	},
+	useSteps() {
+		return [
+			{
+				slug: 'domains',
+				asyncComponent: () => import( './internals/steps-repository/domains' ),
+			},
+			{
+				slug: 'plans',
+				asyncComponent: () => import( './internals/steps-repository/plans' ),
+			},
+			{
+				slug: 'siteCreationStep',
+				asyncComponent: () => import( './internals/steps-repository/site-creation-step' ),
+			},
+			{
+				slug: 'processing',
+				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
+			},
+		];
+	},
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = ONBOARDING_FLOW;
+		const siteSlug = useSiteSlug();
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: currentStep, flowName } );
+		const { domain, provider } = useDomainParams();
+
+		setStepProgress( flowProgress );
+
+		// trigger guides on step movement, we don't care about failures or response
+		wpcom.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: flowName,
+				step: currentStep,
+			}
+		);
+
+		function goBack() {
+			if ( 'domains' === currentStep ) {
+				return window.location.assign(
+					encodeURIComponent( `/setup/${ flowName }/launchpad?siteSlug=${ siteSlug }` )
+				);
+			}
+			if ( 'plans' === currentStep ) {
+				navigate( 'domains' );
+			}
+		}
+
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, '', flowName, currentStep, undefined, {
+				provider,
+				domain,
+			} );
+
+			switch ( currentStep ) {
+				case 'domains':
+					return navigate( 'plans' );
+				case 'plans':
+					return navigate( 'siteCreationStep' );
+				case 'siteCreationStep':
+					clearSignupDestinationCookie(); // not sure if this is needed and if it is, where it should go
+					return navigate( 'processing' );
+				case 'processing': {
+					clearSignupDestinationCookie();
+					const destination = `/domains/mapping/${ providedDependencies.siteSlug }/setup/${ domain }?firstVisit=true`;
+					const returnUrl = encodeURIComponent( destination );
+
+					persistSignupDestination( destination ); // not sure if this is needed
+					setSignupCompleteSlug( providedDependencies?.siteSlug );
+					setSignupCompleteFlowName( flowName );
+
+					return window.location.assign(
+						`/checkout/${ encodeURIComponent(
+							( providedDependencies?.siteSlug as string ) ?? ''
+						) }?redirect_to=${ returnUrl }&signup=1`
+					);
+				}
+			}
+
+			return providedDependencies;
+		}
+
+		return {
+			submit,
+			goBack,
+		};
+	},
+	useAssertConditions() {
+		const flowName = ONBOARDING_FLOW;
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+		const locale = useLocale();
+		const logInUrl =
+			locale && locale !== 'en'
+				? `/start/account/user/${ locale }?redirect_to=/setup/${ flowName }`
+				: `/start/account/user?redirect_to=/setup/${ flowName }`;
+
+		if ( ! userIsLoggedIn ) {
+			window.location.assign( logInUrl );
+
+			return {
+				state: AssertConditionState.FAILURE,
+			};
+		}
+
+		return {
+			state: AssertConditionState.SUCCESS,
+		};
+	},
+};
+
+export default onboarding;

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -2,6 +2,7 @@ import { UserSelect } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { ONBOARDING_FLOW, useFlowProgress } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import {
 	clearSignupDestinationCookie,
@@ -10,7 +11,6 @@ import {
 	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
 import { useDomainParams } from '../hooks/use-domain-params';
-import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { AssertConditionState, ProvidedDependencies } from './internals/types';
@@ -18,6 +18,9 @@ import type { Flow } from './internals/types';
 
 const onboarding: Flow = {
 	name: ONBOARDING_FLOW,
+	get title() {
+		return translate( 'Onboarding' );
+	},
 	useSteps() {
 		return [
 			{
@@ -40,7 +43,6 @@ const onboarding: Flow = {
 	},
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = ONBOARDING_FLOW;
-		const siteSlug = useSiteSlug();
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: currentStep, flowName } );
 		const { domain, provider } = useDomainParams();
@@ -59,12 +61,13 @@ const onboarding: Flow = {
 			}
 		);
 
+		// DomainsStep apparently has a default behavior for the back button to exit the flow `to` "/sites" page
+		// It can also be overriden via the `goBack` prop below
+		function exitFlow( to: string ) {
+			window.location.assign( to );
+		}
+
 		function goBack() {
-			if ( 'domains' === currentStep ) {
-				return window.location.assign(
-					encodeURIComponent( `/setup/${ flowName }/launchpad?siteSlug=${ siteSlug }` )
-				);
-			}
 			if ( 'plans' === currentStep ) {
 				navigate( 'domains' );
 			}
@@ -107,6 +110,7 @@ const onboarding: Flow = {
 		return {
 			submit,
 			goBack,
+			exitFlow,
 		};
 	},
 	useAssertConditions() {

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -85,21 +85,29 @@ const onboarding: Flow = {
 				case 'plans':
 					return navigate( 'siteCreationStep' );
 				case 'siteCreationStep':
-					clearSignupDestinationCookie(); // not sure if this is needed and if it is, where it should go
+					// clearSignupDestinationCookie(); // not sure if this is needed and if it is, where it should go
 					return navigate( 'processing' );
 				case 'processing': {
-					clearSignupDestinationCookie();
-					const destination = `/setup/site-setup/goals?siteSlug=${ providedDependencies.siteSlug }&notice=purchase-success`;
-					const returnUrl = encodeURIComponent( destination );
+					// clearSignupDestinationCookie();
+					if ( providedDependencies?.goToCheckout ) {
+						const destination = `/setup/site-setup/goals?siteSlug=${ providedDependencies.siteSlug }&notice=purchase-success`;
+						const returnUrl = encodeURIComponent( destination );
 
-					persistSignupDestination( destination ); // not sure if this is needed
-					setSignupCompleteSlug( providedDependencies?.siteSlug );
-					setSignupCompleteFlowName( flowName );
+						persistSignupDestination( destination ); // not sure if this is needed
+						setSignupCompleteSlug( providedDependencies?.siteSlug );
+						setSignupCompleteFlowName( flowName );
+
+						return window.location.assign(
+							`/checkout/${ encodeURIComponent(
+								( providedDependencies?.siteSlug as string ) ?? ''
+							) }?redirect_to=${ returnUrl }&signup=1`
+						);
+					}
 
 					return window.location.assign(
-						`/checkout/${ encodeURIComponent(
-							( providedDependencies?.siteSlug as string ) ?? ''
-						) }?redirect_to=${ returnUrl }&signup=1`
+						`/setup/site-setup/goals?siteSlug=${
+							encodeURIComponent( providedDependencies?.siteSlug as string ) ?? ''
+						}`
 					);
 				}
 			}

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -8,7 +8,7 @@ import {
 	TRANSFERRING_HOSTED_SITE_FLOW,
 	IMPORT_HOSTED_SITE_FLOW,
 	BULK_DOMAIN_TRANSFER,
-	ONBOARDING_PM_LOW,
+	ONBOARDING_PM_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -103,7 +103,7 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 		),
 	[ IMPORT_HOSTED_SITE_FLOW ]: () =>
 		import( /* webpackChunkName: "import-hosted-site-flow" */ './import-hosted-site' ),
-	[ ONBOARDING_PM_LOW ]: () =>
+	[ ONBOARDING_PM_FLOW ]: () =>
 		import( /* webpackChunkName: "new-hosted-site-flow" */ './onboarding-pm' ),
 };
 

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -8,6 +8,7 @@ import {
 	TRANSFERRING_HOSTED_SITE_FLOW,
 	IMPORT_HOSTED_SITE_FLOW,
 	BULK_DOMAIN_TRANSFER,
+	ONBOARDING_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -102,6 +103,8 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 		),
 	[ IMPORT_HOSTED_SITE_FLOW ]: () =>
 		import( /* webpackChunkName: "import-hosted-site-flow" */ './import-hosted-site' ),
+	[ ONBOARDING_FLOW ]: () =>
+		import( /* webpackChunkName: "new-hosted-site-flow" */ './onboarding' ),
 };
 
 availableFlows[ 'plugin-bundle' ] = () =>

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -8,7 +8,7 @@ import {
 	TRANSFERRING_HOSTED_SITE_FLOW,
 	IMPORT_HOSTED_SITE_FLOW,
 	BULK_DOMAIN_TRANSFER,
-	ONBOARDING_FLOW,
+	ONBOARDING_PM_LOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -103,8 +103,8 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 		),
 	[ IMPORT_HOSTED_SITE_FLOW ]: () =>
 		import( /* webpackChunkName: "import-hosted-site-flow" */ './import-hosted-site' ),
-	[ ONBOARDING_FLOW ]: () =>
-		import( /* webpackChunkName: "new-hosted-site-flow" */ './onboarding' ),
+	[ ONBOARDING_PM_LOW ]: () =>
+		import( /* webpackChunkName: "new-hosted-site-flow" */ './onboarding-pm' ),
 };
 
 availableFlows[ 'plugin-bundle' ] = () =>

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -23,7 +23,7 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 	}, [] );
 
 	return useCallback( () => {
-		// FIXME: once moving to the Stepper verion of User step,
+		// FIXME: once moving to the Stepper version of User step,
 		// wire the value of `isNewUser()` from the user store.
 		const isNewUser = ! siteCount;
 

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -48,11 +48,12 @@ export const useLoginUrl = ( params: {
 	flowName?: string;
 	redirectTo?: string;
 	pageTitle?: string;
+	loginPath?: string;
 } ): string => {
 	const locale = useLocale();
 
-	const loginPath =
-		locale && locale !== 'en' ? `/start/account/user/${ locale }` : `/start/account/user`;
+	const loginPath = params.loginPath ?? `/start/account/user/`;
+	const localizedLoginPath = locale && locale !== 'en' ? `${ loginPath }${ locale }` : loginPath;
 
 	const nonEmptyQueryParameters = Object.entries( params )
 		.filter( ( [ , value ] ) => value )
@@ -69,5 +70,5 @@ export const useLoginUrl = ( params: {
 
 	nonEmptyQueryParameters.push( [ 'toStepper', 'true' ] );
 
-	return addQueryArgs( loginPath, Object.fromEntries( nonEmptyQueryParameters ) );
+	return addQueryArgs( localizedLoginPath, Object.fromEntries( nonEmptyQueryParameters ) );
 };

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -149,6 +149,17 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
+			name: 'onboarding-pm-dev',
+			steps: [ 'user' ],
+			destination: getRedirectDestination,
+			description:
+				'The intermittent user step for the GF foundation version of the paid media flow.',
+			lastModified: '2023-06/17',
+			showRecaptcha: true,
+			providesDependenciesInQuery: [ 'toStepper' ],
+			optionalDependenciesInQuery: [ 'toStepper' ],
+		},
+		{
 			name: 'import',
 			steps: [ 'user', 'domains', 'plans-import' ],
 			destination: ( dependencies ) =>

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -149,7 +149,7 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
-			name: 'onboarding-pm-dev',
+			name: 'onboarding-media',
 			steps: [ 'user' ],
 			destination: getRedirectDestination,
 			description:

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -185,7 +185,7 @@
 		"onboarding",
 		"onboarding-with-email",
 		"onboarding-pm",
-		"onboarding-pm-dev",
+		"onboarding-media",
 		"with-add-ons",
 		"newsletter",
 		"setup-site",

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -185,6 +185,7 @@
 		"onboarding",
 		"onboarding-with-email",
 		"onboarding-pm",
+		"onboarding-pm-dev",
 		"with-add-ons",
 		"newsletter",
 		"setup-site",

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -5,6 +5,7 @@ import {
 	LINK_IN_BIO_TLD_FLOW,
 	FREE_FLOW,
 	COPY_SITE_FLOW,
+	ONBOARDING_PM_FLOW,
 } from '../utils/flows';
 
 /* eslint-disable no-restricted-imports */
@@ -88,6 +89,11 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		processing: 2,
 		'automated-copy': 3,
 		'processing-copy': 3,
+	},
+	[ ONBOARDING_PM_FLOW ]: {
+		user: 0,
+		domains: 1,
+		plans: 2,
 	},
 };
 

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -27,7 +27,11 @@ export const WITH_THEME_FLOW = 'with-theme';
 export const WITH_THEME_ASSEMBLER_FLOW = 'with-theme-assembler';
 export const UPDATE_DESIGN_FLOW = 'update-design';
 export const DOMAIN_UPSELL_FLOW = 'domain-upsell';
-export const ONBOARDING_PM_FLOW = 'onboarding-pm';
+export const BULK_DOMAIN_TRANSFER = 'bulk-domain-transfer';
+
+// TODO:
+// Once it is finalized, update it to just `onboarding-pm`
+export const ONBOARDING_PM_FLOW = 'onboarding-pm-dev';
 export const isOnboardingPMFlow = ( flowName: string | null | undefined ) => {
 	return Boolean( flowName && [ ONBOARDING_PM_FLOW ].includes( flowName ) );
 };

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -27,9 +27,9 @@ export const WITH_THEME_FLOW = 'with-theme';
 export const WITH_THEME_ASSEMBLER_FLOW = 'with-theme-assembler';
 export const UPDATE_DESIGN_FLOW = 'update-design';
 export const DOMAIN_UPSELL_FLOW = 'domain-upsell';
-export const ONBOARDING_PM_LOW = 'onboarding-pm';
+export const ONBOARDING_PM_FLOW = 'onboarding-pm';
 export const isOnboardingPMFlow = ( flowName: string | null | undefined ) => {
-	return Boolean( flowName && [ ONBOARDING_PM_LOW ].includes( flowName ) );
+	return Boolean( flowName && [ ONBOARDING_PM_FLOW ].includes( flowName ) );
 };
 export const isLinkInBioFlow = ( flowName: string | null | undefined ) => {
 	return Boolean(

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -29,6 +29,10 @@ export const UPDATE_DESIGN_FLOW = 'update-design';
 export const DOMAIN_UPSELL_FLOW = 'domain-upsell';
 export const BULK_DOMAIN_TRANSFER = 'bulk-domain-transfer';
 
+export const ONBOARDING_FLOW = 'onboarding';
+export const isOnboardingFlow = ( flowName: string | null | undefined ) => {
+	return Boolean( flowName && [ ONBOARDING_FLOW ].includes( flowName ) );
+};
 export const isLinkInBioFlow = ( flowName: string | null | undefined ) => {
 	return Boolean(
 		flowName &&

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -27,11 +27,9 @@ export const WITH_THEME_FLOW = 'with-theme';
 export const WITH_THEME_ASSEMBLER_FLOW = 'with-theme-assembler';
 export const UPDATE_DESIGN_FLOW = 'update-design';
 export const DOMAIN_UPSELL_FLOW = 'domain-upsell';
-export const BULK_DOMAIN_TRANSFER = 'bulk-domain-transfer';
-
-export const ONBOARDING_FLOW = 'onboarding';
-export const isOnboardingFlow = ( flowName: string | null | undefined ) => {
-	return Boolean( flowName && [ ONBOARDING_FLOW ].includes( flowName ) );
+export const ONBOARDING_PM_LOW = 'onboarding-pm';
+export const isOnboardingPMFlow = ( flowName: string | null | undefined ) => {
+	return Boolean( flowName && [ ONBOARDING_PM_LOW ].includes( flowName ) );
 };
 export const isLinkInBioFlow = ( flowName: string | null | undefined ) => {
 	return Boolean(

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -31,7 +31,7 @@ export const BULK_DOMAIN_TRANSFER = 'bulk-domain-transfer';
 export const ONBOARDING_PM_FLOW = 'onboarding-media';
 
 export const isOnboardingPMFlow = ( flowName: string | null | undefined ) => {
-	return Boolean( flowName && [ ONBOARDING_PM_FLOW ].includes( flowName ) );
+	return Boolean( flowName && flowName === ONBOARDING_PM_FLOW );
 };
 export const isLinkInBioFlow = ( flowName: string | null | undefined ) => {
 	return Boolean(

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -28,10 +28,8 @@ export const WITH_THEME_ASSEMBLER_FLOW = 'with-theme-assembler';
 export const UPDATE_DESIGN_FLOW = 'update-design';
 export const DOMAIN_UPSELL_FLOW = 'domain-upsell';
 export const BULK_DOMAIN_TRANSFER = 'bulk-domain-transfer';
+export const ONBOARDING_PM_FLOW = 'onboarding-media';
 
-// TODO:
-// Once it is finalized, update it to just `onboarding-pm`
-export const ONBOARDING_PM_FLOW = 'onboarding-pm-dev';
 export const isOnboardingPMFlow = ( flowName: string | null | undefined ) => {
 	return Boolean( flowName && [ ONBOARDING_PM_FLOW ].includes( flowName ) );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/growth-foundations#70

## Proposed Changes

Adds a minimal `/setup/onboarding-pm-dev` flow that should be identical to `/start` -> with "log in", "domains", "plans", "checkout", steps.

### Not covered under this PR

- Update the term toggle to 1y/2y
-  Processing step: the progress bar is not filled-up properly
-  Processing step: the progress bar should attach to the top as https://github.com/Automattic/wp-calypso/pull/77801#discussion_r1226681785 said
-  In the main onboarding flow, there is a Business upsell shown after picking the Premium plan. We should replicate that here.
-  Confirm that is_domain_mapping and is_domain_transfer are properly set for calypso_signup_completion event.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding-pm-dev` and confirm the flow end to end. It should behave identically to `/start`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
