### PR TITLE
Customize Jetpack connection signup screen for woocommerce core profiler flow

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -664,7 +664,7 @@ class SignupForm extends Component {
 				{ this.props.displayUsernameInput && (
 					<>
 						<FormLabel htmlFor="username">
-							{ this.props.isReskinned || this.props.isWoo
+							{ this.props.isReskinned || ( this.props.isWoo && ! this.props.isWooCoreProfilerFlow )
 								? this.props.translate( 'Username' )
 								: this.props.translate( 'Choose a username' ) }
 						</FormLabel>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1296,6 +1296,9 @@ function TrackRender( { children, eventName } ) {
 export default connect(
 	( state, props ) => {
 		const oauth2Client = getCurrentOAuth2Client( state );
+		const isWooCoreProfilerFlow =
+			'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' );
+
 		return {
 			currentUser: getCurrentUser( state ),
 			oauth2Client,
@@ -1305,7 +1308,8 @@ export default connect(
 			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
-			isWoo: isWooOAuth2Client( oauth2Client ),
+			isWoo: isWooOAuth2Client( oauth2Client ) || isWooCoreProfilerFlow,
+			isWooCoreProfilerFlow,
 			isP2Flow:
 				isP2Flow( props.flowName ) || get( getCurrentQueryArguments( state ), 'from' ) === 'p2',
 		};

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -12,6 +13,7 @@ import { login } from 'calypso/lib/paths';
 import { isWpccFlow } from 'calypso/signup/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import SocialSignupToS from './social-signup-tos';
 
@@ -187,7 +189,9 @@ export default connect(
 	( state ) => ( {
 		currentRoute: getCurrentRoute( state ),
 		oauth2Client: getCurrentOAuth2Client( state ),
-		isWoo: isWooOAuth2Client( getCurrentOAuth2Client( state ) ),
+		isWoo:
+			isWooOAuth2Client( getCurrentOAuth2Client( state ) ) ||
+			'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
 	} ),
 	{ recordTracksEvent }
 )( localize( SocialSignupForm ) );

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import Site from 'calypso/blocks/site';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { decodeEntities } from 'calypso/lib/formatting';
+import { login } from 'calypso/lib/paths';
 import versionCompare from 'calypso/lib/version-compare';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getAuthorizationData } from 'calypso/state/jetpack-connect/selectors';
@@ -139,9 +140,32 @@ export class AuthFormHeader extends Component {
 		}
 
 		if ( isWooCoreProfiler ) {
-			return translate(
-				"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack, you'll need to connect your store to your WordPress.com account."
-			);
+			switch ( currentState ) {
+				case 'logged-out':
+					return translate(
+						"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
+						{
+							components: {
+								br: <br />,
+								a: (
+									<a
+										href={ login( {
+											isJetpack: true,
+											redirectTo: window.location.href,
+											from: this.props.authQuery.from,
+										} ) }
+									/>
+								),
+							},
+							comment:
+								'Link displayed on the Jetpack Connect signup page for users to log in with a WordPress.com account',
+						}
+					);
+				default:
+					return translate(
+						"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack, you'll need to connect your store to your WordPress.com account."
+					);
+			}
 		}
 
 		if ( wooDnaConfig && wooDnaConfig.isWooDnaFlow() ) {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -5,11 +5,9 @@ import {
 } from '@automattic/calypso-products';
 import { Button, Card, Gridicon, Spinner, JetpackLogo } from '@automattic/components';
 import { Spinner as WPSpinner } from '@wordpress/components';
-import { removeQueryArgs } from '@wordpress/url';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
 import { flowRight, get, includes, startsWith } from 'lodash';
-import page from 'page';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -22,7 +20,6 @@ import Gravatar from 'calypso/components/gravatar';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
-import Notice from 'calypso/components/notice';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { navigate } from 'calypso/lib/navigate';
 import { login } from 'calypso/lib/paths';
@@ -84,6 +81,7 @@ import {
 } from './persistence-utils';
 import { authQueryPropTypes, getRoleFromScope } from './utils';
 import wooDnaConfig from './woo-dna-config';
+import WooInstallExtSuccessNotice from './woo-install-ext-success-notice';
 
 /**
  * Constants
@@ -873,24 +871,7 @@ export class JetpackAuthorize extends Component {
 							</div>
 						</div>
 					</div>
-					{ authQuery.installedExtSuccess && (
-						<Notice
-							className="jetpack-connect__woo-core-profiler-notice"
-							status="is-success"
-							showDismiss={ false }
-							text={ translate( 'Extensions successfully installed!' ) }
-							isCompact={ false }
-							duration={ 3000 }
-							onDismissClick={ () => {
-								page.replace(
-									removeQueryArgs(
-										window.location.pathname + window.location.search,
-										'installed_ext_success'
-									)
-								);
-							} }
-						/>
-					) }
+					{ authQuery.installedExtSuccess && <WooInstallExtSuccessNotice /> }
 				</Fragment>
 			);
 		}

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -48,6 +48,7 @@ import HelpButton from './help-button';
 import MainWrapper from './main-wrapper';
 import { authQueryPropTypes } from './utils';
 import wooDnaConfig from './woo-dna-config';
+import WooInstallExtSuccessNotice from './woo-install-ext-success-notice';
 
 const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );
 const noop = () => {};
@@ -119,9 +120,14 @@ export class JetpackSignup extends Component {
 		this.props.resetAuthAccountType();
 	};
 
-	isWoo() {
+	isWooOnboarding() {
 		const { authQuery } = this.props;
 		return 'woocommerce-onboarding' === authQuery.from;
+	}
+
+	isWooCoreProfiler( props = this.props ) {
+		const { from } = props.authQuery;
+		return 'woocommerce-core-profiler' === from;
 	}
 
 	getWooDnaConfig() {
@@ -261,6 +267,10 @@ export class JetpackSignup extends Component {
 
 	renderFooterLink() {
 		const { authQuery } = this.props;
+
+		if ( this.isWooCoreProfiler() ) {
+			return null;
+		}
 
 		return (
 			<LoggedOutFormLinks>
@@ -447,10 +457,17 @@ export class JetpackSignup extends Component {
 		}
 		const { isCreatingAccount } = this.state;
 		return (
-			<MainWrapper isWooOnboarding={ this.isWoo() }>
+			<MainWrapper
+				isWooOnboarding={ this.isWooOnboarding() }
+				isWooCoreProfiler={ this.isWooCoreProfiler() }
+			>
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderLocaleSuggestions() }
-					<AuthFormHeader authQuery={ this.props.authQuery } isWooOnboarding={ this.isWoo() } />
+					<AuthFormHeader
+						authQuery={ this.props.authQuery }
+						isWooOnboarding={ this.isWooOnboarding() }
+						isWooCoreProfiler={ this.isWooCoreProfiler() }
+					/>
 					<SignupForm
 						disabled={ isCreatingAccount }
 						email={ this.props.authQuery.userEmail }
@@ -470,6 +487,9 @@ export class JetpackSignup extends Component {
 
 					{ this.renderLoginUser() }
 				</div>
+				{ this.isWooCoreProfiler() && this.props.authQuery.installedExtSuccess && (
+					<WooInstallExtSuccessNotice />
+				) }
 			</MainWrapper>
 		);
 	}

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -7,7 +7,7 @@
  */
 
 import { isEnabled } from '@automattic/calypso-config';
-import { Gridicon } from '@automattic/components';
+import { Gridicon, JetpackLogo } from '@automattic/components';
 import { Button, Card } from '@wordpress/components';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
@@ -456,6 +456,7 @@ export class JetpackSignup extends Component {
 			return this.renderWooDna();
 		}
 		const { isCreatingAccount } = this.state;
+		const isWooCoreProfiler = this.isWooCoreProfiler();
 		return (
 			<MainWrapper
 				isWooOnboarding={ this.isWooOnboarding() }
@@ -479,7 +480,11 @@ export class JetpackSignup extends Component {
 							{ auth_approved: true },
 							window.location.href
 						) }
-						submitButtonText={ this.props.translate( 'Create your account' ) }
+						submitButtonText={
+							isWooCoreProfiler
+								? this.props.translate( 'Create an account' )
+								: this.props.translate( 'Create your account' )
+						}
 						submitForm={ this.handleSubmitSignup }
 						submitting={ isCreatingAccount }
 						suggestedUsername=""
@@ -487,8 +492,14 @@ export class JetpackSignup extends Component {
 
 					{ this.renderLoginUser() }
 				</div>
-				{ this.isWooCoreProfiler() && this.props.authQuery.installedExtSuccess && (
+				{ isWooCoreProfiler && this.props.authQuery.installedExtSuccess && (
 					<WooInstallExtSuccessNotice />
+				) }
+				{ isWooCoreProfiler && (
+					<div className="jetpack-connect__jetpack-logo-wrapper">
+						<JetpackLogo monochrome size={ 18 } />{ ' ' }
+						<span>{ this.props.translate( 'Jetpack powered' ) }</span>
+					</div>
 				) }
 			</MainWrapper>
 		);

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -677,7 +677,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 /**
  * Onboarding styles
  **/
-.layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow),
+.layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow):not(.is-woocommerce-core-profiler-flow),
 .layout.is-section-purchase-product {
 	&.layout {
 		position: relative;
@@ -725,33 +725,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		&:hover,
 		&:focus {
 			color: var(--color-accent);
-		}
-	}
-
-	.jetpack-connect__features_wrapper {
-		display: flex;
-		flex-direction: row;
-		gap: 18px;
-		margin-top: 32px;
-
-		.jetpack-connect__features {
-			list-style: none;
-			margin: 0;
-			flex: 1;
-
-			li {
-				display: flex;
-				margin-bottom: 8px;
-				font-size: 0.75rem;
-				color: $gray-800;
-				align-items: center;
-			}
-
-			svg {
-				fill: #008a20;
-				margin-right: 8px;
-				min-width: 20px;
-			}
 		}
 	}
 
@@ -1074,201 +1047,241 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	&.is-jetpack-woo-dna-flow .login__form-header-wrapper {
 		display: none;
 	}
+}
 
-	&.is-woocommerce-core-profiler-flow {
-		.jetpack-connect__site.card {
-			border: 1px solid $gray-400;
-			border-radius: 2px;
-			background: #fff;
+.jetpack-connect__features_wrapper {
+	display: flex;
+	flex-direction: row;
+	gap: 18px;
+	margin-top: 32px;
+
+	.jetpack-connect__features {
+		list-style: none;
+		margin: 0;
+		flex: 1;
+
+		li {
 			display: flex;
-			flex-direction: row;
-			align-items: center;
-			padding: 16px 24px;
-			gap: 16px;
-			max-width: 405px;
-			margin: 48px auto 16px;
-
-			@include breakpoint-deprecated( "<660px" ) {
-				max-width: 100%;
-				margin: 40px 20px 16px;
-			}
-
-			.site__content {
-				text-decoration: none;
-				padding: 0;
-			}
-
-			.site-icon {
-				border-radius: 50%;
-				margin-right: 16px;
-				height: 40px !important;
-				width: 40px !important;
-				background: #f0f0f1;
-
-				svg {
-					fill: $gray-600;
-				}
-			}
-
-			.site__title {
-				color: var(--studio-gray-100);
-				font-size: 1rem;
-				font-weight: 500;
-			}
-
-			.site__domain {
-				font-size: 0.875rem;
-				line-height: 24px;
-				color: $gray-700;
-			}
-		}
-
-		.jetpack-connect__logged-in-card {
-			display: flex;
-			flex-direction: row;
-			align-items: center;
-			padding: 16px 24px;
-			gap: 16px;
-			background: #fff;
-			border: 1px solid $gray-400;
-			border-radius: 2px;
-			max-width: 405px;
-			margin: 0;
-
-			@include breakpoint-deprecated( "<660px" ) {
-				max-width: 100%;
-			}
-
-			.gravatar {
-				margin: 0;
-			}
-
-			.jetpack-connect__logged-in-form-user-text {
-				color: var(--studio-gray-100);
-				font-size: 1rem;
-				font-weight: 500;
-				text-align: left;
-
-				small {
-					font-size: 0.875rem;
-					line-height: 24px;
-					font-weight: 400;
-					color: $gray-700;
-				}
-			}
-
-			.logged-out-form__link-item {
-				margin: 8px 0 0;
-				padding: 0;
-				text-align: left;
-				text-decoration: none;
-				color: var(--wp-admin-theme-color);
-				font-size: 0.875rem;
-				line-height: 18px;
-			}
-		}
-
-		.jetpack-connect__logged-in-content {
-			margin: 0 auto;
-			max-width: 405px;
-
-			@include breakpoint-deprecated( "<660px" ) {
-				max-width: 100%;
-			}
-		}
-
-		.jetpack-connect__action-disclaimer {
-			padding: 0;
-			margin-top: 32px;
-
-			.button {
-				font-weight: 500;
-			}
-		}
-
-		.jetpack-connect__tos-link {
-			margin: 40px auto 0;
-			letter-spacing: -0.08px;
-			line-height: 18px;
-			color: $gray-700;
+			margin-bottom: 8px;
 			font-size: 0.75rem;
-			max-width: 400px;
-
-			@include breakpoint-deprecated( "<660px" ) {
-				margin: 12px auto 0;
-			}
-
-			a {
-				color: $gray-700;
-				text-decoration: none;
-				font-size: 0.75rem;
-			}
+			color: $gray-800;
+			align-items: center;
 		}
 
-		.jetpack-connect__jetpack-logo-wrapper {
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			margin-top: 70px;
+		svg {
+			fill: #008a20;
+			margin-right: 8px;
+			min-width: 20px;
+		}
+	}
+}
+
+.layout.is-section-jetpack-connect.is-woocommerce-core-profiler-flow {
+	.jetpack-connect__site.card {
+		border: 1px solid $gray-400;
+		border-radius: 2px;
+		background: #fff;
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		padding: 16px 24px;
+		gap: 16px;
+		max-width: 405px;
+		margin: 48px auto 16px;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			max-width: 100%;
+			margin: 40px 20px 16px;
+		}
+
+		.site__content {
+			text-decoration: none;
+			padding: 0;
+		}
+
+		.site-icon {
+			border-radius: 50%;
+			margin-right: 16px;
+			height: 40px !important;
+			width: 40px !important;
+			background-color: #f0f0f1;
 
 			svg {
-				margin-right: 6px;
-			}
-
-			span {
-				font-size: 0.75rem;
-				color: #1e1e1e;
-			}
-
-			@include breakpoint-deprecated( "<660px" ) {
-				margin-top: 20px;
+				fill: $gray-600;
 			}
 		}
 
-		.jetpack-connect__logged-in-bottom {
-			.spinner__outer,
-			.spinner__inner {
-				border-top-color: #fff;
-				border-right-color: transparent;
-			}
+		.site__title {
+			color: var(--studio-gray-100);
+			font-size: 1rem;
+			font-weight: 500;
+		}
 
-			@include breakpoint-deprecated( "<660px" ) {
-				position: absolute;
-				bottom: 24px;
-				padding-right: 20px;
-				width: fill-available;
+		.site__domain {
+			font-size: 0.875rem;
+			line-height: 24px;
+			color: $gray-700;
+		}
+	}
+
+	.jetpack-connect__logged-in-card {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		padding: 16px 24px;
+		gap: 16px;
+		background: #fff;
+		border: 1px solid $gray-400;
+		border-radius: 2px;
+		max-width: 405px;
+		margin: 0;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			max-width: 100%;
+		}
+
+		.gravatar {
+			margin: 0;
+		}
+
+		.jetpack-connect__logged-in-form-user-text {
+			color: var(--studio-gray-100);
+			font-size: 1rem;
+			font-weight: 500;
+			text-align: left;
+
+			small {
+				font-size: 0.875rem;
+				line-height: 24px;
+				font-weight: 400;
+				color: $gray-700;
 			}
 		}
 
-		.jetpack-connect__woo-core-profiler-notice {
-			width: 262px;
-			height: 50px;
+		.logged-out-form__link-item {
+			margin: 8px 0 0;
+			padding: 0;
+			text-align: left;
+			text-decoration: none;
+			color: var(--wp-admin-theme-color);
+			font-size: 0.875rem;
+			line-height: 18px;
+		}
+	}
+
+	.jetpack-connect__logged-in-content {
+		margin: 0 auto;
+		max-width: 405px;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			max-width: 100%;
+		}
+	}
+
+	.jetpack-connect__action-disclaimer {
+		padding: 0;
+		margin-top: 32px;
+
+		.button {
+			font-weight: 500;
+		}
+	}
+
+	.jetpack-connect__tos-link {
+		margin: 40px auto 0;
+		letter-spacing: -0.08px;
+		line-height: 18px;
+		color: $gray-700;
+		font-size: 0.75rem;
+		max-width: 400px;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			margin: 12px auto 0;
+		}
+
+		a {
+			color: $gray-700;
+			text-decoration: none;
+			font-size: 0.75rem;
+		}
+	}
+
+	.jetpack-connect__jetpack-logo-wrapper {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		margin-top: 70px;
+
+		svg {
+			margin-right: 6px;
+		}
+
+		span {
+			font-size: 0.75rem;
+			color: #1e1e1e;
+		}
+
+		@include breakpoint-deprecated( "<660px" ) {
+			margin-top: 20px;
+		}
+	}
+
+	.jetpack-connect__logged-in-bottom {
+		.spinner__outer,
+		.spinner__inner {
+			border-top-color: #fff;
+			border-right-color: transparent;
+		}
+
+		@include breakpoint-deprecated( "<660px" ) {
 			position: absolute;
-			left: 36px;
-			bottom: 32px;
+			bottom: 24px;
+			padding-right: 20px;
+			width: fill-available;
+		}
+	}
 
-			@include breakpoint-deprecated( "<660px" ) {
-				position: absolute;
-				left: 0;
-				bottom: 20px;
-				width: calc(100% - 40px);
-				margin: 0 20px;
+	.jetpack-connect__woo-core-profiler-notice {
+		width: 262px;
+		height: 50px;
+		position: absolute;
+		left: 36px;
+		bottom: 32px;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			position: absolute;
+			left: 0;
+			bottom: 20px;
+			width: calc(100% - 40px);
+			margin: 0 20px;
+		}
+
+		.notice__icon-wrapper {
+			background: inherit;
+			padding: 0 3px 0 11px;
+			width: fit-content;
+
+			.notice__icon {
+				color: var(--studio-green-30);
 			}
+		}
 
-			.notice__icon-wrapper {
-				background: inherit;
-				padding: 0 3px 0 11px;
-				width: fit-content;
+		.notice__content {
+			font-size: 0.8125rem; /* stylelint-disable-line scales/font-sizes */
+			line-height: 16px;
+			padding: 17px 8px;
+		}
+	}
 
-				.notice__icon {
-					color: var(--studio-green-30);
+	// Sign up
+	.jetpack-connect__authorize-form {
+		.jetpack-connect__site.card {
+			.site-icon {
+				background-color: rgba(var(--wp-admin-theme-color--rgb), 0.15);
+
+				svg {
+					fill: var(--wp-admin-theme-color);
 				}
-			}
-
-			.notice__content {
-				font-size: 0.8125rem; /* stylelint-disable-line scales/font-sizes */
-				line-height: 16px;
-				padding: 17px 8px;
 			}
 		}
 	}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1247,6 +1247,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		left: 36px;
 		bottom: 32px;
 		z-index: 999;
+		margin-bottom: 0;
 
 		@include breakpoint-deprecated( "<660px" ) {
 			left: 0;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1077,6 +1077,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .layout.is-section-jetpack-connect.is-woocommerce-core-profiler-flow {
+	.jetpack-connect__main {
+		max-width: 615px;
+	}
+
 	.jetpack-connect__site.card {
 		border: 1px solid $gray-400;
 		border-radius: 2px;
@@ -1279,6 +1283,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				}
 			}
 		}
+	}
+
+	.signup-form__terms-of-service-link {
+		margin-bottom: 12px;
 	}
 
 	.signup-form__social {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1188,7 +1188,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	.jetpack-connect__tos-link {
-		margin: 40px auto 0;
+		margin: 40px auto 70px;
 		letter-spacing: -0.08px;
 		line-height: 18px;
 		color: $gray-700;
@@ -1196,7 +1196,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		max-width: 400px;
 
 		@include breakpoint-deprecated( "<660px" ) {
-			margin: 12px auto 0;
+			margin: 12px auto 20px;
 		}
 
 		a {
@@ -1210,7 +1210,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		margin-top: 70px;
 
 		svg {
 			margin-right: 6px;
@@ -1219,10 +1218,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		span {
 			font-size: 0.75rem;
 			color: #1e1e1e;
-		}
-
-		@include breakpoint-deprecated( "<660px" ) {
-			margin-top: 20px;
 		}
 	}
 
@@ -1284,6 +1279,11 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				}
 			}
 		}
+	}
+
+	.signup-form__social {
+		padding-bottom: 0;
+		margin-bottom: 48px;
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1239,12 +1239,12 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	.jetpack-connect__woo-core-profiler-notice {
 		width: 262px;
 		height: 50px;
-		position: absolute;
+		position: fixed;
 		left: 36px;
 		bottom: 32px;
+		z-index: 999;
 
 		@include breakpoint-deprecated( "<660px" ) {
-			position: absolute;
 			left: 0;
 			bottom: 20px;
 			width: calc(100% - 40px);

--- a/client/jetpack-connect/woo-install-ext-success-notice.tsx
+++ b/client/jetpack-connect/woo-install-ext-success-notice.tsx
@@ -1,0 +1,27 @@
+import { removeQueryArgs } from '@wordpress/url';
+import { localize, LocalizeProps } from 'i18n-calypso';
+import page from 'page';
+import Notice from 'calypso/components/notice';
+
+const WooInstallExtSuccessNotice = ( { translate }: LocalizeProps ) => {
+	return (
+		<Notice
+			className="jetpack-connect__woo-core-profiler-notice"
+			status="is-success"
+			showDismiss={ false }
+			text={ translate( 'Extensions successfully installed!' ) }
+			isCompact={ false }
+			duration={ 3000 }
+			onDismissClick={ () => {
+				page.replace(
+					removeQueryArgs(
+						window.location.pathname + window.location.search,
+						'installed_ext_success'
+					)
+				);
+			} }
+		/>
+	);
+};
+
+export default localize( WooInstallExtSuccessNotice );

--- a/client/jetpack-connect/woo-install-ext-success-notice.tsx
+++ b/client/jetpack-connect/woo-install-ext-success-notice.tsx
@@ -11,7 +11,7 @@ const WooInstallExtSuccessNotice = ( { translate }: LocalizeProps ) => {
 			showDismiss={ false }
 			text={ translate( 'Extensions successfully installed!' ) }
 			isCompact={ false }
-			duration={ 3000 }
+			duration={ 6000 }
 			onDismissClick={ () => {
 				page.replace(
 					removeQueryArgs(

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -233,6 +233,7 @@
 
 
 	.jetpack-connect__logged-in-form .formatted-header,
+	.jetpack-connect__authorize-form .formatted-header,
 	.login__form-header-wrapper,
 	.signup-form__woo-wrapper {
 		text-align: center;
@@ -766,7 +767,8 @@
 			}
 		}
 
-		.login form {
+		.login form,
+		.signup-form {
 			max-width: 405px;
 			margin: 0 auto;
 		}
@@ -794,10 +796,12 @@
 			}
 		}
 
-		.login__form-userdata label.form-label {
+		.login__form-userdata label.form-label,
+		.logged-out-form label.form-label {
 			font-weight: 500;
 			text-transform: uppercase;
 			font-size: rem(11px);
+			color: $gray-900;
 		}
 
 		.jetpack-connect__action-disclaimer .button.is-primary,
@@ -809,7 +813,7 @@
 			background-color: var(--wp-admin-theme-color);
 		}
 
-		.login__social-buttons .social-buttons__service-name {
+		span.social-buttons__service-name {
 			font-weight: 600;
 		}
 
@@ -836,6 +840,29 @@
 		.jetpack-connect__features_wrapper {
 			@media screen and ( max-width: 660px ) {
 				display: none !important;
+			}
+		}
+
+		.signup-form {
+			padding-top: 24px;
+		}
+
+		// Log in link on signup page
+		.formatted-header__subtitle a {
+			color: var(--wp-admin-theme-color);
+		}
+
+		.form-input-validation {
+			padding: 8px 0 11px;
+
+			p,
+			a {
+				line-height: 16px;
+			}
+
+			// Hide form validation icon
+			svg {
+				display: none;
 			}
 		}
 	}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -771,6 +771,14 @@
 		.signup-form {
 			max-width: 405px;
 			margin: 0 auto;
+
+			input.form-text-input {
+				border-color: #bbb;
+
+				&.is-valid {
+					border-color: #bbb;
+				}
+			}
 		}
 
 		.login__form-header h3,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77888 

## Proposed Changes

Customize Jetpack connection **signup** screen for woocommerce core profiler flow

![Screenshot 2023-06-09 at 15 28 15](https://github.com/Automattic/wp-calypso/assets/4344253/f9400241-78f1-4e86-a1a5-97b1fd842ed5)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up [woocommerce-start-dev-env](https://github.com/woocommerce/woocommerce-start-dev-env)
* Create a JN site
* Go to OBW and continue until Jetpack connection step (/jetpack/connect/authorize)
* Log out your wp account or open the current tab in an incognito window
* Change query parameter `from` to `woocommerce-core-profiler` and add `installed_ext_success=1` query parameter
* Observe the `Extensions successfully installed!` notice is shown and automatically dismissed
* Confirm the screen matches the design (Y5pUYSJPsGEud1vknUZhi8-fi-739_54680)
* Reload the page
* Observe the `Extensions successfully installed!` is not shown.
* Enable track debugging `localStorage.setItem( 'debug', 'calypso:analytics' );`

**Scenario: User clicks on No, Thanks**

1. Clicks on `No, Thanks` button
2. You should be redirected to your JN site
3.  Observe that `calypso_wc_coreprofiler_jpc_skip` event is recorded

**Scenario: User creation fails with validation errors**

1. Go back to JPC Signup page
2. Enter an invalid email address or username
3. Observe that the error message is shown under each form field

**Scenario: User clicks on Create an account button**

1. Clicks on `Create an account` button
2. Create a new account
3. Observe that `calypso_jpc_create_account` event is recorded
4. Should be redirected to the Jetpack connection screen
5. Should be authorized automatically (see the button is loading)
7. You should be redirected to your site
8. Log in if you're not logged in to your JN site
9. You should be redirected to `WooCommerce > Home`
10. Go to `Jetpack > My Jetpack` and Confirm the Jetpack is connected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?