### PR TITLE
Pricing page: Fix price `line-through` mis-aligned in Firefox browser.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -58,8 +58,21 @@
 
 	.plan-price.is-original {
 		color: var(--studio-gray-50);
-		text-decoration: line-through;
 		font-weight: 600;
+		position: relative;
+		white-space: nowrap;
+	}
+
+	// Price strike-through:
+	// (`text-decoration: line-through;` is misaligned in Firefox, so using
+	// pseudo-element is more compatible with all browsers.)
+	.plan-price.is-original::after {
+		border-top: 2px solid var(--studio-gray-50);
+		position: absolute;
+		content: "";
+		right: 0;
+		top: 44%;
+		left: 0;
 	}
 
 	.plan-price.is-discounted {
@@ -90,16 +103,6 @@
 	.display-price__billing-time-frame {
 		max-height: 40px;
 		margin-top: 0;
-	}
-}
-
-/*
-Hack to fix line-through not showing in the middle of the text in firefox browser.
-*/
-@-moz-document url-prefix() {
-	.plan-price {
-		/* stylelint-disable-next-line scales/font-sizes */
-		font-size: 1.4rem;
 	}
 }
 


### PR DESCRIPTION
This PR fixes the mis-aligned strike-through in the discounted price on the Pricing page.  (See before & after screenshots.)

| **BEFORE** | **AFTER** |
|--------|--------|
| <img width="313" alt="Screenshot on 2023-06-09 at 11-52-14" src="https://github.com/Automattic/wp-calypso/assets/11078128/e12e4cfa-94e0-42f5-b3aa-bb302cf8d30d">| <img width="315" alt="Screenshot on 2023-06-09 at 11-53-11" src="https://github.com/Automattic/wp-calypso/assets/11078128/deccfd27-eb0a-41cd-9656-ab2f91c549f2"> | 


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Asana task: 1198218726984184-as-1204724712227212/f

## Proposed Changes

* Replaced `text-decoration: line-through;` with a pseudo-element for more browser compatibility. (`line-through` is mis-aligned in Firefox and there is no way to adjust the line-through position/height.)

## Testing Instructions

- Do any one of these
    * Using the Firefox browser, click on the `Jetpack Cloud live (direct link)` below, then goto `/pricing`
    * or boot up this PR 
        * Run `git fetch && git checkout fix/price-strike-through-misaligned`
        * Run `yarn start-jetpack-cloud`
        * Using the Firefox browser goto: http://jetpack.cloud.localhost:3000/pricing
- Verify the strike-through line on the discounted price is vertically centered and it looks good.
- You can compare with production and see how the strike-through line is mis-aligned prior to this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?