### PR TITLE
Adds the credits section to the new Advertising page

### DIFF
--- a/client/data/promote-post/use-promote-post-credit-balance-query.ts
+++ b/client/data/promote-post/use-promote-post-credit-balance-query.ts
@@ -15,7 +15,7 @@ const useCreditBalanceQuery = ( queryOptions = {} ) => {
 					wpcomUserId,
 					`/credits/balance`
 				);
-				return balance;
+				return balance ? parseInt( balance ) : undefined;
 			}
 			throw new Error( 'wpcomUserId is undefined' );
 		},

--- a/client/my-sites/promote-post-i2/components/credit-balance/index.tsx
+++ b/client/my-sites/promote-post-i2/components/credit-balance/index.tsx
@@ -6,8 +6,9 @@ interface Props {
 	balance?: number;
 }
 
-const CreditBalance = ( { balance }: Props ) => {
-	if ( balance === undefined || balance === 0 ) {
+const CreditBalance = ( { balance = 0 }: Props ) => {
+	// Hide the section if balance is invalid or is 0
+	if ( ! balance || balance === 0 ) {
 		return null;
 	}
 

--- a/client/my-sites/promote-post-i2/components/credit-balance/index.tsx
+++ b/client/my-sites/promote-post-i2/components/credit-balance/index.tsx
@@ -1,0 +1,37 @@
+import { memo } from '@wordpress/element';
+import { translate, numberFormat } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+
+interface Props {
+	balance?: number;
+}
+
+const CreditBalance = ( { balance }: Props ) => {
+	if ( balance === undefined || balance === 0 ) {
+		return null;
+	}
+
+	return (
+		<div className="promote-post-i2__aux-wrapper">
+			<div className="empty-promotion-list__container">
+				<h3 className="empty-promotion-list__title wp-brand-font">
+					${ numberFormat( balance, 2 ) }
+				</h3>
+				<p className="empty-promotion-list__body">
+					{ translate(
+						'Available credits that will be automatically applied toward your next campaigns. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',
+						{
+							components: {
+								learnMoreLink: (
+									<InlineSupportLink supportContext="blaze_credits" showIcon={ false } />
+								),
+							},
+						}
+					) }
+				</p>
+			</div>
+		</div>
+	);
+};
+
+export default memo( CreditBalance );

--- a/client/my-sites/promote-post-i2/components/empty-promotion-list/style.scss
+++ b/client/my-sites/promote-post-i2/components/empty-promotion-list/style.scss
@@ -1,12 +1,17 @@
+@import "@automattic/color-studio/dist/color-variables";
 .promote-post-i2 {
 	.empty-promotion-list__container {
 		text-align: center;
 		margin-top: 80px;
 		padding: 0 20px;
 		.empty-promotion-list__title {
-			font-weight: 700;
-			font-size: $font-title-small;
+			font-weight: 400;
+			font-size: $font-title-large;
 			margin-bottom: 20px;
+		}
+		.empty-promotion-list__body {
+			font-size: $font-body;
+			color: $studio-gray-50;
 		}
 	}
 }

--- a/client/my-sites/promote-post-i2/components/promoted-post-filter/index.tsx
+++ b/client/my-sites/promote-post-i2/components/promoted-post-filter/index.tsx
@@ -1,8 +1,9 @@
+import { numberFormat } from 'i18n-calypso';
+import { useRef } from 'react';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import { TabType } from 'calypso/my-sites/promote-post/main';
-import { TabOption } from 'calypso/my-sites/promote-post-i2/main';
+import { TabOption, TabType } from 'calypso/my-sites/promote-post-i2/main';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getAdvertisingDashboardPath } from '../../utils';
@@ -15,20 +16,40 @@ type Props = {
 export default function PromotePostTabBar( { tabs, selectedTab }: Props ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
+	// Smooth horizontal scrolling on mobile views
+	const tabsRef = useRef< { [ key: string ]: HTMLSpanElement | null } >( {} );
+	const onTabClick = ( key: string ) => {
+		tabsRef.current[ key ]?.scrollIntoView( {
+			behavior: 'smooth',
+			block: 'nearest',
+			inline: 'center',
+		} );
+	};
+
 	return (
 		<SectionNav>
 			<NavTabs>
-				{ tabs.map( ( { id, name, itemCount } ) => {
-					return (
-						<NavItem
-							key={ id }
-							path={ getAdvertisingDashboardPath( `/${ selectedSiteSlug }/${ id }` ) }
-							selected={ selectedTab === id }
-							children={ name }
-							count={ itemCount }
-						/>
-					);
-				} ) }
+				{ tabs
+					.filter( ( { enabled = true } ) => enabled )
+					.map( ( { id, name, itemCount, isCountAmount, className } ) => {
+						return (
+							<NavItem
+								key={ id }
+								path={ getAdvertisingDashboardPath( `/${ selectedSiteSlug }/${ id }` ) }
+								selected={ selectedTab === id }
+								className={ className }
+								onClick={ () => onTabClick( id ) }
+							>
+								<span ref={ ( el ) => ( tabsRef.current[ id ] = el ) }>{ name }</span>
+								{ itemCount && itemCount !== 0 ? (
+									<span className="count">
+										{ isCountAmount ? '$' : null }
+										{ numberFormat( itemCount, isCountAmount ? 2 : 0 ) }
+									</span>
+								) : null }
+							</NavItem>
+						);
+					} ) }
 			</NavTabs>
 		</SectionNav>
 	);

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -12,6 +12,7 @@ import Main from 'calypso/components/main';
 import useCampaignsQueryPaged, {
 	Campaign,
 } from 'calypso/data/promote-post/use-promote-post-campaigns-query-paged';
+import useCreditBalanceQuery from 'calypso/data/promote-post/use-promote-post-credit-balance-query';
 import usePostsQueryPaged from 'calypso/data/promote-post/use-promote-post-posts-query-paged';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import CampaignsList from 'calypso/my-sites/promote-post-i2/components/campaigns-list';
@@ -21,16 +22,20 @@ import { SearchOptions } from 'calypso/my-sites/promote-post-i2/components/searc
 import { getPagedBlazeSearchData } from 'calypso/my-sites/promote-post-i2/utils';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import CreditBalance from './components/credit-balance';
 import { BlazablePost } from './components/post-item';
 import PostsListBanner from './components/posts-list-banner';
 import useOpenPromoteWidget from './hooks/use-open-promote-widget';
 import { getAdvertisingDashboardPath } from './utils';
 
-export type TabType = 'posts' | 'campaigns';
+export type TabType = 'posts' | 'campaigns' | 'credits';
 export type TabOption = {
 	id: TabType;
 	name: string;
-	itemCount: number | null;
+	itemCount?: number;
+	isCountAmount?: boolean;
+	className?: string;
+	enabled?: boolean;
 };
 
 interface Props {
@@ -52,7 +57,7 @@ export type PagedBlazeSearchResponse = {
 };
 
 export default function PromotedPosts( { tab }: Props ) {
-	const selectedTab = tab === 'campaigns' ? 'campaigns' : 'posts';
+	const selectedTab = tab && [ 'campaigns', 'posts', 'credits' ].includes( tab ) ? tab : 'posts';
 	const selectedSite = useSelector( getSelectedSite );
 	const selectedSiteId = selectedSite?.ID || 0;
 	const translate = useTranslate();
@@ -60,6 +65,8 @@ export default function PromotedPosts( { tab }: Props ) {
 		keyValue: 'post-0', // post 0 means to open post selector in widget
 		entrypoint: 'promoted_posts-header',
 	} );
+
+	const { data: creditBalance } = useCreditBalanceQuery();
 
 	/* query for campaigns */
 	const [ campaignsSearchOptions, setCampaignsSearchOptions ] = useState< SearchOptions >( {} );
@@ -126,12 +133,20 @@ export default function PromotedPosts( { tab }: Props ) {
 		{
 			id: 'posts',
 			name: translate( 'Ready to promote' ),
-			itemCount: totalPostsUnfiltered || null,
+			itemCount: totalPostsUnfiltered,
 		},
 		{
 			id: 'campaigns',
 			name: translate( 'Campaigns' ),
-			itemCount: totalCampaignsUnfiltered || null,
+			itemCount: totalCampaignsUnfiltered,
+		},
+		{
+			id: 'credits',
+			name: translate( 'Credits' ),
+			className: 'pull-right',
+			itemCount: creditBalance,
+			isCountAmount: true,
+			enabled: creditBalance !== undefined && creditBalance !== 0,
 		},
 	];
 
@@ -218,7 +233,9 @@ export default function PromotedPosts( { tab }: Props ) {
 			{ showBanner && <PostsListBanner /> }
 
 			<PromotePostTabBar tabs={ tabs } selectedTab={ selectedTab } />
-			{ selectedTab === 'campaigns' ? (
+
+			{ /* Render campaigns tab */ }
+			{ selectedTab === 'campaigns' && (
 				<>
 					<PageViewTracker
 						path={ getAdvertisingDashboardPath( '/:site/campaigns' ) }
@@ -235,24 +252,37 @@ export default function PromotedPosts( { tab }: Props ) {
 						campaigns={ campaigns as Campaign[] }
 					/>
 				</>
-			) : (
-				<PageViewTracker
-					path={ getAdvertisingDashboardPath( '/:site/posts' ) }
-					title="Advertising > Ready to Blaze"
-				/>
 			) }
 
-			{ selectedTab === 'posts' && (
-				<PostsList
-					isLoading={ postsIsLoadingNewContent }
-					isFetching={ postIsFetching }
-					isError={ postError as DSPMessage }
-					fetchNextPage={ fetchPostsNextPage }
-					handleSearchOptions={ setPostsSearchOptions }
-					totalCampaigns={ totalPostsUnfiltered || 0 }
-					hasMorePages={ postsHasMorePages }
-					posts={ posts as BlazablePost[] }
-				/>
+			{ /* Render credits tab */ }
+			{ selectedTab === 'credits' && (
+				<>
+					<PageViewTracker
+						path={ getAdvertisingDashboardPath( '/:site/credits' ) }
+						title="Advertising > Credits"
+					/>
+					<CreditBalance balance={ creditBalance } />
+				</>
+			) }
+
+			{ /* Render products tab */ }
+			{ selectedTab !== 'campaigns' && selectedTab !== 'credits' && (
+				<>
+					<PageViewTracker
+						path={ getAdvertisingDashboardPath( '/:site/posts' ) }
+						title="Advertising > Ready to Promote"
+					/>
+					<PostsList
+						isLoading={ postsIsLoadingNewContent }
+						isFetching={ postIsFetching }
+						isError={ postError as DSPMessage }
+						fetchNextPage={ fetchPostsNextPage }
+						handleSearchOptions={ setPostsSearchOptions }
+						totalCampaigns={ totalPostsUnfiltered || 0 }
+						hasMorePages={ postsHasMorePages }
+						posts={ posts as BlazablePost[] }
+					/>
+				</>
 			) }
 		</Main>
 	);

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -66,7 +66,7 @@ export default function PromotedPosts( { tab }: Props ) {
 		entrypoint: 'promoted_posts-header',
 	} );
 
-	const { data: creditBalance } = useCreditBalanceQuery();
+	const { data: creditBalance = 0 } = useCreditBalanceQuery();
 
 	/* query for campaigns */
 	const [ campaignsSearchOptions, setCampaignsSearchOptions ] = useState< SearchOptions >( {} );
@@ -146,7 +146,7 @@ export default function PromotedPosts( { tab }: Props ) {
 			className: 'pull-right',
 			itemCount: creditBalance,
 			isCountAmount: true,
-			enabled: creditBalance !== undefined && creditBalance !== 0,
+			enabled: creditBalance > 0,
 		},
 	];
 
@@ -265,7 +265,7 @@ export default function PromotedPosts( { tab }: Props ) {
 				</>
 			) }
 
-			{ /* Render products tab */ }
+			{ /* Render posts tab */ }
 			{ selectedTab !== 'campaigns' && selectedTab !== 'credits' && (
 				<>
 					<PageViewTracker

--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -35,7 +35,7 @@ body.is-section-promote-post-i2 {
 						display: flex;
 						margin: 0 64px;
 						max-width: 1040px;
-						width: 100%;
+						width: auto;
 					}
 				}
 
@@ -108,6 +108,7 @@ body.is-section-promote-post-i2 {
 		}
 
 		&-buttons {
+			display: flex;
 			.is-primary {
 				background: #3858ea;
 				border: none;
@@ -149,13 +150,25 @@ body.is-section-promote-post-i2 {
 			color: $studio-gray-100;
 		}
 
-		.is-selected .section-nav-tab__link .count {
+		.section-nav-tab__link .count {
 			background: var(--studio-gray-0);
 			color: $studio-gray-80;
 		}
 
 		.section-nav__mobile-header {
 			display: none;
+		}
+
+		@media screen and (max-width: $break-medium) {
+			overflow: auto;
+
+			/* Hide scrollbar for Chrome, Safari and Opera */
+			&::-webkit-scrollbar {
+				display: none;
+			}
+			/* Hide scrollbar for IE, Edge and Firefox */
+			-ms-overflow-style: none;  /* IE and Edge */
+			scrollbar-width: none;  /* Firefox */
 		}
 	}
 
@@ -182,6 +195,15 @@ body.is-section-promote-post-i2 {
 					line-height: 1.67;
 					padding: 0 8px;
 				}
+			}
+		}
+
+		&.pull-right {
+			margin-left: auto;
+			margin-right: 0;
+
+			@media screen and (max-width: $break-medium) {
+				margin: 0;
 			}
 		}
 	}

--- a/client/my-sites/promote-post/components/credit-balance/index.tsx
+++ b/client/my-sites/promote-post/components/credit-balance/index.tsx
@@ -1,7 +1,7 @@
 import './style.scss';
 import { memo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { translate } from 'i18n-calypso';
+import { numberFormat, translate } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import useCreditBalanceQuery from 'calypso/data/promote-post/use-promote-post-credit-balance-query';
@@ -10,7 +10,7 @@ const CreditBalance = () => {
 	const creditBalance = useCreditBalanceQuery();
 	const { data: balance } = creditBalance;
 
-	if ( ! balance || balance === '0.00' ) {
+	if ( ! balance || balance === 0 ) {
 		return null;
 	}
 
@@ -25,7 +25,7 @@ const CreditBalance = () => {
 
 	return (
 		<div className="credit-balance__nav-item">
-			{ __( `Credits: ` ) + `$${ balance }` }
+			{ __( `Credits: ` ) + `$${ numberFormat( balance, 2 ) }` }
 			<InfoPopover
 				className="credit-balance__help-icon"
 				icon="help-outline"

--- a/client/my-sites/promote-post/test/credit-balance.test.tsx
+++ b/client/my-sites/promote-post/test/credit-balance.test.tsx
@@ -10,7 +10,15 @@ jest.mock( 'calypso/data/promote-post/use-promote-post-credit-balance-query' );
 
 describe( 'CreditBalance component', () => {
 	test( 'displays null when balance is not available', () => {
-		useCreditBalanceQuery.mockReturnValue( { data: null } );
+		useCreditBalanceQuery.mockReturnValue( { data: undefined } );
+
+		render( <CreditBalance /> );
+
+		expect( screen.queryByText( /Credits: \$.+/ ) ).toBeNull();
+	} );
+
+	test( 'displays null when balance is invalid', () => {
+		useCreditBalanceQuery.mockReturnValue( { data: NaN } );
 
 		render( <CreditBalance /> );
 
@@ -18,7 +26,7 @@ describe( 'CreditBalance component', () => {
 	} );
 
 	test( 'displays null when balance is 0.00', () => {
-		const mockBalance = '0.00';
+		const mockBalance = 0.0;
 		useCreditBalanceQuery.mockReturnValue( { data: mockBalance } );
 
 		render( <CreditBalance /> );
@@ -26,12 +34,12 @@ describe( 'CreditBalance component', () => {
 		expect( screen.queryByText( /Credits: \$.+/ ) ).toBeNull();
 	} );
 
-	test( 'displays "Credits: $10" when balance is set to 10', () => {
-		const mockBalance = '10.00';
+	test( 'displays "Credits: $10.00" when balance is set to 10', () => {
+		const mockBalance = 10.0;
 		useCreditBalanceQuery.mockReturnValue( { data: mockBalance } );
 
 		render( <CreditBalance /> );
 
-		expect( screen.getByText( /Credits: \$.+/ ) ).toHaveTextContent( `Credits: $${ mockBalance }` );
+		expect( screen.getByText( /Credits: \$.+/ ) ).toHaveTextContent( 'Credits: $10.00' );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

Recently we added the possibility of using credits to promote a post. That functionality already lives inside the Advertising page. 
This PR aims to include that new section in the new design.

**Desktop view:**
![Screenshot 2023-06-07 at 19 52 19](https://github.com/Automattic/wp-calypso/assets/1258162/8f31f667-ec43-4ac5-bcda-dbfb78122227)

**Mobile view:**
![Screenshot 2023-06-07 at 19 52 35](https://github.com/Automattic/wp-calypso/assets/1258162/ddecbaf3-8de9-45d0-9a29-bf38690c1f76)

**Mobile navigation when you have all tabs enabled:**
![2023-06-07 19 53 19](https://github.com/Automattic/wp-calypso/assets/1258162/99797ca6-cc94-4592-9852-3aa02a33e15b)

## Testing Instructions

You will need to have credits for your account; ping me if you need some.

* Check out this branch or enable the `promote-post/redesign-i2` flag in the live preview URL
* Go to Tools->Advertising
* Check that the credit tab is displayed on desktop at the right of the navigation bar
* Click on that tab, and check that the credits page is shown correctly
* Change to a mobile viewport and check that the Credits tabs is shown next to the Campaigns tab
* Click it and verify that the page is shown correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
