### PR TITLE
Hosting Configuration: Only show data center picker when eligible

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -212,7 +212,7 @@ export const EligibilityWarnings = ( {
 				</CompactCard>
 			) }
 
-			{ showDataCenterPicker && (
+			{ showDataCenterPicker && isEligible && ! hasBlockingHold( listHolds ) && (
 				<CompactCard className="eligibility-warnings__data-center-picker">
 					<TrackComponentView eventName="calypso_automated_transfer_datacenter_picker_display" />
 					<DataCenterPicker


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2672

## Proposed Changes

Only shows the data center picker when the site is eligible for transfer and has no blocking holds:

<img width="857" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/401f6033-a8d1-4d3c-87af-03d323504ac5">

<img width="891" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/3857a188-e288-4472-883b-ad075ff5fe71">

Previously, the data center picker would show if there was a blocking hold:

![image](https://github.com/Automattic/wp-calypso/assets/36432/d152a27a-def9-4488-bd37-07793eba518a)


## Testing Instructions

1. Create a new Business site and navigate to 'Hosting Configuration'.
2. Click 'Activate'.
3. Verify the data center picker appears and works as expected.
4. Take the site Atomic.
5. After the site is Atomic, visit `/hosting-config/activate/<site-slug>`.
6. Verify the data center picker doesn't appear.