### PR TITLE
Blogger onboarding binary selection page css fixes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
@@ -1,5 +1,4 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
+@import "@automattic/onboarding/styles/variables";
 @import "@automattic/onboarding/styles/mixins";
 @import "jetpack-connect/colors.scss";
 
@@ -16,22 +15,27 @@
 		display: none;
 	}
 
+	.step-container__content {
+		min-height: calc(100vh - 100px);
+	}
+
 	.blogger-intent__container {
 		display: flex;
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
-		min-height: 80vh;
 		margin-left: 20px;
 		margin-right: 20px;
+
 		margin-top: 104px;
+		@include break-small {
+			margin-top: 0;
+			min-height: calc(100vh - 100px);
+		}
 	}
 
 	.blogger-intent__heading {
-		@include onboarding-font-recoleta;
-		font-size: $font-title-large;
-		text-align: left;
-		color: var(--color-neutral-100);
+		@include onboarding-heading-title;
 	}
 
 	.blogger-intent__content {
@@ -45,7 +49,7 @@
 		hr {
 			color: var(--color-neutral-10);
 			width: 100%;
-			margin-bottom: 6px; // 32 - 26
+			margin-bottom: 6px;
 		}
 	}
 
@@ -61,19 +65,24 @@
 			display: flex;
 			align-items: center;
 			color: var(--color-neutral-100);
-			margin-top: 24px; // mobile gap
+			margin-top: 24px;
+
+			margin-left: 5px;
+			@include break-mobile {
+				margin-left: 0;
+			}
 
 			.blogger-intent__icon {
-				margin-right: 26px;
+				margin-right: 22px;
 				@include break-mobile {
-					margin-right: 22px;
+					margin-right: 26px;
 				}
 			}
 		}
 
 		.blogger-intent__button {
-			margin-top: 24px; // mobile gap
-			margin-left: 64px; // mobile, desktop = 100+
+			margin-top: 24px;
+			margin-left: 52px;
 			background-color: var(--studio-blue-50);
 			border-color: var(--studio-blue-50);
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
@@ -3,6 +3,10 @@
 @import "jetpack-connect/colors.scss";
 
 .blog.blogger-intent {
+	.step-container__header {
+		margin: 0;
+	}
+
 	.wordpress-logo {
 		position: absolute;
 		inset-block-start: 20px;
@@ -16,7 +20,7 @@
 	}
 
 	.step-container__content {
-		min-height: calc(100vh - 100px);
+		min-height: calc(100vh - 170px);
 	}
 
 	.blogger-intent__container {
@@ -66,10 +70,12 @@
 			align-items: center;
 			color: var(--color-neutral-100);
 			margin-top: 24px;
-
+			margin-right: 40px;
 			margin-left: 5px;
+
 			@include break-mobile {
 				margin-left: 0;
+				margin-right: 0;
 			}
 
 			.blogger-intent__icon {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/77879
Related to https://github.com/Automattic/wp-calypso/pull/77780

## Proposed Changes

* Style clean up

## Testing Instructions

* http://calypso.localhost:3000/setup/blog
* Mobile design should match figma CZ07QdsC7bmWbLiSO5K9T5-fi-1831_59424
* Desktop should be matching too (moved JP footer element to the bottom of the page)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?