### PR TITLE
Revert "Fix - Plan upgrade credit information on the checkout page"

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -776,17 +776,19 @@ function isCouponApplied( { coupon_savings_integer = 0 }: ResponseCartProduct ) 
 	return coupon_savings_integer > 0;
 }
 
-function UpgradeCreditInformation( { product }: { product: ResponseCartProduct } ) {
+function FirstTermDiscountCallout( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
+	const planSlug = product.product_slug;
 	const origCost = product.item_original_subtotal_integer;
 	const finalCost = product.item_subtotal_integer;
-	const upgradeCredit = origCost - finalCost;
-	const planSlug = product.product_slug;
 	const isRenewal = product.is_renewal;
 
+	// Do not display discount reason if there is an introductory offer.
+	if ( product.introductory_offer_terms?.enabled ) {
+		return null;
+	}
+
 	if (
-		// Do not display discount reason if there is an introductory offer.
-		product.introductory_offer_terms?.enabled ||
 		// Do not display discount reason for non-wpcom, non-jetpack products.
 		( ! isWpComPlan( planSlug ) && ! isJetpackProductSlug( planSlug ) ) ||
 		// Do not display discount reason if there is no discount.
@@ -798,59 +800,19 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 	) {
 		return null;
 	}
+
 	if ( isMonthlyProduct( product ) ) {
-		return (
-			<>
-				{ translate( 'Upgrade Credit: %(upgradeCredit)s applied in first month only', {
-					comment:
-						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
-						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
-					args: {
-						upgradeCredit: formatCurrency( upgradeCredit, product.currency, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ),
-					},
-				} ) }
-			</>
-		);
+		return <DiscountCallout>{ translate( 'Discount for first month' ) }</DiscountCallout>;
 	}
 
 	if ( isYearly( product ) ) {
-		return (
-			<>
-				{ translate( 'Upgrade Credit: %(upgradeCredit)s applied in first year only', {
-					comment:
-						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
-						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
-					args: {
-						discount: formatCurrency( upgradeCredit, product.currency, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ),
-					},
-				} ) }
-			</>
-		);
+		return <DiscountCallout>{ translate( 'Discount for first year' ) }</DiscountCallout>;
 	}
 
 	if ( isBiennially( product ) || isTriennially( product ) ) {
-		return (
-			<>
-				{ translate( 'Upgrade Credit: %(discount)s applied in first term only', {
-					comment:
-						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
-						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
-					args: {
-						discount: formatCurrency( upgradeCredit, product.currency, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ),
-					},
-				} ) }
-			</>
-		);
+		return <DiscountCallout>{ translate( 'Discount for first term' ) }</DiscountCallout>;
 	}
+
 	return null;
 }
 
@@ -1035,17 +997,13 @@ function WPLineItem( {
 			</span>
 
 			{ product && ! containsPartnerCoupon && (
-				<>
-					<LineItemMeta>
-						<UpgradeCreditInformation product={ product } />
-					</LineItemMeta>
-					<LineItemMeta>
-						<LineItemSublabelAndPrice product={ product } />
-						<DomainDiscountCallout product={ product } />
-						<CouponDiscountCallout product={ product } />
-						<IntroductoryOfferCallout product={ product } />
-					</LineItemMeta>
-				</>
+				<LineItemMeta>
+					<LineItemSublabelAndPrice product={ product } />
+					<DomainDiscountCallout product={ product } />
+					<FirstTermDiscountCallout product={ product } />
+					<CouponDiscountCallout product={ product } />
+					<IntroductoryOfferCallout product={ product } />
+				</LineItemMeta>
 			) }
 
 			{ product && containsPartnerCoupon && (


### PR DESCRIPTION
Reverts Automattic/wp-calypso#77720

Reverting because translations are not ready