### PR TITLE
Import flow: Migration handler improvement

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -5,8 +5,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import useAddTempSiteToSourceOptionMutation from 'calypso/data/site-migration/use-add-temp-site-mutation';
 import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
-import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
-import { SITE_PICKER_FILTER_CONFIG } from 'calypso/landing/stepper/constants';
 import MigrationError from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/migration-error';
 import { ProcessingResult } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/processing-step/constants';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -62,7 +60,6 @@ const importFlow: Flow = {
 
 	useStepNavigation( _currentStep, navigate ) {
 		const { setStepProgress, setPendingAction } = useDispatch( ONBOARD_STORE );
-		const { data: sites } = useSiteExcerptsQuery( SITE_PICKER_FILTER_CONFIG );
 		const { addTempSiteToSourceOption } = useAddTempSiteToSourceOptionMutation();
 		const urlQueryParams = useQuery();
 		const fromParam = urlQueryParams.get( 'from' );
@@ -97,7 +94,7 @@ const importFlow: Flow = {
 		};
 
 		const handleMigrationRedirects = ( providedDependencies: ProvidedDependencies = {} ) => {
-			const userHasSite = sites && sites.length > 0;
+			const { userHasSite } = providedDependencies;
 
 			if ( providedDependencies?.status === 'inactive' ) {
 				// This means they haven't kick off the migration before, so we send them to select/create a new site

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -6,6 +6,8 @@ import NotAuthorized from 'calypso/blocks/importer/components/not-authorized';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
+import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
+import { SITE_PICKER_FILTER_CONFIG } from 'calypso/landing/stepper/constants';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -28,6 +30,7 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 	const onSourceMigrationStatusError = () => {
 		setIsUnAuthorized( true );
 	};
+	const { data: sites } = useSiteExcerptsQuery( SITE_PICKER_FILTER_CONFIG );
 	const { data: sourceSiteMigrationStatus, isError: isErrorSourceSiteMigrationStatus } =
 		useSourceMigrationStatusQuery( sourceSiteSlug, onSourceMigrationStatusError );
 
@@ -37,7 +40,7 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 	}, [] );
 
 	useEffect( () => {
-		if ( ! submit || ! sourceSiteMigrationStatus || isErrorSourceSiteMigrationStatus ) {
+		if ( ! submit || ! sourceSiteMigrationStatus || isErrorSourceSiteMigrationStatus || ! sites ) {
 			return;
 		}
 
@@ -48,8 +51,9 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 			isAdminOnTarget: sourceSiteMigrationStatus?.is_target_blog_admin,
 			isTargetBlogUpgraded: sourceSiteMigrationStatus?.is_target_blog_upgraded,
 			targetBlogSlug: sourceSiteMigrationStatus?.target_blog_slug,
+			userHasSite: sites && sites.length > 0,
 		} );
-	}, [ isErrorSourceSiteMigrationStatus, sourceSiteMigrationStatus ] );
+	}, [ isErrorSourceSiteMigrationStatus, sourceSiteMigrationStatus, sites ] );
 
 	const getCurrentMessage = () => {
 		return __( 'Scanning your site' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -37,22 +37,18 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 	}, [] );
 
 	useEffect( () => {
-		if ( submit ) {
-			if ( isErrorSourceSiteMigrationStatus ) {
-				return;
-			}
-			if ( sourceSiteMigrationStatus ) {
-				submit( {
-					isFromMigrationPlugin: true,
-					status: sourceSiteMigrationStatus?.status,
-					targetBlogId: sourceSiteMigrationStatus?.target_blog_id,
-					isAdminOnTarget: sourceSiteMigrationStatus?.is_target_blog_admin,
-					isTargetBlogUpgraded: sourceSiteMigrationStatus?.is_target_blog_upgraded,
-					targetBlogSlug: sourceSiteMigrationStatus?.target_blog_slug,
-				} );
-			}
+		if ( ! submit || ! sourceSiteMigrationStatus || isErrorSourceSiteMigrationStatus ) {
+			return;
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+
+		submit( {
+			isFromMigrationPlugin: true,
+			status: sourceSiteMigrationStatus?.status,
+			targetBlogId: sourceSiteMigrationStatus?.target_blog_id,
+			isAdminOnTarget: sourceSiteMigrationStatus?.is_target_blog_admin,
+			isTargetBlogUpgraded: sourceSiteMigrationStatus?.is_target_blog_upgraded,
+			targetBlogSlug: sourceSiteMigrationStatus?.target_blog_slug,
+		} );
 	}, [ isErrorSourceSiteMigrationStatus, sourceSiteMigrationStatus ] );
 
 	const getCurrentMessage = () => {


### PR DESCRIPTION
Related to #77783

## Proposed Changes

* Fixed race condition case when the sites object is empty initially. More info: #77783
* `userHasSite` checking logic has been moved from the import `flow` file to the `migrationHandler` step

## Testing Instructions
- Create a JN site
- Install the Move to WordPress.com plugin
- Press the "Getting started" button
- Check if you end up with sitePicker instead of Site creation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
