### PR TITLE
Jetpack Pro Dashboard: Change the verify email error code to show correct error message

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
@@ -75,7 +75,7 @@ export function useValidateVerificationCode(): {
 			await handleSetMonitoringContacts( data, params );
 		},
 		onError: async ( error, params ) => {
-			if ( error?.code === 'jetpack_agency_non_existent_contact' ) {
+			if ( error?.code === 'jetpack_agency_contact_is_verified' ) {
 				// Add the contact to the list of contacts if already verified
 				setIsAlreadyVerifed( true );
 				await handleSetMonitoringContacts( { verified: true }, params );


### PR DESCRIPTION
Related to 1204408201748644-as-1204764046259368

## Proposed Changes

This PR changes the error code from `jetpack_agency_non_existent_contact` to `jetpack_agency_contact_is_verified` when the contact is already verified. 

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Apply this [D111846-code](D112868-code) and sandbox the public API.
2. Run `git checkout add/fix-contact-verification-error-message` and `yarn start-jetpack-cloud`.
3. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
4. Enable monitor if not enabled already.
5. Click on the clock icon next to the monitor toggle.
6. Follow the testing instructions: steps 6-14(https://github.com/Automattic/wp-calypso/pull/77583) or you can just look at the diff and make sure the same change is done in the UI

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?