### PR TITLE
Launchpad: Adds the keep building card

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -45,3 +45,4 @@ export const TASK_USE_BUILT_BY = 'home-task-use-built-by';
 export const TASK_STAGING = 'home-task-staging';
 export const TASK_FIVERR = 'home-task-fiverr';
 export const TASK_DOMAIN_UPSELL = 'home-task-domain-upsell';
+export const LAUNCHPAD_KEEP_BUILDING = 'home-launchpad-keep-building';

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.jsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.jsx
@@ -4,7 +4,7 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const LaunchpadKeepBuilding = ( { siteSlug } ) => {
-	return <Launchpad siteSlug={ siteSlug } />;
+	return <Launchpad siteSlug={ siteSlug } checklistSlug="keep-building" />;
 };
 
 const ConnectedLaunchpadKeepBuilding = connect( ( state ) => {

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.jsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.jsx
@@ -1,0 +1,18 @@
+import { Launchpad } from '@automattic/launchpad';
+import { connect } from 'react-redux';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const LaunchpadKeepBuilding = ( { siteSlug } ) => {
+	return <Launchpad siteSlug={ siteSlug } />;
+};
+
+const ConnectedLaunchpadKeepBuilding = connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteSlug: getSiteSlug( state, siteId ),
+	};
+} )( LaunchpadKeepBuilding );
+
+export default ConnectedLaunchpadKeepBuilding;

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -31,7 +31,9 @@ import {
 	TASK_REACTIVATE_RESTORE_BACKUP,
 	TASK_FIVERR,
 	TASK_DOMAIN_UPSELL,
+	LAUNCHPAD_KEEP_BUILDING,
 } from 'calypso/my-sites/customer-home/cards/constants';
+import LaunchpadKeepBuilding from 'calypso/my-sites/customer-home/cards/launchpad/keep-building';
 import CelebrateSiteCopy from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-copy';
 import CelebrateSiteCreation from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-creation';
 import CelebrateSiteLaunch from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-launch';
@@ -78,6 +80,7 @@ const cardComponents = {
 	[ TASK_REACTIVATE_RESTORE_BACKUP ]: ReviveAutoRevertedAtomic,
 	[ TASK_SITE_RESUME_COPY ]: SiteResumeCopy,
 	[ TASK_SITE_SETUP_CHECKLIST ]: SiteSetupList,
+	[ LAUNCHPAD_KEEP_BUILDING ]: LaunchpadKeepBuilding,
 	[ TASK_UPSELL_TITAN ]: TitanBanner,
 	[ TASK_WEBINARS ]: Webinars,
 	[ TASK_WP_COURSES ]: WPCourses,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


Related to #77330

## Proposed Changes

* Adds the "Keep building" Launchpad to the customer home.

## Testing Instructions

* Sandbox the `public-api` and apply D112878-code to your sandbox.
* Apply this PR to your local Calypso project or use the calypso.live
* Create a new free site and go through the setup flow until you land on the home page.
* If you are a Serenity team member, the checklist should be replaced with the new "Keep building" launchpad.
  * In case you are not a Serenity team member add your ID to the following function: fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Szh%2Qcyhtvaf%2Snhgbznggvp%2Qshapgvbaf.cuc%3Se%3Qn046764r%231377-og
* If you are a Serenity team member, you can also test removing your ID from the list mentioned above. You should see the current checklist. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?