### PR TITLE
Import onboarding: Hide Getting started video from the Hooray screen for the redesigned flow

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -235,7 +235,7 @@ export class ImportEverything extends SectionMigrate {
 						? this.renderDefaultHoorayScreen()
 						: this.renderHoorayScreenWithDomainInfo() }
 				</Hooray>
-				<GettingStartedVideo />
+				{ ! isEnabled( 'onboarding/import-redesign' ) && <GettingStartedVideo /> }
 			</>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77949

## Proposed Changes

* Hide Getting started video from the Hooray screen for the redesigned flow

## Testing Instructions

* Start the migration flow
* `/setup/import-focused?siteSlug={SITE_SLUG}`
* Enter the source site (could be JN site)
* Run the migration
* Check if the final Hooray screen is without Getting Started video

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
