### PR TITLE
Theme Card: Fix active theme card CSS specificity

### DIFF
--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -3,7 +3,7 @@
 $theme-card-info-height: 48px;
 $theme-card-info-margin-top: 16px;
 
-.theme-card.card {
+.card.theme-card {
 	background: none;
 	border-radius: 2px;
 	box-shadow: none;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77820

## Proposed Changes

This PR fixes a regression issue introduced in #77820, which caused active theme cards to be styled incorrectly.

| Before | After |
| --- | --- |
| ![Screenshot 2023-06-07 at 7 52 32 AM](https://github.com/Automattic/wp-calypso/assets/797888/ce4ad662-347a-4b7c-a4d4-5098c0882d6d) |  ![Screenshot 2023-06-07 at 7 52 39 AM](https://github.com/Automattic/wp-calypso/assets/797888/a3f5613c-7a01-4173-80a7-688ab6791e08) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase.
* Ensure that the active theme card is styled correctly as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
