### PR TITLE
(chore)(error-tracking)(sentry) Change the `sentry-cli` install command in the `Dockerfile.base` to install the latest stable version

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -330,7 +330,7 @@ private object HappyBlocks : WPComPluginBuild(
 private object GutenbergUploadSourceMapsToSentry: BuildType() {
 	init {
 		name = "Upload Source Maps";
-		description = "Uploads sourcemaps for various WordPress.com plugins to Sentry. Often triggered per-comment by a WPCOM post-deploy job.";
+		description = "Uploads sourcemaps for various WordPress.com plugins to Sentry. Often triggered per-commit by a WPCOM post-deploy job.";
 
 		id("WPComPlugins_GutenbergUploadSourceMapsToSentry");
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -119,7 +119,9 @@ RUN wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_
  	apt-get upgrade -y && \
 	apt-get install -y php7.4-cli php7.4-xml php7.4-mbstring docker-compose && \
 	composer install && \
-	# Install sentry-cli.
-	wget -O - https://sentry.io/get-cli/ | bash
+	# Install sentry-cli. We pin it to a version to make it easier to know at a
+	# glance what is the version being used. It's important to keep the JS SDK and
+	# the CLI updated to their latest stable versions.
+	wget -O - https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="2.18.1" bash
 
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/77931.

## Proposed Changes

Change the install combo of commands in the `Dockerfile.base` for installing `sentry-cli` to install the latest stable version. 

I've noticed that source-maps were not working well on Sentry, and it was due to assets not being uploaded or only partially uploaded sometimes (or not being available in the given release, for some reason). I contacted Sentry's support and they told me they changed the way it works in a certain version of the SDK/CLI, and that I either needed to downgrade to a specific version or update the SDK/CLI to the last stable versions currently. This PR aims at updating the `sentry-cli` version.

## Testing Instructions

Similar to the ones here: https://github.com/Automattic/wp-calypso/pull/67240.

