### PR TITLE
Launchpad: Add taskFilter to Launchpad component

### DIFF
--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -1,6 +1,6 @@
 import { useLaunchpad } from '@automattic/data-stores';
 import Checklist from './checklist';
-import { Task } from './types';
+import type { Task } from './types';
 
 export interface LaunchpadProps {
 	siteSlug: string;

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -1,16 +1,25 @@
 import { useLaunchpad } from '@automattic/data-stores';
 import Checklist from './checklist';
+import { Task } from './types';
 
 export interface LaunchpadProps {
 	siteSlug: string;
 	checklistSlug?: string | 0 | null | undefined;
 	makeLastTaskPrimaryAction?: boolean;
+	taskFilter?: ( tasks: Task[] ) => Task[];
 }
 
-const Launchpad = ( { siteSlug, checklistSlug, makeLastTaskPrimaryAction }: LaunchpadProps ) => {
-	const { isFetchedAfterMount, data } = useLaunchpad( siteSlug || '', checklistSlug );
+const Launchpad = ( {
+	siteSlug,
+	checklistSlug,
+	taskFilter,
+	makeLastTaskPrimaryAction,
+}: LaunchpadProps ) => {
+	const launchpadData = useLaunchpad( siteSlug || '', checklistSlug );
+	const { isFetchedAfterMount, data } = launchpadData;
 
-	const tasks = data.checklist || [];
+	const originalTasks = data.checklist || [];
+	const tasks = taskFilter ? taskFilter( originalTasks ) : originalTasks;
 
 	return (
 		<div className="launchpad__checklist-wrapper">

--- a/packages/launchpad/src/test/launchpad.tsx
+++ b/packages/launchpad/src/test/launchpad.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Launchpad from '../launchpad';
+import '@testing-library/jest-dom';
+import { Task } from '../types';
+
+jest.mock( '@automattic/data-stores', () => {
+	const { buildTask } = require( './lib/fixtures' );
+	return {
+		useLaunchpad: jest.fn( () => {
+			return {
+				isFetchedAfterMount: true,
+				data: {
+					checklist: [
+						buildTask( { id: 'task1' } ),
+						buildTask( { id: 'task2' } ),
+						buildTask( { id: 'task3' } ),
+					],
+				},
+			};
+		} ),
+	};
+} );
+
+describe( 'Launchpad', () => {
+	describe( 'when no taskFilter is provided', () => {
+		it( 'then all tasks from useLaunchpad are rendered', () => {
+			render( <Launchpad siteSlug="any site" /> );
+			const checklistItems = screen.queryAllByRole( 'listitem' );
+			expect( checklistItems.length ).toBe( 3 );
+		} );
+	} );
+
+	describe( 'when taskFilter is provided', () => {
+		it( 'then render only tasks returned from the callback', () => {
+			const filter = ( tasks: Task[] ) => {
+				// return only the first task
+				return [ tasks[ 0 ] ];
+			};
+
+			render( <Launchpad siteSlug="any site" taskFilter={ filter } /> );
+			const checklistItems = screen.queryAllByRole( 'listitem' );
+			expect( checklistItems.length ).toBe( 1 );
+		} );
+	} );
+} );

--- a/packages/launchpad/src/test/launchpad.tsx
+++ b/packages/launchpad/src/test/launchpad.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import Launchpad from '../launchpad';
 import '@testing-library/jest-dom';
-import { Task } from '../types';
+import type { Task } from '../types';
 
 jest.mock( '@automattic/data-stores', () => {
 	const { buildTask } = require( './lib/fixtures' );
@@ -41,6 +41,9 @@ describe( 'Launchpad', () => {
 			render( <Launchpad siteSlug="any site" taskFilter={ filter } /> );
 			const checklistItems = screen.queryAllByRole( 'listitem' );
 			expect( checklistItems.length ).toBe( 1 );
+
+			const taskId = checklistItems[ 0 ].querySelector( 'button' )?.getAttribute( 'data-task' );
+			expect( taskId ).toBe( 'task1' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Depends on https://github.com/Automattic/wp-calypso/pull/77857

## Proposed Changes

* Added `taskFilter` prop to `<Launchpad />` component, so we can change the tasks that are shown (like it's done on Stepper)
* Added unit tests to test the filter

## Testing Instructions

* Visual inspection
* `yarn run test-packages launchpad` 
