### PR TITLE
LoggedOut Layout - use currentRoute instead of window object for paths

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -68,16 +68,14 @@ const LayoutLoggedOut = ( {
 	const isCheckout = sectionName === 'checkout';
 	const isCheckoutPending = sectionName === 'checkout-pending';
 	const isJetpackCheckout =
-		sectionName === 'checkout' && window.location.pathname.startsWith( '/checkout/jetpack' );
+		sectionName === 'checkout' && currentRoute.startsWith( '/checkout/jetpack' );
 
 	const isJetpackThankYou =
-		sectionName === 'checkout' &&
-		window.location.pathname.startsWith( '/checkout/jetpack/thank-you' );
+		sectionName === 'checkout' && currentRoute.startsWith( '/checkout/jetpack/thank-you' );
 
-	const isReaderTagPage =
-		sectionName === 'reader' && window.location.pathname.startsWith( '/tag/' );
-	const isReaderSearchPage =
-		sectionName === 'reader' && window.location.pathname.startsWith( '/read/search' );
+	const isReaderTagPage = sectionName === 'reader' && currentRoute.startsWith( '/tag/' );
+
+	const isReaderSearchPage = sectionName === 'reader' && currentRoute.startsWith( '/read/search' );
 
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-Rz-p2  - There is a noted issue in that PT about "Tags navigation changes", noting sometimes the wrong header is displayed on the tags page. 


## Proposed Changes

* Replaces `window.location.pathname` with `currentRoute` in the logged-out-layout component.

Upon investigation, sometimes when loading a tags (`/tag/*`) page, this component would still read `/tags` from `window.location.pathname` making checks like `isReaderTagPage` give false negatives and render the wrong header.  It seems the `currentRoute` hook was added a few months ago and seems to always have the correct data (will appropriately return `/tag/*` even when `window.location.pathname` is still returning an outdated value. 

This PR replaces all instances of `window.location.pathname` with `currentRoute` in this component, influencing more checks than just `isReaderTagPage` (also `isReaderSearchPage`, `isJetpackCheckout`, and `isJetpackThankYou`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of calypso.
* Go to logged out tags page at `*/tags`.  (This should have the full header component)
* Navigate to individual tags from here, and verify that it always has the minimal header component in the top (different than the home `*/tags` page).
* Smoke test logged out `*/read/search` and verify it is working as expected. (This may fix a bug here as in production this link does not seem to work).
* smoke test logged out `*/checkout/jetpack` and `*/checkout/jetpack/thank-you`. These currently seem to prompt users to log-in in production currently anyways.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?