### PR TITLE
Design Picker: Fix Premium Badge Style Specificity

### DIFF
--- a/packages/design-picker/src/components/premium-badge/style.scss
+++ b/packages/design-picker/src/components/premium-badge/style.scss
@@ -37,7 +37,7 @@
 	}
 }
 
-.premium-badge__popover {
+.premium-badge__popover.popover {
 	max-width: 300px;
 	outline: none;
 	.popover__inner {
@@ -62,7 +62,7 @@
 			}
 		}
 	}
-	.popover__arrow {
-		border: 10px dashed transparent;
-	}
+}
+.premium-badge__popover .popover__arrow {
+	border: 10px dashed transparent;
 }

--- a/packages/design-picker/src/components/premium-badge/style.scss
+++ b/packages/design-picker/src/components/premium-badge/style.scss
@@ -62,7 +62,7 @@
 			}
 		}
 	}
-}
-.premium-badge__popover .popover__arrow {
-	border: 10px dashed transparent;
+	.popover__arrow {
+		border-color: transparent;
+	}
 }


### PR DESCRIPTION
Related to #77757 and possibly #77640

## Proposed Changes

* Increase the specificity of the Premium Badge popover styles to ensure they override the default Popover styles regardless of the CSS loading order.

This seems to be caused by CSS loading in a different order in different environments.
The issue was only happening in non-`development` environments, but everything was fine in `dev`.

| Before | After |
|--------|--------|
| <img width="341" alt="Screenshot 2023-06-02 at 18 03 45" src="https://github.com/Automattic/wp-calypso/assets/2070010/5c312ed6-528a-439d-86c0-36dfd20c94e9"> | <img width="341" alt="Screenshot 2023-06-02 at 18 04 44" src="https://github.com/Automattic/wp-calypso/assets/2070010/62a66988-8fe1-4948-928c-662bab30be22"> | 

## Testing Instructions

* Open the Design Picker at `/setup/site-setup/designSetup?siteSlug={ siteSlug }`.
* Find a Premium theme and hover on its "Premium" label.
* Ensure the tooltip is displayed correctly in all environments.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
