### PR TITLE
Update tailored flows to Product menus for /themes, /plugins and /tags

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -104,6 +104,17 @@ const UniversalNavbarHeader = ( {
 															target="_self"
 														/>
 														<ClickableItem
+															titleValue={ __( 'Newsletter', __i18n_text_domain__ ) }
+															content={ __( 'Newsletter', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl(
+																'//wordpress.com/setup/newsletter/intro',
+																locale,
+																isLoggedIn
+															) }
+															type="dropdown"
+															target="_self"
+														/>
+														<ClickableItem
 															titleValue={ __( 'Professional Email', __i18n_text_domain__ ) }
 															content={ __( 'Professional Email', __i18n_text_domain__ ) }
 															urlValue={ localizeUrl( '//wordpress.com/professional-email/' ) }
@@ -129,20 +140,9 @@ const UniversalNavbarHeader = ( {
 															target="_self"
 														/>
 														<ClickableItem
-															titleValue={ __( 'Course', __i18n_text_domain__ ) }
-															content={ __( 'Course', __i18n_text_domain__ ) }
+															titleValue={ __( 'Course Maker', __i18n_text_domain__ ) }
+															content={ __( 'Course Maker', __i18n_text_domain__ ) }
 															urlValue={ localizeUrl( '//wordpress.com/create-a-course/' ) }
-															type="dropdown"
-															target="_self"
-														/>
-														<ClickableItem
-															titleValue={ __( 'Newsletter', __i18n_text_domain__ ) }
-															content={ __( 'Newsletter', __i18n_text_domain__ ) }
-															urlValue={ localizeUrl(
-																'//wordpress.com/setup/newsletter/intro',
-																locale,
-																isLoggedIn
-															) }
 															type="dropdown"
 															target="_self"
 														/>
@@ -430,6 +430,16 @@ const UniversalNavbarHeader = ( {
 												type="menu"
 											/>
 											<ClickableItem
+												titleValue={ __( 'Newsletter', __i18n_text_domain__ ) }
+												content={ __( 'Newsletter', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl(
+													'//wordpress.com/setup/newsletter/intro',
+													locale,
+													isLoggedIn
+												) }
+												type="menu"
+											/>
+											<ClickableItem
 												titleValue={ __( 'Professional Email', __i18n_text_domain__ ) }
 												content={ __( 'Professional Email', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/professional-email/' ) }
@@ -451,19 +461,9 @@ const UniversalNavbarHeader = ( {
 												type="menu"
 											/>
 											<ClickableItem
-												titleValue={ __( 'Course', __i18n_text_domain__ ) }
-												content={ __( 'Course', __i18n_text_domain__ ) }
+												titleValue={ __( 'Course Maker', __i18n_text_domain__ ) }
+												content={ __( 'Course Maker', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/create-a-course/' ) }
-												type="menu"
-											/>
-											<ClickableItem
-												titleValue={ __( 'Newsletter', __i18n_text_domain__ ) }
-												content={ __( 'Newsletter', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl(
-													'//wordpress.com/setup/newsletter/intro',
-													locale,
-													isLoggedIn
-												) }
 												type="menu"
 											/>
 											<ClickableItem

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -108,9 +108,10 @@ const UniversalNavbarHeader = ( {
 															titleValue={ __( 'Newsletter', __i18n_text_domain__ ) }
 															content={ __( 'Newsletter', __i18n_text_domain__ ) }
 															urlValue={ localizeUrl(
-																'//wordpress.com/setup/newsletter/intro',
+																'//wordpress.com/setup/newsletter',
 																locale,
-																isLoggedIn
+																isLoggedIn,
+																true
 															) }
 															type="dropdown"
 															target="_self"
@@ -442,9 +443,10 @@ const UniversalNavbarHeader = ( {
 												titleValue={ __( 'Newsletter', __i18n_text_domain__ ) }
 												content={ __( 'Newsletter', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl(
-													'//wordpress.com/setup/newsletter/intro',
+													'//wordpress.com/setup/newsletter',
 													locale,
-													isLoggedIn
+													isLoggedIn,
+													true
 												) }
 												type="menu"
 											/>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -115,42 +115,16 @@ const UniversalNavbarHeader = ( {
 																titleValue={ __( 'Website Design Services', __i18n_text_domain__ ) }
 																content={ __( 'Website Design Services', __i18n_text_domain__ ) }
 																urlValue={ localizeUrl(
-																	'//wordpress.com/website-design-service/?ref=main-menu'
+																	'//wordpress.com/website-design-service/'
 																) }
 																type="dropdown"
 																target="_self"
 															/>
 														) }
 														<ClickableItem
-															titleValue={ __( 'Link in Bio', __i18n_text_domain__ ) }
-															content={ __( 'Link in Bio', __i18n_text_domain__ ) }
-															urlValue={ localizeUrl(
-																'//wordpress.com/setup/link-in-bio/intro?ref=main-menu',
-																locale,
-																isLoggedIn
-															) }
-															type="dropdown"
-															target="_self"
-														/>
-														<ClickableItem
-															titleValue={ __( 'Newsletter', __i18n_text_domain__ ) }
-															content={ __( 'Newsletter', __i18n_text_domain__ ) }
-															urlValue={ localizeUrl(
-																'//wordpress.com/setup/newsletter/intro?ref=main-menu',
-																locale,
-																isLoggedIn
-															) }
-															type="dropdown"
-															target="_self"
-														/>
-														<ClickableItem
-															titleValue={ __( 'Video', __i18n_text_domain__ ) }
-															content={ __( 'Video', __i18n_text_domain__ ) }
-															urlValue={ localizeUrl(
-																'//wordpress.com/setup/videopress/intro?ref=main-menu',
-																locale,
-																isLoggedIn
-															) }
+															titleValue={ __( 'Store', __i18n_text_domain__ ) }
+															content={ __( 'Store', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl( '//wordpress.com/ecommerce/' ) }
 															type="dropdown"
 															target="_self"
 														/>
@@ -158,6 +132,17 @@ const UniversalNavbarHeader = ( {
 															titleValue={ __( 'Course', __i18n_text_domain__ ) }
 															content={ __( 'Course', __i18n_text_domain__ ) }
 															urlValue={ localizeUrl( '//wordpress.com/create-a-course/' ) }
+															type="dropdown"
+															target="_self"
+														/>
+														<ClickableItem
+															titleValue={ __( 'Newsletter', __i18n_text_domain__ ) }
+															content={ __( 'Newsletter', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl(
+																'//wordpress.com/setup/newsletter/intro',
+																locale,
+																isLoggedIn
+															) }
 															type="dropdown"
 															target="_self"
 														/>
@@ -454,47 +439,31 @@ const UniversalNavbarHeader = ( {
 												<ClickableItem
 													titleValue={ __( 'Website Design Services', __i18n_text_domain__ ) }
 													content={ __( 'Website Design Services', __i18n_text_domain__ ) }
-													urlValue={ localizeUrl(
-														'//wordpress.com/website-design-service/?ref=main-menu'
-													) }
+													urlValue={ localizeUrl( '//wordpress.com/website-design-service/' ) }
 													type="menu"
 													target="_self"
 												/>
 											) }
 											<ClickableItem
-												titleValue={ __( 'Link in Bio', __i18n_text_domain__ ) }
-												content={ __( 'Link in Bio', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl(
-													'//wordpress.com/setup/link-in-bio/intro?ref=main-menu',
-													locale,
-													isLoggedIn
-												) }
-												type="menu"
-											/>
-											<ClickableItem
-												titleValue={ __( 'Newsletter', __i18n_text_domain__ ) }
-												content={ __( 'Newsletter', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl(
-													'//wordpress.com/setup/newsletter/intro?ref=main-menu',
-													locale,
-													isLoggedIn
-												) }
-												type="menu"
-											/>
-											<ClickableItem
-												titleValue={ __( 'Video', __i18n_text_domain__ ) }
-												content={ __( 'Video', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl(
-													'//wordpress.com/setup/videopress/intro?ref=main-menu',
-													locale,
-													isLoggedIn
-												) }
+												titleValue={ __( 'Store', __i18n_text_domain__ ) }
+												content={ __( 'Store', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl( '//wordpress.com/ecommerce/' ) }
 												type="menu"
 											/>
 											<ClickableItem
 												titleValue={ __( 'Course', __i18n_text_domain__ ) }
 												content={ __( 'Course', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/create-a-course/' ) }
+												type="menu"
+											/>
+											<ClickableItem
+												titleValue={ __( 'Newsletter', __i18n_text_domain__ ) }
+												content={ __( 'Newsletter', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl(
+													'//wordpress.com/setup/newsletter/intro',
+													locale,
+													isLoggedIn
+												) }
 												type="menu"
 											/>
 											<ClickableItem

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { WordPressWordmark } from '@automattic/components';
 import { useLocalizeUrl, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import { HeaderProps } from '../types';
@@ -17,6 +17,7 @@ const UniversalNavbarHeader = ( {
 }: HeaderProps ) => {
 	const locale = useLocale();
 	const localizeUrl = useLocalizeUrl();
+	const { __, hasTranslation } = useI18n();
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
 	const isEnglishLocale = useIsEnglishLocale();
 
@@ -140,8 +141,16 @@ const UniversalNavbarHeader = ( {
 															target="_self"
 														/>
 														<ClickableItem
-															titleValue={ __( 'Course Maker', __i18n_text_domain__ ) }
-															content={ __( 'Course Maker', __i18n_text_domain__ ) }
+															titleValue={
+																locale === 'en' || hasTranslation?.( 'Course Maker' )
+																	? __( 'Course Maker', __i18n_text_domain__ )
+																	: __( 'Course', __i18n_text_domain__ )
+															}
+															content={
+																locale === 'en' || hasTranslation?.( 'Course Maker' )
+																	? __( 'Course Maker', __i18n_text_domain__ )
+																	: __( 'Course', __i18n_text_domain__ )
+															}
 															urlValue={ localizeUrl( '//wordpress.com/create-a-course/' ) }
 															type="dropdown"
 															target="_self"
@@ -461,8 +470,16 @@ const UniversalNavbarHeader = ( {
 												type="menu"
 											/>
 											<ClickableItem
-												titleValue={ __( 'Course Maker', __i18n_text_domain__ ) }
-												content={ __( 'Course Maker', __i18n_text_domain__ ) }
+												titleValue={
+													locale === 'en' || hasTranslation?.( 'Course Maker' )
+														? __( 'Course Maker', __i18n_text_domain__ )
+														: __( 'Course', __i18n_text_domain__ )
+												}
+												content={
+													locale === 'en' || hasTranslation?.( 'Course Maker' )
+														? __( 'Course Maker', __i18n_text_domain__ )
+														: __( 'Course', __i18n_text_domain__ )
+												}
 												urlValue={ localizeUrl( '//wordpress.com/create-a-course/' ) }
 												type="menu"
 											/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2621, https://github.com/Automattic/dotcom-forge/issues/2602, https://github.com/Automattic/dotcom-forge/issues/2671, https://github.com/Automattic/dotcom-forge/issues/2671

## Proposed Changes

- Removed the "Video" and "Link in Bio" links in the Products menu.
- Added the "Store" menu item and changed the order to blog, ecommerce (aka store), course, newsletter.
- Removed 'ref=main-menu' from the links (https://github.com/Automattic/dotcom-forge/issues/2602)
- Move `Newsletter` under `Create a blog`
- Rename `Course` to `Course Maker`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout to this branch
* Check the desktop/mobile menus for `/themes`, `/tags`, `/plugins`
* Check the links and make sure they are not broken

Desktop
![desktop](https://github.com/Automattic/wp-calypso/assets/402286/00fa2f9a-2df0-40fa-a804-f8382553fcb9)

Mobile
![mobile](https://github.com/Automattic/wp-calypso/assets/402286/1461a548-10f6-4ab4-ace5-1f6b5b7ce71d)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?