### PR TITLE
Import onboarding: Add unit tests

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @jest-environment jsdom
+ */
+import { SiteDetails } from '@automattic/data-stores';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { useSiteMigrateInfo } from 'calypso/blocks/importer/hooks/use-site-can-migrate';
+import { createReduxStore } from 'calypso/state';
+import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
+import initialReducer from 'calypso/state/reducer';
+import { setStore } from 'calypso/state/redux-store';
+import isRequestingSiteCredentials from 'calypso/state/selectors/is-requesting-site-credentials';
+import PreMigration from '../index';
+
+const user = {
+	ID: 1234,
+	username: 'testUser',
+	email: 'testemail@wordpress.com',
+	email_verified: false,
+};
+
+const sourceSite: Partial< SiteDetails > = {
+	ID: 777712,
+	slug: 'self-hosted.example.com',
+	URL: 'https://self-hosted.example.com',
+};
+
+const targetSite: Partial< SiteDetails > = {
+	ID: 9123123,
+	URL: 'https://example_test.wordpress.com',
+};
+
+const onContentOnlyClick = jest.fn();
+
+jest.mock( 'react-router-dom', () => ( {
+	...( jest.requireActual( 'react-router-dom' ) as object ),
+	useLocation: jest.fn().mockImplementation( () => ( {
+		pathname: '/setup/import-focused/importerWordpress',
+		search: `?from=${ sourceSite.URL }&siteSlug=${ targetSite.URL }&option=everything`,
+		hash: '',
+		state: undefined,
+	} ) ),
+} ) );
+
+jest.mock( 'calypso/blocks/importer/hooks/use-site-can-migrate' );
+jest.mock( 'calypso/state/selectors/is-requesting-site-credentials' );
+
+function renderPreMigrationScreen( props?: any ) {
+	const initialState = getInitialState( initialReducer, user.ID );
+	const reduxStore = createReduxStore(
+		{
+			...initialState,
+			currentUser: {
+				user: {
+					...user,
+				},
+			},
+		},
+		initialReducer
+	);
+
+	setStore( reduxStore, getStateFromCache( user.ID ) );
+	const queryClient = new QueryClient();
+
+	return render(
+		<Provider store={ reduxStore }>
+			<QueryClientProvider client={ queryClient }>
+				<PreMigration { ...props } />
+			</QueryClientProvider>
+		</Provider>
+	);
+}
+
+describe( 'PreMigration', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'should show Upgrade plan screen', () => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		useSiteMigrateInfo.mockReturnValue( {
+			sourceSiteId: 777712,
+			sourceSite: sourceSite as SiteDetails,
+			fetchMigrationEnabledStatus: '',
+			isFetchingData: false,
+		} );
+
+		renderPreMigrationScreen( {
+			targetSite: targetSite,
+			isTargetSitePlanCompatible: false,
+			isMigrateFromWp: true,
+			onContentOnlyClick,
+		} );
+
+		expect( screen.getByText( 'Upgrade your plan' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Upgrade and migrate' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Use the content-only import option' ) ).toBeInTheDocument();
+
+		// Click on "Use the content-only import option"
+		const button = screen.getByText( 'Use the content-only import option' );
+		fireEvent.click( button );
+		expect( onContentOnlyClick ).toHaveBeenCalled();
+	} );
+
+	test( 'should show "Move to wordpress.com" plugin update', () => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		useSiteMigrateInfo.mockImplementationOnce(
+			( targetSiteId, sourceSiteSlug, fetchMigrationEnabledOnMount, onfetchCallback ) => {
+				onfetchCallback( false );
+
+				return {
+					sourceSiteId: 777712,
+					sourceSite: sourceSite as SiteDetails,
+					fetchMigrationEnabledStatus: '',
+					isFetchingData: false,
+				};
+			}
+		);
+
+		renderPreMigrationScreen( {
+			targetSite: targetSite,
+			isTargetSitePlanCompatible: false,
+			isMigrateFromWp: true,
+			onContentOnlyClick,
+		} );
+
+		expect( screen.getByText( 'Update ‘Move to WordPress.com’' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Update plugin' ) ).toBeInTheDocument();
+	} );
+
+	test( 'should show "Jetpack" plugin update', () => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		useSiteMigrateInfo.mockImplementationOnce(
+			( targetSiteId, sourceSiteSlug, fetchMigrationEnabledOnMount, onfetchCallback ) => {
+				onfetchCallback( false );
+
+				return {
+					sourceSiteId: 777712,
+					sourceSite: sourceSite as SiteDetails,
+					fetchMigrationEnabledStatus: '',
+					isFetchingData: false,
+				};
+			}
+		);
+
+		renderPreMigrationScreen( {
+			targetSite: targetSite,
+			isTargetSitePlanCompatible: false,
+			isMigrateFromWp: false,
+			onContentOnlyClick,
+		} );
+
+		expect( screen.getAllByText( 'Install Jetpack' ).at( 0 ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Jetpack required' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Install Jetpack manually' ) ).toBeInTheDocument();
+	} );
+
+	test( 'should show migration ready screen', async () => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		useSiteMigrateInfo.mockReturnValue( {
+			sourceSiteId: 777712,
+			sourceSite: sourceSite as SiteDetails,
+			fetchMigrationEnabledStatus: '',
+			isFetchingData: false,
+		} );
+
+		renderPreMigrationScreen( {
+			targetSite: targetSite,
+			isTargetSitePlanCompatible: true,
+			isMigrateFromWp: true,
+			onContentOnlyClick,
+		} );
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		isRequestingSiteCredentials.mockReturnValue( false );
+
+		expect( screen.getByText( 'You are ready to migrate' ) ).toBeInTheDocument();
+
+		const provideCredentialsBtn = screen.getByText( 'Provide the server credentials' );
+		expect( provideCredentialsBtn ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByText( 'Start migration' ) );
+		const confirmModal = await screen.findByText( 'Confirm your choice' );
+		expect( confirmModal ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByText( 'Cancel' ) );
+		expect( confirmModal ).not.toBeInTheDocument();
+
+		fireEvent.click( provideCredentialsBtn );
+		expect( screen.getByText( 'Do you need help locating your credentials?' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Start migration' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Skip credentials (slower setup)' ) ).toBeInTheDocument();
+
+		const hostAddressInput = document.getElementById( 'host-address' ) as HTMLInputElement;
+		expect( hostAddressInput.value ).toBe( sourceSite.slug );
+
+		fireEvent.click( screen.getByText( 'Start migration' ) );
+		expect( screen.getByText( 'Confirm your choice' ) ).toBeInTheDocument();
+		fireEvent.click( screen.getByText( 'Continue' ) );
+		expect(
+			screen.getByText( 'Please make sure all fields are filled in correctly before proceeding.' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
@@ -83,7 +83,7 @@ describe( 'PreMigration', () => {
 		useSiteMigrateInfo.mockReturnValue( {
 			sourceSiteId: 777712,
 			sourceSite: sourceSite as SiteDetails,
-			fetchMigrationEnabledStatus: '',
+			fetchMigrationEnabledStatus: jest.fn(),
 			isFetchingData: false,
 		} );
 
@@ -114,7 +114,7 @@ describe( 'PreMigration', () => {
 				return {
 					sourceSiteId: 777712,
 					sourceSite: sourceSite as SiteDetails,
-					fetchMigrationEnabledStatus: '',
+					fetchMigrationEnabledStatus: jest.fn(),
 					isFetchingData: false,
 				};
 			}
@@ -141,7 +141,7 @@ describe( 'PreMigration', () => {
 				return {
 					sourceSiteId: 777712,
 					sourceSite: sourceSite as SiteDetails,
-					fetchMigrationEnabledStatus: '',
+					fetchMigrationEnabledStatus: jest.fn(),
 					isFetchingData: false,
 				};
 			}
@@ -165,7 +165,7 @@ describe( 'PreMigration', () => {
 		useSiteMigrateInfo.mockReturnValue( {
 			sourceSiteId: 777712,
 			sourceSite: sourceSite as SiteDetails,
-			fetchMigrationEnabledStatus: '',
+			fetchMigrationEnabledStatus: jest.fn(),
 			isFetchingData: false,
 		} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -36,7 +36,6 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 
 	useEffect( () => {
 		setIsMigrateFromWp( true );
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/test/index.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
+import MigrationHandler from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/migration-handler';
+import { createReduxStore } from 'calypso/state';
+import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
+import initialReducer from 'calypso/state/reducer';
+import { setStore } from 'calypso/state/redux-store';
+
+const user = {
+	ID: 1234,
+	username: 'testUser',
+	email: 'testemail@wordpress.com',
+	email_verified: false,
+};
+
+const navigation = {
+	goBack: jest.fn(),
+	goNext: jest.fn(),
+	submit: jest.fn(),
+};
+
+jest.mock( 'react-router-dom', () => ( {
+	...( jest.requireActual( 'react-router-dom' ) as object ),
+	useLocation: jest.fn().mockImplementation( () => ( {
+		pathname: '/setup/import-focused/migrationHandler',
+		search: `?from=self-hosted.site`,
+		hash: '',
+		state: undefined,
+	} ) ),
+} ) );
+
+jest.mock( 'calypso/data/site-migration/use-source-migration-status-query' );
+jest.mock( 'calypso/data/sites/use-site-excerpts-query', () => ( {
+	useSiteExcerptsQuery: () => ( {
+		data: [],
+	} ),
+} ) );
+
+function renderMigrationHandlerStep() {
+	const initialState = getInitialState( initialReducer, user.ID );
+	const reduxStore = createReduxStore(
+		{
+			...initialState,
+			currentUser: {
+				user: {
+					...user,
+				},
+			},
+		},
+		initialReducer
+	);
+	setStore( reduxStore, getStateFromCache( user.ID ) );
+	const queryClient = new QueryClient();
+
+	return render(
+		<Provider store={ reduxStore }>
+			<QueryClientProvider client={ queryClient }>
+				<MigrationHandler
+					flow="import-focused"
+					stepName="migration-handler"
+					navigation={ navigation }
+				/>
+			</QueryClientProvider>
+		</Provider>
+	);
+}
+
+describe( 'MigrationHandlerStep', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'should not run navigation submit', async () => {
+		useSourceMigrationStatusQuery.mockImplementation( () => ( {
+			data: {
+				status: 'inactive',
+				target_blog_id: 1234,
+				is_target_blog_admin: true,
+				is_target_blog_upgraded: true,
+				target_blog_slug: 'test_blog_slug',
+			},
+			isError: true,
+		} ) );
+		renderMigrationHandlerStep();
+
+		expect( screen.getByText( 'Scanning your site' ) ).toBeInTheDocument();
+		expect( jest.spyOn( navigation, 'submit' ) ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should run navigation submit', async () => {
+		useSourceMigrationStatusQuery.mockImplementationOnce( () => ( {
+			data: {
+				status: 'inactive',
+				target_blog_id: 1234,
+				is_target_blog_admin: true,
+				is_target_blog_upgraded: true,
+				target_blog_slug: 'test_blog_slug',
+			},
+			isError: false,
+		} ) );
+
+		renderMigrationHandlerStep();
+
+		expect( screen.getByText( 'Scanning your site' ) ).toBeInTheDocument();
+		expect( jest.spyOn( navigation, 'submit' ) ).toHaveBeenCalled();
+	} );
+
+	test( 'should show non authorized screen', async () => {
+		useSourceMigrationStatusQuery.mockImplementationOnce( ( sourceIdOrSlug, onErrorCallback ) => {
+			onErrorCallback?.();
+			return { data: {}, isError: true };
+		} );
+
+		renderMigrationHandlerStep();
+
+		await waitFor( () => {
+			expect( jest.spyOn( navigation, 'submit' ) ).not.toHaveBeenCalled();
+			expect( screen.getByText( 'You are not authorized to import content' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Please check with your site admin.' ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/test/index.test.tsx
@@ -3,7 +3,6 @@
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { Provider } from 'react-redux';
 import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
 import MigrationHandler from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/migration-handler';
@@ -77,6 +76,8 @@ describe( 'MigrationHandlerStep', () => {
 	} );
 
 	test( 'should not run navigation submit', async () => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
 		useSourceMigrationStatusQuery.mockImplementation( () => ( {
 			data: {
 				status: 'inactive',
@@ -94,6 +95,8 @@ describe( 'MigrationHandlerStep', () => {
 	} );
 
 	test( 'should run navigation submit', async () => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
 		useSourceMigrationStatusQuery.mockImplementationOnce( () => ( {
 			data: {
 				status: 'inactive',
@@ -112,6 +115,8 @@ describe( 'MigrationHandlerStep', () => {
 	} );
 
 	test( 'should show non authorized screen', async () => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
 		useSourceMigrationStatusQuery.mockImplementationOnce( ( sourceIdOrSlug, onErrorCallback ) => {
 			onErrorCallback?.();
 			return { data: {}, isError: true };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
@@ -1,0 +1,153 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE,
+	GroupableSiteLaunchStatuses,
+} from '@automattic/sites';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import nock from 'nock';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import SitePicker from '../site-picker';
+
+const renderComponent = ( component: JSX.Element, initialState = {} ) => {
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	return render(
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ component }</QueryClientProvider>
+		</Provider>
+	);
+};
+
+describe( 'SitePicker', () => {
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	const noop = () => {};
+
+	const defaultProps = {
+		page: 1,
+		perPage: 96,
+		search: '',
+		status: DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE as GroupableSiteLaunchStatuses,
+		onCreateSite: noop,
+		onSelectSite: noop,
+		onQueryParamChange: noop,
+	};
+	const initialState = {
+		sites: {
+			items: {
+				1: {
+					ID: 1,
+					name: 'A Test Site',
+					URL: 'example.wordpress.com',
+					plan: {
+						product_slug: 'free_plan',
+					},
+				},
+				2: {
+					ID: 2,
+					name: 'Another test Site',
+					URL: 'test.wordpress.com',
+					plan: {
+						product_slug: 'free_plan',
+					},
+				},
+			},
+			domains: {
+				items: {
+					1: [
+						{
+							domain: 'example.wordpress.com',
+							isWPCOMDomain: true,
+						},
+					],
+				},
+			},
+			plans: {
+				1: {
+					product_slug: 'free_plan',
+				},
+			},
+		},
+		ui: { selectedSiteId: 1 },
+		preferences: {
+			remoteValues: {
+				'sites-sorting': 'alphabetically-asc',
+			},
+		},
+		currentUser: {
+			capabilities: {},
+		},
+	};
+
+	beforeAll( () => {
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( ( uri ) => uri.startsWith( '/rest/v1.2/me/sites' ) )
+			.reply( 200, { sites: initialState.sites.items } );
+
+		const mockIntersectionObserver = jest.fn();
+		mockIntersectionObserver.mockReturnValue( {
+			observe: () => null,
+			unobserve: () => null,
+			disconnect: () => null,
+		} );
+		window.IntersectionObserver = mockIntersectionObserver;
+	} );
+
+	test( 'renders with correct list of sites', () => {
+		const { getByText, container } = renderComponent(
+			<SitePicker { ...defaultProps } />,
+			initialState
+		);
+
+		expect( getByText( 'Pick your destination' ) ).toBeInTheDocument();
+
+		const allLinks = container.getElementsByClassName( 'components-external-link' );
+		expect( allLinks.length ).toBeGreaterThan( 0 );
+		expect( allLinks[ 0 ] ).toHaveAttribute( 'href', initialState.sites.items[ 1 ].URL );
+	} );
+
+	test( 'renders with correctly sorted list of sites', () => {
+		const state = {
+			...initialState,
+			preferences: {
+				remoteValues: {
+					'sites-sorting': 'lastInteractedWith-desc',
+				},
+			},
+		};
+
+		const { container } = renderComponent( <SitePicker { ...defaultProps } />, state );
+
+		const allLinks = container.getElementsByClassName( 'components-external-link' );
+		expect( allLinks.length ).toBeGreaterThan( 0 );
+		expect( allLinks[ 0 ] ).toHaveAttribute( 'href', initialState.sites.items[ 1 ].URL );
+	} );
+
+	test( 'renders without sites when not valid search term', () => {
+		const props = {
+			...defaultProps,
+			search: 'notfound',
+		};
+
+		renderComponent( <SitePicker { ...props } />, initialState );
+
+		expect( screen.getByText( 'No sites match your search.' ) ).toBeVisible();
+	} );
+
+	test( 'renders without sites when not valid status', () => {
+		const props = {
+			...defaultProps,
+			status: 'private' as GroupableSiteLaunchStatuses,
+		};
+
+		renderComponent( <SitePicker { ...props } />, initialState );
+
+		expect( screen.getByText( 'You have no private sites' ) ).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77842

## Proposed Changes

* Added unit tests for migrationHandler and sitePicker steps

## Testing Instructions

* Regular unit test runner

Or, if you want to run it manually:
- `npx jest -c=test/client/jest.config.js pre-migration steps-repository/site-picker migration-handler`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
