### PR TITLE
Jetpack Pro Dashboard: Implement "Add phone number" button to monitor SMS notifications

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -30,7 +30,7 @@ export default function ConfigureEmailNotification( {
 	};
 
 	return (
-		<div className="configure-email-address__card-container">
+		<div className="configure-contact__card-container">
 			{ allEmailItems.map( ( item ) => (
 				<EmailItemContent
 					key={ item.email }
@@ -42,7 +42,7 @@ export default function ConfigureEmailNotification( {
 			) ) }
 			<Button
 				compact
-				className="configure-email-address__button"
+				className="configure-contact__button"
 				onClick={ handleAddEmailClick }
 				aria-label={ translate( 'Add email address' ) }
 			>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
@@ -1,9 +1,5 @@
 $help-text-color: #757575;
 
-.configure-email-address__card-container {
-	margin: 16px 0 0;
-}
-
 .configure-email-address__card {
 	margin: 0;
 	height: 60px;
@@ -66,17 +62,6 @@ button.configure-email-address__action-icon {
 	font-size: 0.75rem;
 	line-height: 18px;
 	color: var(--studio-gray-50);
-}
-
-button.configure-email-address__button {
-	margin-block-start: 16px;
-	border-radius: 20px; /* stylelint-disable-line scales/radii */
-	color: var(--studio-gray-80) !important;
-	display: flex;
-	align-items: center;
-	width: fit-content;
-	border-color: var(--studio-gray-80);
-	padding: 4px 8px !important;
 }
 
 .configure-email-notification__help-text {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/index.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@automattic/components';
+import { Icon, plus } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+
+interface Props {
+	toggleModal: () => void;
+}
+
+export default function ConfigureSMSNotification( { toggleModal }: Props ) {
+	const translate = useTranslate();
+
+	const handleAddEmailClick = () => {
+		// Record event
+		toggleModal();
+	};
+
+	return (
+		<div className="configure-contact__card-container">
+			<Button
+				compact
+				className="configure-contact__button"
+				onClick={ handleAddEmailClick }
+				aria-label={ translate( 'Add phone number' ) }
+			>
+				<Icon size={ 18 } icon={ plus } />
+				{ translate( 'Add phone number' ) }
+			</Button>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -1,0 +1,36 @@
+import { Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+
+interface Props {
+	toggleModal: () => void;
+}
+
+export default function PhoneNumberEditor( { toggleModal }: Props ) {
+	const translate = useTranslate();
+
+	const onSave = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+
+		// Handle save here
+	};
+
+	const title = translate( 'Add your phone number' );
+	const subTitle = translate( 'Please use an accessible phone number. Only alerts sent.' );
+
+	return (
+		<Modal
+			open={ true }
+			onRequestClose={ toggleModal }
+			title={ title }
+			className="notification-settings__modal"
+		>
+			<div className="notification-settings__sub-title">{ subTitle }</div>
+
+			<form onSubmit={ onSave }>
+				{
+					// Add form fields here
+				 }
+			</form>
+		</Modal>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -1,15 +1,18 @@
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import AlertBanner from 'calypso/components/jetpack/alert-banner';
+import ConfigureSMSNotification from '../../configure-sms-notification';
 
 interface Props {
 	enableSMSNotification: boolean;
 	setEnableSMSNotification: ( isEnabled: boolean ) => void;
+	toggleModal: () => void;
 }
 
 export default function SMSNotification( {
 	enableSMSNotification,
 	setEnableSMSNotification,
+	toggleModal,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -37,11 +40,14 @@ export default function SMSNotification( {
 				</div>
 			</div>
 			{ enableSMSNotification && allPhoneNumbers.length === 0 && (
-				<div className="margin-top-16">
-					<AlertBanner type="warning">
-						{ translate( 'You need at least one phone number' ) }
-					</AlertBanner>
-				</div>
+				<>
+					<div className="margin-top-16">
+						<AlertBanner type="warning">
+							{ translate( 'You need at least one phone number' ) }
+						</AlertBanner>
+					</div>
+					<ConfigureSMSNotification toggleModal={ toggleModal } />
+				</>
 			) }
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -15,6 +15,7 @@ import {
 	getSiteCountText,
 } from '../../sites-overview/utils';
 import EmailAddressEditor from '../configure-email-notification/email-address-editor';
+import PhoneNumberEditor from '../configure-sms-notification/phone-number-editor';
 import EmailNotification from './form-content/email-notification';
 import NotificationSettingsFormFooter from './form-content/footer';
 import MobilePushNotification from './form-content/mobile-push-notification';
@@ -32,6 +33,7 @@ import type {
 } from '../../sites-overview/types';
 
 import './style.scss';
+import '../style.scss';
 
 interface Props {
 	sites: Array< Site >;
@@ -71,6 +73,7 @@ export default function NotificationSettings( {
 	const [ allEmailItems, setAllEmailItems ] = useState< StateMonitorSettingsEmail[] | [] >( [] );
 	const [ validationError, setValidationError ] = useState< string >( '' );
 	const [ isAddEmailModalOpen, setIsAddEmailModalOpen ] = useState< boolean >( false );
+	const [ isAddSMSModalOpen, setIsAddSMSModalOpen ] = useState< boolean >( false );
 	const [ selectedEmail, setSelectedEmail ] = useState< StateMonitorSettingsEmail | undefined >();
 	const [ selectedAction, setSelectedAction ] = useState< AllowedMonitorContactActions >();
 	const [ initialSettings, setInitialSettings ] = useState< InitialMonitorSettings >( {
@@ -122,6 +125,10 @@ export default function NotificationSettings( {
 			setSelectedEmail( undefined );
 			setSelectedAction( undefined );
 		}
+	};
+
+	const toggleAddSMSModal = () => {
+		setIsAddSMSModalOpen( ( isAddSMSModalOpen ) => ! isAddSMSModalOpen );
 	};
 
 	const handleSetAllEmailItems = ( items: StateMonitorSettingsEmail[] ) => {
@@ -292,6 +299,10 @@ export default function NotificationSettings( {
 		);
 	}
 
+	if ( isAddSMSModalOpen ) {
+		return <PhoneNumberEditor toggleModal={ toggleAddSMSModal } />;
+	}
+
 	return (
 		<Modal
 			open={ true }
@@ -316,6 +327,7 @@ export default function NotificationSettings( {
 						<SMSNotification
 							enableSMSNotification={ enableSMSNotification }
 							setEnableSMSNotification={ setEnableSMSNotification }
+							toggleModal={ toggleAddSMSModal }
 						/>
 					) }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/style.scss
@@ -1,0 +1,14 @@
+.configure-contact__card-container {
+	margin: 16px 0 0;
+}
+
+button.configure-contact__button {
+	margin-block-start: 16px;
+	border-radius: 20px; /* stylelint-disable-line scales/radii */
+	color: var(--studio-gray-80) !important;
+	display: flex;
+	align-items: center;
+	width: fit-content;
+	border-color: var(--studio-gray-80);
+	padding: 4px 8px !important;
+}


### PR DESCRIPTION
Related to 1204774821045518-as-1204776216303176

## Proposed Changes

The PR adds 
- "+ Add phone number" button to the downtime monitor SMS notifications.
- Adds a dummy modal when clicked on this button.


#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/add-phone-number-button-to-monitor-sms-notification` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Click on the Mobile notification toggle, and verify that you can now see a "+ Add phone number button" -> Click the button and verify a dummy modal pops up, and clicking on cancel closes it.

<img width="476" alt="Screenshot 2023-06-08 at 5 33 57 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6595819d-e2be-4f24-840b-b188477aacfc">
<img width="540" alt="Screenshot 2023-06-08 at 5 34 00 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/14ac60fc-8e1d-4c21-918b-93bae80c780d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?