### PR TITLE
Signup: store `is_dev_account` property in Tracks

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -941,7 +941,12 @@ class SignupForm extends Component {
 			<SelectCardCheckbox
 				className="signup-form__is-dev-account-checkbox signup-form__span-columns"
 				checked={ this.state.isDevAccount }
-				onChange={ ( isDevAccount ) => this.setState( { isDevAccount } ) }
+				onChange={ ( isDevAccount ) => {
+					recordTracksEvent( 'calypso_signup_dev_account_toggle', {
+						is_dev_account: isDevAccount,
+					} );
+					this.setState( { isDevAccount } );
+				} }
 			>
 				{ preventWidows(
 					translate(

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -533,6 +533,7 @@ class SignupForm extends Component {
 		const userData = {
 			password: formState.getFieldValue( this.state.form, 'password' ),
 			email: formState.getFieldValue( this.state.form, 'email' ),
+			is_dev_account: this.state.isDevAccount,
 		};
 
 		if ( this.props.displayNameInput ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -314,7 +314,10 @@ export class UserStep extends Component {
 				oauth2Signup,
 				...data,
 			},
-			dependencies
+			dependencies,
+			{
+				is_dev_account: data.userData.is_dev_account ?? false,
+			}
 		);
 	};
 

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -107,14 +107,19 @@ export function saveSignupStep( step ) {
 	};
 }
 
-export function submitSignupStep( step, providedDependencies ) {
+export function submitSignupStep( step, providedDependencies, optionalProps ) {
 	assertValidDependencies( step.stepName, providedDependencies );
 	return ( dispatch, getState ) => {
 		const lastKnownFlow = getCurrentFlowName( getState() );
 		const lastUpdated = Date.now();
 		const { intent } = getSignupDependencyStore( getState() );
 
-		dispatch( recordSubmitStep( lastKnownFlow, step.stepName, providedDependencies, { intent } ) );
+		dispatch(
+			recordSubmitStep( lastKnownFlow, step.stepName, providedDependencies, {
+				intent,
+				...optionalProps,
+			} )
+		);
 
 		dispatch( {
 			type: SIGNUP_PROGRESS_SUBMIT_STEP,


### PR DESCRIPTION
## Proposed Changes

**PLEASE ADD THE PROPERTY TO TRACKS BEFORE MERGING THE PR**

Adds `is_dev_account` as a property to the `calypso_signup_actions_submit_step` event.

**PLEASE ADD THE PROPERTY TO TRACKS BEFORE MERGING THE PR**

## Testing Instructions

1.  Enable Tracks logging through `localStorage.setItem('debug', 'calypso:analytics')` and check your console;
2. Browse `/start/hosting` with the `hosting-onboarding-i2` feature flag turned on;
3. Create an account in passwordless mode and check that `calypso_signup_actions_submit_step` was dispatched with `flow: user-hosting` and `is_dev_account: bool`;
4. Create an account by logging in with a social account (Google or Apple) and check that `calypso_signup_actions_submit_step` was dispatched with `flow: user-hosting` and `is_dev_account: bool`;