### PR TITLE
reader search popular sites - add follow button

### DIFF
--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -18,6 +18,7 @@ class ConnectedSubscriptionListItem extends Component {
 		onComponentMountWithNewRailcar: PropTypes.func,
 		showNotificationSettings: PropTypes.bool,
 		showLastUpdatedDate: PropTypes.bool,
+		showFollowedOnDate: PropTypes.bool,
 		isEmailBlocked: PropTypes.bool,
 		isFollowing: PropTypes.bool,
 		followSource: PropTypes.string,
@@ -29,6 +30,7 @@ class ConnectedSubscriptionListItem extends Component {
 		onComponentMountWithNewRailcar: noop,
 		showNotificationSettings: true,
 		showLastUpdatedDate: true,
+		showFollowedOnDate: true,
 	};
 
 	componentDidMount() {
@@ -56,6 +58,7 @@ class ConnectedSubscriptionListItem extends Component {
 			siteId,
 			showNotificationSettings,
 			showLastUpdatedDate,
+			showFollowedOnDate,
 			isFollowing,
 			followSource,
 			railcar,
@@ -70,6 +73,7 @@ class ConnectedSubscriptionListItem extends Component {
 				url={ url }
 				showNotificationSettings={ showNotificationSettings }
 				showLastUpdatedDate={ showLastUpdatedDate }
+				showFollowedOnDate={ showFollowedOnDate }
 				isFollowing={ isFollowing }
 				followSource={ followSource }
 				railcar={ railcar }

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -37,6 +37,7 @@ function ReaderSubscriptionListItem( {
 	followSource,
 	showNotificationSettings,
 	showLastUpdatedDate,
+	showFollowedOnDate,
 	isFollowing,
 	railcar,
 } ) {
@@ -150,19 +151,22 @@ function ReaderSubscriptionListItem( {
 									</span>
 								</li>
 							) }
-							{ feed && feed.date_subscribed && ! isNaN( feed.date_subscribed ) && (
-								<li>
-									<span
-										className="reader-subscription-list-item__date-subscribed"
-										title={ moment( feed.date_subscribed ).format( 'll' ) }
-									>
-										{ translate( 'followed %s', {
-											args: moment( feed.date_subscribed ).format( 'MMM YYYY' ),
-											context: 'date feed was followed',
-										} ) }
-									</span>
-								</li>
-							) }
+							{ showFollowedOnDate &&
+								feed &&
+								feed.date_subscribed &&
+								! isNaN( feed.date_subscribed ) && (
+									<li>
+										<span
+											className="reader-subscription-list-item__date-subscribed"
+											title={ moment( feed.date_subscribed ).format( 'll' ) }
+										>
+											{ translate( 'followed %s', {
+												args: moment( feed.date_subscribed ).format( 'MMM YYYY' ),
+												context: 'date feed was followed',
+											} ) }
+										</span>
+									</li>
+								) }
 						</ul>
 					</div>
 				) }

--- a/client/reader/follow-sources.jsx
+++ b/client/reader/follow-sources.jsx
@@ -5,3 +5,4 @@ export const READER_FOLLOWING_MANAGE_SEARCH_RESULT = 'reader-following-manage-se
 export const READER_FOLLOWING_MANAGE_RECOMMENDATION = 'reader-following-manage-recommendation';
 export const READER_POST_OPTIONS_MENU = 'reader-post-options-menu';
 export const READER_SUGGESTED_FOLLOWS_DIALOG = 'reader-suggested-follows-dialog';
+export const READER_SEARCH_POPULAR_SITES = 'reader-search-popular-sites';

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -212,7 +212,6 @@ class SearchStream extends React.Component {
 								<SiteResults
 									query={ query }
 									sort={ pickSort( sortOrder ) }
-									showLastUpdatedDate={ false }
 									onReceiveSearchResults={ this.setSearchFeed }
 								/>
 							</div>
@@ -227,7 +226,6 @@ class SearchStream extends React.Component {
 							<SiteResults
 								query={ query }
 								sort={ pickSort( sortOrder ) }
-								showLastUpdatedDate={ true }
 								onReceiveSearchResults={ this.setSearchFeed }
 							/>
 						) }

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -27,7 +27,6 @@ class SiteResults extends Component {
 		searchResults: PropTypes.array,
 		searchResultsCount: PropTypes.number,
 		width: PropTypes.number.isRequired,
-		showLastUpdatedDate: PropTypes.bool,
 	};
 
 	fetchNextPage = ( offset ) => {
@@ -42,7 +41,7 @@ class SiteResults extends Component {
 	hasNextPage = ( offset ) => offset < this.props.searchResultsCount;
 
 	render() {
-		const { query, searchResults, width, sort, showLastUpdatedDate } = this.props;
+		const { query, searchResults, width, sort } = this.props;
 		const isEmpty = query?.length > 0 && searchResults?.length === 0;
 
 		if ( isEmpty ) {
@@ -63,7 +62,9 @@ class SiteResults extends Component {
 					hasNextPage={ this.hasNextPage }
 					rowRenderer={ siteRowRenderer }
 					extraRenderItemProps={ {
-						showLastUpdatedDate,
+						showLastUpdatedDate: false,
+						showNotificationSettings: false,
+						showFollowedOnDate: false,
 						followSource: SEARCH_RESULTS_SITES,
 					} }
 				/>

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -267,8 +267,7 @@
 }
 
 // Site results
-.search-stream .search-stream__site-results,
-.search-stream .reader-two-column .reader-tag-sidebar-recommended-sites {
+.search-stream .search-stream__site-results {
 	max-width: 265px;
 	min-width: 265px;
 	margin-left: 40px;
@@ -276,6 +275,11 @@
 	.reader-infinite-stream__row-wrapper {
 		border: 0;
 	}
+}
+
+// Site results and Popular sites
+.search-stream .search-stream__site-results,
+.search-stream .reader-two-column .reader-tag-sidebar-recommended-sites {
 
 	.reader-subscription-list-item .follow-button__label,
 	.reader-subscription-list-item__settings-label {
@@ -298,6 +302,10 @@
 	max-width: 185px;
 }
 
+.search-stream__single-column-results .reader-infinite-stream__row-wrapper {
+	margin-top: 20px;
+}
+
 .search-stream__single-column-results .reader-subscription-list-item__options {
 	align-items: flex-end;
 	display: flex;
@@ -309,16 +317,6 @@
 		align-items: flex-start;
 		min-width: 90px;
 	}
-}
-
-// Hide settings on the search page. https://github.com/Automattic/wp-calypso/pull/77845
-.search-stream .reader-site-notification-settings__button {
-	display: none;
-}
-
-// Hide the last updated date for the moment - see https://github.com/Automattic/wp-calypso/issues/15121
-.search-stream__single-column-results .reader-subscription-list-item__timestamp {
-	display: none;
 }
 
 // Custom styling for cards in post results

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -267,7 +267,8 @@
 }
 
 // Site results
-.search-stream .search-stream__site-results {
+.search-stream .search-stream__site-results,
+.search-stream .reader-two-column .reader-tag-sidebar-recommended-sites {
 	max-width: 265px;
 	min-width: 265px;
 	margin-left: 40px;
@@ -286,7 +287,13 @@
 	}
 }
 
-.search-stream__results.is-two-columns .reader-subscription-list-item__byline {
+// For popular sites list on single column view.
+.search-stream .following:not(.reader-two-column) .reader-subscription-list-item {
+	border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.search-stream__results.is-two-columns .reader-subscription-list-item__byline,
+.search-stream .reader-two-column .reader-subscription-list-item__byline {
 	min-width: 185px;
 	max-width: 185px;
 }
@@ -302,6 +309,11 @@
 		align-items: flex-start;
 		min-width: 90px;
 	}
+}
+
+// Hide settings on the search page. https://github.com/Automattic/wp-calypso/pull/77845
+.search-stream .reader-site-notification-settings__button {
+	display: none;
 }
 
 // Hide the last updated date for the moment - see https://github.com/Automattic/wp-calypso/issues/15121

--- a/client/reader/stream/reader-search-sidebar/index.jsx
+++ b/client/reader/stream/reader-search-sidebar/index.jsx
@@ -39,6 +39,8 @@ const ReaderSearchSidebar = ( { items } ) => {
 			site={ site }
 			url={ site.URL }
 			showLastUpdatedDate={ false }
+			showNotificationSettings={ false }
+			showFollowedOnDate={ false }
 			followSource={ READER_SEARCH_POPULAR_SITES }
 		/>
 	) );

--- a/client/reader/stream/reader-search-sidebar/index.jsx
+++ b/client/reader/stream/reader-search-sidebar/index.jsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
-import ReaderListFollowingItem from 'calypso/reader/stream/reader-list-followed-sites/item';
+import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
+import { READER_SEARCH_POPULAR_SITES } from 'calypso/reader/follow-sources';
 import '../style.scss';
 
 function unescape( str ) {
@@ -31,7 +32,15 @@ const ReaderSearchSidebar = ( { items } ) => {
 		.filter( ( site ) => site !== null );
 
 	const popularSitesLinks = sites.map( ( site ) => (
-		<ReaderListFollowingItem key={ site.feed_ID } site={ site } path="/" />
+		<ConnectedReaderSubscriptionListItem
+			key={ site.feed_ID }
+			feedId={ site.feed_ID }
+			siteId={ site.blog_ID }
+			site={ site }
+			url={ site.URL }
+			showLastUpdatedDate={ false }
+			followSource={ READER_SEARCH_POPULAR_SITES }
+		/>
 	) );
 
 	if ( ! popularSitesLinks.length ) {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -853,13 +853,3 @@
 		border-radius: 6px; /* stylelint-disable-line scales/radii */
 	}
 }
-
-.following.reader-two-column .reader-tag-sidebar-recommended-sites {
-	.reader-subscription-list-item .follow-button__label {
-		display: none;
-	}
-
-	.reader-site-notification-settings__button-label {
-		display: none;
-	}
-}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -853,3 +853,13 @@
 		border-radius: 6px; /* stylelint-disable-line scales/radii */
 	}
 }
+
+.following.reader-two-column .reader-tag-sidebar-recommended-sites {
+	.reader-subscription-list-item .follow-button__label {
+		display: none;
+	}
+
+	.reader-site-notification-settings__button-label {
+		display: none;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-Rz-p2

## Proposed Changes

* This attempts to add the follow button to the popular sites list in reader search (when no search input is present), by using the same component that renders sites results when a search input is present.

I will circle back to add more images and thoughts here, but right now the search results started coming back empty so its a bit hard to test.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?