### PR TITLE
Signup: Fix `hasFilledInputValues` validation bug

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -992,7 +992,19 @@ class SignupForm extends Component {
 	}
 
 	hasFilledInputValues = () => {
-		return Object.values( this.getUserData() ).every( ( value ) => value.trim().length > 0 );
+		const userInputFields = [ 'email', 'username', 'password' ];
+		return userInputFields.every( ( field ) => {
+			const value = formState.getFieldValue( this.state.form, field );
+			if ( typeof value === 'string' ) {
+				return value.trim().length;
+			}
+			// eslint-disable-next-line no-console
+			console.warn(
+				`hasFilledInputValues: field ${ field } has a value of type ${ typeof value }. Expected string.`
+			);
+			// If we can't determine if the field is filled, we assume it is so that the user can submit the form.
+			return true;
+		} );
 	};
 
 	formFooter() {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -996,7 +996,7 @@ class SignupForm extends Component {
 		return userInputFields.every( ( field ) => {
 			const value = formState.getFieldValue( this.state.form, field );
 			if ( typeof value === 'string' ) {
-				return value.trim().length;
+				return value.trim().length > 0;
 			}
 			// eslint-disable-next-line no-console
 			console.warn(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


This PR fixes a bug in WooCommerce signup page. Currently, this error is thrown: `e.trim is not a function` and the page is blank when a user fills in the inputs. The error occurs at this function:

```js
    hasFilledInputValues = () => {
        return Object.values( this.getUserData() ).every( ( value ) => value.trim().length > 0 );
    };
```

We assume all user inputs are string type, but unfortunately, we add a boolean value to userData in https://github.com/Automattic/wp-calypso/pull/77849.


## Proposed Changes

* Update the `hasFilledInputValues`  to only validate the `[ 'email', 'username', 'password' ]` input fields and ignore if the value type is not a string.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open an incognito tab
* Go to https://woocommerce.com/start/
* Replace URL host with your local or calypso live host.
* Create a new account.
* `Get Started` button should be disabled by default and enabled when inputs are filled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
