### PR TITLE
Assembler: The new site from LoTS won't land on Assembler if vpw is 960px

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -7,7 +7,7 @@ import {
 	MARKETPLACE_THEME,
 } from '@automattic/design-picker';
 import { isSiteAssemblerFlow } from '@automattic/onboarding';
-import { isDesktop } from '@automattic/viewport';
+import { isWithinBreakpoint } from '@automattic/viewport';
 import { get, includes, reject } from 'lodash';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import { getQueryArgs } from 'calypso/lib/query-args';
@@ -119,8 +119,8 @@ function getThankYouNoSiteDestination() {
 function getChecklistThemeDestination( { flowName, siteSlug, themeParameter } ) {
 	if ( isSiteAssemblerFlow( flowName ) && themeParameter === BLANK_CANVAS_DESIGN.slug ) {
 		// Go to the site assembler flow if viewport width >= 960px as the layout doesn't support small
-		// screen for now
-		if ( isDesktop() ) {
+		// screen for now.
+		if ( isWithinBreakpoint( '>=960px' ) ) {
 			return addQueryArgs(
 				{
 					theme: themeParameter,

--- a/packages/viewport/src/index.ts
+++ b/packages/viewport/src/index.ts
@@ -47,6 +47,7 @@ const isServer = typeof window === 'undefined' || ! window.matchMedia;
 
 const noop = () => null;
 
+export type QueryOption = { min?: number; max?: number };
 export type QueryItem = false | MinimalMediaQueryList | MediaQueryList;
 export type ListenerCallback = ( matches: boolean ) => void;
 export type UnsubcribeCallback = () => void;
@@ -66,7 +67,7 @@ function addListenerFunctions(
 	};
 }
 
-function createMediaQueryList( args?: { min?: number; max?: number } ): QueryItem {
+function createMediaQueryList( args?: QueryOption ): QueryItem {
 	const { min, max } = args ?? {};
 	if ( min !== undefined && max !== undefined ) {
 		return isServer
@@ -89,30 +90,33 @@ function createMediaQueryList( args?: { min?: number; max?: number } ): QueryIte
 	return false;
 }
 
-const mediaQueryLists: Record< string, QueryItem > = {
-	'<480px': createMediaQueryList( { max: 480 } ),
-	'<660px': createMediaQueryList( { max: 660 } ),
-	'<782px': createMediaQueryList( { max: 782 } ),
-	'<800px': createMediaQueryList( { max: 800 } ),
-	'<960px': createMediaQueryList( { max: 960 } ),
-	'<1040px': createMediaQueryList( { max: 1040 } ),
-	'<1280px': createMediaQueryList( { max: 1280 } ),
-	'<1400px': createMediaQueryList( { max: 1400 } ),
-	'>480px': createMediaQueryList( { min: 480 } ),
-	'>660px': createMediaQueryList( { min: 660 } ),
-	'>782px': createMediaQueryList( { min: 782 } ),
-	'>800px': createMediaQueryList( { min: 800 } ),
-	'>960px': createMediaQueryList( { min: 960 } ),
-	'>1040px': createMediaQueryList( { min: 1040 } ),
-	'>1280px': createMediaQueryList( { min: 1280 } ),
-	'>1400px': createMediaQueryList( { min: 1400 } ),
-	'480px-660px': createMediaQueryList( { min: 480, max: 660 } ),
-	'660px-960px': createMediaQueryList( { min: 660, max: 960 } ),
-	'480px-960px': createMediaQueryList( { min: 480, max: 960 } ),
+// @todo We should algin the behavior with the `break-*` mixins from Gutenberg to include minimums
+// See https://github.com/WordPress/gutenberg/blob/f1d0bd550f85f5fa4279a3fdb9a2b9c28a7544c6/packages/base-styles/_mixins.scss#L27
+const mediaQueryOptions: Record< string, QueryOption > = {
+	'<480px': { max: 480 },
+	'<660px': { max: 660 },
+	'<782px': { max: 782 },
+	'<800px': { max: 800 },
+	'<960px': { max: 960 },
+	'<1040px': { max: 1040 },
+	'<1280px': { max: 1280 },
+	'<1400px': { max: 1400 },
+	'>480px': { min: 480 },
+	'>660px': { min: 660 },
+	'>782px': { min: 782 },
+	'>800px': { min: 800 },
+	'>=960px': { min: 959 },
+	'>960px': { min: 960 },
+	'>1040px': { min: 1040 },
+	'>1280px': { min: 1280 },
+	'>1400px': { min: 1400 },
+	'480px-660px': { min: 480, max: 660 },
+	'660px-960px': { min: 660, max: 960 },
+	'480px-960px': { min: 480, max: 960 },
 };
 
 export function getMediaQueryList( breakpoint: string ): undefined | QueryItem {
-	if ( ! mediaQueryLists.hasOwnProperty( breakpoint ) ) {
+	if ( ! mediaQueryOptions.hasOwnProperty( breakpoint ) ) {
 		try {
 			// eslint-disable-next-line no-console
 			console.warn( 'Undefined breakpoint used in `mobile-first-breakpoint`', breakpoint );
@@ -120,7 +124,7 @@ export function getMediaQueryList( breakpoint: string ): undefined | QueryItem {
 		return undefined;
 	}
 
-	return mediaQueryLists[ breakpoint ];
+	return createMediaQueryList( mediaQueryOptions[ breakpoint ] );
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to `tracks/funnel/view.php?42784/2023-06-01/to/2023-06-07`

## Proposed Changes

Referring to the funnels, there is a 50% drop rate after people select a plan but it's unreasonable. After investigation, the `PatternAssemblerCta` component uses the `useViewportMatch` hook to determine the viewport width, and it will include the minimums. However, we use the `isDesktop` function inside `getChecklistThemeDestination` to determine whether to go to the assembler screen after creating the new site, but it doesn't include the minimums.

![image](https://github.com/Automattic/wp-calypso/assets/13596067/a90d63c8-1dce-4846-afaf-2f7772f47bb8)

So, this PR proposes to support the `>=960px` breakpoint on Calypso to align the behavior. In the long term, I assume we have to include minimums as the `break-*` mixins from Gutenberg also include minimums.

Note that People might still drop out after selecting a plan, and the main reason might be people selecting a non-free plan.

![image](https://github.com/Automattic/wp-calypso/assets/13596067/cb694699-ba7b-414a-9f48-2606ec415730)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Theme Showcase without logging in, and ensure your viewport width is 960px
* Scroll down and select BCPA CTA
* On the User screen, log in or register a new one
* On the domain screen, select a domain
* On the plan screen, select a plan
* After the new site is created, ensure you land on the Assembler screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
