### PR TITLE
Jetpack Pro Dashboard: Add a feature flag for the monitor SMS notification settings project

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -83,6 +83,10 @@ export default function NotificationSettings( {
 		'jetpack/pro-dashboard-monitor-multiple-email-recipients'
 	);
 
+	const isSMSNotificationEnabled: boolean = isEnabled(
+		'jetpack/pro-dashboard-monitor-sms-notification'
+	);
+
 	const mapAndStringifyEmails = ( emails: MonitorSettingsEmail[] ) => {
 		return JSON.stringify( emails.map( ( { name, email } ) => ( { name, email } ) ) );
 	};
@@ -306,6 +310,10 @@ export default function NotificationSettings( {
 						selectedDuration={ selectedDuration }
 						selectDuration={ selectDuration }
 					/>
+					{ isSMSNotificationEnabled && (
+						// Remove this when SMS notification is ready
+						<h3 style={ { marginTop: 16 } }>SMS Notification configuration goes here</h3>
+					) }
 					<MobilePushNotification
 						recordEvent={ recordEvent }
 						enableMobileNotification={ enableMobileNotification }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -52,6 +52,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": true,
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": true,
+		"jetpack/pro-dashboard-monitor-sms-notification": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -45,6 +45,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": false,
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": false,
+		"jetpack/pro-dashboard-monitor-sms-notification": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -48,6 +48,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": false,
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": false,
+		"jetpack/pro-dashboard-monitor-sms-notification": false,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -48,6 +48,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": false,
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": false,
+		"jetpack/pro-dashboard-monitor-sms-notification": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,


### PR DESCRIPTION
Related to 1204774821045518-as-1204776079125745

## Proposed Changes

The PR adds a feature flag for the SMS notification settings for the downtime monitoring project.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/monitor-sms-notification-feature-flag` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Verify that you can see the `SMS Notification configuration goes here` text as shown below.

<img width="476" alt="Screenshot 2023-06-08 at 11 54 37 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/9e8b17a6-66e5-4096-8c0c-a4aa04bc6dfa">

6. Open the config/jetpack-cloud-development.json file and verify that the `jetpack/pro-dashboard-monitor-sms-notification` flag is set to true
7. Open the following files and verify that the value for the `jetpack/pro-dashboard-monitor-sms-notification` flag is set to false:
- config/jetpack-cloud-horizon.json
- config/jetpack-cloud-production.json
- config/jetpack-cloud-stage.json


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?