### PR TITLE
Jetpack Cloud: Show more accurate value in site counter

### DIFF
--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -90,6 +90,21 @@ export function getCurrentUserVisibleSiteCount( state ) {
 }
 
 /**
+ * Returns the number of visible Jetpack sites for the current user.
+ *
+ * @param  {Object}  state  Global state tree
+ * @returns {?number}        Current user visible Jetpack site count
+ */
+export function getCurrentUserJetpackVisibleSiteCount( state ) {
+	const user = getCurrentUser( state );
+	if ( ! user ) {
+		return null;
+	}
+
+	return user.jetpack_visible_site_count || 0;
+}
+
+/**
  * Returns the date (of registration) for the current user.
  *
  * @param  {Object}  state  Global state tree


### PR DESCRIPTION
This pull request aims to improve the accuracy of the count displayed in the "All My Sites" component in the Jetpack Cloud sidebar, by retrieving a different/more appropriate value.

Resolves `1202619025189113-as-1203147992256213`, `1202619025189113-as-1203225745976434`.
Issue referenced in #68837.

## Proposed Changes

* Add a new selector `getCurrentUserJetpackVisibleSiteCount` to retrieve the value of `jetpack_visible_site_count` on the `user` state tree.
* Use the aforementioned new selector in Jetpack Cloud environments where the `realtime-site-count` feature flag is disabled or not set (i.e., Horizon).
* Add documentation inside the `connect` function to explain how site count is determined in various circumstances.

## Known issues

Only active sites are retrieved and filtered when `realtime-site-count` is enabled, but `jetpack_visible_site_count` counts both active and inactive sites. This means that in cases where someone with post editing capabilities logs in, the value in their site counter will vary in environments where the feature flag is in different states.

_**Example:** I have post edit capabilities on 5 Jetpack sites. One of these sites is inactive, meaning it hasn't communicated with Jetpack's servers in the last 30 days. In environments with `realtime-site-count` enabled, the site counter will show 4; however, environments with `realtime-site-count` disabled will show 5._

## Testing Instructions

### Testing the fix

1. Visit cloud.jetpack.com in both production/staging, and in your testing environment (e.g., this PR's live branch). Complete the following steps in each environment. *(**NOTE:** If you use the live branch, `realtime-site-count` is disabled by default.)*
2. Note the number displayed in the site counter in your sidebar.
3. Add the query parameter `flags=realtime-site-count` to your browser's URL to enable real-time site counting, if necessary. Note again the displayed count.
4. Add the query parameter `flags=-realtime-site-count` (notice the leading minus sign) to your browser's URL to disable real-time site counting, if necessary. Note again the displayed count. It may be higher than when the flag was enabled.
5. Verify that the difference in the displayed count in your test environment is smaller or non-existent, compared to the difference in production/staging.

### Testing for regression issues

1. Visit wordpress.com in both production/staging, and in your testing environment.
2. Complete the steps in the previous test case, ensuring that the values are identical between both environments.

<img width="253" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/b3bcc26e-4a24-4afb-8f6b-db21f2d17346">