### PR TITLE
Pricing Grid: Fixes billing timeframe for 2Y & 3Y plans

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -3,15 +3,15 @@ import {
 	isWpcomEnterpriseGridPlan,
 	PLAN_BIENNIAL_PERIOD,
 	PLAN_ANNUAL_PERIOD,
+	PLAN_TRIENNIAL_PERIOD,
 	PlanSlug,
 	getPlanSlugForTermVariant,
 	TERM_ANNUALLY,
 	isWooExpressPlan,
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
-import i18n, { TranslateResult, useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
@@ -35,7 +35,6 @@ function usePerMonthDescription( {
 }: Omit< Props, 'billingTimeframe' > ) {
 	const translate = useTranslate();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const isEnglishLocale = useIsEnglishLocale();
 	const planPrices = usePlanPricesDisplay( {
 		planSlug: planName as PlanSlug,
 		returnMonthly: isMonthlyPlan,
@@ -74,82 +73,69 @@ function usePerMonthDescription( {
 				},
 			} );
 		}
+		return null;
 	}
 
-	if ( ! isMonthlyPlan ) {
-		const discountedPrice = planPrices.discountedPrice;
-		const fullTermDiscountedPriceText =
-			currencyCode && discountedPrice
-				? formatCurrency( discountedPrice, currencyCode, { stripZeros: true } )
-				: null;
-		const rawPrice =
-			currencyCode && planPrices.originalPrice
-				? formatCurrency( planPrices.originalPrice, currencyCode, { stripZeros: true } )
-				: null;
+	const discountedPrice = planPrices.discountedPrice;
+	const fullTermDiscountedPriceText =
+		currencyCode && discountedPrice
+			? formatCurrency( discountedPrice, currencyCode, { stripZeros: true } )
+			: null;
+	const rawPrice =
+		currencyCode && planPrices.originalPrice
+			? formatCurrency( planPrices.originalPrice, currencyCode, { stripZeros: true } )
+			: null;
 
-		// TODO: Remove check once text is translated
-		const displayNewPriceText =
-			isEnglishLocale ||
-			( i18n.hasTranslation( 'per month, %(rawPrice)s billed annually, Excl. Taxes' ) &&
-				i18n.hasTranslation( 'per month, %(rawPrice)s billed every two years, Excl. Taxes' ) &&
-				i18n.hasTranslation(
-					'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes'
-				) &&
-				i18n.hasTranslation(
-					'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes'
-				) );
-		if ( fullTermDiscountedPriceText ) {
-			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-				//per month, $96 billed annually $84 for the first year
+	if ( fullTermDiscountedPriceText ) {
+		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
+			return translate(
+				'per month, %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
+				{
+					args: { fullTermDiscountedPriceText },
+					comment: 'Excl. Taxes is short for excluding taxes',
+				}
+			);
+		}
 
-				return displayNewPriceText
-					? translate(
-							'per month, %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
-							{
-								args: { fullTermDiscountedPriceText },
-								comment: 'Excl. Taxes is short for excluding taxes',
-							}
-					  )
-					: translate( 'per month, %(fullTermDiscountedPriceText)s for the first year', {
-							args: { fullTermDiscountedPriceText },
-					  } );
-			}
+		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
+			return translate(
+				'per month, %(fullTermDiscountedPriceText)s for the first two years, Excl. Taxes',
+				{
+					args: { fullTermDiscountedPriceText },
+					comment: 'Excl. Taxes is short for excluding taxes',
+				}
+			);
+		}
 
-			if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-				return displayNewPriceText
-					? translate(
-							'per month, %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
-							{
-								args: { fullTermDiscountedPriceText, rawPrice },
-								comment: 'Excl. Taxes is short for excluding taxes',
-							}
-					  )
-					: translate( 'per month, %(fullTermDiscountedPriceText)s for the first year', {
-							args: { fullTermDiscountedPriceText },
-					  } );
-			}
-		} else if ( rawPrice ) {
-			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-				return displayNewPriceText
-					? translate( 'per month, %(rawPrice)s billed annually, Excl. Taxes', {
-							args: { rawPrice },
-							comment: 'Excl. Taxes is short for excluding taxes',
-					  } )
-					: translate( 'per month, %(rawPrice)s billed annually', {
-							args: { rawPrice },
-					  } );
-			}
+		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
+			return translate(
+				'per month, %(fullTermDiscountedPriceText)s for the first three years, Excl. Taxes',
+				{
+					args: { fullTermDiscountedPriceText },
+					comment: 'Excl. Taxes is short for excluding taxes',
+				}
+			);
+		}
+	} else if ( rawPrice ) {
+		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
+			return translate( 'per month, %(rawPrice)s billed annually, Excl. Taxes', {
+				args: { rawPrice },
+				comment: 'Excl. Taxes is short for excluding taxes',
+			} );
+		}
 
-			if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-				return displayNewPriceText
-					? translate( 'per month, %(rawPrice)s billed every two years, Excl. Taxes', {
-							args: { rawPrice },
-							comment: 'Excl. Taxes is short for excluding taxes',
-					  } )
-					: translate( 'per month, %(rawPrice)s billed every two years.', {
-							args: { rawPrice },
-					  } );
-			}
+		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
+			return translate( 'per month, %(rawPrice)s billed every two years, Excl. Taxes', {
+				args: { rawPrice },
+				comment: 'Excl. Taxes is short for excluding taxes',
+			} );
+		}
+
+		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
+			return translate( 'per month, %(rawPrice)s billed every three years, Excl. Taxes', {
+				args: { rawPrice },
+				comment: 'Excl. Taxes is short for excluding taxes',
+			} );
 		}
 	}
 

