### PR TITLE
Sites: track empty state view

### DIFF
--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -83,6 +83,7 @@ function emptySites( context: PageJSContext, next: () => void ) {
 
 	context.primary = (
 		<>
+			<PageViewTracker path="/sites" title="Sites Management Page" delay={ 500 } />
 			<Global styles={ emptySitesDashboardGlobalStyles } />
 			<EmptySitesDashboard />
 		</>


### PR DESCRIPTION
## Proposed Changes

We should track the page views for the empty sites page so that we can understand how many people are starting the onboarding flow after signup.

## Testing Instructions

1. Open the dev tools, change the log level to verbose;
2. Type `localStorage.setItem('debug', 'calypso:analytics')` in the console;
3. Browse `/sites` with an account with no sites;
4. Check that the page view event was dispatched with `site_count: 0`.