### PR TITLE
Fix in styles to make the image appear ok when we have a long title

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
@@ -44,14 +44,19 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 	}
 
 	td {
+		border-top: 1px solid #d8d8d8;
 		color: $studio-gray-60;
-		padding-top: 16px;
-		padding-bottom: 16px;
-		border-top: 1px solid #d8d8d8; /* #EEEEEE if bg is white */
 		font-size: 0.875rem;
-		vertical-align: middle;
-		line-height: 1.43;
 		letter-spacing: -0.15px;
+		line-height: 1.43; /* #EEEEEE if bg is white */
+		padding-bottom: 16px;
+		padding-right: 16px;
+		padding-top: 16px;
+		vertical-align: middle;
+	}
+
+	td:last-child {
+		padding-right: 0;
 	}
 
 	.promote-post-i2__campaign-item-wrapper {
@@ -131,6 +136,7 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 	.promote-post-i2__table {
 		td {
 			padding-bottom: 14px;
+			padding-right: 0;
 		}
 	}
 }

--- a/client/my-sites/promote-post-i2/components/post-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/post-item/style.scss
@@ -141,6 +141,7 @@ body.is-section-promote-post-i2 {
 		position: relative;
 		height: 78px;
 		width: 108px;
+		min-width: 108px;
 		align-self: stretch;
 		border: 1px solid #eee;
 		border-radius: 4px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #  SELFSERVE-534

## Proposed Changes

Please check the before and after versions..
![Screenshot 2023-06-08 at 14 12 30](https://github.com/Automattic/wp-calypso/assets/1416426/caddae19-d336-4af0-870d-7961c4d7506b)


![Screenshot 2023-06-08 at 14 12 35](https://github.com/Automattic/wp-calypso/assets/1416426/049ed5f5-ad49-4859-8992-f18d1383f769)

I also added some right padding to the tds so that the title (and the rest of elements) have some spacing when the layout is narrowed down

## Testing Instructions

it is a pretty simple change.. just checkout the branch and check the table :) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
