### PR TITLE
Update CSS to look more like Figma

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -222,10 +222,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 					subHeaderText={
 						<>
 							{ __( 'Help your blog stand out with a custom domain. Not sure yet?' ) }
-							<button
-								className="button navigation-link step-container__navigation-link has-underline is-borderless"
-								onClick={ onSkip }
-							>
+							<button className="formatted-header__subtitle has-underline" onClick={ onSkip }>
 								{ __( 'Decide later.' ) }
 							</button>
 						</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -345,6 +345,8 @@ $videopress-background: #010101;
 
 	.domain-suggestion,
 	.domain-suggestion:hover,
+	.featured-domain-suggestion,
+	.featured-domain-suggestion:hover,
 	.register-domain-step__next-page {
 		background-color: inherit;
 		box-shadow: none;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -336,9 +336,24 @@ $videopress-background: #010101;
 
 	.register-domain-step__next-page-button {
 		padding-bottom: 8px !important;
+		margin: 20px 0;
 	}
 
 	.is-borderless {
 		border: none;
+	}
+
+	.domain-suggestion,
+	.domain-suggestion:hover,
+	.register-domain-step__next-page {
+		background-color: inherit;
+		box-shadow: none;
+		border-top: solid 1px var(--studio-gray-5);
+		padding-left: 0;
+		padding-right: 0;
+	}
+
+	.has-underline {
+		text-decoration: underline;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2483

## Proposed Changes

This PR aims to make the domains step in blog onboarding closer to the style in the Figma. CZ07QdsC7bmWbLiSO5K9T5-fi-1134_53409

Before | After
--|--
![domains-before](https://github.com/Automattic/wp-calypso/assets/140841/e8e50f9a-b316-4b3b-b36b-950bd97d2e5a)  | ![domains-after](https://github.com/Automattic/wp-calypso/assets/140841/6144cc16-a40e-462b-a7cf-30b0f4e94f4a)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Check out the domains step in the 'start-writing' and 'design-first' flows. Check that the styles match the After pic and look closer to the Figma design.
* Ensure these styles aren't bleeding into other areas.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?