### PR TITLE
Blog onboarding: Add Tracks click tracking on button click

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
@@ -14,6 +14,12 @@ import './style.scss';
 const BlogIntent: Step = function BlogIntent() {
 	const translate = useTranslate();
 
+	const handleButtonClick = ( intent: string ) => {
+		recordTracksEvent( 'calypso_blog_onboarding_selection_button_click', {
+			intent: intent,
+		} );
+	};
+
 	const currentUser = useSelect(
 		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
 		[]
@@ -41,7 +47,12 @@ const BlogIntent: Step = function BlogIntent() {
 									<FeatherIcon />
 									{ translate( 'Write your first post' ) }
 								</div>
-								<Button className="blogger-intent__button" primary href="/setup/start-writing">
+								<Button
+									onClick={ () => handleButtonClick( 'start-writing' ) }
+									className="blogger-intent__button"
+									primary
+									href="/setup/start-writing"
+								>
 									{ translate( 'Start Writing' ) }
 								</Button>
 							</div>
@@ -51,7 +62,12 @@ const BlogIntent: Step = function BlogIntent() {
 									<DesignIcon />
 									{ translate( 'Pick a design first' ) }
 								</div>
-								<Button className="blogger-intent__button" primary href="/setup/design-first">
+								<Button
+									onClick={ () => handleButtonClick( 'design-first' ) }
+									className="blogger-intent__button"
+									primary
+									href="/setup/design-first"
+								>
 									{ translate( 'View designs' ) }
 								</Button>
 							</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2137

## Proposed Changes

* Add Tracks click tracking to the blog onboarding binary selection page.

Buttons | Tracks
--|--
![track-clicks](https://github.com/Automattic/wp-calypso/assets/140841/b59ac539-9cdf-4920-94ca-6835d1927ce2)  | ![tracks](https://github.com/Automattic/wp-calypso/assets/140841/bc144cd9-cecd-4db8-9c8b-e7d8c4d4c449)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* With a user account with 0 sites, go to /setup/blog
* "How to See Calypso Tracks Events Fire in Real Time" in Field Guide
* Check that when you click one of the buttons the click is recorded in Tracks (see picture above)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
