### PR TITLE
Subscription Management: Add locale support on route for individual site subscription page.

### DIFF
--- a/client/landing/subscriptions/index.tsx
+++ b/client/landing/subscriptions/index.tsx
@@ -59,7 +59,7 @@ window.AppBoot = async () => {
 						<WindowLocaleEffectManager />
 						<BrowserRouter>
 							<Routes>
-								<Route path="/subscriptions/site/:blogId" element={ <SiteSubscriptionPage /> } />
+								<Route path="/subscriptions/site/:blogId/*" element={ <SiteSubscriptionPage /> } />
 								<Route path="/subscriptions/*" element={ <SubscriptionManagerPage /> } />
 							</Routes>
 						</BrowserRouter>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #77315

## Proposed Changes

* Add locale support on route for individual site subscription page.


## Testing Instructions

You can only test this as an external user as logged-in user inherits locale from the user settings.

**Setup:**
1. Open up an incognito window and go to `calypso.localhost:3000`.
2. Set the `subkey` in the cookie.

**Test:**
1. Open up any individual site subscription page, e.g.  `/subscriptions/site/<site_id_here>/<lang_slug>`.
    - The list of possible `lang_slug` can be seen in `languages-meta.json`.
2. It should render in the desired language.
3. Clicking on the "Manage all subscriptions" button in the top left corner should bring you back to the main Subscription Management portal with the language intact.

**Test for no regression:**
1. Going to `/subscriptions/site/<site_id_here>` without the locale url fragment should still continue to work.

Tip: The `locale` GET param, e.g. `/subscriptions/site/<site_id_here>?locale=<lang_slug>` is also supported.

<img width="929" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/12780f52-f3c6-4379-b63e-f2ef695194fd">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
