### PR TITLE
Migrate to null coalescing for safer Sentry detail check

### DIFF
--- a/client/lib/sentry/index.ts
+++ b/client/lib/sentry/index.ts
@@ -160,7 +160,7 @@ export async function initSentry( { beforeSend, userId }: SentryOptions ) {
 				// Sentry does this, presumably for browsers being browsers 🤷
 				// https://github.com/getsentry/sentry-javascript/blob/4793df5f515575703d9c83ebf4159ac145478410/packages/browser/src/loader.js#L205
 				// @ts-expect-error Fixing up browser weirdness
-				exceptionEvent.reason ?? exceptionEvent?.detail?.reason ?? exceptionEvent
+				exceptionEvent?.reason ?? exceptionEvent?.detail?.reason ?? exceptionEvent
 			);
 
 		window.addEventListener( 'error', errorHandler );

--- a/client/lib/sentry/index.ts
+++ b/client/lib/sentry/index.ts
@@ -159,15 +159,10 @@ export async function initSentry( { beforeSend, userId }: SentryOptions ) {
 			void rejectionQueue.push(
 				// Sentry does this, presumably for browsers being browsers 🤷
 				// https://github.com/getsentry/sentry-javascript/blob/4793df5f515575703d9c83ebf4159ac145478410/packages/browser/src/loader.js#L205
-				// eslint-disable-next-line no-nested-ternary
-				'reason' in exceptionEvent
-					? exceptionEvent.reason
-					: // @ts-expect-error Fixing up browser weirdness
-					'detail' in exceptionEvent && 'reason' in exceptionEvent.detail
-					? // @ts-expect-error Fixing up browser weirdness
-					  exceptionEvent.detail.reason
-					: exceptionEvent
+				// @ts-expect-error Fixing up browser weirdness
+				exceptionEvent.reason ?? exceptionEvent?.detail?.reason ?? exceptionEvent
 			);
+
 		window.addEventListener( 'error', errorHandler );
 		window.addEventListener( 'unhandledrejection', rejectionHandler );
 


### PR DESCRIPTION
Resolves this sentry alert: https://a8c.sentry.io/issues/4241112100/?project=6313676

It shouldn't be that much different, but I guess null coalescing is slightly safer here? The error is `exceptionEvent.detail is not an Object. (evaluating '"reason" in exceptionEvent.detail').

There shouldn't be anything to check really, other than that the code is doing the same thing.
