### PR TITLE
Position "Ready to promote" and "Campaigns" tabs correctly

### DIFF
--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -32,7 +32,9 @@ body.is-section-promote-post-i2 {
 					width: 100%;
 
 					.section-nav-tabs__list {
+						align-items: center;
 						display: flex;
+						height: 55px;
 						margin: 0 64px;
 						max-width: 1040px;
 						width: auto;
@@ -185,6 +187,10 @@ body.is-section-promote-post-i2 {
 				flex: none;
 				width: auto;
 
+				span {
+					vertical-align: middle; // Position tabs Posts and Campaigns vertically equal
+				}
+
 				.count {
 					border: none;
 					border-radius: 2px;
@@ -192,7 +198,7 @@ body.is-section-promote-post-i2 {
 					font-family: $font-sf-pro-text;
 					font-weight: 500;
 					font-size: 0.875rem;
-					line-height: 1.67;
+					line-height: 1.41; // Position tabs Posts and Campaigns vertically equal
 					padding: 0 8px;
 				}
 			}
@@ -209,7 +215,8 @@ body.is-section-promote-post-i2 {
 	}
 
 	.section-nav-tab.is-selected {
-		border-bottom: 2px solid var(--color-neutral-70);
+		border-bottom: 3px solid var(--color-neutral-70);
+		height: 53px;
 	}
 
 	.search {
@@ -224,7 +231,7 @@ body.is-section-promote-post-i2 {
 	&__search-bar-wrapper {
 		.form-text-input.search__input {
 			@include promote-post-i2-font;
-			// border-radius: 4px;
+
 			height: calc(100% - 4px) !important;
 			margin: 2px 2px 2px 0;
 		}
@@ -297,6 +304,7 @@ body.is-section-promote-post-i2 {
 		main.main.promote-post-i2 {
 			&.is-wide-layout {
 				.section-nav-tabs__list {
+					height: 54px;
 					margin: 0 16px;
 				}
 
@@ -411,5 +419,15 @@ $break-huge-collapsed-menu: $break-huge - 222px;
 @media (min-width: $break-huge-collapsed-menu) {
 	body.is-section-promote-post-i2.is-sidebar-collapsed .layout__content .main.is-wide-layout {
 		@include blazepress-huge;
+	}
+}
+
+@media screen and (max-width: $break-mobile) {
+	.layout__content {
+		main.main.promote-post-i2 {
+			.section-nav-tab.is-selected {
+				height: 51px; // Reduce heights increased by adding the bottom border
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to a Slack discussion p1686067623392599-slack-C053FAERCDP

In short, Patrick found that the "Campaign" tab (that were active) is located 1 pixel above the rest of tabs.

<img width="1216" alt="Screenshot 2023-06-12 at 14 11 54" src="https://github.com/Automattic/wp-calypso/assets/115007291/192a4088-8c00-4bfe-8913-6d33922c5989">

Before the change: https://www.loom.com/share/e4b30261453e49fca460d91ca90f3d7f

To make sure we have all tabs located correctly to each other, I've done the proposed changes. 

After the change: https://www.loom.com/share/6bbe7f38c5c24a4f97a41c958f363242

<img width="1225" alt="Screenshot 2023-06-12 at 14 15 40" src="https://github.com/Automattic/wp-calypso/assets/115007291/aa40e1f3-16dc-4153-bced-dabe5b7b80c5">

## Proposed Changes
* Increase the height of a bottom border that highlights active tab
* Ensure all list items (tabs) have the same height/line-height
* Center tab signs vertically

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch in your local development environment
* `yarn && yarn start` 
* Open http://calypso.localhost:3000/advertising/timurads.wordpress.com/campaigns
* Try different screen widths from `1340px` (we should see a banner if there are less than 3 campaigns) down to `360px` (the smallest screen size amongst [popular screen](https://gs.statcounter.com/screen-resolution-stats/mobile/worldwide) sizes)
* All tabs should be positioned vertically the same relative to each other

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
