### PR TITLE
Refactor check for whether a style variation is default or not

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -1,5 +1,9 @@
 import { Card, Button, Gridicon } from '@automattic/components';
-import { DesignPreviewImage, ThemeCard } from '@automattic/design-picker';
+import {
+	DesignPreviewImage,
+	ThemeCard,
+	isDefaultGlobalStylesVariationSlug,
+} from '@automattic/design-picker';
 import { localize } from 'i18n-calypso';
 import { isEmpty, isEqual } from 'lodash';
 import photon from 'photon';
@@ -152,7 +156,10 @@ export class Theme extends Component {
 		//
 		// With that in mind, we only use mShots for non-default style variations to ensure
 		// that there is no flash of image transition from static image to mShots on page load.
-		if ( !! selectedStyleVariation && ! isExternallyManagedTheme ) {
+		if (
+			! isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug ) &&
+			! isExternallyManagedTheme
+		) {
 			const { id: themeId, stylesheet } = theme;
 
 			return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/constants.ts
@@ -1,4 +1,3 @@
-export const DEFAULT_VARIATION_SLUG = 'default';
 export const STEP_NAME = 'design-setup';
 
 /**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -3,6 +3,7 @@ import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { Onboard, useStarterDesignBySlug, useStarterDesignsQuery } from '@automattic/data-stores';
 import {
+	isDefaultGlobalStylesVariationSlug,
 	UnifiedDesignPicker,
 	useCategorizationFromApi,
 	getDesignPreviewUrl,
@@ -44,7 +45,7 @@ import {
 } from '../../analytics/record-design';
 import StepperLoader from '../../components/stepper-loader';
 import { getCategorizationOptions } from './categories';
-import { DEFAULT_VARIATION_SLUG, RETIRING_DESIGN_SLUGS, STEP_NAME } from './constants';
+import { RETIRING_DESIGN_SLUGS, STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
 import PreviewToolbar from './preview-toolbar';
 import UpgradeModal from './upgrade-modal';
@@ -129,8 +130,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			allDesigns.designs = allDesigns.designs.filter( ( design ) => design.is_premium === false );
 
 			allDesigns.designs = allDesigns.designs.map( ( design ) => {
-				design.style_variations = design.style_variations?.filter(
-					( variation ) => variation.slug === 'default'
+				design.style_variations = design.style_variations?.filter( ( variation ) =>
+					isDefaultGlobalStylesVariationSlug( variation.slug )
 				);
 				return design;
 			} );
@@ -577,8 +578,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		const selectStyle = () => {
 			if (
 				shouldLimitGlobalStyles &&
-				selectedStyleVariation &&
-				selectedStyleVariation.slug !== DEFAULT_VARIATION_SLUG
+				! isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug )
 			) {
 				unlockPremiumGlobalStyles();
 			} else {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -8,7 +8,12 @@ import {
 	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
-import { getDesignPreviewUrl, ThemePreview as ThemeWebPreview } from '@automattic/design-picker';
+import {
+	DEFAULT_GLOBAL_STYLES_VARIATION_SLUG,
+	ThemePreview as ThemeWebPreview,
+	getDesignPreviewUrl,
+	isDefaultGlobalStylesVariationSlug,
+} from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import classNames from 'classnames';
@@ -96,7 +101,6 @@ import ThemeStyleVariations from './theme-style-variations';
 
 import './style.scss';
 
-const DEFAULT_VARIATION_SLUG = 'default';
 const noop = () => {};
 
 class ThemeSheet extends Component {
@@ -368,8 +372,9 @@ class ThemeSheet extends Component {
 	shouldRenderUnlockStyleButton() {
 		const { defaultOption, selectedStyleVariationSlug, shouldLimitGlobalStyles, styleVariations } =
 			this.props;
-		const isNonDefaultStyleVariation =
-			selectedStyleVariationSlug && selectedStyleVariationSlug !== DEFAULT_VARIATION_SLUG;
+		const isNonDefaultStyleVariation = ! isDefaultGlobalStylesVariationSlug(
+			selectedStyleVariationSlug
+		);
 
 		return (
 			shouldLimitGlobalStyles &&
@@ -477,8 +482,8 @@ class ThemeSheet extends Component {
 
 	renderWebPreview = () => {
 		const { locale, stylesheet, styleVariations, themeId } = this.props;
-		const baseStyleVariation = styleVariations.find(
-			( style ) => style.slug === DEFAULT_VARIATION_SLUG
+		const baseStyleVariation = styleVariations.find( ( style ) =>
+			isDefaultGlobalStylesVariationSlug( style.slug )
 		);
 		const baseStyleVariationInlineCss = baseStyleVariation?.inline_css || '';
 		const selectedStyleVariationInlineCss = this.getSelectedStyleVariation()?.inline_css || '';
@@ -1042,7 +1047,7 @@ class ThemeSheet extends Component {
 		const { selectedStyleVariationSlug, themeId } = this.props;
 		return {
 			theme_name: themeId,
-			style_variation: selectedStyleVariationSlug ?? DEFAULT_VARIATION_SLUG,
+			style_variation: selectedStyleVariationSlug ?? DEFAULT_GLOBAL_STYLES_VARIATION_SLUG,
 		};
 	};
 

--- a/packages/design-picker/src/components/style-variation-badges/index.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/index.tsx
@@ -1,4 +1,6 @@
 import { useMemo } from 'react';
+import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '../../constants';
+import { isDefaultGlobalStylesVariationSlug } from '../../utils';
 import Badge from './badge';
 import type { StyleVariation } from '../../types';
 import './style.scss';
@@ -20,6 +22,7 @@ const Badges: React.FC< BadgesProps > = ( {
 	onClick,
 	selectedVariation,
 } ) => {
+	const isSelectedVariationDefault = isDefaultGlobalStylesVariationSlug( selectedVariation?.slug );
 	const variationsToShow = useMemo( () => {
 		return variations.slice( 0, maxVariationsToShow );
 	}, [ variations, maxVariationsToShow ] );
@@ -32,7 +35,8 @@ const Badges: React.FC< BadgesProps > = ( {
 					variation={ variation }
 					onClick={ onClick }
 					isSelected={
-						( ! selectedVariation && variation.slug === 'default' ) ||
+						( isSelectedVariationDefault &&
+							variation.slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG ) ||
 						variation.slug === selectedVariation?.slug
 					}
 				/>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -11,6 +11,7 @@ import {
 	getDesignPreviewUrl,
 	getMShotOptions,
 	isBlankCanvasDesign,
+	isDefaultGlobalStylesVariationSlug,
 	filterDesignsByCategory,
 } from '../utils';
 import { UnifiedDesignPickerCategoryFilter } from './design-picker-category-filter/unified-design-picker-category-filter';
@@ -159,7 +160,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 
 	const { style_variations = [] } = design;
 	const trackingDivRef = useTrackDesignView( { category, design, isPremiumThemeAvailable } );
-	const isDefaultVariation = ! selectedStyleVariation || selectedStyleVariation.slug === 'default';
+	const isDefaultVariation = isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug );
 
 	const currentSiteCanInstallWoo = currentPlanFeatures?.includes( FEATURE_WOOP ) ?? false;
 	const designIsBundledWithWoo = design.is_bundled_with_woo_commerce;
@@ -214,7 +215,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 			className="design-button-container"
 			ref={ trackingDivRef }
 			name={
-				isDefaultVariation ? design.title : `${ design.title } – ${ selectedStyleVariation.title }`
+				isDefaultVariation ? design.title : `${ design.title } – ${ selectedStyleVariation?.title }`
 			}
 			image={
 				<DesignPreviewImage

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -4,6 +4,7 @@ export const FONT_TITLES: Partial< Record< Font, string > > = {
 	'Playfair Display': 'Playfair',
 };
 
+export const DEFAULT_GLOBAL_STYLES_VARIATION_SLUG = 'default';
 export const SHOW_ALL_SLUG = 'CLIENT_ONLY_SHOW_ALL_SLUG';
 
 /**

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -18,11 +18,13 @@ export {
 	getDesignUrl,
 	getDesignPreviewUrl,
 	isBlankCanvasDesign,
+	isDefaultGlobalStylesVariationSlug,
 	getMShotOptions,
 } from './utils';
 export {
 	FONT_PAIRINGS,
 	ANCHORFM_FONT_PAIRINGS,
+	DEFAULT_GLOBAL_STYLES_VARIATION_SLUG,
 	DEFAULT_VIEWPORT_WIDTH,
 	DEFAULT_VIEWPORT_HEIGHT,
 	MOBILE_VIEWPORT_WIDTH,

--- a/packages/design-picker/src/utils/global-styles.ts
+++ b/packages/design-picker/src/utils/global-styles.ts
@@ -1,0 +1,5 @@
+import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '../constants';
+
+export function isDefaultGlobalStylesVariationSlug( slug?: string ): boolean {
+	return ! slug || slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG;
+}

--- a/packages/design-picker/src/utils/index.ts
+++ b/packages/design-picker/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from './available-designs-config';
 export * from './available-designs';
 export * from './designs';
 export * from './fonts';
+export * from './global-styles';
 import { SHOW_ALL_SLUG } from '../constants';
 import { isBlankCanvasDesign } from './available-designs';
 import type { Category, Design } from '../types';


### PR DESCRIPTION
## Proposed Changes

This PR consolidates how we check whether a style variation is the default one or not in a utility function in the package `@automattic/design-picker`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the onboarding design picker.
* Ensure that the style variation selection in the theme card, and theme preview works as before.
* Head to the theme showcase.
* Ensure that the style variation selection in the theme card, and theme detail page works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
