### PR TITLE
Subscribers Page: add the subscriber list

### DIFF
--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -1,4 +1,4 @@
-const getSubscribersCacheKey = ( siteId: number, currentPage?: number ) => {
+const getSubscribersCacheKey = ( siteId: number | null, currentPage?: number ) => {
 	const cacheKey = [ 'subscribers', siteId ];
 	if ( currentPage ) {
 		cacheKey.push( currentPage );

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,19 +1,63 @@
 import config from '@automattic/calypso-config';
+import { useLocale } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { Item } from 'calypso/components/breadcrumb';
 import DocumentHead from 'calypso/components/data/document-head';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useSubscribersQuery } from './queries';
+import { SubscriberList } from './subscriber-list/subscriber-list';
+import './styles.scss';
 
 export const Subscribers = () => {
 	const isSubscribersPageEnabled = config.isEnabled( 'subscribers-page' );
+	const locale = useLocale();
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const initialState = { data: { total: 0, subscribers: [] } };
+	const result = useSubscribersQuery( selectedSiteId );
+	const {
+		data: { total, subscribers = [] },
+	} = result && result.data ? result : initialState;
+
+	const navigationItems: Item[] = [
+		{
+			label: 'Subscribers',
+			href: `/subscribers`,
+			helpBubble: (
+				<span>
+					{ translate(
+						'Add subscribers to your site and send them a free or paid {{link}}newsletter{{/link}}.',
+						{
+							components: {
+								link: (
+									<a
+										href="https://wordpress.com/support/launch-a-newsletter/#about-your-subscribers"
+										target="blank"
+									/>
+								),
+							},
+						}
+					) }
+				</span>
+			),
+		},
+	];
 
 	if ( ! isSubscribersPageEnabled ) {
 		return null;
 	}
 
 	return (
-		<Main>
+		<Main wideLayout className="subscribers">
 			<DocumentHead title={ translate( 'Subscribers' ) } />
-			Subscribers
+			<FixedNavigationHeader navigationItems={ navigationItems }></FixedNavigationHeader>
+			<div className="subscribers__header-count">
+				<span className="subscribers__title">{ translate( 'Total' ) }</span>{ ' ' }
+				<span className="subscribers__subscriber-count">{ total }</span>
+			</div>
+			<SubscriberList subscribers={ subscribers } locale={ locale } />
 		</Main>
 	);
 };

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -3,7 +3,7 @@ import wpcom from 'calypso/lib/wp';
 import { getSubscribersCacheKey } from '../helpers';
 import type { SubscriberEndpointResponse } from '../types';
 
-const useSubscribersQuery = ( siteId: number, page = 1, perPage = 10 ) => {
+const useSubscribersQuery = ( siteId: number | null, page = 1, perPage = 10 ) => {
 	return useQuery< SubscriberEndpointResponse >( {
 		queryKey: getSubscribersCacheKey( siteId, page ),
 		queryFn: () =>

--- a/client/my-sites/subscribers/styles.scss
+++ b/client/my-sites/subscribers/styles.scss
@@ -1,0 +1,28 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/breakpoints";
+
+.subscribers__header-count {
+	margin-top: 70px;
+	margin-bottom: 30px;
+	font-size: rem(20px);
+	line-height: 26px;
+
+	.subscribers__title {
+		font-weight: 500;
+		color: $studio-gray-100;
+	}
+
+	.subscribers__subscriber-count {
+		color: $studio-gray-40;
+	}
+}
+
+@media ( max-width: $break-medium ) {
+	.subscribers__header-count {
+		padding-left: 16px;
+		padding-right: 16px;
+		margin-top: 85px;
+		margin-bottom: 6px;
+	}
+}
+

--- a/client/my-sites/subscribers/subscriber-list/styles.scss
+++ b/client/my-sites/subscribers/subscriber-list/styles.scss
@@ -1,0 +1,125 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/breakpoints";
+
+.subscriber-list {
+	margin: 0;
+
+	.row {
+		border-block-end: 1px solid $studio-gray-5;
+		display: flex;
+		align-items: center;
+		flex-direction: row;
+		padding-top: 20px;
+		padding-bottom: 20px;
+
+		* {
+			flex: 1;
+		}
+
+		.hidden {
+			display: none;
+		}
+
+		&.header {
+			padding-bottom: $font-code;
+			padding-top: 0;
+
+			@media (max-width: $break-small) {
+				display: none;
+			}
+		}
+
+		.subscriber-list__checkbox-column,
+		.subscriber-list__profile-column,
+		.subscriber-list__subscription-type-column,
+		.subscriber-list__rate-column,
+		.subscriber-list__since-column,
+		.subscriber-list__menu-column {
+			font-weight: 400;
+			font-size: $font-body-small;
+			font-size: rem(14px);
+			line-height: 20px;
+			letter-spacing: -0.15px;
+			color: $studio-gray-60;
+		}
+
+		.subscriber-list__profile-column {
+			display: flex;
+			align-items: center;
+			flex: 3;
+			min-width: 0;
+
+			.subscriber-profile {
+				display: flex;
+				min-width: 0;
+
+				.subscriber-profile__user-image {
+					height: 40px;
+					width: 40px;
+					border-radius: 50%;
+					margin-right: 12px;
+					flex: 0;
+				}
+
+				.subscriber-profile__user-details {
+					display: flex;
+					flex-direction: column;
+					justify-content: center;
+					max-width: 100%;
+					overflow: hidden;
+					min-width: 0;
+
+					.subscriber-profile__name {
+						overflow: hidden;
+						text-overflow: ellipsis;
+						white-space: nowrap;
+						font-weight: bold;
+						line-height: 17px;
+						min-width: 0;
+						font-size: rem(15px);
+					}
+
+					.subscriber-profile__email {
+						overflow: hidden;
+						text-overflow: ellipsis;
+						white-space: nowrap;
+						font-size: rem(12px);
+						color: $studio-gray-60;
+						min-width: 0;
+					}
+				}
+			}
+		}
+
+		.subscriber-list__checkbox-column {
+			.form-checkbox {
+				height: 20px;
+				width: 20px;
+			}
+		}
+
+		.subscriber-list__menu-column {
+			flex-basis: 36px;
+			flex-grow: initial;
+
+			.gridicon {
+				fill: $studio-gray-50;
+			}
+		}
+
+		&:last-child {
+			border-bottom: none;
+		}
+	}
+}
+
+@media ( max-width: $break-medium ) {
+	.subscriber-list {
+		padding-left: 16px;
+		padding-right: 16px;
+
+		.subscriber-list__since-column {
+			display: none;
+		}
+	}
+}

--- a/client/my-sites/subscribers/subscriber-list/subscriber-list.tsx
+++ b/client/my-sites/subscribers/subscriber-list/subscriber-list.tsx
@@ -1,0 +1,61 @@
+import { useTranslate } from 'i18n-calypso';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import { Subscriber } from '../types';
+import { SubscriberRow } from './subscriber-row';
+import './styles.scss';
+
+type SubscriberListProps = {
+	subscribers: Subscriber[];
+	locale: string;
+};
+
+export const SubscriberList = ( { subscribers, locale }: SubscriberListProps ) => {
+	const translate = useTranslate();
+	return (
+		<ul className="subscriber-list" role="table">
+			<li className="row header" role="row">
+				<span className="subscriber-list__checkbox-column hidden" role="columnheader">
+					<FormCheckbox />
+				</span>
+				<span className="subscriber-list__profile-column" role="columnheader">
+					{ translate( 'Name' ) }
+				</span>
+				<span className="subscriber-list__subscription-type-column hidden" role="columnheader">
+					{ translate( 'Subscription type' ) }
+				</span>
+				<span className="subscriber-list__rate-column hidden" role="columnheader">
+					{ translate( 'Open Rate' ) }
+				</span>
+				<span className="subscriber-list__since-column" role="columnheader">
+					{ translate( 'Since' ) }
+				</span>
+				<span className="subscriber-list__menu-column" role="columnheader"></span>
+			</li>
+			{ subscribers.map(
+				( {
+					user_id,
+					subscription_id,
+					display_name,
+					email_address,
+					subscriptions,
+					openRate,
+					date_subscribed,
+					avatar,
+				}: Subscriber ) => (
+					<SubscriberRow
+						user_id={ user_id }
+						key={ subscription_id }
+						subscription_id={ subscription_id }
+						display_name={ display_name }
+						email_address={ email_address }
+						subscriptions={ subscriptions }
+						openRate={ openRate }
+						date_subscribed={ date_subscribed }
+						avatar={ avatar }
+						locale={ locale }
+					/>
+				)
+			) }
+		</ul>
+	);
+};

--- a/client/my-sites/subscribers/subscriber-list/subscriber-profile.tsx
+++ b/client/my-sites/subscribers/subscriber-list/subscriber-profile.tsx
@@ -1,0 +1,21 @@
+export const SubscriberProfile = ( {
+	avatar,
+	displayName,
+	email,
+}: {
+	avatar: string;
+	displayName: string;
+	email: string;
+} ) => {
+	return (
+		<div className="subscriber-profile">
+			<img src={ avatar } className="subscriber-profile__user-image" alt="Profile pic" />
+			<div className="subscriber-profile__user-details">
+				<span className="subscriber-profile__name">{ displayName }</span>
+				{ email && email !== displayName && (
+					<span className="subscriber-profile__email">{ email }</span>
+				) }
+			</div>
+		</div>
+	);
+};

--- a/client/my-sites/subscribers/subscriber-list/subscriber-row.tsx
+++ b/client/my-sites/subscribers/subscriber-list/subscriber-row.tsx
@@ -1,0 +1,42 @@
+import { Gridicon } from '@automattic/components';
+import moment from 'moment';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import { Subscriber } from '../types';
+import { SubscriberProfile } from './subscriber-profile';
+
+type SubscriberRowProps = Subscriber & {
+	locale: string;
+};
+
+export const SubscriberRow = ( {
+	display_name,
+	email_address,
+	subscriptions,
+	openRate,
+	date_subscribed,
+	avatar,
+	locale,
+}: SubscriberRowProps ) => {
+	return (
+		<li className="subscriber-row row" role="row">
+			<div className="subscriber-list__checkbox-column hidden" role="cell">
+				<FormCheckbox />
+			</div>
+			<span className="subscriber-list__profile-column" role="cell">
+				<SubscriberProfile avatar={ avatar } displayName={ display_name } email={ email_address } />
+			</span>
+			<span className="subscriber-list__subscription-type-column hidden" role="cell">
+				{ subscriptions && subscriptions.map( ( subscription ) => <div>{ subscription }</div> ) }
+			</span>
+			<span className="subscriber-list__rate-column hidden" role="cell">
+				{ openRate }
+			</span>
+			<span className="subscriber-list__since-column" role="cell">
+				{ moment( date_subscribed ).locale( locale ).format( 'LL' ) }
+			</span>
+			<span className="subscriber-list__menu-column" role="cell">
+				<Gridicon icon="ellipsis" size={ 24 } />
+			</span>
+		</li>
+	);
+};

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -24,5 +24,7 @@ export type Subscriber = {
 	email_address: string;
 	avatar: string;
 	display_name: string;
+	subscriptions: SubscriptionPlan[];
 	plans?: SubscriptionPlan[];
+	openRate?: number;
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/77679 and https://github.com/Automattic/wp-calypso/issues/77684

## Proposed Changes

This PR introduces the subscriber list and the total counter on the Subscribers Page:

<img width="735" alt="Screenshot 2023-06-05 at 23 01 36 2" src="https://github.com/Automattic/wp-calypso/assets/3832570/88275634-6397-49a3-9dcb-3cf3383c1154">

Note: we are using mocks at this stage.

## Testing Instructions

1. Apply this PR and start the application.
2. Go to this URL: `http://calypso.localhost:3000/subscribers/[the-domain-of-your-site]`.
3. Check you can see a list like the image above.