--- a/client/my-sites/plan-features-2023-grid/components/test/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/test/billing-timeframe.tsx
@@ -21,8 +21,10 @@ import {
 	PLAN_BIENNIAL_PERIOD,
 	PLAN_BUSINESS,
 	PLAN_BUSINESS_2_YEARS,
+	PLAN_BUSINESS_3_YEARS,
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_MONTHLY_PERIOD,
+	PLAN_TRIENNIAL_PERIOD,
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import { render } from '@testing-library/react';
@@ -122,6 +124,105 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		const discountedPrice = formatCurrency( planPrices.discountedPrice, 'INR', {
 			stripZeros: true,
 		} );
-		expect( container ).toHaveTextContent( `per month, ${ discountedPrice } for the first year` );
+		expect( container ).toHaveTextContent(
+			`per month, ${ discountedPrice } for the first two years`
+		);
+	} );
+
+	test( 'should show full-term discounted price when plan is 3-yearly', () => {
+		const planPrices: PlanPricesDisplay = {
+			discountedPrice: 150,
+			originalPrice: 200,
+		};
+
+		usePlanPricesDisplay.mockImplementation( jest.fn( () => planPrices ) );
+
+		const { container } = render(
+			<PlanFeatures2023GridBillingTimeframe
+				currentSitePlanSlug=""
+				{ ...defaultProps }
+				planName={ PLAN_BUSINESS_3_YEARS }
+				isMonthlyPlan={ false }
+				billingPeriod={ PLAN_TRIENNIAL_PERIOD }
+			/>
+		);
+		const discountedPrice = formatCurrency( planPrices.discountedPrice, 'INR', {
+			stripZeros: true,
+		} );
+		expect( container ).toHaveTextContent(
+			`per month, ${ discountedPrice } for the first three years`
+		);
+	} );
+
+	test( 'should show full-term price when plan is yearly', () => {
+		const planPrices: PlanPricesDisplay = {
+			discountedPrice: 0,
+			originalPrice: 200,
+		};
+
+		usePlanPricesDisplay.mockImplementation( jest.fn( () => planPrices ) );
+
+		const { container } = render(
+			<PlanFeatures2023GridBillingTimeframe
+				currentSitePlanSlug=""
+				{ ...defaultProps }
+				planName={ PLAN_BUSINESS }
+				isMonthlyPlan={ false }
+				billingPeriod={ PLAN_ANNUAL_PERIOD }
+			/>
+		);
+
+		const originalPrice = formatCurrency( planPrices.originalPrice, 'INR', {
+			stripZeros: true,
+		} );
+		expect( container ).toHaveTextContent( `per month, ${ originalPrice } billed annually` );
+	} );
+
+	test( 'should show full-term price when plan is 2-yearly', () => {
+		const planPrices: PlanPricesDisplay = {
+			discountedPrice: 0,
+			originalPrice: 200,
+		};
+
+		usePlanPricesDisplay.mockImplementation( jest.fn( () => planPrices ) );
+
+		const { container } = render(
+			<PlanFeatures2023GridBillingTimeframe
+				currentSitePlanSlug=""
+				{ ...defaultProps }
+				planName={ PLAN_BUSINESS_2_YEARS }
+				isMonthlyPlan={ false }
+				billingPeriod={ PLAN_BIENNIAL_PERIOD }
+			/>
+		);
+		const originalPrice = formatCurrency( planPrices.originalPrice, 'INR', {
+			stripZeros: true,
+		} );
+		expect( container ).toHaveTextContent( `per month, ${ originalPrice } billed every two years` );
+	} );
+
+	test( 'should show full-term price when plan is 3-yearly', () => {
+		const planPrices: PlanPricesDisplay = {
+			discountedPrice: 0,
+			originalPrice: 200,
+		};
+
+		usePlanPricesDisplay.mockImplementation( jest.fn( () => planPrices ) );
+
+		const { container } = render(
+			<PlanFeatures2023GridBillingTimeframe
+				currentSitePlanSlug=""
+				{ ...defaultProps }
+				planName={ PLAN_BUSINESS_3_YEARS }
+				isMonthlyPlan={ false }
+				billingPeriod={ PLAN_TRIENNIAL_PERIOD }
+			/>
+		);
+		const originalPrice = formatCurrency( planPrices.originalPrice, 'INR', {
+			stripZeros: true,
+		} );
+		expect( container ).toHaveTextContent(
+			`per month, ${ originalPrice } billed every three years`
+		);
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1811

## Proposed Changes

**Note: Once the PR is approved, I'll add the `String Freeze` label to send the new text for translations.**

* Fixes the billing timeframe for 2Y and 3Y plans. The billing timeframe refers to the text below the price in the pricing grid.
* Screenshots:

2Y plans:

| Before | After |
|--------|--------|
|<img width="1293" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/bc9535eb-cd19-4618-aefa-062208ec0608">|<img width="1250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/5b8df95c-1081-4a87-9d20-2bf4784ea852"> | 

3Y plans:

| Before | After |
|--------|--------|
|<img width="1260" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/0cf867c7-c4a7-4e69-9f71-4f48f6249e57">|<img width="1258" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/b329b80d-063d-4d8a-a12e-00c6d99e60f9"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The unit tests should cover all possible cases.
* On a site with a 2Y plan, go to `/plans` and confirm that the text matches the screenshot.
* On a site with a 3Y plan, go to `/plans` and confirm that the text matches the screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
