### PR TITLE
Downtime Monitor add SMS section to the modal

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -1,0 +1,25 @@
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+
+export default function SmsNotification() {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<div className="notification-settings__toggle-container">
+				<div className="notification-settings__toggle">
+					<ToggleControl />
+				</div>
+				<div className="notification-settings__toggle-content">
+					<div className="notification-settings__content-heading-with-beta">
+						<div className="notification-settings__content-heading">{ translate( 'Mobile' ) }</div>
+						<div className="notification-settings__beta-tag">{ translate( 'BETA' ) }</div>
+					</div>
+					<div className="notification-settings__content-sub-heading">
+						{ translate( 'Set up text messages to send to one or more people' ) }
+					</div>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -1,14 +1,18 @@
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 
-export default function SmsNotification() {
+export default function SMSNotification() {
 	const translate = useTranslate();
+
+	const handleToggleClick = () => {
+		return null;
+	};
 
 	return (
 		<>
 			<div className="notification-settings__toggle-container">
 				<div className="notification-settings__toggle">
-					<ToggleControl />
+					<ToggleControl onChange={ handleToggleClick } />
 				</div>
 				<div className="notification-settings__toggle-content">
 					<div className="notification-settings__content-heading-with-beta">

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -311,7 +311,7 @@ export default function NotificationSettings( {
 						selectedDuration={ selectedDuration }
 						selectDuration={ selectDuration }
 					/>
-					{ isSMSNotificationEnabled && <SmsNotification /> }
+					{ isSMSNotificationEnabled && <SMSNotification /> }
 
 					<MobilePushNotification
 						recordEvent={ recordEvent }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -19,6 +19,7 @@ import EmailNotification from './form-content/email-notification';
 import NotificationSettingsFormFooter from './form-content/footer';
 import MobilePushNotification from './form-content/mobile-push-notification';
 import NotificationDuration from './form-content/notification-duration';
+import SmsNotification from './form-content/sms-notification';
 import type {
 	MonitorSettings,
 	Site,
@@ -310,10 +311,8 @@ export default function NotificationSettings( {
 						selectedDuration={ selectedDuration }
 						selectDuration={ selectDuration }
 					/>
-					{ isSMSNotificationEnabled && (
-						// Remove this when SMS notification is ready
-						<h3 style={ { marginTop: 16 } }>SMS Notification configuration goes here</h3>
-					) }
+					{ isSMSNotificationEnabled && <SmsNotification /> }
+
 					<MobilePushNotification
 						recordEvent={ recordEvent }
 						enableMobileNotification={ enableMobileNotification }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -19,7 +19,7 @@ import EmailNotification from './form-content/email-notification';
 import NotificationSettingsFormFooter from './form-content/footer';
 import MobilePushNotification from './form-content/mobile-push-notification';
 import NotificationDuration from './form-content/notification-duration';
-import SmsNotification from './form-content/sms-notification';
+import SMSNotification from './form-content/sms-notification';
 import type {
 	MonitorSettings,
 	Site,


### PR DESCRIPTION
Related to # 1204774821045518-as-1204776079125766/f

## Proposed Changes

* This PR adds a simple component to add the SMS section to the settings modal
* It does not add functionality as that will be addressed in other tasks in this project
* Note that PR 77902 will change the title of the push notification setting so we won't have 2 "mobile" sections

![Screenshot 2023-06-07 at 10 10 41 AM](https://github.com/Automattic/wp-calypso/assets/12895386/b00eb116-405d-43ae-af70-56c31edd0c0f)

## Testing Instructions

* visit the Jetpack Cloud live link, click the settings icon for monitoring next to one of the sites.  You will now see 3 sections with the top one being for SMS.  You may or may not see the push notification labelled as "mobile" depending on when the above mentioned PR is deployed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?