### PR TITLE
Launchpad: Added new prop to control primary button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -197,7 +197,11 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 						</p>
 					</div>
 				) }
-				{ isFetchedAfterMount ? <Checklist tasks={ enhancedTasks } /> : <Checklist.Placeholder /> }
+				{ isFetchedAfterMount ? (
+					<Checklist tasks={ enhancedTasks } makeLastTaskPrimaryAction={ true } />
+				) : (
+					<Checklist.Placeholder />
+				) }
 			</div>
 			<div className="launchpad__sidebar-admin-link">
 				<StepNavigationLink

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -86,7 +86,7 @@
 	line-height: 20px;
 }
 
-.checklist-item__task:nth-last-child(2) {
+.checklist__has-primary-action .checklist-item__task:nth-last-child(2) {
 
 	// remove bottom border for last checklist item before the primary button
 	.checklist-item__task-content,

--- a/packages/launchpad/src/checklist/index.tsx
+++ b/packages/launchpad/src/checklist/index.tsx
@@ -5,9 +5,10 @@ import './style.scss';
 
 interface ChecklistProps {
 	tasks: Task[] | null;
+	makeLastTaskPrimaryAction?: boolean;
 }
 
-const Checklist = ( { tasks }: ChecklistProps ) => {
+const Checklist = ( { tasks, makeLastTaskPrimaryAction }: ChecklistProps ) => {
 	return (
 		<ul className="checklist__tasks" aria-label="Launchpad Checklist">
 			{ tasks &&
@@ -15,7 +16,7 @@ const Checklist = ( { tasks }: ChecklistProps ) => {
 					<ChecklistItem
 						key={ task.id }
 						task={ task }
-						isPrimaryAction={ tasks.length - 1 === index }
+						isPrimaryAction={ makeLastTaskPrimaryAction && index === tasks.length - 1 }
 					/>
 				) ) }
 		</ul>

--- a/packages/launchpad/src/checklist/index.tsx
+++ b/packages/launchpad/src/checklist/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import ChecklistItem from '../checklist-item';
 import { Task } from '../types';
 
@@ -10,7 +11,12 @@ interface ChecklistProps {
 
 const Checklist = ( { tasks, makeLastTaskPrimaryAction }: ChecklistProps ) => {
 	return (
-		<ul className="checklist__tasks" aria-label="Launchpad Checklist">
+		<ul
+			className={ classNames( 'checklist__tasks', {
+				'checklist__has-primary-action': makeLastTaskPrimaryAction,
+			} ) }
+			aria-label="Launchpad Checklist"
+		>
 			{ tasks &&
 				tasks.map( ( task: Task, index: number ) => (
 					<ChecklistItem

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -4,16 +4,21 @@ import Checklist from './checklist';
 export interface LaunchpadProps {
 	siteSlug: string;
 	checklistSlug?: string | 0 | null | undefined;
+	makeLastTaskPrimaryAction?: boolean;
 }
 
-const Launchpad = ( { siteSlug, checklistSlug }: LaunchpadProps ) => {
+const Launchpad = ( { siteSlug, checklistSlug, makeLastTaskPrimaryAction }: LaunchpadProps ) => {
 	const { isFetchedAfterMount, data } = useLaunchpad( siteSlug || '', checklistSlug );
 
 	const tasks = data.checklist || [];
 
 	return (
 		<div className="launchpad__checklist-wrapper">
-			{ isFetchedAfterMount ? <Checklist tasks={ tasks } /> : <Checklist.Placeholder /> }
+			{ isFetchedAfterMount ? (
+				<Checklist tasks={ tasks } makeLastTaskPrimaryAction={ makeLastTaskPrimaryAction } />
+			) : (
+				<Checklist.Placeholder />
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/77912


## Proposed Changes

* Added new prop to `<Checklist />` and `<Launchpad />` to be able to control is the last task is rendered as a primary button. Without this prop, it's always the case.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the launchpad page for a [new] site (should look the same as production)

![image](https://github.com/Automattic/wp-calypso/assets/3801502/cc7aadb4-e1f0-472c-9e11-2c353152aee9)

* Change `client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx:201`
from `<Checklist tasks={ enhancedTasks } makeLastTaskPrimaryAction={ true } />` to `<Checklist tasks={ enhancedTasks } makeLastTaskPrimaryAction={ false } />`

![image](https://github.com/Automattic/wp-calypso/assets/3801502/61cfcc3f-ec41-4c21-9dc5-78a6d5b3be7c)

