### PR TITLE
Ensure private data isn't recored in the `calypso_signup_actions_submit_step` event

### DIFF
--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -25,12 +25,19 @@ function addProvidedDependencies( step, providedDependencies ) {
 	return { ...step, providedDependencies };
 }
 
+// These properties are never recorded in the tracks event for security reasons.
+const EXCLUDED_DEPENDENCIES = [ 'bearer_token', 'token', 'password', 'password_confirm' ];
+
 function recordSubmitStep( flow, stepName, providedDependencies, optionalProps ) {
 	// Transform the keys since tracks events only accept snaked prop names.
 	// And anonymize personally identifiable information.
 	const inputs = reduce(
 		providedDependencies,
 		( props, propValue, propName ) => {
+			if ( EXCLUDED_DEPENDENCIES.includes( propName ) ) {
+				return props;
+			}
+
 			propName = snakeCase( propName );
 
 			if ( stepName === 'from-url' && propName === 'site_preview_image_blob' ) {
@@ -46,6 +53,10 @@ function recordSubmitStep( flow, stepName, providedDependencies, optionalProps )
 
 			// Ensure we don't capture identifiable user data we don't need.
 			if ( propName === 'email' ) {
+				propName = `user_entered_${ propName }`;
+				propValue = !! propValue;
+			}
+			if ( propName === 'username' ) {
 				propName = `user_entered_${ propName }`;
 				propValue = !! propValue;
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The `calypso_signup_actions_submit_step` step is recording too much information for passwordless signup steps. This PR:

* Prevents the `bearer_token` from being recorded with the `calypso_signup_actions_submit_step` action in passwordless signup steps
* Removes the `username` prop for signup steps since this is needless personal information. We usually just record whether the field has been set or not.

Changes to event registration: https://github.com/Automattic/tracks-events-registration/pull/1656

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the signup flow starting at `/start/hosting` to get a passwordless signup form
* Using the network tools confirm, filter by `calypso_signup_actions_submit_step` and confirm the `GET` request which records the event no longer contains `bearer_token` and `username` props

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
