### PR TITLE
Import onboarding: Exclude staging sites from the Site Picker and show Unauthorized screen

### DIFF
--- a/client/blocks/importer/types.ts
+++ b/client/blocks/importer/types.ts
@@ -12,6 +12,7 @@ export type StepNavigator = {
 	goToIntentPage?: () => void;
 	goToImportCapturePage?: () => void;
 	goToSiteViewPage?: () => void;
+	goToDashboardPage?: () => void;
 	goToCheckoutPage?: () => void;
 	goToWpAdminImportPage?: () => void;
 	goToWpAdminWordPressPluginPage?: () => void;

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -143,7 +143,21 @@ export class ImportEverything extends SectionMigrate {
 			showConfirmDialog = true,
 			isMigrateFromWp,
 			onContentOnlySelection,
+			translate,
+			recordTracksEvent,
 		} = this.props;
+
+		if ( targetSite.is_wpcom_staging_site ) {
+			return (
+				<NotAuthorized
+					onStartBuilding={ () => {
+						recordTracksEvent( 'calypso_site_importer_skip_to_dashboard' );
+						stepNavigator.goToDashboardPage();
+					} }
+					onStartBuildingText={ translate( 'Skip to dashboard' ) }
+				/>
+			);
+		}
 
 		if ( isEnabled( 'onboarding/import-redesign' ) ) {
 			return (

--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -27,13 +27,20 @@ const fetchSites = (
 	} );
 };
 
-export const useSiteExcerptsQuery = ( siteFilter?: string[] ) => {
+export const useSiteExcerptsQuery = (
+	fetchFilter?: string[],
+	sitesFilterFn?: ( site: SiteExcerptData ) => boolean
+) => {
 	const store = useStore();
 
 	return useQuery( {
 		queryKey: [ USE_SITE_EXCERPTS_QUERY_KEY ],
-		queryFn: () => fetchSites( siteFilter ),
-		select: ( data ) => data?.sites.map( computeFields( data?.sites ) ),
+		queryFn: () => fetchSites( fetchFilter ),
+		select: ( data ) => {
+			const sites = data?.sites.map( computeFields( data?.sites ) ) || [];
+
+			return sitesFilterFn ? sites.filter( sitesFilterFn ) : sites;
+		},
 		initialData: () => {
 			// Not using `useSelector` (i.e. calling `getSites` directly) because we
 			// only want to get the initial state. We don't want to be updated when the

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
@@ -43,6 +43,13 @@ export function useStepNavigator(
 		} );
 	}
 
+	function goToDashboardPage() {
+		navigation.submit?.( {
+			type: 'redirect',
+			url: '/',
+		} );
+	}
+
 	function goToWpAdminImportPage() {
 		navigation.submit?.( {
 			type: 'redirect',
@@ -94,6 +101,7 @@ export function useStepNavigator(
 		goToIntentPage,
 		goToImportCapturePage,
 		goToSiteViewPage,
+		goToDashboardPage,
 		goToCheckoutPage,
 		goToWpAdminImportPage,
 		goToWpAdminWordPressPluginPage,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -40,7 +40,10 @@ const SitePicker = function SitePicker( props: Props ) {
 		onQueryParamChange,
 	} = props;
 	const { sitesSorting, onSitesSortingChange } = useSitesSorting();
-	const { data: allSites = [], isLoading } = useSiteExcerptsQuery( SITE_PICKER_FILTER_CONFIG );
+	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
+		SITE_PICKER_FILTER_CONFIG,
+		( site ) => ! site.is_wpcom_staging_site
+	);
 
 	return (
 		<div className="site-picker--container">


### PR DESCRIPTION
Closes #77948

## Proposed Changes

* Extend `useSiteExcerptsQuery` method supporting custom filter function
* Exclude staging sites from the site picker step
* Show unauthorized screen if set a target site via query param

## Testing Instructions

**Site picker**
* Go to `/setup/import-focused/sitePicker?from={JN_SITE}`
* Check if there are no staging sites available for selection

**Direct link**
* Go to `/setup/import-focused/importerWordpress?from={SOURCE_JN_SITE}&siteSlug={TARGET_STAGING_SLUG}&option=everything `
* Check if there is unauthorized screen
<img width="707" alt="Screenshot 2023-06-10 at 23 44 41" src="https://github.com/Automattic/wp-calypso/assets/1241413/92c15d2a-c88c-4054-992f-6a174dbed939">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
