### PR TITLE
Subscribers Page: Add "Subscribers" fallback menu item

### DIFF
--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -462,6 +462,13 @@ export default function buildFallbackResponse( {
 				},
 				{
 					parent: 'users.php',
+					slug: 'subscribers',
+					title: translate( 'Subscribers' ),
+					type: 'submenu-item',
+					url: `/subscribers/${ siteDomain }`,
+				},
+				{
+					parent: 'users.php',
 					slug: 'users-my-profile',
 					title: translate( 'My Profile' ),
 					type: 'submenu-item',


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/77531.

⚠️ Only merge and deploy this PR once:

- we know if all EN translations are ready: https://github.com/Automattic/wp-calypso/issues/78050
- all other features are in for Milestone I.

## Proposed Changes

* add "Subscribers" fallback menu item for the new Subscribers Page

## Testing Instructions

1. Check out the branch and build it.
2. Navigate to http://calypso.localhost:3000
3. Open Network settings, search for "menu"request, block the request URL and clear the cache:

![Markup on 2023-06-12 at 11:05:35](https://github.com/Automattic/wp-calypso/assets/25105483/cb8a015c-b3a2-45f1-86f7-f2ffd5ca1107)
 
4. Reload the page. Once loaded, the "Subscribers" menu item should load:

![Markup on 2023-06-12 at 11:03:43](https://github.com/Automattic/wp-calypso/assets/25105483/10f522f7-42aa-48da-b99d-68e56e57ef3e)

5. Once you click on it, the new Subscribers page should be loaded correctly.
6. Don't forget to unblock the request URL in the Network tab so it won't trick you next time you test some other PR. 🙂 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
