### PR TITLE
Odyssey Stats: Combine translation process to the build process

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -234,15 +234,6 @@ private object OdysseyStats : WPComPluginBuild(
 	docsLink = "PejTkB-3N-p2",
 	buildSteps = {
 		bashNodeScript {
-			name = "Translate Odyssey Stats"
-			scriptContent = """
-				cd apps/odyssey-stats
-
-				# generate language files
-				yarn translate
-			"""
-		}
-		bashNodeScript {
 			name = "Run Unit Tests"
 			scriptContent = """
 				cd apps/odyssey-stats

--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -18,7 +18,7 @@
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
 		"clean": "npx rimraf dist",
-		"build": "NODE_ENV=production yarn dev",
+		"build": "NODE_ENV=production yarn dev && yarn translate",
 		"build:stats": "calypso-build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/calypso-stats",
 		"show-stats": "NODE_ENV=production EMIT_STATS=true yarn build",


### PR DESCRIPTION
## Proposed Changes

The translation process of Odyssey Stats has been failing for the last a couple of weeks despite we didn't change anything regarding the build process. I highly suspect it's about the upgrade of TC which somehow changed env among the building steps. However there's no evidence of any errors - The translation files are generate successfully but only not bundled. 

The PR proposes to combine the translation process to the build process, which should preserved the translation files.

----update----

I checked the TeamCity build, the language files are sucessfully bundled for the PR.

## Testing Instructions

* Open Odyssey build task
* Ensure the built bundle includes `languages` folder

<img width="483" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/8cd2a9b1-a96d-4542-b85f-7a2a10b7ed19">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
