### PR TITLE
Assembler: Enable the pattern-assembler/logged-in-showcase flag on production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -107,7 +107,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/all-patterns-category": true,
-		"pattern-assembler/logged-in-showcase": false,
+		"pattern-assembler/logged-in-showcase": true,
 		"pattern-assembler/show-waitlist-patterns": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -102,7 +102,7 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/all-patterns-category": true,
-		"pattern-assembler/logged-in-showcase": false,
+		"pattern-assembler/logged-in-showcase": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2679

## Proposed Changes

* Enable `pattern-assembler/logged-in-showcase` on production

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase on your existing site
* Scroll down and ensure you're able to see the BCPA CTA
* Select BCPA CTA
* On the Assembler screen, select layout and styles
* When you finish the Assembler screen, ensure you're able to land on the site editor and your homepage is what you want

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
