### PR TITLE
Look up blaze credit balance using site id instead of user id

### DIFF
--- a/client/data/promote-post/use-promote-post-credit-balance-query.ts
+++ b/client/data/promote-post/use-promote-post-credit-balance-query.ts
@@ -1,18 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
 import { requestDSP } from 'calypso/lib/promote-post';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const useCreditBalanceQuery = ( queryOptions = {} ) => {
-	const currentUser = useSelector( getCurrentUser );
-	const wpcomUserId = currentUser?.ID;
+	const selectedSiteId = useSelector( getSelectedSiteId );
 
 	return useQuery( {
-		queryKey: [ 'promote-post-credit-balance', wpcomUserId ],
+		queryKey: [ 'promote-post-credit-balance-siteid', selectedSiteId ],
 		queryFn: async () => {
-			if ( typeof wpcomUserId === 'number' ) {
+			if ( typeof selectedSiteId === 'number' ) {
 				const { balance } = await requestDSP< { balance: string } >(
-					wpcomUserId,
+					selectedSiteId,
 					`/credits/balance`
 				);
 				return balance;
@@ -20,7 +19,7 @@ const useCreditBalanceQuery = ( queryOptions = {} ) => {
 			throw new Error( 'wpcomUserId is undefined' );
 		},
 		...queryOptions,
-		enabled: !! wpcomUserId,
+		enabled: !! selectedSiteId,
 		retryDelay: 3000,
 		meta: {
 			persist: false,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2641

## Proposed Changes

* Use selected site id instead of current user id for fetching blaze credits.

## Testing Instructions

* http://calypso.localhost:3000/advertising/testingtesterson32.wordpress.com/campaigns?flags=-promote-post/redesign-i2 (modify your site url)

Should no longer see 404 errors with Invalid Site Specified coming from centralize.php (line link in issue) and /credits/balance endpoint should be responding with e.g. 0 credits.