### PR TITLE
Plugin Management: Disable the purchase button of paid plugins on a Jetpack site.

### DIFF
--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -26,6 +26,7 @@ import { getProductsList } from 'calypso/state/products-list/selectors';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { isCompatiblePlugin } from '../plugin-compatibility';
 import { getPeriodVariationValue } from '../plugin-price';
 
@@ -255,8 +256,16 @@ export class PluginInstallButton extends Component {
 	}
 
 	renderNoticeOrButton() {
-		const { plugin, isEmbed, selectedSite, siteIsConnected, siteIsWpcomAtomic, translate } =
-			this.props;
+		const {
+			plugin,
+			isEmbed,
+			selectedSite,
+			siteIsConnected,
+			siteIsJetpackSite,
+			siteIsWpcomAtomic,
+			translate,
+			canInstallPurchasedPlugins,
+		} = this.props;
 
 		if ( siteIsConnected === false ) {
 			return (
@@ -302,6 +311,23 @@ export class PluginInstallButton extends Component {
 			) : null;
 		}
 
+		if ( siteIsJetpackSite && ! siteIsWpcomAtomic && plugin.isMarketplaceProduct ) {
+			return (
+				<PluginInstallNotice
+					warningText={
+						canInstallPurchasedPlugins
+							? translate( 'Purchase disabled' )
+							: translate( 'Upgrade disabled' )
+					}
+					isEmbed={ isEmbed }
+				>
+					<div>
+						<p>{ translate( 'Paid plugins are not yet available for Jetpack Sites.' ) }</p>
+					</div>
+				</PluginInstallNotice>
+			);
+		}
+
 		if ( ! plugin.isMarketplaceProduct ) {
 			return this.renderButton();
 		}
@@ -338,6 +364,7 @@ export default connect(
 			userId: getCurrentUserId( state ),
 			siteIsConnected: getSiteConnectionStatus( state, siteId ),
 			siteIsWpcomAtomic: isSiteWpcomAtomic( state, siteId ),
+			siteIsJetpackSite: isJetpackSite( state, siteId ),
 			canInstallPurchasedPlugins: siteHasFeature(
 				state,
 				siteId,

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-row-formatter.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-row-formatter.test.tsx
@@ -12,7 +12,7 @@ import siteConnection from 'calypso/state/site-connection/reducer';
 import { reducer as ui } from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import PluginRowFormatter from '../plugin-row-formatter';
-import { site, plugin } from './utils/constants';
+import { site, plugin, paidPlugin } from './utils/constants';
 
 const initialReduxState = {
 	siteConnection: { items: { [ site.ID ]: true } },
@@ -159,6 +159,14 @@ describe( '<PluginRowFormatter>', () => {
 		const { getAllByText } = render( <PluginRowFormatter { ...props } /> );
 
 		const [ autoManagedSite ] = getAllByText( `Install` );
+		expect( autoManagedSite ).toBeInTheDocument();
+	} );
+
+	test( 'should render correctly and show disabled upgrade button', () => {
+		props.columnKey = 'install';
+		const { getAllByText } = render( <PluginRowFormatter { ...props } item={ paidPlugin } /> );
+
+		const [ autoManagedSite ] = getAllByText( `Upgrade disabled` );
 		expect( autoManagedSite ).toBeInTheDocument();
 	} );
 } );

--- a/client/my-sites/plugins/plugin-management-v2/test/utils/constants.ts
+++ b/client/my-sites/plugins/plugin-management-v2/test/utils/constants.ts
@@ -2,6 +2,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 const siteId = 12345678;
 const pluginId = 'test';
+const paidPluginId = 'test-paid';
 
 const site: SiteDetails = {
 	ID: siteId,
@@ -9,6 +10,7 @@ const site: SiteDetails = {
 	description: 'test site',
 	URL: 'https://test.wordpress.com',
 	launch_status: '',
+	title: '',
 	jetpack: true,
 	logo: { id: 'logoId', sizes: [ 'small' ], url: 'logoURL' },
 	options: {
@@ -57,4 +59,11 @@ const plugin = {
 	update: { new_version: '11.5', canUpdateFiles: true },
 };
 
-export { site, plugin };
+const paidPlugin = {
+	...plugin,
+	id: paidPluginId,
+	slug: paidPluginId,
+	isMarketplaceProduct: true,
+};
+
+export { site, plugin, paidPlugin };


### PR DESCRIPTION
This PR fixes an issue with the Paid Plugin page where users can click the **'Purchase/Upgrade'** button in the **Manage Sites modal** for JP sites. Clicking the button will lead the users to a checkout page with an invalid cart.

<img width="1191" alt="Screen Shot 2023-06-07 at 7 35 42 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d7d6c180-52c7-46b4-b5d6-d2a61489c4fd">


_Currently, Paid plugins are not yet available for Jetpack sites, which should reflect on the cta button._
<img width="1190" alt="Screen Shot 2023-06-07 at 7 40 03 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f8cea829-0dd6-4f57-bd5e-3db96c9205a8">


Related to  1202619025189113-as-1204700551594170

## Proposed Changes

* Updates the `PluginInstallButton` component to check context if it is rendering for a JP Site and it is a marketplace product. If it is, show a warning message to the user.

<img width="330" alt="Screen Shot 2023-06-07 at 7 46 00 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e2b8ae7e-0464-436a-8d4a-a5c06ed59973">


## Testing Instructions

***Calypso Blue***
* Spin up a JN site and connect it with your WP account.
* Use the Calypso live link and goto `/plugins/wordpress-seo-premium`
* Click 'manage sites' button
<img width="1219" alt="Screen Shot 2023-06-07 at 7 55 09 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/14458fd3-3b1e-47fa-995a-359917f842e3">

* Confirm that the upgrade button is disabled for the JP site. Click the tooltip and ensure a message is displayed explaining the paid plugins are not yet available for JP sites.

<img width="330" alt="Screen Shot 2023-06-07 at 7 46 00 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e2b8ae7e-0464-436a-8d4a-a5c06ed59973">

***Calypso Green***
* Spin up a JN site and connect it with your WP account.
* Use the Jetpack cloud live link and goto `/plugins/wordpress-seo-premium`
* Confirm the the upgrade button is disabled for the JP sites in the available site list.

<img width="1659" alt="Screen Shot 2023-06-07 at 7 57 21 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/51914eff-a60f-4db6-b880-42c25b6e8b96">

***Regular plugins (free)***
* Use Calypso or Jetpack cloud live link and goto `/plugins/wordpress-seo`
* Confirm that the CTA button is enabled and is working as expected.

<img width="968" alt="Screen Shot 2023-06-07 at 8 01 51 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/30a8835f-4532-4976-a1b7-131070ef440a">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1204700551594170