### PR TITLE
Stats: Force update button ref with state and callback to module settings

### DIFF
--- a/client/blocks/stats-navigation/page-module-toggler.tsx
+++ b/client/blocks/stats-navigation/page-module-toggler.tsx
@@ -2,7 +2,7 @@ import { Popover } from '@automattic/components';
 import { FormToggle } from '@wordpress/components';
 import { Icon, cog } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef, ReactElement } from 'react';
+import { useState, useRef, ReactElement, useCallback } from 'react';
 
 type PageModuleTogglerProps = {
 	availableModules: ModuleToggleItem[];
@@ -27,8 +27,16 @@ export default function PageModuleToggler( {
 	onTooltipDismiss,
 }: PageModuleTogglerProps ) {
 	const translate = useTranslate();
-	const settingsActionRef = useRef( null );
+
+	// Use state to update the ref of the setting action button to avoid null element.
+	const [ settingsActionRef, setSettingsActionRef ] = useState( useRef( null ) );
 	const [ isSettingsMenuVisible, setIsSettingsMenuVisible ] = useState( false );
+
+	const buttonRefCallback = useCallback( ( node ) => {
+		if ( settingsActionRef.current === null ) {
+			setSettingsActionRef( { current: node } );
+		}
+	}, [] );
 
 	const toggleSettingsMenu = () => {
 		onTooltipDismiss();
@@ -41,7 +49,7 @@ export default function PageModuleToggler( {
 		<div className="page-modules-settings">
 			<button
 				className="page-modules-settings-action"
-				ref={ settingsActionRef }
+				ref={ buttonRefCallback }
 				onClick={ toggleSettingsMenu }
 			>
 				<Icon className="gridicon" icon={ cog } />

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -62,7 +62,6 @@ const HighlightCardsSettings = function ( {
 }: HighlightCardsSettingsProps ) {
 	const translate = useTranslate();
 
-	const settingsActionRef = useRef( null );
 	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
 
 	const togglePopoverMenu = useCallback( () => {
@@ -72,11 +71,19 @@ const HighlightCardsSettings = function ( {
 		} );
 	}, [ onTooltipDismiss ] );
 
+	const [ settingsActionRef, setSettingsActionRef ] = useState( useRef( null ) );
+
+	const buttonRefCallback = useCallback( ( node ) => {
+		if ( settingsActionRef.current === null ) {
+			setSettingsActionRef( { current: node } );
+		}
+	}, [] );
+
 	return (
 		<div className="highlight-cards-heading__settings">
 			<button
 				className="highlight-cards-heading__settings-action"
-				ref={ settingsActionRef }
+				ref={ buttonRefCallback }
 				onClick={ togglePopoverMenu }
 			>
 				<Icon className="gridicon" icon={ moreVertical } />

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -71,6 +71,7 @@ const HighlightCardsSettings = function ( {
 		} );
 	}, [ onTooltipDismiss ] );
 
+	// Use state to update the ref of the setting action button to avoid null element.
 	const [ settingsActionRef, setSettingsActionRef ] = useState( useRef( null ) );
 
 	const buttonRefCallback = useCallback( ( node ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The component `PageModuleToggler` wouldn't re-render when the button ref changes. The PR proposes to use a ref callback to update the state of the component when the button ref is set to the referenced node.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open live branch
* Apply feature flags `?flags=stats/module-settings,stats/highlights-settings`
* Open Traffic page on a site that tooltips are not dismissed before
* Ensure two tooltips are shown

<img width="371" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/97e6e5e0-6d9d-4881-813f-24f02cfb6355">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
