### PR TITLE
Plans 2023: Update gated content feature title

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -2154,7 +2154,7 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_PREMIUM_CONTENT_JP ]: {
 		getSlug: () => FEATURE_PREMIUM_CONTENT_JP,
-		getTitle: () => i18n.translate( 'Add paid subscriptions and gated content' ),
+		getTitle: () => i18n.translate( 'Gated content' ),
 		getDescription: () => i18n.translate( 'Sell access to premium content, right from your site.' ),
 	},
 	[ FEATURE_VIDEOPRESS_JP ]: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

**Note to self -- don't merge until string translations are complete**

Related to https://github.com/Automattic/martech/issues/1829

While working on the 2023 Plans Feature Grid, @lucasmendes-design noted the potentially confusing wording of the Add paid subscriptions and gated content feature, which appears to have semantic overlap with the Paid subscribers feature.

<img width="1594" alt="Screenshot 2023-06-08 at 3 08 13 PM" src="https://github.com/Automattic/martech/assets/5414230/3530fabb-e608-4177-bdf3-93f2075f1079">

## Proposed Changes

* Remove the `Add paid subscriptions` portion of the `Add paid subscriptions and gated content` title so that it becomes `Gated content`

## Screenshots

<img width="1489" alt="Screenshot 2023-06-09 at 12 48 11 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/511c7a3b-3ea4-425c-a5f9-4de4230e4834">

<img width="1308" alt="Screenshot 2023-06-09 at 12 48 21 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/9f5951d0-2377-4143-90a7-b5f347febf80">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this branch and run `yarn` and `yarn start` if needed. 
2. Navigate to the 2023 pricing grid in onboarding http://calypso.localhost:3000/start/plans
3. Verify that the `Gated content` line item is shown in the feature grid under the Free plan column. Verify that the feature tooltip is still rendered on hover
4. Verify that that the `Gated content` line item is categorized under `Growth and Monetization Tools` in the comparison grid. Verify that the feature tooltip is rendered on hover.
5. Navigate to the 2023 pricing grid in the plans page http://calypso.localhost:3000/plans/{SITE_SLUG}
6. Repeat step 3 and 4

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
