### PR TITLE
Subscribers Page: Open the subscriber site for EN users.

### DIFF
--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { useLocale } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { Item } from 'calypso/components/breadcrumb';
@@ -20,6 +21,7 @@ type SubscribersProps = {
 const DEFAULT_PER_PAGE = 10;
 
 export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
+	const locale = useLocale();
 	const isSubscribersPageEnabled = config.isEnabled( 'subscribers-page' );
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const initialState = { data: { total: 0, subscribers: [], per_page: DEFAULT_PER_PAGE } };
@@ -54,7 +56,7 @@ export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
 		},
 	];
 
-	if ( ! isSubscribersPageEnabled ) {
+	if ( ! isSubscribersPageEnabled || locale !== 'en' ) {
 		return null;
 	}
 

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -128,7 +128,7 @@
 		"storage-addon": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-page": false,
+		"subscribers-page": true,
 		"subscription-gifting": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,

--- a/config/production.json
+++ b/config/production.json
@@ -154,7 +154,7 @@
 		"storage-addon": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-page": false,
+		"subscribers-page": true,
 		"subscription-gifting": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -146,7 +146,7 @@
 		"storage-addon": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-page": false,
+		"subscribers-page": true,
 		"subscription-gifting": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -160,7 +160,7 @@
 		"storage-addon": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-page": false,
+		"subscribers-page": true,
 		"subscription-gifting": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,


### PR DESCRIPTION
☢️☢️☢️ Please, do not merge this PR until the release date of the Subscribers Page! ☢️☢️☢️

Closes https://github.com/Automattic/wp-calypso/issues/78046

## Proposed Changes

The changes in this PR open the Subscriber Page to all EN users.

## Testing Instructions

1. Apply this PR.
2. Set your account language to "English" in `http://calypso.localhost:3000/me/account`.
3. Go to `http://calypso.localhost:3000/subscribers/[the-domain-of-your-site]`. You should see the list of subscribers on your site:

<img width="1140" alt="Screenshot 2023-06-12 at 12 02 09" src="https://github.com/Automattic/wp-calypso/assets/3832570/f19d3397-4c67-4a74-b45c-7d581c830a87">
4. Set your account language to any non-English language in `http://calypso.localhost:3000/me/account`.
5. Go again to `http://calypso.localhost:3000/subscribers/[the-domain-of-your-site]`. You should see nothing this time.

