### PR TITLE
Add the wpcom-migration plugin as an incompatible plugin

### DIFF
--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -153,6 +153,7 @@ const incompatiblePlugins = new Set( [
 	'wp-monero-miner-pro',
 	'wp-monero-miner-using-coin-hive',
 	'wp-optimize-by-xtraffic',
+	'wpcom-migration',
 	'wpematico',
 	'wpstagecoach',
 	'yuzo-related-post',


### PR DESCRIPTION
## Proposed Changes

* Add the wpcom-migration plugin to the list of incompatible plugins as it should not be installed on a wpcom site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try to install the Move to WordPress.com plugin. You should see the plugin is greyed out and can not be installed as below:

<img width="1152" alt="Screenshot 2566-06-08 at 11 42 19" src="https://github.com/Automattic/wp-calypso/assets/10244734/bc16c679-2161-41ab-b502-15d1062291f9">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
