### PR TITLE
Stats: Refactor module toggling panel

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -168,20 +168,20 @@ class StatsNavigation extends Component {
 					) }
 
 					{ ! config.isEnabled( 'stats/subscribers-section' ) && <SubscribersCount /> }
+
+					{ isModuleSettingsEnabled && AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] && (
+						<PageModuleToggler
+							availableModules={ AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] }
+							pageModules={ pageModules }
+							onToggleModule={ this.onToggleModule }
+							isTooltipShown={ showSettingsTooltip && ! isPageSettingsTooltipDismissed }
+							onTooltipDismiss={ this.onTooltipDismiss }
+						/>
+					) }
 				</SectionNav>
 
 				{ isLegacy && showIntervals && (
 					<Intervals selected={ interval } pathTemplate={ pathTemplate } standalone />
-				) }
-
-				{ isModuleSettingsEnabled && AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] && (
-					<PageModuleToggler
-						availableModules={ AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] }
-						pageModules={ pageModules }
-						onToggleModule={ this.onToggleModule }
-						isTooltipShown={ showSettingsTooltip && ! isPageSettingsTooltipDismissed }
-						onTooltipDismiss={ this.onTooltipDismiss }
-					/>
 				) }
 			</div>
 		);

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -1,11 +1,8 @@
 import config from '@automattic/calypso-config';
-import { Popover } from '@automattic/components';
-import { FormToggle } from '@wordpress/components';
-import { Icon, cog } from '@wordpress/icons';
 import classNames from 'classnames';
-import { localize, translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component, createRef } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import SubscribersCount from 'calypso/blocks/subscribers-count';
 import SectionNav from 'calypso/components/section-nav';
