### PR TITLE
downtime monitor sms notification change mobile to push

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/mobile-push-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/mobile-push-notification.tsx
@@ -27,7 +27,7 @@ export default function MobilePushNotification( {
 				/>
 			</div>
 			<div className="notification-settings__toggle-content">
-				<div className="notification-settings__content-heading">{ translate( 'Mobile' ) }</div>
+				<div className="notification-settings__content-heading">{ translate( 'Push' ) }</div>
 				<div className="notification-settings__content-sub-heading">
 					{ translate( 'Receive notifications via the {{a}}Jetpack App{{/a}}.', {
 						components: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 1204774821045518-as-1204776216303169/f

## Proposed Changes

* Change the word "mobile" to "push" to be able to use the word "mobile" for the SMS notifications

![Screenshot 2023-06-07 at 9 31 53 AM](https://github.com/Automattic/wp-calypso/assets/12895386/2c94c809-b16d-40d7-be32-c9c9cc45825c)


## Testing Instructions

* fire up jetpack cloud live link below.  Click on the settings for one of your sites, verify the modal now says "push" instead of "mobile"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?