### PR TITLE
Fixes the campaigns list page for the new Advertising redesign

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
@@ -104,7 +104,7 @@ const useCampaignsQueryPaged = (
 		async ( { pageParam = 1 } ) => {
 			const resultQuery = await requestDSP< CampaignQueryResult >(
 				siteId,
-				`/search/campaigns?order=asc&order_by=post_date&page=${ pageParam }&site_id=${ siteId }&${ searchQueryParams }`
+				`/search/campaigns/site/${ siteId }?order=asc&order_by=post_date&page=${ pageParam }&${ searchQueryParams }`
 			);
 
 			const { campaigns, page, total_items, total_pages } = resultQuery;


### PR DESCRIPTION
## Proposed Changes

This PR fixes an issue in the new Advertising page related to a renamed endpoint in the API.
The endpoint was renamed from `/search/campaigns` to `/search/campaigns/site/{SITE_ID}` to include the user site in the URL.

## Testing Instructions

* Checkout this branch (or activate the `promote-post/redesign-i2` flag in the Live preview)
* Go to Tools->Advertising and then click on Campaigns
* Check that you see the campaigns page correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
