### PR TITLE
Jetpack Pro Dashboard: Show alert when no phone number is added for monitor SMS notifications

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -1,18 +1,30 @@
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import AlertBanner from 'calypso/components/jetpack/alert-banner';
 
-export default function SMSNotification() {
+interface Props {
+	enableSMSNotification: boolean;
+	setEnableSMSNotification: ( isEnabled: boolean ) => void;
+}
+
+export default function SMSNotification( {
+	enableSMSNotification,
+	setEnableSMSNotification,
+}: Props ) {
 	const translate = useTranslate();
 
-	const handleToggleClick = () => {
-		return null;
+	const handleToggleClick = ( isEnabled: boolean ) => {
+		// Record event here
+		setEnableSMSNotification( isEnabled );
 	};
+
+	const allPhoneNumbers = []; // TODO: Get all phone numbers from the API when it is ready
 
 	return (
 		<>
 			<div className="notification-settings__toggle-container">
 				<div className="notification-settings__toggle">
-					<ToggleControl onChange={ handleToggleClick } />
+					<ToggleControl onChange={ handleToggleClick } checked={ enableSMSNotification } />
 				</div>
 				<div className="notification-settings__toggle-content">
 					<div className="notification-settings__content-heading-with-beta">
@@ -24,6 +36,13 @@ export default function SMSNotification() {
 					</div>
 				</div>
 			</div>
+			{ enableSMSNotification && allPhoneNumbers.length === 0 && (
+				<div className="margin-top-16">
+					<AlertBanner type="warning">
+						{ translate( 'You need at least one phone number' ) }
+					</AlertBanner>
+				</div>
+			) }
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -59,6 +59,7 @@ export default function NotificationSettings( {
 
 	const defaultDuration = durations.find( ( duration ) => duration.time === 5 );
 
+	const [ enableSMSNotification, setEnableSMSNotification ] = useState< boolean >( false );
 	const [ enableMobileNotification, setEnableMobileNotification ] = useState< boolean >( false );
 	const [ enableEmailNotification, setEnableEmailNotification ] = useState< boolean >( false );
 	const [ selectedDuration, setSelectedDuration ] = useState< MonitorDuration | undefined >(
@@ -311,7 +312,12 @@ export default function NotificationSettings( {
 						selectedDuration={ selectedDuration }
 						selectDuration={ selectDuration }
 					/>
-					{ isSMSNotificationEnabled && <SMSNotification /> }
+					{ isSMSNotificationEnabled && (
+						<SMSNotification
+							enableSMSNotification={ enableSMSNotification }
+							setEnableSMSNotification={ setEnableSMSNotification }
+						/>
+					) }
 
 					<MobilePushNotification
 						recordEvent={ recordEvent }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -459,3 +459,7 @@
 .is-loading {
 	opacity: 0.5;
 }
+
+.margin-top-16 {
+	margin-top: 16px;
+}


### PR DESCRIPTION
Related to 1204774821045518-as-1204776079125750

## Proposed Changes

The PR adds an alert banner to the Downtime Monitor SMS notification when no phone number is added 

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/show-alert-banner-for-monitor-sms-notification` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Click on the Mobile notification toggle, verify it is enabled when clicking and an alert banner is shown as below

<img width="467" alt="Screenshot 2023-06-08 at 4 53 16 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8d4c4038-700d-4ff6-ac7a-4dce5b5725ef">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?