### PR TITLE
Pattern Assembler: Fix broken previews when the assets are failed to load

### DIFF
--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -60,7 +60,7 @@ const ScaledBlockRendererContainer = ( {
 
 	const editorStyles = useMemo( () => {
 		const mergedStyles = [ ...( styles || [] ), ...( customStyles || [] ) ]
-			// Ingore svgs since the current version of EditorStyles doesn't support it
+			// Ignore svgs since the current version of EditorStyles doesn't support it
 			.filter( ( style: RenderedStyle ) => style.__unstableType !== 'svgs' );
 
 		if ( ! inlineCss ) {

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -59,7 +59,9 @@ const ScaledBlockRendererContainer = ( {
 	const styleAssets = useParsedAssets( assets?.styles ) as HTMLLinkElement[];
 
 	const editorStyles = useMemo( () => {
-		const mergedStyles = [ ...( styles || [] ), ...( customStyles || [] ) ];
+		const mergedStyles = [ ...( styles || [] ), ...( customStyles || [] ) ]
+			// Ingore svgs since the current version of EditorStyles doesn't support it
+			.filter( ( style: RenderedStyle ) => style.__unstableType !== 'svgs' );
 
 		if ( ! inlineCss ) {
 			return mergedStyles;

--- a/packages/block-renderer/src/utils/load-scripts.ts
+++ b/packages/block-renderer/src/utils/load-scripts.ts
@@ -1,11 +1,17 @@
 const loadScript = async ( element: HTMLElement, { id, src, textContent }: HTMLScriptElement ) => {
-	return new Promise( ( resolve, reject ) => {
+	return new Promise( ( resolve ) => {
 		const script = element.ownerDocument.createElement( 'script' ) as HTMLScriptElement;
 		script.id = id;
 		if ( src ) {
 			script.src = src;
 			script.onload = () => resolve( script );
-			script.onerror = () => reject();
+			script.onerror = () => {
+				// eslint-disable-next-line no-console
+				console.warn( `Error while loading the script: ${ src }` );
+
+				// Resolve the promise to ignore the error.
+				resolve( script );
+			};
 		} else {
 			script.textContent = textContent;
 			resolve( script );

--- a/packages/block-renderer/src/utils/load-styles.ts
+++ b/packages/block-renderer/src/utils/load-styles.ts
@@ -2,7 +2,7 @@ const loadStyle = async (
 	element: HTMLElement,
 	{ tagName, id, href, rel, media, textContent }: HTMLLinkElement
 ) => {
-	return new Promise( ( resolve, reject ) => {
+	return new Promise( ( resolve ) => {
 		const style = element.ownerDocument.createElement( tagName ) as HTMLLinkElement;
 		style.id = id;
 		if ( href ) {
@@ -10,7 +10,13 @@ const loadStyle = async (
 			style.rel = rel;
 			style.media = media;
 			style.onload = () => resolve( style );
-			style.onerror = () => reject();
+			style.onerror = () => {
+				// eslint-disable-next-line no-console
+				console.warn( `Error while loading the CSS: ${ href }` );
+
+				// Resolve the promise to ignore the error.
+				resolve( style );
+			};
 		} else {
 			style.textContent = textContent;
 			resolve( style );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-1sJ-p2#comment-2642, pekYwv-1Om-p2#comment-1333

## Proposed Changes

* Fix the broken previews when the assets are unavailable. For example, `<your_site>/_static/??-eJx9jcEOwjAMQ3+ILgLBxAXxKajtuimlTaqm3fh8cgAkOOCb7ScbtmI8UwvUIApMYUUfymOIsoPvKrPDFEyXUO2imUGa+ZfL3ZTUFyQB6U58xdKQ1c2cEm9/8Bhasf7+8vrGBDckD65jmsDbynqdPtw7GDKSzl7zZT+eT8fxoIpP/sRPfA==`

Here is the follow-up issue: https://github.com/Automattic/wp-calypso/issues/77805

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open your atomic site on Safari
* Head to the Theme Showcase
* Select the BCPA CTA
* On the Pattern Assembler screen
  * Select a header
  * Ensure you're able to see the previews instead of the blank

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?