### PR TITLE
Launchpad: Use `<Launchpad />` component on Stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,6 +1,6 @@
 import { Gridicon, CircularProgressBar } from '@automattic/components';
 import { OnboardSelect, useLaunchpad } from '@automattic/data-stores';
-import { Checklist } from '@automattic/launchpad';
+import { Launchpad } from '@automattic/launchpad';
 import { isBlogOnboardingFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useRef, useState } from '@wordpress/element';
@@ -57,7 +57,6 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 
 	const {
 		data: { checklist_statuses: checklistStatuses, checklist: launchpadChecklist },
-		isFetchedAfterMount,
 	} = useLaunchpad( siteSlug, siteIntentOption );
 
 	const selectedDomain = useSelect(
@@ -197,11 +196,11 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 						</p>
 					</div>
 				) }
-				{ isFetchedAfterMount ? (
-					<Checklist tasks={ enhancedTasks } makeLastTaskPrimaryAction={ true } />
-				) : (
-					<Checklist.Placeholder />
-				) }
+				<Launchpad
+					siteSlug={ siteSlug }
+					taskFilter={ () => enhancedTasks }
+					makeLastTaskPrimaryAction={ true }
+				/>
 			</div>
 			<div className="launchpad__sidebar-admin-link">
 				<StepNavigationLink


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/77286

## Proposed Changes

* Replaces the use of `<Checklist />` and its Placeholder by `<Launchpad />`

## Testing Instructions

* Access the launchpad for a [new] site and confirm the behaviour and look are still the same.