### PR TITLE
Import: remove site request from loading check to prevent re-render

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -30,12 +30,9 @@ import {
 	isImporterStatusHydrated as isImporterStatusHydratedSelector,
 } from 'calypso/state/imports/selectors';
 import { analyzeUrl } from 'calypso/state/imports/url-analyzer/actions';
-import { getUrlData, isAnalyzing } from 'calypso/state/imports/url-analyzer/selectors';
+import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import {
-	hasAllSitesList,
-	isRequestingSite as isRequestingSiteSelector,
-} from 'calypso/state/sites/selectors';
+import { hasAllSitesList } from 'calypso/state/sites/selectors';
 import { StepProps } from '../../types';
 import { useAtomicTransferQueryParamUpdate } from './hooks/use-atomic-transfer-query-param-update';
 import { useInitialQueryRun } from './hooks/use-initial-query-run';
@@ -65,9 +62,6 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		const canImport = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
 		const siteImports = useSelector( ( state ) => getImporterStatusForSiteId( state, siteId ) );
 		const hasAllSitesFetched = useSelector( ( state ) => hasAllSitesList( state ) );
-		const isRequestingSite: boolean = useSelector( ( state ) =>
-			isRequestingSiteSelector( state, siteId )
-		);
 		const isImporterStatusHydrated = useSelector( isImporterStatusHydratedSelector );
 		const isMigrateFromWp = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIsMigrateFromWp(),
@@ -75,7 +69,6 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		);
 		const fromSite = currentSearchParams.get( 'from' ) || '';
 		const fromSiteData = useSelector( getUrlData );
-		const fromSiteDataIsAnalyzing = useSelector( isAnalyzing );
 		const stepNavigator = useStepNavigator( flow, navigation, siteId, siteSlug, fromSite );
 
 		/**
@@ -140,12 +133,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		}
 
 		function isLoading(): boolean {
-			return (
-				! isImporterStatusHydrated ||
-				! hasAllSitesFetched ||
-				fromSiteDataIsAnalyzing ||
-				isRequestingSite
-			);
+			return ! isImporterStatusHydrated || ! hasAllSitesFetched;
 		}
 
 		function checkFromSiteData(): void {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77874

## Proposed Changes

*  We improved the loading logic earlier in https://github.com/Automattic/wp-calypso/pull/77793, but this seems to be causing issues after the migration is done. Please see the video below:

https://github.com/Automattic/wp-calypso/assets/4074459/1b8b7d82-3be0-4c08-92fd-bc6f2d9de277

What happened above seems to be:
- When a migration is finished it re-fetch the site data.
- Once it re-fetch the [isLoading part](https://github.com/Automattic/wp-calypso/blob/12d42ea5d277a1ce672a2f14d7b5ccb32046493f/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx#L142-L149) got triggered again so all child component got re-render

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a JN site and start a migration
* Make sure you see the hooray screen after migration is done
* Also double check the site Picker issue following instructions https://github.com/Automattic/wp-calypso/pull/77793 to make sure you don't see page not found component.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
