### PR TITLE
Subscribers Page: Create Grow your Audience section

### DIFF
--- a/client/my-sites/subscribers/components/empty-list-view/styles.scss
+++ b/client/my-sites/subscribers/components/empty-list-view/styles.scss
@@ -66,7 +66,7 @@
 }
 
 @media screen and (max-width: $break-large) {
-	.is-sidebar-overflow {
+	body:not(.is-sidebar-collapsed) {
 		.empty-list-view .empty-list-view__cta-link {
 			width: 100%;
 		}

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -22,7 +22,7 @@ const GrowYourAudienceCard = ( { icon, text, title, url }: GrowYourAudienceCardP
 					<Icon className="grow-your-audience__card-icon" icon={ icon } size={ 20 } />
 					{ title }
 				</h3>
-				<span className="grow-your-audience__card-text">{ text }</span>
+				<p className="grow-your-audience__card-text">{ text }</p>
 				<a className="grow-your-audience__card-link" href={ url } target="_blank" rel="noreferrer">
 					{ translate( 'Learn more' ) }
 				</a>

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -1,6 +1,8 @@
 import { Card, CardBody, Icon } from '@wordpress/components';
 import { chartBar, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import './styles.scss';
 
 type GrowYourAudienceCardProps = {
@@ -31,6 +33,7 @@ const GrowYourAudienceCard = ( { icon, text, title, url }: GrowYourAudienceCardP
 
 const GrowYourAudience = () => {
 	const translate = useTranslate();
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
 	return (
 		<div className="grow-your-audience">
@@ -61,7 +64,7 @@ const GrowYourAudience = () => {
 						'Allow your readers to support your work with paid subscriptions, gated content, or tips.'
 					) }
 					title={ translate( 'Start earning' ) }
-					url="https://wordpress.com/earn/"
+					url={ `https://wordpress.com/earn/${ selectedSiteSlug }` }
 				/>
 			</div>
 		</div>

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -1,6 +1,7 @@
 import { Card, CardBody, Icon } from '@wordpress/components';
 import { chartBar, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { SectionContainer } from 'calypso/components/section';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import './styles.scss';
@@ -36,7 +37,7 @@ const GrowYourAudience = () => {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
 	return (
-		<div className="grow-your-audience">
+		<SectionContainer className="grow-your-audience">
 			<h2 className="grow-your-audience__title">{ translate( 'Grow your audience' ) }</h2>
 
 			<div className="grow-your-audience__cards">
@@ -67,7 +68,7 @@ const GrowYourAudience = () => {
 					url={ `https://wordpress.com/earn/${ selectedSiteSlug }` }
 				/>
 			</div>
-		</div>
+		</SectionContainer>
 	);
 };
 

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -1,0 +1,71 @@
+import { Card, CardBody, Icon } from '@wordpress/components';
+import { chartBar, people, trendingUp } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import './styles.scss';
+
+type GrowYourAudienceCardProps = {
+	icon: JSX.Element;
+	text: string;
+	title: string;
+	url: string;
+};
+
+const GrowYourAudienceCard = ( { icon, text, title, url }: GrowYourAudienceCardProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<Card className="grow-your-audience__card" size="small">
+			<CardBody className="grow-your-audience__card-body">
+				<h3 className="grow-your-audience__card-title">
+					<Icon className="grow-your-audience__card-icon" icon={ icon } size={ 20 } />
+					{ title }
+				</h3>
+				<span className="grow-your-audience__card-text">{ text }</span>
+				<a className="grow-your-audience__card-link" href={ url } target="_blank" rel="noreferrer">
+					{ translate( 'Learn more' ) }
+				</a>
+			</CardBody>
+		</Card>
+	);
+};
+
+const GrowYourAudience = () => {
+	const translate = useTranslate();
+
+	return (
+		<div className="grow-your-audience">
+			<h2 className="grow-your-audience__title">{ translate( 'Grow your audience' ) }</h2>
+
+			<div className="grow-your-audience__cards">
+				<GrowYourAudienceCard
+					icon={ chartBar }
+					text={ translate(
+						'Using a subscriber block is the first step to growing your audience.'
+					) }
+					title={ translate( 'Every visitor is a potential subscriber' ) }
+					url="https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/"
+				/>
+
+				<GrowYourAudienceCard
+					icon={ people }
+					text={ translate(
+						'Create fresh content, publish regularly, and understand your audience with site stats.'
+					) }
+					title={ translate( 'Keep your readers engaged' ) }
+					url="https://wordpress.com/go/content-blogging/how-to-start-a-successful-blog-that-earns-links-traffic-and-revenue/#creating-a-blog-content-strategy"
+				/>
+
+				<GrowYourAudienceCard
+					icon={ trendingUp }
+					text={ translate(
+						'Allow your readers to support your work with paid subscriptions, gated content, or tips.'
+					) }
+					title={ translate( 'Start earning' ) }
+					url="https://wordpress.com/earn/"
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default GrowYourAudience;

--- a/client/my-sites/subscribers/components/grow-your-audience/index.ts
+++ b/client/my-sites/subscribers/components/grow-your-audience/index.ts
@@ -1,0 +1,1 @@
+export { default as GrowYourAudience } from './grow-your-audience';

--- a/client/my-sites/subscribers/components/grow-your-audience/styles.scss
+++ b/client/my-sites/subscribers/components/grow-your-audience/styles.scss
@@ -5,13 +5,20 @@
 .grow-your-audience {
 	color: $studio-gray-100;
 	font-family: "SF Pro Text", $sans !important;
-	padding: 64px 0;
+	padding: 64px 0 !important;
+
+	&::before {
+		background-color: $studio-gray-0 !important;
+		margin-top: -64px !important;
+		z-index: 0 !important;
+	}
 
 	.grow-your-audience__title {
 		font-weight: 500;
 		font-size: $font-title-small;
 		line-height: rem(26px);
 		margin-bottom: 16px;
+		position: relative;
 	}
 
 	.grow-your-audience__cards {

--- a/client/my-sites/subscribers/components/grow-your-audience/styles.scss
+++ b/client/my-sites/subscribers/components/grow-your-audience/styles.scss
@@ -1,0 +1,78 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
+.grow-your-audience {
+	color: $studio-gray-100;
+	font-family: "SF Pro Text", $sans !important;
+	padding: 64px 0;
+
+	.grow-your-audience__title {
+		font-weight: 500;
+		font-size: $font-title-small;
+		line-height: rem(26px);
+		margin-bottom: 16px;
+	}
+
+	.grow-your-audience__cards {
+		display: flex;
+		gap: 32px;
+	}
+
+	.grow-your-audience__card {
+		box-shadow: none;
+		border: 1px solid $studio-gray-5;
+		border-radius: 4px;
+		flex-basis: 33.3%;
+
+		.components-card__body {
+			padding: 16px 24px;
+		}
+	}
+
+	.grow-your-audience__card-title {
+		color: $studio-gray-100;
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		font-weight: 500;
+		font-size: $font-body-small;
+		line-height: rem(20px);
+		margin-bottom: 8px;
+	}
+
+	.grow-your-audience__card-text {
+		color: $studio-gray-60;
+		font-size: $font-body-extra-small;
+		line-height: rem(20px);
+	}
+
+	.grow-your-audience__card-link {
+		display: block;
+		font-weight: 500;
+		font-size: $font-body-small;
+		margin-top: 16px;
+	}
+}
+
+@media screen and (max-width: $break-large) {
+	.is-sidebar-overflow {
+		.grow-your-audience__cards {
+			flex-direction: column;
+		}
+
+		.grow-your-audience__card {
+			flex-basis: 100%;
+		}
+	}
+}
+
+@media ( max-width: $break-medium ) {
+	.grow-your-audience__cards {
+		flex-direction: column;
+	}
+
+	.grow-your-audience__card {
+		flex-basis: 100%;
+	}
+}

--- a/client/my-sites/subscribers/components/grow-your-audience/styles.scss
+++ b/client/my-sites/subscribers/components/grow-your-audience/styles.scss
@@ -41,6 +41,10 @@
 		margin-bottom: 8px;
 	}
 
+	.grow-your-audience__card-icon {
+		flex-basis: 20px;
+	}
+
 	.grow-your-audience__card-text {
 		color: $studio-gray-60;
 		font-size: $font-body-extra-small;
@@ -55,10 +59,11 @@
 	}
 }
 
-@media screen and (max-width: $break-large) {
-	.is-sidebar-overflow {
+@media screen and (max-width: $break-xlarge) {
+	body:not(.is-sidebar-collapsed) {
 		.grow-your-audience__cards {
 			flex-direction: column;
+			gap: 16px !important;
 		}
 
 		.grow-your-audience__card {
@@ -70,6 +75,7 @@
 @media ( max-width: $break-medium ) {
 	.grow-your-audience__cards {
 		flex-direction: column;
+		gap: 16px !important;
 	}
 
 	.grow-your-audience__card {

--- a/client/my-sites/subscribers/components/grow-your-audience/styles.scss
+++ b/client/my-sites/subscribers/components/grow-your-audience/styles.scss
@@ -72,7 +72,7 @@
 	}
 }
 
-@media ( max-width: $break-medium ) {
+@media (max-width: $break-medium) {
 	.grow-your-audience__cards {
 		flex-direction: column;
 		gap: 16px !important;

--- a/client/my-sites/subscribers/components/subscriber-list/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-list/styles.scss
@@ -13,7 +13,7 @@
 		padding-top: 20px;
 		padding-bottom: 20px;
 
-		* {
+		> * {
 			flex: 1;
 		}
 

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -61,11 +61,11 @@ export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
 	}
 
 	return (
-		<div className="subscribers">
-			<Main wideLayout className="subscribers__main">
-				<DocumentHead title={ translate( 'Subscribers' ) } />
-				<FixedNavigationHeader navigationItems={ navigationItems }></FixedNavigationHeader>
+		<Main wideLayout className="subscribers">
+			<DocumentHead title={ translate( 'Subscribers' ) } />
+			<FixedNavigationHeader navigationItems={ navigationItems }></FixedNavigationHeader>
 
+			<section className="subscribers__section">
 				{ total ? (
 					<>
 						<div className="subscribers__header-count">
@@ -85,15 +85,9 @@ export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
 					total={ total }
 					pageClick={ pageClickCallback }
 				/>
-			</Main>
+			</section>
 
-			{ !! total && (
-				<div className="subscribers__footer">
-					<Main wideLayout className="subscribers__footer-main">
-						<GrowYourAudience />
-					</Main>
-				</div>
-			) }
-		</div>
+			{ !! total && <GrowYourAudience /> }
+		</Main>
 	);
 };

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -8,6 +8,7 @@ import Main from 'calypso/components/main';
 import Pagination from 'calypso/components/pagination';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { EmptyListView } from './components/empty-list-view';
+import { GrowYourAudience } from './components/grow-your-audience';
 import { SubscriberList } from './components/subscriber-list/subscriber-list';
 import { usePagination } from './hooks';
 import { useSubscribersQuery } from './queries';
@@ -60,29 +61,39 @@ export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
 	}
 
 	return (
-		<Main wideLayout className="subscribers">
-			<DocumentHead title={ translate( 'Subscribers' ) } />
-			<FixedNavigationHeader navigationItems={ navigationItems }></FixedNavigationHeader>
+		<div className="subscribers">
+			<Main wideLayout className="subscribers__main">
+				<DocumentHead title={ translate( 'Subscribers' ) } />
+				<FixedNavigationHeader navigationItems={ navigationItems }></FixedNavigationHeader>
 
-			{ total ? (
-				<>
-					<div className="subscribers__header-count">
-						<span className="subscribers__title">{ translate( 'Total' ) }</span>{ ' ' }
-						<span className="subscribers__subscriber-count">{ total }</span>
-					</div>
-					<SubscriberList subscribers={ subscribers } />
-				</>
-			) : (
-				<EmptyListView />
+				{ total ? (
+					<>
+						<div className="subscribers__header-count">
+							<span className="subscribers__title">{ translate( 'Total' ) }</span>{ ' ' }
+							<span className="subscribers__subscriber-count">{ total }</span>
+						</div>
+						<SubscriberList subscribers={ subscribers } />
+					</>
+				) : (
+					<EmptyListView />
+				) }
+
+				<Pagination
+					className="subscribers__pagination"
+					page={ page }
+					perPage={ per_page }
+					total={ total }
+					pageClick={ pageClickCallback }
+				/>
+			</Main>
+
+			{ !! total && (
+				<div className="subscribers__footer">
+					<Main wideLayout className="subscribers__footer-main">
+						<GrowYourAudience />
+					</Main>
+				</div>
 			) }
-
-			<Pagination
-				className="subscribers__pagination"
-				page={ page }
-				perPage={ per_page }
-				total={ total }
-				pageClick={ pageClickCallback }
-			/>
-		</Main>
+		</div>
 	);
 };

--- a/client/my-sites/subscribers/styles.scss
+++ b/client/my-sites/subscribers/styles.scss
@@ -2,24 +2,11 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 
-.subscribers {
-	.subscribers__main {
-		margin-bottom: 68px;
-	}
+.subscribers.main {
+	padding: 0 32px;
 
-	.subscribers__footer {
-		background-color: $studio-gray-0;
-
-		.subscribers__footer-main {
-			padding-bottom: 0 !important;
-		}
-	}
-
-	.subscribers__main,
-	.subscribers__footer {
-		padding-bottom: 0 !important;
-		padding-left: 32px;
-		padding-right: 32px;
+	.subscribers__section {
+		margin-bottom: 64px;
 	}
 }
 

--- a/client/my-sites/subscribers/styles.scss
+++ b/client/my-sites/subscribers/styles.scss
@@ -2,6 +2,27 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 
+.subscribers {
+	.subscribers__main {
+		margin-bottom: 68px;
+	}
+
+	.subscribers__footer {
+		background-color: $studio-gray-0;
+
+		.subscribers__footer-main {
+			padding-bottom: 0 !important;
+		}
+	}
+
+	.subscribers__main,
+	.subscribers__footer {
+		padding-bottom: 0 !important;
+		padding-left: 32px;
+		padding-right: 32px;
+	}
+}
+
 .subscribers__header-count {
 	margin-top: 70px;
 	margin-bottom: 30px;
@@ -19,11 +40,17 @@
 }
 
 @media ( max-width: $break-medium ) {
-	.subscribers__header-count {
-		padding-left: 16px;
-		padding-right: 16px;
-		margin-top: 85px;
-		margin-bottom: 6px;
+	.is-section-subscribers .layout__content {
+		padding-left: 0 !important;
+		padding-right: 0 !important;
+		padding-bottom: 0 !important;
 	}
 }
 
+.is-section-subscribers .layout__content {
+	background-color: $studio-white;
+	padding-left: var(--sidebar-width-max);
+	padding-right: 0;
+	padding-top: calc(var(--masterbar-height) + 71px);
+	padding-bottom: 0;
+}

--- a/client/my-sites/subscribers/styles.scss
+++ b/client/my-sites/subscribers/styles.scss
@@ -39,18 +39,21 @@
 	}
 }
 
+.is-section-subscribers {
+	background-color: $studio-white;
+}
+
+.is-section-subscribers .layout__content {
+	padding-left: var(--sidebar-width-max);
+	padding-right: 0;
+	padding-top: calc(var(--masterbar-height) + 71px);
+	padding-bottom: 0;
+}
+
 @media ( max-width: $break-medium ) {
 	.is-section-subscribers .layout__content {
 		padding-left: 0 !important;
 		padding-right: 0 !important;
 		padding-bottom: 0 !important;
 	}
-}
-
-.is-section-subscribers .layout__content {
-	background-color: $studio-white;
-	padding-left: var(--sidebar-width-max);
-	padding-right: 0;
-	padding-top: calc(var(--masterbar-height) + 71px);
-	padding-bottom: 0;
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78065

## Proposed Changes

* Create Grow your Audience section
* Update Subscribers page background to match Figma design
* Fix media query for EmptyView with expanded sidebar
* Fix text alignment for email-only rows
* Fix subscribers page container paddings and margins to match Figma design

## Testing Instructions

* Apply this PR to your local env
* Go to http://calypso.localhost:3000/subscribers/{site-slug}?flags=subscribers-page
* Verify if the Grow your Audience section is rendered as expected, check Figma design h8tMpJlCqNFemEerU9owHI-fi-1981_71935
* Verify if the section is rendered as expected with different screen sizes and with the sidebar expanded and collapsed
* Check for regressions on a page without subscribers (Empty View)

<img width="1165" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/72b3314b-ac93-4f84-b727-fea1eb5f98a3">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?