### PR TITLE
Adjust the mobile style of the sharing modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/style.scss
@@ -2,9 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 
 .wpcom-block-editor-post-published-sharing-modal {
-	@media only screen and (max-width: 600px) {
-		border-radius: 0;
-	}
 	.components-modal__content {
 		margin-top: 0;
 		padding-bottom: 0;
@@ -17,6 +14,7 @@
 				p a {
 					color: var(--color-text);
 					text-decoration: underline;
+					white-space: nowrap;
 
 					&:hover {
 						color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
@@ -44,13 +42,16 @@
 				flex-direction: column-reverse;
 
 				.wpcom-block-editor-post-published-sharing-modal__left {
-					padding: 52px 0;
+					padding: 44px 0 20px;
 					width: 100%;
 				}
 				.wpcom-block-editor-post-published-sharing-modal__right {
 					border-left: none;
-					padding: 52px 0;
+					padding: 52px 0 0;
 					width: 100%;
+				}
+				.wpcom-block-editor-post-published-sharing-modal__image {
+					height: 140px;
 				}
 			}
 		}
@@ -58,10 +59,18 @@
 			margin-top: 0;
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 26px;
+			@media only screen and (max-width: 600px) {
+				font-size: 2.25rem;
+				font-weight: 500;
+				line-height: 1;
+			}
 		}
 		p {
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 18px;
+			@media only screen and (max-width: 600px) {
+				font-size: 1rem;
+			}
 		}
 		.link-button {
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/77786

Adjusts height of modal components so that the modal will not require scrolling on mobile devices 
* I targeted iPhone SE which is 375w*667h
I Adjusted font styles to match the mobile design of the videopress modal.
I left the desktop version as it is.

**Before:**
<img width="376" alt="Screen Shot 2023-06-07 at 11 13 29 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/57509da3-cfa2-407e-bcc0-b3e4b971e0ce">

**After:**
<img width="375" alt="Screen Shot 2023-06-07 at 11 01 32 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/b884d200-a3a8-4c53-95f6-0197c4e84550">

**Videopress modal for reference.**
<img width="344" alt="Screen Shot 2023-06-07 at 11 01 41 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/3662d8af-dbdb-452b-9237-6072f4a06b7b">

### Testing instructions
* Sandbox a test site.
* Sync changes to your sandbox with `cd apps/editing-toolkit && yarn dev --sync`
* Publish a new post
* Using the mobile emulator in chrome dev tools, select iphone SE (and test other resolutions)