### PR TITLE
Fediverse: remove temp strings from translations

### DIFF
--- a/client/my-sites/site-settings/reading-fediverse-settings/JetpackFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/JetpackFediverseSettingsSection.js
@@ -17,14 +17,12 @@ export const JetpackFediverseSettingsSection = ( { siteId } ) => {
 			<QueryPlugins siteId={ siteId } />
 			<Card className="site-settings__card">
 				<p>
-					{ translate(
-						'The fediverse is a network of social media sites like Mastodon and Pixelfed and Calckey and Peertube and Pleroma, oh my!'
-					) }
+					The fediverse is a network of social media sites like Mastodon and Pixelfed and Calckey
+					and Peertube and Pleroma, oh my!
 				</p>
 				<p>
-					{ translate(
-						'Your site can publish to the same ActivityPub protocol that powers all of them, just install the ActivityPub plugin!:'
-					) }
+					Your site can publish to the same ActivityPub protocol that powers all of them, just
+					install the ActivityPub plugin:
 				</p>
 				<p>
 					{ pluginIsActive ? (

--- a/client/my-sites/site-settings/reading-fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/WpcomFediverseSettingsSection.js
@@ -37,9 +37,8 @@ const EnabledSettingsSection = ( { siteId } ) => {
 	return (
 		<Card className="site-settings__card">
 			<p>
-				{ translate(
-					'Lots of cool customizations and bonus features coming soon with WordPress.com Premium and up!'
-				) }
+				Lots of cool customizations and bonus features coming soon with WordPress.com Premium and
+				up!
 			</p>
 			<hr />
 			<p>{ translate( 'The fediverse can follow your site with this alias:' ) }</p>
@@ -84,14 +83,12 @@ export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 		<>
 			<Card className="site-settings__card">
 				<p>
-					{ translate(
-						'The fediverse is a network of social media sites like Mastodon and Pixelfed and Calckey and Peertube and Pleroma, oh my!'
-					) }
+					The fediverse is a network of social media sites like Mastodon and Pixelfed and Calckey
+					and Peertube and Pleroma, oh my!
 				</p>
 				<p>
-					{ translate(
-						'Your site can publish to the same ActivityPub protocol that powers all of them, just enable:'
-					) }
+					Your site can publish to the same ActivityPub protocol that powers all of them, just
+					enable:
 				</p>
 				<ToggleControl
 					label={ translate( 'Enter the fediverse' ) }


### PR DESCRIPTION
[This translation bot comment](https://github.com/Automattic/wp-calypso/pull/77298#issuecomment-1579466001) made me realize that some of these strings are very much whimsical placeholders that will need replacing.

I'm ride or die with "Enter the fediverse" though 

Related to #77298

## Proposed Changes

* remove some translatable strings

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
