### PR TITLE
Permafailing E2E: extend Site Assembler timeout.

### DIFF
--- a/test/e2e/specs/onboarding/setup__site-assembler.ts
+++ b/test/e2e/specs/onboarding/setup__site-assembler.ts
@@ -79,7 +79,7 @@ describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
 				startSiteFlow.clickButton( 'Continue' ),
 			] );
 			await page.waitForURL( /site-editor/, {
-				timeout: 45 * 1000,
+				timeout: 60 * 1000,
 			} );
 		} );
 	} );


### PR DESCRIPTION
Related to #77831.

## Proposed Changes

This PR extends timeout of the final step of being redirected to the Site Editor to 60 seconds.


## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
