### PR TITLE
Add image-cdn and image-guide to Boost features on checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
@@ -54,6 +54,8 @@ function getFeatureStrings(
 				translate( 'Deferred non-essential JavaScript' ),
 				translate( 'Optimized CSS loading' ),
 				translate( 'Lazy image loading' ),
+				translate( 'CDN for images' ),
+				translate( 'Image optimaization guide' ),
 			];
 		case 'complete':
 			return [

--- a/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
@@ -55,7 +55,7 @@ function getFeatureStrings(
 				translate( 'Optimized CSS loading' ),
 				translate( 'Lazy image loading' ),
 				translate( 'CDN for images' ),
-				translate( 'Image optimaization guide' ),
+				translate( 'Image optimization guide' ),
 			];
 		case 'complete':
 			return [


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/boost-cloud#235

## Proposed Changes

* Added "CDN for images" to the list of Boost features on checkout
* Added "Image optimaization guide" to the list of Boost features on checkout

## Testing Instructions
- Go to https://wordpress.com/checkout/jetpack_boost_yearly and https://wordpress.com/checkout/jetpack_boost_monthly and select a site
- Make sure the new lines are present under "Included with your purchase"
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<img width="937" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3737780/57e4f4a9-a2b8-49d6-b319-65fbc3e806ed">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
