### PR TITLE
Reader search - add margin to section nav on smaller viewports

### DIFF
--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
 // Reader-specific tweaks to components
 
 // Overrides default 720px width
@@ -777,10 +779,24 @@
 	border-bottom: 1px solid var(--color-neutral-10);
 	box-shadow: none;
 	margin-bottom: 0;
+	margin-top: 60px;
 	padding-bottom: 0;
 
 	@include breakpoint-deprecated( ">480px" ) {
 		height: 58px;
+	}
+
+	// Add margin so that suggestions dont cover tabs on smaller devices.
+	@include break-mobile {
+		margin-top: 40px;
+	}
+
+	@include break-small {
+		margin-top: 20px;
+	}
+
+	@include break-medium {
+		margin-top: 0;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Currently on smaller screens, recommended tags on the search feed can cover the posts/sites column tabs:
<img width="293" alt="Screenshot 2023-06-07 at 11 30 04 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/a91773c7-a93d-40ec-a2d6-87bb6d44a5ef">

This adds different levels of margin on smaller viewports, such that there is enough room available to show our longer tag recommendations:
<img width="410" alt="Screenshot 2023-06-07 at 11 26 21 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/cc342353-78c1-424c-a4eb-3ee4b3fb9054">

Note - I would like to do this in a better way without margin per breakpoints, however the current layout with fixed/absolute positions of different items makes this difficult without a more comprehensive refactor. This should help in the meantime.

## Testing Instructions


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test this calypso build on the search page without a search query.
* You can use the browser tools to replace shorter tags with some of our longer ones such as "Young Adult Fiction", "Knowledge Management", and "Mental Health".
* Test at diferrent device sizes (you can select specific devices within the dev tools, such as "Galaxy Fold".
* Verify the tabs are more generally accessible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
