### PR TITLE
Reader: Add ellipsis menu to tag stream posts

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -254,6 +254,7 @@ class ReaderPostCard extends Component {
 					expandCard={ expandCard }
 					site={ site }
 					postKey={ postKey }
+					teams={ teams }
 				></TagPost>
 			);
 		} else if ( isPhotoPost ) {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -895,3 +895,8 @@
 .reader-post-card__featured-images-img {
 	vertical-align: middle;
 }
+
+.tag-stream__main .reader-post-card__byline-details {
+	display: flex;
+	justify-content: space-between;
+}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -899,4 +899,9 @@
 .tag-stream__main .reader-post-card__byline-details {
 	display: flex;
 	justify-content: space-between;
+
+	.reader-post-options-menu__ellipsis-menu {
+		margin-top: -2px;
+		margin-left: 5px;
+	}
 }

--- a/client/blocks/reader-post-card/tag-post.jsx
+++ b/client/blocks/reader-post-card/tag-post.jsx
@@ -1,12 +1,13 @@
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
+import ReaderPostEllipsisMenu from 'calypso/blocks/reader-post-options-menu/reader-post-ellipsis-menu';
 import AutoDirection from 'calypso/components/auto-direction';
 import TimeSince from 'calypso/components/time-since';
 import { recordPermalinkClick } from 'calypso/reader/stats';
 import FeaturedAsset from './featured-asset';
 
-const TagPost = ( { post, isDiscover, expandCard, postKey, isExpanded, site } ) => {
+const TagPost = ( { post, isDiscover, expandCard, postKey, isExpanded, site, teams } ) => {
 	const onVideoThumbnailClick =
 		post.canonical_media?.mediaType === 'video'
 			? () => expandCard( { postKey, post, site } )
@@ -60,6 +61,12 @@ const TagPost = ( { post, isDiscover, expandCard, postKey, isExpanded, site } ) 
 							</span>
 						) }
 					</div>
+					<ReaderPostEllipsisMenu
+						site={ site }
+						teams={ teams }
+						post={ post }
+						showFollow={ false }
+					/>
 				</div>
 			</div>
 			<FeaturedAsset

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -241,6 +241,8 @@ class ReaderPostEllipsisMenu extends Component {
 		event.preventDefault();
 	};
 
+	stopPropagation = ( event ) => event.stopPropagation();
+
 	render() {
 		const {
 			post,
@@ -286,6 +288,7 @@ class ReaderPostEllipsisMenu extends Component {
 				popoverClassName="reader-post-options-menu__popover ignore-click"
 				onToggle={ this.onMenuToggle }
 				position={ position }
+				onClick={ this.stopPropagation }
 			>
 				{ showConversationFollowButton && (
 					<ConversationFollowButton


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-Rz-p2

## Proposed Changes

* Adds the ellipsis menu to posts in the tag stream pages:

<img width="644" alt="Screenshot 2023-06-08 at 10 39 11 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/e93530be-6127-4c90-97c5-6c137df92f6a">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso build
* Goto a tags page in the reader
* test the ellipsis menu and verify it works as expected and its layout is as expected
* go to other areas of the reader using the `reader-posts-card` and `reader-ellipsis-menu` and smoke test to verify there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?