@@ -24,6 +21,7 @@ import {
 import { getModuleToggles } from 'calypso/state/stats/module-toggles/selectors';
 import { AVAILABLE_PAGE_MODULES, navItems, intervals as intervalConstants } from './constants';
 import Intervals from './intervals';
+import PageModuleToggler from './page-module-toggler';
 
 import './style.scss';
 
@@ -64,7 +62,6 @@ class StatsNavigation extends Component {
 	};
 
 	state = {
-		isPageSettingsPopoverVisible: false,
 		// Dismiss the tooltip before the API call is finished.
 		isPageSettingsTooltipDismissed: false,
 		// Only traffic page modules are supported for now.
@@ -85,21 +82,14 @@ class StatsNavigation extends Component {
 		return null;
 	}
 
-	settingsActionRef = createRef();
-
-	togglePopoverMenu = ( isPageSettingsPopoverVisible ) => {
-		this.onTooltipDismiss();
-		this.setState( { isPageSettingsPopoverVisible } );
-	};
-
-	onToggleModule = ( page, module, isShow ) => {
+	onToggleModule = ( module, isShow ) => {
 		const seletedPageModules = Object.assign( {}, this.state.pageModules );
 		seletedPageModules[ module ] = isShow;
 
 		this.setState( { pageModules: seletedPageModules } );
 
 		this.props.updateModuleToggles( this.props.siteId, {
-			[ page ]: seletedPageModules,
+			[ this.props.selectedItem ]: seletedPageModules,
 		} );
 	};
 
@@ -136,8 +126,7 @@ class StatsNavigation extends Component {
 
 	render() {
 		const { slug, selectedItem, interval, isLegacy, showSettingsTooltip } = this.props;
-		const { pageModules, isPageSettingsPopoverVisible, isPageSettingsTooltipDismissed } =
-			this.state;
+		const { pageModules, isPageSettingsTooltipDismissed } = this.state;
 		const { label, showIntervals, path } = navItems[ selectedItem ];
 		const slugPath = slug ? `/${ slug }` : '';
 		const pathTemplate = `${ path }/{{ interval }}${ slugPath }`;
@@ -186,58 +175,13 @@ class StatsNavigation extends Component {
 				) }
 
 				{ isModuleSettingsEnabled && AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] && (
-					<div className="page-modules-settings">
-						<button
-							className="page-modules-settings-action"
-							ref={ this.settingsActionRef }
-							onClick={ () => {
-								this.togglePopoverMenu( ! isPageSettingsPopoverVisible );
-							} }
-						>
-							<Icon className="gridicon" icon={ cog } />
-						</button>
-						<Popover
-							className="tooltip tooltip--darker highlight-card-tooltip highlight-card__settings-tooltip"
-							isVisible={ showSettingsTooltip && ! isPageSettingsTooltipDismissed }
-							position="bottom left"
-							context={ this.settingsActionRef.current }
-						>
-							<div className="highlight-card-tooltip-content">
-								<p>{ translate( 'Here’s where you can find all your Jetpack Stats settings.' ) }</p>
-								<button onClick={ this.onTooltipDismiss }>{ translate( 'Got it' ) }</button>
-							</div>
-						</Popover>
-						<Popover
-							className="tooltip highlight-card-popover page-modules-settings-popover"
-							isVisible={ isPageSettingsPopoverVisible }
-							position="bottom left"
-							context={ this.settingsActionRef.current }
-							focusOnShow={ false }
-						>
-							<div>{ translate( 'Modules visibility' ) }</div>
-							<div className="page-modules-settings-toggle-wrapper">
-								{ AVAILABLE_PAGE_MODULES[ this.props.selectedItem ].map( ( toggleItem ) => {
-									return (
-										<div key={ toggleItem.key } className="page-modules-settings-toggle">
-											<Icon className="gridicon" icon={ toggleItem.icon } />
-											<span>{ toggleItem.label }</span>
-											<FormToggle
-												className="page-modules-settings-toggle-control"
-												checked={ pageModules[ toggleItem.key ] !== false }
-												onChange={ ( event ) => {
-													this.onToggleModule(
-														this.props.selectedItem,
-														toggleItem.key,
-														event.target.checked
-													);
-												} }
-											/>
-										</div>
-									);
-								} ) }
-							</div>
-						</Popover>
-					</div>
+					<PageModuleToggler
+						availableModules={ AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] }
+						pageModules={ pageModules }
+						onToggleModule={ this.onToggleModule }
+						isTooltipShown={ showSettingsTooltip && ! isPageSettingsTooltipDismissed }
+						onTooltipDismiss={ this.onTooltipDismiss }
+					/>
 				) }
 			</div>
 		);

--- a/client/blocks/stats-navigation/page-module-toggler.tsx
+++ b/client/blocks/stats-navigation/page-module-toggler.tsx
@@ -1,0 +1,88 @@
+import { Popover } from '@automattic/components';
+import { FormToggle } from '@wordpress/components';
+import { Icon, cog } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useRef, ReactElement } from 'react';
+
+type PageModuleTogglerProps = {
+	availableModules: ModuleToggleItem[];
+	pageModules: { [ name: string ]: boolean };
+	onToggleModule: ( module: string, isShow: boolean ) => void;
+	isTooltipShown: boolean;
+	onTooltipDismiss: () => void;
+};
+
+type ModuleToggleItem = {
+	label: string;
+	key: string;
+	icon: ReactElement;
+	defaultValue: boolean;
+};
+
+export default function PageModuleToggler( {
+	availableModules,
+	pageModules,
+	onToggleModule,
+	isTooltipShown,
+	onTooltipDismiss,
+}: PageModuleTogglerProps ) {
+	const translate = useTranslate();
+	const settingsActionRef = useRef( null );
+	const [ isSettingsMenuVisible, setIsSettingsMenuVisible ] = useState( false );
+
+	const toggleSettingsMenu = () => {
+		onTooltipDismiss();
+		setIsSettingsMenuVisible( ( isSettingsMenuVisible ) => {
+			return ! isSettingsMenuVisible;
+		} );
+	};
+
+	return (
+		<div className="page-modules-settings">
+			<button
+				className="page-modules-settings-action"
+				ref={ settingsActionRef }
+				onClick={ toggleSettingsMenu }
+			>
+				<Icon className="gridicon" icon={ cog } />
+			</button>
+			<Popover
+				className="tooltip tooltip--darker highlight-card-tooltip highlight-card__settings-tooltip"
+				isVisible={ isTooltipShown }
+				position="bottom left"
+				context={ settingsActionRef.current }
+			>
+				<div className="highlight-card-tooltip-content">
+					<p>{ translate( 'Here’s where you can find all your Jetpack Stats settings.' ) }</p>
+					<button onClick={ onTooltipDismiss }>{ translate( 'Got it' ) }</button>
+				</div>
+			</Popover>
+			<Popover
+				className="tooltip highlight-card-popover page-modules-settings-popover"
+				isVisible={ isSettingsMenuVisible }
+				position="bottom left"
+				context={ settingsActionRef.current }
+				focusOnShow={ false }
+			>
+				<div>{ translate( 'Modules visibility' ) }</div>
+				<div className="page-modules-settings-toggle-wrapper">
+					{ availableModules.map( ( toggleItem: ModuleToggleItem ) => {
+						return (
+							<div key={ toggleItem.key } className="page-modules-settings-toggle">
+								<Icon className="gridicon" icon={ toggleItem.icon } />
+								<span>{ toggleItem.label }</span>
+								<FormToggle
+									className="page-modules-settings-toggle-control"
+									checked={ pageModules[ toggleItem.key ] !== false }
+									onChange={ ( event: React.FormEvent< HTMLInputElement > ) => {
+										onToggleModule( toggleItem.key, event.target.checked );
+									} }
+								/>
+							</div>
+						);
+					} ) }
+				</div>
+			</Popover>
+		</div>
+	);
+}

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -7,6 +7,11 @@
 		display: flex;
 		align-items: center;
 
+		// For not open .section-nav on mobile.
+		@media ( max-width: $break-mobile ) {
+			padding-bottom: 8px;
+		}
+
 		button {
 			height: 24px;
 			cursor: pointer;
@@ -78,6 +83,10 @@
 							line-height: 24px;
 
 						}
+					}
+
+					.page-modules-settings {
+						padding: 8px 0 8px 4px;
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1686093958058099/1686093826.760519-slack-C04UCBZMBAA.

## Proposed Changes

* Refactor module toggling panel to `PageModuleToggler`.
* Move `PageModuleToggler` into `SectionNav` of `StatsNavigation` to adjust the launch button position on mobile.

|Before|After|
|-|-|
|<img width="504" alt="截圖 2023-06-09 上午1 26 38" src="https://github.com/Automattic/wp-calypso/assets/6869813/9c629442-663f-4ee8-a8bd-d7fddcc37984">|<img width="515" alt="截圖 2023-06-09 上午1 26 01" src="https://github.com/Automattic/wp-calypso/assets/6869813/c348cc48-0d6b-4cba-ad12-ea9896955eb3">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the live branch link.
* Navigate to Stats > `Traffic` page.
* Append feature flag to the URL: `flags=stats/module-settings`.
* Ensure the module toggling launch button display as previously on PC and tablet.
* Ensure the module toggling launch button locates at a better position on mobile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?