### PR TITLE
Hide non-SSO jetpack sites from reader-share site list

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -152,8 +152,10 @@ class ReaderShare extends Component {
 		}
 	};
 
+	// Hide jetpack sites without SSO enabled as they do not currently work with this feature.
+	// pe7F0s-X2-p2
 	sitesFilter = ( site ) => {
-		if ( site.jetpack && ! site.is_wpcom_atomic ) {
+		if ( site?.jetpack && ! site?.options?.active_modules?.includes( 'sso' ) ) {
 			return false;
 		}
 		return true;

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -152,6 +152,13 @@ class ReaderShare extends Component {
 		}
 	};
 
+	sitesFilter = ( site ) => {
+		if ( site.jetpack && ! site.is_wpcom_atomic ) {
+			return false;
+		}
+		return true;
+	};
+
 	render() {
 		const { onCopyLinkClick } = this.props;
 		const buttonClasses = classnames( {
@@ -220,6 +227,7 @@ class ReaderShare extends Component {
 								className="reader-share__site-selector"
 								onSiteSelect={ this.pickSiteToShareTo }
 								groups
+								filter={ this.sitesFilter }
 							/>
 						) }
 					</ReaderPopoverMenu>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1686313489610819/1686239372.646259-slack-C029GN3KD

## Proposed Changes

* It was noticed that jetpack connected self hosted sites without SSO enabled do not work with reader share. the underlying problem is more broad, as they are redirected to the jetpack site's wp-admin to login when attempting to access the editor in general. We will discuss more how to better resolve this in p2, but for now we may want to hide non-SSO enabled jetpack sites from the reader share list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply this calypso branch
* goto the reader and try to share a post
* search for a non-SSO jetpack connected site in the sites list, verify they are not present. (you may need to create and jetpack connect a self hosted site without enabling SSO).
* search for other sites you would expect to see here and verify they are present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?