### PR TITLE
Editor Domain Upsell: Check for site-intent on php

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/class-wpcom-domain-upsell-callout.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/class-wpcom-domain-upsell-callout.php
@@ -83,7 +83,22 @@ class WPCOM_Domain_Upsell_Callout {
 	private function should_not_show_callout() {
 		$blog_id = defined( 'IS_WPCOM' ) && IS_WPCOM ? get_current_blog_id() : \Jetpack_Options::get_option( 'id' );
 
-		return $this->blog_has_custom_domain( $blog_id ) || $this->user_has_email_unverified() || $this->blog_is_p2( $blog_id );
+		return $this->has_unlaunched_launchpad() || $this->blog_has_custom_domain( $blog_id ) || $this->user_has_email_unverified() || $this->blog_is_p2( $blog_id );
+	}
+
+	/**
+	 * Check for site-intent and not launched site on launchpad.
+	 */
+	private function has_unlaunched_launchpad() {
+		$site_intent      = defined( 'IS_WPCOM' ) && IS_WPCOM ? get_option( 'site_intent' ) : \Jetpack_Options::get_option( 'site_intent' );
+		$task_statuses    = get_option( 'launchpad_checklist_tasks_statuses', array() );
+		$site_is_launched = ! isset( $task_statuses['site_launched'] ) || ! $task_statuses['site_launched'];
+
+		if ( ! $site_intent || ! $site_is_launched ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/class-wpcom-domain-upsell-callout.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/class-wpcom-domain-upsell-callout.php
@@ -92,9 +92,9 @@ class WPCOM_Domain_Upsell_Callout {
 	private function has_unlaunched_launchpad() {
 		$site_intent      = get_option( 'site_intent' );
 		$task_statuses    = get_option( 'launchpad_checklist_tasks_statuses', array() );
-		$site_is_launched = ! isset( $task_statuses['site_launched'] ) || ! $task_statuses['site_launched'];
+		$site_is_launched = isset( $task_statuses['site_launched'] ) && $task_statuses['site_launched'];
 
-		if ( ! $site_intent || ! $site_is_launched ) {
+		if ( ! $site_intent || ( $site_intent && $site_is_launched ) ) {
 			return false;
 		}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/class-wpcom-domain-upsell-callout.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/class-wpcom-domain-upsell-callout.php
@@ -90,7 +90,7 @@ class WPCOM_Domain_Upsell_Callout {
 	 * Check for site-intent and not launched site on launchpad.
 	 */
 	private function has_unlaunched_launchpad() {
-		$site_intent      = defined( 'IS_WPCOM' ) && IS_WPCOM ? get_option( 'site_intent' ) : \Jetpack_Options::get_option( 'site_intent' );
+		$site_intent      = get_option( 'site_intent' );
 		$task_statuses    = get_option( 'launchpad_checklist_tasks_statuses', array() );
 		$site_is_launched = ! isset( $task_statuses['site_launched'] ) || ! $task_statuses['site_launched'];
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/src/domain-upsell-callout.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/src/domain-upsell-callout.jsx
@@ -3,7 +3,6 @@ import { dispatch, select, subscribe } from '@wordpress/data';
 import { render } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { close, globe, Icon } from '@wordpress/icons';
-import useSiteIntent from '../../dotcom-fse/lib/site-intent/use-site-intent';
 
 import './domain-upsell-callout.scss';
 
@@ -35,12 +34,6 @@ const shouldShowDomainUpsell = () => {
 };
 
 const DomainUpsellCallout = () => {
-	const { siteIntent: intent, siteIntentFetched: intentFetched } = useSiteIntent();
-
-	if ( ! intentFetched || intent ) {
-		return;
-	}
-
 	const siteSlug = window.location.hostname;
 	const target = '_parent';
 	const trackEventView = 'calypso_block_editor_domain_upsell_callout_view';


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2617

## Proposed Changes
As some signup flows keep the `site-intent` alive after finishing the process, we checked for the launchpad status if the `site-intent` is still alive, and we need to make it in PHP.

#### Conditions to show the callout
- User has a verified email
- Site has no custom domain
- Site is not a P2
- Not show if it has `site-intent` and not launched (like start-writing, link-in-bio, etc)
- Should show if it has `site-intent` and is launched (like write flow)

## Testing Instructions

- You need to sandbox your testing site domain
- Go to `/apps/editing-toolkit`
- Run `yarn dev --sync`
- On Calypso, go to `/posts` (and `/pages`) and edit or create new.
- Or, change the view to classic and use `/wp-admin`
- You should see the callout if conditions match.
- Test it with a site created using the `write` flow as this flow keeps the `site-intent` alive after launching the site.

To test on Atomic Sites, follow the instructions here: PCYsg-ly5-p2 (**ETK and Atomic Sites**)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->