### PR TITLE
`/read/subscriptions`: Implement mobile design for the new recommended sites component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -468,6 +468,7 @@ module.exports = {
 				'@wordpress/components': [
 					'__experimentalDivider',
 					'__experimentalHStack',
+					'__experimentalVStack',
 					'__experimentalItem',
 					'__experimentalItemGroup',
 					'__experimentalNavigationBackButton',

--- a/client/reader/recommended-sites/recommended-site.tsx
+++ b/client/reader/recommended-sites/recommended-site.tsx
@@ -3,7 +3,6 @@ import {
 	Card,
 	Flex,
 	__experimentalHStack as HStack,
-	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { close } from '@wordpress/icons';

--- a/client/reader/recommended-sites/recommended-sites.tsx
+++ b/client/reader/recommended-sites/recommended-sites.tsx
@@ -1,7 +1,7 @@
-import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { BreakpointValues } from '@automattic/viewport';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import DotPager from 'calypso/components/dot-pager';
 import { requestRecommendedSites } from 'calypso/state/reader/recommended-sites/actions';
@@ -19,15 +19,61 @@ type RecommendedSite = {
 	feedId: number;
 };
 
+const shouldShowDotPagerView = ( containerWidth: number ) =>
+	containerWidth < BreakpointValues.Px660;
+
 const RecommendedSitesResponsiveContainer: React.FC = ( { children } ) => {
-	const isMobile = useMobileBreakpoint();
-	if ( isMobile ) {
-		return <DotPager isClickEnabled={ true }>{ children }</DotPager>;
-	}
+	const divRef = useRef< HTMLDivElement >( null );
+	const [ showDotPagerView, setShowDotPagerView ] = useState< boolean >();
+
+	useEffect( () => {
+		// Ensure the ref is current and ResizeObserver API is supported
+		if ( divRef.current && typeof ResizeObserver !== 'undefined' ) {
+			// Implement ResizeObserver to track the width changes of the container.
+			// This approach offers an improved user experience as it accounts for the Calypso sidebar
+			// that collapses at certain points, expanding the container width despite a decrease in window width.
+			// Depending solely on viewport breakpoints doesn't yield satisfactory visual results, as it doesn't
+			// consider these dynamic UI changes.
+			setShowDotPagerView( shouldShowDotPagerView( divRef.current.offsetWidth ) );
+			const observer = new ResizeObserver( ( [ entry ] ) => {
+				if ( ! entry ) {
+					return;
+				}
+
+				setShowDotPagerView( shouldShowDotPagerView( entry.contentRect.width ) );
+			} );
+			observer.observe( divRef.current );
+
+			return () => {
+				if ( observer ) {
+					observer.disconnect();
+				}
+			};
+		}
+	}, [] ); // Empty dependency array ensures this runs on mount and unmount only
+
+	const wrappedChildren = useMemo( () => {
+		if ( showDotPagerView === undefined ) {
+			// Do not display anything until the current container width is determined,
+			// i.e. until the ResizeObserver callback is triggered
+			return null;
+		}
+
+		if ( showDotPagerView ) {
+			return <DotPager isClickEnabled={ true }>{ children }</DotPager>;
+		}
+
+		return (
+			<HStack className="recommended-sites__horizontal-list" spacing={ 6 } as="ul">
+				{ children }
+			</HStack>
+		);
+	}, [ children, showDotPagerView ] );
+
 	return (
-		<HStack className="recommended-sites__list" spacing={ 6 } as="ul">
-			{ children }
-		</HStack>
+		<div ref={ divRef } style={ { width: '100%', height: '100%' } }>
+			{ wrappedChildren }
+		</div>
 	);
 };
 

--- a/client/reader/recommended-sites/recommended-sites.tsx
+++ b/client/reader/recommended-sites/recommended-sites.tsx
@@ -1,7 +1,9 @@
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import DotPager from 'calypso/components/dot-pager';
 import { requestRecommendedSites } from 'calypso/state/reader/recommended-sites/actions';
 import {
 	getReaderRecommendedSites,
@@ -12,26 +14,49 @@ import './style.scss';
 
 const seed = Math.floor( Math.random() * 10001 );
 
+type RecommendedSite = {
+	blogId: number;
+	feedId: number;
+};
+
+const RecommendedSitesResponsiveContainer: React.FC = ( { children } ) => {
+	const isMobile = useMobileBreakpoint();
+	if ( isMobile ) {
+		return <DotPager isClickEnabled={ true }>{ children }</DotPager>;
+	}
+	return (
+		<HStack className="recommended-sites__list" spacing={ 6 } as="ul">
+			{ children }
+		</HStack>
+	);
+};
+
 const RecommendedSites = () => {
 	const translate = useTranslate();
+
 	const dispatch = useDispatch();
-	const recommendedSites = useSelector( ( state ) => getReaderRecommendedSites( state, seed ) );
+	const recommendedSites = useSelector(
+		( state ) => getReaderRecommendedSites( state, seed ) as RecommendedSite[]
+	);
 	const offset = useSelector( ( state ) => getReaderRecommendedSitesPagingOffset( state, seed ) );
+
 	useEffect( () => {
 		dispatch( requestRecommendedSites( { seed, offset } ) );
 	}, [ dispatch, offset ] );
 
-	// todo: Render loading state
+	const slicedRecommendedSites = useMemo( () => {
+		return Array.isArray( recommendedSites ) ? recommendedSites.slice( 0, 2 ) : [];
+	}, [ recommendedSites ] );
 
-	if ( ! recommendedSites?.length ) {
+	if ( ! slicedRecommendedSites?.length ) {
 		return null;
 	}
 
 	return (
 		<div className="recommended-sites">
 			<h2 className="recommended-sites__heading">{ translate( 'Recommended sites' ) }</h2>
-			<HStack className="recommended-sites__list" spacing={ 6 } as="ul">
-				{ recommendedSites.slice( 0, 2 ).map( ( { blogId, feedId } ) => {
+			<RecommendedSitesResponsiveContainer>
+				{ slicedRecommendedSites.map( ( { blogId, feedId } ) => {
 					return (
 						<RecommendedSite
 							key={ `${ blogId }-${ feedId }` }
@@ -40,7 +65,7 @@ const RecommendedSites = () => {
 						/>
 					);
 				} ) }
-			</HStack>
+			</RecommendedSitesResponsiveContainer>
 		</div>
 	);
 };

--- a/client/reader/recommended-sites/recommended-sites.tsx
+++ b/client/reader/recommended-sites/recommended-sites.tsx
@@ -1,7 +1,7 @@
-import { BreakpointValues } from '@automattic/viewport';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import DotPager from 'calypso/components/dot-pager';
 import { requestRecommendedSites } from 'calypso/state/reader/recommended-sites/actions';
@@ -19,61 +19,15 @@ type RecommendedSite = {
 	feedId: number;
 };
 
-const shouldShowDotPagerView = ( containerWidth: number ) =>
-	containerWidth < BreakpointValues.Px660;
-
 const RecommendedSitesResponsiveContainer: React.FC = ( { children } ) => {
-	const divRef = useRef< HTMLDivElement >( null );
-	const [ showDotPagerView, setShowDotPagerView ] = useState< boolean >();
-
-	useEffect( () => {
-		// Ensure the ref is current and ResizeObserver API is supported
-		if ( divRef.current && typeof ResizeObserver !== 'undefined' ) {
-			// Implement ResizeObserver to track the width changes of the container.
-			// This approach offers an improved user experience as it accounts for the Calypso sidebar
-			// that collapses at certain points, expanding the container width despite a decrease in window width.
-			// Depending solely on viewport breakpoints doesn't yield satisfactory visual results, as it doesn't
-			// consider these dynamic UI changes.
-			setShowDotPagerView( shouldShowDotPagerView( divRef.current.offsetWidth ) );
-			const observer = new ResizeObserver( ( [ entry ] ) => {
-				if ( ! entry ) {
-					return;
-				}
-
-				setShowDotPagerView( shouldShowDotPagerView( entry.contentRect.width ) );
-			} );
-			observer.observe( divRef.current );
-
-			return () => {
-				if ( observer ) {
-					observer.disconnect();
-				}
-			};
-		}
-	}, [] ); // Empty dependency array ensures this runs on mount and unmount only
-
-	const wrappedChildren = useMemo( () => {
-		if ( showDotPagerView === undefined ) {
-			// Do not display anything until the current container width is determined,
-			// i.e. until the ResizeObserver callback is triggered
-			return null;
-		}
-
-		if ( showDotPagerView ) {
-			return <DotPager isClickEnabled={ true }>{ children }</DotPager>;
-		}
-
-		return (
-			<HStack className="recommended-sites__horizontal-list" spacing={ 6 } as="ul">
-				{ children }
-			</HStack>
-		);
-	}, [ children, showDotPagerView ] );
-
+	const displayAsDotPager = useBreakpoint( '<1040px' );
+	if ( displayAsDotPager ) {
+		return <DotPager isClickEnabled>{ children }</DotPager>;
+	}
 	return (
-		<div ref={ divRef } style={ { width: '100%', height: '100%' } }>
-			{ wrappedChildren }
-		</div>
+		<HStack className="recommended-sites__horizontal-list" spacing={ 6 } as="ul">
+			{ children }
+		</HStack>
 	);
 };
 

--- a/client/reader/recommended-sites/style.scss
+++ b/client/reader/recommended-sites/style.scss
@@ -1,5 +1,6 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 
 %ellipsis {
 	overflow: hidden;
@@ -21,7 +22,7 @@
 		margin: 0 0 16px 0;
 	}
 
-	&__list {
+	&__horizontal-list {
 		margin: 0;
 	}
 
@@ -87,6 +88,17 @@
 			border-radius: 4px;
 			padding-left: 24px;
 			padding-right: 24px;
+		}
+	}
+
+	.dot-pager {
+		&__controls {
+			padding: 0 4px;
+		}
+
+		.recommended-site {
+			width: auto;
+			margin: 1px 1px 32px 1px;
 		}
 	}
 }

--- a/client/wp-components-types.d.ts
+++ b/client/wp-components-types.d.ts
@@ -7,6 +7,7 @@ declare module '@wordpress/components' {
 
 	export const __experimentalDivider: React.ComponentType< Props >;
 	export const __experimentalHStack: React.ComponentType< Props >;
+	export const __experimentalVStack: React.ComponentType< Props >;
 	export const __experimentalItem: React.ComponentType< Props >;
 	export const __experimentalItemGroup: React.ComponentType< Props >;
 	export const __experimentalNavigatorBackButton: React.ComponentType< Props >;

--- a/packages/viewport/src/index.ts
+++ b/packages/viewport/src/index.ts
@@ -43,6 +43,16 @@ const SERVER_WIDTH = 769;
 export const MOBILE_BREAKPOINT = '<480px';
 export const DESKTOP_BREAKPOINT = '>960px';
 
+export const enum BreakpointValues {
+	Px480 = 480,
+	Px660 = 660,
+	Px800 = 800,
+	Px960 = 960,
+	Px1040 = 1040,
+	Px1280 = 1280,
+	Px1400 = 1400,
+}
+
 const isServer = typeof window === 'undefined' || ! window.matchMedia;
 
 const noop = () => null;

--- a/packages/viewport/src/index.ts
+++ b/packages/viewport/src/index.ts
@@ -43,16 +43,6 @@ const SERVER_WIDTH = 769;
 export const MOBILE_BREAKPOINT = '<480px';
 export const DESKTOP_BREAKPOINT = '>960px';
 
-export const enum BreakpointValues {
-	Px480 = 480,
-	Px660 = 660,
-	Px800 = 800,
-	Px960 = 960,
-	Px1040 = 1040,
-	Px1280 = 1280,
-	Px1400 = 1400,
-}
-
 const isServer = typeof window === 'undefined' || ! window.matchMedia;
 
 const noop = () => null;


### PR DESCRIPTION
![Screen Capture on 2023-06-08 at 12-24-12](https://github.com/Automattic/wp-calypso/assets/2019970/3c1e36a3-d12c-4279-8b86-a28827977daa)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/77889

## Proposed Changes

* For the initial version of our mobile design, let's use `DotPager` from `@automattic/components`. It doesn't perfectly match our Figma designs, but it's a solid starting point.
  * If we decide to pursue the Figma design, I suggest we extend this very component. I couldn't find any other existing component in Calypso that better matches our designs.
* Initially, I intended to incorporate a `ResizeObserver` to track container width changes due to Calypso's dynamic sidebar. However, after evaluation, I opted to postpone this ([the commit that showcases the difference between the 2 approaches](https://github.com/Automattic/wp-calypso/pull/77956/commits/87349930f6c5549a1de6311982cfb3019f934d67)) due to the complexity it would introduce, outweighing its current value. While not immediately beneficial, should we implement a collapsible sidebar in the future, the `ResizeObserver` might become necessary to ensure optimal user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/read/subscriptions, and play around with resizing the window

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

cc @saygunnyc 
