### PR TITLE
Help Center: Reduce further the amount of AI search requests

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -184,8 +184,8 @@ export const HelpCenterContactForm = () => {
 		supportSite = currentSite as HelpCenterSite;
 	}
 
-	const [ debouncedMessage ] = useDebounce( message || '', 1000 );
-	const [ debouncedSubject ] = useDebounce( subject || '', 1000 );
+	const [ debouncedMessage ] = useDebounce( message || '', 3000 );
+	const [ debouncedSubject ] = useDebounce( subject || '', 3000 );
 
 	const enableGPTResponse =
 		config.isEnabled( 'help/gpt-response' ) && ! ( params.get( 'disable-gpt' ) === 'true' );

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -462,11 +462,7 @@ export const HelpCenterContactForm = () => {
 		jpSearchAiQueryText = `${ debouncedSubject }\n\n${ debouncedMessage }`;
 	}
 
-	const {
-		isFetching: isFetchingGPTResponse,
-		isError: isGPTError,
-		data: gptResponse,
-	} = useJetpackSearchAIQuery( {
+	const { isFetching: isFetchingGPTResponse, isError: isGPTError } = useJetpackSearchAIQuery( {
 		siteId: '9619154',
 		query: jpSearchAiQueryText,
 		stopAt: 'response',
@@ -552,7 +548,10 @@ export const HelpCenterContactForm = () => {
 						/>
 					) }
 				</section>
-				{ gptResponse?.response && [ 'CHAT', 'EMAIL' ].includes( mode ) && getHEsTraySection() }
+				{ ! isFetchingGPTResponse &&
+					showingGPTResponse &&
+					[ 'CHAT', 'EMAIL' ].includes( mode ) &&
+					getHEsTraySection() }
 			</div>
 		);
 	}


### PR DESCRIPTION
Follow up to #77528

## Proposed Changes

* Increase the delay to 3000ms from (1000). This should help reduce the unnecessary requests that we make, as fewer non-finished messages will be sent to the server
* Clean up the use of the response in the contact form since we don't really need them there.

## Testing Instructions

* Open the help center
* Click on "Still need help"
* Choose one of the options
* In the form, start typing your message.
* Notice how many requests go out to the jetpack-search/ai endpoint
* Make sure the response is shown as expected after clicking continue.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
