### PR TITLE
Subscribers Page: Integrate empty view to the subscribers page

### DIFF
--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -7,6 +7,7 @@ import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
 import Pagination from 'calypso/components/pagination';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { EmptyListView } from './components/empty-list-view';
 import { SubscriberList } from './components/subscriber-list/subscriber-list';
 import { usePagination } from './hooks';
 import { useSubscribersQuery } from './queries';
@@ -62,12 +63,18 @@ export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
 		<Main wideLayout className="subscribers">
 			<DocumentHead title={ translate( 'Subscribers' ) } />
 			<FixedNavigationHeader navigationItems={ navigationItems }></FixedNavigationHeader>
-			<div className="subscribers__header-count">
-				<span className="subscribers__title">{ translate( 'Total' ) }</span>{ ' ' }
-				<span className="subscribers__subscriber-count">{ total }</span>
-			</div>
 
-			<SubscriberList subscribers={ subscribers } />
+			{ total ? (
+				<>
+					<div className="subscribers__header-count">
+						<span className="subscribers__title">{ translate( 'Total' ) }</span>{ ' ' }
+						<span className="subscribers__subscriber-count">{ total }</span>
+					</div>
+					<SubscriberList subscribers={ subscribers } />
+				</>
+			) : (
+				<EmptyListView />
+			) }
 
 			<Pagination
 				className="subscribers__pagination"


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78048

## Proposed Changes

* Integrate empty view to the subscribers page.

## Testing Instructions

* Apply this PR to your local env
* Go to http://calypso.localhost:3000/subscribers/{site-slug}?flags=subscribers-page
* Verify if the Empty view is displayed correctly on sites without subscribers
* Verify if the Subscribers list and the Total header are displayed as expected on sites with subscribers
* Check if no regressions were made

<img width="1113" alt="Screenshot 2023-06-12 at 11 00 16" src="https://github.com/Automattic/wp-calypso/assets/3113712/3c0b8614-84d6-4afe-9fb3-70537b6bef61">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
