### PR TITLE
Reader: fix search icon spacing

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -58,7 +58,7 @@
 }
 
 .reader-subscription-list-item .site-icon {
-	margin-top: 5px;
+	margin-top: 4px;
 
 	img {
 		border-radius: 100%;


### PR DESCRIPTION
PR fixes spacing around icon in Reader search sites sidebar.

### Before
<img width="455" alt="Screenshot 2023-06-06 at 17 06 41" src="https://github.com/Automattic/wp-calypso/assets/5560595/3c45b7a3-d3fb-40a3-9e77-bb279ab8ba7a">

### After
<img width="367" alt="Screenshot 2023-06-06 at 17 13 28" src="https://github.com/Automattic/wp-calypso/assets/5560595/49d83278-3c20-4c87-a13d-97962252bd51">
