### PR TITLE
Stats: Clean up after subscriber section release

### DIFF
--- a/apps/odyssey-stats/src/routes.ts
+++ b/apps/odyssey-stats/src/routes.ts
@@ -55,10 +55,8 @@ export default function ( pageBase = '/' ) {
 	// Stat Insights Page
 	statsPage( '/stats/insights/:site', insights );
 
-	if ( config.isEnabled( 'stats/subscribers-section' ) ) {
-		// Stat Subscribers Page (do not confuse with people/subscribers/)
-		statsPage( '/stats/subscribers/:site', subscribers );
-	}
+	// Stat Subscribers Page (do not confuse with people/subscribers/)
+	statsPage( '/stats/subscribers/:site', subscribers );
 
 	// Stat Site Pages
 	statsPage( `/stats/:period(${ validPeriods })/:site`, site );

--- a/client/blocks/stats-navigation/constants.ts
+++ b/client/blocks/stats-navigation/constants.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { commentAuthorAvatar, video } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 
@@ -80,14 +79,11 @@ const assembleNavItems = () => {
 	const navItems = {
 		traffic,
 		insights,
+		subscribers,
 		store,
 		wordads,
 		googleMyBusiness,
 	} as NavItems;
-
-	if ( config.isEnabled( 'stats/subscribers-section' ) ) {
-		navItems.subscribers = subscribers;
-	}
 
 	return navItems;
 };

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -4,7 +4,6 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import SubscribersCount from 'calypso/blocks/subscribers-count';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -172,8 +171,6 @@ class StatsNavigation extends Component {
 					{ isLegacy && showIntervals && (
 						<Intervals selected={ interval } pathTemplate={ pathTemplate } />
 					) }
-
-					{ ! config.isEnabled( 'stats/subscribers-section' ) && <SubscribersCount /> }
 
 					{ isModuleSettingsEnabled && AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] && (
 						<PageModuleToggler

--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -30,7 +30,6 @@ $grid-vertical-gutters: 32px;
 }
 
 .stats__module-list.stats__module--unified.subscribers-page {
-
 	@include stats-desktop-grid(
 		"followers followers followers followers followers followers publicize publicize publicize publicize publicize publicize"
 		"emails emails emails emails emails emails emails emails emails emails emails emails",
@@ -74,54 +73,33 @@ $grid-vertical-gutters: 32px;
 	&.is-jetpack {
 		@include stats-desktop-grid(
 			"tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories comments comments comments comments comments comments"
-			"followers followers followers followers followers followers publicize publicize publicize publicize publicize publicize"
 			"latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary social-followers social-followers social-followers social-followers social-followers social-followers",
-			3
+			2
 		);
 
 		@include stats-tablet-grid(
-			"tags-categories tags-categories tags-categories tags-categories comments comments comments comments"
-			"followers followers followers followers followers followers followers followers"
-			"publicize publicize publicize publicize latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
-			"social-followers social-followers social-followers social-followers social-followers social-followers social-followers social-followers",
+			"tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories"
+			"comments comments comments comments comments comments comments comments"
+			"latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
+			"social-followers social-followers social-followers social-followers social-followers social-followers social-followers social-followers social-followers",
 			4
-		);
-
-		@include stats-mobile-grid(
-			"tags-categories tags-categories tags-categories tags-categories"
-			"comments comments comments comments"
-			"followers followers followers followers"
-			"publicize publicize publicize publicize"
-			"latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
-			"social-followers social-followers social-followers social-followers",
-			6
 		);
 	}
 
 	@include stats-desktop-grid(
-		"tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories comments comments comments comments comments comments"
-		"shares shares shares shares followers followers followers followers publicize publicize publicize publicize"
+		"tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories"
+		"comments comments comments comments comments comments shares shares shares shares shares shares"
 		"latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary social-followers social-followers social-followers social-followers social-followers social-followers",
 		3
 	);
 
 	@include stats-tablet-grid(
-		"tags-categories tags-categories tags-categories tags-categories comments comments comments comments"
-		"shares shares shares shares followers followers followers followers"
-		"publicize publicize publicize publicize latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
+		"tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories"
+		"comments comments comments comments comments comments comments comments"
+		"shares shares shares shares shares shares shares shares"
+		"latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
 		"social-followers social-followers social-followers social-followers social-followers social-followers social-followers social-followers",
-		4
-	);
-
-	@include stats-mobile-grid(
-		"tags-categories tags-categories tags-categories tags-categories"
-		"comments comments comments comments"
-		"shares shares shares shares"
-		"followers followers followers followers"
-		"publicize publicize publicize publicize"
-		"latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
-		"social-followers social-followers social-followers social-followers",
-		7
+		5
 	);
 
 	.stats__module-wrapper--tags-categories,
@@ -139,11 +117,6 @@ $grid-vertical-gutters: 32px;
 		grid-area: shares;
 	}
 
-	.stats__module-wrapper--followers,
-	.list-followers {
-		grid-area: followers;
-	}
-
 	.stats__module-wrapper--total-followers,
 	.list-total-followers {
 		grid-area: social-followers;
@@ -152,11 +125,6 @@ $grid-vertical-gutters: 32px;
 	.stats__module-wrapper--latest-post-summary,
 	.list-latest-post-summary {
 		grid-area: latest-post-summary;
-	}
-
-	.stats__module-wrapper--publicize,
-	.list-publicize {
-		grid-area: publicize;
 	}
 }
 

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
@@ -55,11 +54,9 @@ export default function () {
 	// Stat Insights Page
 	statsPage( '/stats/insights/:site', insights );
 
-	if ( config.isEnabled( 'stats/subscribers-section' ) ) {
-		// Stat Subscribers Page (do not confuse with people/subscribers/)
-		statsPage( '/stats/subscribers/:site', subscribers );
-		statsPage( `/stats/subscribers/:period(${ validPeriods })/:site`, subscribers );
-	}
+	// Stat Subscribers Page (do not confuse with people/subscribers/)
+	statsPage( '/stats/subscribers/:site', subscribers );
+	statsPage( `/stats/subscribers/:period(${ validPeriods })/:site`, subscribers );
 
 	// Stat Site Pages
 	statsPage( `/stats/:period(${ validPeriods })/:site`, site );

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -17,11 +17,9 @@ import AllTimeViewsSection from '../all-time-views-section';
 import AnnualHighlightsSection from '../annual-highlights-section';
 import PostingActivity from '../post-trends';
 import Comments from '../stats-comments';
-import Followers from '../stats-followers';
 import StatsModule from '../stats-module';
 import StatsPageHeader from '../stats-page-header';
 import PageViewTracker from '../stats-page-view-tracker';
-import Reach from '../stats-reach';
 import StatShares from '../stats-shares';
 import statsStrings from '../stats-strings';
 
@@ -78,9 +76,6 @@ const StatsInsights = ( props ) => {
 
 					{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for all Jetpack Sites for now. */ }
 					{ ! isJetpack && <StatShares siteId={ siteId } /> }
-
-					<Followers path="followers" />
-					<Reach />
 				</div>
 				<JetpackColophon />
 			</div>

--- a/config/client.json
+++ b/config/client.json
@@ -29,7 +29,6 @@
 	"stats/module-settings",
 	"stats/new-video-summary",
 	"stats/subscribers-chart-section",
-	"stats/subscribers-section",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",
 	"wpcom_signup_key",

--- a/config/development.json
+++ b/config/development.json
@@ -187,7 +187,6 @@
 		"stats/module-settings": true,
 		"stats/new-video-summary": true,
 		"stats/subscribers-chart-section": false,
-		"stats/subscribers-section": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -124,7 +124,6 @@
 		"stats/module-settings": false,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/subscribers-section": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": false,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -150,7 +150,6 @@
 		"stats/module-settings": false,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/subscribers-section": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": false,
 		"subscriber-csv-upload": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -142,7 +142,6 @@
 		"stats/module-settings": false,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/subscribers-section": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": false,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -102,7 +102,6 @@
 		"stats/module-settings": false,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/subscribers-section": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": false,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -156,7 +156,6 @@
 		"stats/module-settings": false,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/subscribers-section": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": false,
 		"subscriber-csv-upload": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77928

## Proposed Changes

Before|After
-|-
<img width="1306" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/d2f394ad-98b6-4f55-aa9a-a997b2075226">|<img width="1282" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/022af9a7-f7ae-4b01-91be-aa9b4efd5cb0">

* Removes defunct feature flag (`stats/subscribers-section`).
* Removes duplicate modules ("Subscribers" and "Number of Subscribers") on the insights page.
* Updates the grid layout on the insights page to reflect the smaller number of modules.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the live branch for this PR.
* Navigate to the insights page and ensure that the redundant modules have been removed.
* Ensure that the grid layout works as expected in different viewport sizes.
* Verify that the removed modules are still available on the subscriber stats page on `/stats/subscribers/example.com`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
