### PR TITLE
Signup: Add Domain Origin Prop to Tracks Event

### DIFF
--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -65,6 +65,8 @@ export function recordSignupComplete(
 		);
 	}
 
+	const signUpDomainOrigin = window.localStorage.getItem( 'SIGNUP_DOMAIN_ORIGIN' );
+
 	// Tracks
 	// Note that Tracks expects blog_id to differntiate sites, hence using
 	// blog_id instead of site_id here. We keep using "siteId" otherwise since
@@ -83,7 +85,10 @@ export function recordSignupComplete(
 		starting_point: startingPoint,
 		is_transfer: isTransfer,
 		is_mapping: isMapping,
+		signup_domain_origin: signUpDomainOrigin,
 	} );
+
+	window.localStorage.removeItem( 'SIGNUP_DOMAIN_ORIGIN' );
 
 	// Google Analytics
 	const flags = [

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -9,6 +9,7 @@ import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { identifyUser } from 'calypso/lib/analytics/identify-user';
 import { addToQueue } from 'calypso/lib/analytics/queue';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { SIGNUP_DOMAIN_ORIGIN_KEY } from './utils/signup_domain_origin';
 
 const signupDebug = debug( 'calypso:analytics:signup' );
 
@@ -65,7 +66,7 @@ export function recordSignupComplete(
 		);
 	}
 
-	const signUpDomainOrigin = window.localStorage.getItem( 'SIGNUP_DOMAIN_ORIGIN' );
+	const signUpDomainOrigin = window.localStorage.getItem( SIGNUP_DOMAIN_ORIGIN_KEY );
 
 	// Tracks
 	// Note that Tracks expects blog_id to differntiate sites, hence using
@@ -88,7 +89,7 @@ export function recordSignupComplete(
 		signup_domain_origin: signUpDomainOrigin,
 	} );
 
-	window.localStorage.removeItem( 'SIGNUP_DOMAIN_ORIGIN' );
+	window.localStorage.removeItem( SIGNUP_DOMAIN_ORIGIN_KEY );
 
 	// Google Analytics
 	const flags = [

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -9,7 +9,10 @@ import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { identifyUser } from 'calypso/lib/analytics/identify-user';
 import { addToQueue } from 'calypso/lib/analytics/queue';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { SIGNUP_DOMAIN_ORIGIN_KEY } from './utils/signup_domain_origin';
+import {
+	getDomainOrigin,
+	removeDomainOrigin,
+} from 'calypso/lib/analytics/utils/signup_domain_origin';
 
 const signupDebug = debug( 'calypso:analytics:signup' );
 
@@ -66,7 +69,7 @@ export function recordSignupComplete(
 		);
 	}
 
-	const signUpDomainOrigin = window.localStorage.getItem( SIGNUP_DOMAIN_ORIGIN_KEY );
+	const signUpDomainOrigin = getDomainOrigin();
 
 	// Tracks
 	// Note that Tracks expects blog_id to differntiate sites, hence using
@@ -89,7 +92,7 @@ export function recordSignupComplete(
 		signup_domain_origin: signUpDomainOrigin,
 	} );
 
