### PR TITLE
Stats: force update when ref changes

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -150,6 +150,13 @@ class StatsNavigation extends Component {
 
 		// @TODO: Add loading status of modules settings to avoid toggling modules before they are loaded.
 
+		const buttonRefCallback = ( node ) => {
+			if ( this.settingsActionRef.current === null ) {
+				this.settingsActionRef.current = node;
+				this.forceUpdate();
+			}
+		};
+
 		return (
 			<div className={ wrapperClass }>
 				<SectionNav selectedText={ label }>
@@ -189,7 +196,7 @@ class StatsNavigation extends Component {
 					<div className="page-modules-settings">
 						<button
 							className="page-modules-settings-action"
-							ref={ this.settingsActionRef }
+							ref={ buttonRefCallback }
 							onClick={ () => {
 								this.togglePopoverMenu( ! isPageSettingsPopoverVisible );
 							} }


### PR DESCRIPTION
## Proposed Changes

The component `StatsNavigation` wouldn't re-render when ref changes. I suspect this is bug of reactjs (not sure). The PR proposes to use a ref callback to force update the component when ref.current is set to the referenced node.

## Testing Instructions

* Open live branch
* Apply feature flags `?flags=stats/module-settings,stats/highlights-settings`
* Open Traffic page on a site that tooltips are not dismissed before
* Ensure two tooltips are shown

<img width="371" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/97e6e5e0-6d9d-4881-813f-24f02cfb6355">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
