### PR TITLE
Theme Upsell Modal: Remove feature tags and update feature list (2nd try) 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -163,6 +163,11 @@ $design-button-primary-hover-color: var(--color-primary-60);
 		li {
 			display: flex;
 			align-items: flex-start;
+
+			> div {
+				display: flex;
+				align-items: center;
+			}
 		}
 
 		.gridicon {
@@ -170,6 +175,17 @@ $design-button-primary-hover-color: var(--color-primary-60);
 			flex-shrink: 0;
 			margin-right: 10px;
 			margin-top: 4px;
+		}
+
+		.components-popover.components-tooltip .components-popover__content {
+			border-radius: 4px;
+			margin: 8px;
+			max-width: 210px;
+			background-color: var(--studio-gray-100);
+			padding: 8px 10px;
+			text-align: start;
+			white-space: pre-line;
+			width: max-content;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -9,13 +9,13 @@ import {
 	FEATURE_ISOLATED_INFRA,
 	FEATURE_LIVE_CHAT_SUPPORT,
 	FEATURE_PREMIUM_THEMES_V2,
-	FEATURE_SEO_JP,
 	FEATURE_STYLE_CUSTOMIZATION,
 	FEATURE_WAF_V2,
 	FEATURE_WORDADS,
 } from '@automattic/calypso-products';
 import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
 import { ProductsList } from '@automattic/data-stores';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { ExternalLink, Tooltip } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import classNames from 'classnames';
@@ -43,7 +43,7 @@ interface UpgradeModalContent {
 
 const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps ) => {
 	const translate = useTranslate();
-	const currentLocale = i18n.getLocaleSlug();
+	const isEnglishLocale = useIsEnglishLocale();
 	const theme = useThemeDetails( slug );
 	// Check current theme: Does it have a plugin bundled?
 	const theme_software_set = theme?.data?.taxonomies?.theme_software_set?.length;
@@ -71,8 +71,7 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 			),
 			text: (
 				<p>
-					{ currentLocale === 'en' ||
-					currentLocale?.startsWith( 'en-' ) ||
+					{ isEnglishLocale ||
 					i18n.hasTranslation(
 						"Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It's {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee."
 					)
@@ -167,7 +166,6 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 			FEATURE_LIVE_CHAT_SUPPORT,
 			FEATURE_AD_FREE_EXPERIENCE,
 			FEATURE_WORDADS,
-			FEATURE_SEO_JP,
 			FEATURE_BANDWIDTH,
 			FEATURE_GLOBAL_EDGE_CACHING,
 			FEATURE_BURST,
@@ -180,13 +178,22 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 
 	let modalData = null;
 	let featureList = null;
+	let featureListHeader = null;
 
 	if ( showBundleVersion ) {
 		modalData = getBundledFirstPartyPurchaseModalData();
 		featureList = getBundledFirstPartyPurchaseFeatureList();
+		featureListHeader =
+			isEnglishLocale || i18n.hasTranslation( 'Included with your Business plan' )
+				? translate( 'Included with your Business plan' )
+				: translate( 'Included with your purchase' );
 	} else {
 		modalData = getStandardPurchaseModalData();
 		featureList = getStandardPurchaseFeatureList();
+		featureListHeader =
+			isEnglishLocale || i18n.hasTranslation( 'Included with your Premium plan' )
+				? translate( 'Included with your Premium plan' )
+				: translate( 'Included with your purchase' );
 	}
 
 	return (
@@ -207,11 +214,11 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 					</div>
 					<div className="upgrade-modal__col">
 						<div className="upgrade-modal__included">
-							<h2>{ translate( 'Included with your purchase' ) }</h2>
+							<h2>{ featureListHeader }</h2>
 							<ul>
 								{ featureList.map( ( feature, i ) => (
 									<li key={ i } className="upgrade-modal__included-item">
-										<Tooltip text={ feature.getDescription() } delay={ 0 }>
+										<Tooltip text={ feature.getDescription() } delay={ 300 } position="top">
 											<div>
 												<Gridicon icon="checkmark" size={ 16 } />
 												{ feature.getTitle() }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77945 #77299

## Proposed Changes

This PR updates the theme upsell modal used in the onboarding design picker, by removing feature tags and updating the feature list. In addition, this PR adds tooltips to the feature list which contains the feature description. The feature list is taken from https://wordpress.com/pricing, needs review from @autumnfjeld and @lucasmendes-design.

![Screenshot 2023-06-08 at 3 27 54 PM](https://github.com/Automattic/wp-calypso/assets/797888/4c7f2f8d-1799-42f8-8238-a98cb8baad48)

**Premium Themes**
| Before | After |
| --- | --- |
| ![Screenshot 2023-06-08 at 3 28 26 PM](https://github.com/Automattic/wp-calypso/assets/797888/34fa6b97-1e38-4f4d-9aaa-776d4d99bed2) |  ![Screenshot 2023-06-08 at 3 14 38 PM](https://github.com/Automattic/wp-calypso/assets/797888/c796a3ea-c30f-43db-b463-1a92a4e3cb6a) |

**WooCommerce Themes**
| Before | After |
| --- | --- |
| ![Screenshot 2023-06-08 at 3 28 45 PM](https://github.com/Automattic/wp-calypso/assets/797888/a4896200-9d39-4c8c-aff5-f44c2755590b) | ![Screenshot 2023-06-08 at 3 15 04 PM](https://github.com/Automattic/wp-calypso/assets/797888/2ab7c431-4d1a-4b67-91c7-aa80ead8aa5b)|

EDIT: The feature list heading has been updated as suggested in https://github.com/Automattic/wp-calypso/pull/77945#issuecomment-1583485356:

Premium plan:
![Screenshot 2023-06-12 at 1 13 38 PM](https://github.com/Automattic/wp-calypso/assets/797888/5cade47c-2a6b-4fbf-ba2a-24d30302c68c)

Business plan:
![Screenshot 2023-06-12 at 1 13 30 PM](https://github.com/Automattic/wp-calypso/assets/797888/eced305d-c31e-4e0b-89bf-0e98b93c196d)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/site-setup?siteSlug=${site_slug}`.
* Continue until you land on the Design Picker.
* Select a Premium/WooCommerce theme, and click the Unlock Theme button.
* Ensure that the upsell modal is updated as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
