### PR TITLE
Checkout: Convert ManagedContactDetailsFormFields to TypeScript

### DIFF
--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -38,7 +38,7 @@ import './style.scss';
 const debug = debugFactory( 'calypso:managed-contact-details-form-fields' );
 
 export interface ManagedContactDetailsFormFieldsProps {
-	eventFormName: string;
+	eventFormName?: string;
 	contactDetails: DomainContactDetailsData;
 	contactDetailsErrors: DomainContactDetailsErrors;
 	onContactDetailsChange: ( details: DomainContactDetailsData ) => void;

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -388,7 +388,7 @@ export class ManagedContactDetailsFormFields extends Component<
 						onChange={ this.handleFieldChangeEvent }
 						onBlur={ this.handleBlur( 'last-name' ) }
 						value={ this.props.contactDetails.lastName }
-						name="first-name"
+						name="last-name"
 						eventFormName={ this.props.eventFormName }
 					/>
 				</div>

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -30,7 +30,7 @@ import {
 import RegionAddressFieldsets from './custom-form-fieldsets/region-address-fieldsets';
 import { GSuiteFields } from './g-suite-fields';
 import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
-import type { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
+import type { DomainContactDetailsErrors, ManagedContactDetails } from '@automattic/wpcom-checkout';
 import type { IAppState } from 'calypso/state/types';
 
 import './style.scss';
@@ -412,6 +412,10 @@ export class ManagedContactDetailsFormFields extends Component<
 	}
 
 	renderGoogleAppsDetails = () => {
+		if ( ! this.props.countriesList ) {
+			return null;
+		}
+
 		// Convert this.props.contactDetails (DomainContactDetails) back into
 		// ManagedContactDetails, originally changed by
 		// `prepareDomainContactDetails()` back up in ContactDetailsContainer.
@@ -421,7 +425,7 @@ export class ManagedContactDetailsFormFields extends Component<
 		);
 
 		// Convert the ManagedContactDetails back to DomainContactDetails for the update.
-		const onChange = ( updatedManagedContactInfo ) => {
+		const onChange = ( updatedManagedContactInfo: ManagedContactDetails ) => {
 			this.props.onContactDetailsChange( prepareDomainContactDetails( updatedManagedContactInfo ) );
 		};
 

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -157,24 +157,18 @@ export class ManagedContactDetailsFormFields extends Component<
 
 	getFieldProps = ( name: string, { customErrorMessage = null } ) => {
 		const { eventFormName, getIsFieldDisabled } = this.props;
-		const form = getFormFromContactDetails(
-			this.props.contactDetails,
-			this.props.contactDetailsErrors
-		);
 		const camelName = camelCase( name );
 
-		const basicValue = form[ camelName ]?.value ?? '';
-		let value = basicValue;
-		if ( name === 'phone' ) {
-			value = { phoneNumber: basicValue, countryCode: this.state.phoneCountryCode };
-		}
+		const value = this.props.contactDetails[ camelName as keyof DomainContactDetailsData ];
 
 		return {
 			labelClass: 'contact-details-form-fields__label',
 			additionalClasses: 'contact-details-form-fields__field',
 			disabled: getIsFieldDisabled( name ),
-			isError: !! form[ camelName ]?.errors?.length,
-			errorMessage: customErrorMessage || getFirstError( form[ camelName ] ),
+			isError: !! this.props.contactDetailsErrors[ camelName as keyof DomainContactDetailsErrors ],
+			errorMessage:
+				customErrorMessage ||
+				this.props.contactDetailsErrors[ camelName as keyof DomainContactDetailsErrors ],
 			onChange: this.handleFieldChangeEvent,
 			onBlur: this.handleBlur( name ),
 			value,

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -348,9 +348,21 @@ export class ManagedContactDetailsFormFields extends Component<
 			<div className="contact-details-form-fields__row">
 				<Input
 					label={ this.props.translate( 'Alternate email address' ) }
-					{ ...this.getFieldProps( 'email', {
-						customErrorMessage: this.props.contactDetailsErrors?.email,
-					} ) }
+					description={
+						this.props.isLoggedOutCart
+							? this.props.translate( "You'll use this email address to access your account later" )
+							: undefined
+					}
+					labelClass="contact-details-form-fields__label"
+					additionalClasses="contact-details-form-fields__field"
+					disabled={ this.props.getIsFieldDisabled( 'email' ) }
+					isError={ !! this.props.contactDetailsErrors.email }
+					errorMessage={ this.props.contactDetailsErrors.email }
+					onChange={ this.handleFieldChangeEvent }
+					onBlur={ this.handleBlur( 'email' ) }
+					value={ this.props.contactDetails.email }
+					name="email"
+					eventFormName={ this.props.eventFormName }
 				/>
 			</div>
 		);

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -234,19 +234,8 @@ export class ManagedContactDetailsFormFields extends Component<
 
 		return (
 			<>
-				<div className="contact-details-form-fields__row">{ this.createEmailField() }</div>
-
 				<div className="contact-details-form-fields__row">
-					<CountrySelectMenu
-						countriesList={ this.props.countriesList }
-						errorMessage={ this.props.contactDetailsErrors.countryCode }
-						isDisabled={ this.props.getIsFieldDisabled( 'country-code' ) }
-						isError={ !! this.props.contactDetailsErrors.countryCode }
-						onChange={ ( event ) => {
-							this.handleFieldChange( 'country-code', event.currentTarget.value );
-						} }
-						currentValue={ this.props.contactDetails.countryCode }
-					/>
+					{ this.createEmailField() }
 					<FormPhoneMediaInput
 						label={ this.props.translate( 'Phone' ) }
 						name="phone"
@@ -264,6 +253,19 @@ export class ManagedContactDetailsFormFields extends Component<
 						onChange={ this.handlePhoneChange }
 						countriesList={ this.props.countriesList }
 						additionalClasses="contact-details-form-fields__field"
+					/>
+				</div>
+
+				<div className="contact-details-form-fields__row">
+					<CountrySelectMenu
+						countriesList={ this.props.countriesList }
+						errorMessage={ this.props.contactDetailsErrors.countryCode }
+						isDisabled={ this.props.getIsFieldDisabled( 'country-code' ) }
+						isError={ !! this.props.contactDetailsErrors.countryCode }
+						onChange={ ( event ) => {
+							this.handleFieldChange( 'country-code', event.currentTarget.value );
+						} }
+						currentValue={ this.props.contactDetails.countryCode }
 					/>
 				</div>
 			</>

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -257,16 +257,18 @@ export class ManagedContactDetailsFormFields extends Component<
 				</div>
 
 				<div className="contact-details-form-fields__row">
-					<CountrySelectMenu
-						countriesList={ this.props.countriesList }
-						errorMessage={ this.props.contactDetailsErrors.countryCode }
-						isDisabled={ this.props.getIsFieldDisabled( 'country-code' ) }
-						isError={ !! this.props.contactDetailsErrors.countryCode }
-						onChange={ ( event ) => {
-							this.handleFieldChange( 'country-code', event.currentTarget.value );
-						} }
-						currentValue={ this.props.contactDetails.countryCode }
-					/>
+					<div className="contact-details-form-fields__country">
+						<CountrySelectMenu
+							countriesList={ this.props.countriesList }
+							errorMessage={ this.props.contactDetailsErrors.countryCode }
+							isDisabled={ this.props.getIsFieldDisabled( 'country-code' ) }
+							isError={ !! this.props.contactDetailsErrors.countryCode }
+							onChange={ ( event ) => {
+								this.handleFieldChange( 'country-code', event.currentTarget.value );
+							} }
+							currentValue={ this.props.contactDetails.countryCode }
+						/>
+					</div>
 				</div>
 			</>
 		);

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -24,6 +24,16 @@
 		margin-top: 15px;
 	}
 
+	.contact-details-form-fields__country {
+		flex-grow: 1;
+		flex-basis: 0;
+		margin-top: 15px;
+	}
+
+	.contact-details-form-fields__country label {
+		margin-bottom: 5px;
+	}
+
 	@include breakpoint-deprecated( ">660px" ) {
 		.contact-details-form-fields__field.last-name,
 		.contact-details-form-fields__field.phone {

--- a/client/components/forms/form-phone-media-input/index.tsx
+++ b/client/components/forms/form-phone-media-input/index.tsx
@@ -4,7 +4,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import PhoneInput from 'calypso/components/phone-input';
 import type { CountryListItem } from '@automattic/wpcom-checkout';
 import type { PhoneInputValue } from 'calypso/components/phone-input';
-import type { FC, MutableRefObject } from 'react';
+import type { FC, MutableRefObject, ReactNode } from 'react';
 
 export type FormPhoneMediaInputProps = {
 	additionalClasses?: string;
@@ -13,7 +13,7 @@ export type FormPhoneMediaInputProps = {
 	value: PhoneInputValue;
 	className?: string;
 	disabled?: boolean;
-	errorMessage?: string;
+	errorMessage?: ReactNode;
 	isError?: boolean;
 	onChange: ( newValueAndCountry: PhoneInputValue ) => void;
 	countriesList: CountryListItem[];

--- a/client/components/phone-input/phone-number.ts
+++ b/client/components/phone-input/phone-number.ts
@@ -275,7 +275,7 @@ export function toE164( inputNumber: string, country: CountryData ) {
 	return '+' + country.dialCode + nationalNumber;
 }
 
-export function toIcannFormat( inputNumber: string, country: CountryData ) {
+export function toIcannFormat( inputNumber: string, country: CountryData | undefined ) {
 	if ( ! country ) {
 		return inputNumber;
 	}

--- a/client/my-sites/checkout/composite-checkout/components/country-select-menu.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/country-select-menu.tsx
@@ -5,7 +5,6 @@ import type { CountryListItem } from '@automattic/wpcom-checkout';
 import type { HTMLProps, ReactChild } from 'react';
 
 export default function CountrySelectMenu( {
-	translate,
 	onChange,
 	isDisabled,
 	isError,
@@ -13,7 +12,6 @@ export default function CountrySelectMenu( {
 	currentValue,
 	countriesList,
 }: {
-	translate: ReturnType< typeof useTranslate >;
 	onChange: HTMLProps< HTMLSelectElement >[ 'onChange' ];
 	isDisabled?: boolean;
 	isError?: boolean;
@@ -24,6 +22,7 @@ export default function CountrySelectMenu( {
 	const countrySelectorId = 'country-selector';
 	const countrySelectorLabelId = 'country-selector-label';
 	const countrySelectorDescriptionId = 'country-selector-description';
+	const translate = useTranslate();
 
 	return (
 		<FormFieldAnnotation

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -71,7 +71,6 @@ export default function TaxFields( {
 
 	const fields: JSX.Element[] = [
 		<CountrySelectMenu
-			translate={ translate }
 			onChange={ ( event: ChangeEvent< HTMLSelectElement > ) => {
 				onChange(
 					updateOnChangePayload(


### PR DESCRIPTION
## Proposed Changes

This converts the `ManagedContactDetailsFormFields` component to TypeScript and in the process refactors it to render explicit input components rather than using React's `createElement()`.

Before and after this change, the component should look something like this:

<img width="575" alt="Screenshot 2023-06-12 at 7 10 36 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/99505a4c-3c72-4a54-acf8-1e43144aac05">

## Testing Instructions

- Visit the calypso home page for a site and click "Upgrades" > "Domains" in the sidebar.
- Follow the flow to add a domain to your shopping cart.
- You should end up in checkout.
- Click "Edit" on the contact details step if it is already completed.
- Verify that the step looks the same before and after this change.
- Change the viewport width to be sure that the form looks good at different widths.
- Change the country (eg: Canada and France have quite different fields) to verify that the form looks good with different sets of fields.