### PR TITLE
Assembler: Allow user to go back to the Theme Showcase

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -11,6 +11,7 @@ import {
 import { compose } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useMemo } from 'react';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import { createRecordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -61,6 +62,7 @@ const PatternAssembler = ( {
 	noticeList,
 	noticeOperations,
 }: StepProps & withNotices.Props ) => {
+	const translate = useTranslate();
 	const navigator = useNavigator();
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
@@ -660,8 +662,9 @@ const PatternAssembler = ( {
 			stepName="pattern-assembler"
 			hideBack={
 				navigator.location.path !== NAVIGATOR_PATHS.ACTIVATION &&
-				( navigator.location.path !== NAVIGATOR_PATHS.MAIN || isSiteAssemblerFlow( flow ) )
+				navigator.location.path !== NAVIGATOR_PATHS.MAIN
 			}
+			backLabelText={ isSiteAssemblerFlow( flow ) ? translate( 'Back to themes' ) : undefined }
 			goBack={ onBack }
 			goNext={ goNext }
 			isHorizontalLayout={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -664,7 +664,11 @@ const PatternAssembler = ( {
 				navigator.location.path !== NAVIGATOR_PATHS.ACTIVATION &&
 				navigator.location.path !== NAVIGATOR_PATHS.MAIN
 			}
-			backLabelText={ isSiteAssemblerFlow( flow ) ? translate( 'Back to themes' ) : undefined }
+			backLabelText={
+				isSiteAssemblerFlow( flow ) && navigator.location.path === NAVIGATOR_PATHS.MAIN
+					? translate( 'Back to themes' )
+					: undefined
+			}
 			goBack={ onBack }
 			goNext={ goNext }
 			isHorizontalLayout={ false }

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -89,7 +89,15 @@ const withThemeAssemblerFlow: Flow = {
 			}
 		};
 
-		return { submit };
+		const goBack = () => {
+			switch ( _currentStep ) {
+				case 'patternAssembler': {
+					return window.location.assign( `/themes/${ siteSlug }` );
+				}
+			}
+		};
+
+		return { submit, goBack };
 	},
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p7DVsv-hEU-p2#comment-46296

## Proposed Changes

* Allow the user to go back to the Theme Showcase if they're from the Theme Showcase (even from the logged-out TS)

![image](https://github.com/Automattic/wp-calypso/assets/13596067/de4fa3ef-ad13-4b4a-aeeb-6c399304b05f)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/themes/<your_site>`
* Scroll down and select BCPA CTA
* On the Assembler screen, ensure you're able to see the “Back to themes” button at the top-left corner
* Click that button, and ensure you're able to go back to the Theme Showcase

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?