### PR TITLE
Hosting import flow: reset onboarding store when starting flow to avoid managed_subdomain_not_available API error.

### DIFF
--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { IMPORT_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import MigrationError from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/migration-error';
 import { ProcessingResult } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/processing-step/constants';
@@ -22,6 +23,12 @@ const importHostedSiteFlow: Flow = {
 	name: IMPORT_HOSTED_SITE_FLOW,
 
 	useSteps() {
+		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
+
+		useEffect( () => {
+			resetOnboardStore();
+		}, [] );
+
 		return [
 			{ slug: 'import', component: ImportWithSiteAddressStep },
 			{ slug: 'importReady', component: ImportReady },

--- a/client/state/signup/dependency-store/reducer.js
+++ b/client/state/signup/dependency-store/reducer.js
@@ -16,7 +16,7 @@ function reducer( state = EMPTY, action ) {
 			return { ...state, ...action.dependencies };
 
 		case SIGNUP_DEPENDENCY_STORE_REMOVE_SITE_SLUG: {
-			const { siteId, siteSlug, ...dependenciesWithoutSiteIdentifiers } = state;
+			const { siteId, siteSlug, siteTitle, ...dependenciesWithoutSiteIdentifiers } = state;
 			return dependenciesWithoutSiteIdentifiers;
 		}
 

--- a/client/state/signup/dependency-store/reducer.js
+++ b/client/state/signup/dependency-store/reducer.js
@@ -16,7 +16,7 @@ function reducer( state = EMPTY, action ) {
 			return { ...state, ...action.dependencies };
 
 		case SIGNUP_DEPENDENCY_STORE_REMOVE_SITE_SLUG: {
-			const { siteId, siteSlug, siteTitle, ...dependenciesWithoutSiteIdentifiers } = state;
+			const { siteId, siteSlug, ...dependenciesWithoutSiteIdentifiers } = state;
 			return dependenciesWithoutSiteIdentifiers;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/77588#issuecomment-1576189253

## Proposed Changes

* Reset the onboarding store when starting the new import flow. This avoids using a stale domain from a previous flow which then produces a `400` API response. 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On trunk, go to `/setup/newsletter` or `/setup/link-in-bio` and choose the free domain and Free plan. 
* Wait until you're sent to Launchpad, then change the URL to `/setup/import-hosted-site` and use a JN site (I used https://dark-potter.jurassic.ninja/) to start the import flow. Continue through the flow and you should see an error:

<img width="790" alt="Screenshot 2566-06-07 at 11 54 12" src="https://github.com/Automattic/wp-calypso/assets/6851384/ba3d0185-b9a0-45ae-a353-1ed74e114ab2">

![Screenshot 2566-06-07 at 11 54 19](https://github.com/Automattic/wp-calypso/assets/6851384/2554e8e2-917a-4fcd-82e2-2c7fdcbeb733)

The problem is that the payload contains `blog_name` with value `test9042.home.blog`, the free domain from the newsletter flow. 

* Checkout this branch or use Calypso Live
* Repeat the process above and confirm that you confirm the flow (at least until it tells your to upgrade to Business)

This PR fixes the bug, but I wonder why `siteTitle` from a previously completed flow is still in the `dependencyStore` anyway? Can you see a better way to fix it?


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
