### PR TITLE
Jetpack Pro Dashboard: Implement add phone number to monitor SMS notifications

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -94,7 +94,7 @@ export default function EmailAddressEditor( {
 			components: {
 				button: (
 					<Button
-						className={ classNames( 'configure-email-notification__resend-code-button', {
+						className={ classNames( 'configure-contact__resend-code-button', {
 							'is-loading': resendCode.isLoading,
 						} ) }
 						borderless
@@ -336,7 +336,7 @@ export default function EmailAddressEditor( {
 		>
 			<div className="notification-settings__sub-title">{ subTitle }</div>
 
-			<form className="configure-email-notification__form" onSubmit={ onSave }>
+			<form className="configure-contact__form" onSubmit={ onSave }>
 				{ isRemoveAction ? (
 					selectedEmail && <EmailItemContent isRemoveAction item={ selectedEmail } />
 				) : (
@@ -352,7 +352,7 @@ export default function EmailAddressEditor( {
 								aria-describedby={ ! isVerifyAction ? 'name-help-text' : undefined }
 							/>
 							{ ! isVerifyAction && (
-								<div className="configure-email-notification__help-text" id="name-help-text">
+								<div className="configure-contact__help-text" id="name-help-text">
 									{ translate( 'Give this email a nickname for your personal reference.' ) }
 								</div>
 							) }
@@ -374,7 +374,7 @@ export default function EmailAddressEditor( {
 								</div>
 							) }
 							{ ! isVerifyAction && (
-								<div className="configure-email-notification__help-text" id="email-help-text">
+								<div className="configure-contact__help-text" id="email-help-text">
 									{ translate( 'We’ll send a code to verify your email address.' ) }
 								</div>
 							) }
@@ -396,7 +396,7 @@ export default function EmailAddressEditor( {
 										{ validationError.code }
 									</div>
 								) }
-								<div className="configure-email-notification__help-text" id="code-help-text">
+								<div className="configure-contact__help-text" id="code-help-text">
 									{ helpText ??
 										( resendCodeClicked && resendCode.isLoading
 											? translate( 'Sending code' )

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
@@ -64,28 +64,6 @@ button.configure-email-address__action-icon {
 	color: var(--studio-gray-50);
 }
 
-.configure-email-notification__help-text {
-	font-weight: 400;
-	font-size: 0.75rem;
-	line-height: 15px;
-	color: var(--studio-gray-40);
-}
-
-.configure-email-notification__form {
-	margin-block-start: 24px;
-
-	.notification-settings__footer-validation-error {
-		margin-block: 8px;
-	}
-}
-
-.configure-email-notification__resend-code-button {
-	@extend .configure-email-notification__help-text;
-	padding: 0;
-	color: var(--studio-green-50) !important;
-	text-decoration: underline;
-}
-
 .configure-email-address__popover-menu {
 	z-index: 999999;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/index.tsx
@@ -1,25 +1,31 @@
 import { Button } from '@automattic/components';
 import { Icon, plus } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import type { StateMonitorSettingsSMS } from '../../sites-overview/types';
 
 interface Props {
 	toggleModal: () => void;
+	allPhoneItems: Array< StateMonitorSettingsSMS >;
 }
 
-export default function ConfigureSMSNotification( { toggleModal }: Props ) {
+export default function ConfigureSMSNotification( { toggleModal, allPhoneItems }: Props ) {
 	const translate = useTranslate();
 
-	const handleAddEmailClick = () => {
+	const handleAddPhoneClick = () => {
 		// Record event
 		toggleModal();
 	};
 
 	return (
 		<div className="configure-contact__card-container">
+			{ allPhoneItems.map( ( item ) => (
+				// TODO: Replace with the correct component
+				<li key={ item.phoneNumberFull }>{ item.phoneNumberFull }</li>
+			) ) }
 			<Button
 				compact
 				className="configure-contact__button"
-				onClick={ handleAddEmailClick }
+				onClick={ handleAddPhoneClick }
 				aria-label={ translate( 'Add phone number' ) }
 			>
 				<Icon size={ 18 } icon={ plus } />

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -1,21 +1,130 @@
+import { Button } from '@automattic/components';
 import { Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormPhoneInput from 'calypso/components/forms/form-phone-input';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import { useSelector } from 'calypso/state';
+import getCountries from 'calypso/state/selectors/get-countries';
+import type { StateMonitorSettingsSMS } from '../../sites-overview/types';
 
 interface Props {
 	toggleModal: () => void;
+	allPhoneItems: Array< StateMonitorSettingsSMS >;
+	setAllPhoneItems: ( phoneNumbers: Array< StateMonitorSettingsSMS > ) => void;
 }
 
-export default function PhoneNumberEditor( { toggleModal }: Props ) {
+export default function PhoneNumberEditor( {
+	toggleModal,
+	allPhoneItems,
+	setAllPhoneItems,
+}: Props ) {
 	const translate = useTranslate();
+
+	const countriesList = useSelector( ( state ) => getCountries( state, 'sms' ) ?? [] );
+
+	const [ showCodeVerification, setShowCodeVerification ] = useState< boolean >( false );
+	const [ validationStatus, setValidationStatus ] = useState< {
+		isValid: boolean;
+		errorMessage: string;
+	} >( {
+		isValid: true,
+		errorMessage: '',
+	} );
+	const [ validationError, setValidationError ] = useState<
+		{ phone?: string; code?: string } | undefined
+	>();
+	const [ smsItem, setSMSItem ] = useState< {
+		name: string;
+		countryCode: string;
+		phoneNumber: string;
+		phoneNumberFull: string;
+	} >( {
+		name: '',
+		countryCode: '',
+		phoneNumber: '',
+		phoneNumberFull: '',
+	} );
+
+	const handleSetSMSItems = useCallback(
+		( isVerified = true ) => {
+			const updatedPhoneItem = {
+				...smsItem,
+				verified: isVerified,
+			};
+			// Check if exists when editing
+			allPhoneItems.push( updatedPhoneItem );
+			setAllPhoneItems( allPhoneItems );
+			toggleModal();
+		},
+		[ allPhoneItems, smsItem, setAllPhoneItems, toggleModal ]
+	);
+
+	const handleRequestVerificationCode = () => {
+		setShowCodeVerification( true );
+		// TODO: Make API call to request verification code
+	};
+
+	// Save unverified phone number to the list when user clicks on Later button
+	function onSaveLater() {
+		handleSetSMSItems( false );
+	}
 
 	const onSave = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
-
-		// Handle save here
+		setValidationError( undefined );
+		if ( validationStatus.isValid ) {
+			if ( showCodeVerification ) {
+				// TODO: Add code verification
+			}
+			return handleRequestVerificationCode();
+		}
+		setValidationError( { phone: validationStatus.errorMessage } );
 	};
+
+	const handleChange = useCallback(
+		( key ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {
+			setSMSItem( ( prevState ) => ( { ...prevState, [ key ]: event.target.value } ) );
+		},
+		[]
+	);
 
 	const title = translate( 'Add your phone number' );
 	const subTitle = translate( 'Please use an accessible phone number. Only alerts sent.' );
+
+	const onChangePhoneInput = ( {
+		phoneNumberFull,
+		phoneNumber,
+		countryData,
+		isValid,
+		validation,
+	}: {
+		phoneNumberFull: string;
+		phoneNumber: string;
+		countryData: {
+			code: string;
+		};
+		isValid: boolean;
+		validation: {
+			message: string;
+		};
+	} ) => {
+		setValidationStatus( {
+			isValid,
+			errorMessage: validation.message,
+		} );
+		setSMSItem( ( prevState ) => ( {
+			...prevState,
+			phoneNumberFull,
+			phoneNumber,
+			countryCode: countryData.code,
+		} ) );
+	};
+
+	const noCountryList = countriesList.length === 0;
 
 	return (
 		<Modal
@@ -26,10 +135,62 @@ export default function PhoneNumberEditor( { toggleModal }: Props ) {
 		>
 			<div className="notification-settings__sub-title">{ subTitle }</div>
 
-			<form onSubmit={ onSave }>
-				{
-					// Add form fields here
-				 }
+			<form className="configure-contact__form" onSubmit={ onSave }>
+				<>
+					<FormFieldset>
+						<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
+						<FormTextInput
+							id="name"
+							name="name"
+							value={ smsItem.name }
+							onChange={ handleChange( 'name' ) }
+							aria-describedby="name-help-text"
+							disabled={ showCodeVerification }
+						/>
+						<div className="configure-contact__help-text" id="name-help-text">
+							{ translate( 'Give this number a name for your personal reference.' ) }
+						</div>
+					</FormFieldset>
+					{
+						// Fetch countries list only if not available
+						noCountryList && <QuerySmsCountries />
+					}
+					<FormPhoneInput
+						isDisabled={ noCountryList || showCodeVerification }
+						countriesList={ countriesList }
+						initialCountryCode={ smsItem.countryCode }
+						initialPhoneNumber={ smsItem.phoneNumber }
+						onChange={ onChangePhoneInput }
+						className="configure-contact__phone-input"
+					/>
+					{ ! validationStatus.isValid && validationError?.phone && (
+						<div className="notification-settings__footer-validation-error" role="alert">
+							{ validationStatus.errorMessage }
+						</div>
+					) }
+					<div className="configure-contact__help-text" id="phone-help-text">
+						{ translate( 'We’ll send a code to verify your phone number.' ) }
+					</div>
+					{ showCodeVerification && (
+						<h3 style={ { marginTop: 16 } }>
+							TODO: Allow users to verify their phone number by entering a code.
+						</h3>
+					) }
+				</>
+				<div className="notification-settings__footer">
+					<div className="notification-settings__footer-buttons">
+						<Button onClick={ showCodeVerification ? onSaveLater : toggleModal }>
+							{ showCodeVerification ? translate( 'Later' ) : translate( 'Back' ) }
+						</Button>
+						<Button
+							disabled={ ! smsItem.name || ! smsItem.countryCode || ! smsItem.phoneNumber }
+							type="submit"
+							primary
+						>
+							{ translate( 'Verify' ) }
+						</Button>
+					</div>
+				</div>
 			</form>
 		</Modal>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -17,6 +17,13 @@ interface Props {
 	setAllPhoneItems: ( phoneNumbers: Array< StateMonitorSettingsSMS > ) => void;
 }
 
+interface FormPhoneInputChangeResult {
+	name: string;
+	countryCode: string;
+	phoneNumber: string;
+	phoneNumberFull: string;
+}
+
 export default function PhoneNumberEditor( {
 	toggleModal,
 	allPhoneItems,
@@ -37,12 +44,7 @@ export default function PhoneNumberEditor( {
 	const [ validationError, setValidationError ] = useState<
 		{ phone?: string; code?: string } | undefined
 	>();
-	const [ smsItem, setSMSItem ] = useState< {
-		name: string;
-		countryCode: string;
-		phoneNumber: string;
-		phoneNumberFull: string;
-	} >( {
+	const [ smsItem, setSMSItem ] = useState< FormPhoneInputChangeResult >( {
 		name: '',
 		countryCode: '',
 		phoneNumber: '',

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -2,17 +2,20 @@ import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import AlertBanner from 'calypso/components/jetpack/alert-banner';
 import ConfigureSMSNotification from '../../configure-sms-notification';
+import type { StateMonitorSettingsSMS } from '../../../sites-overview/types';
 
 interface Props {
 	enableSMSNotification: boolean;
 	setEnableSMSNotification: ( isEnabled: boolean ) => void;
 	toggleModal: () => void;
+	allPhoneItems: Array< StateMonitorSettingsSMS >;
 }
 
 export default function SMSNotification( {
 	enableSMSNotification,
 	setEnableSMSNotification,
 	toggleModal,
+	allPhoneItems,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -20,8 +23,6 @@ export default function SMSNotification( {
 		// Record event here
 		setEnableSMSNotification( isEnabled );
 	};
-
-	const allPhoneNumbers = []; // TODO: Get all phone numbers from the API when it is ready
 
 	return (
 		<>
@@ -39,14 +40,16 @@ export default function SMSNotification( {
 					</div>
 				</div>
 			</div>
-			{ enableSMSNotification && allPhoneNumbers.length === 0 && (
+			{ enableSMSNotification && (
 				<>
-					<div className="margin-top-16">
-						<AlertBanner type="warning">
-							{ translate( 'You need at least one phone number' ) }
-						</AlertBanner>
-					</div>
-					<ConfigureSMSNotification toggleModal={ toggleModal } />
+					{ allPhoneItems.length === 0 && (
+						<div className="margin-top-16">
+							<AlertBanner type="warning">
+								{ translate( 'You need at least one phone number' ) }
+							</AlertBanner>
+						</div>
+					) }
+					<ConfigureSMSNotification toggleModal={ toggleModal } allPhoneItems={ allPhoneItems } />
 				</>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -30,6 +30,7 @@ import type {
 	UpdateMonitorSettingsParams,
 	MonitorDuration,
 	InitialMonitorSettings,
+	StateMonitorSettingsSMS,
 } from '../../sites-overview/types';
 
 import './style.scss';
@@ -71,6 +72,7 @@ export default function NotificationSettings( {
 		[]
 	);
 	const [ allEmailItems, setAllEmailItems ] = useState< StateMonitorSettingsEmail[] | [] >( [] );
+	const [ allPhoneItems, setAllPhoneItems ] = useState< StateMonitorSettingsSMS[] | [] >( [] );
 	const [ validationError, setValidationError ] = useState< string >( '' );
 	const [ isAddEmailModalOpen, setIsAddEmailModalOpen ] = useState< boolean >( false );
 	const [ isAddSMSModalOpen, setIsAddSMSModalOpen ] = useState< boolean >( false );
@@ -133,6 +135,11 @@ export default function NotificationSettings( {
 
 	const handleSetAllEmailItems = ( items: StateMonitorSettingsEmail[] ) => {
 		setAllEmailItems( items );
+		setHasUnsavedChanges( false );
+	};
+
+	const handleSetAllPhoneItems = ( items: StateMonitorSettingsSMS[] ) => {
+		setAllPhoneItems( items );
 		setHasUnsavedChanges( false );
 	};
 
@@ -300,7 +307,13 @@ export default function NotificationSettings( {
 	}
 
 	if ( isAddSMSModalOpen ) {
-		return <PhoneNumberEditor toggleModal={ toggleAddSMSModal } />;
+		return (
+			<PhoneNumberEditor
+				toggleModal={ toggleAddSMSModal }
+				allPhoneItems={ allPhoneItems }
+				setAllPhoneItems={ handleSetAllPhoneItems }
+			/>
+		);
 	}
 
 	return (
@@ -328,9 +341,9 @@ export default function NotificationSettings( {
 							enableSMSNotification={ enableSMSNotification }
 							setEnableSMSNotification={ setEnableSMSNotification }
 							toggleModal={ toggleAddSMSModal }
+							allPhoneItems={ allPhoneItems }
 						/>
 					) }
-
 					<MobilePushNotification
 						recordEvent={ recordEvent }
 						enableMobileNotification={ enableMobileNotification }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/style.scss
@@ -12,3 +12,43 @@ button.configure-contact__button {
 	border-color: var(--studio-gray-80);
 	padding: 4px 8px !important;
 }
+
+.configure-contact__form {
+	margin-block-start: 24px;
+
+	.notification-settings__footer-validation-error {
+		margin-block: 8px;
+	}
+}
+
+.configure-contact__help-text {
+	font-weight: 400;
+	font-size: 0.75rem;
+	line-height: 15px;
+	color: var(--studio-gray-40);
+	margin-block-start: 8px;
+}
+
+.configure-contact__resend-code-button {
+	@extend .configure-contact__help-text;
+	padding: 0;
+	color: var(--studio-green-50) !important;
+	text-decoration: underline;
+}
+
+.configure-contact__phone-input {
+	display: flex;
+
+	fieldset {
+		margin-block-end: 0;
+
+		&:first-child {
+			width: 50%;
+			margin-inline-end: 8px;
+
+			select {
+				width: inherit;
+			}
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/style.scss
@@ -24,7 +24,6 @@ button.configure-contact__button {
 .configure-contact__help-text {
 	font-weight: 400;
 	font-size: 0.75rem;
-	line-height: 15px;
 	color: var(--studio-gray-40);
 	margin-block-start: 8px;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -318,3 +318,11 @@ export interface ResendVerificationCodeParams {
 	type: 'email';
 	value: string;
 }
+
+export interface StateMonitorSettingsSMS {
+	name: string;
+	countryCode: string;
+	phoneNumber: string;
+	phoneNumberFull: string;
+	verified: boolean;
+}


### PR DESCRIPTION
Related to 1204774821045518-as-1204776216303193 & 1204774821045518-as-1204783884585814

## Proposed Changes

The PR implements UI to add a phone number including name and country code.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-add-phone-number-to-monitor-notification` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Click on the Mobile notification toggle, and click the "+ Add phone number" button -> Verify the modal now has fields for name, country code, and phone number.

<img width="469" alt="Screenshot 2023-06-09 at 2 01 10 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/dd1894c0-499b-4513-8460-ea09f2dfcb2a">

6. Enter your name, and select the country code and phone numbers. Enter invalid numbers and see if validation errors are shown.

<img width="469" alt="Screenshot 2023-06-09 at 2 01 27 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8c4264b6-85f2-40e9-964f-58e84cfb770a">


7. Click the "Verify" button and verify that you can see the "TODO: Allow users to verify their phone number by entering a code." message 

<img width="476" alt="Screenshot 2023-06-09 at 2 01 36 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/19376518-97ed-4903-9a0b-015c58569660">

8. Now click "Later" and verify the added contact is shown in the list and that the alert banner is not shown anymore.

<img width="472" alt="Screenshot 2023-06-09 at 12 35 41 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/eb7d834b-89db-4791-b201-3bf86f1c1435">

**Alert banner**

<img width="447" alt="Screenshot 2023-06-09 at 12 37 34 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2b059760-7ad0-4ad2-a8b9-5b2d831f2406">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?