### PR TITLE
Hosting onboarding: update data center picker step

### DIFF
--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -253,7 +253,7 @@ const DataCenterPicker = ( {
 			{ isFormShowing && (
 				<Form>
 					<FormHeadingContainer>
-						<FormHeading>{ translate( 'Primary data center' ) }</FormHeading>
+						<FormHeading>{ translate( 'Pick your primary data center' ) }</FormHeading>
 						<Button isTertiary={ true } onClick={ onCancel }>
 							{ translate( 'Cancel' ) }
 						</Button>

--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -167,7 +167,7 @@ const DataCenterPicker = ( {
 		return (
 			<div className="data-center-picker">
 				<FormHeadingContainer>
-					<FormHeading>{ translate( 'Primary data center' ) }</FormHeading>
+					<FormHeading>{ translate( 'Pick your primary data center' ) }</FormHeading>
 				</FormHeadingContainer>
 				<FormDescription className="data-center-picker__description">
 					{ translate(

--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -197,7 +197,9 @@ const DataCenterPicker = ( {
 						/>
 						<PickerOption>
 							<PickerOptionLabel>{ translate( 'Optimal data center' ) }</PickerOptionLabel>
-							<span>{ translate( 'Automatically place my site in the optimal data center' ) }</span>
+							<span>
+								{ translate( 'Automatically place my site in the optimal data center.' ) }
+							</span>
 						</PickerOption>
 					</CompactLabel>
 					<CompactLabel>

--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -292,7 +292,9 @@ const DataCenterPicker = ( {
 								checked={ isRecommendedDataCenterPicked }
 								onChange={ () => onChange( RECOMMENDED_DATA_CENTER ) }
 							/>
-							<span>{ translate( 'Automatically place my site in the optimal data center' ) }</span>
+							<span>
+								{ translate( 'Automatically place my site in the optimal data center.' ) }
+							</span>
 						</AutomaticFormLabel>
 						<FormRadiosBar
 							isThumbnail

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -8,7 +8,6 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { useRef } from 'react';
 import { useSelector } from 'react-redux';
-import siteOptionsUrl from 'calypso/assets/images/onboarding/site-options.svg';
 import DataCenterPicker from 'calypso/blocks/data-center-picker';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -142,7 +141,6 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 				backLabelText={ __( 'Back' ) }
 				hideBack={ hostingFlow }
 				goBack={ goBack }
-				headerImageUrl={ siteOptionsUrl }
 				hideSkip={ true }
 				isHorizontalLayout
 				formattedHeader={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -96,7 +96,7 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 					'no-site-picker': ! shouldShowGeoAffinityPicker,
 				} ) }
 			>
-				<FormLabel htmlFor="siteTitle">{ translate( 'Site title' ) }</FormLabel>
+				<FormLabel htmlFor="siteTitle">{ translate( 'Give your site a name' ) }</FormLabel>
 				<FormInput
 					name="siteTitle"
 					id="siteTitle"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
@@ -157,6 +157,12 @@ body:has(.new-hosted-site.options) {
 
 .new-hosted-site.options {
 
+	@include break-small {
+		.step-container.is-horizontal-layout {
+			margin-top: 32px;
+		}
+	}
+
 	.step-container__content {
 		flex-basis: unset;
 		width: 100%;
@@ -229,5 +235,14 @@ body:has(.new-hosted-site.options) {
 
 	.site-options__submit-button {
 		margin-top: 24px;
+	}
+
+	@media ( max-width: $break-small ) {
+		.site-options__submit-button {
+			width: 100%;
+		}
+		.step-container__header {
+			align-self: flex-start;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
@@ -102,6 +102,7 @@
 		padding: 9px 48px;
 		border-radius: 4px;
 		font-weight: 500;
+		align-self: center;
 
 		// override unnecessary super specificity added by another class
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05) !important;
@@ -155,6 +156,25 @@ body:has(.new-hosted-site.options) {
 }
 
 .new-hosted-site.options {
+
+	@include break-small {
+		.step-container__content {
+			flex-basis: unset;
+		}
+	}
+
+	&.is-step-write {
+		.step-container__header {
+			text-align: center;
+		}
+	}
+
+	.step-container.site-options {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+
 	.form-input-validation {
 		animation: none;
 	}
@@ -166,6 +186,11 @@ body:has(.new-hosted-site.options) {
 		&__icon {
 			margin-right: 10px;
 		}
+	}
+
+	.site-options__form {
+		display: flex;
+		flex-direction: column;
 	}
 
 	.site-options__form-fieldset {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
@@ -157,10 +157,10 @@ body:has(.new-hosted-site.options) {
 
 .new-hosted-site.options {
 
-	@include break-small {
-		.step-container__content {
-			flex-basis: unset;
-		}
+	.step-container__content {
+		flex-basis: unset;
+		width: 100%;
+		max-width: 600px;
 	}
 
 	&.is-step-write {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/2570

## Proposed Changes

* Update the data center picker to match the mockup

| Trunk mobile | Branch mobile |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/6851384/9ba42a28-abd9-4d8d-8667-37a8bd99072f) | ![image](https://github.com/Automattic/wp-calypso/assets/6851384/3be88d2b-9851-4492-b88a-08d2535d012a) |


| Trunk desktop | Branch desktop |
| ------------- | ------------- |
|  ![image](https://github.com/Automattic/wp-calypso/assets/6851384/d45c0a2e-6504-458b-8a32-ae05242bb12d)
 | ![image](https://github.com/Automattic/wp-calypso/assets/6851384/df539629-ae9d-4c78-ac13-1f929237bc60)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch and then navigate to `http://calypso.localhost:3000/setup/new-hosted-site/options?source=sites-dashboard`
* Compare the design against the rendered content. I listed out the differences I could find in the "Done is" section here https://github.com/Automattic/dotcom-forge/issues/2570
* Most of the changes are for the hosting options, but you can check other locations like: `/setup/videopress/options`, 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
