### PR TITLE
Add new migration flow tests

### DIFF
--- a/test/e2e/specs/onboarding/setup__migrate-to-wordpress.ts
+++ b/test/e2e/specs/onboarding/setup__migrate-to-wordpress.ts
@@ -1,0 +1,66 @@
+/**
+ * @group calypso-pr
+ */
+
+import { DataHelper, SecretsManager, StartImportFlow, TestAccount } from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Move to WordPress.com' ), () => {
+	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
+
+	let page: Page;
+	let startImportFlow: StartImportFlow;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		startImportFlow = new StartImportFlow( page, 'migration' );
+
+		const testAccount = new TestAccount( 'defaultUser' );
+		await testAccount.authenticate( page );
+	} );
+
+	/**
+	 * Navigate to site picker page.
+	 *
+	 * @param siteSlug The site slug URL.
+	 */
+	const navigateToSitePicker = (
+		siteSlug: string,
+		queryStrings: { [ key: string ]: string } = {}
+	) => {
+		it( `Navigate to Site Picker page from ${ siteSlug }`, async () => {
+			await startImportFlow.startMigrate( { from: siteSlug, ...queryStrings } );
+		} );
+	};
+
+	describe( 'Show the site selector', () => {
+		navigateToSitePicker( 'example.com' );
+
+		it( 'Has the first site to be selected', async () => {
+			await startImportFlow.validateSitePickerHasSite(
+				credentials.testSites?.primary?.url as string
+			);
+		} );
+	} );
+
+	describe( 'Show an empty site selector with invalid search string', () => {
+		navigateToSitePicker( 'example.com', { search: 'notfound' } );
+
+		it( 'Has the first site to be selected', async () => {
+			await startImportFlow.validateSitePickerHasNoSites();
+		} );
+	} );
+
+	describe( 'Select first element', () => {
+		navigateToSitePicker( 'example.com' );
+
+		it( 'A modal is shown when the user select the first element', async () => {
+			await startImportFlow.clickButton( 'Select this site' );
+			await page.waitForSelector( 'h1:text("Confirm your choice")' );
+		} );
+	} );
+
+	// p2User
+} );

--- a/test/e2e/specs/onboarding/setup__migrate-to-wordpress.ts
+++ b/test/e2e/specs/onboarding/setup__migrate-to-wordpress.ts
@@ -65,13 +65,13 @@ describe( DataHelper.createSuiteTitle( 'Move to WordPress.com' ), () => {
 		} );
 	} );
 
-	describe( 'Select first site and confirm', () => {
+	/* describe( 'Select first site and confirm', () => {
 		navigateToSitePicker( 'example.com' );
 
 		test( 'The importer error page is selected when using an invalid start site', async () => {
 			await startImportFlow.selectMigrationSite( true, false );
 		} );
-	} );
+	} ); */
 
 	/* describe( 'Select site and confirm', () => {
 		navigateToSitePicker( 'make.wordpress.org' );
@@ -79,5 +79,5 @@ describe( DataHelper.createSuiteTitle( 'Move to WordPress.com' ), () => {
 		test( 'The importer success page is selected when using a valid start site', async () => {
 			await startImportFlow.selectMigrationSite( true, true );
 		} );
-	} );*/
+	} ); */
 } );


### PR DESCRIPTION
This PR adds tests for the new migration flow.

Related to #77369

## Proposed Changes

* Add new tests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Be sure to follow the installation procedure on [test/e2e/README.md](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/README.md)
* `yarn workspace wp-e2e-tests test -- specs/onboarding/setup__migrate-to-wordpress.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
