### PR TITLE
Update the theme switch modal to make it "less wrong"

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,7 +4,7 @@ const storybookDefaultConfig = require( '@automattic/calypso-storybook' );
 
 const storybookConfig = storybookDefaultConfig( {
 	stories: [
-		'../client/**/*.stories.{ts,tsx}',
+		'../client/**/*.stories.{js,jsx,ts,tsx}',
 		'../packages/design-picker/src/**/*.stories.{ts,tsx}',
 		'../packages/components/src/**/*.stories.{js,jsx,ts,tsx}',
 	],

--- a/client/components/forms/form-radio/style.scss
+++ b/client/components/forms/form-radio/style.scss
@@ -1,3 +1,7 @@
+@import "@automattic/typography/styles/variables";
+// stylelint-disable-next-line scss/at-import-no-partial-leading-underscore
+@import "../../../assets/stylesheets/shared/_extends-forms.scss";
+
 .form-radio {
 	@extend %form-field;
 

--- a/client/components/forms/form-radio/style.scss
+++ b/client/components/forms/form-radio/style.scss
@@ -1,6 +1,6 @@
 @import "@automattic/typography/styles/variables";
 // stylelint-disable-next-line scss/at-import-no-partial-leading-underscore
-@import "../../../assets/stylesheets/shared/_extends-forms.scss";
+@import "calypso/assets/stylesheets/shared/_extends-forms.scss";
 
 .form-radio {
 	@extend %form-field;

--- a/client/components/premium-global-styles-upgrade-modal/style.scss
+++ b/client/components/premium-global-styles-upgrade-modal/style.scss
@@ -51,7 +51,7 @@
 
 	h1.upgrade-modal__heading {
 		@extend .wp-brand-font;
-		font-size: $font-headline-small;
+		font-size: $font-title-large;
 		line-height: 1.1;
 		margin-bottom: 15px;
 		&.bundle {

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -49,6 +49,7 @@ export class AutoLoadingHomepageModal extends Component {
 		this.state = {
 			// Used to reset state when dialog re-opens, see `getDerivedStateFromProps`
 			wasVisible: props.isVisible,
+			hasConfirmed: false,
 		};
 	}
 
@@ -105,6 +106,9 @@ export class AutoLoadingHomepageModal extends Component {
 			isCurrentTheme,
 			isVisible = false,
 		} = this.props;
+
+		const { hasConfirmed } = this.state;
+
 		// Nothing to do when it's the current theme.
 		if ( isCurrentTheme ) {
 			return null;
@@ -171,12 +175,15 @@ export class AutoLoadingHomepageModal extends Component {
 						label={ translate(
 							'I understand that this layout will replace my existing homepage.'
 						) }
-						// TODO:
-						checked={ true }
-						onChange={ () => {} }
+						checked={ hasConfirmed }
+						onChange={ () => this.setState( { hasConfirmed: ! hasConfirmed } ) }
 					/>
 					<div className="auto-loading-homepage-modal__actions">
-						<Button primary onClick={ this.closeModalHandler( 'activeTheme' ) }>
+						<Button
+							primary
+							onClick={ this.closeModalHandler( 'activeTheme' ) }
+							disabled={ ! hasConfirmed }
+						>
 							{ translate( 'Activate %(themeName)s', {
 								args: { themeName },
 							} ) }

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -154,8 +154,10 @@ export class AutoLoadingHomepageModal extends Component {
 					<ScreenReaderText>{ translate( 'Close modal' ) }</ScreenReaderText>
 				</Button>
 				<div className="themes__theme-preview-wrapper">
-					<h1>{ translate( 'Activate this theme' ) }</h1>
-					<p>
+					<h1 className="auto-loading-homepage-modal__heading">
+						{ translate( 'Activate this theme' ) }
+					</h1>
+					<p className="auto-loading-homepage-modal__description">
 						{ translate(
 							'After activation, this layout will replace your existing homepage. But you can still access your old content. {{a}}Learn more{{/a}}.',
 							{
@@ -172,6 +174,7 @@ export class AutoLoadingHomepageModal extends Component {
 						) }
 					</p>
 					<CheckboxControl
+						className="auto-loading-homepage-modal__checkbox"
 						label={ translate(
 							'I understand that this layout will replace my existing homepage.'
 						) }

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -30,7 +30,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './auto-loading-homepage-modal.scss';
 
-class AutoLoadingHomepageModal extends Component {
+export class AutoLoadingHomepageModal extends Component {
 	static propTypes = {
 		source: PropTypes.oneOf( [ 'details', 'list', 'upload' ] ).isRequired,
 		theme: PropTypes.shape( {

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -47,26 +47,21 @@ export class AutoLoadingHomepageModal extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			homepageAction: 'keep_current_homepage',
 			// Used to reset state when dialog re-opens, see `getDerivedStateFromProps`
 			wasVisible: props.isVisible,
 		};
 	}
+
 	static getDerivedStateFromProps( nextProps, prevState ) {
 		// This component doesn't unmount when the dialog closes, so the state
 		// needs to be reset back to defaults each time it opens.
-		// Reseting `homepageAction` ensures the default option will be selected.
 		if ( nextProps.isVisible && ! prevState.wasVisible ) {
-			return { homepageAction: 'keep_current_homepage', wasVisible: true };
+			return { wasVisible: true };
 		} else if ( ! nextProps.isVisible && prevState.wasVisible ) {
 			return { wasVisible: false };
 		}
 		return null;
 	}
-
-	handleHomepageAction = ( event ) => {
-		this.setState( { homepageAction: event.currentTarget.value } );
-	};
 
 	closeModalHandler =
 		( action = 'dismiss' ) =>
@@ -74,7 +69,13 @@ export class AutoLoadingHomepageModal extends Component {
 			const { installingThemeId, siteId, source } = this.props;
 			if ( 'activeTheme' === action ) {
 				this.props.acceptAutoLoadingHomepageWarning( installingThemeId );
-				const keepCurrentHomepage = this.state.homepageAction === 'keep_current_homepage';
+
+				/**
+				 * We don't want to keep the current homepage since it's "broken" for now.
+				 * Update this when we find a way to improve the theme switch experience as a whole.
+				 */
+				const keepCurrentHomepage = false;
+
 				recordTracksEvent( 'calypso_theme_autoloading_homepage_modal_activate_click', {
 					theme: installingThemeId,
 					keep_current_homepage: keepCurrentHomepage,
@@ -86,12 +87,6 @@ export class AutoLoadingHomepageModal extends Component {
 					false,
 					keepCurrentHomepage
 				);
-			} else if ( 'keepCurrentTheme' === action ) {
-				recordTracksEvent( 'calypso_theme_autoloading_homepage_modal_dismiss', {
-					action: 'button',
-					theme: installingThemeId,
-				} );
-				return this.props.hideAutoLoadingHomepageWarning();
 			} else if ( 'dismiss' === action ) {
 				recordTracksEvent( 'calypso_theme_autoloading_homepage_modal_dismiss', {
 					action: 'escape',

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -124,11 +124,7 @@ export class AutoLoadingHomepageModal extends Component {
 			return null;
 		}
 
-		const {
-			// TODO: Show theme name in the modal
-			// name: themeName,
-			id: themeId,
-		} = this.props.theme;
+		const { name: themeName, id: themeId } = this.props.theme;
 
 		return (
 			<Dialog
@@ -150,7 +146,9 @@ export class AutoLoadingHomepageModal extends Component {
 				</Button>
 				<div className="themes__theme-preview-wrapper">
 					<h1 className="auto-loading-homepage-modal__heading">
-						{ translate( 'Activate this theme' ) }
+						{ translate( 'Activate %(themeName)s', {
+							args: { themeName },
+						} ) }
 					</h1>
 					<p className="auto-loading-homepage-modal__description">
 						{ translate(
@@ -179,7 +177,9 @@ export class AutoLoadingHomepageModal extends Component {
 					/>
 					<div className="auto-loading-homepage-modal__actions">
 						<Button primary onClick={ this.closeModalHandler( 'activeTheme' ) }>
-							{ translate( 'Activate this theme' ) }
+							{ translate( 'Activate %(themeName)s', {
+								args: { themeName },
+							} ) }
 						</Button>
 					</div>
 				</div>

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -1,7 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Dialog, Gridicon, Spinner } from '@automattic/components';
+import { Dialog, Gridicon, Spinner, Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
+import { CheckboxControl } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -193,6 +194,37 @@ export class AutoLoadingHomepageModal extends Component {
 					eventProperties={ { theme: themeId } }
 				/>
 				<div className="themes__theme-preview-wrapper">
+					<h1>{ translate( 'Activate this theme' ) }</h1>
+					<p>
+						{ translate(
+							'After activation, this layout will replace your existing homepage. But you can still access your old content. {{a}}Learn more{{/a}}.',
+							{
+								components: {
+									a: (
+										<a
+											href={ localizeUrl( 'https://wordpress.com/support/themes/changing-themes' ) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+						) }
+					</p>
+					<CheckboxControl
+						label={ translate(
+							'I understand that this layout will replace my existing homepage.'
+						) }
+						// TODO:
+						checked={ true }
+						onChange={ () => {} }
+					/>
+					<div className="auto-loading-homepage-modal__actions">
+						<Button primary onClick={ this.closeModalHandler( 'activeTheme' ) }>
+							{ translate( 'Activate this theme' ) }
+						</Button>
+					</div>
+
 					<h1>
 						{ translate( 'How would you like to use %(themeName)s?', {
 							args: { themeName },

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Dialog, Gridicon, Button } from '@automattic/components';
+import { Dialog, Gridicon, Button, ScreenReaderText } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { CheckboxControl } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
@@ -141,15 +141,18 @@ export class AutoLoadingHomepageModal extends Component {
 				isVisible={ isVisible }
 				onClose={ this.closeModalHandler( 'dismiss' ) }
 			>
-				<Gridicon
-					icon="cross"
-					className="themes__auto-loading-homepage-modal-close-icon"
-					onClick={ this.closeModalHandler( 'dismiss' ) }
-				/>
 				<TrackComponentView
 					eventName="calypso_theme_autoloading_homepage_modal_view"
 					eventProperties={ { theme: themeId } }
 				/>
+				<Button
+					className="themes__auto-loading-homepage-modal-close-icon"
+					borderless
+					onClick={ this.closeModalHandler( 'dismiss' ) }
+				>
+					<Gridicon icon="cross" size={ 12 } />
+					<ScreenReaderText>{ translate( 'Close modal' ) }</ScreenReaderText>
+				</Button>
 				<div className="themes__theme-preview-wrapper">
 					<h1>{ translate( 'Activate this theme' ) }</h1>
 					<p>

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -74,6 +74,8 @@ export class AutoLoadingHomepageModal extends Component {
 				/**
 				 * We don't want to keep the current homepage since it's "broken" for now.
 				 * Update this when we find a way to improve the theme switch experience as a whole.
+				 *
+				 * @see pbxlJb-3Uv-p2
 				 */
 				const keepCurrentHomepage = false;
 

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -1,3 +1,4 @@
+@import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -3,7 +3,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.themes__auto-loading-homepage-modal {
+.dialog__content.themes__auto-loading-homepage-modal {
 	position: relative;
 	padding: 45px 45px 17px;
 	max-width: 640px;
@@ -35,7 +35,7 @@
 }
 
 .auto-loading-homepage-modal__checkbox {
-	margin-bottom: 60px;
+	margin-bottom: 52px;
 	.components-checkbox-control__label {
 		font-size: $font-body;
 	}
@@ -50,12 +50,15 @@
 		border-radius: 4px;
 		font-weight: 500;
 		&.is-primary {
-			background: var(--color-accent);
-			border-color: var(--color-accent);
-			&:hover,
+			background: var(--studio-blue-50);
+			border-color: var(--studio-blue-50);
+			&:hover {
+				background: var(--studio-blue-60);
+				border-color: var(--studio-blue-60);
+			}
 			&:focus {
-				background: var(--color-accent-60);
-				border-color: var(--color-accent-60);
+				box-shadow: 0 0 0 2px var(--color-primary-light);
+				outline: 0;
 			}
 		}
 	}

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -10,7 +10,7 @@
 	box-sizing: border-box;
 	.auto-loading-homepage-modal__heading {
 		@extend .wp-brand-font;
-		font-size: $font-headline-small;
+		font-size: $font-title-large;
 		line-height: 1.1;
 		width: 100%;
 		margin-bottom: 16px;

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -5,7 +5,7 @@
 
 .dialog__content.themes__auto-loading-homepage-modal {
 	position: relative;
-	padding: 45px 45px 17px;
+	padding: 45px 45px 35px;
 	max-width: 640px;
 	box-sizing: border-box;
 	.auto-loading-homepage-modal__heading {

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -1,139 +1,62 @@
 @import "@automattic/typography/styles/variables";
+@import "@automattic/typography/styles/fonts";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
 .themes__auto-loading-homepage-modal {
 	position: relative;
-
-	h1 {
-		margin-bottom: 1em;
-		text-align: center;
+	padding: 45px 45px 17px;
+	max-width: 600px;
+	box-sizing: border-box;
+	.auto-loading-homepage-modal__heading {
+		@extend .wp-brand-font;
+		font-size: $font-headline-small;
+		line-height: 1.1;
+		width: 100%;
+		margin-bottom: 15px;
 	}
-}
-
-.themes__auto-loading-homepage-modal-close-icon {
-	cursor: pointer;
-	width: 16px;
-	height: 16px;
-	position: absolute;
-	top: 10px;
-	right: 10px;
-
-	@include break-medium {
-		width: 24px;
-		height: 24px;
-		right: 20px;
-		top: 20px;
-	}
-}
-
-.themes__auto-loading-homepage-modal-homepage-hint {
-	margin-left: 1.5em;
-	font-size: $font-body-small;
-	font-style: italic;
-	margin-top: -5px;
 }
 
 .themes__theme-preview-wrapper {
 	display: flex;
 	flex-direction: column;
-	align-items: center;
-	max-width: 700px;
 }
 
-.themes__autoloading-homepage-option-description {
-	font-size: $font-body-small;
-	min-height: 90px;
+.themes__auto-loading-homepage-modal-close-icon {
+	cursor: pointer;
+	color: var(--color-text-subtle);
+	position: absolute;
+	top: 0;
+	right: 8px;
+}
 
-	@include break-medium {
-		width: 70%;
-		min-height: 0;
+.auto-loading-homepage-modal__description {
+	margin-bottom: 30px;
+}
+
+.auto-loading-homepage-modal__checkbox {
+	margin-bottom: 60px;
+	.components-checkbox-control__label {
+		font-size: $font-body;
 	}
 }
 
-.themes__theme-preview-items {
+.auto-loading-homepage-modal__actions {
 	display: flex;
-	flex-direction: column;
-	margin: 0 0 1em;
-	max-width: 700px;
+	justify-content: flex-end;
 
-	@include break-medium {
-		flex-direction: row;
-	}
-}
-
-.themes__theme-preview-item {
-	img,
-	.themes__iframe-wrapper {
-		display: none;
-	}
-
-	@include break-medium {
-		border: 1px solid var(--color-border-subtle);
-		border-radius: 2px;
-		width: 48%;
-		margin-left: 2%;
-
-		img,
-		.themes__iframe-wrapper,
-		.themes__theme-preview-image-wrapper {
-			display: block;
-			height: 100%;
-		}
-
-		.themes__iframe-wrapper,
-		.themes__theme-preview-image-wrapper {
-			max-height: 235px;
-			overflow: hidden;
-		}
-
-		.form-label {
-			height: 100%;
-		}
-
-		.form-radio {
-			margin: 1em;
-		}
-
-		.form-radio__label {
-			margin: 1em 1em 1em 3em;
-		}
-
-		&:first-of-type {
-			margin-left: 0;
-			margin-right: 2%;
+	.button {
+		padding: 9px 25px;
+		border-radius: 4px;
+		font-weight: 500;
+		&.is-primary {
+			background: var(--color-accent);
+			border-color: var(--color-accent);
+			&:hover,
+			&:focus {
+				background: var(--color-accent-60);
+				border-color: var(--color-accent-60);
+			}
 		}
 	}
-
-	img {
-		width: 100%;
-		height: auto;
-	}
-}
-
-.themes__theme-preview-item-iframe-container {
-	display: flex;
-	flex-direction: column;
-
-	.themes__iframe-wrapper {
-		flex-grow: 1;
-		overflow: hidden;
-		position: relative;
-		pointer-events: none;
-	}
-	iframe {
-		height: 357%;
-		width: 357%;
-		max-width: 357%;
-		transform: scale(0.28);
-		transform-origin: top left;
-		position: absolute;
-		top: 0;
-		left: 0;
-	}
-}
-
-.themes__iframe-wrapper .spinner {
-	position: relative;
-	top: 50%;
 }

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -36,6 +36,10 @@
 
 .auto-loading-homepage-modal__checkbox {
 	margin-bottom: 22px;
+	.components-base-control__field {
+		display: flex;
+		align-items: center;
+	}
 	.components-checkbox-control__label {
 		font-size: $font-body;
 	}

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -5,7 +5,7 @@
 
 .dialog__content.themes__auto-loading-homepage-modal {
 	position: relative;
-	padding: 45px 45px 35px;
+	padding: 48px 48px 16px;
 	max-width: 640px;
 	box-sizing: border-box;
 	.auto-loading-homepage-modal__heading {
@@ -13,7 +13,7 @@
 		font-size: $font-headline-small;
 		line-height: 1.1;
 		width: 100%;
-		margin-bottom: 15px;
+		margin-bottom: 16px;
 	}
 }
 
@@ -26,16 +26,16 @@
 	cursor: pointer;
 	color: var(--color-text-subtle);
 	position: absolute;
-	top: 1px;
-	right: 9px;
+	top: 4px;
+	right: 12px;
 }
 
 .auto-loading-homepage-modal__description {
-	margin-bottom: 60px;
+	margin-bottom: 56px;
 }
 
 .auto-loading-homepage-modal__checkbox {
-	margin-bottom: 22px;
+	margin-bottom: 16px;
 	.components-base-control__field {
 		display: flex;
 		align-items: center;

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -6,7 +6,7 @@
 .themes__auto-loading-homepage-modal {
 	position: relative;
 	padding: 45px 45px 17px;
-	max-width: 600px;
+	max-width: 640px;
 	box-sizing: border-box;
 	.auto-loading-homepage-modal__heading {
 		@extend .wp-brand-font;

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -49,18 +49,22 @@
 		padding: 9px 25px;
 		border-radius: 4px;
 		font-weight: 500;
-		&.is-primary {
-			background: var(--studio-blue-50);
+		&.is-primary:not(:disabled) {
+			background-color: var(--studio-blue-50);
 			border-color: var(--studio-blue-50);
-			&:hover,
-			&:disabled {
-				background: var(--studio-blue-60);
+			&:hover {
+				background-color: var(--studio-blue-60);
 				border-color: var(--studio-blue-60);
 			}
 			&:focus {
 				box-shadow: 0 0 0 2px var(--color-primary-light);
 				outline: 0;
 			}
+		}
+		&.is-primary:disabled {
+			color: var(--studio-white);
+			background-color: var(--studio-gray-5);
+			border-color: var(--studio-gray-5);
 		}
 	}
 }

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -31,11 +31,11 @@
 }
 
 .auto-loading-homepage-modal__description {
-	margin-bottom: 30px;
+	margin-bottom: 60px;
 }
 
 .auto-loading-homepage-modal__checkbox {
-	margin-bottom: 52px;
+	margin-bottom: 22px;
 	.components-checkbox-control__label {
 		font-size: $font-body;
 	}

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -52,7 +52,8 @@
 		&.is-primary {
 			background: var(--studio-blue-50);
 			border-color: var(--studio-blue-50);
-			&:hover {
+			&:hover,
+			&:disabled {
 				background: var(--studio-blue-60);
 				border-color: var(--studio-blue-60);
 			}

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -26,8 +26,8 @@
 	cursor: pointer;
 	color: var(--color-text-subtle);
 	position: absolute;
-	top: 0;
-	right: 8px;
+	top: 1px;
+	right: 9px;
 }
 
 .auto-loading-homepage-modal__description {

--- a/client/my-sites/themes/auto-loading-homepage-modal.stories.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.stories.jsx
@@ -1,0 +1,35 @@
+import { action } from '@storybook/addon-actions';
+import { ReduxDecorator } from 'calypso/__mocks__/storybook/redux';
+import { AutoLoadingHomepageModal } from './auto-loading-homepage-modal';
+
+export default {
+	title: 'client/my-sites/themes/AutoLoadingHomepageModal',
+	component: AutoLoadingHomepageModal,
+	decorators: [
+		( Story ) => {
+			return (
+				<ReduxDecorator store={ { bumpStat: () => {}, recordTracksEvent: () => {} } }>
+					<Story></Story>
+				</ReduxDecorator>
+			);
+		},
+	],
+};
+
+const Template = ( args ) => <AutoLoadingHomepageModal { ...args } />;
+
+export const isVisible = Template.bind( {} );
+isVisible.args = {
+	hasActivated: false,
+	hasAutoLoadingHomepage: true,
+	hideAutoLoadingHomepageWarning: action( 'hideAutoLoadingHomepageWarning' ),
+	isActivating: false,
+	isVisible: true,
+	source: 'details',
+	theme: {
+		author: 'author',
+		author_uri: 'author_uri',
+		id: 'id',
+		name: 'name',
+	},
+};

--- a/client/my-sites/themes/auto-loading-homepage-modal.stories.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.stories.jsx
@@ -18,18 +18,45 @@ export default {
 
 const Template = ( args ) => <AutoLoadingHomepageModal { ...args } />;
 
-export const isVisible = Template.bind( {} );
-isVisible.args = {
+const baseProps = {
 	hasActivated: false,
 	hasAutoLoadingHomepage: true,
 	hideAutoLoadingHomepageWarning: action( 'hideAutoLoadingHomepageWarning' ),
 	isActivating: false,
+	isCurrentTheme: false,
 	isVisible: true,
 	source: 'details',
 	theme: {
 		author: 'author',
 		author_uri: 'author_uri',
 		id: 'id',
-		name: 'name',
+		name: 'Sample Theme',
 	},
+};
+
+export const isVisible = Template.bind( {} );
+isVisible.args = {
+	...baseProps,
+};
+
+/**
+ * Don't show the modal in the patterns below.
+ */
+
+export const isCurrentTheme = Template.bind( {} );
+isCurrentTheme.args = {
+	...baseProps,
+	isCurrentTheme: true,
+};
+
+export const noAutoLoadingHomepage = Template.bind( {} );
+noAutoLoadingHomepage.args = {
+	...baseProps,
+	hasAutoLoadingHomepage: false,
+};
+
+export const isActivating = Template.bind( {} );
+isActivating.args = {
+	...baseProps,
+	isActivating: true,
 };

--- a/client/my-sites/themes/auto-loading-homepage-modal.stories.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.stories.jsx
@@ -19,6 +19,8 @@ export default {
 const Template = ( args ) => <AutoLoadingHomepageModal { ...args } />;
 
 const baseProps = {
+	acceptAutoLoadingHomepageWarning: action( 'acceptAutoLoadingHomepageWarning' ),
+	activateTheme: action( 'activateTheme' ),
 	hasActivated: false,
 	hasAutoLoadingHomepage: true,
 	hideAutoLoadingHomepageWarning: action( 'hideAutoLoadingHomepageWarning' ),

--- a/client/package.json
+++ b/client/package.json
@@ -215,6 +215,7 @@
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@sentry/webpack-plugin": "^1.18.8",
+		"@storybook/addon-actions": "^7.0.18",
 		"@tanstack/query-sync-storage-persister": "^4.29.1",
 		"@testing-library/dom": "^8.13.0",
 		"@testing-library/jest-dom": "^5.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11154,6 +11154,7 @@ __metadata:
     "@github/webauthn-json": ^0.4.1
     "@sentry/react": ^7.54.0
     "@sentry/webpack-plugin": ^1.18.8
+    "@storybook/addon-actions": ^7.0.18
     "@stripe/react-stripe-js": ^2.1.0
     "@stripe/stripe-js": ^1.53.0
     "@tanstack/query-sync-storage-persister": ^4.29.1


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2222

## Proposed Changes

- Remove the preview images and the "persist my homepage" option (always use the "replace my homepage option").
- Update copy and the modal style.

This is meant to be an interim fix to the modal. Once we ship Live Preview in the Theme Showcase pbxlJb-3Uv-p2 we will likely remove this modal, and work on an appropriate messaging/UX for Theme Switch at that time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the Theme Showcase page (`/themes/<your-site>`)
- Select a theme
	- Note that it shows the modal only when the theme includes `auto-loading-homepage` in the taxonomy (e.g. Hey/George Lois/Appleton, c.f. [state/themes/actions/activate.js#L65-L76](https://github.com/Automattic/wp-calypso/blob/85fee3b090174b1c41e9f121f9b08b6b58f841a2/client/state/themes/actions/activate.js#L65-L76), [state/themes/selectors/theme-has-auto-loading-homepage.js#L34](https://github.com/Automattic/wp-calypso/blob/85fee3b090174b1c41e9f121f9b08b6b58f841a2/client/state/themes/selectors/theme-has-auto-loading-homepage.js#L34)). This is not changed from the existing behavior. 
- Activate the theme

before

https://github.com/Automattic/wp-calypso/assets/5287479/0798c965-c677-4d2b-8bcc-aa8a6f2a7ca6

after

https://github.com/Automattic/wp-calypso/assets/5287479/ccdec01b-14a8-4185-8851-e14e214515fd

<!--
https://github.com/Automattic/wp-calypso/assets/5287479/713cf5a2-d3bf-4ff7-9c06-d44e164d8c80
-->

<!--
We can try activation from other places, such as the theme thumbnail in the Theme Showcase, after buying a premium theme, after uploading a theme.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

## Other Resources

- Figma Tv3pYqA3EcRfiXC31IxrXE-fi-716_25378
- The logic for theme switching: `POST /themes/mine`
	- Simple sites fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qnpgvir%2Qgurzr%2Qraqcbvag.cuc%3Se%3Q1p463405%2330-og
	- Atomic sites fbhepr%2Skers%2Swrgcnpx%2Scebwrpgf%2Scyhtvaf%2Swrgcnpx%2Swfba%2Qraqcbvagf%2Swrgcnpx%2Spynff.wrgcnpx%2Qwfba%2Qncv%2Qgurzrf%2Qnpgvir%2Qraqcbvag.cuc%3Se%3Q3n3p4nqp%2336-og
