### PR TITLE
Subscription Management: Add blog url route support.

### DIFF
--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -12,12 +12,15 @@ import SiteSubscriptionDetails from './site-subscription-details';
 const SiteSubscriptionPage = () => {
 	const translate = useTranslate();
 	const navigate = useNavigate();
-	const { blogId = '' } = useParams();
-	const { data, isLoading, error } = SubscriptionManager.useSiteSubscriptionDetailsQuery( blogId );
+	const { blogIdOrUrl = '' } = useParams();
+	const { data, isLoading, error } =
+		SubscriptionManager.useSiteSubscriptionDetailsQuery( blogIdOrUrl );
 
 	if ( isLoading ) {
 		return <WordPressLogo size={ 72 } className="wpcom-site__logo" />;
 	}
+
+	const blogId = data && 'blog_ID' in data ? data.blog_ID : null;
 
 	return (
 		<div className="site-subscription-page">

--- a/client/landing/subscriptions/index.tsx
+++ b/client/landing/subscriptions/index.tsx
@@ -59,7 +59,10 @@ window.AppBoot = async () => {
 						<WindowLocaleEffectManager />
 						<BrowserRouter>
 							<Routes>
-								<Route path="/subscriptions/site/:blogId/*" element={ <SiteSubscriptionPage /> } />
+								<Route
+									path="/subscriptions/site/:blogIdOrUrl/*"
+									element={ <SiteSubscriptionPage /> }
+								/>
 								<Route path="/subscriptions/*" element={ <SubscriptionManagerPage /> } />
 							</Routes>
 						</BrowserRouter>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This is a draft PR. Do not merge.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
