### PR TITLE
Stats: show one tooltip at a time

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -19,8 +19,8 @@ const CONFLICT_NOTICE_ID_GROUPS: Record< string, Array< keyof Notices > > = {
  * Only allow one notice in a conflict group to be active at a time.
  */
 const processConflictNotices = ( notices: Notices ): Notices => {
-	let foundActiveNotice = false;
 	for ( const conflictNoticeGroup in CONFLICT_NOTICE_ID_GROUPS ) {
+		let foundActiveNotice = false;
 		for ( const confilictNoticeId of CONFLICT_NOTICE_ID_GROUPS[ conflictNoticeGroup ] ) {
 			if ( foundActiveNotice ) {
 				notices[ confilictNoticeId ] = false;

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -24,7 +24,6 @@ const processConflictNotices = ( notices: Notices ): Notices => {
 		for ( const confilictNoticeId of CONFLICT_NOTICE_ID_GROUPS[ conflictNoticeGroup ] ) {
 			if ( foundActiveNotice ) {
 				notices[ confilictNoticeId ] = false;
-				continue;
 			} else if ( notices?.[ confilictNoticeId ] ) {
 				foundActiveNotice = true;
 			}

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -47,6 +47,7 @@ export default function useNoticeVisibilityQuery( siteId: number | null, noticeI
 		queryKey: [ 'stats', 'notices-visibility', siteId ],
 		queryFn: () => queryNotices( siteId ),
 		select: ( payload: Record< string, boolean > ): boolean => !! payload?.[ noticeId ],
+		staleTime: 1000 * 30, // 30 seconds
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds
 	} );

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -9,12 +9,38 @@ export type Notices = {
 	traffic_page_settings: boolean;
 };
 
-export function queryNotices( siteId: number | null ): Promise< Notices > {
-	return wpcom.req.get( {
+// These notices are mutually exclusive, so if one is active, the other should be hidden.
+// The IDs are sorted by priory from high to low.
+const CONFLICT_NOTICE_ID_GROUPS: Record< string, Array< keyof Notices > > = {
+	settings_tool_tips: [ 'traffic_page_settings', 'traffic_page_highlights_module_settings' ],
+};
+
+/**
+ * Only allow one notice in a conflict group to be active at a time.
+ */
+const processConflictNotices = ( notices: Notices ): Notices => {
+	let foundActiveNotice = false;
+	for ( const conflictNoticeGroup in CONFLICT_NOTICE_ID_GROUPS ) {
+		for ( const confilictNoticeId of CONFLICT_NOTICE_ID_GROUPS[ conflictNoticeGroup ] ) {
+			if ( foundActiveNotice ) {
+				notices[ confilictNoticeId ] = false;
+				continue;
+			} else if ( notices?.[ confilictNoticeId ] ) {
+				foundActiveNotice = true;
+			}
+		}
+	}
+	return notices;
+};
+
+export async function queryNotices( siteId: number | null ): Promise< Notices > {
+	const payload = await wpcom.req.get( {
 		method: 'GET',
 		apiNamespace: 'wpcom/v2',
 		path: `/sites/${ siteId }/jetpack-stats-dashboard/notices`,
 	} );
+
+	return processConflictNotices( payload );
 }
 
 export default function useNoticeVisibilityQuery( siteId: number | null, noticeId: string ) {
@@ -22,7 +48,6 @@ export default function useNoticeVisibilityQuery( siteId: number | null, noticeI
 		queryKey: [ 'stats', 'notices-visibility', siteId ],
 		queryFn: () => queryNotices( siteId ),
 		select: ( payload: Record< string, boolean > ): boolean => !! payload?.[ noticeId ],
-		staleTime: 1000 * 60 * 1, // 1 minutes
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds
 	} );


### PR DESCRIPTION
Related to #77934 

## Proposed Changes

The PR introduces conflict notice group and make only one of the notices in a group is active at a time.

## Testing Instructions

* Open live branch
* Apply feature flags `?flags=stats/module-settings,stats/highlights-settings`
* Open Traffic page on a site that no tooltips have been dismissed (or purge `stats_dashboard_options` from sandbox)
* Ensure module settings tooltip is shown first
* Dismiss the tooltip
* Ensure highlights tooltip is shown
* Dismiss the tooltip
* Refresh
* Ensure no tooltip shown


https://github.com/Automattic/wp-calypso/assets/1425433/c7fd445d-a758-40a9-8b23-d60562bf0de9



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
