### PR TITLE
Stats: stop call dismissing API when already dismissed

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -96,9 +96,11 @@ class StatsNavigation extends Component {
 	};
 
 	onTooltipDismiss = () => {
+		if ( ! this.state.isPageSettingsTooltipDismissed ) {
+			this.props.mutateNoticeVisbilityAsync().finally( this.props.refetchNotices );
+		}
 		this.setState( { isPageSettingsTooltipDismissed: true } );
 		localStorage.setItem( 'notices_dismissed__traffic_page_settings', 1 );
-		this.props.mutateNoticeVisbilityAsync().finally( this.props.refetchNotices );
 	};
 
 	isValidItem = ( item ) => {

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -96,11 +96,12 @@ class StatsNavigation extends Component {
 	};
 
 	onTooltipDismiss = () => {
-		if ( ! this.state.isPageSettingsTooltipDismissed ) {
-			this.props.mutateNoticeVisbilityAsync().finally( this.props.refetchNotices );
+		if ( this.state.isPageSettingsTooltipDismissed ) {
+			return;
 		}
 		this.setState( { isPageSettingsTooltipDismissed: true } );
 		localStorage.setItem( 'notices_dismissed__traffic_page_settings', 1 );
+		this.props.mutateNoticeVisbilityAsync().finally( this.props.refetchNotices );
 	};
 
 	isValidItem = ( item ) => {

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -96,7 +96,7 @@ class StatsNavigation extends Component {
 	};
 
 	onTooltipDismiss = () => {
-		if ( this.state.isPageSettingsTooltipDismissed ) {
+		if ( this.state.isPageSettingsTooltipDismissed || ! this.props.showSettingsTooltip ) {
 			return;
 		}
 		this.setState( { isPageSettingsTooltipDismissed: true } );

--- a/client/my-sites/stats/highlights-section/index.tsx
+++ b/client/my-sites/stats/highlights-section/index.tsx
@@ -70,11 +70,12 @@ export default function HighlightsSection( {
 	);
 
 	const dismissSettingsTooltip = useCallback( () => {
-		if ( ! settingsTooltipDismissed ) {
-			mutateNoticeVisbilityAsync().finally( refetchNotices );
+		if ( settingsTooltipDismissed ) {
+			return;
 		}
 		setSettingsTooltipDismissed( true );
 		localStorage.setItem( 'notices_dismissed__traffic_page_highlights_module_settings', '1' );
+		return mutateNoticeVisbilityAsync().finally( refetchNotices );
 	}, [] );
 
 	return (

--- a/client/my-sites/stats/highlights-section/index.tsx
+++ b/client/my-sites/stats/highlights-section/index.tsx
@@ -4,7 +4,7 @@ import {
 	BETWEEN_PAST_EIGHT_AND_FIFTEEN_DAYS,
 	BETWEEN_PAST_THIRTY_ONE_AND_SIXTY_DAYS,
 } from '@automattic/components';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import useNoticeVisibilityQuery from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -69,11 +69,13 @@ export default function HighlightsSection( {
 		!! localStorage.getItem( 'notices_dismissed__traffic_page_highlights_module_settings' )
 	);
 
-	const dismissSettingsTooltip = () => {
+	const dismissSettingsTooltip = useCallback( () => {
+		if ( ! settingsTooltipDismissed ) {
+			mutateNoticeVisbilityAsync().finally( refetchNotices );
+		}
 		setSettingsTooltipDismissed( true );
 		localStorage.setItem( 'notices_dismissed__traffic_page_highlights_module_settings', '1' );
-		return mutateNoticeVisbilityAsync().finally( refetchNotices );
-	};
+	}, [] );
 
 	return (
 		<WeeklyHighlightCards

--- a/client/my-sites/stats/highlights-section/index.tsx
+++ b/client/my-sites/stats/highlights-section/index.tsx
@@ -70,13 +70,13 @@ export default function HighlightsSection( {
 	);
 
 	const dismissSettingsTooltip = useCallback( () => {
-		if ( settingsTooltipDismissed ) {
+		if ( settingsTooltipDismissed || ! showSettingsTooltip ) {
 			return;
 		}
 		setSettingsTooltipDismissed( true );
 		localStorage.setItem( 'notices_dismissed__traffic_page_highlights_module_settings', '1' );
 		return mutateNoticeVisbilityAsync().finally( refetchNotices );
-	}, [] );
+	}, [ settingsTooltipDismissed, showSettingsTooltip ] );
 
 	return (
 		<WeeklyHighlightCards


### PR DESCRIPTION
Related to #78030 

## Proposed Changes

Return early when a notice is already dismissed, so that we don't perform the API and additional unnecessary actions.

## Testing Instructions

* Open Live branch
* Click Module settings icon
* Ensure no calling notice API `sites/{blog-id}/jetpack-stats-dashboard/notices`
* Click Highlights settings icon
* Ensure no calling notice API `sites/{blog-id}/jetpack-stats-dashboard/notices`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
