### PR TITLE
Subscription Management: Add clickable url on individual site subscription page.

### DIFF
--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
@@ -3,6 +3,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useEffect, useState, useMemo } from 'react';
+import ExternalLink from 'calypso/components/external-link';
 import FormattedHeader from 'calypso/components/formatted-header';
 import TimeSince from 'calypso/components/time-since';
 import { Notice, NoticeState, NoticeType } from 'calypso/landing/subscriptions/components/notice';
@@ -107,9 +108,9 @@ const SiteSubscriptionDetails = ( {
 	}, [ url ] );
 
 	const urlLink = hostname ? (
-		<a href={ url } className="url" rel="noreferrer noopener" target="_blank">
+		<ExternalLink href={ url } rel="noreferrer noopener" target="_blank">
 			{ hostname }
-		</a>
+		</ExternalLink>
 	) : (
 		''
 	);

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
@@ -2,7 +2,7 @@ import { SubscriptionManager, Reader } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useTranslate, numberFormat } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import TimeSince from 'calypso/components/time-since';
 import { Notice, NoticeState, NoticeType } from 'calypso/landing/subscriptions/components/notice';
@@ -90,13 +90,37 @@ const SiteSubscriptionDetails = ( {
 		}
 	}, [ paymentDetails ] );
 
-	const subHeaderText = subscriberCount
+	const subscriberCountText = subscriberCount
 		? translate( '%s subscriber', '%s subscribers', {
 				count: subscriberCount,
 				args: [ numberFormat( subscriberCount, 0 ) ],
 				comment: '%s is the number of subscribers. For example: "12,000,000"',
 		  } )
 		: '';
+
+	const hostname = useMemo( () => {
+		try {
+			return new URL( url ).hostname;
+		} catch ( e ) {
+			return '';
+		}
+	}, [ url ] );
+
+	const urlLink = hostname ? (
+		<a href={ url } className="url" rel="noreferrer noopener" target="_blank">
+			{ hostname }
+		</a>
+	) : (
+		''
+	);
+
+	const subHeaderText = (
+		<>
+			{ subscriberCountText }
+			{ hostname ? ' · ' : '' }
+			{ urlLink }
+		</>
+	);
 
 	useEffect( () => {
 		// todo: style the button (underline, color?, etc.)

--- a/client/landing/subscriptions/components/site-subscription-page/styles.scss
+++ b/client/landing/subscriptions/components/site-subscription-page/styles.scss
@@ -48,7 +48,7 @@
 				font-weight: 400;
 				color: $studio-gray-40;
 
-				.url {
+				.external-link {
 					color: $studio-gray-40;
 					white-space: nowrap;
 

--- a/client/landing/subscriptions/components/site-subscription-page/styles.scss
+++ b/client/landing/subscriptions/components/site-subscription-page/styles.scss
@@ -47,6 +47,15 @@
 				font-family: "SF Pro Text", $sans;
 				font-weight: 400;
 				color: $studio-gray-40;
+
+				.url {
+					color: $studio-gray-40;
+					white-space: nowrap;
+
+					&:hover {
+						text-decoration: underline;
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/77380

## Proposed Changes

* Add clickable url on individual site subscription page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/subscriptions/site/<site_id_here>` (or click from the sites list).
* You should see the clickable url next to the subscriber count.
* Clicking on it should open the site in a new tab.

## Screenshots

<img width="704" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/145d0c03-f87f-4bea-9126-2b3ea532d0f8">

<img width="704" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/e1b4ed5e-c88f-4535-bd01-dffc213b7a5e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
