### PR TITLE
E2E: update expectations for the Reader spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -1,4 +1,4 @@
-import { Page, Response } from 'playwright';
+import { Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 
 const selectors = {
@@ -36,8 +36,9 @@ export class ReaderPage {
 	 *
 	 * Example {@link https://wordpress.com/read}
 	 */
-	async visit(): Promise< Response | null > {
-		return await this.page.goto( getCalypsoURL( 'read' ) );
+	async visit(): Promise< void > {
+		await this.page.goto( getCalypsoURL( 'read' ) );
+		await this.page.waitForURL( /read/ );
 	}
 
 	/**

--- a/test/e2e/specs/published-content/reader__view.ts
+++ b/test/e2e/specs/published-content/reader__view.ts
@@ -35,7 +35,7 @@ describe( DataHelper.createSuiteTitle( 'Reader: View' ), function () {
 	it( 'Reader stream is present', async function () {
 		await Promise.any( [
 			page.getByRole( 'link', { name: 'Find sites to follow' } ),
-			page.getByRole( 'article' ),
+			page.getByRole( 'main' ).getByRole( 'article' ),
 		] );
 	} );
 } );

--- a/test/e2e/specs/published-content/reader__view.ts
+++ b/test/e2e/specs/published-content/reader__view.ts
@@ -7,7 +7,6 @@ import {
 	DataHelper,
 	TestAccount,
 	ReaderPage,
-	SecretsManager,
 	TestAccountName,
 	envVariables,
 } from '@automattic/calypso-e2e';
@@ -18,28 +17,25 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Reader: View' ), function () {
 	let page: Page;
 	let readerPage: ReaderPage;
-	const user: TestAccountName =
+	const accountName: TestAccountName =
 		envVariables.JETPACK_TARGET === 'remote-site' ? 'jetpackRemoteSiteUser' : 'commentingUser';
-	const expectedSiteName =
-		envVariables.JETPACK_TARGET === 'remote-site'
-			? SecretsManager.secrets.testAccounts.jetpackRemoteSiteUser.testSites?.primary.url
-			: SecretsManager.secrets.otherTestSites.notifications;
 	let testAccount: TestAccount;
 
 	beforeAll( async function () {
 		page = await browser.newPage();
-		testAccount = new TestAccount( user );
+		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 	} );
 
-	it( 'View the Reader stream', async function () {
+	it( 'Visit the Reader', async function () {
 		readerPage = new ReaderPage( page );
 		await readerPage.visit();
-		const siteOfLatestPost = await readerPage.siteOfLatestPost();
-		expect( siteOfLatestPost ).toEqual( expectedSiteName );
 	} );
 
-	it( 'Visit latest post', async function () {
-		await readerPage.visitPost( { index: 1 } );
+	it( 'Reader stream is present', async function () {
+		await Promise.any( [
+			page.getByRole( 'link', { name: 'Find sites to follow' } ),
+			page.getByRole( 'article' ),
+		] );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #77993.

## Proposed Changes

This PR updates the test expectation for the `Reader` spec.

Key changes:
- check for the CTA button (no subscribed users) or the presence of an article card (subscribed user).

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
