### PR TITLE
Editor auth redirect - use native editor for redirect_to url for non-SSO jetpack sites

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -127,8 +127,6 @@ export const authenticate = ( context, next ) => {
 		isDesktop || // The desktop app can store third-party cookies.
 		context.query.authWpAdmin; // Redirect back from the WP Admin login page to Calypso.
 
-	const isJetpackNonSSO = isJetpack && ! isSSOEnabled( state, siteId );
-
 	if ( isDesktop && isJetpack && ! isSSOEnabled( state, siteId ) ) {
 		isAuthenticated = false;
 	}
@@ -164,7 +162,7 @@ export const authenticate = ( context, next ) => {
 
 	// If non-SSO Jetpack lets ensure return URL uses the sites native editor, as the dotcom
 	// redirect does not happen.
-	if ( isJetpackNonSSO ) {
+	if ( isJetpack && ! isSSOEnabled( state, siteId ) ) {
 		const postType = determinePostType( context );
 		const postId = getPostID( context );
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -176,10 +176,10 @@ export const authenticate = ( context, next ) => {
 		} else {
 			returnUrl = `${ siteAdminUrl }site-editor.php`;
 		}
-	}
 
-	// pass along parameters, for example press-this
-	returnUrl = addQueryArgs( context.query, returnUrl );
+		// pass along parameters, for example press-this
+		returnUrl = addQueryArgs( context.query, returnUrl );
+	}
 
 	const wpAdminLoginUrl = addQueryArgs(
 		{ redirect_to: returnUrl },

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -127,10 +127,7 @@ export const authenticate = ( context, next ) => {
 		isDesktop || // The desktop app can store third-party cookies.
 		context.query.authWpAdmin; // Redirect back from the WP Admin login page to Calypso.
 
-	let isJetpackNonSSO = false;
-	if ( isJetpack && ! isSSOEnabled( state, siteId ) ) {
-		isJetpackNonSSO = true;
-	}
+	const isJetpackNonSSO = isJetpack && ! isSSOEnabled( state, siteId );
 
 	if ( isDesktop && isJetpack && ! isSSOEnabled( state, siteId ) ) {
 		isAuthenticated = false;

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -158,6 +158,7 @@ export const authenticate = ( context, next ) => {
 		{ ...context.query, authWpAdmin: true },
 		`${ origin }${ context.path }`
 	);
+
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 
 	// If non-SSO Jetpack lets ensure return URL uses the sites native editor, as the dotcom


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/78014 - 78014 hides non-SSO jetpack sites from the reader-sharing site list until we can find a working solution for them. This PR attempts to resolve the underlying issue and allow those to work as expected.

## Proposed Changes

* When a non-SSO Jetpack site fails authentication when loading the editor, ensure the `redirect_to` url uses that site's native wp-admin editor. In the state previous to this PR, the `redirect_to` url was filled with the original wpcom editor address which does not work as a redirect from that site causing the user to land in the root of wp-admin after login.

NOTE - I think this is the safe approach as we only make changes for non-SSO connected Jetpack sites after auth failure. I am uncertain if these changes would be beneficial to other circumstances or not and am limiting this to avoid any other potential regressions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso build.
* Enter calypso and select a self-hosted site that is connected via Jetpack without SSO (wpcom login) enabled.
* Go to posts and "add new".
* After being prompted to login on your self-hosted site, verify you are loaded into the editor. (previously this landed in root wp-admin).
* Go back to the calypso and visit the reader.
* Select a post to share in the reader and select the same site noted above as the site to share from.
* After logging into the self-hosted site, verify you land in the editor. An embed block should be inserted as a result of reader-sharing. (previously this was also landing users in root wp-admin).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
