### PR TITLE
Update tailored flows to Product menus for happy-blocks (/support)

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -156,7 +156,7 @@ $happy_blocks_is_english = ( 0 === stripos( get_locale(), 'en' ) );
 								</a>
 							</li>
 							<li>
-								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_tailored_flow_url( '//wordpress.com/setup/newsletter/intro' ) ); ?>" title="<?php echo esc_attr( fixme__( 'Newsletter', 'happy-blocks' ) ); ?>" tabindex="-1">
+								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_tailored_flow_url( '//wordpress.com/setup/newsletter' ) ); ?>" title="<?php echo esc_attr( __( 'Newsletter', 'happy-blocks' ) ); ?>" tabindex="-1">
 									<?php echo esc_html( __( 'Newsletter', 'happy-blocks' ) ); ?>
 								</a>
 							</li>
@@ -336,7 +336,7 @@ $happy_blocks_is_english = ( 0 === stripos( get_locale(), 'en' ) );
 									</a>
 								</li>
 								<li class="x-menu-grid-item">
-									<a role="menuitem" class="x-menu-link x-link" href="<?php echo esc_url( localized_tailored_flow_url( '//wordpress.com/setup/newsletter/intro' ) ); ?>" title="<?php echo esc_attr( __( 'Newsletter', 'happy-blocks' ) ); ?>" tabindex="-1">
+									<a role="menuitem" class="x-menu-link x-link" href="<?php echo esc_url( localized_tailored_flow_url( '//wordpress.com/setup/newsletter' ) ); ?>" title="<?php echo esc_attr( __( 'Newsletter', 'happy-blocks' ) ); ?>" tabindex="-1">
 										<?php echo esc_html( __( 'Newsletter', 'happy-blocks' ) ); ?>
 									</a>
 								</li>

--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -141,23 +141,23 @@ $happy_blocks_is_english = ( 0 === stripos( get_locale(), 'en' ) );
 								</a>
 							</li>
 							<li>
-								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_tailored_flow_url( '//wordpress.com/setup/link-in-bio/intro?ref=main-menu' ) ); ?>" title="<?php echo esc_attr( fixme__( 'Link in Bio', 'happy-blocks' ) ); ?>" tabindex="-1">
-									<?php echo esc_html( fixme__( 'Link in Bio', 'happy-blocks' ) ); ?>
+								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/website-design-service/' ) ); ?>" title="<?php echo esc_attr( __( 'Website Design Services', 'happy-blocks' ) ); ?>" tabindex="-1">
+									<?php echo esc_html( __( 'Website Design Services', 'happy-blocks' ) ); ?>
 								</a>
 							</li>
 							<li>
-								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_tailored_flow_url( '//wordpress.com/setup/newsletter/intro?ref=main-menu' ) ); ?>" title="<?php echo esc_attr( fixme__( 'Newsletter', 'happy-blocks' ) ); ?>" tabindex="-1">
-									<?php echo esc_html( fixme__( 'Newsletter', 'happy-blocks' ) ); ?>
+								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/ecommerce/' ) ); ?>" title="<?php echo esc_attr( __( 'Store', 'happy-blocks' ) ); ?>" tabindex="-1">
+									<?php echo esc_html( __( 'Store', 'happy-blocks' ) ); ?>
 								</a>
 							</li>
 							<li>
-								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_tailored_flow_url( '//wordpress.com/setup/videopress/intro?ref=main-menu' ) ); ?>" title="<?php echo esc_attr( fixme__( 'Video', 'happy-blocks' ) ); ?>" tabindex="-1">
-									<?php echo esc_html( fixme__( 'Video', 'happy-blocks' ) ); ?>
+								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/create-a-course/' ) ); ?>" title="<?php echo esc_attr( __( 'Course', 'happy-blocks' ) ); ?>" tabindex="-1">
+									<?php echo esc_html( __( 'Course', 'happy-blocks' ) ); ?>
 								</a>
 							</li>
 							<li>
