### PR TITLE
New hosted site: Track site title and geo affinity changes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -72,8 +72,7 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 		}
 
 		recordTracksEvent( 'calypso_signup_site_options_submit', {
-			has_site_title: true,
-			has_changed_title: hasChangedInput.current.title,
+			has_site_title: hasChangedInput.current.title,
 			has_changed_geo_affinity: hasChangedInput.current.geoAffinity,
 		} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -73,7 +73,7 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 
 		recordTracksEvent( 'calypso_signup_site_options_submit', {
 			has_site_title: hasChangedInput.current.title,
-			has_changed_geo_affinity: hasChangedInput.current.geoAffinity,
+			has_geo_affinity: hasChangedInput.current.geoAffinity,
 		} );
 
 		submit?.( { siteTitle, siteGeoAffinity } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useSelector } from 'react-redux';
 import siteOptionsUrl from 'calypso/assets/images/onboarding/site-options.svg';
 import DataCenterPicker from 'calypso/blocks/data-center-picker';
@@ -60,6 +60,7 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 
 	const isSiteTitleEmpty = ! siteTitle || siteTitle.trim().length === 0;
 	const isFormSubmitDisabled = isSiteTitleEmpty;
+	const hasChangedInput = useRef( { geoAffinity: false, title: false } );
 
 	const handleSubmit = async ( event: React.FormEvent ) => {
 		event.preventDefault();
@@ -71,7 +72,9 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 		}
 
 		recordTracksEvent( 'calypso_signup_site_options_submit', {
-			has_site_title: !! siteTitle,
+			has_site_title: true,
+			has_changed_title: hasChangedInput.current.title,
+			has_changed_geo_affinity: hasChangedInput.current.geoAffinity,
 		} );
 
 		submit?.( { siteTitle, siteGeoAffinity } );
@@ -81,6 +84,7 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 		setFormTouched( true );
 
 		if ( event.currentTarget.name === 'siteTitle' ) {
+			hasChangedInput.current.title = true;
 			return setSiteTitle( event.currentTarget.value );
 		}
 	};
@@ -113,7 +117,14 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 				) }
 			</FormFieldset>
 			{ shouldShowGeoAffinityPicker && (
-				<DataCenterPicker onChange={ setSiteGeoAffinity } value={ siteGeoAffinity } compact />
+				<DataCenterPicker
+					onChange={ ( value ) => {
+						hasChangedInput.current.geoAffinity = true;
+						setSiteGeoAffinity( value );
+					} }
+					value={ siteGeoAffinity }
+					compact
+				/>
 			) }
 			<Button className="site-options__submit-button" type="submit" primary>
 				{ translate( 'Continue' ) }


### PR DESCRIPTION
## Proposed Changes

Adds `has_site_title` and `has_geo_affinity` as properties to the `calypso_signup_site_options_submit` event.

This is useful to understand whether the users are going with the defaults defined by us.

## Testing Instructions

1.  Enable Tracks logging through `localStorage.setItem('debug', 'calypso:analytics')` and check your console;
2. Browse `/start/new-hosted-site`;
3. Pick a Business plan;
4. Go through the site options step, changing the title and data center;
5. Check that `calypso_signup_site_options_submit` was dispatched with `has_site_title` and `has_geo_affinity` according to your activities on the page.