### PR TITLE
Fixes the campaign stats on the Advertising page

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
@@ -41,26 +41,21 @@ export type Campaign = {
 	moderation_status: number | null;
 	type: string;
 	display_delivery_estimate: string;
-	impressions_total: number;
 	delivery_percent: number;
 	status: string;
 	target_url: string;
-	clicks_total: number;
-	spent_budget_cents: number;
 	deliver_margin_multiplier: number;
 	audience_list: AudienceList;
 	display_name: string;
 	avatar_url: string;
 	creative_html: string;
 	campaign_stats_loading: boolean;
+	campaign_stats?: CampaignStats;
 };
 
 export type CampaignStats = {
 	campaign_id: number;
-	display_delivery_estimate: string;
 	impressions_total: number;
-	delivery_percent: number;
-	target_url: string;
 	clicks_total: number;
 	spent_budget_cents: number;
 	deliver_margin_multiplier: number;

--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -40,26 +40,21 @@ export type Campaign = {
 	moderation_status: number | null;
 	type: string;
 	display_delivery_estimate: string;
-	impressions_total: number;
 	delivery_percent: number;
 	status: string;
 	target_url: string;
-	clicks_total: number;
-	spent_budget_cents: number;
 	deliver_margin_multiplier: number;
 	audience_list: AudienceList;
 	display_name: string;
 	avatar_url: string;
 	creative_html: string;
 	campaign_stats_loading: boolean;
+	campaign_stats?: CampaignStats;
 };
 
 export type CampaignStats = {
 	campaign_id: number;
-	display_delivery_estimate: string;
 	impressions_total: number;
-	delivery_percent: number;
-	target_url: string;
 	clicks_total: number;
 	spent_budget_cents: number;
 	deliver_margin_multiplier: number;

--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -44,11 +44,13 @@ export default function CampaignItem( props: Props ) {
 		status,
 		end_date,
 		budget_cents,
-		impressions_total,
-		clicks_total,
-		spent_budget_cents,
 		start_date,
+		campaign_stats,
 	} = campaign;
+
+	const clicks_total = campaign_stats?.clicks_total ?? 0;
+	const spent_budget_cents = campaign_stats?.spent_budget_cents ?? 0;
+	const impressions_total = campaign_stats?.impressions_total ?? 0;
 
 	const moment = useLocalizedMoment();
 

--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -46,7 +46,6 @@ export default function CampaignItem( { campaign, expanded, onClickCampaign }: P
 		type,
 		content_config,
 		moderation_reason,
-		spent_budget_cents,
 		start_date,
 		end_date,
 		budget_cents,
@@ -54,11 +53,14 @@ export default function CampaignItem( { campaign, expanded, onClickCampaign }: P
 		display_delivery_estimate,
 		display_name,
 		creative_html,
-		impressions_total = 0,
-		clicks_total = 0,
 		target_url = '',
 		campaign_stats_loading,
+		campaign_stats,
 	} = campaign;
+
+	const clicks_total = campaign_stats?.clicks_total ?? 0;
+	const spent_budget_cents = campaign_stats?.spent_budget_cents ?? 0;
+	const impressions_total = campaign_stats?.impressions_total ?? 0;
 
 	const campaignStatus = useMemo( () => normalizeCampaignStatus( campaign ), [ campaign ] );
 


### PR DESCRIPTION
Because a change in the DSP backend, now the Advertising section is now showing any stats for all of the user's campaigns.

## Proposed Changes

This PR changes the location in the API response where the component looks for the stats. Primary for the impressions/clicks and budget.

This is how the page should look like:
![Screenshot 2023-06-09 at 19 55 21](https://github.com/Automattic/wp-calypso/assets/1258162/af6379c8-0488-4378-baff-a2a95a44110b)

## Testing Instructions

1- Log in with your WordPress user
2- Go to the Tools->Advertising section
3- Click on Campaigns
4- Verify that the stats are loaded correctly for campaigns in progress or completed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
