### PR TITLE
Stats: subscribers overview cards data - add index to query key to avoid potential duplicate

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -85,8 +85,8 @@ export function useSubscribersQueries(
 	quantity: number,
 	dates: string[]
 ): { isLoading: boolean; isError: boolean; subscribersData: SubscribersData[] } {
-	const queryConfigs = dates.map( ( date ) => ( {
-		queryKey: [ 'stats', 'subscribers', siteId, period, quantity, date ],
+	const queryConfigs = dates.map( ( date, index ) => ( {
+		queryKey: [ 'stats', 'subscribers', index, siteId, period, quantity, date ],
 		queryFn: () => querySubscribers( siteId, period, quantity, date ),
 		select: selectSubscribers,
 		staleTime: 1000 * 60 * 5, // 5 minutes


### PR DESCRIPTION
## Proposed Changes

* This PR addresses the issue that both queries in the hook can potentially have the same cache key `queryKey: [ 'stats', 'subscribers', siteId, period, quantity, date ]` It addresses the issue by adding another piece to one of the cache keys

## Testing Instructions

* Open the live branch for this PR.
* Navigate to `/stats/day/:siteSlug`
* Add `?flags=stats/subscribers-section` to the URL to enable the subscriber stats page.
* Scroll down to locate the overview cards (immediately under the chart)
* Check that they load data correctly, still behave acceptably on resize etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
