### PR TITLE
Hosting onboarding: Fix issue plan not displaying on sidebar.

### DIFF
--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -1,6 +1,6 @@
 import { TRANSFERRING_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
-import { useDispatch as dispatcher } from 'react-redux';
+import { useDispatch as useReduxDispatch } from 'react-redux';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
@@ -30,7 +30,7 @@ const transferringHostedSite: Flow = {
 		const flowName = this.name;
 		const siteId = useSiteIdParam();
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
-		const dispatch = dispatcher();
+		const dispatch = useReduxDispatch();
 
 		const flowProgress = useSiteSetupFlowProgress( currentStep, '' );
 		setStepProgress( flowProgress );

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -1,5 +1,7 @@
 import { TRANSFERRING_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
+import { useDispatch as dispatcher } from 'react-redux';
+import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
 import { ONBOARD_STORE } from '../stores';
@@ -28,6 +30,7 @@ const transferringHostedSite: Flow = {
 		const flowName = this.name;
 		const siteId = useSiteIdParam();
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const dispatch = dispatcher();
 
 		const flowProgress = useSiteSetupFlowProgress( currentStep, '' );
 		setStepProgress( flowProgress );
@@ -46,6 +49,8 @@ const transferringHostedSite: Flow = {
 					if ( processingResult === ProcessingResult.FAILURE ) {
 						return navigate( 'error' );
 					}
+
+					dispatch( requestAdminMenu( siteId ) );
 
 					return exitFlow( '/home/' + siteId );
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Whenever we make an atomic transfer from the `new-hosted-site` flow for new users the home page uses the 
default menu items without fetching the menu for the newly atomic site. This causes the plan text to not be displayed.

This PR fixes that issue.

Closing https://github.com/Automattic/dotcom-forge/issues/2685

## Proposed Changes

* Fetch fresh admin menu when site is successfully transferred to Atomic.

## Testing Instructions

- go to `/start/hosting` and start with a new user
- Create a new site with a business plan
- Verify the plan is now shown besides the `Upgrade` menu Item on the sidebar when redirected home.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

![image](https://github.com/Automattic/wp-calypso/assets/47489215/d701806b-4132-4cfc-a8a8-a5858a592c9f)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
