### PR TITLE
Help Center AI quick answers: log the answer source in tracks

### DIFF
--- a/packages/data-stores/src/queries/use-jetpack-search-ai.ts
+++ b/packages/data-stores/src/queries/use-jetpack-search-ai.ts
@@ -24,6 +24,7 @@ export type JetpackSearchAIResult = {
 	step: string;
 	urls: AIResponseURL[];
 	terms: string[];
+	source: null | string;
 };
 
 export function useJetpackSearchAIQuery( config: JetpackSearchAIConfig ) {

--- a/packages/data-stores/src/queries/use-jetpack-search-ai.ts
+++ b/packages/data-stores/src/queries/use-jetpack-search-ai.ts
@@ -24,7 +24,7 @@ export type JetpackSearchAIResult = {
 	step: string;
 	urls: AIResponseURL[];
 	terms: string[];
-	source: null | string;
+	source: string;
 };
 
 export function useJetpackSearchAIQuery( config: JetpackSearchAIConfig ) {
@@ -48,5 +48,8 @@ export function useJetpackSearchAIQuery( config: JetpackSearchAIConfig ) {
 		keepPreviousData: false,
 		enabled: config.enabled && !! config.query,
 		retry: false,
+		select: ( data ) => {
+			return { ...data, source: data.source ?? 'sitebot' };
+		},
 	} );
 }

--- a/packages/help-center/src/components/help-center-gpt.tsx
+++ b/packages/help-center/src/components/help-center-gpt.tsx
@@ -82,6 +82,7 @@ export function HelpCenterGPT() {
 		if ( data?.response ) {
 			recordTracksEvent( 'calypso_helpcenter_show_gpt_response', {
 				location: 'help-center',
+				answer_source: data?.source ?? 'sitebot',
 			} );
 		}
 	}, [ data ] );
@@ -101,17 +102,19 @@ export function HelpCenterGPT() {
 		delayBetweenWords: 1400,
 	} );
 
-	const doThumbsUp = () => {
+	const doThumbsUp = ( source: string ) => {
 		setFeedbackGiven( true );
 		recordTracksEvent( 'calypso_helpcenter_gpt_response_thumbs_up', {
 			location: 'help-center',
+			answer_source: source,
 		} );
 	};
 
-	const doThumbsDown = () => {
+	const doThumbsDown = ( source: string ) => {
 		setFeedbackGiven( true );
 		recordTracksEvent( 'calypso_helpcenter_gpt_response_thumbs_down', {
 			location: 'help-center',
+			answer_source: source,
 		} );
 	};
 
@@ -175,8 +178,12 @@ export function HelpCenterGPT() {
 										</div>
 									) : (
 										<>
-											<Button onClick={ doThumbsUp }>&#128077;</Button>
-											<Button onClick={ doThumbsDown }>&#128078;</Button>
+											<Button onClick={ () => doThumbsUp( data?.source ?? 'sitebot' ) }>
+												&#128077;
+											</Button>
+											<Button onClick={ () => doThumbsDown( data?.source ?? 'sitebot' ) }>
+												&#128078;
+											</Button>
 										</>
 									) }
 								</div>

--- a/packages/help-center/src/components/help-center-gpt.tsx
+++ b/packages/help-center/src/components/help-center-gpt.tsx
@@ -82,7 +82,7 @@ export function HelpCenterGPT() {
 		if ( data?.response ) {
 			recordTracksEvent( 'calypso_helpcenter_show_gpt_response', {
 				location: 'help-center',
-				answer_source: data?.source ?? 'sitebot',
+				answer_source: data?.source,
 			} );
 		}
 	}, [ data ] );

--- a/packages/help-center/src/components/help-center-gpt.tsx
+++ b/packages/help-center/src/components/help-center-gpt.tsx
@@ -103,19 +103,23 @@ export function HelpCenterGPT() {
 	} );
 
 	const doThumbsUp = ( source: string ) => {
-		setFeedbackGiven( true );
-		recordTracksEvent( 'calypso_helpcenter_gpt_response_thumbs_up', {
-			location: 'help-center',
-			answer_source: source,
-		} );
+		return () => {
+			setFeedbackGiven( true );
+			recordTracksEvent( 'calypso_helpcenter_gpt_response_thumbs_up', {
+				location: 'help-center',
+				answer_source: source,
+			} );
+		};
 	};
 
 	const doThumbsDown = ( source: string ) => {
-		setFeedbackGiven( true );
-		recordTracksEvent( 'calypso_helpcenter_gpt_response_thumbs_down', {
-			location: 'help-center',
-			answer_source: source,
-		} );
+		return () => {
+			setFeedbackGiven( true );
+			recordTracksEvent( 'calypso_helpcenter_gpt_response_thumbs_down', {
+				location: 'help-center',
+				answer_source: source,
+			} );
+		};
 	};
 
 	return (
@@ -178,12 +182,8 @@ export function HelpCenterGPT() {
 										</div>
 									) : (
 										<>
-											<Button onClick={ () => doThumbsUp( data?.source ?? 'sitebot' ) }>
-												&#128077;
-											</Button>
-											<Button onClick={ () => doThumbsDown( data?.source ?? 'sitebot' ) }>
-												&#128078;
-											</Button>
+											<Button onClick={ doThumbsUp( data?.source ) }>&#128077;</Button>
+											<Button onClick={ doThumbsDown( data?.source ) }>&#128078;</Button>
 										</>
 									) }
 								</div>


### PR DESCRIPTION
While testing Docsbot, answers generated by docsbot will contain a "source" key. If the key isn't set, then the answer comes from Sitebot.

This logs the source in thumbs up/down events, and in the `calypso_helpcenter_show_gpt_response` tracks event.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D112433-code (and activate a variation as per the instructions there)
* Open the Help Center, and click on "Still need help"
* Choose any contact method
* Enter your message and click on "Continue"
* After the answer is loaded, click thumbs up/down
* Verify in the dev console that tracks requests for the events `calypso_helpcenter_gpt_response_thumbs_up`, `calypso_helpcenter_gpt_response_thumbs_down` and `calypso_helpcenter_show_gpt_response` contain an `answer_source` property

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?