-								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/create-a-course' ) ); ?>" title="<?php echo esc_attr( fixme__( 'Course', 'happy-blocks' ) ); ?>" tabindex="-1">
-									<?php echo esc_html( fixme__( 'Course', 'happy-blocks' ) ); ?>
+								<a role="menuitem" class="x-dropdown-link x-link" href="<?php echo esc_url( localized_tailored_flow_url( '//wordpress.com/setup/newsletter/intro' ) ); ?>" title="<?php echo esc_attr( fixme__( 'Newsletter', 'happy-blocks' ) ); ?>" tabindex="-1">
+									<?php echo esc_html( __( 'Newsletter', 'happy-blocks' ) ); ?>
 								</a>
 							</li>
 						</ul>
@@ -318,6 +318,26 @@ $happy_blocks_is_english = ( 0 === stripos( get_locale(), 'en' ) );
 								<li class="x-menu-grid-item">
 									<a role="menuitem" class="x-menu-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/professional-email/' ) ); ?>" title="<?php echo esc_attr( fixme__( 'Professional Email', __( 'Email', 'happy-blocks' ) ) ); ?>" tabindex="-1">
 										<?php echo esc_html( fixme__( 'Professional Email', __( 'Email', 'happy-blocks' ) ) ); ?>
+									</a>
+								</li>
+								<li class="x-menu-grid-item">
+									<a role="menuitem" class="x-menu-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/website-design-service/' ) ); ?>" title="<?php echo esc_attr( __( 'Website Design Services', 'happy-blocks' ) ); ?>" tabindex="-1">
+										<?php echo esc_html( __( 'Website Design Services', 'happy-blocks' ) ); ?>
+									</a>
+								</li>
+								<li class="x-menu-grid-item">
+									<a role="menuitem" class="x-menu-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/ecommerce/' ) ); ?>" title="<?php echo esc_attr( __( 'Store', 'happy-blocks' ) ); ?>" tabindex="-1">
+										<?php echo esc_html( __( 'Store', 'happy-blocks' ) ); ?>
+									</a>
+								</li>
+								<li class="x-menu-grid-item">
+									<a role="menuitem" class="x-menu-link x-link" href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/create-a-course/' ) ); ?>" title="<?php echo esc_attr( __( 'Course', 'happy-blocks' ) ); ?>" tabindex="-1">
+										<?php echo esc_html( __( 'Course', 'happy-blocks' ) ); ?>
+									</a>
+								</li>
+								<li class="x-menu-grid-item">
+									<a role="menuitem" class="x-menu-link x-link" href="<?php echo esc_url( localized_tailored_flow_url( '//wordpress.com/setup/newsletter/intro' ) ); ?>" title="<?php echo esc_attr( __( 'Newsletter', 'happy-blocks' ) ); ?>" tabindex="-1">
+										<?php echo esc_html( __( 'Newsletter', 'happy-blocks' ) ); ?>
 									</a>
 								</li>
 								<li class="x-menu-grid-item">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2621, https://github.com/Automattic/dotcom-forge/issues/2602

## Proposed Changes

- Removed the "Video" and "Link in Bio" links in the Products menu.
- Added the "Store" menu item and changed the order to blog, ecommerce (aka store), course, newsletter.
- Removed 'ref=main-menu' from the links (https://github.com/Automattic/dotcom-forge/issues/2602)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout to this branch
* `cd apps/happy-blocks`
* `yarn dev --sync`
* sandbox `wordpress.com`
* Check the desktop/mobile menus for `/support`
* Check the links and make sure they are not broken
* Check locales

Desktop
![desktop](https://github.com/Automattic/wp-calypso/assets/6586048/f3732dc0-8c33-4a81-a063-44a1cf340b89)

Mobile
![mobile](https://github.com/Automattic/wp-calypso/assets/6586048/e7a50ebc-e9ae-4948-a0ff-e77e270fcb62)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?