### PR TITLE
Theme Upsell Modal: Remove feature tags and update feature list

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -57,6 +57,11 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 		return false;
 	}
 
+	// Do not limit Global Styles on self-hosted Jetpack sites.
+	if ( wpcom_global_styles_is_self_hosted_site( $blog_id ) ) {
+		return false;
+	}
+
 	return true;
 }
 
@@ -95,6 +100,20 @@ function wpcom_global_styles_has_blog_sticker( $blog_sticker, $blog_id ) {
 		return true;
 	}
 	return false;
+}
+
+/**
+ * Wrapper to test whether a blog is a self-hosted site
+ *
+ * @param int $blog_id The WPCOM blog ID.
+ * @return bool Whether the site has the blog sticker.
+ */
+function wpcom_global_styles_is_self_hosted_site( $blog_id ) {
+	if ( ! function_exists( 'is_jetpack_site' ) || ! function_exists( 'is_blog_atomic' ) ) {
+		return true;
+	}
+
+	return is_jetpack_site( $blog_id ) && ! is_blog_atomic( get_blog_details( $blog_id ) );
 }
 
 /**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -163,6 +163,11 @@ $design-button-primary-hover-color: var(--color-primary-60);
 		li {
 			display: flex;
 			align-items: flex-start;
+
+			> div {
+				display: flex;
+				align-items: center;
+			}
 		}
 
 		.gridicon {
@@ -170,6 +175,17 @@ $design-button-primary-hover-color: var(--color-primary-60);
 			flex-shrink: 0;
 			margin-right: 10px;
 			margin-top: 4px;
+		}
+
+		.components-popover.components-tooltip .components-popover__content {
+			border-radius: 4px;
+			margin: 8px;
+			max-width: 210px;
+			background-color: var(--studio-gray-100);
+			padding: 8px 10px;
+			text-align: start;
+			white-space: pre-line;
+			width: max-content;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -14,8 +14,7 @@ import classnames from 'classnames';
 import { useState, useRef, useMemo } from 'react';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import { createRecordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { activateOrInstallThenActivate, setActiveTheme } from 'calypso/state/themes/actions';
 import { getThemeIdFromStylesheet } from 'calypso/state/themes/utils';
 import { useQuery } from '../../../../hooks/use-query';
@@ -87,7 +86,6 @@ const PatternAssembler = ( {
 	const locale = useLocale();
 	// New sites are created from 'site-setup' and 'with-site-assembler' flows
 	const isNewSite = !! useQuery().get( 'isNewSite' ) || isSiteSetupFlow( flow );
-	const isSiteJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 
 	// The categories api triggers the ETK plugin before the PTK api request
 	const categories = usePatternCategories( site?.ID );
@@ -393,13 +391,14 @@ const PatternAssembler = ( {
 		if ( isEnabled( 'pattern-assembler/logged-in-showcase' ) ) {
 			setPendingAction( () =>
 				Promise.resolve()
-					.then( () =>
-						reduxDispatch(
-							activateOrInstallThenActivate( themeId, site?.ID, 'assembler', false, false )
-						)
+					.then(
+						() =>
+							reduxDispatch(
+								activateOrInstallThenActivate( themeId, site?.ID, 'assembler', false, false )
+							) as PromiseLike< string >
 					)
-					.then( () =>
-						assembleSite( siteSlugOrId, isSiteJetpack ? themeId : stylesheet, {
+					.then( ( activeThemeStylesheet: string ) =>
+						assembleSite( siteSlugOrId, activeThemeStylesheet, {
 							homeHtml: sections.map( ( pattern ) => pattern.html ).join( '' ),
 							headerHtml: header?.html,
 							footerHtml: footer?.html,

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -3,6 +3,7 @@ import { BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
 import { useFlowProgress, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
+import { useQueryTheme } from 'calypso/components/data/query-theme';
 import { useQuery } from '../hooks/use-query';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
@@ -22,6 +23,9 @@ const withThemeAssemblerFlow: Flow = {
 	useSideEffect() {
 		const { setSelectedDesign, setIntent } = useDispatch( ONBOARD_STORE );
 		const selectedTheme = useQuery().get( 'theme' );
+
+		// We have to query theme for the Jetpack site.
+		useQueryTheme( 'wpcom', selectedTheme );
 
 		useEffect( () => {
 			if ( selectedTheme === BLANK_CANVAS_DESIGN.slug ) {

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -84,6 +84,7 @@ export function activateTheme(
 				dispatch(
 					themeActivated( themeStylesheet, siteId, source, purchased, styleVariationSlug )
 				);
+				return themeStylesheet;
 			} )
 			.catch( ( error ) => {
 				if ( isMarketplaceThemeSubscribed( getState(), themeId, siteId ) ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77299

## Proposed Changes

This PR updates the theme upsell modal used in the onboarding design picker, by removing feature tags and updating the feature list. In addition, this PR adds tooltips to the feature list which contains the feature description. The feature list is taken from https://wordpress.com/pricing, needs review from @autumnfjeld and @lucasmendes-design.

![Screenshot 2023-06-08 at 3 27 54 PM](https://github.com/Automattic/wp-calypso/assets/797888/4c7f2f8d-1799-42f8-8238-a98cb8baad48)

**Premium Themes**
| Before | After |
| --- | --- |
| ![Screenshot 2023-06-08 at 3 28 26 PM](https://github.com/Automattic/wp-calypso/assets/797888/34fa6b97-1e38-4f4d-9aaa-776d4d99bed2) |  ![Screenshot 2023-06-08 at 3 14 38 PM](https://github.com/Automattic/wp-calypso/assets/797888/c796a3ea-c30f-43db-b463-1a92a4e3cb6a) |

**WooCommerce Themes**
| Before | After |
| --- | --- |
| ![Screenshot 2023-06-08 at 3 28 45 PM](https://github.com/Automattic/wp-calypso/assets/797888/a4896200-9d39-4c8c-aff5-f44c2755590b) | ![Screenshot 2023-06-08 at 3 15 04 PM](https://github.com/Automattic/wp-calypso/assets/797888/2ab7c431-4d1a-4b67-91c7-aa80ead8aa5b)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/site-setup?siteSlug=${site_slug}`.
* Continue until you land on the Design Picker.
* Select a Premium/WooCommerce theme, and click the Unlock Theme button.
* Ensure that the upsell modal is updated as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
