### PR TITLE
Stats: Persist highlights setting notice status

### DIFF
--- a/client/my-sites/stats/highlights-section/index.tsx
+++ b/client/my-sites/stats/highlights-section/index.tsx
@@ -59,11 +59,11 @@ export default function HighlightsSection( {
 
 	const { data: showSettingsTooltip, refetch: refetchNotices } = useNoticeVisibilityQuery(
 		siteId,
-		'traffic_page_settings'
+		'traffic_page_highlights_module_settings'
 	);
 	const { mutateAsync: mutateNoticeVisbilityAsync } = useNoticeVisibilityMutation(
 		siteId,
-		'traffic_page_settings'
+		'traffic_page_highlights_module_settings'
 	);
 	const [ settingsTooltipDismissed, setSettingsTooltipDismissed ] = useState( false );
 

--- a/client/my-sites/stats/highlights-section/index.tsx
+++ b/client/my-sites/stats/highlights-section/index.tsx
@@ -5,7 +5,7 @@ import {
 	BETWEEN_PAST_THIRTY_ONE_AND_SIXTY_DAYS,
 } from '@automattic/components';
 import { useEffect, useMemo, useState } from 'react';
-import wpcom from 'calypso/lib/wp';
+import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import useNoticeVisibilityQuery from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { useDispatch, useSelector } from 'calypso/state';
 import { requestHighlights } from 'calypso/state/stats/highlights/actions';
@@ -61,20 +61,15 @@ export default function HighlightsSection( {
 		siteId,
 		'traffic_page_settings'
 	);
+	const { mutateAsync: mutateNoticeVisbilityAsync } = useNoticeVisibilityMutation(
+		siteId,
+		'traffic_page_settings'
+	);
 	const [ settingsTooltipDismissed, setSettingsTooltipDismissed ] = useState( false );
 
 	const dismissSettingsTooltip = () => {
 		setSettingsTooltipDismissed( true );
-		return wpcom.req
-			.post( {
-				apiNamespace: 'wpcom/v2',
-				path: `/sites/${ siteId }/jetpack-stats-dashboard/notices`,
-				body: {
-					id: 'traffic_page_settings',
-					status: 'dismissed',
-				},
-			} )
-			.finally( refetchNotices );
+		return mutateNoticeVisbilityAsync().finally( refetchNotices );
 	};
 
 	return (

--- a/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
@@ -24,5 +24,7 @@ export default function useNoticeVisibilityMutation(
 	return useMutation( {
 		mutationKey: [ 'stats', 'notices-visibility', siteId, noticeId ],
 		mutationFn: () => dismissNotice( siteId, noticeId, status ),
+		retry: 1,
+		retryDelay: 3 * 1000, // 3 seconds
 	} );
 }

--- a/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
@@ -8,7 +8,7 @@ export function dismissNotice(
 	siteId: number | null,
 	noticeId: keyof Notices,
 	status: Status,
-	postponedFor: number | null = null
+	postponedFor = 0
 ): Promise< any > {
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
@@ -25,7 +25,7 @@ export default function useNoticeVisibilityMutation(
 	siteId: number | null,
 	noticeId: keyof Notices,
 	status: Status = 'dismissed',
-	postponedFor: number | null = null
+	postponedFor = 0
 ) {
 	return useMutation( {
 		mutationKey: [ 'stats', 'notices-visibility', siteId, noticeId ],

--- a/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export function dismissNotice(
+	siteId: number | null,
+	noticeId: string,
+	status: string
+): Promise< any > {
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/sites/${ siteId }/jetpack-stats-dashboard/notices`,
+		body: {
+			id: noticeId,
+			status: status,
+		},
+	} );
+}
+
+export default function useNoticeVisibilityMutation(
+	siteId: number | null,
+	noticeId: string,
+	status = 'dismissed'
+) {
+	return useMutation( {
+		mutationKey: [ 'stats', 'notices-visibility', siteId, noticeId ],
+		mutationFn: () => dismissNotice( siteId, noticeId, status ),
+	} );
+}

--- a/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
@@ -1,10 +1,14 @@
 import { useMutation } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import { Notices } from './use-notice-visibility-query';
+
+type Status = 'dismissed' | 'postponed';
 
 export function dismissNotice(
 	siteId: number | null,
-	noticeId: string,
-	status: string
+	noticeId: keyof Notices,
+	status: Status,
+	postponedFor: number | null = null
 ): Promise< any > {
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
@@ -12,18 +16,20 @@ export function dismissNotice(
 		body: {
 			id: noticeId,
 			status: status,
+			postponed_for: postponedFor,
 		},
 	} );
 }
 
 export default function useNoticeVisibilityMutation(
 	siteId: number | null,
-	noticeId: string,
-	status = 'dismissed'
+	noticeId: keyof Notices,
+	status: Status = 'dismissed',
+	postponedFor: number | null = null
 ) {
 	return useMutation( {
 		mutationKey: [ 'stats', 'notices-visibility', siteId, noticeId ],
-		mutationFn: () => dismissNotice( siteId, noticeId, status ),
+		mutationFn: () => dismissNotice( siteId, noticeId, status, postponedFor ),
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds
 	} );

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export function queryNotices( siteId: number | null ): Promise< any > {
+	return wpcom.req.get( {
+		method: 'GET',
+		apiNamespace: 'wpcom/v2',
+		path: `/sites/${ siteId }/jetpack-stats-dashboard/notices`,
+	} );
+}
+
+export default function useNoticeVisibilityQuery( siteId: number | null, noticeId: string ) {
+	return useQuery( {
+		queryKey: [ 'stats', 'notices-visibility', siteId ],
+		queryFn: () => queryNotices( siteId ),
+		select: ( payload: Record< string, boolean > ): boolean => !! payload?.[ noticeId ],
+		staleTime: 1000 * 60 * 1, // 1 minutes
+	} );
+}

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -15,5 +15,7 @@ export default function useNoticeVisibilityQuery( siteId: number | null, noticeI
 		queryFn: () => queryNotices( siteId ),
 		select: ( payload: Record< string, boolean > ): boolean => !! payload?.[ noticeId ],
 		staleTime: 1000 * 60 * 1, // 1 minutes
+		retry: 1,
+		retryDelay: 3 * 1000, // 3 seconds
 	} );
 }

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -1,7 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-export function queryNotices( siteId: number | null ): Promise< any > {
+export type Notices = {
+	new_stats_feedback: boolean;
+	opt_in_new_stats: boolean;
+	opt_out_new_stats: boolean;
+	traffic_page_highlights_module_settings: boolean;
+	traffic_page_settings: boolean;
+};
+
+export function queryNotices( siteId: number | null ): Promise< Notices > {
 	return wpcom.req.get( {
 		method: 'GET',
 		apiNamespace: 'wpcom/v2',

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -38,11 +38,15 @@ type WeeklyHighlightCardsProps = {
 	onClickVisitors: ( event: MouseEvent ) => void;
 	onTogglePeriod: ( period: string ) => void;
 	currentPeriod: string;
+	onSettingsTooltipDismiss: () => void;
+	showSettingsTooltip: boolean;
 };
 
 type HighlightCardsSettingsProps = {
 	onTogglePeriod: ( period: string ) => void;
 	currentPeriod: string;
+	onTooltipDismiss: () => void;
+	showTooltip: boolean;
 };
 
 export const PAST_SEVEN_DAYS = 'past_seven_days';
@@ -53,30 +57,20 @@ export const BETWEEN_PAST_THIRTY_ONE_AND_SIXTY_DAYS = 'between_past_thirty_one_a
 const HighlightCardsSettings = function ( {
 	currentPeriod,
 	onTogglePeriod,
+	onTooltipDismiss,
+	showTooltip = false,
 }: HighlightCardsSettingsProps ) {
 	const translate = useTranslate();
 
-	// @TODO: Fetch the state from API to determine whether showing the settings tooltip.
-	const showSettingsTooltip =
-		sessionStorage.getItem( 'jp-stats-hide-traffic-highlights-tooltip' ) === '1' ? false : true;
-
 	const settingsActionRef = useRef( null );
-	const [ isSettingsTooltipVisible, setSettingsTooltipVisible ] = useState( showSettingsTooltip );
 	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
 
-	// @TODO: Update the state to the API endpoint when users dismiss the settings tooltip.
-	const dismissSettingsTooltip = useCallback( () => {
-		sessionStorage.setItem( 'jp-stats-hide-traffic-highlights-tooltip', '1' );
-		setSettingsTooltipVisible( false );
-	}, [] );
-
-	// @TODO: Set the popover to disappear when the users click outside of the popover.
 	const togglePopoverMenu = useCallback( () => {
-		dismissSettingsTooltip();
+		onTooltipDismiss();
 		setPopoverVisible( ( isVisible ) => {
 			return ! isVisible;
 		} );
-	}, [ dismissSettingsTooltip ] );
+	}, [ onTooltipDismiss ] );
 
 	return (
 		<div className="highlight-cards-heading__settings">
@@ -89,7 +83,7 @@ const HighlightCardsSettings = function ( {
 			</button>
 			<Popover
 				className="tooltip tooltip--darker highlight-card-tooltip highlight-card__settings-tooltip"
-				isVisible={ isSettingsTooltipVisible }
+				isVisible={ showTooltip }
 				position="bottom left"
 				context={ settingsActionRef.current }
 			>
@@ -97,13 +91,7 @@ const HighlightCardsSettings = function ( {
 					<p>
 						{ translate( 'You can now tailor your site highlights by adjusting the time range.' ) }
 					</p>
-					<button
-						onClick={ () => {
-							dismissSettingsTooltip();
-						} }
-					>
-						{ translate( 'Got it' ) }
-					</button>
+					<button onClick={ onTooltipDismiss }>{ translate( 'Got it' ) }</button>
 				</div>
 			</Popover>
 			<Popover
@@ -145,6 +133,8 @@ export default function WeeklyHighlightCards( {
 	previousCounts,
 	showValueTooltip,
 	currentPeriod,
+	onSettingsTooltipDismiss,
+	showSettingsTooltip,
 }: WeeklyHighlightCardsProps ) {
 	const translate = useTranslate();
 
@@ -219,6 +209,8 @@ export default function WeeklyHighlightCards( {
 					<HighlightCardsSettings
 						currentPeriod={ currentPeriod }
 						onTogglePeriod={ onTogglePeriod }
+						onTooltipDismiss={ onSettingsTooltipDismiss }
+						showTooltip={ showSettingsTooltip }
 					/>
 				) }
 			</h3>


### PR DESCRIPTION
Related to #77548 

## Proposed Changes

The PR proposes to query notices status with `react-query` and calls API to persist the dismissed status for Highlights settings tooltip.

## Testing Instructions
* Apply D112871-code to your sandbox
* Sandbox `public-api.wordpress.com` 
* Open the Traffic page on the Calypso Live site
* Apply feature flag `?flags=stats/highlights-settings`
* Ensure you see the tooltip for Highlights settings

* Click 'Got it' or the hamburger icon
* Ensure the tooltip is dismissed
* Refresh the page
* Ensure the tooltip doesn't come up again

<img width="1227" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/2f64e9de-952e-46f2-9bf3-4d43d21e2e1c">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?