### PR TITLE
Stats: Fixing position of an empty page message

### DIFF
--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -257,9 +257,6 @@ class VideoPressStatsModule extends Component {
 							) }
 						</SectionHeader>
 						<Card compact className={ cardClasses }>
-							{ noData && <ErrorPanel message={ moduleStrings.empty } /> }
-							{ hasError && <ErrorPanel /> }
-
 							<div className="videopress-stats-module__grid">
 								<div className="videopress-stats-module__header-row-wrapper">
 									<div className="videopress-stats-module__grid-header">Title</div>
@@ -323,6 +320,8 @@ class VideoPressStatsModule extends Component {
 									</div>
 								) ) }
 							</div>
+							{ noData && <ErrorPanel message={ moduleStrings.empty } /> }
+							{ hasError && <ErrorPanel /> }
 							<StatsModulePlaceholder isLoading={ isLoading } />
 						</Card>
 					</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76801

## Proposed Changes

* moving empty page message below column headers

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the Stats page for a blog without videos
* navigate to `View details` on the video module
* verify that the message about no videos is below the column headers

| Before | After |
| --- | --- |
| ![SCR-20230609-pnor](https://github.com/Automattic/wp-calypso/assets/112354940/c2adeaf7-18de-4d15-81e6-3d4ce3c20f01) | ![SCR-20230609-pnrj](https://github.com/Automattic/wp-calypso/assets/112354940/037b85e1-8521-46e8-922d-9b5adf70b976) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
