### PR TITLE
Stats: subscribers overview cards data - move data query out of component

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -84,7 +84,7 @@ export function useSubscribersQueries(
 	period: string,
 	quantity: number,
 	dates: string[]
-): UseQueryResult< SubscribersData, unknown >[] {
+): { isLoading: boolean; isError: boolean; subscribersData: SubscribersData[] } {
 	const queryConfigs = dates.map( ( date ) => ( {
 		queryKey: [ 'stats', 'subscribers', siteId, period, quantity, date ],
 		queryFn: () => querySubscribers( siteId, period, quantity, date ),
@@ -92,5 +92,14 @@ export function useSubscribersQueries(
 		staleTime: 1000 * 60 * 5, // 5 minutes
 	} ) );
 
-	return useQueries( { queries: queryConfigs } ) as UseQueryResult< SubscriberPayload, unknown >[];
+	const results = useQueries( { queries: queryConfigs } ) as UseQueryResult<
+		SubscriberPayload,
+		unknown
+	>[];
+
+	const isLoading = results.some( ( result ) => result.isLoading );
+	const isError = results.some( ( result ) => result.isError );
+	const subscribersData = results.map( ( result ) => result.data );
+
+	return { isLoading, isError, subscribersData };
 }

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -9,9 +9,9 @@ export interface SubscriberPayload {
 }
 
 export interface SubscribersData {
-	date: string;
-	unit: string;
-	data: {
+	date?: string;
+	unit?: string;
+	data?: {
 		[ key: string ]: string | number;
 	}[];
 }

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -49,6 +49,7 @@ function selectSubscribers( payload: SubscriberPayload ): SubscribersData {
 	}
 
 	return {
+		// For `week` period replace `W` separator to match the format.
 		date: payload.date,
 		unit: payload.unit,
 		data: payload.data.map( ( dataSet ) => {

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -40,10 +40,6 @@ function querySubscribers(
 		},
 		query
 	);
-	// .then( ( response ) => {
-	// 	const selectedData = selectSubscribers( response );
-	// 	return selectedData;
-	// } );
 }
 
 function selectSubscribers( payload: SubscriberPayload ): SubscribersData {

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -43,13 +43,9 @@ function querySubscribers(
 }
 
 function selectSubscribers( payload: SubscriberPayload ): SubscribersData {
-	if ( ! payload || ! payload.data ) {
-		// return default SubscribersData object if no payload data
-		return {
-			date: '',
-			unit: '',
-			data: [],
-		};
+	if ( ! payload?.data ) {
+		// return an empty SubscribersData object if no payload data
+		return {};
 	}
 
 	return {
@@ -97,5 +93,3 @@ export function useSubscribersQueries(
 
 	return useQueries( { queries: queryConfigs } ) as UseQueryResult< SubscriberPayload, unknown >[];
 }
-
-export type { SubscribersData };

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -32,19 +32,18 @@ function querySubscribers(
 		date: formattedDate,
 	};
 
-	return wpcom.req
-		.get(
-			{
-				method: 'GET',
-				apiNamespace: 'rest/v1.1',
-				path: `/sites/${ siteId }/stats/subscribers`,
-			},
-			query
-		)
-		.then( ( response ) => {
-			const selectedData = selectSubscribers( response );
-			return selectedData;
-		} );
+	return wpcom.req.get(
+		{
+			method: 'GET',
+			apiNamespace: 'rest/v1.1',
+			path: `/sites/${ siteId }/stats/subscribers`,
+		},
+		query
+	);
+	// .then( ( response ) => {
+	// 	const selectedData = selectSubscribers( response );
+	// 	return selectedData;
+	// } );
 }
 
 function selectSubscribers( payload: SubscriberPayload ): SubscribersData {

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -8,7 +8,7 @@ export interface SubscriberPayload {
 	fields: string[];
 }
 
-interface SubscribersData {
+export interface SubscribersData {
 	date: string;
 	unit: string;
 	data: {

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -58,7 +58,7 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 
 	const isLoading = subscribersQueries.some( ( result ) => result.isLoading );
 	const isError = subscribersQueries.some( ( result ) => result.isError );
-	const subscribersData = subscribersQueries.map( ( result ) => result.data );
+	const subscribersData = subscribersQueries.map( ( result ) => result?.data );
 
 	const overviewCardStats = SubscribersOverviewCardStats( subscribersData );
 

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -22,15 +22,9 @@ function calculateQueryDate( daysToSubtract: number ) {
 }
 
 // calculate the stats to display in the cards
-<<<<<<< HEAD
-function SubscribersOverviewCardStats( subscribersDataArrays: SubscribersData[][] ) {
-	const getCount = ( index: number ) => {
-		return subscribersDataArrays[ index ]?.[ 0 ]?.subscribers || 0;
-=======
 function SubscribersOverviewCardStats( subscribersData: SubscribersData[] ) {
 	const getCount = ( index: number ) => {
 		return subscribersData[ index ]?.data[ 0 ]?.subscribers || 0;
->>>>>>> 381e70c6a8 (move data query out of component)
 	};
 
 	const overviewCardStats = [

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -54,11 +54,12 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 	const quantity = 1;
 	const dates = cardIndices.map( calculateQueryDate );
 
-	const subscribersQueries = useSubscribersQueries( siteId, period, quantity, dates );
-
-	const isLoading = subscribersQueries.some( ( result ) => result.isLoading );
-	const isError = subscribersQueries.some( ( result ) => result.isError );
-	const subscribersData = subscribersQueries.map( ( result ) => result?.data );
+	const { isLoading, isError, subscribersData } = useSubscribersQueries(
+		siteId,
+		period,
+		quantity,
+		dates
+	);
 
 	const overviewCardStats = SubscribersOverviewCardStats( subscribersData );
 

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -1,26 +1,13 @@
 import { CountComparisonCard } from '@automattic/components';
-import { UseQueryResult, useQueries } from '@tanstack/react-query';
 import { translate } from 'i18n-calypso';
 import React from 'react';
 import {
-	querySubscribers,
-	selectSubscribers,
+	useSubscribersQueries,
+	SubscribersData,
 } from 'calypso/my-sites/stats/hooks/use-subscribers-query';
 
 // array of indices to use to calculate the dates to query for
 const cardIndices = [ 0, 30, 60, 90 ];
-
-interface SubscribersData {
-	period: string;
-	subscribers: number;
-	subscribers_change: number;
-}
-
-interface SubscribersDataResult {
-	data: SubscribersData[];
-	unit: string;
-	date: string;
-}
 
 interface SubscribersOverviewProps {
 	siteId: number | null;
@@ -35,9 +22,15 @@ function calculateQueryDate( daysToSubtract: number ) {
 }
 
 // calculate the stats to display in the cards
+<<<<<<< HEAD
 function SubscribersOverviewCardStats( subscribersDataArrays: SubscribersData[][] ) {
 	const getCount = ( index: number ) => {
 		return subscribersDataArrays[ index ]?.[ 0 ]?.subscribers || 0;
+=======
+function SubscribersOverviewCardStats( subscribersData: SubscribersData[] ) {
+	const getCount = ( index: number ) => {
+		return subscribersData[ index ]?.data[ 0 ]?.subscribers || 0;
+>>>>>>> 381e70c6a8 (move data query out of component)
 	};
 
 	const overviewCardStats = [
@@ -66,18 +59,12 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 	const period = 'day';
 	const quantity = 1;
 	const dates = cardIndices.map( calculateQueryDate );
-	const subscribersQueries = useQueries( {
-		queries: dates.map( ( date ) => ( {
-			queryKey: [ 'stats', 'subscribers', siteId, period, quantity, date ],
-			queryFn: () => querySubscribers( siteId, period, quantity, date ),
-			select: selectSubscribers,
-			staleTime: 1000 * 60 * 5, // 5 minutes
-		} ) ),
-	} ) as UseQueryResult< SubscribersDataResult >[];
+
+	const subscribersQueries = useSubscribersQueries( siteId, period, quantity, dates );
 
 	const isLoading = subscribersQueries.some( ( result ) => result.isLoading );
 	const isError = subscribersQueries.some( ( result ) => result.isError );
-	const subscribersData = subscribersQueries.map( ( result ) => result.data?.data || [] );
+	const subscribersData = subscribersQueries.map( ( result ) => result.data );
 
 	const overviewCardStats = SubscribersOverviewCardStats( subscribersData );
 


### PR DESCRIPTION
Related to #77513

## Proposed Changes

* This PR moves data fetching out of the component and into to the original hook. This is because `querySubscribers` and `selectSubscribers` should not be manipulated by components consuming data.

## Testing Instructions

* Open the live branch for this PR.
* Navigate to `/stats/day/:siteSlug`
* Add `?flags=stats/subscribers-section` to the URL to enable the subscriber stats page.
* Scroll down to locate the overview cards (immediately under the chart)
* Check that they load data correctly, still behave acceptably on resize etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