-	window.localStorage.removeItem( SIGNUP_DOMAIN_ORIGIN_KEY );
+	removeDomainOrigin();
 
 	// Google Analytics
 	const flags = [

--- a/client/lib/analytics/utils/signup_domain_origin.js
+++ b/client/lib/analytics/utils/signup_domain_origin.js
@@ -1,0 +1,8 @@
+const SIGNUP_DOMAIN_ORIGIN = {
+	use_your_domain: 'use your domain',
+	choose_later: 'choose later',
+	free: 'free',
+	custom: 'custom',
+};
+
+export default SIGNUP_DOMAIN_ORIGIN;

--- a/client/lib/analytics/utils/signup_domain_origin.js
+++ b/client/lib/analytics/utils/signup_domain_origin.js
@@ -1,8 +1,8 @@
-const SIGNUP_DOMAIN_ORIGIN = {
+export const SIGNUP_DOMAIN_ORIGIN = {
 	use_your_domain: 'use your domain',
 	choose_later: 'choose later',
 	free: 'free',
 	custom: 'custom',
 };
 
-export default SIGNUP_DOMAIN_ORIGIN;
+export const SIGNUP_DOMAIN_ORIGIN_KEY = 'SIGNUP_DOMAIN_ORIGIN';

--- a/client/lib/analytics/utils/signup_domain_origin.js
+++ b/client/lib/analytics/utils/signup_domain_origin.js
@@ -3,6 +3,19 @@ export const SIGNUP_DOMAIN_ORIGIN = {
 	choose_later: 'choose later',
 	free: 'free',
 	custom: 'custom',
+	not_set: 'not set',
 };
 
-export const SIGNUP_DOMAIN_ORIGIN_KEY = 'SIGNUP_DOMAIN_ORIGIN';
+const SIGNUP_DOMAIN_ORIGIN_KEY = 'SIGNUP_DOMAIN_ORIGIN';
+
+export function getDomainOrigin() {
+	return window.localStorage.getItem( SIGNUP_DOMAIN_ORIGIN_KEY ) || SIGNUP_DOMAIN_ORIGIN.not_set;
+}
+
+export function setDomainOrigin( origin ) {
+	window.localStorage.setItem( SIGNUP_DOMAIN_ORIGIN_KEY, origin );
+}
+
+export function removeDomainOrigin() {
+	window.localStorage.removeItem( SIGNUP_DOMAIN_ORIGIN_KEY );
+}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -14,7 +14,10 @@ import { recordUseYourDomainButtonClick } from 'calypso/components/domains/regis
 import ReskinSideExplainer from 'calypso/components/domains/reskin-side-explainer';
 import UseMyDomain from 'calypso/components/domains/use-my-domain';
 import Notice from 'calypso/components/notice';
-import SIGNUP_DOMAIN_ORIGIN from 'calypso/lib/analytics/utils/signup_domain_origin';
+import {
+	SIGNUP_DOMAIN_ORIGIN,
+	SIGNUP_DOMAIN_ORIGIN_KEY,
+} from 'calypso/lib/analytics/utils/signup_domain_origin';
 import {
 	domainRegistration,
 	domainMapping,
@@ -159,7 +162,7 @@ class DomainsStep extends Component {
 		const domainOrigin = suggestion?.is_free
 			? SIGNUP_DOMAIN_ORIGIN.free
 			: SIGNUP_DOMAIN_ORIGIN.custom;
-		window.localStorage.setItem( 'SIGNUP_DOMAIN_ORIGIN', domainOrigin );
+		window.localStorage.setItem( SIGNUP_DOMAIN_ORIGIN_KEY, domainOrigin );
 
 		const stepData = {
 			stepName: this.props.stepName,
@@ -248,14 +251,14 @@ class DomainsStep extends Component {
 	};
 
 	handleDomainExplainerClick = () => {
-		window.localStorage.setItem( 'SIGNUP_DOMAIN_ORIGIN', SIGNUP_DOMAIN_ORIGIN.choose_later );
+		window.localStorage.setItem( SIGNUP_DOMAIN_ORIGIN_KEY, SIGNUP_DOMAIN_ORIGIN.choose_later );
 		const hideFreePlan = true;
 		this.handleSkip( undefined, hideFreePlan );
 	};
 
 	handleUseYourDomainClick = () => {
 		this.props.recordUseYourDomainButtonClick( this.getAnalyticsSection() );
-		window.localStorage.setItem( 'SIGNUP_DOMAIN_ORIGIN', SIGNUP_DOMAIN_ORIGIN.use_your_domain );
+		window.localStorage.setItem( SIGNUP_DOMAIN_ORIGIN_KEY, SIGNUP_DOMAIN_ORIGIN.use_your_domain );
 		page( this.getUseYourDomainUrl() );
 	};
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -14,6 +14,7 @@ import { recordUseYourDomainButtonClick } from 'calypso/components/domains/regis
 import ReskinSideExplainer from 'calypso/components/domains/reskin-side-explainer';
 import UseMyDomain from 'calypso/components/domains/use-my-domain';
 import Notice from 'calypso/components/notice';
+import SIGNUP_DOMAIN_ORIGIN from 'calypso/lib/analytics/utils/signup_domain_origin';
 import {
 	domainRegistration,
 	domainMapping,
@@ -155,6 +156,11 @@ class DomainsStep extends Component {
 	};
 
 	handleAddDomain = ( suggestion, position ) => {
+		const domainOrigin = suggestion?.is_free
+			? SIGNUP_DOMAIN_ORIGIN.free
+			: SIGNUP_DOMAIN_ORIGIN.custom;
+		window.localStorage.setItem( 'SIGNUP_DOMAIN_ORIGIN', domainOrigin );
+
 		const stepData = {
 			stepName: this.props.stepName,
 			suggestion,
@@ -242,12 +248,14 @@ class DomainsStep extends Component {
 	};
 
 	handleDomainExplainerClick = () => {
+		window.localStorage.setItem( 'SIGNUP_DOMAIN_ORIGIN', SIGNUP_DOMAIN_ORIGIN.choose_later );
 		const hideFreePlan = true;
 		this.handleSkip( undefined, hideFreePlan );
 	};
 
 	handleUseYourDomainClick = () => {
 		this.props.recordUseYourDomainButtonClick( this.getAnalyticsSection() );
+		window.localStorage.setItem( 'SIGNUP_DOMAIN_ORIGIN', SIGNUP_DOMAIN_ORIGIN.use_your_domain );
 		page( this.getUseYourDomainUrl() );
 	};
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -16,7 +16,7 @@ import UseMyDomain from 'calypso/components/domains/use-my-domain';
 import Notice from 'calypso/components/notice';
 import {
 	SIGNUP_DOMAIN_ORIGIN,
-	SIGNUP_DOMAIN_ORIGIN_KEY,
+	setDomainOrigin,
 } from 'calypso/lib/analytics/utils/signup_domain_origin';
 import {
 	domainRegistration,
@@ -162,7 +162,7 @@ class DomainsStep extends Component {
 		const domainOrigin = suggestion?.is_free
 			? SIGNUP_DOMAIN_ORIGIN.free
 			: SIGNUP_DOMAIN_ORIGIN.custom;
-		window.localStorage.setItem( SIGNUP_DOMAIN_ORIGIN_KEY, domainOrigin );
+		setDomainOrigin( domainOrigin );
 
 		const stepData = {
 			stepName: this.props.stepName,
@@ -251,14 +251,14 @@ class DomainsStep extends Component {
 	};
 
 	handleDomainExplainerClick = () => {
-		window.localStorage.setItem( SIGNUP_DOMAIN_ORIGIN_KEY, SIGNUP_DOMAIN_ORIGIN.choose_later );
+		setDomainOrigin( SIGNUP_DOMAIN_ORIGIN.choose_later );
 		const hideFreePlan = true;
 		this.handleSkip( undefined, hideFreePlan );
 	};
 
 	handleUseYourDomainClick = () => {
 		this.props.recordUseYourDomainButtonClick( this.getAnalyticsSection() );
-		window.localStorage.setItem( SIGNUP_DOMAIN_ORIGIN_KEY, SIGNUP_DOMAIN_ORIGIN.use_your_domain );
+		setDomainOrigin( SIGNUP_DOMAIN_ORIGIN.use_your_domain );
 		page( this.getUseYourDomainUrl() );
 	};
 


### PR DESCRIPTION
Fixes 71-gh-Automattic/growth-foundations

### Proposed Changes
Add `signup_domain_origin` prop to `calypso_signup_complete` tracks event to differentiate between all the places in the UI from which a user can select a domain.

### Testing
1. Checkout this branch
2. Run `yarn` and `yarn start`
3. Go to `http://calypso.localhost:3000/start`
4. Open [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) so you can monitor tracks events
5. Click on **Choose my domain later** in the sidebar. Continue through the flow until you see the `calypso_signup_complete` event fire in tracks vigilante. Confirm the even has the following property:
`signup_domain_origin: 'choose later'`
6. Click on **Use a domain I own** in the sidebar. Continue through the flow until you see the `calypso_signup_complete` event fire in tracks vigilante. Confirm the even has the following property:
`signup_domain_origin: 'use your domain'`
7. Select the free .wordpress.com domain. Continue through the flow until you see the `calypso_signup_complete` event fire in tracks vigilante. Confirm the even has the following property:
`signup_domain_origin: 'free'`
8. Select the one of the custom suggested domains. Continue through the flow until you see the `calypso_signup_complete` event fire in tracks vigilante. Confirm the even has the following property:
`signup_domain_origin: 'custom'`
9. If for some reason the domain origin can't be retrieved from `localStorage`, the value of the `signup_domain_origin` should be `not set`

