### PR TITLE
Hosting flows: add `is_in_hosting_flow` property to `calypso_signup_step_start`

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -13,11 +13,9 @@ import {
 	getSignupCompleteFlowNameAndClear,
 	getSignupCompleteStepNameAndClear,
 } from 'calypso/signup/storageUtils';
-import { useSelector } from 'calypso/state';
 import { useSite } from '../../hooks/use-site';
 import useSyncRoute from '../../hooks/use-sync-route';
 import { ONBOARD_STORE } from '../../stores';
-import { isInHostingFlow } from '../../utils/is-in-hosting-flow';
 import kebabCase from '../../utils/kebabCase';
 import recordStepStart from './analytics/record-step-start';
 import StepRoute from './components/step-route';
@@ -51,7 +49,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 		[]
 	);
-	const hostingFlow = useSelector( isInHostingFlow );
 
 	const site = useSite();
 	const ref = useQuery().get( 'ref' ) || '';
@@ -135,7 +132,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		if ( ! isReEnteringStep ) {
 			recordStepStart( flow.name, kebabCase( currentStepRoute ), {
 				intent,
-				is_in_hosting_flow: hostingFlow,
 			} );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -13,9 +13,11 @@ import {
 	getSignupCompleteFlowNameAndClear,
 	getSignupCompleteStepNameAndClear,
 } from 'calypso/signup/storageUtils';
+import { useSelector } from 'calypso/state';
 import { useSite } from '../../hooks/use-site';
 import useSyncRoute from '../../hooks/use-sync-route';
 import { ONBOARD_STORE } from '../../stores';
+import { isInHostingFlow } from '../../utils/is-in-hosting-flow';
 import kebabCase from '../../utils/kebabCase';
 import recordStepStart from './analytics/record-step-start';
 import StepRoute from './components/step-route';
@@ -49,6 +51,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 		[]
 	);
+	const hostingFlow = useSelector( isInHostingFlow );
 
 	const site = useSite();
 	const ref = useQuery().get( 'ref' ) || '';
@@ -130,7 +133,10 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		const isReEnteringStep =
 			signupCompleteFlowName === flow.name && signupCompleteStepName === currentStepRoute;
 		if ( ! isReEnteringStep ) {
-			recordStepStart( flow.name, kebabCase( currentStepRoute ), { intent } );
+			recordStepStart( flow.name, kebabCase( currentStepRoute ), {
+				intent,
+				is_in_hosting_flow: hostingFlow,
+			} );
 		}
 
 		// Also record page view for data and analytics

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -130,9 +130,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		const isReEnteringStep =
 			signupCompleteFlowName === flow.name && signupCompleteStepName === currentStepRoute;
 		if ( ! isReEnteringStep ) {
-			recordStepStart( flow.name, kebabCase( currentStepRoute ), {
-				intent,
-			} );
+			recordStepStart( flow.name, kebabCase( currentStepRoute ), { intent } );
 		}
 
 		// Also record page view for data and analytics

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -28,6 +28,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
+import { isInHostingFlow } from 'calypso/landing/stepper/utils/is-in-hosting-flow';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import {
 	recordSignupStart,
@@ -135,6 +136,7 @@ class Signup extends Component {
 		stepName: PropTypes.string,
 		pageTitle: PropTypes.string,
 		stepSectionName: PropTypes.string,
+		hostingFlow: PropTypes.bool.isRequired,
 	};
 
 	state = {
@@ -312,7 +314,7 @@ class Signup extends Component {
 	};
 
 	getRecordProps() {
-		const { signupDependencies } = this.props;
+		const { signupDependencies, hostingFlow } = this.props;
 		let theme = get( signupDependencies, 'selectedDesign.theme' );
 
 		if ( ! theme && signupDependencies.themeParameter ) {
@@ -326,6 +328,7 @@ class Signup extends Component {
 			theme,
 			intent: get( signupDependencies, 'intent' ),
 			starting_point: get( signupDependencies, 'startingPoint' ),
+			is_in_hosting_flow: hostingFlow,
 		};
 	}
 
@@ -921,6 +924,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state ) || getSiteId( state, signupDependencies.siteSlug );
 		const siteDomains = getDomainsBySiteId( state, siteId );
 		const oauth2Client = getCurrentOAuth2Client( state );
+		const hostingFlow = isInHostingFlow( state );
 
 		return {
 			domainsWithPlansOnly: getCurrentUser( state )
@@ -941,6 +945,7 @@ export default connect(
 			localeSlug: getCurrentLocaleSlug( state ),
 			oauth2Client,
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
+			hostingFlow,
 		};
 	},
 	{


### PR DESCRIPTION
## Proposed Changes

**PLEASE ADD THE PROPERTY TO TRACKS BEFORE MERGING THE PR**

Adds `is_in_hosting_flow` as a property to the `calypso_signup_step_start` event.

**PLEASE ADD THE PROPERTY TO TRACKS BEFORE MERGING THE PR**

## Testing Instructions

1.  Enable Tracks logging through `localStorage.setItem('debug', 'calypso:analytics')` and check your console;
2. Browse `/start/new-hosted-site?hosting-flow=true`;
3. Check that `calypso_signup_step_start` was dispatched with `is_in_hosting_flow: true`;
4. Remove the query parameter, refresh the page and check that the same event gets dispatched but with `is_in_hosting_flow` set to `false`.