### PR TITLE
JP Pro Dashboard: Implement checker for unsaved SMS notification settings.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -300,6 +300,17 @@ export interface StateMonitorSettingsEmail extends MonitorSettingsEmail {
 	isDefault?: boolean;
 }
 
+export interface StateMonitorSettingsSMS {
+	name: string;
+	countryCode: string;
+	phoneNumber: string;
+	phoneNumberFull: string;
+	verified: boolean;
+}
+
+export type MonitorSettingsContact = Partial< MonitorSettingsEmail > &
+	Partial< StateMonitorSettingsSMS >;
+
 export type AllowedMonitorContactActions = 'add' | 'verify' | 'edit' | 'remove';
 
 export interface RequestVerificationCodeParams {
@@ -324,20 +335,14 @@ export interface MonitorContactsResponse {
 export type MonitorDuration = { label: string; time: number };
 
 export interface InitialMonitorSettings {
+	enableSMSNotification: boolean;
 	enableEmailNotification: boolean;
 	enableMobileNotification: boolean;
 	selectedDuration: MonitorDuration | undefined;
 	emailContacts?: MonitorSettingsEmail[] | [];
+	phoneContacts?: StateMonitorSettingsSMS[] | [];
 }
 export interface ResendVerificationCodeParams {
 	type: 'email';
 	value: string;
-}
-
-export interface StateMonitorSettingsSMS {
-	name: string;
-	countryCode: string;
-	phoneNumber: string;
-	phoneNumberFull: string;
-	verified: boolean;
 }


### PR DESCRIPTION
Related to  1204774821045518-as-1204793234816299

## Proposed Changes

This PR adds checker for unsaved SMS notification settings in the Monitor Settings modal.

## Testing Instructions
**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

Instructions

- Run git checkout `add/implementation-to-check-unsave-sms-notification-settings` and `yarn start-jetpack-cloud`
- Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
- Enable monitor if not enabled already.
- Click on the clock icon next to the monitor toggle.
- Click on the Mobile notification toggle, and click the "+ Add phone number" button -> Input valid phone details and verify.
- Click **Later** button, and the new phone number should show in the Phone list.
- Click **Cancel** button, and confirm that the modal notifies you of unsaved changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?