### PR TITLE
Launchpad: Add my home specific launchpad styles

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/keep-building.jsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.jsx
@@ -4,7 +4,7 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const LaunchpadKeepBuilding = ( { siteSlug } ) => {
-	return <Launchpad siteSlug={ siteSlug } checklistSlug="keep-building" />;
+	return <Launchpad siteSlug={ siteSlug } />;
 };
 
 const ConnectedLaunchpadKeepBuilding = connect( ( state ) => {

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.jsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.jsx
@@ -4,7 +4,7 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const LaunchpadKeepBuilding = ( { siteSlug } ) => {
-	return <Launchpad siteSlug={ siteSlug } />;
+	return <Launchpad siteSlug={ siteSlug } checklistSlug="keep-building" />;
 };
 
 const ConnectedLaunchpadKeepBuilding = connect( ( state ) => {

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.jsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.jsx
@@ -1,10 +1,33 @@
+import { CircularProgressBar } from '@automattic/components';
 import { Launchpad } from '@automattic/launchpad';
+import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
+import './style.scss';
+
 const LaunchpadKeepBuilding = ( { siteSlug } ) => {
-	return <Launchpad siteSlug={ siteSlug } checklistSlug="keep-building" />;
+	const translate = useTranslate();
+
+	return (
+		<div className="launchpad-keep-building">
+			<div className="launchpad-keep-building__header">
+				<h2 className="launchpad-keep-building__title">
+					{ translate( 'Next steps for your site' ) }
+				</h2>
+				<div className="launchpad-keep-building__progress-bar-container">
+					<CircularProgressBar
+						size={ 40 }
+						enableDesktopScaling
+						currentStep={ 2 }
+						numberOfSteps={ 5 }
+					/>
+				</div>
+			</div>
+			<Launchpad siteSlug={ siteSlug } />
+		</div>
+	);
 };
 
 const ConnectedLaunchpadKeepBuilding = connect( ( state ) => {

--- a/client/my-sites/customer-home/cards/launchpad/style.scss
+++ b/client/my-sites/customer-home/cards/launchpad/style.scss
@@ -1,0 +1,22 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/components/src/styles/typography";
+@import "@wordpress/base-styles/breakpoints";
+
+.launchpad-keep-building {
+	padding: 24px;
+
+	.launchpad-keep-building__header {
+		display: flex;
+
+		.launchpad-keep-building__progress-bar-container {
+			margin: 5px;
+		}
+
+		.launchpad-keep-building__title {
+			flex: 1;
+			font-size: $font-title-small;
+			font-weight: 500;
+			font-family: $font-sf-pro-display;
+		}
+	}
+}

--- a/packages/launchpad/src/checklist/style.scss
+++ b/packages/launchpad/src/checklist/style.scss
@@ -6,8 +6,4 @@
 	list-style: none;
 	margin: 0;
 	padding: 0;
-
-	@include break-large {
-		margin: 20px auto;
-	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
