### PR TITLE
Stats: subscribers overview cards data - handle errors and loading status separately

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-overview.ts
+++ b/client/my-sites/stats/hooks/use-subscribers-overview.ts
@@ -1,0 +1,49 @@
+import { translate } from 'i18n-calypso';
+import { useSubscribersQueries } from './use-subscribers-query';
+
+// array of indices to use to calculate the dates to query for
+const DATES_TO_QUERY = [ 0, 30, 60, 90 ];
+
+function getLabels( dateToQuery: number ) {
+	switch ( dateToQuery ) {
+		case 0:
+			return translate( 'Today' );
+		case 30:
+			return translate( '30 days ago' );
+		case 60:
+			return translate( '60 days ago' );
+		case 90:
+			return translate( '90 days ago' );
+		default:
+			return '';
+	}
+}
+
+// calculate the date to query for based on the number of days to subtract
+function calculateQueryDate( daysToSubtract: number ) {
+	const today = new Date();
+	const date = new Date( today );
+	date.setDate( date.getDate() - daysToSubtract );
+	return date.toISOString().split( 'T' )[ 0 ];
+}
+
+export default function useSubscribersOverview( siteId: number | null ) {
+	const period = 'day';
+	const quantity = 1;
+	const dates = DATES_TO_QUERY.map( calculateQueryDate );
+	const { isLoading, isError, subscribersData } = useSubscribersQueries(
+		siteId,
+		period,
+		quantity,
+		dates
+	);
+	const overviewData = subscribersData.map( ( data, index ) => {
+		const count = data?.data?.[ 0 ]?.subscribers || null;
+		const label = getLabels( DATES_TO_QUERY[ index ] );
+		return {
+			count,
+			label,
+		};
+	} );
+	return { isLoading, isError, overviewData };
+}

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -13,7 +13,7 @@ export interface SubscribersData {
 	date?: string;
 	unit?: string;
 	data?: {
-		[ key: string ]: string | number;
+		[ key: string ]: number | null;
 	}[];
 }
 

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -56,22 +56,50 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 	const quantity = 1;
 	const dates = cardIndices.map( calculateQueryDate );
 
+<<<<<<< HEAD
 	const { isLoading, isError, subscribersData } = useSubscribersQueries(
 		siteId,
 		period,
 		quantity,
 		dates
 	);
+=======
+<<<<<<< HEAD
+	const isLoading = subscribersQueries.some( ( result ) => result.isLoading );
+	const isError = subscribersQueries.some( ( result ) => result.isError );
+	const subscribersData = subscribersQueries.map( ( result ) => result.data?.data || [] );
+>>>>>>> d97a8b8aa8 (handle errors and loading status separately)
 
 	const overviewCardStats = SubscribersOverviewCardStats( subscribersData );
+=======
+	const subscribersQueries = useSubscribersQueries( siteId, period, quantity, dates );
+>>>>>>> 37a7f330e2 (handle errors and loading status separately)
 
 	return (
+<<<<<<< HEAD
 		<div className="stats-subscribers-overview highlight-cards">
 			{ isLoading && <div>Loading...</div> }
 			{ isError && <div>Error: Failed to load data.</div> }
 			{ ! isLoading && ! isError && (
 				<div className="highlight-cards-list">
 					{ overviewCardStats.map( ( overviewCardStat ) => (
+=======
+		<div className="subscribers-overview highlight-cards">
+			<div className="highlight-cards-list">
+				{ subscribersQueries.map( ( result, index ) => {
+					if ( result.isLoading ) {
+						return <div key={ index }>Loading...</div>;
+					}
+
+					if ( result.isError ) {
+						return <div key={ index }>Error: Failed to load data.</div>;
+					}
+
+					const subscribersData = result.data;
+					const overviewCardStat = SubscribersOverviewCardStats( [ subscribersData ] )[ 0 ];
+
+					return (
+>>>>>>> d97a8b8aa8 (handle errors and loading status separately)
 						<CountComparisonCard
 							key={ overviewCardStat.count }
 							heading={ overviewCardStat.heading }
@@ -79,9 +107,9 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 							showValueTooltip
 							icon={ false }
 						/>
-					) ) }
-				</div>
-			) }
+					);
+				} ) }
+			</div>
 		</div>
 	);
 };

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -6,8 +6,6 @@ import {
 	SubscribersData,
 } from 'calypso/my-sites/stats/hooks/use-subscribers-query';
 
