### PR TITLE
Theme Showcase: Delist taxonomy terms in the client-side

### DIFF
--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -7,6 +7,7 @@ import KeyedSuggestions from 'calypso/components/keyed-suggestions';
 import Search, { SEARCH_MODE_ON_ENTER } from 'calypso/components/search';
 import { useSelector } from 'calypso/state';
 import { getThemeFilters } from 'calypso/state/themes/selectors';
+import { filterDelistedTaxonomyTermSlugs } from 'calypso/state/themes/utils';
 import { allowSomeThemeFilters, computeEditedSearchElement, insertSuggestion } from './utils';
 import type { ThemeFilters } from './types';
 import './style.scss';
@@ -23,8 +24,11 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 	const suggestionsRef = useRef< KeyedSuggestions | null >( null );
 	const translate = useTranslate();
 	const filters = useSelector( ( state ) =>
-		allowSomeThemeFilters( getThemeFilters( state ) as ThemeFilters )
+		filterDelistedTaxonomyTermSlugs(
+			allowSomeThemeFilters( getThemeFilters( state ) as ThemeFilters )
+		)
 	);
+
 	const [ searchInput, setSearchInput ] = useState( query );
 	const [ cursorPosition, setCursorPosition ] = useState( 0 );
 	const [ editedSearchElement, setEditedSearchElement ] = useState( '' );

--- a/client/my-sites/theme/theme-features-card.js
+++ b/client/my-sites/theme/theme-features-card.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
 import SectionHeader from 'calypso/components/section-header';
 import { isAmbiguousThemeFilterTerm } from 'calypso/state/themes/selectors';
+import { isDelistedTaxonomyTermSlug } from 'calypso/state/themes/utils';
 
 const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onClick } ) => {
 	if ( isEmpty( features ) ) {
@@ -37,10 +38,15 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onCli
 };
 
 export default connect( ( state, { taxonomies } ) => {
-	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-	const features = get( taxonomies, 'theme_feature', [] ).map( ( { name, slug } ) => {
-		const term = isAmbiguousThemeFilterTerm( state, slug ) ? `feature:${ slug }` : slug;
-		return { name, slug, term };
-	} );
+	const features = get( taxonomies, 'theme_feature', [] )
+		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+		.filter( ( { slug } ) => ! isDelistedTaxonomyTermSlug( slug ) )
+		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+		.map( ( { name, slug } ) => ( {
+			name,
+			slug,
+			term: isAmbiguousThemeFilterTerm( state, slug ) ? `feature:${ slug }` : slug,
+		} ) );
+
 	return { features };
 } )( localize( ThemeFeaturesCard ) );

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -270,7 +270,7 @@ export function filterDelistedTaxonomyTermSlugs( filters ) {
 	const result = {};
 	for ( const taxonomy in filters ) {
 		result[ taxonomy ] = Object.fromEntries(
-			Object.entries( filters[ taxonomy ] ).filter(
+			Object.entries( filters[ taxonomy ] || {} ).filter(
 				( [ slug ] ) => ! isDelistedTaxonomyTermSlug( slug )
 			)
 		);

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -10,6 +10,13 @@ const REGEXP_SERIALIZED_QUERY = /^(?:(\d+):)?(.*)$/;
 // we normalize to taxonomies.theme_feature to be consistent with results from WPCOM.)
 const SEARCH_TAXONOMIES = [ 'feature' ];
 
+// Used for client-side delisting of taxonomy terms. Note that these taxonomy terms often
+// have functional purposes, which is why they cannot be removed in the endpoint payload.
+//
+// As a rule of thumb, only add terms here if you want to hide them visually in the UI.
+// Otherwise, they should be delisted in the backend.
+const DELISTED_TAXONOMY_TERM_SLUGS = [ 'auto-loading-homepage' ];
+
 /**
  * Utility
  */
@@ -241,4 +248,33 @@ export function isThemeMatchingQuery( query, theme ) {
 export function getThemeTaxonomySlugs( theme, taxonomy ) {
 	const items = get( theme, [ 'taxonomies', taxonomy ], [] );
 	return items.map( ( { slug } ) => slug );
+}
+
+/**
+ * Returns true if a taxonomy term slug is delisted.
+ *
+ * @param  {string}  slug   The term slug to check for delisting
+ * @returns {boolean}       True if term slug is delisted
+ */
+export function isDelistedTaxonomyTermSlug( slug ) {
+	return DELISTED_TAXONOMY_TERM_SLUGS.includes( slug );
+}
+
+/**
+ * Returns the list of available theme filters, excluding the delisted taxonomy terms.
+ *
+ * @param {Object}  filters A list of filters.
+ * @returns {Object}        A nested list of theme filters, keyed by term slug
+ */
+export function filterDelistedTaxonomyTermSlugs( filters ) {
+	const result = {};
+	for ( const taxonomy in filters ) {
+		result[ taxonomy ] = Object.fromEntries(
+			Object.entries( filters[ taxonomy ] ).filter(
+				( [ slug ] ) => ! isDelistedTaxonomyTermSlug( slug )
+			)
+		);
+	}
+
+	return result;
 }


### PR DESCRIPTION
## Proposed Changes

This PR delists taxonomy terms on the client-side. Since they have functional purposes, we just want to hide them visually in the Theme Detail page, and the Theme Showcase's search suggestion dropdown.

Theme Detail page
| Before | After |
| --- | --- |
| ![Screenshot 2023-06-13 at 2 39 47 PM](https://github.com/Automattic/wp-calypso/assets/797888/c0970f9a-e4df-4149-8c4d-944dda2a3322) | ![Screenshot 2023-06-13 at 2 39 51 PM](https://github.com/Automattic/wp-calypso/assets/797888/b683ca64-c853-4ca6-ab5e-7e6951c51027) |

Theme Showcase
| Before | After |
| --- | --- |
|![Screenshot 2023-06-13 at 2 40 50 PM](https://github.com/Automattic/wp-calypso/assets/797888/7737e09d-070d-4240-84be-c7e80f0bcee7) | ![Screenshot 2023-06-13 at 2 40 43 PM](https://github.com/Automattic/wp-calypso/assets/797888/4ffdb02e-5ca4-46d2-ab7f-46331fb6af74)|
|![Screenshot 2023-06-13 at 2 40 56 PM](https://github.com/Automattic/wp-calypso/assets/797888/30426be6-57bd-463a-835f-eb1bb9a5c2e8)|   ![Screenshot 2023-06-13 at 2 41 03 PM](https://github.com/Automattic/wp-calypso/assets/797888/a34a8f20-0e46-4ba7-9647-65811e557bec)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase, and ensure that the search dropdown is updated as described above.
* Head to the Theme Detail page of Hey, or Vetro, and ensure that the feature tags are updated as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
