### PR TITLE
Blog onboarding: Use site name for default domain search field

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -14,6 +14,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
@@ -39,7 +40,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	const [ isCartPendingUpdate, setIsCartPendingUpdate ] = useState( false );
 	const [ isCartPendingUpdateDomain, setIsCartPendingUpdateDomain ] =
 		useState< DomainSuggestion >();
-	const siteSlug = getQueryArg( window.location.search, 'siteSlug' );
+	const site = useSite();
 
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
 
@@ -47,13 +48,6 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	const onAddDomain = ( selectedDomain: any ) => {
 		setDomain( selectedDomain );
 		submit?.( { domain: selectedDomain } );
-	};
-
-	const getInitialSuggestion = function () {
-		const wpcomSubdomainWithRandomNumberSuffix = /^(.+?)([0-9]{5,})\.wordpress\.com$/i;
-		const [ , strippedHostname ] =
-			String( siteSlug ).match( wpcomSubdomainWithRandomNumberSuffix ) || [];
-		return strippedHostname ?? String( siteSlug ).split( '.' )[ 0 ];
 	};
 
 	const onSkip = async () => {
@@ -103,10 +97,13 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	};
 
 	const getBlogOnboardingFlowStepContent = () => {
+		const siteName = site?.name;
+		const domainSuggestion = siteName && siteName !== 'Site Title' ? siteName : '';
+
 		return (
 			<CalypsoShoppingCartProvider>
 				<RegisterDomainStep
-					suggestion={ getInitialSuggestion() }
+					suggestion={ domainSuggestion }
 					domainsWithPlansOnly={ true }
 					onAddDomain={ submitWithDomain }
 					includeWordPressDotCom={ true }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2589

## Proposed Changes

* This PR sets the default domain name suggestion for blog onboarding to the site name (if it's set), and leaves the suggestion field blank, if not.

Example of a blank domain suggestion:
![no-name](https://github.com/Automattic/wp-calypso/assets/140841/b5459e4b-cb7d-45e4-b82a-58c89e220f37)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Go to the start-writing and/or design-first flows.
* Once inside the Launchpad Go to the "Choose a domain" step. The suggestion field should be blank.
* Use the back button and "Name your blog".
* Go back to "Choose a domain", it should use your site name as the suggestion field.
* Ensure these changes only affect the start-writing and design-first flows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
