### PR TITLE
Import: fix cache issue on reselect the same site in site picker

### DIFF
--- a/client/blocks/importer/hooks/use-site-can-migrate.ts
+++ b/client/blocks/importer/hooks/use-site-can-migrate.ts
@@ -10,7 +10,6 @@ export function useSiteMigrateInfo(
 	targetSiteId: SiteId,
 	sourceSiteSlug: string,
 	fetchMigrationEnabledOnMount: boolean,
-	isMigrateFromWp: boolean,
 	onfetchCallback?: ( checkCanSiteMigrate: boolean ) => void
 ) {
 	const [ sourceSiteId, setSourceSiteId ] = useState( 0 );
@@ -24,7 +23,7 @@ export function useSiteMigrateInfo(
 		setSourceSiteId( 0 );
 	};
 
-	const checkCanSiteMigrate = ( isMigrateFromWp: boolean, data: MigrationEnabledResponse ) => {
+	const checkCanSiteMigrate = ( data: MigrationEnabledResponse ) => {
 		if ( ! data ) {
 			return false;
 		}
@@ -37,7 +36,7 @@ export function useSiteMigrateInfo(
 	};
 
 	const onMigrationEnabledSuccess = ( data: MigrationEnabledResponse ) => {
-		if ( checkCanSiteMigrate( isMigrateFromWp, data ) ) {
+		if ( checkCanSiteMigrate( data ) ) {
 			setSiteCanMigrate( true );
 			setSourceSiteId( data.source_blog_id );
 		} else {
@@ -60,6 +59,7 @@ export function useSiteMigrateInfo(
 		onMigrationEnabledSuccess,
 		onMigrationEnabledError
 	);
+
 	useEffect( () => {
 		// After the data is fetched or error, we call the callback if it is provided
 		if ( isFetched || isError ) {

--- a/client/blocks/importer/hooks/use-site-can-migrate.ts
+++ b/client/blocks/importer/hooks/use-site-can-migrate.ts
@@ -36,36 +36,28 @@ export function useSiteMigrateInfo(
 	};
 
 	const onMigrationEnabledSuccess = ( data: MigrationEnabledResponse ) => {
-		if ( checkCanSiteMigrate( data ) ) {
+		const canMigrate = checkCanSiteMigrate( data );
+		if ( canMigrate ) {
 			setSiteCanMigrate( true );
 			setSourceSiteId( data.source_blog_id );
 		} else {
 			resetMigrationEnabled();
 		}
+		onfetchCallback && onfetchCallback( canMigrate );
 	};
 
 	const onMigrationEnabledError = () => {
 		resetMigrationEnabled();
+		const canMigrate = false;
+		onfetchCallback && onfetchCallback( canMigrate );
 	};
-	const {
-		refetch,
-		isFetching: isMigrationEnabledFetching,
-		isFetched,
-		isError,
-	} = useMigrationEnabledInfoQuery(
+	const { refetch, isFetching: isMigrationEnabledFetching } = useMigrationEnabledInfoQuery(
 		targetSiteId,
 		sourceSiteSlug,
 		fetchMigrationEnabledOnMount,
 		onMigrationEnabledSuccess,
 		onMigrationEnabledError
 	);
-
-	useEffect( () => {
-		// After the data is fetched or error, we call the callback if it is provided
-		if ( isFetched || isError ) {
-			onfetchCallback && onfetchCallback( siteCanMigrate );
-		}
-	}, [ isFetched, isError, siteCanMigrate, onfetchCallback ] );
 
 	useEffect( () => {
 		// If has source site id and we do not have the source site, it means the data is not up to date, so we request the site

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -79,7 +79,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 			targetSite.ID,
 			sourceSiteSlug,
 			fetchMigrationEnabledOnMount,
-			isMigrateFromWp,
 			onfetchCallback
 		);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77784

## Proposed Changes

* The way we call `onFetchCallback` was not ideal when user reselect the cached data, in this PR we change the way we call the `onFetchCallback` and make sure it only calls when a request is made.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Spin up a JN site, go to the plugin home page and link to your WordPress.com user account
- Once you're on the sitePicker step, pick a site, click go back button on the top left corner.
- Choose the same site you picked earlier.
- Make sure you don't see the update information first if your site is able to migrate

To see how it fails now, please check out the demo video below:

https://github.com/Automattic/wp-calypso/assets/4074459/57683b67-b6c9-4c34-8daa-36615fb20c81

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
