### PR TITLE
Fix/migration reset endpoint

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -84,7 +84,7 @@ export class SectionMigrate extends Component {
 			this.updateFromAPI();
 		}
 
-		if ( 'done' === this.state.migrationStatus ) {
+		if ( 'done' === this.state.migrationStatus && prevState.migrationStatus !== 'done' ) {
 			this.finishMigration();
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67999

## Proposed Changes

When a migration is done, we call the reset-migration endpoint. This is triggered by `componentDidUpdate` which is triggered continuously before, during, and after a migration. This triggers the code that calls the endpoint over and over again as soon as the migration status is `done`.

This PR introduces a check to make sure the endpoint only gets called when the migration status changes to done and prevents it from running whenever the `componentDidUpdate` is triggered.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new JN site.
2. Connect site with Move to WordPress plugin.
3. Switch url of site from wordpress.com/... to calypso.localhost:3000/...
4. Start a migration
5. Check that at the end of the migration (the 'hooray' screen) only 1 request to the `reset-migration` endpoint is done when staying on that page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