-import './style.scss';
-
 // array of indices to use to calculate the dates to query for
 const cardIndices = [ 0, 30, 60, 90 ];
 
@@ -24,10 +22,10 @@ function calculateQueryDate( daysToSubtract: number ) {
 }
 
 // calculate the stats to display in the cards
-	function SubscribersOverviewCardStats( subscribersData: SubscribersData, index: number ) {
-		const getCount = () => {
-			return subscribersData?.data?.[ 0 ]?.subscribers || 0;
-		};
+function SubscribersOverviewCardStats( subscribersData: SubscribersData, index: number ) {
+	const getCount = () => {
+		return subscribersData?.data?.[ 0 ]?.subscribers || 0;
+	};
 
 	let heading;
 	switch ( index ) {
@@ -61,13 +59,6 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 	const quantity = 1;
 	const dates = cardIndices.map( calculateQueryDate );
 
-	const { isLoading, isError, subscribersData } = useSubscribersQueries(
-		siteId,
-		period,
-		quantity,
-		dates
-	);
-
 	const subscribersQueries = useSubscribersQueries( siteId, period, quantity, dates );
 
 	return (
@@ -83,13 +74,13 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 					}
 
 					const subscribersData = result.data;
-					const overviewCardStat = getCountComparisonCardProps( result.data, index );
+					const overviewCardStat = SubscribersOverviewCardStats( subscribersData, index );
 
 					return (
 						<CountComparisonCard
-							key={ overviewCardStat.count }
+							key={ overviewCardStat.heading }
 							heading={ overviewCardStat.heading }
-							count={ overviewCardStat.count ? parseInt( String( overviewCardStat.count ) ) : null }
+							count={ overviewCardStat.count }
 							showValueTooltip
 							icon={ false }
 						/>

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -24,29 +24,39 @@ function calculateQueryDate( daysToSubtract: number ) {
 }
 
 // calculate the stats to display in the cards
+<<<<<<< HEAD
 function SubscribersOverviewCardStats( subscribersData: SubscribersData[] ) {
 	const getCount = ( index: number ) => {
 		return subscribersData[ index ]?.data?.[ 0 ]?.subscribers || 0;
+=======
+function SubscribersOverviewCardStats( subscribersData: SubscribersData, index: number ) {
+	const getCount = () => {
+		return subscribersData?.data[ 0 ]?.subscribers || 0;
+>>>>>>> fde9323cdb (use a switch for headings)
 	};
 
-	const overviewCardStats = [
-		{
-			heading: translate( 'Today' ),
-			count: getCount( 0 ),
-		},
-		{
-			heading: translate( '30 days ago' ),
-			count: getCount( 1 ),
-		},
-		{
-			heading: translate( '60 days ago' ),
-			count: getCount( 2 ),
-		},
-		{
-			heading: translate( '90 days ago' ),
-			count: getCount( 3 ),
-		},
-	];
+	let heading;
+	switch ( index ) {
+		case 0:
+			heading = translate( 'Today' );
+			break;
+		case 1:
+			heading = translate( '30 days ago' );
+			break;
+		case 2:
+			heading = translate( '60 days ago' );
+			break;
+		case 3:
+			heading = translate( '90 days ago' );
+			break;
+		default:
+			heading = '';
+	}
+
+	const overviewCardStat = {
+		heading,
+		count: getCount(),
+	};
 
 	return overviewCardStats;
 }
@@ -56,6 +66,7 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 	const quantity = 1;
 	const dates = cardIndices.map( calculateQueryDate );
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 	const { isLoading, isError, subscribersData } = useSubscribersQueries(
 		siteId,
@@ -72,8 +83,9 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 
 	const overviewCardStats = SubscribersOverviewCardStats( subscribersData );
 =======
+=======
+>>>>>>> fde9323cdb (use a switch for headings)
 	const subscribersQueries = useSubscribersQueries( siteId, period, quantity, dates );
->>>>>>> 37a7f330e2 (handle errors and loading status separately)
 
 	return (
 <<<<<<< HEAD

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -1,86 +1,24 @@
 import { CountComparisonCard } from '@automattic/components';
-import { translate } from 'i18n-calypso';
 import React from 'react';
-import {
-	useSubscribersQueries,
-	SubscribersData,
-} from 'calypso/my-sites/stats/hooks/use-subscribers-query';
-
-// array of indices to use to calculate the dates to query for
-const cardIndices = [ 0, 30, 60, 90 ];
+import useSubscribersOverview from 'calypso/my-sites/stats/hooks/use-subscribers-overview';
 
 interface SubscribersOverviewProps {
 	siteId: number | null;
 }
 
-// calculate the date to query for based on the number of days to subtract
-function calculateQueryDate( daysToSubtract: number ) {
-	const today = new Date();
-	const date = new Date( today );
-	date.setDate( date.getDate() - daysToSubtract );
-	return date.toISOString().split( 'T' )[ 0 ];
-}
-
-// calculate the stats to display in the cards
-function SubscribersOverviewCardStats( subscribersData: SubscribersData, index: number ) {
-	const getCount = () => {
-		return subscribersData?.data?.[ 0 ]?.subscribers || 0;
-	};
-
-	let heading;
-	switch ( index ) {
-		case 0:
-			heading = translate( 'Today' );
-			break;
-		case 1:
-			heading = translate( '30 days ago' );
-			break;
-		case 2:
-			heading = translate( '60 days ago' );
-			break;
-		case 3:
-			heading = translate( '90 days ago' );
-			break;
-		default:
-			heading = '';
-			break;
-	}
-
-	const overviewCardStat = {
-		heading,
-		count: getCount(),
-	};
-
-	return overviewCardStat;
-}
-
 const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } ) => {
-	const period = 'day';
-	const quantity = 1;
-	const dates = cardIndices.map( calculateQueryDate );
-
-	const subscribersQueries = useSubscribersQueries( siteId, period, quantity, dates );
+	const { isLoading, isError, overviewData } = useSubscribersOverview( siteId );
 
 	return (
 		<div className="subscribers-overview highlight-cards">
 			<div className="highlight-cards-list">
-				{ subscribersQueries.map( ( result, index ) => {
-					if ( result.isLoading ) {
-						return <div key={ index }>Loading...</div>;
-					}
-
-					if ( result.isError ) {
-						return <div key={ index }>Error: Failed to load data.</div>;
-					}
-
-					const subscribersData = result.data;
-					const overviewCardStat = SubscribersOverviewCardStats( subscribersData, index );
-
+				{ overviewData.map( ( { count, label }, index ) => {
 					return (
+						// TODO: Communicate loading vs error state to the user.
 						<CountComparisonCard
-							key={ overviewCardStat.heading }
-							heading={ overviewCardStat.heading }
-							count={ overviewCardStat.count }
+							key={ index }
+							heading={ label }
+							count={ isLoading || isError ? null : count }
 							showValueTooltip
 							icon={ false }
 						/>

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -45,6 +45,7 @@ function calculateQueryDate( daysToSubtract: number ) {
 			break;
 		default:
 			heading = '';
+			break;
 	}
 
 	const overviewCardStat = {

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -24,16 +24,10 @@ function calculateQueryDate( daysToSubtract: number ) {
 }
 
 // calculate the stats to display in the cards
-<<<<<<< HEAD
-function SubscribersOverviewCardStats( subscribersData: SubscribersData[] ) {
-	const getCount = ( index: number ) => {
-		return subscribersData[ index ]?.data?.[ 0 ]?.subscribers || 0;
-=======
-function SubscribersOverviewCardStats( subscribersData: SubscribersData, index: number ) {
-	const getCount = () => {
-		return subscribersData?.data[ 0 ]?.subscribers || 0;
->>>>>>> fde9323cdb (use a switch for headings)
-	};
+	function SubscribersOverviewCardStats( subscribersData: SubscribersData, index: number ) {
+		const getCount = () => {
+			return subscribersData?.data?.[ 0 ]?.subscribers || 0;
+		};
 
 	let heading;
 	switch ( index ) {
@@ -58,7 +52,7 @@ function SubscribersOverviewCardStats( subscribersData: SubscribersData, index: 
 		count: getCount(),
 	};
 
-	return overviewCardStats;
+	return overviewCardStat;
 }
 
 const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } ) => {
@@ -66,36 +60,16 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 	const quantity = 1;
 	const dates = cardIndices.map( calculateQueryDate );
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 	const { isLoading, isError, subscribersData } = useSubscribersQueries(
 		siteId,
 		period,
 		quantity,
 		dates
 	);
-=======
-<<<<<<< HEAD
-	const isLoading = subscribersQueries.some( ( result ) => result.isLoading );
-	const isError = subscribersQueries.some( ( result ) => result.isError );
-	const subscribersData = subscribersQueries.map( ( result ) => result.data?.data || [] );
->>>>>>> d97a8b8aa8 (handle errors and loading status separately)
 
-	const overviewCardStats = SubscribersOverviewCardStats( subscribersData );
-=======
-=======
->>>>>>> fde9323cdb (use a switch for headings)
 	const subscribersQueries = useSubscribersQueries( siteId, period, quantity, dates );
 
 	return (
-<<<<<<< HEAD
-		<div className="stats-subscribers-overview highlight-cards">
-			{ isLoading && <div>Loading...</div> }
-			{ isError && <div>Error: Failed to load data.</div> }
-			{ ! isLoading && ! isError && (
-				<div className="highlight-cards-list">
-					{ overviewCardStats.map( ( overviewCardStat ) => (
-=======
 		<div className="subscribers-overview highlight-cards">
 			<div className="highlight-cards-list">
 				{ subscribersQueries.map( ( result, index ) => {
@@ -108,10 +82,9 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 					}
 
 					const subscribersData = result.data;
-					const overviewCardStat = SubscribersOverviewCardStats( [ subscribersData ] )[ 0 ];
+					const overviewCardStat = getCountComparisonCardProps( result.data, index );
 
 					return (
->>>>>>> d97a8b8aa8 (handle errors and loading status separately)
 						<CountComparisonCard
 							key={ overviewCardStat.count }
 							heading={ overviewCardStat.heading }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/77513

## Proposed Changes

* This PR changes the component and hook to handle errors and loading status separately for the cards. This is because we still want to show the working cards even when some of them error out or are still loading.

## Testing Instructions

**To test the normal functioning of cards**

* Open the live branch for this PR.
* Navigate to `/stats/day/:siteSlug`
* Add `?flags=stats/subscribers-section` to the URL to enable the subscriber stats page.
* Scroll down to locate the overview cards (immediately under the chart)
* Check that they load data correctly, still behave acceptably on resize etc.

**To test error handling of individual cards of cards**

* In your local dev env, use the branch `update/stats-subscriber-overview-cards-errors`
* To test by simulating an error on just one card, you can replace the `useSubscribersQueries()` function in the `use-subscribers-query` hook file with the following snippet. replace the date with either today's date, the date 30, 60 or 90 days ago to test. If you're not sure which dates to try with, this will console log the four dates and their formats being used. 

```
export function useSubscribersQueries(
	siteId: number | null,
	period: string,
	quantity: number,
	dates: string[]
): UseQueryResult< SubscribersData, unknown >[] {
	const queryConfigs = dates.map( ( date ) => {
		console.log( date ); // log each date
		return {
			queryKey: [ 'stats', 'subscribers', siteId, period, quantity, date ],
			queryFn: () => {
				if ( date == '2023-05-09' ) {
					console.log( 'Simulating error for date: ' + date );
					// simulate error
					return Promise.reject( new Error( 'Error' ) );
				}
				return querySubscribers( siteId, period, quantity, date );
			},
			select: selectSubscribers,
			staleTime: 1000 * 60 * 5, // 5 minutes
		};
	} );
```

* Navigate to `/stats/day/:siteSlug`
* Add `?flags=stats/subscribers-section` to the URL to enable the subscriber stats page.
* Check that only the one card matching the date you entered into the code snippet is showing an 'Error: Failed to load data' or 'loading...`  
* Confirm remaining 3 cards all display correctly. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
