### PR TITLE
Help page: Change the Courses link

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/educational-content-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/educational-content-step.tsx
@@ -338,10 +338,7 @@ export default function EducationalCotnentStep( { type, site, ...props }: StepPr
 												/>
 											),
 											seo: (
-												<Button
-													href="https://wpcourses.com/course/intro-to-search-engine-optimization-seo/"
-													isLink
-												/>
+												<Button href="https://wordpress.com/learn/courses/intro-to-seo/" isLink />
 											),
 										},
 									}

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -144,7 +144,7 @@ class Help extends PureComponent {
 				</CompactCard>
 				<CompactCard
 					className="help__support-link"
-					href="https://wpcourses.com/?ref=wpcom-help-more-resources"
+					href="https://wordpress.com/learn/courses?ref=wpcom-help-more-resources"
 					target="_blank"
 				>
 					<Gridicon icon="mail" size={ 36 } />

--- a/client/my-sites/marketing/index.js
+++ b/client/my-sites/marketing/index.js
@@ -20,9 +20,7 @@ export default function () {
 	} );
 
 	page( '/marketing/ultimate-traffic-guide*', function redirectToWPCoursesPage() {
-		window.location.replace(
-			'https://wpcourses.com/course/intro-to-search-engine-optimization-seo/'
-		);
+		window.location.replace( 'https://wordpress.com/learn/courses/intro-to-seo/' );
 	} );
 
 	const paths = [

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -250,7 +250,7 @@ export const MarketingTools: FunctionComponent = () => {
 					>
 						<Button
 							onClick={ handleSEOCourseClick }
-							href="https://wpcourses.com/course/intro-to-search-engine-optimization-seo/"
+							href="https://wordpress.com/learn/courses/intro-to-seo/"
 							target="_blank"
 						>
 							{ translate( 'Register now' ) }


### PR DESCRIPTION
## What

We're changing the Courses link here:
![image](https://github.com/Automattic/wp-calypso/assets/52076348/9779a8ce-fd2c-4ab9-9e94-4838dce8deb3)

on https://wordpress.com/help 

From:   `https://wpcourses.com/?ref=wpcom-help-more-resources`
To:       `https://wordpress.com/learn/courses`

------

Here:
<img width="629" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/88b680ae-773a-46b8-9efd-0424f2f04c61">

On http://wordpress.com/marketing/tools/
From: `https://wpcourses.com/course/intro-to-search-engine-optimization-seo/`
To: `https://wordpress.com/learn/courses/intro-to-seo/`

---
Going to `https://wordpress.com/marketing/ultimate-traffic-guide` should bring you to `https://wordpress.com/learn/courses/intro-to-seo/` instead of `https://wpcourses.com/course/intro-to-search-engine-optimization-seo/`

---

## Testing

1. Check the Live Link on GitHub.
2. Visit the various changes mentioned above.
3. Clicking on `Courses` on the various page should bring you to `https://wordpress.com/learn/courses/[page]`