### PR TITLE
 Plans 2023: Update biennial discounted billing timeframe messaging

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -118,7 +118,7 @@ function usePerMonthDescription( {
 			if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
 				return displayNewPriceText
 					? translate(
-							'per month, %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
+							'per month, %(fullTermDiscountedPriceText)s for the first two years, Excl. Taxes',
 							{
 								args: { fullTermDiscountedPriceText, rawPrice },
 								comment: 'Excl. Taxes is short for excluding taxes',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1742 and https://github.com/Automattic/wp-calypso/pull/75725

## Proposed Changes

* As far as I can tell, the plans page pro-rated credit messaging, implemented [here](https://github.com/Automattic/wp-calypso/pull/75725), works as expected for biennial plans
* The only updates I've made here are to the text translation to clarify that the biennial plan is a two year term

## Screenshots
### Pro-rated Monthly Plan Purchase ( other than WooCommerce ) 
#### 1 Yr
<img width="1592" alt="Screenshot 2023-06-05 at 6 36 27 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/98b1a5f7-09c9-49c3-a9d7-a2d807e101ab">

#### 2 Yr
<img width="1599" alt="Screenshot 2023-06-05 at 6 35 42 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/10d70c64-97f0-4a5a-ad07-03cc2e199ba0"> 

### Pro-rated Yearly Plan Purchase ( other than WooCommerce )
#### 1 Yr
<img width="1592" alt="Screenshot 2023-06-05 at 6 38 50 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/9dfad74f-96a2-4c79-81c2-1982fcbbe025">

#### 2 Yr
<img width="1590" alt="Screenshot 2023-06-05 at 6 38 59 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/5438b5ea-9115-4a2d-baa5-9da4c0f2060f">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site through calypso.localhost:3000/start and choose a premium monthly plan
* Add `showBiannualToggle={ true }` to the PlanTypeSelector component https://github.com/Automattic/wp-calypso/blob/eef95a6ae74cb109be40f522a5f32f29b9f9fd21/client/my-sites/plans-features-main/index.jsx#L720-L724
* Navigate to the /plans page
* Verify that the `Credit applied` badge is rendered appropriately
* Verify that the billing timeframe text is correct
* Repeat all steps but for a premium yearly plan instead of a premium monthly plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
