### PR TITLE
Subscribers Page: Hide view button from the popover menu

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-list/styles.scss
@@ -139,3 +139,9 @@
 		}
 	}
 }
+
+.subscriber-popover .hidden {
+	visibility: hidden;
+	height: 0;
+	padding: 0;
+}

--- a/client/my-sites/subscribers/components/subscriber-list/subscriber-popover.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/subscriber-popover.tsx
@@ -38,7 +38,7 @@ const SubscriberPopover = ( { onUnsubscribe, onView }: SubscriberPopoverProps ) 
 				className="subscriber-popover"
 				focusOnShow={ false }
 			>
-				<PopoverMenuItem onClick={ onView }>
+				<PopoverMenuItem onClick={ onView } className="hidden">
 					<Icon icon={ seen } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
 					{ translate( 'View' ) }
 				</PopoverMenuItem>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78063

## Proposed Changes

* Hide view button on Subscribers row menu

## Testing Instructions

* Apply this patch to your local env
* Go to http://calypso.localhost:3000/subscribers/{site-slug}?flags=subscribers-page
* Verify if Unsubscribe is the only button on the menu

<img width="354" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/75f45992-1c39-443f-ae33-e95969323e42">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
