### PR TITLE
Customize Jetpack connection logged-in screen for woocommerce core profiler flow

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -664,7 +664,7 @@ class SignupForm extends Component {
 				{ this.props.displayUsernameInput && (
 					<>
 						<FormLabel htmlFor="username">
-							{ this.props.isReskinned || this.props.isWoo
+							{ this.props.isReskinned || ( this.props.isWoo && ! this.props.isWooCoreProfilerFlow )
 								? this.props.translate( 'Username' )
 								: this.props.translate( 'Choose a username' ) }
 						</FormLabel>
@@ -1296,6 +1296,9 @@ function TrackRender( { children, eventName } ) {
 export default connect(
 	( state, props ) => {
 		const oauth2Client = getCurrentOAuth2Client( state );
+		const isWooCoreProfilerFlow =
+			'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' );
+
 		return {
 			currentUser: getCurrentUser( state ),
 			oauth2Client,
@@ -1305,7 +1308,8 @@ export default connect(
 			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
-			isWoo: isWooOAuth2Client( oauth2Client ),
+			isWoo: isWooOAuth2Client( oauth2Client ) || isWooCoreProfilerFlow,
+			isWooCoreProfilerFlow,
 			isP2Flow:
 				isP2Flow( props.flowName ) || get( getCurrentQueryArguments( state ), 'from' ) === 'p2',
 		};

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -12,6 +13,7 @@ import { login } from 'calypso/lib/paths';
 import { isWpccFlow } from 'calypso/signup/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import SocialSignupToS from './social-signup-tos';
 
@@ -187,7 +189,9 @@ export default connect(
 	( state ) => ( {
 		currentRoute: getCurrentRoute( state ),
 		oauth2Client: getCurrentOAuth2Client( state ),
-		isWoo: isWooOAuth2Client( getCurrentOAuth2Client( state ) ),
+		isWoo:
+			isWooOAuth2Client( getCurrentOAuth2Client( state ) ) ||
+			'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
 	} ),
 	{ recordTracksEvent }
 )( localize( SocialSignupForm ) );

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -53,6 +53,8 @@ class Site extends Component {
 		isSiteP2: false,
 
 		isReskinned: false,
+
+		defaultIcon: null,
 	};
 
 	static propTypes = {
@@ -72,6 +74,7 @@ class Site extends Component {
 		isP2Hub: PropTypes.bool,
 		isSiteP2: PropTypes.bool,
 		isReskinned: PropTypes.bool,
+		defaultIcon: PropTypes.node,
 	};
 
 	onSelect = ( event ) => {
@@ -179,7 +182,7 @@ class Site extends Component {
 					}
 				>
 					<SiteIcon
-						defaultIcon={ this.props.isReskinned ? layout : null }
+						defaultIcon={ this.props.isReskinned ? layout : this.props.defaultIcon }
 						site={ site }
 						// eslint-disable-next-line no-nested-ternary
 						size={ this.props.compact ? 24 : this.props.isReskinned ? 50 : 32 }

--- a/client/components/jetpack-header/index.jsx
+++ b/client/components/jetpack-header/index.jsx
@@ -13,15 +13,28 @@ export class JetpackHeader extends PureComponent {
 	static propTypes = {
 		darkColorScheme: PropTypes.bool,
 		partnerSlug: PropTypes.string,
-		isWoo: PropTypes.bool,
+		isWooOnboarding: PropTypes.bool,
+		isWooCoreProfiler: PropTypes.bool,
 		isWooDna: PropTypes.bool,
 		width: PropTypes.number,
 	};
 
 	renderLogo() {
-		const { darkColorScheme, partnerSlug, width, isWoo, isWooDna, translate } = this.props;
+		const {
+			darkColorScheme,
+			partnerSlug,
+			width,
+			isWooOnboarding,
+			isWooCoreProfiler,
+			isWooDna,
+			translate,
+		} = this.props;
 
-		if ( isWoo ) {
+		if ( isWooCoreProfiler ) {
+			return null;
+		}
+
+		if ( isWooOnboarding ) {
 			// @todo Implement WooCommerce + partner co-branding in the future.
 			return (
 				<JetpackPartnerLogoGroup

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -16,7 +16,8 @@ import { authQueryPropTypes } from './utils';
 export class AuthFormHeader extends Component {
 	static propTypes = {
 		authQuery: authQueryPropTypes.isRequired,
-		isWoo: PropTypes.bool,
+		isWooOnboarding: PropTypes.bool,
+		isWooCoreProfiler: PropTypes.bool,
 		isWpcomMigration: PropTypes.bool,
 		wooDnaConfig: PropTypes.object,
 
@@ -48,7 +49,14 @@ export class AuthFormHeader extends Component {
 	}
 
 	getHeaderText() {
-		const { translate, partnerSlug, isWoo, wooDnaConfig, isWpcomMigration } = this.props;
+		const {
+			translate,
+			partnerSlug,
+			isWooOnboarding,
+			isWooCoreProfiler,
+			wooDnaConfig,
+			isWpcomMigration,
+		} = this.props;
 
 		if ( wooDnaConfig && wooDnaConfig.isWooDnaFlow() ) {
 			return wooDnaConfig.getServiceName();
@@ -82,13 +90,17 @@ export class AuthFormHeader extends Component {
 
 		const currentState = this.getState();
 
-		if ( isWoo ) {
+		if ( isWooOnboarding ) {
 			switch ( currentState ) {
 				case 'logged-out':
 					return translate( 'Create a Jetpack account' );
 				default:
 					return translate( 'Connecting your store' );
 			}
+		}
+
+		if ( isWooCoreProfiler ) {
+			return translate( 'One last step!' );
 		}
 
 		if ( isWpcomMigration ) {
@@ -110,10 +122,11 @@ export class AuthFormHeader extends Component {
 	}
 
 	getSubHeaderText() {
-		const { translate, isWoo, wooDnaConfig, isWpcomMigration } = this.props;
+		const { translate, isWooOnboarding, isWooCoreProfiler, wooDnaConfig, isWpcomMigration } =
+			this.props;
 		const currentState = this.getState();
 
-		if ( isWoo ) {
+		if ( isWooOnboarding ) {
 			switch ( currentState ) {
 				case 'logged-out':
 					return translate(
@@ -122,6 +135,12 @@ export class AuthFormHeader extends Component {
 				default:
 					return translate( "Once connected we'll continue setting up your store" );
 			}
+		}
+
+		if ( isWooCoreProfiler ) {
+			return translate(
+				"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack, you'll need to connect your store to your WordPress.com account."
+			);
 		}
 
 		if ( wooDnaConfig && wooDnaConfig.isWooDnaFlow() ) {

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import Site from 'calypso/blocks/site';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { decodeEntities } from 'calypso/lib/formatting';
+import { login } from 'calypso/lib/paths';
 import versionCompare from 'calypso/lib/version-compare';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getAuthorizationData } from 'calypso/state/jetpack-connect/selectors';
@@ -139,9 +140,32 @@ export class AuthFormHeader extends Component {
 		}
 
 		if ( isWooCoreProfiler ) {
-			return translate(
-				"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack, you'll need to connect your store to your WordPress.com account."
-			);
+			switch ( currentState ) {
+				case 'logged-out':
+					return translate(
+						"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
+						{
+							components: {
+								br: <br />,
+								a: (
+									<a
+										href={ login( {
+											isJetpack: true,
+											redirectTo: window.location.href,
+											from: this.props.authQuery.from,
+										} ) }
+									/>
+								),
+							},
+							comment:
+								'Link displayed on the Jetpack Connect signup page for users to log in with a WordPress.com account',
+						}
+					);
+				default:
+					return translate(
+						"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack, you'll need to connect your store to your WordPress.com account."
+					);
+			}
 		}
 
 		if ( wooDnaConfig && wooDnaConfig.isWooDnaFlow() ) {

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -1,5 +1,6 @@
 import { safeImageUrl } from '@automattic/calypso-url';
 import { CompactCard } from '@automattic/components';
+import { Icon, globe } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -179,7 +180,7 @@ export class AuthFormHeader extends Component {
 	}
 
 	getSiteCard() {
-		const { isWpcomMigration } = this.props;
+		const { isWpcomMigration, isWooCoreProfiler } = this.props;
 		const { jpVersion } = this.props.authQuery;
 		if ( ! versionCompare( jpVersion, '4.0.3', '>' ) ) {
 			return null;
@@ -207,7 +208,7 @@ export class AuthFormHeader extends Component {
 
 		return (
 			<CompactCard className="jetpack-connect__site">
-				<Site site={ site } />
+				<Site site={ site } defaultIcon={ isWooCoreProfiler ? <Icon icon={ globe } /> : null } />
 			</CompactCard>
 		);
 	}

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -5,11 +5,9 @@ import {
 } from '@automattic/calypso-products';
 import { Button, Card, Gridicon, Spinner, JetpackLogo } from '@automattic/components';
 import { Spinner as WPSpinner } from '@wordpress/components';
-import { removeQueryArgs } from '@wordpress/url';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
 import { flowRight, get, includes, startsWith } from 'lodash';
-import page from 'page';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -22,7 +20,6 @@ import Gravatar from 'calypso/components/gravatar';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
-import Notice from 'calypso/components/notice';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { navigate } from 'calypso/lib/navigate';
 import { login } from 'calypso/lib/paths';
@@ -84,6 +81,7 @@ import {
 } from './persistence-utils';
 import { authQueryPropTypes, getRoleFromScope } from './utils';
 import wooDnaConfig from './woo-dna-config';
+import WooInstallExtSuccessNotice from './woo-install-ext-success-notice';
 
 /**
  * Constants
@@ -873,24 +871,7 @@ export class JetpackAuthorize extends Component {
 							</div>
 						</div>
 					</div>
-					{ authQuery.installedExtSuccess && (
-						<Notice
-							className="jetpack-connect__woo-core-profiler-notice"
-							status="is-success"
-							showDismiss={ false }
-							text={ translate( 'Extensions successfully installed!' ) }
-							isCompact={ false }
-							duration={ 3000 }
-							onDismissClick={ () => {
-								page.replace(
-									removeQueryArgs(
-										window.location.pathname + window.location.search,
-										'installed_ext_success'
-									)
-								);
-							} }
-						/>
-					) }
+					{ authQuery.installedExtSuccess && <WooInstallExtSuccessNotice /> }
 				</Fragment>
 			);
 		}

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -445,7 +445,7 @@ export class JetpackAuthorize extends Component {
 		if ( 'woocommerce-onboarding' === from ) {
 			recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { different_account: true } );
 		} else if ( from === 'woocommerce-core-profiler' ) {
-			recordTracksEvent( 'wcadmin_coreprofiler_connect_store', { different_account: true } );
+			recordTracksEvent( 'calypso_jpc_different_user_click' );
 		}
 	};
 
@@ -510,8 +510,6 @@ export class JetpackAuthorize extends Component {
 
 		if ( 'woocommerce-onboarding' === from ) {
 			recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { use_account: true } );
-		} else if ( from === 'woocommerce-core-profiler' ) {
-			recordTracksEvent( 'wcadmin_coreprofiler_connect_store', { use_account: true } );
 		}
 
 		return this.authorize();

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -404,6 +404,7 @@ export class JetpackAuthorize extends Component {
 				'woocommerce-services-auto-authorize',
 				'woocommerce-setup-wizard',
 				'woocommerce-onboarding',
+				'woocommerce-core-profiler',
 			].includes( from ) || this.getWooDnaConfig( props ).isWooDnaFlow()
 		);
 	};

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -4,6 +4,7 @@ import {
 	WPCOM_FEATURES_BACKUPS,
 } from '@automattic/calypso-products';
 import { Button, Card, Gridicon, Spinner, JetpackLogo } from '@automattic/components';
+import { Spinner as WPSpinner } from '@wordpress/components';
 import { removeQueryArgs } from '@wordpress/url';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -997,13 +998,28 @@ export class JetpackAuthorize extends Component {
 			return null;
 		}
 
-		if (
+		const isLoading =
 			this.props.isFetchingAuthorizationSite ||
 			this.props.isRequestingSitePurchases ||
 			this.isAuthorizing() ||
 			this.retryingAuth ||
-			authorizeSuccess
-		) {
+			authorizeSuccess;
+
+		if ( this.isWooCoreProfiler() ) {
+			return (
+				<LoggedOutFormFooter className="jetpack-connect__action-disclaimer">
+					<Button
+						primary
+						disabled={ isLoading || this.isAuthorizing() || this.props.hasXmlrpcError }
+						onClick={ this.handleSubmit }
+					>
+						{ isLoading ? <WPSpinner /> : this.getButtonText() }
+					</Button>
+				</LoggedOutFormFooter>
+			);
+		}
+
+		if ( isLoading ) {
 			return (
 				<div className="jetpack-connect__logged-in-form-loading">
 					<span>{ this.getButtonText() }</span> <Spinner size={ 20 } duration={ 3000 } />
@@ -1012,10 +1028,9 @@ export class JetpackAuthorize extends Component {
 		}
 
 		const { blogname } = this.props.authQuery;
-
 		return (
 			<LoggedOutFormFooter className="jetpack-connect__action-disclaimer">
-				{ ! this.isWooCoreProfiler() && <Disclaimer siteName={ decodeEntities( blogname ) } /> }
+				<Disclaimer siteName={ decodeEntities( blogname ) } />
 				<Button
 					primary
 					disabled={ this.isAuthorizing() || this.props.hasXmlrpcError }

--- a/client/jetpack-connect/features.tsx
+++ b/client/jetpack-connect/features.tsx
@@ -1,0 +1,42 @@
+import { Icon, check } from '@wordpress/icons';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+
+export const JetpackFeatures = ( { className }: { className?: string } ) => {
+	const translate = useTranslate();
+
+	const col1Features = [
+		translate( 'Speed up images and photos' ),
+		translate( 'Prevent brute force attacks' ),
+		translate( 'Secure user authentication' ),
+		translate( 'Enhanced site stats and insights' ),
+	];
+
+	const col2Features = [
+		translate( 'Daily or real-time backups' ),
+		translate( 'Keep plugins auto-updated' ),
+		translate( 'Immediate downtime alerts' ),
+		translate( 'Bulk site management from one dashboard' ),
+	];
+
+	return (
+		<div className={ classNames( 'jetpack-connect__features_wrapper', className ) }>
+			<ul className="jetpack-connect__features">
+				{ col1Features.map( ( feature, index ) => (
+					<li key={ index }>
+						<Icon size={ 20 } icon={ check } />
+						<span>{ feature }</span>
+					</li>
+				) ) }
+			</ul>
+			<ul className="jetpack-connect__features">
+				{ col2Features.map( ( feature, index ) => (
+					<li key={ index }>
+						<Icon size={ 20 } icon={ check } />
+						<span>{ feature }</span>
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+};

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -12,7 +12,8 @@ import { retrieveMobileRedirect } from './persistence-utils';
 export class JetpackConnectMainWrapper extends PureComponent {
 	static propTypes = {
 		isWide: PropTypes.bool,
-		isWoo: PropTypes.bool,
+		isWooOnboarding: PropTypes.bool,
+		isWooCoreProfiler: PropTypes.bool,
 		isWpcomMigration: PropTypes.bool,
 		wooDnaConfig: PropTypes.object,
 		partnerSlug: PropTypes.string,
@@ -22,14 +23,16 @@ export class JetpackConnectMainWrapper extends PureComponent {
 
 	static defaultProps = {
 		isWide: false,
-		isWoo: false,
+		isWooOnboarding: false,
+		isWooCoreProfiler: false,
 		wooDnaConfig: null,
 	};
 
 	render() {
 		const {
 			isWide,
-			isWoo,
+			isWooOnboarding,
+			isWooCoreProfiler,
 			isWpcomMigration,
 			className,
 			children,
@@ -43,12 +46,13 @@ export class JetpackConnectMainWrapper extends PureComponent {
 
 		const wrapperClassName = classNames( 'jetpack-connect__main', {
 			'is-wide': isWide,
-			'is-woocommerce': isWoo || isWooDna,
+			'is-woocommerce': isWooOnboarding || isWooDna || isWooCoreProfiler,
+			'is-woocommerce-core-profiler-flow': isWooCoreProfiler,
 			'is-mobile-app-flow': !! retrieveMobileRedirect(),
 			'is-wpcom-migration': isWpcomMigration,
 		} );
 
-		const width = isWoo || isWooDna ? 200 : undefined;
+		const width = isWooOnboarding || isWooDna ? 200 : undefined;
 		const darkColorScheme = false;
 
 		return (
@@ -61,7 +65,8 @@ export class JetpackConnectMainWrapper extends PureComponent {
 					{ ! isWpcomMigration && (
 						<JetpackHeader
 							partnerSlug={ partnerSlug }
-							isWoo={ isWoo }
+							isWooOnboarding={ isWooOnboarding }
+							isWooCoreProfiler={ isWooCoreProfiler }
 							isWooDna={ isWooDna }
 							width={ width }
 							darkColorScheme={ darkColorScheme }

--- a/client/jetpack-connect/schema.js
+++ b/client/jetpack-connect/schema.js
@@ -41,5 +41,6 @@ export const authorizeQueryDataSchema = {
 		woodna_help_url: { type: 'string' },
 		skip_user: { type: 'string' }, // deprecated, to be removed soon
 		allow_site_connection: { type: 'string' }, // '1' if true
+		installed_ext_success: { type: 'string' }, // '1' if true
 	},
 };

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -447,10 +447,10 @@ export class JetpackSignup extends Component {
 		}
 		const { isCreatingAccount } = this.state;
 		return (
-			<MainWrapper isWoo={ this.isWoo() }>
+			<MainWrapper isWooOnboarding={ this.isWoo() }>
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderLocaleSuggestions() }
-					<AuthFormHeader authQuery={ this.props.authQuery } isWoo={ this.isWoo() } />
+					<AuthFormHeader authQuery={ this.props.authQuery } isWooOnboarding={ this.isWoo() } />
 					<SignupForm
 						disabled={ isCreatingAccount }
 						email={ this.props.authQuery.userEmail }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -7,7 +7,7 @@
  */
 
 import { isEnabled } from '@automattic/calypso-config';
-import { Gridicon } from '@automattic/components';
+import { Gridicon, JetpackLogo } from '@automattic/components';
 import { Button, Card } from '@wordpress/components';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
@@ -48,6 +48,7 @@ import HelpButton from './help-button';
 import MainWrapper from './main-wrapper';
 import { authQueryPropTypes } from './utils';
 import wooDnaConfig from './woo-dna-config';
+import WooInstallExtSuccessNotice from './woo-install-ext-success-notice';
 
 const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );
 const noop = () => {};
@@ -119,9 +120,14 @@ export class JetpackSignup extends Component {
 		this.props.resetAuthAccountType();
 	};
 
-	isWoo() {
+	isWooOnboarding() {
 		const { authQuery } = this.props;
 		return 'woocommerce-onboarding' === authQuery.from;
+	}
+
+	isWooCoreProfiler( props = this.props ) {
+		const { from } = props.authQuery;
+		return 'woocommerce-core-profiler' === from;
 	}
 
 	getWooDnaConfig() {
@@ -261,6 +267,10 @@ export class JetpackSignup extends Component {
 
 	renderFooterLink() {
 		const { authQuery } = this.props;
+
+		if ( this.isWooCoreProfiler() ) {
+			return null;
+		}
 
 		return (
 			<LoggedOutFormLinks>
@@ -446,11 +456,19 @@ export class JetpackSignup extends Component {
 			return this.renderWooDna();
 		}
 		const { isCreatingAccount } = this.state;
+		const isWooCoreProfiler = this.isWooCoreProfiler();
 		return (
-			<MainWrapper isWooOnboarding={ this.isWoo() }>
+			<MainWrapper
+				isWooOnboarding={ this.isWooOnboarding() }
+				isWooCoreProfiler={ this.isWooCoreProfiler() }
+			>
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderLocaleSuggestions() }
-					<AuthFormHeader authQuery={ this.props.authQuery } isWooOnboarding={ this.isWoo() } />
+					<AuthFormHeader
+						authQuery={ this.props.authQuery }
+						isWooOnboarding={ this.isWooOnboarding() }
+						isWooCoreProfiler={ this.isWooCoreProfiler() }
+					/>
 					<SignupForm
 						disabled={ isCreatingAccount }
 						email={ this.props.authQuery.userEmail }
@@ -462,7 +480,11 @@ export class JetpackSignup extends Component {
 							{ auth_approved: true },
 							window.location.href
 						) }
-						submitButtonText={ this.props.translate( 'Create your account' ) }
+						submitButtonText={
+							isWooCoreProfiler
+								? this.props.translate( 'Create an account' )
+								: this.props.translate( 'Create your account' )
+						}
 						submitForm={ this.handleSubmitSignup }
 						submitting={ isCreatingAccount }
 						suggestedUsername=""
@@ -470,6 +492,15 @@ export class JetpackSignup extends Component {
 
 					{ this.renderLoginUser() }
 				</div>
+				{ isWooCoreProfiler && this.props.authQuery.installedExtSuccess && (
+					<WooInstallExtSuccessNotice />
+				) }
+				{ isWooCoreProfiler && (
+					<div className="jetpack-connect__jetpack-logo-wrapper">
+						<JetpackLogo monochrome size={ 18 } />{ ' ' }
+						<span>{ this.props.translate( 'Jetpack powered' ) }</span>
+					</div>
+				) }
 			</MainWrapper>
 		);
 	}

--- a/client/jetpack-connect/store-header.tsx
+++ b/client/jetpack-connect/store-header.tsx
@@ -28,8 +28,9 @@ export default function StoreHeader() {
 			<div className={ headerClass }>
 				<JetpackHeader
 					partnerSlug={ partnerSlug }
-					isWoo={ false }
+					isWooOnboarding={ false }
 					isWooDna={ false }
+					isWooCoreProfiler={ false }
 					darkColorScheme
 				/>
 			</div>

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1103,6 +1103,11 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				margin-right: 16px;
 				height: 40px !important;
 				width: 40px !important;
+				background: #f0f0f1;
+
+				svg {
+					fill: $gray-600;
+				}
 			}
 
 			.site__title {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1177,20 +1177,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			}
 		}
 
-		.jetpack-connect__logged-in-form-loading {
-			margin-top: 15px;
-
-			span {
-				font-size: 0.875rem;
-			}
-
-			.spinner__outer,
-			.spinner__inner {
-				border-top-color: var(--wp-admin-theme-color);
-				border-right-color: var(--wp-admin-theme-color);
-			}
-		}
-
 		.jetpack-connect__action-disclaimer {
 			padding: 0;
 			margin-top: 32px;
@@ -1240,6 +1226,12 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 
 		.jetpack-connect__logged-in-bottom {
+			.spinner__outer,
+			.spinner__inner {
+				border-top-color: #fff;
+				border-right-color: transparent;
+			}
+
 			@include breakpoint-deprecated( "<660px" ) {
 				position: absolute;
 				bottom: 24px;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1,3 +1,4 @@
+@import "@wordpress/base-styles/colors";
 @import "colors";
 
 $colophon-height: 50px; // wpcomColophon element at the bottom
@@ -42,7 +43,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 }
 
-.jetpack-connect__main.main {
+.jetpack-connect__main.main:not(.is-woocommerce-core-profiler-flow) {
 	max-width: 400px;
 
 	.formatted-header {
@@ -727,6 +728,33 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 	}
 
+	.jetpack-connect__features_wrapper {
+		display: flex;
+		flex-direction: row;
+		gap: 18px;
+		margin-top: 32px;
+
+		.jetpack-connect__features {
+			list-style: none;
+			margin: 0;
+			flex: 1;
+
+			li {
+				display: flex;
+				margin-bottom: 8px;
+				font-size: 0.75rem;
+				color: $gray-800;
+				align-items: center;
+			}
+
+			svg {
+				fill: #008a20;
+				margin-right: 8px;
+				min-width: 20px;
+			}
+		}
+	}
+
 	.plan-features__table-item,
 	.plan-features--signup .plan-features__row:last-of-type .plan-features__table-item {
 		border: none;
@@ -1045,6 +1073,207 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 	&.is-jetpack-woo-dna-flow .login__form-header-wrapper {
 		display: none;
+	}
+
+	&.is-woocommerce-core-profiler-flow {
+		.jetpack-connect__site.card {
+			border: 1px solid $gray-400;
+			border-radius: 2px;
+			background: #fff;
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			padding: 16px 24px;
+			gap: 16px;
+			max-width: 405px;
+			margin: 48px auto 16px;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				max-width: 100%;
+				margin: 40px 20px 16px;
+			}
+
+			.site__content {
+				text-decoration: none;
+				padding: 0;
+			}
+
+			.site-icon {
+				border-radius: 50%;
+				margin-right: 16px;
+				height: 40px !important;
+				width: 40px !important;
+			}
+
+			.site__title {
+				color: var(--studio-gray-100);
+				font-size: 1rem;
+				font-weight: 500;
+			}
+
+			.site__domain {
+				font-size: 0.875rem;
+				line-height: 24px;
+				color: $gray-700;
+			}
+		}
+
+		.jetpack-connect__logged-in-card {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			padding: 16px 24px;
+			gap: 16px;
+			background: #fff;
+			border: 1px solid $gray-400;
+			border-radius: 2px;
+			max-width: 405px;
+			margin: 0;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				max-width: 100%;
+			}
+
+			.gravatar {
+				margin: 0;
+			}
+
+			.jetpack-connect__logged-in-form-user-text {
+				color: var(--studio-gray-100);
+				font-size: 1rem;
+				font-weight: 500;
+				text-align: left;
+
+				small {
+					font-size: 0.875rem;
+					line-height: 24px;
+					font-weight: 400;
+					color: $gray-700;
+				}
+			}
+
+			.logged-out-form__link-item {
+				margin: 8px 0 0;
+				padding: 0;
+				text-align: left;
+				text-decoration: none;
+				color: var(--wp-admin-theme-color);
+				font-size: 0.875rem;
+				line-height: 18px;
+			}
+		}
+
+		.jetpack-connect__logged-in-content {
+			margin: 0 auto;
+			max-width: 405px;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				max-width: 100%;
+			}
+		}
+
+		.jetpack-connect__logged-in-form-loading {
+			margin-top: 15px;
+
+			span {
+				font-size: 0.875rem;
+			}
+
+			.spinner__outer,
+			.spinner__inner {
+				border-top-color: var(--wp-admin-theme-color);
+				border-right-color: var(--wp-admin-theme-color);
+			}
+		}
+
+		.jetpack-connect__action-disclaimer {
+			padding: 0;
+			margin-top: 32px;
+
+			.button {
+				font-weight: 500;
+			}
+		}
+
+		.jetpack-connect__tos-link {
+			margin: 40px auto 0;
+			letter-spacing: -0.08px;
+			line-height: 18px;
+			color: $gray-700;
+			font-size: 0.75rem;
+			max-width: 400px;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				margin: 12px auto 0;
+			}
+
+			a {
+				color: $gray-700;
+				text-decoration: none;
+				font-size: 0.75rem;
+			}
+		}
+
+		.jetpack-connect__jetpack-logo-wrapper {
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			margin-top: 70px;
+
+			svg {
+				margin-right: 6px;
+			}
+
+			span {
+				font-size: 0.75rem;
+				color: #1e1e1e;
+			}
+
+			@include breakpoint-deprecated( "<660px" ) {
+				margin-top: 20px;
+			}
+		}
+
+		.jetpack-connect__logged-in-bottom {
+			@include breakpoint-deprecated( "<660px" ) {
+				position: absolute;
+				bottom: 24px;
+				padding-right: 20px;
+				width: fill-available;
+			}
+		}
+
+		.jetpack-connect__woo-core-profiler-notice {
+			width: 262px;
+			height: 50px;
+			position: absolute;
+			left: 36px;
+			bottom: 32px;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				position: absolute;
+				left: 0;
+				bottom: 20px;
+				width: calc(100% - 40px);
+				margin: 0 20px;
+			}
+
+			.notice__icon-wrapper {
+				background: inherit;
+				padding: 0 3px 0 11px;
+				width: fit-content;
+
+				.notice__icon {
+					color: var(--studio-green-30);
+				}
+			}
+
+			.notice__content {
+				font-size: 0.8125rem; /* stylelint-disable-line scales/font-sizes */
+				line-height: 16px;
+				padding: 17px 8px;
+			}
+		}
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -677,7 +677,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 /**
  * Onboarding styles
  **/
-.layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow),
+.layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow):not(.is-woocommerce-core-profiler-flow),
 .layout.is-section-purchase-product {
 	&.layout {
 		position: relative;
@@ -725,33 +725,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		&:hover,
 		&:focus {
 			color: var(--color-accent);
-		}
-	}
-
-	.jetpack-connect__features_wrapper {
-		display: flex;
-		flex-direction: row;
-		gap: 18px;
-		margin-top: 32px;
-
-		.jetpack-connect__features {
-			list-style: none;
-			margin: 0;
-			flex: 1;
-
-			li {
-				display: flex;
-				margin-bottom: 8px;
-				font-size: 0.75rem;
-				color: $gray-800;
-				align-items: center;
-			}
-
-			svg {
-				fill: #008a20;
-				margin-right: 8px;
-				min-width: 20px;
-			}
 		}
 	}
 
@@ -1074,203 +1047,252 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	&.is-jetpack-woo-dna-flow .login__form-header-wrapper {
 		display: none;
 	}
+}
 
-	&.is-woocommerce-core-profiler-flow {
-		.jetpack-connect__site.card {
-			border: 1px solid $gray-400;
-			border-radius: 2px;
-			background: #fff;
+.jetpack-connect__features_wrapper {
+	display: flex;
+	flex-direction: row;
+	gap: 18px;
+	margin-top: 32px;
+
+	.jetpack-connect__features {
+		list-style: none;
+		margin: 0;
+		flex: 1;
+
+		li {
 			display: flex;
-			flex-direction: row;
-			align-items: center;
-			padding: 16px 24px;
-			gap: 16px;
-			max-width: 405px;
-			margin: 48px auto 16px;
-
-			@include breakpoint-deprecated( "<660px" ) {
-				max-width: 100%;
-				margin: 40px 20px 16px;
-			}
-
-			.site__content {
-				text-decoration: none;
-				padding: 0;
-			}
-
-			.site-icon {
-				border-radius: 50%;
-				margin-right: 16px;
-				height: 40px !important;
-				width: 40px !important;
-				background: #f0f0f1;
-
-				svg {
-					fill: $gray-600;
-				}
-			}
-
-			.site__title {
-				color: var(--studio-gray-100);
-				font-size: 1rem;
-				font-weight: 500;
-			}
-
-			.site__domain {
-				font-size: 0.875rem;
-				line-height: 24px;
-				color: $gray-700;
-			}
-		}
-
-		.jetpack-connect__logged-in-card {
-			display: flex;
-			flex-direction: row;
-			align-items: center;
-			padding: 16px 24px;
-			gap: 16px;
-			background: #fff;
-			border: 1px solid $gray-400;
-			border-radius: 2px;
-			max-width: 405px;
-			margin: 0;
-
-			@include breakpoint-deprecated( "<660px" ) {
-				max-width: 100%;
-			}
-
-			.gravatar {
-				margin: 0;
-			}
-
-			.jetpack-connect__logged-in-form-user-text {
-				color: var(--studio-gray-100);
-				font-size: 1rem;
-				font-weight: 500;
-				text-align: left;
-
-				small {
-					font-size: 0.875rem;
-					line-height: 24px;
-					font-weight: 400;
-					color: $gray-700;
-				}
-			}
-
-			.logged-out-form__link-item {
-				margin: 8px 0 0;
-				padding: 0;
-				text-align: left;
-				text-decoration: none;
-				color: var(--wp-admin-theme-color);
-				font-size: 0.875rem;
-				line-height: 18px;
-			}
-		}
-
-		.jetpack-connect__logged-in-content {
-			margin: 0 auto;
-			max-width: 405px;
-
-			@include breakpoint-deprecated( "<660px" ) {
-				max-width: 100%;
-			}
-		}
-
-		.jetpack-connect__action-disclaimer {
-			padding: 0;
-			margin-top: 32px;
-
-			.button {
-				font-weight: 500;
-			}
-		}
-
-		.jetpack-connect__tos-link {
-			margin: 40px auto 0;
-			letter-spacing: -0.08px;
-			line-height: 18px;
-			color: $gray-700;
+			margin-bottom: 8px;
 			font-size: 0.75rem;
-			max-width: 400px;
-
-			@include breakpoint-deprecated( "<660px" ) {
-				margin: 12px auto 0;
-			}
-
-			a {
-				color: $gray-700;
-				text-decoration: none;
-				font-size: 0.75rem;
-			}
+			color: $gray-800;
+			align-items: center;
 		}
 
-		.jetpack-connect__jetpack-logo-wrapper {
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			margin-top: 70px;
+		svg {
+			fill: #008a20;
+			margin-right: 8px;
+			min-width: 20px;
+		}
+	}
+}
+
+.layout.is-section-jetpack-connect.is-woocommerce-core-profiler-flow {
+	.jetpack-connect__main {
+		max-width: 615px;
+	}
+
+	.jetpack-connect__site.card {
+		border: 1px solid $gray-400;
+		border-radius: 2px;
+		background: #fff;
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		padding: 16px 24px;
+		gap: 16px;
+		max-width: 405px;
+		margin: 48px auto 16px;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			max-width: 100%;
+			margin: 40px 20px 16px;
+		}
+
+		.site__content {
+			text-decoration: none;
+			padding: 0;
+		}
+
+		.site-icon {
+			border-radius: 50%;
+			margin-right: 16px;
+			height: 40px !important;
+			width: 40px !important;
+			background-color: #f0f0f1;
 
 			svg {
-				margin-right: 6px;
-			}
-
-			span {
-				font-size: 0.75rem;
-				color: #1e1e1e;
-			}
-
-			@include breakpoint-deprecated( "<660px" ) {
-				margin-top: 20px;
+				fill: $gray-600;
 			}
 		}
 
-		.jetpack-connect__logged-in-bottom {
-			.spinner__outer,
-			.spinner__inner {
-				border-top-color: #fff;
-				border-right-color: transparent;
-			}
+		.site__title {
+			color: var(--studio-gray-100);
+			font-size: 1rem;
+			font-weight: 500;
+		}
 
-			@include breakpoint-deprecated( "<660px" ) {
-				position: absolute;
-				bottom: 24px;
-				padding-right: 20px;
-				width: fill-available;
+		.site__domain {
+			font-size: 0.875rem;
+			line-height: 24px;
+			color: $gray-700;
+		}
+	}
+
+	.jetpack-connect__logged-in-card {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		padding: 16px 24px;
+		gap: 16px;
+		background: #fff;
+		border: 1px solid $gray-400;
+		border-radius: 2px;
+		max-width: 405px;
+		margin: 0;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			max-width: 100%;
+		}
+
+		.gravatar {
+			margin: 0;
+		}
+
+		.jetpack-connect__logged-in-form-user-text {
+			color: var(--studio-gray-100);
+			font-size: 1rem;
+			font-weight: 500;
+			text-align: left;
+
+			small {
+				font-size: 0.875rem;
+				line-height: 24px;
+				font-weight: 400;
+				color: $gray-700;
 			}
 		}
 
-		.jetpack-connect__woo-core-profiler-notice {
-			width: 262px;
-			height: 50px;
+		.logged-out-form__link-item {
+			margin: 8px 0 0;
+			padding: 0;
+			text-align: left;
+			text-decoration: none;
+			color: var(--wp-admin-theme-color);
+			font-size: 0.875rem;
+			line-height: 18px;
+		}
+	}
+
+	.jetpack-connect__logged-in-content {
+		margin: 0 auto;
+		max-width: 405px;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			max-width: 100%;
+		}
+	}
+
+	.jetpack-connect__action-disclaimer {
+		padding: 0;
+		margin-top: 32px;
+
+		.button {
+			font-weight: 500;
+		}
+	}
+
+	.jetpack-connect__tos-link {
+		margin: 40px auto 70px;
+		letter-spacing: -0.08px;
+		line-height: 18px;
+		color: $gray-700;
+		font-size: 0.75rem;
+		max-width: 400px;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			margin: 12px auto 20px;
+		}
+
+		a {
+			color: $gray-700;
+			text-decoration: none;
+			font-size: 0.75rem;
+		}
+	}
+
+	.jetpack-connect__jetpack-logo-wrapper {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+
+		svg {
+			margin-right: 6px;
+		}
+
+		span {
+			font-size: 0.75rem;
+			color: #1e1e1e;
+		}
+	}
+
+	.jetpack-connect__logged-in-bottom {
+		.spinner__outer,
+		.spinner__inner {
+			border-top-color: #fff;
+			border-right-color: transparent;
+		}
+
+		@include breakpoint-deprecated( "<660px" ) {
 			position: absolute;
-			left: 36px;
-			bottom: 32px;
+			bottom: 24px;
+			padding-right: 20px;
+			width: fill-available;
+		}
+	}
 
-			@include breakpoint-deprecated( "<660px" ) {
-				position: absolute;
-				left: 0;
-				bottom: 20px;
-				width: calc(100% - 40px);
-				margin: 0 20px;
+	.jetpack-connect__woo-core-profiler-notice {
+		width: 262px;
+		height: 50px;
+		position: fixed;
+		left: 36px;
+		bottom: 32px;
+		z-index: 999;
+		margin-bottom: 0;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			left: 0;
+			bottom: 20px;
+			width: calc(100% - 40px);
+			margin: 0 20px;
+		}
+
+		.notice__icon-wrapper {
+			background: inherit;
+			padding: 0 3px 0 11px;
+			width: fit-content;
+
+			.notice__icon {
+				color: var(--studio-green-30);
 			}
+		}
 
-			.notice__icon-wrapper {
-				background: inherit;
-				padding: 0 3px 0 11px;
-				width: fit-content;
+		.notice__content {
+			font-size: 0.8125rem; /* stylelint-disable-line scales/font-sizes */
+			line-height: 16px;
+			padding: 17px 8px;
+		}
+	}
 
-				.notice__icon {
-					color: var(--studio-green-30);
+	// Sign up
+	.jetpack-connect__authorize-form {
+		.jetpack-connect__site.card {
+			.site-icon {
+				background-color: rgba(var(--wp-admin-theme-color--rgb), 0.15);
+
+				svg {
+					fill: var(--wp-admin-theme-color);
 				}
 			}
-
-			.notice__content {
-				font-size: 0.8125rem; /* stylelint-disable-line scales/font-sizes */
-				line-height: 16px;
-				padding: 17px 8px;
-			}
 		}
+	}
+
+	.signup-form__terms-of-service-link {
+		margin-bottom: 12px;
+	}
+
+	.signup-form__social {
+		padding-bottom: 0;
+		margin-bottom: 48px;
 	}
 }
 

--- a/client/jetpack-connect/test/__snapshots__/utils.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/utils.js.snap
@@ -11,6 +11,7 @@ Object {
   "closeWindowAfterLogin": false,
   "from": "[unknown]",
   "homeUrl": "https://yourjetpack.blog",
+  "installedExtSuccess": "1",
   "isPopup": false,
   "jpVersion": null,
   "nonce": "foobar",

--- a/client/jetpack-connect/test/utils.js
+++ b/client/jetpack-connect/test/utils.js
@@ -85,6 +85,7 @@ describe( 'parseAuthorizationQuery', () => {
 			site_url: 'https://yourjetpack.blog',
 			state: '1',
 			allow_site_connection: '1',
+			installed_ext_success: '1',
 		};
 		const result = parseAuthorizationQuery( data );
 		expect( result ).not.toBeNull();

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -43,6 +43,8 @@ export function authQueryTransformer( queryObject ) {
 		woodna_service_name: queryObject.woodna_service_name || null,
 		woodna_help_url: queryObject.woodna_help_url || null,
 		allowSiteConnection: queryObject.skip_user || queryObject.allow_site_connection || null,
+		// Used by woo core profiler flow to determine if we need to show a success notice after installing extensions or not.
+		installedExtSuccess: queryObject.installed_ext_success || null,
 	};
 }
 
@@ -64,6 +66,7 @@ export const authQueryPropTypes = PropTypes.shape( {
 	siteUrl: PropTypes.string,
 	state: PropTypes.string.isRequired,
 	userEmail: PropTypes.string,
+	installedExtSuccess: PropTypes.string,
 } );
 
 export function addCalypsoEnvQueryArg( url ) {

--- a/client/jetpack-connect/woo-install-ext-success-notice.tsx
+++ b/client/jetpack-connect/woo-install-ext-success-notice.tsx
@@ -1,0 +1,27 @@
+import { removeQueryArgs } from '@wordpress/url';
+import { localize, LocalizeProps } from 'i18n-calypso';
+import page from 'page';
+import Notice from 'calypso/components/notice';
+
+const WooInstallExtSuccessNotice = ( { translate }: LocalizeProps ) => {
+	return (
+		<Notice
+			className="jetpack-connect__woo-core-profiler-notice"
+			status="is-success"
+			showDismiss={ false }
+			text={ translate( 'Extensions successfully installed!' ) }
+			isCompact={ false }
+			duration={ 6000 }
+			onDismissClick={ () => {
+				page.replace(
+					removeQueryArgs(
+						window.location.pathname + window.location.search,
+						'installed_ext_success'
+					)
+				);
+			} }
+		/>
+	);
+};
+
+export default localize( WooInstallExtSuccessNotice );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -22,6 +22,7 @@ import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import HtmlIsIframeClassname from 'calypso/layout/html-is-iframe-classname';
 import EmptyMasterbar from 'calypso/layout/masterbar/empty';
 import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
+import WooCoreProfilerMasterbar from 'calypso/layout/masterbar/woo-core-profiler';
 import OfflineStatus from 'calypso/layout/offline-status';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
@@ -228,6 +229,10 @@ class Layout extends Component {
 		if ( this.props.masterbarIsHidden ) {
 			return <EmptyMasterbar />;
 		}
+		if ( this.props.isWooCoreProfilerFlow ) {
+			return <WooCoreProfilerMasterbar />;
+		}
+
 		const MasterbarComponent = config.isEnabled( 'jetpack-cloud' )
 			? JetpackCloudMasterbar
 			: MasterbarLoggedIn;
@@ -256,6 +261,8 @@ class Layout extends Component {
 			'is-jetpack-woocommerce-flow': this.props.isJetpackWooCommerceFlow,
 			'is-jetpack-woo-dna-flow': this.props.isJetpackWooDnaFlow,
 			'is-wccom-oauth-flow': isWooOAuth2Client( this.props.oauth2Client ) && this.props.wccomFrom,
+			'is-woocommerce-core-profiler-flow': this.props.isWooCoreProfilerFlow,
+			woo: this.props.isWooCoreProfilerFlow,
 		} );
 
 		const optionalBodyProps = () => {
@@ -384,9 +391,13 @@ export default withCurrentRoute(
 		const isJetpack =
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
+		const isWooCoreProfilerFlow =
+			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
+			'woocommerce-core-profiler' === currentQuery?.from;
 		const noMasterbarForRoute =
 			isJetpackLogin || currentRoute === '/me/account/closed' || isDomainAndPlanPackageFlow;
-		const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
+		const noMasterbarForSection =
+			! isWooCoreProfilerFlow && [ 'signup', 'jetpack-connect' ].includes( sectionName );
 		const masterbarIsHidden =
 			! masterbarIsVisible( state ) ||
 			noMasterbarForSection ||
@@ -423,6 +434,7 @@ export default withCurrentRoute(
 			isJetpackWooCommerceFlow,
 			isJetpackWooDnaFlow,
 			isJetpackMobileFlow,
+			isWooCoreProfilerFlow,
 			isEligibleForJITM,
 			oauth2Client,
 			wccomFrom,

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -7,6 +7,7 @@ import WooLogo from 'calypso/assets/images/icons/woocommerce-logo.svg';
 import SVGIcon from 'calypso/components/svg-icon';
 import './typekit';
 import './woo.scss';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getRedirectToOriginal } from 'calypso/state/login/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -45,10 +46,16 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 						</li>
 						<li className="masterbar__woo-nav-item">
 							{ typeof redirectTo === 'string' && redirectTo.length && (
-								<Button href={ redirectTo } className="masterbar__no-thanks-button">
-									{ translate( 'No, Thanks' ) }
-								</Button>
-							) }
+								<Button
+								onClick={ () => {
+									recordTracksEvent( 'calypso_wc_coreprofiler_jpc_skip' );
+									window.location.href = redirectTo;
+								} }
+								className="masterbar__no-thanks-button"
+							>
+								{ translate( 'No, Thanks' ) }
+							</Button>
+							)}
 						</li>
 					</ul>
 				</nav>

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -48,7 +48,7 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 							{ typeof redirectTo === 'string' && redirectTo.length && (
 								<Button
 									onClick={ () => {
-										recordTracksEvent( 'calypso_wc_coreprofiler_jpc_skip' );
+										recordTracksEvent( 'calypso_jpc_wc_coreprofiler_skip' );
 										window.location.href = redirectTo;
 									} }
 									className="masterbar__no-thanks-button"

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -47,15 +47,15 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 						<li className="masterbar__woo-nav-item">
 							{ typeof redirectTo === 'string' && redirectTo.length && (
 								<Button
-								onClick={ () => {
-									recordTracksEvent( 'calypso_wc_coreprofiler_jpc_skip' );
-									window.location.href = redirectTo;
-								} }
-								className="masterbar__no-thanks-button"
-							>
-								{ translate( 'No, Thanks' ) }
-							</Button>
-							)}
+									onClick={ () => {
+										recordTracksEvent( 'calypso_wc_coreprofiler_jpc_skip' );
+										window.location.href = redirectTo;
+									} }
+									className="masterbar__no-thanks-button"
+								>
+									{ translate( 'No, Thanks' ) }
+								</Button>
+							) }
 						</li>
 					</ul>
 				</nav>

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -232,12 +232,14 @@
 	}
 
 
+	.jetpack-connect__logged-in-form .formatted-header,
 	.login__form-header-wrapper,
 	.signup-form__woo-wrapper {
 		text-align: center;
 		margin: 0 auto;
 		line-height: 28px;
 
+		h1,
 		h3 {
 			font-weight: 600;
 			font-size: 2.75rem;
@@ -340,7 +342,8 @@
 
 	.wp-login__container,
 	.magic-login,
-	.step-wrapper {
+	.step-wrapper,
+	.jetpack-connect__main-logo {
 		box-sizing: border-box;
 		padding: 60px 0 0;
 		width: 100%;
@@ -717,6 +720,8 @@
 	}
 
 	&.is-woocommerce-core-profiler-flow {
+		background: #fff;
+
 		* {
 			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 		}
@@ -733,6 +738,10 @@
 				outline: none;
 				box-shadow: none;
 			}
+		}
+
+		.masterbar {
+			display: flex;
 		}
 
 		.masterbar__woo-nav-item:first-child {
@@ -776,8 +785,13 @@
 			font-weight: 500;
 		}
 
-		.login__header-subtitle {
+		.login__header-subtitle,
+		.formatted-header__subtitle {
 			color: $gray-700;
+
+			@media screen and ( max-width: 660px ) {
+				width: auto;
+			}
 		}
 
 		.login__form-userdata label.form-label {
@@ -786,6 +800,7 @@
 			font-size: rem(11px);
 		}
 
+		.jetpack-connect__action-disclaimer .button.is-primary,
 		.form-button.is-primary {
 			border-radius: 2px;
 			height: 48px;
@@ -808,6 +823,19 @@
 
 			a {
 				line-height: 16px;
+			}
+		}
+
+		.jetpack-connect__logged-in-content {
+			@media screen and ( max-width: 660px ) {
+				padding-left: $woo-form-whitespace-660;
+				padding-right: $woo-form-whitespace-660;
+			}
+		}
+
+		.jetpack-connect__features_wrapper {
+			@media screen and ( max-width: 660px ) {
+				display: none !important;
 			}
 		}
 	}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -233,6 +233,7 @@
 
 
 	.jetpack-connect__logged-in-form .formatted-header,
+	.jetpack-connect__authorize-form .formatted-header,
 	.login__form-header-wrapper,
 	.signup-form__woo-wrapper {
 		text-align: center;
@@ -766,9 +767,18 @@
 			}
 		}
 
-		.login form {
+		.login form,
+		.signup-form {
 			max-width: 405px;
 			margin: 0 auto;
+
+			input.form-text-input {
+				border-color: #bbb;
+
+				&.is-valid {
+					border-color: #bbb;
+				}
+			}
 		}
 
 		.login__form-header h3,
@@ -794,10 +804,12 @@
 			}
 		}
 
-		.login__form-userdata label.form-label {
+		.login__form-userdata label.form-label,
+		.logged-out-form label.form-label {
 			font-weight: 500;
 			text-transform: uppercase;
 			font-size: rem(11px);
+			color: $gray-900;
 		}
 
 		.jetpack-connect__action-disclaimer .button.is-primary,
@@ -809,7 +821,7 @@
 			background-color: var(--wp-admin-theme-color);
 		}
 
-		.login__social-buttons .social-buttons__service-name {
+		span.social-buttons__service-name {
 			font-weight: 600;
 		}
 
@@ -836,6 +848,29 @@
 		.jetpack-connect__features_wrapper {
 			@media screen and ( max-width: 660px ) {
 				display: none !important;
+			}
+		}
+
+		.signup-form {
+			padding-top: 24px;
+		}
+
+		// Log in link on signup page
+		.formatted-header__subtitle a {
+			color: var(--wp-admin-theme-color);
+		}
+
+		.form-input-validation {
+			padding: 8px 0 11px;
+
+			p,
+			a {
+				line-height: 16px;
+			}
+
+			// Hide form validation icon
+			svg {
+				display: none;
 			}
 		}
 	}

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/style.scss
@@ -2,7 +2,7 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
 
-.layout.is-section-jetpack-connect {
+.layout.is-section-jetpack-connect:not(.is-woocommerce-core-profiler-flow) {
 	background-color: #f6f6f6;
 	#content.layout__content {
 		padding: 44px 17px 26px 18px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/woocommerce/team-ghidorah/issues/213

## Proposed Changes

* Customize jetpack connection (Logged-in) screen for woocommerce core profiler flow

![Screenshot 2023-06-07 at 14 55 34](https://github.com/Automattic/wp-calypso/assets/4344253/c483a9e1-a606-47bf-bc2b-df57870f8b80)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a JN site
* Go to OBW and continue until Jetpack connection step (/jetpack/connect/authorize)
* Replace the host `wordpress.com` with your Calypso host
* Change query parameter `from` to `woocommerce-core-profiler` and add `installed_ext_success=1` query parameter
* Observe the `Extensions successfully installed!` notice is shown and automatically dismissed
* Confirm the screen matches the design (Y5pUYSJPsGEud1vknUZhi8-fi-739_54533)
* Reload the page
* Observe the `Extensions successfully installed!` is not shown.
* Enable track debugging `localStorage.setItem( 'debug', 'calypso:analytics' );`

**Scenario: User clicks on Sign in as a different user**

1. Open dev tools console and tick `Preserve log` option
2. Clicks on `Sign in as a different user`
3. You should be redirected to login page.
4. Observe that `calypso_jpc_different_user_click` event is recorded

**Scenario: User clicks on No, Thanks**

1. Go back to Jetpack connection page
2. Clicks on `No, Thanks` button
3. You should be redirected to `WooCommerce -> Home`
4.  Observe that `calypso_wc_coreprofiler_jpc_skip` event is recorded

**Scenario: User clicks on Connect your account button**

1. Go back to Jetpack connection page
2. Clicks on `Connect your account` button
5. Connect  to Jetpack
6. You should be redirected to `WooCommerce -> Home`
7. Observe that `calypso_jpc_approve_click` event is recorded




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?