### PR TITLE
Stats: Adjust z-index for overlapping of settings tooltip and popover

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -141,6 +141,8 @@ $z-layers: (
 		".drop-zone__content": 1010,
 		".main.customize.is-iframe": 9999,
 		".tooltip.popover": 100000,
+		".tooltip.popover.page-modules-settings-popover": 175,
+		".tooltip.popover.highlight-card__settings-tooltip": 170,
 		".fullscreen-overlay": 100005,
 		"#wp_editbtns": 100020,
 		"#wp-fullscreen-body": 100010,

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -224,11 +224,16 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 
 	// Modules settings popover
 	&.page-modules-settings-popover {
-		// Make the popover be under `#header.masterbar`.
-		z-index: 1;
+		// Make the popover under `#header.masterbar` of z-index: 180.
+		z-index: z-index("root", ".tooltip.popover.page-modules-settings-popover");
 		.popover__inner {
 			padding: 14px 16px;
 		}
+	}
+
+	&.highlight-card__settings-tooltip {
+		// Make the popover under `.page-modules-settings-popover` of z-index: 175.
+		z-index: z-index("root", ".tooltip.popover.highlight-card__settings-tooltip");
 	}
 
 	// @TODO: Introduce the support for the border of white background arrows in the popover component.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adjust the z-index of module settings popover and highlights settings tooltip to make the overlapping more sense.

|Before|After|
|-|-|
|<img width="1289" alt="截圖 2023-06-12 下午1 14 09" src="https://github.com/Automattic/wp-calypso/assets/6869813/7cab32ec-7126-4414-8aa3-6ee3bd4ebb10">|<img width="1292" alt="截圖 2023-06-12 下午1 26 30" src="https://github.com/Automattic/wp-calypso/assets/6869813/9cd70118-e459-4641-981c-a78f243d7791">|



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the live branch link.
* Navigate to Stats > `Traffic` page.
* Dismiss the module settings tooltip.
* Click the module settings panel launch button.
* Ensure the module settings panel overlaps the highlights settings tooltip.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
