### PR TITLE
Subscribers Page: Introduce `useSubscribersQuery` hook

### DIFF
--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+//import { useSubscribersQuery } from './queries';
 
 export const Subscribers = () => {
 	const isSubscribersPageEnabled = config.isEnabled( 'subscribers-page' );
@@ -9,6 +10,9 @@ export const Subscribers = () => {
 	if ( ! isSubscribersPageEnabled ) {
 		return null;
 	}
+
+	//const { data } = useSubscribersQuery(); // needs to be passed a siteId
+	//console.log( 'data: ', data );
 
 	return (
 		<Main>

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
-//import { useSubscribersQuery } from './queries';
 
 export const Subscribers = () => {
 	const isSubscribersPageEnabled = config.isEnabled( 'subscribers-page' );
@@ -10,9 +9,6 @@ export const Subscribers = () => {
 	if ( ! isSubscribersPageEnabled ) {
 		return null;
 	}
-
-	//const { data } = useSubscribersQuery(); // needs to be passed a siteId
-	//console.log( 'data: ', data );
 
 	return (
 		<Main>

--- a/client/my-sites/subscribers/queries/index.ts
+++ b/client/my-sites/subscribers/queries/index.ts
@@ -1,0 +1,1 @@
+export { default as useSubscribersQuery } from './use-subscribers-query';

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+const useSubscribersQuery = ( siteId: number ) => {
+	return useQuery( {
+		queryKey: [ 'subscribers', siteId ],
+		queryFn: () =>
+			wpcom.req.get( {
+				path: `/sites/${ siteId }/subscribers?per_page=10`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		enabled: !! siteId,
+	} );
+};
+
+export default useSubscribersQuery;

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-const useSubscribersQuery = ( siteId: number ) => {
+const useSubscribersQuery = ( siteId: number, page = 1 ) => {
 	return useQuery( {
-		queryKey: [ 'subscribers', siteId ],
+		queryKey: [ 'subscribers', siteId, page ],
 		queryFn: () =>
 			wpcom.req.get( {
-				path: `/sites/${ siteId }/subscribers?per_page=10`,
+				path: `/sites/${ siteId }/subscribers?per_page=10&page=${ page }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
 		enabled: !! siteId,


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/77732.

## Proposed Changes

* introduce `useSubscribersQuery` query

## Testing Instructions

1. Check out this PR.
2. Apply test code to `client/my-sites/subscribers/main.tsx`:

```tsx
import { useSubscribersQuery } from './queries';

// ...

const { data } = useSubscribersQuery( 123456789 ); // real `siteId` needs to be provided
console.log( 'data: ', data );
```

3. Replace the `123456789` with your own site ID.
4. Build the app.
5. Check the Network tab or Console to make sure the request is made correctly and the correct data are returned.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?