### PR TITLE
Plans 2023: Move Paid Subscribers feature into the free plan

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -559,6 +559,7 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SPAM_JP,
 		FEATURE_LTD_SOCIAL_MEDIA_JP,
 		FEATURE_CONTACT_FORM_JP,
+		FEATURE_PAID_SUBSCRIBERS_JP,
 	],
 	get2023PlanComparisonJetpackFeatureOverride: () => [
 		FEATURE_STATS_JP,
@@ -790,10 +791,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_FAST_DNS,
 		FEATURE_SUPPORT_EMAIL,
 	],
-	get2023PricingGridSignupJetpackFeatures: () => [
-		FEATURE_PAID_SUBSCRIBERS_JP,
-		FEATURE_PREMIUM_CONTENT_JP,
-	],
+	get2023PricingGridSignupJetpackFeatures: () => [ FEATURE_PREMIUM_CONTENT_JP ],
 	get2023PricingGridSignupStorageOptions: () => [ FEATURE_6GB_STORAGE ],
 	get2023PlanComparisonConditionalFeatures: () => [ FEATURE_SHARES_SOCIAL_MEDIA_JP ],
 	getNewsletterDescription: () =>

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -562,6 +562,7 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_CONTACT_FORM_JP,
 	],
 	get2023PlanComparisonJetpackFeatureOverride: () => [
+		FEATURE_PAID_SUBSCRIBERS_JP,
 		FEATURE_STATS_JP,
 		FEATURE_SPAM_JP,
 		FEATURE_CONTACT_FORM_JP,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -555,11 +555,11 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SECURITY_DDOS,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [
+		FEATURE_PAID_SUBSCRIBERS_JP,
 		FEATURE_STATS_JP,
 		FEATURE_SPAM_JP,
 		FEATURE_LTD_SOCIAL_MEDIA_JP,
 		FEATURE_CONTACT_FORM_JP,
-		FEATURE_PAID_SUBSCRIBERS_JP,
 	],
 	get2023PlanComparisonJetpackFeatureOverride: () => [
 		FEATURE_STATS_JP,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1744

## Proposed Changes

* Currently, Earn features are only available for sites with a paid plan. We want to unlock Earn features for everybody, including the free plan users.
* With recent releases of earn features on free, we're updating the 2023 pricing page accordingly.
* More context here https://github.com/Automattic/martech/issues/1744#issuecomment-1555962306

## Screenshots
### Features Grid Before
<img width="1489" alt="Screenshot 2023-06-07 at 1 15 28 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/e18a9a38-27ff-4097-b306-2cc003a633cc">

### Features Grid After
<img width="1492" alt="Screenshot 2023-06-08 at 10 31 49 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/1069c040-dd23-4a90-b4da-61277cd0b8eb">

### Comparison Grid After
<img width="1289" alt="Screenshot 2023-06-08 at 10 38 26 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/4981eca2-0b14-4c94-b7a6-7f2966712e12">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this branch and run `yarn` and `yarn start` if needed. 
2. Navigate to the 2023 pricing grid in onboarding http://calypso.localhost:3000/start/plans
3. Verify that the `Paid subscribers` line item is now under the Free plan as opposed to the Personal plan. Verify that the feature tooltip is still rendered on hover
4. Verify that that the `Paid subscribers` line item is categorized under Growth and Monetization Tools in the comparison grid. Verify that the feature tooltip is rendered on hover and that there is a check mark for every column.
5. Navigate to the 2023 pricing grid in the plans page http://calypso.localhost:3000/plans/{SITE_SLUG}
6. Repeat steps 3 and 4

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
