### PR TITLE
(devex)(error-tracking) Generate JS source-maps for the notifications app

### DIFF
--- a/apps/notifications/webpack.config.js
+++ b/apps/notifications/webpack.config.js
@@ -10,6 +10,7 @@ const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 
 const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'false';
+const isDevelopment = process.env.NODE_ENV !== 'production';
 
 /**
  * Return a webpack config object
@@ -108,6 +109,7 @@ function getWebpackConfig(
 				} ),
 			new ExtensiveLodashReplacementPlugin(),
 		].filter( Boolean ),
+		devtool: isDevelopment ? 'inline-cheap-source-map' : 'source-map',
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes

Generate source-maps for the `notifications` _standalone_ app JS assets. When `NODE_ENV` is _not_ `production`, it will use `inline-cheap-source-map` as `devtool`. For production builds, `source-map` will be used, following the same pattern of other Calypso apps (such as ETK).

## Testing Instructions

### Production build

1. Run `yarn build`
2. Verify `dist/build.min.js.map` is present (see screenshot below):
![Screenshot from 2023-06-12 17-57-22](https://github.com/Automattic/wp-calypso/assets/81248/e6135321-9a7a-41f2-875d-960bd5da2d50)

#### Verify that source-maps are applied in production by sandboxing `widgets.wp.com`:

1. Sandbox `widgets.wp.com`;
2. Run `yarn build`
3. `cd dist` and then run `rsync -azP  --exclude .git --exclude --delete user@sandbox:~/public_html/widgets.wp.com/notifications`
4. Open the notifications panel by clicking the bell icon on the upper-right corner of the screen
5. Verify source-maps have been applied:

![Screenshot from 2023-06-12 18-27-10](https://github.com/Automattic/wp-calypso/assets/81248/31897671-52e4-47e8-a4e7-02b6014043d0)

This tests that source-maps have been applied to the standalone app.


#### Verify source-maps are applied in production in the `wp-calypso` web app:

Source-maps are already being generated for the Calypso web app. The notification is rendered within the Calypso client, which already has source-map generation setup (see https://github.com/Automattic/wp-calypso/pull/62965). It uses `hidden-source-maps`, so they are not loaded by the devtools and we can't easily verify, but we'll trust it's already working :) '

### Development mode

1. Run `yarn dev`
7. Open `dist/build.min.js`, scroll to the bottom and notice the inline source-map:
![Screenshot from 2023-06-12 17-56-27](https://github.com/Automattic/wp-calypso/assets/81248/4e5f246d-45b2-4c4c-a276-e92a6298ed13)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
