### PR TITLE
Jetpack Pro Dashboard: Implement API changes to fetch and save phone numbers in downtime monitoring

### DIFF
--- a/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
@@ -21,9 +21,9 @@ const useFetchMonitorVerfiedContacts = ( isPartnerOAuthTokenLoaded: boolean ) =>
 					emails: contacts?.emails
 						.filter( ( email ) => email.verified )
 						.map( ( email ) => email.email_address ),
-					phoneNumbers: contacts?.phone_numbers
-						?.filter( ( phone ) => phone.verified )
-						.map( ( phone ) => phone.phone_number ),
+					phoneNumbers: contacts.sms_numbers
+						.filter( ( sms ) => sms.verified )
+						.map( ( sms ) => `${ sms.country_numeric_code }${ sms.sms_number }` ), // Add country code to phone number
 				};
 			},
 			enabled: isPartnerOAuthTokenLoaded && isMultipleEmailEnabled,

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -24,6 +24,7 @@ interface Props {
 interface FormPhoneInputChangeResult {
 	name: string;
 	countryCode: string;
+	countryNumericCode: string;
 	phoneNumber: string;
 	phoneNumberFull: string;
 	verificationCode?: string;
@@ -54,6 +55,7 @@ export default function PhoneNumberEditor( {
 	const [ phoneItem, setPhoneItem ] = useState< FormPhoneInputChangeResult >( {
 		name: '',
 		countryCode: '',
+		countryNumericCode: '',
 		phoneNumber: '',
 		phoneNumberFull: '',
 	} );
@@ -83,6 +85,7 @@ export default function PhoneNumberEditor( {
 			value: Number( phoneItem.phoneNumber ),
 			site_ids: sites?.map( ( site ) => site.blog_id ) ?? [],
 			country_code: phoneItem.countryCode,
+			country_numeric_code: phoneItem.countryNumericCode,
 		} );
 	};
 
@@ -180,6 +183,7 @@ export default function PhoneNumberEditor( {
 		phoneNumber: string;
 		countryData: {
 			code: string;
+			numeric_code: string;
 		};
 		isValid: boolean;
 		validation: {
@@ -195,6 +199,7 @@ export default function PhoneNumberEditor( {
 			phoneNumberFull,
 			phoneNumber,
 			countryCode: countryData.code,
+			countryNumericCode: countryData.numeric_code,
 		} ) );
 		if ( isValid ) {
 			setValidationError( {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -299,6 +299,7 @@ export interface RequestVerificationCodeParams {
 	value: string | number;
 	site_ids: Array< number >;
 	country_code?: string;
+	country_numeric_code?: string;
 }
 
 export interface ValidateVerificationCodeParams {
@@ -309,7 +310,7 @@ export interface ValidateVerificationCodeParams {
 
 export interface MonitorContactsResponse {
 	emails: [ { verified: boolean; email_address: string } ];
-	phone_numbers: [ { verified: boolean; phone_number: string } ];
+	sms_numbers: [ { verified: boolean; sms_number: string; country_numeric_code: string } ];
 }
 
 export type MonitorDuration = { label: string; time: number };


### PR DESCRIPTION
Related to 1204774821045518-as-1204812856978752

## Proposed Changes

This PR implements 

- Params to request code API endpoint now includes country numeric code.
- Minor refactor to fetch the phone number contacts

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Get the latest trunk in WP.com and sandbox the public API.
2. Run `git checkout add/api-changes-to-monitor-sms-contacts` and `yarn start-jetpack-cloud`
3. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
4. Enable monitor if not enabled already.
5. Click on the clock icon next to the monitor toggle.
6. Click the `+ Add phone number` button -> Enter the name, select the country code and phone number -> Click `Verify` and ensure the API call is being made to the `/jetpack-agency/contacts` API endpoint and the `Verify` button is disabled.
7. Now click "Later," and open the network tab and verify the GET /contacts API now includes the country code and country numeric code for the newly added phone number contact.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?