### PR TITLE
Launchpad: Added complementary styles to Customer home launchpad

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/keep-building.jsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.jsx
@@ -1,10 +1,33 @@
+import { CircularProgressBar } from '@automattic/components';
 import { Launchpad } from '@automattic/launchpad';
+import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
+import './style.scss';
+
 const LaunchpadKeepBuilding = ( { siteSlug } ) => {
-	return <Launchpad siteSlug={ siteSlug } checklistSlug="keep-building" />;
+	const translate = useTranslate();
+
+	return (
+		<div className="launchpad-keep-building">
+			<div className="launchpad-keep-building__header">
+				<h2 className="launchpad-keep-building__title">
+					{ translate( 'Next steps for your site' ) }
+				</h2>
+				<div className="launchpad-keep-building__progress-bar-container">
+					<CircularProgressBar
+						size={ 40 }
+						enableDesktopScaling
+						currentStep={ 2 }
+						numberOfSteps={ 5 }
+					/>
+				</div>
+			</div>
+			<Launchpad siteSlug={ siteSlug } />
+		</div>
+	);
 };
 
 const ConnectedLaunchpadKeepBuilding = connect( ( state ) => {

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -1,5 +1,6 @@
 import { CircularProgressBar } from '@automattic/components';
-import { Launchpad } from '@automattic/launchpad';
+import { useLaunchpad } from '@automattic/data-stores';
+import { Launchpad, Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -7,8 +8,18 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
-const LaunchpadKeepBuilding = ( { siteSlug } ) => {
+interface LaunchpadKeepBuildingProps {
+	siteSlug: string;
+}
+
+const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ) => {
 	const translate = useTranslate();
+	const {
+		data: { checklist },
+	} = useLaunchpad( siteSlug );
+
+	const numberOfSteps = checklist?.length || 0;
+	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 
 	return (
 		<div className="launchpad-keep-building">
@@ -20,8 +31,8 @@ const LaunchpadKeepBuilding = ( { siteSlug } ) => {
 					<CircularProgressBar
 						size={ 40 }
 						enableDesktopScaling
-						currentStep={ 2 }
-						numberOfSteps={ 5 }
+						numberOfSteps={ numberOfSteps }
+						currentStep={ completedSteps }
 					/>
 				</div>
 			</div>

--- a/client/my-sites/customer-home/cards/launchpad/style.scss
+++ b/client/my-sites/customer-home/cards/launchpad/style.scss
@@ -1,0 +1,22 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/components/src/styles/typography";
+@import "@wordpress/base-styles/breakpoints";
+
+.launchpad-keep-building {
+	padding: 24px;
+
+	.launchpad-keep-building__header {
+		display: flex;
+
+		.launchpad-keep-building__progress-bar-container {
+			margin: 5px;
+		}
+
+		.launchpad-keep-building__title {
+			flex: 1;
+			font-size: $font-title-small;
+			font-weight: 500;
+			font-family: $font-sf-pro-display;
+		}
+	}
+}

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -96,6 +96,14 @@
 	}
 }
 
+.checklist-item__task:last-child {
+	.checklist-item__task-content,
+	.checklist-item__task-content:hover,
+	.checklist-item__task-content:focus {
+		border-bottom: none;
+	}
+}
+
 // completed tasks (both enabled and disabled)
 .checklist-item__task.completed.disabled,
 .checklist-item__task.completed.enabled {

--- a/packages/launchpad/src/checklist/style.scss
+++ b/packages/launchpad/src/checklist/style.scss
@@ -6,8 +6,4 @@
 	list-style: none;
 	margin: 0;
 	padding: 0;
-
-	@include break-large {
-		margin: 20px auto;
-	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/77285

## Proposed Changes

* Added title, progress and styles to the Customer Home Launchpad component.

## Testing Instructions

* Change this line on `client/my-sites/customer-home/locations/primary/index.jsx:82` from:


`[ TASK_SITE_SETUP_CHECKLIST ]: SiteSetupList,` to `[ TASK_SITE_SETUP_CHECKLIST ]: LaunchpadKeepBuilding,`

* Open the customer home page and compare the designs with the result

Figma:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/7c91d262-e875-4902-a560-b932ecc656df)

Screenshot:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/c837d3dd-ff72-4c25-9953-fc2da26c35b7)
