### PR TITLE
Add woocommerce core profiler jetpack login screen

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -276,6 +276,7 @@ class Login extends Component {
 			action,
 			currentQuery,
 			isGravatar,
+			isWooCoreProfilerFlow,
 		} = this.props;
 
 		let headerText = translate( 'Log in to your account' );
@@ -421,6 +422,16 @@ class Login extends Component {
 					</p>
 				);
 			}
+		} else if ( isWooCoreProfilerFlow ) {
+			headerText = <h3>{ translate( 'One last step' ) }</h3>;
+			preHeader = null;
+			postHeader = (
+				<p className="login__header-subtitle">
+					{ translate(
+						'In order to take advantage of the benefits offered by Jetpack, please log in to your WordPress.com account below.'
+					) }
+				</p>
+			);
 		} else if ( isJetpackWooCommerceFlow ) {
 			headerText = translate( 'Log in to your WordPress.com account' );
 			preHeader = (
@@ -711,6 +722,8 @@ export default connect(
 		partnerSlug: getPartnerSlugFromQuery( state ),
 		isJetpackWooCommerceFlow:
 			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
+		isWooCoreProfilerFlow:
+			'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 		isAnchorFmSignup: getIsAnchorFmSignup(
 			get( getCurrentQueryArguments( state ), 'redirect_to' )

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -558,7 +558,6 @@ export class LoginForm extends Component {
 		} = this.props;
 
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
-
 		const isFormFilled =
 			this.state.usernameOrEmail.trim().length === 0 || this.state.password.trim().length === 0;
 		const isSubmitButtonDisabled = isWoo && ! isPartnerSignup ? isFormFilled : isFormDisabled;

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -498,11 +498,11 @@ export class LoginForm extends Component {
 	}
 
 	renderUsernameorEmailLabel() {
-		if ( this.props.isWooCoreProfilerFlow ) {
-			return this.props.translate( 'Your email address' );
-		}
-
-		if ( this.props.isP2Login || ( this.props.isWoo && ! this.props.isPartnerSignup ) ) {
+		if (
+			this.props.isP2Login ||
+			( this.props.isWoo && ! this.props.isPartnerSignup ) ||
+			this.props.isWooCoreProfilerFlow
+		) {
 			return this.props.translate( 'Your email address or username' );
 		}
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -158,38 +158,33 @@ export class LoginForm extends Component {
 	};
 
 	isFullView() {
-		const { accountType, hasAccountTypeLoaded, socialAccountIsLinking, isWooCoreProfilerFlow } =
-			this.props;
+		const { accountType, hasAccountTypeLoaded, socialAccountIsLinking } = this.props;
 
 		return (
 			socialAccountIsLinking ||
 			( hasAccountTypeLoaded && isRegularAccount( accountType ) ) ||
-			( this.props.isWoo && ! this.props.isPartnerSignup ) ||
-			isWooCoreProfilerFlow
+			( this.props.isWoo && ! this.props.isPartnerSignup )
 		);
 	}
 
 	isPasswordView() {
-		const { accountType, hasAccountTypeLoaded, socialAccountIsLinking, isWooCoreProfilerFlow } =
-			this.props;
+		const { accountType, hasAccountTypeLoaded, socialAccountIsLinking } = this.props;
 
 		return (
 			! socialAccountIsLinking &&
 			hasAccountTypeLoaded &&
 			isRegularAccount( accountType ) &&
-			! ( this.props.isWoo && ! this.props.isPartnerSignup ) &&
-			! isWooCoreProfilerFlow
+			! ( this.props.isWoo && ! this.props.isPartnerSignup )
 		);
 	}
 
 	isUsernameOrEmailView() {
-		const { hasAccountTypeLoaded, socialAccountIsLinking, isWooCoreProfilerFlow } = this.props;
+		const { hasAccountTypeLoaded, socialAccountIsLinking } = this.props;
 
 		return (
 			! socialAccountIsLinking &&
 			! hasAccountTypeLoaded &&
-			! ( this.props.isWoo && ! this.props.isPartnerSignup ) &&
-			! isWooCoreProfilerFlow
+			! ( this.props.isWoo && ! this.props.isPartnerSignup )
 		);
 	}
 
@@ -498,11 +493,7 @@ export class LoginForm extends Component {
 	}
 
 	renderUsernameorEmailLabel() {
-		if (
-			this.props.isP2Login ||
-			( this.props.isWoo && ! this.props.isPartnerSignup ) ||
-			this.props.isWooCoreProfilerFlow
-		) {
+		if ( this.props.isP2Login || ( this.props.isWoo && ! this.props.isPartnerSignup ) ) {
 			return this.props.translate( 'Your email address or username' );
 		}
 
@@ -564,15 +555,13 @@ export class LoginForm extends Component {
 			showSocialLoginFormOnly,
 			isWoo,
 			isPartnerSignup,
-			isWooCoreProfilerFlow,
 		} = this.props;
 
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
 
 		const isFormFilled =
 			this.state.usernameOrEmail.trim().length === 0 || this.state.password.trim().length === 0;
-		const isSubmitButtonDisabled =
-			( isWoo && ! isPartnerSignup ) || isWooCoreProfilerFlow ? isFormFilled : isFormDisabled;
+		const isSubmitButtonDisabled = isWoo && ! isPartnerSignup ? isFormFilled : isFormDisabled;
 		const isOauthLogin = !! oauth2Client;
 		const isPasswordHidden = this.isUsernameOrEmailView();
 
@@ -741,8 +730,7 @@ export class LoginForm extends Component {
 					</div>
 
 					<p className="login__form-terms">{ socialToS }</p>
-					{ ( ( isWoo && ! isPartnerSignup ) || isWooCoreProfilerFlow ) &&
-						this.renderLostPasswordLink() }
+					{ isWoo && ! isPartnerSignup && this.renderLostPasswordLink() }
 					<div className="login__form-action">
 						<FormsButton primary disabled={ isSubmitButtonDisabled }>
 							{ this.getLoginButtonText() }
@@ -774,7 +762,7 @@ export class LoginForm extends Component {
 							socialService={ this.props.socialService }
 							socialServiceResponse={ this.props.socialServiceResponse }
 							uxMode={ this.shouldUseRedirectLoginFlow() ? 'redirect' : 'popup' }
-							shouldRenderToS={ ( this.props.isWoo && ! isPartnerSignup ) || isWooCoreProfilerFlow }
+							shouldRenderToS={ this.props.isWoo && ! isPartnerSignup }
 						/>
 					</Fragment>
 				) }
@@ -804,10 +792,10 @@ export default connect(
 			oauth2Client: getCurrentOAuth2Client( state ),
 			isJetpackWooCommerceFlow:
 				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
-			isWooCoreProfilerFlow:
-				'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
 			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
-			isWoo: isWooOAuth2Client( getCurrentOAuth2Client( state ) ),
+			isWoo:
+				isWooOAuth2Client( getCurrentOAuth2Client( state ) ) ||
+				'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
 			isPartnerSignup: isPartnerSignupQuery( getCurrentQueryArguments( state ) ),
 			redirectTo: getRedirectToOriginal( state ),
 			requestError: getRequestError( state ),

--- a/client/blocks/login/social-login-tos.jsx
+++ b/client/blocks/login/social-login-tos.jsx
@@ -1,7 +1,40 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+import { connect } from 'react-redux';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 
 function SocialLoginTos( props ) {
+	if ( props.isWooCoreProfilerFlow ) {
+		return (
+			<p className="login-form__social-buttons-tos">
+				{ props.translate(
+					'If you continue with Google or Apple, you agree to our' +
+						' {{tosLink}}Terms of Service{{/tosLink}}, and have' +
+						' read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+					{
+						components: {
+							tosLink: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+							privacyLink: (
+								<a
+									href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+			</p>
+		);
+	}
+
 	return (
 		<p className="login-form__social-buttons-tos">
 			{ props.translate(
@@ -22,4 +55,7 @@ function SocialLoginTos( props ) {
 	);
 }
 
-export default localize( SocialLoginTos );
+export default connect( ( state ) => ( {
+	isWooCoreProfilerFlow:
+		'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
+} ) )( localize( SocialLoginTos ) );

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 @import "calypso/assets/stylesheets/p2-extends";
 
-.layout:not(.is-jetpack-woocommerce-flow):not(.is-jetpack-woo-dna-flow):not(.is-wccom-oauth-flow) {
+.layout:not(.is-jetpack-woocommerce-flow):not(.is-jetpack-woo-dna-flow):not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
 	.login.is-jetpack {
 		.button.is-primary {
 			background-color: var(--studio-jetpack-green-50);

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -3,7 +3,7 @@
 $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__main:not(.is-woocommerce):not(.is-wpcom-migration),
-.layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow):not(.is-jetpack-woocommerce-flow):not(.is-jetpack-woo-dna-flow):not(.is-wpcom-migration) {
+.layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow):not(.is-jetpack-woocommerce-flow):not(.is-jetpack-woo-dna-flow):not(.is-wpcom-migration):not(.is-woocommerce-core-profiler-flow) {
 	@include jetpack-connect-colors();
 }
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -13,6 +13,7 @@ import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import MasterbarLoggedOut from 'calypso/layout/masterbar/logged-out';
 import MasterbarLogin from 'calypso/layout/masterbar/login';
 import OauthClientMasterbar from 'calypso/layout/masterbar/oauth-client';
+import WooCoreProfilerMasterbar from 'calypso/layout/masterbar/woo-core-profiler';
 import PoweredByWPFooter from 'calypso/layout/powered-by-wp-footer';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
@@ -57,6 +58,7 @@ const LayoutLoggedOut = ( {
 	showGdprBanner,
 	isPartnerSignup,
 	isPartnerSignupStart,
+	isWooCoreProfilerFlow,
 	locale,
 } ) => {
 	const localizeUrl = useLocalizeUrl();
@@ -93,6 +95,7 @@ const LayoutLoggedOut = ( {
 		'is-wccom-oauth-flow': isWooOAuth2Client( oauth2Client ) && wccomFrom,
 		'is-p2-login': isP2Login,
 		'is-gravatar': isGravatar,
+		'is-woocommerce-core-profiler-flow': isWooCoreProfilerFlow,
 	};
 
 	let masterbar = null;
@@ -133,6 +136,10 @@ const LayoutLoggedOut = ( {
 				{ ...( sectionName === 'subscriptions' && { variant: 'minimal' } ) }
 			/>
 		);
+	} else if ( isWooCoreProfilerFlow ) {
+		classes.woo = true;
+		classes[ 'has-no-masterbar' ] = false;
+		masterbar = <WooCoreProfilerMasterbar />;
 	} else {
 		masterbar = (
 			<MasterbarLoggedOut
@@ -245,6 +252,7 @@ export default withCurrentRoute(
 			! isWooOAuth2Client( oauth2Client ) &&
 			[ 'signup', 'jetpack-connect' ].includes( sectionName );
 		const isJetpackWooCommerceFlow = 'woocommerce-onboarding' === currentQuery?.from;
+		const isWooCoreProfilerFlow = 'woocommerce-core-profiler' === currentQuery?.from;
 		const wccomFrom = currentQuery?.[ 'wccom-from' ];
 		const masterbarIsHidden =
 			! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute;
@@ -266,6 +274,7 @@ export default withCurrentRoute(
 			useOAuth2Layout: showOAuth2Layout( state ),
 			isPartnerSignup,
 			isPartnerSignupStart,
+			isWooCoreProfilerFlow,
 		};
 	} )( localize( LayoutLoggedOut ) )
 );

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -44,7 +44,7 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 							</a>
 						</li>
 						<li className="masterbar__woo-nav-item">
-							{ typeof redirectTo === 'string' && (
+							{ typeof redirectTo === 'string' && redirectTo.length && (
 								<Button href={ redirectTo } className="masterbar__no-thanks-button">
 									{ translate( 'No, Thanks' ) }
 								</Button>

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -35,7 +35,7 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 						<li className="masterbar__woo-nav-item">
 							{ redirectToSanitized && (
 								<Button href={ redirectToSanitized } className="masterbar__no-thanks-button">
-									{ translate( 'No Thanks' ) }
+									{ translate( 'No, Thanks' ) }
 								</Button>
 							) }
 						</li>

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -1,5 +1,6 @@
 import { ProgressBar } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import { getQueryArg } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
 import { Fragment } from 'react';
 import WooLogo from 'calypso/assets/images/icons/woocommerce-logo.svg';
@@ -8,11 +9,21 @@ import './typekit';
 import './woo.scss';
 import { useSelector } from 'calypso/state';
 import { getRedirectToOriginal } from 'calypso/state/login/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 // Masterbar for WooCommerce Core Profiler Jetpack step
 const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) => string } ) => {
-	// Get the redirect URL from the state. It should be set by the Jetpack Connection screen
-	const redirectToSanitized = useSelector( ( state ) => getRedirectToOriginal( state ) );
+	const redirectTo = useSelector( ( state ) => {
+		switch ( getCurrentRoute( state ) ) {
+			case '/jetpack/connect/authorize':
+				return getCurrentQueryArguments( state )?.redirect_after_auth;
+			case '/log-in/jetpack':
+				return getQueryArg( getRedirectToOriginal( state ) || '', 'redirect_after_auth' );
+			default:
+				return null;
+		}
+	} );
 
 	return (
 		<Fragment>
@@ -33,8 +44,8 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 							</a>
 						</li>
 						<li className="masterbar__woo-nav-item">
-							{ redirectToSanitized && (
-								<Button href={ redirectToSanitized } className="masterbar__no-thanks-button">
+							{ typeof redirectTo === 'string' && (
+								<Button href={ redirectTo } className="masterbar__no-thanks-button">
 									{ translate( 'No, Thanks' ) }
 								</Button>
 							) }

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -1,0 +1,49 @@
+import { ProgressBar } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { localize } from 'i18n-calypso';
+import { Fragment } from 'react';
+import WooLogo from 'calypso/assets/images/icons/woocommerce-logo.svg';
+import SVGIcon from 'calypso/components/svg-icon';
+import './typekit';
+import './woo.scss';
+import { useSelector } from 'calypso/state';
+import { getRedirectToOriginal } from 'calypso/state/login/selectors';
+
+// Masterbar for WooCommerce Core Profiler Jetpack step
+const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) => string } ) => {
+	// Get the redirect URL from the state. It should be set by the Jetpack Connection screen
+	const redirectToSanitized = useSelector( ( state ) => getRedirectToOriginal( state ) );
+
+	return (
+		<Fragment>
+			<ProgressBar className="masterbar__progress-bar" value={ 95 } />
+			<header className="masterbar masterbar__woo">
+				<nav className="masterbar__woo-nav-wrapper">
+					<ul className="masterbar__woo-nav">
+						<li className="masterbar__woo-nav-item">
+							<a href="https://woocommerce.com" className="masterbar__woo-link">
+								<SVGIcon
+									name="woocommerce-logo"
+									icon={ WooLogo }
+									classes="masterbar__woo-client-logo"
+									width="38"
+									height="23"
+									viewBox="0 0 38 23"
+								/>
+							</a>
+						</li>
+						<li className="masterbar__woo-nav-item">
+							{ redirectToSanitized && (
+								<Button href={ redirectToSanitized } className="masterbar__no-thanks-button">
+									{ translate( 'No Thanks' ) }
+								</Button>
+							) }
+						</li>
+					</ul>
+				</nav>
+			</header>
+		</Fragment>
+	);
+};
+
+export default localize( WooCoreProfilerMasterbar );

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -745,6 +745,10 @@
 			text-decoration: none;
 		}
 
+		.masterbar__woo-link {
+			display: flex;
+		}
+
 		.wp-login__container,
 		.magic-login,
 		.step-wrapper {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -108,6 +108,10 @@
 		height: 8px;
 		top: 0;
 		position: absolute;
+
+		.progress-bar__progress {
+			border-radius: 0;
+		}
 	}
 
 	// masterbar styles

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1,63 +1,5 @@
-.masterbar__woo {
-	background: transparent;
-	border-bottom: none;
-	position: absolute;
-	height: 72px;
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	padding: 28px 24px;
-
-	.masterbar__woo-nav {
-		display: flex;
-		flex-direction: row;
-		align-items: center;
-		margin: 0;
-		list-style-type: none;
-		width: 100%;
-
-		.masterbar__login-back-link {
-			margin-top: -10px;
-			font-weight: 500;
-
-			@media screen and ( max-width: 660px ) {
-				display: none;
-			}
-		}
-	}
-}
-
-.masterbar__woo-nav-item a.masterbar__login-back-link {
-	color: var(--studio-gray-100);
-	text-decoration: none;
-	display: flex;
-	font-weight: 500;
-}
-
-.masterbar__woo-mobile-nav {
-	display: none;
-	flex-direction: row;
-	align-items: center;
-	margin: 0;
-	list-style-type: none;
-	width: 100%;
-	position: fixed;
-	bottom: 0;
-	padding: 24px 0;
-	box-shadow: inset 0 1px 0 #e2e4e7;
-	background-color: #fff;
-	z-index: 999;
-
-	@media screen and ( max-width: 660px ) {
-		display: flex;
-	}
-
-	.masterbar__login-back-link {
-		@media screen and ( max-width: 660px ) {
-			display: block;
-		}
-	}
-}
+@import "@wordpress/base-styles/colors";
+@import "@automattic/typography/styles/woo-commerce";
 
 .woo {
 	$woo-purple-50: #7f54b3;
@@ -161,6 +103,79 @@
 		background-color: initial;
 	}
 
+	.masterbar__progress-bar {
+		background-color: transparent;
+		height: 8px;
+		top: 0;
+		position: absolute;
+	}
+
+	// masterbar styles
+	.masterbar__woo {
+		background: transparent;
+		border-bottom: none;
+		position: absolute;
+		height: 72px;
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		padding: 28px 24px;
+
+		.masterbar__woo-nav {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			margin: 0;
+			list-style-type: none;
+			width: 100%;
+
+			.masterbar__login-back-link {
+				margin-top: -10px;
+				font-weight: 500;
+
+				@media screen and ( max-width: 660px ) {
+					display: none;
+				}
+			}
+		}
+	}
+
+	.masterbar__woo-nav-wrapper {
+		width: 100%;
+	}
+
+	.masterbar__woo-nav-item a.masterbar__login-back-link {
+		color: var(--studio-gray-100);
+		text-decoration: none;
+		display: flex;
+		font-weight: 500;
+	}
+
+	.masterbar__woo-mobile-nav {
+		display: none;
+		flex-direction: row;
+		align-items: center;
+		margin: 0;
+		list-style-type: none;
+		width: 100%;
+		position: fixed;
+		bottom: 0;
+		padding: 24px 0;
+		box-shadow: inset 0 1px 0 #e2e4e7;
+		background-color: #fff;
+		z-index: 999;
+
+		@media screen and ( max-width: 660px ) {
+			display: flex;
+		}
+
+		.masterbar__login-back-link {
+			@media screen and ( max-width: 660px ) {
+				display: block;
+			}
+		}
+	}
+
 	&.is-section-signup .layout__content,
 	.layout__content {
 		padding-top: 85px;
@@ -222,7 +237,6 @@
 			font-weight: 600;
 			font-size: 2.75rem;
 			line-height: 52px;
-
 
 			@media screen and ( max-width: 660px ) {
 				text-align: left;
@@ -694,6 +708,80 @@
 			border-radius: 24px; /* stylelint-disable-line scales/radii */
 			padding: 12px;
 			margin-top: 0;
+		}
+	}
+
+	&.is-woocommerce-core-profiler-flow {
+		* {
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+		}
+
+		input[type="text"].form-text-input,
+		input[type="email"].form-text-input,
+		input[type="password"].form-text-input,
+		input[type="tel"].form-text-input,
+		textarea.form-text-input {
+			&:focus,
+			&:hover,
+			&:focus:hover {
+				border-color: var(--wp-admin-theme-color);
+				outline: none;
+				box-shadow: none;
+			}
+		}
+
+		.masterbar__woo-nav-item:first-child {
+			margin-right: auto;
+		}
+
+		.masterbar__no-thanks-button {
+			color: var(--wp-admin-theme-color);
+			font-size: $woo-font-body-extra-small;
+			text-decoration: none;
+		}
+
+		.wp-login__container,
+		.magic-login,
+		.step-wrapper {
+			@media screen and ( max-width: 660px ) {
+				padding-top: 40px;
+			}
+		}
+
+		.login__form-header {
+			margin-bottom: 12px;
+		}
+
+		.login__form-header-wrapper h3 {
+			font-weight: 500;
+		}
+
+		.login__header-subtitle {
+			color: $gray-700;
+		}
+
+		.form-label {
+			font-weight: 500;
+			text-transform: uppercase;
+		}
+
+		.form-button.is-primary {
+			border-radius: 2px;
+			height: 48px;
+			padding: 10px 16px;
+			background-color: var(--wp-admin-theme-color);
+		}
+
+		.login__social-buttons .social-buttons__service-name {
+			font-weight: bold;
+		}
+
+		.login-form__social-buttons-tos {
+			text-align: center;
+
+			@media screen and ( max-width: 660px ) {
+				text-align: start;
+			}
 		}
 	}
 }

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -762,8 +762,14 @@
 			margin: 0 auto;
 		}
 
-		.login__form-header {
+		.login__form-header h3,
+		.formatted-header .formatted-header__title {
 			margin-bottom: 12px;
+			font-size: $woo-font-title-large;
+
+			@media screen and ( max-width: 660px ) {
+				font-size: rem(28px);
+			}
 		}
 
 		.login__form-header-wrapper h3 {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -111,6 +111,7 @@
 
 		.progress-bar__progress {
 			border-radius: 0;
+			background-color: var(--wp-admin-theme-color);
 		}
 	}
 
@@ -752,6 +753,11 @@
 			}
 		}
 
+		.login form {
+			max-width: 405px;
+			margin: 0 auto;
+		}
+
 		.login__form-header {
 			margin-bottom: 12px;
 		}
@@ -764,27 +770,34 @@
 			color: $gray-700;
 		}
 
-		.form-label {
+		.login__form-userdata label.form-label {
 			font-weight: 500;
 			text-transform: uppercase;
+			font-size: rem(11px);
 		}
 
 		.form-button.is-primary {
 			border-radius: 2px;
 			height: 48px;
 			padding: 10px 16px;
+			font-weight: 500;
 			background-color: var(--wp-admin-theme-color);
 		}
 
 		.login__social-buttons .social-buttons__service-name {
-			font-weight: bold;
+			font-weight: 600;
 		}
 
 		.login-form__social-buttons-tos {
 			text-align: center;
+			line-height: 16px;
 
 			@media screen and ( max-width: 660px ) {
 				text-align: start;
+			}
+
+			a {
+				line-height: 16px;
 			}
 		}
 	}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -239,6 +239,8 @@ export class Login extends Component {
 			path,
 			signupUrl,
 			action,
+			isWooCoreProfilerFlow,
+			isPartnerSignup,
 		} = this.props;
 
 		if ( privateSite && isLoggedIn ) {
@@ -252,7 +254,8 @@ export class Login extends Component {
 			! socialConnect &&
 			! isJetpackMagicLinkSignUpFlow &&
 			// We don't want to render the footer for woo oauth2 flows but render it if it's partner signup
-			! ( isWooOAuth2Client( this.props.oauth2Client ) && ! this.props.isPartnerSignup );
+			! ( isWooOAuth2Client( oauth2Client ) && ! isPartnerSignup ) &&
+			! isWooCoreProfilerFlow;
 
 		const footer = (
 			<>
@@ -340,6 +343,8 @@ export default connect(
 			get( getCurrentQueryArguments( state ), 'from' ),
 			'wpcom-migration'
 		),
+		isWooCoreProfilerFlow:
+			'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
 	} ),
 	{
 		recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -152,7 +152,7 @@ $image-height: 47px;
 	}
 }
 
-.layout.is-jetpack-login:not(.is-jetpack-woocommerce-flow):not(.is-wccom-oauth-flow) {
+.layout.is-jetpack-login:not(.is-jetpack-woocommerce-flow):not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
 	@include jetpack-connect-colors();
 }
 
@@ -162,7 +162,7 @@ $image-height: 47px;
 	@include woocommerce-colors();
 }
 
-.layout.is-jetpack-login {
+.layout.is-jetpack-login:not(.is-woocommerce-core-profiler-flow) {
 
 	.login__form input:focus,
 	.logged-out-form input:focus {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/woocommerce/team-ghidorah/issues/215

## Proposed Changes

Add woocommerce core profiler jetpack login screen

* Use `from` query param to check it's from woocommerce core profile flow
* Customize and add styles for the login screen if it's from woocommerce core profile flow


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to woocommerce jetpack login screen `/log-in/jetpack?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D219799967%26redirect_uri%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fhandler%253Djetpack-connection-webhooks%2526action%253Dauthorize%2526_wpnonce%253D3f81798d85%2526redirect%253Dhttps%25253A%25252F%25252Fdull-wasp.jurassic.ninja%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Dwc-admin%26state%3D1%26scope%3Dadministrator%253Ae0a0df66fa6e6d2b7c0969d37fa165d4%26user_email%3Dchi-hsuan.huang%2540automattic.com%26user_login%3Dchihsuanhuang%26jp_version%3D12.1.1%26secret%3DuDAtkilHDeWP4lnJewWTAH5Gv7EQVJxt%26blogname%3DDull%2BWasp%26site_url%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja%26home_url%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja%26site_icon%26site_lang%3Den_US%26site_created%3D2023-06-05%2B07%253A02%253A54%26allow_site_connection%3D1%26locale%3Den%26_ui%3D42367338%26_ut%3Dwpcom%253Auser_id%26calypso_env%3Dproduction%26_as%3Dwp-cli%26from%3Dwoocommerce-onboarding%26purchase_nonce%3Di5V9KqSt%26_wp_nonce%3De48c9f86a6%26redirect_after_auth%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin%26site%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja&from=woocommerce-core-profiler`
2. Confirm it matches the design (Y5pUYSJPsGEud1vknUZhi8-fi-739_54872)
3. Click on `No, thanks`
4. Should redirect to Jetpack connection screen (/jetpack/connect/authorize)
 

![Screenshot 2023-06-06 at 15 03 05](https://github.com/Automattic/wp-calypso/assets/4344253/8e1af973-1024-495c-b20a-0e8667e8a5a6)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?