### PR TITLE
Pro Dashboard: Implement verify later flow on SMS Notification settings.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/index.tsx
@@ -6,10 +6,15 @@ import type { StateMonitorSettingsSMS } from '../../sites-overview/types';
 interface Props {
 	toggleModal: () => void;
 	allPhoneItems: Array< StateMonitorSettingsSMS >;
+	recordEvent: ( action: string, params?: object ) => void;
 	verifiedPhoneNumber?: string;
 }
 
-export default function ConfigureSMSNotification( { toggleModal, allPhoneItems }: Props ) {
+export default function ConfigureSMSNotification( {
+	toggleModal,
+	recordEvent,
+	allPhoneItems,
+}: Props ) {
 	const translate = useTranslate();
 
 	const handleAddPhoneClick = () => {
@@ -20,7 +25,12 @@ export default function ConfigureSMSNotification( { toggleModal, allPhoneItems }
 	return (
 		<div className="configure-contact__card-container">
 			{ allPhoneItems.map( ( item ) => (
-				<SMSItemContent key={ item.phoneNumberFull } item={ item } />
+				<SMSItemContent
+					toggleModal={ toggleModal }
+					recordEvent={ recordEvent }
+					key={ item.phoneNumberFull }
+					item={ item }
+				/>
 			) ) }
 
 			<Button

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -11,10 +11,16 @@ import { useSelector } from 'calypso/state';
 import getCountries from 'calypso/state/selectors/get-countries';
 import DashboardDataContext from '../../sites-overview/dashboard-data-context';
 import { useRequestVerificationCode } from '../hooks';
-import type { StateMonitorSettingsSMS, Site } from '../../sites-overview/types';
+import type {
+	StateMonitorSettingsSMS,
+	Site,
+	AllowedMonitorContactActions,
+} from '../../sites-overview/types';
 
 interface Props {
 	toggleModal: () => void;
+	selectedPhone?: StateMonitorSettingsSMS;
+	selectedAction?: AllowedMonitorContactActions;
 	allPhoneItems: Array< StateMonitorSettingsSMS >;
 	setAllPhoneItems: ( phoneNumbers: Array< StateMonitorSettingsSMS > ) => void;
 	setVerifiedPhoneNumber: ( item: string ) => void;
@@ -32,6 +38,8 @@ interface FormPhoneInputChangeResult {
 
 export default function PhoneNumberEditor( {
 	toggleModal,
+	selectedPhone,
+	selectedAction = 'add',
 	allPhoneItems,
 	setAllPhoneItems,
 	setVerifiedPhoneNumber,
@@ -53,14 +61,16 @@ export default function PhoneNumberEditor( {
 		{ phone?: string; verificationCode?: string } | undefined
 	>();
 	const [ phoneItem, setPhoneItem ] = useState< FormPhoneInputChangeResult >( {
-		name: '',
-		countryCode: '',
-		countryNumericCode: '',
-		phoneNumber: '',
-		phoneNumberFull: '',
+		name: selectedPhone?.name ?? '',
+		countryCode: selectedPhone?.countryCode ?? '',
+		countryNumericCode: selectedPhone?.countryNumericCode ?? '',
+		phoneNumber: selectedPhone?.phoneNumber ?? '',
+		phoneNumberFull: selectedPhone?.phoneNumberFull ?? '',
 	} );
 
 	const { verifiedContacts } = useContext( DashboardDataContext );
+
+	const isVerifyAction = selectedAction === 'verify';
 
 	const requestVerificationCode = useRequestVerificationCode();
 
@@ -71,11 +81,13 @@ export default function PhoneNumberEditor( {
 				verified: isVerified,
 			};
 			// Check if exists when editing
-			allPhoneItems.push( updatedPhoneItem );
+			if ( ! isVerifyAction ) {
+				allPhoneItems.push( updatedPhoneItem );
+			}
 			setAllPhoneItems( allPhoneItems );
 			toggleModal();
 		},
-		[ allPhoneItems, phoneItem, setAllPhoneItems, toggleModal ]
+		[ allPhoneItems, isVerifyAction, phoneItem, setAllPhoneItems, toggleModal ]
 	);
 
 	// Function to handle request verification code
@@ -88,6 +100,14 @@ export default function PhoneNumberEditor( {
 			country_numeric_code: phoneItem.countryNumericCode,
 		} );
 	};
+
+	// Trigger resend code when user chooses to verify email action
+	useEffect( () => {
+		if ( isVerifyAction ) {
+			setShowCodeVerification( true );
+			// TODO: call resend verification code API
+		}
+	}, [ isVerifyAction ] );
 
 	// Show code input when verification code request is successful
 	useEffect( () => {
@@ -169,8 +189,13 @@ export default function PhoneNumberEditor( {
 		[]
 	);
 
-	const title = translate( 'Add your phone number' );
-	const subTitle = translate( 'Please use an accessible phone number. Only alerts sent.' );
+	let title = translate( 'Add your phone number' );
+	let subTitle = translate( 'Please use an accessible phone number. Only alerts sent.' );
+
+	if ( isVerifyAction ) {
+		title = translate( 'Verify your phone number' );
+		subTitle = translate( 'We’ll send a code to verify your phone number.' );
+	}
 
 	const onChangePhoneInput = ( {
 		phoneNumberFull,
@@ -235,12 +260,14 @@ export default function PhoneNumberEditor( {
 							name="name"
 							value={ phoneItem.name }
 							onChange={ handleChange( 'name' ) }
-							aria-describedby="name-help-text"
+							aria-describedby={ ! isVerifyAction ? 'name-help-text' : undefined }
 							disabled={ showCodeVerification }
 						/>
-						<div className="configure-contact__help-text" id="name-help-text">
-							{ translate( 'Give this number a name for your personal reference.' ) }
-						</div>
+						{ ! isVerifyAction && (
+							<div className="configure-contact__help-text" id="name-help-text">
+								{ translate( 'Give this number a name for your personal reference.' ) }
+							</div>
+						) }
 					</FormFieldset>
 					<div className="configure-contact__phone-input-container">
 						{
@@ -260,9 +287,11 @@ export default function PhoneNumberEditor( {
 								{ validationError?.phone }
 							</div>
 						) }
-						<div className="configure-contact__help-text" id="phone-help-text">
-							{ translate( 'We’ll send a code to verify your phone number.' ) }
-						</div>
+						{ ! isVerifyAction && (
+							<div className="configure-contact__help-text" id="phone-help-text">
+								{ translate( 'We’ll send a code to verify your phone number.' ) }
+							</div>
+						) }
 					</div>
 					{ showCodeVerification && (
 						<FormFieldset>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/sms-item-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/sms-item-content.tsx
@@ -5,23 +5,26 @@ import { useState, useRef } from 'react';
 import Badge from 'calypso/components/badge';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import type { StateMonitorSettingsSMS } from '../../sites-overview/types';
+import type {
+	AllowedMonitorContactActions,
+	StateMonitorSettingsSMS,
+} from '../../sites-overview/types';
 
 import '../style.scss';
 
 interface Props {
 	item: StateMonitorSettingsSMS;
+	toggleModal?: ( item?: StateMonitorSettingsSMS, action?: AllowedMonitorContactActions ) => void;
+	recordEvent?: ( action: string, params?: object ) => void;
 }
 
-// events actions have not yet been implemented, silencing this warning
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const EVENT_NAMES = {
 	edit: 'downtime_monitoring_sms_number_edit_click',
 	remove: 'downtime_monitoring_sms_number_remove_click',
 	verify: 'downtime_monitoring_sms_number_verify_click',
 };
 
-export default function SMSItemContent( { item }: Props ) {
+export default function SMSItemContent( { item, toggleModal, recordEvent }: Props ) {
 	const translate = useTranslate();
 	const [ isOpen, setIsOpen ] = useState( false );
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
@@ -34,11 +37,12 @@ export default function SMSItemContent( { item }: Props ) {
 		setIsOpen( false );
 	};
 
-	// silencing error until action handling is added
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const handleToggleModal = () => {
-		// Here you can handle actions
-		return null;
+	const handleToggleModal = ( action: AllowedMonitorContactActions ) => {
+		toggleModal?.( item, action );
+		if ( recordEvent ) {
+			const eventName = EVENT_NAMES?.[ action as keyof typeof EVENT_NAMES ];
+			recordEvent( eventName );
+		}
 	};
 
 	const isVerified = item.verified;
@@ -55,14 +59,8 @@ export default function SMSItemContent( { item }: Props ) {
 					<span
 						role="button"
 						tabIndex={ 0 }
-						onKeyPress={ () => {
-							//TODO add verification handling
-							return null;
-						} }
-						onClick={ () => {
-							//TODO add verification handling
-							return null;
-						} }
+						onKeyPress={ () => handleToggleModal( 'verify' ) }
+						onClick={ () => handleToggleModal( 'verify' ) }
 						className="configure-contact-info__verification-status cursor-pointer"
 					>
 						<Badge type="warning">{ translate( 'Pending' ) }</Badge>
@@ -90,12 +88,7 @@ export default function SMSItemContent( { item }: Props ) {
 					onClose={ closeDropdown }
 					position="bottom left"
 				>
-					<PopoverMenuItem
-						onClick={ () => {
-							//TODO handle actions
-							return null;
-						} }
-					>
+					<PopoverMenuItem onClick={ () => handleToggleModal( 'verify' ) }>
 						{ translate( 'Verify' ) }
 					</PopoverMenuItem>
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -5,6 +5,7 @@ import ConfigureSMSNotification from '../../configure-sms-notification';
 import type { StateMonitorSettingsSMS } from '../../../sites-overview/types';
 
 interface Props {
+	recordEvent: ( action: string, params?: object ) => void;
 	enableSMSNotification: boolean;
 	setEnableSMSNotification: ( isEnabled: boolean ) => void;
 	toggleModal: () => void;
@@ -13,6 +14,7 @@ interface Props {
 }
 
 export default function SMSNotification( {
+	recordEvent,
 	enableSMSNotification,
 	setEnableSMSNotification,
 	toggleModal,
@@ -54,6 +56,7 @@ export default function SMSNotification( {
 					<ConfigureSMSNotification
 						toggleModal={ toggleModal }
 						allPhoneItems={ allPhoneItems }
+						recordEvent={ recordEvent }
 						verifiedPhoneNumber={ verifiedItem?.phone }
 					/>
 				</>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -78,6 +78,7 @@ export default function NotificationSettings( {
 	const [ isAddEmailModalOpen, setIsAddEmailModalOpen ] = useState< boolean >( false );
 	const [ isAddSMSModalOpen, setIsAddSMSModalOpen ] = useState< boolean >( false );
 	const [ selectedEmail, setSelectedEmail ] = useState< StateMonitorSettingsEmail | undefined >();
+	const [ selectedPhone, setSelectedPhone ] = useState< StateMonitorSettingsSMS | undefined >();
 	const [ selectedAction, setSelectedAction ] = useState< AllowedMonitorContactActions >();
 	const [ initialSettings, setInitialSettings ] = useState< InitialMonitorSettings >( {
 		enableSMSNotification: false,
@@ -151,8 +152,19 @@ export default function NotificationSettings( {
 		}
 	};
 
-	const toggleAddSMSModal = () => {
+	const toggleAddSMSModal = (
+		item?: StateMonitorSettingsSMS,
+		action?: AllowedMonitorContactActions
+	) => {
+		if ( item && action ) {
+			setSelectedPhone( item );
+			setSelectedAction( action );
+		}
 		setIsAddSMSModalOpen( ( isAddSMSModalOpen ) => ! isAddSMSModalOpen );
+		if ( isAddSMSModalOpen ) {
+			setSelectedEmail( undefined );
+			setSelectedAction( undefined );
+		}
 	};
 
 	const handleSetAllEmailItems = ( items: StateMonitorSettingsEmail[] ) => {
@@ -357,7 +369,9 @@ export default function NotificationSettings( {
 		return (
 			<PhoneNumberEditor
 				toggleModal={ toggleAddSMSModal }
+				selectedPhone={ selectedPhone }
 				allPhoneItems={ allPhoneItems }
+				selectedAction={ selectedAction }
 				setAllPhoneItems={ handleSetAllPhoneItems }
 				setVerifiedPhoneNumber={ ( item ) => handleSetVerifiedItem( 'phone', item ) }
 				sites={ sites }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -387,6 +387,7 @@ export default function NotificationSettings( {
 					/>
 					{ isSMSNotificationEnabled && (
 						<SMSNotification
+							recordEvent={ recordEvent }
 							enableSMSNotification={ enableSMSNotification }
 							setEnableSMSNotification={ setEnableSMSNotification }
 							toggleModal={ toggleAddSMSModal }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -291,6 +291,7 @@ export interface MonitorSettingsEmail {
 export interface StateMonitorSettingsSMS {
 	name: string;
 	countryCode: string;
+	countryNumericCode: string;
 	phoneNumber: string;
 	phoneNumberFull: string;
 	verified: boolean;


### PR DESCRIPTION
Related to 1204774821045518-as-1204793234816292

## Proposed Changes
This PR implements the verify later flow by adding the missing implementation on the verify button on the Phone number list action component.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**
1. Apply this D113345-code and sandbox the public API.
1. Run git checkout `add/verify-later-flow-on-sms-notification-settings` and `yarn start-jetpack-cloud`
1. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the `/dashboard`.
1. Enable monitor if not enabled already.
1. Click on the clock icon next to the monitor toggle.
1. Click on the Mobile notification toggle, and click the "+ Add phone number" button -> Input valid phone details and click **verify** button.
1. Click **Later** button, and the new phone number should show in the Phone list with **pending** status.
1. Click the **bullets** icon then **verify** button.
 
<img width="447" alt="Screen Shot 2023-06-13 at 3 04 18 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e8a5106d-f71f-4440-9e04-e4914203488a"> 
<img width="217" alt="Screen Shot 2023-06-13 at 3 06 26 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9411380a-4edc-420f-86e3-0c3eceb0db4d">


* Confirm that the Verify modal shows up with existing data showing up as disabled.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?