### PR TITLE
Jetpack Pro Dashboard: Implement request verification code & verification UI for downtime monitoring

### DIFF
--- a/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
@@ -21,6 +21,9 @@ const useFetchMonitorVerfiedContacts = ( isPartnerOAuthTokenLoaded: boolean ) =>
 					emails: contacts?.emails
 						.filter( ( email ) => email.verified )
 						.map( ( email ) => email.email_address ),
+					phoneNumbers: contacts?.phone_numbers
+						?.filter( ( phone ) => phone.verified )
+						.map( ( phone ) => phone.phone_number ),
 				};
 			},
 			enabled: isPartnerOAuthTokenLoaded && isMultipleEmailEnabled,

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/index.tsx
@@ -6,9 +6,14 @@ import type { StateMonitorSettingsSMS } from '../../sites-overview/types';
 interface Props {
 	toggleModal: () => void;
 	allPhoneItems: Array< StateMonitorSettingsSMS >;
+	verifiedPhoneNumber?: string;
 }
 
-export default function ConfigureSMSNotification( { toggleModal, allPhoneItems }: Props ) {
+export default function ConfigureSMSNotification( {
+	toggleModal,
+	allPhoneItems,
+	verifiedPhoneNumber,
+}: Props ) {
 	const translate = useTranslate();
 
 	const handleAddPhoneClick = () => {
@@ -20,7 +25,11 @@ export default function ConfigureSMSNotification( { toggleModal, allPhoneItems }
 		<div className="configure-contact__card-container">
 			{ allPhoneItems.map( ( item ) => (
 				// TODO: Replace with the correct component
-				<li key={ item.phoneNumberFull }>{ item.phoneNumberFull }</li>
+				<li key={ item.phoneNumberFull }>
+					{ item.phoneNumberFull }
+					{ item.phoneNumberFull === verifiedPhoneNumber && item.verified && ': Verified' }
+					{ ! item.verified && ': Pending' }
+				</li>
 			) ) }
 			<Button
 				compact

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -9,6 +9,7 @@ interface Props {
 	setEnableSMSNotification: ( isEnabled: boolean ) => void;
 	toggleModal: () => void;
 	allPhoneItems: Array< StateMonitorSettingsSMS >;
+	verifiedItem?: { [ key: string ]: string };
 }
 
 export default function SMSNotification( {
@@ -16,6 +17,7 @@ export default function SMSNotification( {
 	setEnableSMSNotification,
 	toggleModal,
 	allPhoneItems,
+	verifiedItem,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -49,7 +51,11 @@ export default function SMSNotification( {
 							</AlertBanner>
 						</div>
 					) }
-					<ConfigureSMSNotification toggleModal={ toggleModal } allPhoneItems={ allPhoneItems } />
+					<ConfigureSMSNotification
+						toggleModal={ toggleModal }
+						allPhoneItems={ allPhoneItems }
+						verifiedPhoneNumber={ verifiedItem?.phone }
+					/>
 				</>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -312,6 +312,8 @@ export default function NotificationSettings( {
 				toggleModal={ toggleAddSMSModal }
 				allPhoneItems={ allPhoneItems }
 				setAllPhoneItems={ handleSetAllPhoneItems }
+				setVerifiedPhoneNumber={ ( item ) => handleSetVerifiedItem( 'phone', item ) }
+				sites={ sites }
 			/>
 		);
 	}
@@ -342,6 +344,7 @@ export default function NotificationSettings( {
 							setEnableSMSNotification={ setEnableSMSNotification }
 							toggleModal={ toggleAddSMSModal }
 							allPhoneItems={ allPhoneItems }
+							verifiedItem={ verifiedItem }
 						/>
 					) }
 					<MobilePushNotification

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/style.scss
@@ -33,6 +33,12 @@ button.configure-contact__button {
 	padding: 0;
 	color: var(--studio-green-50) !important;
 	text-decoration: underline;
+	margin-block-start: 0;
+	line-height: 1.5;
+}
+
+.configure-contact__phone-input-container {
+	margin-block-end: 20px;
 }
 
 .configure-contact__phone-input {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context.ts
@@ -4,6 +4,7 @@ import type { DashboardDataContextInterface } from './types';
 const DashboardDataContext = createContext< DashboardDataContextInterface >( {
 	verifiedContacts: {
 		emails: [],
+		phoneNumbers: [],
 		refetchIfFailed: () => {
 			return undefined;
 		},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -282,6 +282,7 @@ export default function SitesOverview() {
 								value={ {
 									verifiedContacts: {
 										emails: verifiedContacts?.emails ?? [],
+										phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
 										refetchIfFailed: () => {
 											if ( fetchContactFailed ) {
 												refetchContacts();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -197,7 +197,11 @@ export interface SitesOverviewContextInterface extends DashboardOverviewContextI
 }
 
 export interface DashboardDataContextInterface {
-	verifiedContacts: { emails: Array< string >; refetchIfFailed: () => void };
+	verifiedContacts: {
+		emails: Array< string >;
+		phoneNumbers: Array< string >;
+		refetchIfFailed: () => void;
+	};
 }
 
 export type AgencyDashboardFilterOption =
@@ -291,9 +295,10 @@ export interface StateMonitorSettingsEmail extends MonitorSettingsEmail {
 export type AllowedMonitorContactActions = 'add' | 'verify' | 'edit' | 'remove';
 
 export interface RequestVerificationCodeParams {
-	type: 'email';
-	value: string;
+	type: 'email' | 'sms';
+	value: string | number;
 	site_ids: Array< number >;
+	country_code?: string;
 }
 
 export interface ValidateVerificationCodeParams {
@@ -304,6 +309,7 @@ export interface ValidateVerificationCodeParams {
 
 export interface MonitorContactsResponse {
 	emails: [ { verified: boolean; email_address: string } ];
+	phone_numbers: [ { verified: boolean; phone_number: string } ];
 }
 
 export type MonitorDuration = { label: string; time: number };


### PR DESCRIPTION
Related to 1204774821045518-as-1204783884585793 & 1204774821045518-as-1204793234816309

## Proposed Changes

This PR implements 

- API integration with the UI to request verification(code)
- UI to enter the verification code

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Apply this D113345-code and sandbox the public API.
2. Run `git checkout add/implement-verify-phone-for-monitor-notifications` and `yarn start-jetpack-cloud`
3. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
4. Enable monitor if not enabled already.
5. Click on the clock icon next to the monitor toggle.
6. Click the `+ Add phone number` button -> Enter the name, select the country code and phone number -> Click `Verify` and ensure the API call is being made to the `/jetpack-agency/contacts` API endpoint and the `Verify` button is disabled.
7. Once the API call is complete, verify the UI to enter the verification code shown. Please note: clicking on "resend" or "Verify" here doesn't do anything, and this will be implemented later in a different PR.

<img width="475" alt="Screenshot 2023-06-12 at 1 19 29 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4c0b6233-4376-4ca2-a661-bf8f77663193">

8. Repeat step 6 and enter the previously entered phone number again and verify it shows the below error.

<img width="471" alt="Screenshot 2023-06-12 at 1 58 35 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4f34b5c8-72fb-4b4f-807d-577d68158391">

9. Now, search for the `useFetchMonitorVerfiedContacts` hook -> Replace the code

```phoneNumbers: contacts?.phone_numbers
	?.filter( ( phone ) => phone.verified )
	.map( ( phone ) => phone.phone_number ),
```
with 

```
phoneNumbers: [ '+919999999999' ],
```

and repeat step 6 -> Enter number 9999999999 if you are selecting India as the country code(you can use  -> Verify the contact is directly added as verified, and the "Verified" badge is shown for 10 sec.

**More error scenarios**

When the POST /contacts API fails

<img width="471" alt="Screenshot 2023-06-12 at 3 48 32 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/eced9fec-acc3-4875-ba70-78eb66f390e1">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?