### PR TITLE
Stats: save dismissed status to localStorage

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -63,7 +63,9 @@ class StatsNavigation extends Component {
 
 	state = {
 		// Dismiss the tooltip before the API call is finished.
-		isPageSettingsTooltipDismissed: false,
+		isPageSettingsTooltipDismissed: !! localStorage.getItem(
+			'notices_dismissed__traffic_page_settings'
+		),
 		// Only traffic page modules are supported for now.
 		pageModules: Object.assign(
 			...AVAILABLE_PAGE_MODULES.traffic.map( ( module ) => {
@@ -95,6 +97,7 @@ class StatsNavigation extends Component {
 
 	onTooltipDismiss = () => {
 		this.setState( { isPageSettingsTooltipDismissed: true } );
+		localStorage.setItem( 'notices_dismissed__traffic_page_settings', 1 );
 		this.props.mutateNoticeVisbilityAsync().finally( this.props.refetchNotices );
 	};
 

--- a/client/my-sites/stats/highlights-section/index.tsx
+++ b/client/my-sites/stats/highlights-section/index.tsx
@@ -65,10 +65,13 @@ export default function HighlightsSection( {
 		siteId,
 		'traffic_page_highlights_module_settings'
 	);
-	const [ settingsTooltipDismissed, setSettingsTooltipDismissed ] = useState( false );
+	const [ settingsTooltipDismissed, setSettingsTooltipDismissed ] = useState(
+		!! localStorage.getItem( 'notices_dismissed__traffic_page_highlights_module_settings' )
+	);
 
 	const dismissSettingsTooltip = () => {
 		setSettingsTooltipDismissed( true );
+		localStorage.setItem( 'notices_dismissed__traffic_page_highlights_module_settings', '1' );
 		return mutateNoticeVisbilityAsync().finally( refetchNotices );
 	};
 


### PR DESCRIPTION
## Proposed Changes

If user have multiple sites, the tooltip would be shown only once for all sites in Calypso. We'll possibly change to save the status to user meta instead in the future.

## Testing Instructions

* Open Calypso Live
* Dismiss a tooltip in Calypso
* Ensure it doesn't come up again for other sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
