### PR TITLE
Backup: Fix typo on clone flow confirmation dialog

### DIFF
--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -315,7 +315,7 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 			<div className="clone-flow__confirmation-popover-heading">{ translate( 'Important!' ) }</div>
 			<div className="clone-flow__confirmation-popover-info">
 				{ translate(
-					'Before continue, be aware that any current content on {{strong}}%(destinationUrl)s{{/strong}} will be overriden based on what you configured to copy.',
+					'Before continuing, be aware that any current content on {{strong}}%(destinationUrl)s{{/strong}} will be overriden based on what you configured to copy.',
 					{
 						args: {
 							destinationUrl: getDestinationUrl(),


### PR DESCRIPTION
Reference: p1686175655145829-slack-CS8UYNPEE

## Proposed Changes
* Fix typo on clone flow confirmation dialog.

<img width="697" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/3140b17f-1d72-4ed7-9a26-195e78ba77e0">

## Testing Instructions
N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?