### PR TITLE
Subscribers Page: some fixes based on feedback

### DIFF
--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { useLocale } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { Item } from 'calypso/components/breadcrumb';
@@ -13,7 +12,6 @@ import './styles.scss';
 
 export const Subscribers = () => {
 	const isSubscribersPageEnabled = config.isEnabled( 'subscribers-page' );
-	const locale = useLocale();
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const initialState = { data: { total: 0, subscribers: [] } };
 	const result = useSubscribersQuery( selectedSiteId );
@@ -57,7 +55,7 @@ export const Subscribers = () => {
 				<span className="subscribers__title">{ translate( 'Total' ) }</span>{ ' ' }
 				<span className="subscribers__subscriber-count">{ total }</span>
 			</div>
-			<SubscriberList subscribers={ subscribers } locale={ locale } />
+			<SubscriberList subscribers={ subscribers } />
 		</Main>
 	);
 };

--- a/client/my-sites/subscribers/styles.scss
+++ b/client/my-sites/subscribers/styles.scss
@@ -1,10 +1,11 @@
 @import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 
 .subscribers__header-count {
 	margin-top: 70px;
 	margin-bottom: 30px;
-	font-size: rem(20px);
+	font-size: $font-title-small;
 	line-height: 26px;
 
 	.subscribers__title {

--- a/client/my-sites/subscribers/subscriber-list/styles.scss
+++ b/client/my-sites/subscribers/subscriber-list/styles.scss
@@ -1,4 +1,5 @@
 @import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 
 .subscriber-list {
@@ -37,7 +38,6 @@
 		.subscriber-list__menu-column {
 			font-weight: 400;
 			font-size: $font-body-small;
-			font-size: rem(14px);
 			line-height: 20px;
 			letter-spacing: -0.15px;
 			color: $studio-gray-60;
@@ -76,14 +76,14 @@
 						font-weight: bold;
 						line-height: 17px;
 						min-width: 0;
-						font-size: rem(15px);
+						font-size: $font-code;
 					}
 
 					.subscriber-profile__email {
 						overflow: hidden;
 						text-overflow: ellipsis;
 						white-space: nowrap;
-						font-size: rem(12px);
+						font-size: $font-body-extra-small;
 						color: $studio-gray-60;
 						min-width: 0;
 					}

--- a/client/my-sites/subscribers/subscriber-list/subscriber-list.tsx
+++ b/client/my-sites/subscribers/subscriber-list/subscriber-list.tsx
@@ -8,7 +8,7 @@ type SubscriberListProps = {
 	subscribers: Subscriber[];
 };
 
-export const SubscriberList = ( subscribers: SubscriberListProps ) => {
+export const SubscriberList = ( { subscribers }: SubscriberListProps ) => {
 	const translate = useTranslate();
 	return (
 		<ul className="subscriber-list" role="table">

--- a/client/my-sites/subscribers/subscriber-list/subscriber-list.tsx
+++ b/client/my-sites/subscribers/subscriber-list/subscriber-list.tsx
@@ -6,10 +6,9 @@ import './styles.scss';
 
 type SubscriberListProps = {
 	subscribers: Subscriber[];
-	locale: string;
 };
 
-export const SubscriberList = ( { subscribers, locale }: SubscriberListProps ) => {
+export const SubscriberList = ( subscribers: SubscriberListProps ) => {
 	const translate = useTranslate();
 	return (
 		<ul className="subscriber-list" role="table">
@@ -37,7 +36,6 @@ export const SubscriberList = ( { subscribers, locale }: SubscriberListProps ) =
 					subscription_id,
 					display_name,
 					email_address,
-					subscriptions,
 					openRate,
 					date_subscribed,
 					avatar,
@@ -48,11 +46,9 @@ export const SubscriberList = ( { subscribers, locale }: SubscriberListProps ) =
 						subscription_id={ subscription_id }
 						display_name={ display_name }
 						email_address={ email_address }
-						subscriptions={ subscriptions }
 						openRate={ openRate }
 						date_subscribed={ date_subscribed }
 						avatar={ avatar }
-						locale={ locale }
 					/>
 				)
 			) }

--- a/client/my-sites/subscribers/subscriber-list/subscriber-row.tsx
+++ b/client/my-sites/subscribers/subscriber-list/subscriber-row.tsx
@@ -1,22 +1,16 @@
 import { Gridicon } from '@automattic/components';
-import moment from 'moment';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import TimeSince from 'calypso/components/time-since';
 import { Subscriber } from '../types';
 import { SubscriberProfile } from './subscriber-profile';
-
-type SubscriberRowProps = Subscriber & {
-	locale: string;
-};
 
 export const SubscriberRow = ( {
 	display_name,
 	email_address,
-	subscriptions,
 	openRate,
 	date_subscribed,
 	avatar,
-	locale,
-}: SubscriberRowProps ) => {
+}: Subscriber ) => {
 	return (
 		<li className="subscriber-row row" role="row">
 			<div className="subscriber-list__checkbox-column hidden" role="cell">
@@ -25,14 +19,12 @@ export const SubscriberRow = ( {
 			<span className="subscriber-list__profile-column" role="cell">
 				<SubscriberProfile avatar={ avatar } displayName={ display_name } email={ email_address } />
 			</span>
-			<span className="subscriber-list__subscription-type-column hidden" role="cell">
-				{ subscriptions && subscriptions.map( ( subscription ) => <div>{ subscription }</div> ) }
-			</span>
+			<span className="subscriber-list__subscription-type-column hidden" role="cell"></span>
 			<span className="subscriber-list__rate-column hidden" role="cell">
 				{ openRate }
 			</span>
 			<span className="subscriber-list__since-column" role="cell">
-				{ moment( date_subscribed ).locale( locale ).format( 'LL' ) }
+				<TimeSince date={ date_subscribed } dateFormat="LL" />
 			</span>
 			<span className="subscriber-list__menu-column" role="cell">
 				<Gridicon icon="ellipsis" size={ 24 } />

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -24,7 +24,6 @@ export type Subscriber = {
 	email_address: string;
 	avatar: string;
 	display_name: string;
-	subscriptions: SubscriptionPlan[];
 	plans?: SubscriptionPlan[];
 	openRate?: number;
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/78003

## Proposed Changes

The fixes done in this PR are:

1. Remove subscriptions from the Subscriber type in `client/my-sites/subscribers/types/index.ts`.
2. Use font variables in `client/my-sites/subscribers/subscriber-list/styles.scss` instead of pixel values directly.
3. Use the TimeSince component in the since column in `client/my-sites/subscribers/subscriber-list/subscriber-row.tsx`.

## Testing Instructions

1. Apply this PR and start the application.
2. Go to this URL: http://calypso.localhost:3000/subscribers/[the-domain-of-your-site].
3. Check you can see a list like the design: h8tMpJlCqNFemEerU9owHI-fi-812_37857
