### PR TITLE
Stats: Add module toggling tooltip

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -39,6 +39,7 @@ class StatsNavigation extends Component {
 
 	state = {
 		isPageSettingsPopoverVisible: false,
+		isPageSettingsTooltipVisible: true,
 		// Only traffic page modules are supported for now.
 		pageModules: Object.assign(
 			...AVAILABLE_PAGE_MODULES.traffic.map( ( module ) => {
@@ -60,6 +61,7 @@ class StatsNavigation extends Component {
 	settingsActionRef = createRef();
 
 	togglePopoverMenu = ( isPageSettingsPopoverVisible ) => {
+		this.onTooltipDismiss();
 		this.setState( { isPageSettingsPopoverVisible } );
 	};
 
@@ -72,6 +74,10 @@ class StatsNavigation extends Component {
 		this.props.updateModuleToggles( this.props.siteId, {
 			[ page ]: seletedPageModules,
 		} );
+	};
+
+	onTooltipDismiss = () => {
+		this.setState( { isPageSettingsTooltipVisible: false } );
 	};
 
 	isValidItem = ( item ) => {
@@ -102,7 +108,7 @@ class StatsNavigation extends Component {
 
 	render() {
 		const { slug, selectedItem, interval, isLegacy } = this.props;
-		const { pageModules, isPageSettingsPopoverVisible } = this.state;
+		const { pageModules, isPageSettingsPopoverVisible, isPageSettingsTooltipVisible } = this.state;
 		const { label, showIntervals, path } = navItems[ selectedItem ];
 		const slugPath = slug ? `/${ slug }` : '';
 		const pathTemplate = `${ path }/{{ interval }}${ slugPath }`;
@@ -161,6 +167,21 @@ class StatsNavigation extends Component {
 						>
 							<Icon className="gridicon" icon={ cog } />
 						</button>
+						<Popover
+							className="tooltip tooltip--darker highlight-card-tooltip highlight-card__settings-tooltip"
+							isVisible={ isPageSettingsTooltipVisible }
+							position="bottom left"
+							context={ this.settingsActionRef.current }
+						>
+							<div className="highlight-card-tooltip-content">
+								<p>
+									{ translate(
+										'You can now tailor your site highlights by adjusting the time range.'
+									) }
+								</p>
+								<button onClick={ this.onTooltipDismiss }>{ translate( 'Got it' ) }</button>
+							</div>
+						</Popover>
 						<Popover
 							className="tooltip highlight-card-popover page-modules-settings-popover"
 							isVisible={ isPageSettingsPopoverVisible }

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -146,7 +146,7 @@ class StatsNavigation extends Component {
 			'stats-navigation--modernized': ! isLegacy,
 		} );
 
-		const isHighlightsSettingsEnabled = config.isEnabled( 'stats/module-settings' );
+		const isModuleSettingsEnabled = config.isEnabled( 'stats/module-settings' );
 
 		// @TODO: Add loading status of modules settings to avoid toggling modules before they are loaded.
 
@@ -185,7 +185,7 @@ class StatsNavigation extends Component {
 					<Intervals selected={ interval } pathTemplate={ pathTemplate } standalone />
 				) }
 
-				{ isHighlightsSettingsEnabled && AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] && (
+				{ isModuleSettingsEnabled && AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] && (
 					<div className="page-modules-settings">
 						<button
 							className="page-modules-settings-action"

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -203,11 +203,7 @@ class StatsNavigation extends Component {
 							context={ this.settingsActionRef.current }
 						>
 							<div className="highlight-card-tooltip-content">
-								<p>
-									{ translate(
-										'You can now tailor your site highlights by adjusting the time range.'
-									) }
-								</p>
+								<p>{ translate( 'Here’s where you can find all your Jetpack Stats settings.' ) }</p>
 								<button onClick={ this.onTooltipDismiss }>{ translate( 'Got it' ) }</button>
 							</div>
 						</Popover>

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -211,6 +211,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	}
 }
 .tooltip.popover {
+	// @TODO: Refactor styling into the Popover component for more extensive usage. E.g., tooltip and popover in StatsNavigation.
 	&.highlight-card-tooltip,
 	&.highlight-card-popover { // overload tooltip's styles
 		.popover__inner {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #77861 

## Proposed Changes

* Add the notice tooltip to the module toggling panel along with API requests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the live branch link.
* Navigate to the Stats > `Traffic` page.
* Append the feature flag to the URL: `?flags=stats/module-settings`.
* Ensure the notice tooltip shows attaching on the module toggling panel launch button.
* Dismiss the tooltip by clicking the `Got it` button or the launching button.
* Ensure the notice tooltip is dismissed.
* Reload the page.
* Ensure the notice tooltip is dismissed permanently.

<img width="1288" alt="截圖 2023-06-08 上午5 12 56" src="https://github.com/Automattic/wp-calypso/assets/6869813/f9d506a9-af59-479d-af9f-70f57b6ebaba">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
