### PR TITLE
Subscribers Page: Remove subscriber mutation

### DIFF
--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -1,0 +1,9 @@
+const getSubscribersCacheKey = ( siteId: number, currentPage?: number ) => {
+	const cacheKey = [ 'subscribers', siteId ];
+	if ( currentPage ) {
+		cacheKey.push( currentPage );
+	}
+	return cacheKey;
+};
+
+export { getSubscribersCacheKey };

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -2,23 +2,9 @@ import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
-import { useSubscriberRemoveMutation } from './mutations';
-import { useSubscribersQuery } from './queries';
-
-type Subscriber = {
-	user_id: number;
-	subscription_id: number;
-	email_address: string;
-	plans: {
-		paid_subscription_id: number;
-	}[];
-};
 
 export const Subscribers = () => {
 	const isSubscribersPageEnabled = config.isEnabled( 'subscribers-page' );
-	const mutate = useSubscriberRemoveMutation( 210703284, 1 );
-
-	const { data } = useSubscribersQuery( 210703284, 1 );
 
 	if ( ! isSubscribersPageEnabled ) {
 		return null;
@@ -28,22 +14,6 @@ export const Subscribers = () => {
 		<Main>
 			<DocumentHead title={ translate( 'Subscribers' ) } />
 			Subscribers
-			<table>
-				<tr>
-					<th>email</th>
-					<th>plan?</th>
-					<th>Unsubscribe</th>
-				</tr>
-				{ data?.subscribers?.map( ( subscriber: Subscriber ) => (
-					<tr key={ subscriber.email_address }>
-						<td>{ subscriber.email_address }</td>
-						<td>{ subscriber.plans?.length ? 'yes' : 'no' }</td>
-						<td>
-							<button onClick={ () => mutate.mutate( subscriber ) }>Unsubscribe</button>
-						</td>
-					</tr>
-				) ) }
-			</table>
 		</Main>
 	);
 };

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -2,9 +2,23 @@ import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import { useSubscriberRemoveMutation } from './mutations';
+import { useSubscribersQuery } from './queries';
+
+type Subscriber = {
+	user_id: number;
+	subscription_id: number;
+	email_address: string;
+	plans: {
+		paid_subscription_id: number;
+	}[];
+};
 
 export const Subscribers = () => {
 	const isSubscribersPageEnabled = config.isEnabled( 'subscribers-page' );
+	const mutate = useSubscriberRemoveMutation( 210703284, 1 );
+
+	const { data } = useSubscribersQuery( 210703284, 1 );
 
 	if ( ! isSubscribersPageEnabled ) {
 		return null;
@@ -14,6 +28,22 @@ export const Subscribers = () => {
 		<Main>
 			<DocumentHead title={ translate( 'Subscribers' ) } />
 			Subscribers
+			<table>
+				<tr>
+					<th>email</th>
+					<th>plan?</th>
+					<th>Unsubscribe</th>
+				</tr>
+				{ data?.subscribers?.map( ( subscriber: Subscriber ) => (
+					<tr key={ subscriber.email_address }>
+						<td>{ subscriber.email_address }</td>
+						<td>{ subscriber.plans?.length ? 'yes' : 'no' }</td>
+						<td>
+							<button onClick={ () => mutate.mutate( subscriber ) }>Unsubscribe</button>
+						</td>
+					</tr>
+				) ) }
+			</table>
 		</Main>
 	);
 };

--- a/client/my-sites/subscribers/mutations/index.ts
+++ b/client/my-sites/subscribers/mutations/index.ts
@@ -1,0 +1,1 @@
+export { default as useSubscriberRemoveMutation } from './use-subscriber-remove-mutation';

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -1,0 +1,88 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+type SubscriberEndpointResponse = {
+	per_page: number;
+	total: number;
+	page: number;
+	pages: number;
+	subscribers: Subscriber[];
+};
+
+type Subscriber = {
+	user_id: number;
+	subscription_id: number;
+	plans: {
+		paid_subscription_id: number;
+	}[];
+};
+
+const useSubscriberRemoveMutation = ( siteId: number, currentPage: number ) => {
+	const queryClient = useQueryClient();
+
+	return useMutation( {
+		mutationFn: async ( subscriber: Subscriber ) => {
+			if ( ! siteId || ! subscriber ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while unsubscribing.'
+				);
+			}
+
+			if ( subscriber.plans?.length ) {
+				// unsubscribe this user from all plans
+				const promises = subscriber.plans.map( ( plan ) =>
+					wpcom.req.post(
+						`/sites/${ siteId }/memberships/subscriptions/${ plan.paid_subscription_id }/cancel`,
+						{
+							user_id: subscriber.user_id,
+						}
+					)
+				);
+
+				await Promise.all( promises );
+			}
+
+			if ( subscriber.user_id ) {
+				await wpcom.req.post( `/sites/${ siteId }/followers/${ subscriber.user_id }/delete` );
+			} else {
+				await wpcom.req.post(
+					`/sites/${ siteId }/email-followers/${ subscriber.subscription_id }/delete`
+				);
+			}
+
+			return true;
+		},
+		onMutate: async ( subscriber ) => {
+			const cacheKey = [ 'subscribers', siteId, currentPage ];
+			await queryClient.cancelQueries( cacheKey );
+
+			const previousSubscribers =
+				queryClient.getQueryData< SubscriberEndpointResponse >( cacheKey );
+
+			// remove blog from site subscriptions
+			if ( previousSubscribers ) {
+				queryClient.setQueryData( cacheKey, {
+					...previousSubscribers,
+					subscribers: previousSubscribers.subscribers.filter( ( prevSubscriber ) => {
+						return prevSubscriber.subscription_id !== subscriber.subscription_id;
+					} ),
+				} );
+			}
+
+			return {
+				previousSubscribers,
+			};
+		},
+		onError: ( error, variables, context ) => {
+			if ( context?.previousSubscribers ) {
+				queryClient.setQueryData( [ 'subscribers', siteId ], context.previousSubscribers );
+			}
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries( [ 'subscribers', siteId ] );
+		},
+	} );
+};
+
+export default useSubscriberRemoveMutation;

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,15 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import { getSubscribersCacheKey } from '../helpers';
+import type { SubscriberEndpointResponse } from '../types';
 
-const useSubscribersQuery = ( siteId: number, page = 1 ) => {
-	return useQuery( {
-		queryKey: [ 'subscribers', siteId, page ],
+const useSubscribersQuery = ( siteId: number, page = 1, perPage = 10 ) => {
+	return useQuery< SubscriberEndpointResponse >( {
+		queryKey: getSubscribersCacheKey( siteId, page ),
 		queryFn: () =>
 			wpcom.req.get( {
-				path: `/sites/${ siteId }/subscribers?per_page=10&page=${ page }`,
+				path: `/sites/${ siteId }/subscribers?per_page=${ perPage }&page=${ page }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
 		enabled: !! siteId,
+		keepPreviousData: true,
 	} );
 };
 

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -1,0 +1,27 @@
+export type SubscriberEndpointResponse = {
+	per_page: number;
+	total: number;
+	page: number;
+	pages: number;
+	subscribers: Subscriber[];
+};
+
+export type SubscriptionPlan = {
+	paid_subscription_id: string;
+	status: string;
+	title: string;
+	currency: string;
+	renewal_period: string;
+	start_date: string;
+	end_date: string;
+};
+
+export type Subscriber = {
+	user_id: number;
+	subscription_id: number;
+	date_subscribed: string;
+	email_address: string;
+	avatar: string;
+	display_name: string;
+	plans?: SubscriptionPlan[];
+};


### PR DESCRIPTION
Fixes #77730

## Proposed Changes

This is a WIP that adds the remove subscriber mutation.

It also:
- Adds the `SubscriberEndpointResponse`, `SubscriptionPlan` and `Subscriber` type.
- Adds `keepPreviousData` to the query ([doc](https://tanstack.com/query/v4/docs/react/guides/paginated-queries))
- Adds an optional perPage argument to the query

## Testing Instructions
1. Apply this PR
2. Open `client/my-sites/subscribers/main.tsx` and paste this testing boilerplate:

```js
import config from '@automattic/calypso-config';
import { Button } from '@automattic/components';
import { translate } from 'i18n-calypso';
import { useState } from 'react';
import DocumentHead from 'calypso/components/data/document-head';
import Main from 'calypso/components/main';
import { useSubscriberRemoveMutation } from './mutations';
import { useSubscribersQuery } from './queries';

export const Subscribers = () => {
	const isSubscribersPageEnabled = config.isEnabled( 'subscribers-page' );
	const [ page, setPage ] = useState( 1 );

	const mutate = useSubscriberRemoveMutation( 210703284, page );

	const { data } = useSubscribersQuery( 210703284, page, 3 );

	if ( ! isSubscribersPageEnabled ) {
		return null;
	}

	return (
		<Main>
			<DocumentHead title={ translate( 'Subscribers' ) } />
			Subscribers page { page }
			<div>
				<Button onClick={ () => setPage( page - 1 ) } disabled={ data?.page === 1 }>
					Previous
				</Button>

				<Button onClick={ () => setPage( page + 1 ) } disabled={ data?.pages === page }>
					Next
				</Button>
			</div>
			<table>
				<tr>
					<th>email</th>
					<th>plan?</th>
					<th>Unsubscribe</th>
				</tr>
				{ data?.subscribers?.map( ( subscriber ) => (
					<tr key={ subscriber.email_address }>
						<td>{ subscriber.email_address }</td>
						<td>{ subscriber.plans?.length ? 'yes' : 'no' }</td>
						<td>
							<button onClick={ () => mutate.mutate( subscriber ) }>Unsubscribe</button>
						</td>
					</tr>
				) ) }
			</table>
		</Main>
	);
};
```

Replace `210703284` (twice) with your siteid.

3. Test removing subscriptions for both: non WPCOM users, WPCOM users & paid subscriptions. 
4. Also test going forward & backwards with the pagination, and deleting an item on the first page. The optimistic update should append the first item that was on the second page on the first page, keeping the number of items per page at 3.

(For testing purposes this test script fetches 3 items per page).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
