### PR TITLE
Visually fix logged out masterbar in reader

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -374,7 +374,7 @@
 	}
 
 	.layout__header-section-content {
-		padding: 24px 24px 36px;
+		padding: 0 24px 36px;
 		@include break-medium {
 			padding: 24px 108px 36px;
 		}
@@ -384,6 +384,16 @@
 		border-bottom: none;
 		background: transparent;
 		color: var(--studio-white);
+		position: static;
+
+		@include breakpoint-deprecated( "<480px" ) {
+			.masterbar__item {
+				padding: 0 4px;
+				&:last-child {
+					padding-right: 20px;
+				}
+			}
+		}
 	}
 
 	// logged out master bar


### PR DESCRIPTION
Currently the `/tag/$tag` and `/read/search` pages show the masterbar when the user is logged out.
Currently the bar is `position:fixed` with a transparent background which causes text to become illegible when scrolling down.
This PR makes the bar static position and also tweaks the mobile padding around the links.

#### Before

https://github.com/Automattic/wp-calypso/assets/22446385/f0e506d3-57d3-4ea9-b0ec-9bce21ec4566

#### After

https://github.com/Automattic/wp-calypso/assets/22446385/32957174-5660-4391-aad9-870922078db9

### Testing instructions
go to the logged out `/tag/art` page and check out the masterbar on mobile and desktop
test that it hasn't affected the logged in tag pages or other reader pages.

