### PR TITLE
Launchpad: Added launchpad as secondary card

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/style.scss
+++ b/client/my-sites/customer-home/cards/launchpad/style.scss
@@ -4,6 +4,9 @@
 
 .launchpad-keep-building {
 	padding: 24px;
+	border-radius: 3px; /* stylelint-disable-line scales/radii */
+	box-shadow: 0 0 0 1px var(--color-border-subtle);
+	margin-bottom: 16px;
 
 	.launchpad-keep-building__header {
 		display: flex;

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -6,10 +6,12 @@ import {
 	SECTION_LEARN_GROW,
 	FEATURE_SUPPORT,
 	SECTION_BLOGGING_PROMPT,
+	LAUNCHPAD_KEEP_BUILDING,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import DomainUpsell from 'calypso/my-sites/customer-home/cards/features/domain-upsell';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
 import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
+import LaunchpadKeepBuilding from 'calypso/my-sites/customer-home/cards/launchpad/keep-building';
 import LearnGrow from './learn-grow';
 
 const cardComponents = {
@@ -18,6 +20,7 @@ const cardComponents = {
 	[ SECTION_LEARN_GROW ]: LearnGrow,
 	[ SECTION_BLOGGING_PROMPT ]: BloggingPrompt,
 	[ FEATURE_SUPPORT ]: HelpSearch,
+	[ LAUNCHPAD_KEEP_BUILDING ]: LaunchpadKeepBuilding,
 };
 
 const Secondary = ( { cards, siteId } ) => {


### PR DESCRIPTION
## Proposed Changes

* Added Launchpad Keep building checklist to the customer home, on the secondary spot.
* This PR should not change anything until it's backend counterpart is enabled.
* It set up calypso to handle the Launchpad component as an option for the `secondary` spot in the customer home (left column).

## Testing Instructions
* Run this PR and see that nothing changed.
* Sandbox the API and apply [D113406](D113406-code) 
* Open customer home again:

Design:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/c0073a4d-a598-4448-a5b0-d5d900b20df9)

HTML:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/f93b8285-65bc-41f2-9f02-d60eca063a4e)