### PR TITLE
Subscription Management: Allow user to resubscribe to a site.

### DIFF
--- a/client/landing/subscriptions/components/settings/settings-popover/settings-popover.tsx
+++ b/client/landing/subscriptions/components/settings/settings-popover/settings-popover.tsx
@@ -33,7 +33,7 @@ const SettingsPopover = ( { children, className }: SettingsPopoverProps ) => {
 				context={ buttonRef.current }
 				className={ classNames( 'settings-popover', className ) }
 			>
-				{ children }
+				{ typeof children === 'function' ? children( onClose ) : children }
 			</Popover>
 		</div>
 	);

--- a/client/landing/subscriptions/components/settings/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings/settings-popover/styles.scss
@@ -60,7 +60,8 @@
 		width: 212px;
 	}
 
-	.unsubscribe-button.components-button.has-icon {
+	.unsubscribe-button.components-button.has-icon,
+	.resubscribe-button.components-button.has-icon {
 		height: auto;
 		padding: 0;
 		font-size: $font-body-small;

--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -11,6 +11,8 @@ import NotifyMeOfNewPostsToggle from './notify-me-of-new-posts-toggle';
 import './styles.scss';
 import '../styles.scss';
 
+const ResubscribeIcon = UnsubscribeIcon;
+
 type SiteSettingsProps = {
 	notifyMeOfNewPosts: boolean;
 	onNotifyMeOfNewPostsChange: ( value: boolean ) => void;
@@ -79,28 +81,55 @@ const SiteSettings = ( {
 type SiteSettingsPopoverProps = SiteSettingsProps & {
 	onUnsubscribe: () => void;
 	unsubscribing: boolean;
+	onResubscribe: () => void;
+	resubscribing: boolean;
+	isDeleted: boolean;
 };
 
 export const SiteSettingsPopover = ( {
 	onUnsubscribe,
 	unsubscribing,
+	onResubscribe,
+	resubscribing,
+	isDeleted,
 	...props
 }: SiteSettingsPopoverProps ) => {
 	const translate = useTranslate();
 	return (
 		<SettingsPopover className="site-settings-popover">
-			<SiteSettings { ...props } />
+			{ ( close: () => void ) => (
+				<>
+					<SiteSettings { ...props } />
 
-			<hr className="subscriptions__separator" />
+					<hr className="subscriptions__separator" />
 
-			<Button
-				className={ classNames( 'unsubscribe-button', { 'is-loading': unsubscribing } ) }
-				disabled={ unsubscribing }
-				icon={ <UnsubscribeIcon className="settings-popover__item-icon" /> }
-				onClick={ onUnsubscribe }
-			>
-				{ translate( 'Unsubscribe' ) }
-			</Button>
+					{ isDeleted ? (
+						<Button
+							className={ classNames( 'resubscribe-button', { 'is-loading': resubscribing } ) }
+							disabled={ resubscribing }
+							icon={ <ResubscribeIcon className="settings-popover__item-icon" /> }
+							onClick={ () => {
+								onResubscribe();
+								close();
+							} }
+						>
+							{ translate( 'Resubscribe' ) }
+						</Button>
+					) : (
+						<Button
+							className={ classNames( 'unsubscribe-button', { 'is-loading': unsubscribing } ) }
+							disabled={ unsubscribing }
+							icon={ <UnsubscribeIcon className="settings-popover__item-icon" /> }
+							onClick={ () => {
+								onUnsubscribe();
+								close();
+							} }
+						>
+							{ translate( 'Unsubscribe' ) }
+						</Button>
+					) }
+				</>
+			) }
 		</SettingsPopover>
 	);
 };

--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -11,8 +11,6 @@ import NotifyMeOfNewPostsToggle from './notify-me-of-new-posts-toggle';
 import './styles.scss';
 import '../styles.scss';
 
-const ResubscribeIcon = UnsubscribeIcon;
-
 type SiteSettingsProps = {
 	notifyMeOfNewPosts: boolean;
 	onNotifyMeOfNewPostsChange: ( value: boolean ) => void;
@@ -81,17 +79,11 @@ const SiteSettings = ( {
 type SiteSettingsPopoverProps = SiteSettingsProps & {
 	onUnsubscribe: () => void;
 	unsubscribing: boolean;
-	onResubscribe: () => void;
-	resubscribing: boolean;
-	isDeleted: boolean;
 };
 
 export const SiteSettingsPopover = ( {
 	onUnsubscribe,
 	unsubscribing,
-	onResubscribe,
-	resubscribing,
-	isDeleted,
 	...props
 }: SiteSettingsPopoverProps ) => {
 	const translate = useTranslate();
@@ -103,31 +95,17 @@ export const SiteSettingsPopover = ( {
 
 					<hr className="subscriptions__separator" />
 
-					{ isDeleted ? (
-						<Button
-							className={ classNames( 'resubscribe-button', { 'is-loading': resubscribing } ) }
-							disabled={ resubscribing }
-							icon={ <ResubscribeIcon className="settings-popover__item-icon" /> }
-							onClick={ () => {
-								onResubscribe();
-								close();
-							} }
-						>
-							{ translate( 'Resubscribe' ) }
-						</Button>
-					) : (
-						<Button
-							className={ classNames( 'unsubscribe-button', { 'is-loading': unsubscribing } ) }
-							disabled={ unsubscribing }
-							icon={ <UnsubscribeIcon className="settings-popover__item-icon" /> }
-							onClick={ () => {
-								onUnsubscribe();
-								close();
-							} }
-						>
-							{ translate( 'Unsubscribe' ) }
-						</Button>
-					) }
+					<Button
+						className={ classNames( 'unsubscribe-button', { 'is-loading': unsubscribing } ) }
+						disabled={ unsubscribing }
+						icon={ <UnsubscribeIcon className="settings-popover__item-icon" /> }
+						onClick={ () => {
+							onUnsubscribe();
+							close();
+						} }
+					>
+						{ translate( 'Unsubscribe' ) }
+					</Button>
 				</>
 			) }
 		</SettingsPopover>

--- a/client/landing/subscriptions/components/settings/site-settings/styles.scss
+++ b/client/landing/subscriptions/components/settings/site-settings/styles.scss
@@ -9,7 +9,8 @@
 		}
 	}
 
-	.unsubscribe-button.components-button.has-icon {
+	.unsubscribe-button.components-button.has-icon,
+	.resubscribe-button.components-button.has-icon {
 		margin-top: 24px;
 	}
 }

--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
@@ -1,6 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import TimeSince from 'calypso/components/time-since';
@@ -64,6 +65,7 @@ export default function SiteRow( {
 	is_wpforteams_site,
 	is_paid_subscription,
 	onSiteTitleClick,
+	isDeleted,
 }: SiteRowProps ) {
 	const translate = useTranslate();
 	const hostname = useMemo( () => {
@@ -87,9 +89,11 @@ export default function SiteRow( {
 		SubscriptionManager.useSiteEmailMeNewCommentsMutation();
 	const { mutate: unsubscribe, isLoading: unsubscribing } =
 		SubscriptionManager.useSiteUnsubscribeMutation();
+	const { mutate: resubscribe, isLoading: resubscribing } =
+		SubscriptionManager.useSiteSubscribeMutation();
 
 	return (
-		<li className="row" role="row">
+		<li className={ classnames( 'row', { deleted: isDeleted } ) } role="row">
 			<div className="title-cell" role="cell">
 				<Button
 					icon={ <SiteIcon iconUrl={ site_icon } siteName={ name } /> }
@@ -171,8 +175,11 @@ export default function SiteRow( {
 						updateEmailMeNewComments( { blog_id: blog_ID, send_comments } )
 					}
 					updatingEmailMeNewComments={ updatingEmailMeNewComments }
-					onUnsubscribe={ () => unsubscribe( { blog_id: blog_ID, url: url } ) }
+					onUnsubscribe={ () => unsubscribe( { blog_id: blog_ID, url } ) }
 					unsubscribing={ unsubscribing }
+					isDeleted={ isDeleted }
+					onResubscribe={ () => resubscribe( { blog_id: blog_ID, url } ) }
+					resubscribing={ resubscribing }
 				/>
 			</span>
 		</li>

--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
@@ -175,10 +175,14 @@ export default function SiteRow( {
 						updateEmailMeNewComments( { blog_id: blog_ID, send_comments } )
 					}
 					updatingEmailMeNewComments={ updatingEmailMeNewComments }
-					onUnsubscribe={ () => unsubscribe( { blog_id: blog_ID, url } ) }
+					onUnsubscribe={ () =>
+						unsubscribe( { blog_id: blog_ID, url, doNotInvalidateSiteSubscriptions: true } )
+					}
 					unsubscribing={ unsubscribing }
 					isDeleted={ isDeleted }
-					onResubscribe={ () => resubscribe( { blog_id: blog_ID, url } ) }
+					onResubscribe={ () =>
+						resubscribe( { blog_id: blog_ID, url, doNotInvalidateSiteSubscriptions: true } )
+					}
 					resubscribing={ resubscribing }
 				/>
 			</span>

--- a/client/landing/subscriptions/components/site-subscriptions-manager/styles.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/styles.scss
@@ -32,6 +32,10 @@
 				}
 			}
 
+			&.deleted {
+				opacity: 0.5;
+			}
+
 			.title-cell {
 				display: flex;
 				align-items: center;

--- a/client/landing/subscriptions/index.tsx
+++ b/client/landing/subscriptions/index.tsx
@@ -11,6 +11,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { AnyAction } from 'redux';
 import { setupLocale } from 'calypso/boot/locale';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
+import GlobalNotices from 'calypso/components/global-notices';
 import MomentProvider from 'calypso/components/localized-moment/provider';
 import { WindowLocaleEffectManager } from 'calypso/landing/stepper/utils/window-locale-effect-manager';
 import { SiteSubscriptionPage } from 'calypso/landing/subscriptions/components/site-subscription-page';
@@ -54,6 +55,7 @@ window.AppBoot = async () => {
 	ReactDom.render(
 		<CalypsoI18nProvider>
 			<Provider store={ reduxStore }>
+				<GlobalNotices />
 				<QueryClientProvider client={ queryClient }>
 					<MomentProvider>
 						<WindowLocaleEffectManager />

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -7,6 +7,7 @@ import type { SiteSubscriptionDetails } from '../types';
 type SubscribeParams = {
 	blog_id?: number | string;
 	url?: string;
+	doNotInvalidateSiteSubscriptions?: boolean;
 };
 
 type SubscribeResponse = {
@@ -68,6 +69,7 @@ const useSiteSubscribeMutation = ( blog_id?: string ) => {
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
+
 			if ( previousSiteSubscriptions ) {
 				queryClient.setQueryData( siteSubscriptionsCacheKey, {
 					...previousSiteSubscriptions,
@@ -106,8 +108,10 @@ const useSiteSubscribeMutation = ( blog_id?: string ) => {
 				);
 			}
 		},
-		onSettled: () => {
-			queryClient.invalidateQueries( siteSubscriptionsCacheKey );
+		onSettled: ( _data, _error, params: SubscribeParams ) => {
+			if ( params.doNotInvalidateSiteSubscriptions !== true ) {
+				queryClient.invalidateQueries( siteSubscriptionsCacheKey );
+			}
 			queryClient.invalidateQueries( subscriptionsCountCacheKey );
 			queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey );
 		},

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -81,6 +81,10 @@ const useSiteSubscribeMutation = ( blog_id?: string ) => {
 								...siteSubscription,
 								isDeleted:
 									siteSubscription.blog_ID === params.blog_id ? false : siteSubscription.isDeleted,
+								date_subscribed:
+									siteSubscription.blog_ID === params.blog_id
+										? new Date()
+										: siteSubscription.date_subscribed,
 							} ) ),
 						};
 					} ),
@@ -98,9 +102,13 @@ const useSiteSubscribeMutation = ( blog_id?: string ) => {
 				} );
 			}
 
-			return { previousSiteSubscriptionDetails };
+			return { previousSiteSubscriptions, previousSiteSubscriptionDetails };
 		},
 		onError: ( error, variables, context ) => {
+			if ( context?.previousSiteSubscriptions ) {
+				queryClient.setQueryData( siteSubscriptionsCacheKey, context.previousSiteSubscriptions );
+			}
+
 			if ( context?.previousSiteSubscriptionDetails ) {
 				queryClient.setQueryData(
 					siteSubscriptionDetailsCacheKey,

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -80,10 +80,11 @@ const useSiteUnsubscribeMutation = ( blog_id?: string ) => {
 					pages: previousSiteSubscriptions.pages.map( ( page ) => {
 						return {
 							...page,
-							subscriptions: page.subscriptions.filter(
-								( siteSubscription ) => siteSubscription.blog_ID !== params.blog_id
-							),
 							total_subscriptions: page.total_subscriptions - 1,
+							subscriptions: page.subscriptions.map( ( siteSubscription ) => ( {
+								...siteSubscription,
+								isDeleted: siteSubscription.blog_ID === params.blog_id,
+							} ) ),
 						};
 					} ),
 				} );
@@ -140,7 +141,7 @@ const useSiteUnsubscribeMutation = ( blog_id?: string ) => {
 			}
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries( siteSubscriptionsCacheKey );
+			queryClient.invalidateQueries( siteSubscriptionsCacheKey, { refetchType: 'inactive' } );
 			queryClient.invalidateQueries( subscriptionsCountCacheKey );
 			queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey, { refetchType: 'none' } );
 		},

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -83,7 +83,8 @@ const useSiteUnsubscribeMutation = ( blog_id?: string ) => {
 							total_subscriptions: page.total_subscriptions - 1,
 							subscriptions: page.subscriptions.map( ( siteSubscription ) => ( {
 								...siteSubscription,
-								isDeleted: siteSubscription.blog_ID === params.blog_id,
+								isDeleted:
+									siteSubscription.blog_ID === params.blog_id ? true : siteSubscription.isDeleted,
 							} ) ),
 						};
 					} ),

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -10,6 +10,7 @@ import {
 type UnsubscribeParams = {
 	blog_id: number | string;
 	url?: string;
+	doNotInvalidateSiteSubscriptions?: boolean;
 };
 
 type UnsubscribeResponse = {
@@ -141,8 +142,10 @@ const useSiteUnsubscribeMutation = ( blog_id?: string ) => {
 				);
 			}
 		},
-		onSettled: () => {
-			queryClient.invalidateQueries( siteSubscriptionsCacheKey, { refetchType: 'inactive' } );
+		onSettled: ( _data, _error, params ) => {
+			if ( params.doNotInvalidateSiteSubscriptions !== true ) {
+				queryClient.invalidateQueries( siteSubscriptionsCacheKey );
+			}
 			queryClient.invalidateQueries( subscriptionsCountCacheKey );
 			queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey, { refetchType: 'none' } );
 		},

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -69,6 +69,7 @@ export type SiteSubscription = {
 	meta: SiteSubscriptionMeta;
 	is_wpforteams_site: boolean;
 	is_paid_subscription: boolean;
+	isDeleted: boolean;
 };
 
 export type SiteSubscriptionPage = {


### PR DESCRIPTION
Fixes #78057


## Proposed Changes

This PR allows a user to resubscribe, in case they accidentally remove a subscriber.

https://github.com/Automattic/wp-calypso/assets/528287/1c993db2-17f6-47b9-a1e3-5324394f22e5

It also adds support to pass a function as the child of SettingsPopover. This function is called with a `close` function, which the child can use to close the dialog. I did this because when unsubscribing, the dialog would stay open, which seems a bit weird.

```js
	<SettingsPopover className="site-settings-popover">
			{ ( close: () => void ) => ( ... )
		</SettingsPopover>
```

The `useSiteSubscribeMutation` and `useSiteUnsubscribeMutation` now both take an extra parameter called `doNotInvalidateSiteSubscriptions` to make these mutations skip the invalidation of the queries, making this magic possible.

## Testing Instructions

1. Apply this PR
2. Surf to http://calypso.localhost:3000/subscriptions/sites
3. Unsubscribe from a site
4. This site should be grayed out in the list
5. Click the three dots again
6. Click resubscribe
7. You should be subscribed again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
