### PR TITLE
Theme Showcase: Hide the retired themes from the search result

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -17,7 +17,7 @@ import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { upsellCardDisplayed as upsellCardDisplayedAction } from 'calypso/state/themes/actions';
-import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
+import { DEFAULT_THEME_QUERY, RETIRED_THEME_SLUGS_SET } from 'calypso/state/themes/constants';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -108,6 +108,7 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 			props.wpOrgThemes?.filter(
 				( wpOrgTheme ) =>
 					! themeSlugs.includes( wpOrgTheme?.id?.toLowerCase() ) && // Avoid duplicate themes. Some free themes are available in both wpcom and wporg.
+					! RETIRED_THEME_SLUGS_SET.has( wpOrgTheme?.id?.toLowerCase() ) && // Avoid retired themes.
 					( wpOrgTheme?.name?.toLowerCase() === props.searchTerm.toLowerCase() ||
 						wpOrgTheme?.id?.toLowerCase() === props.searchTerm.toLowerCase() )
 			) || []

--- a/client/state/themes/constants.js
+++ b/client/state/themes/constants.js
@@ -6,3 +6,10 @@ export const DEFAULT_THEME_QUERY = {
 	offset: 0,
 	page: 1,
 };
+
+// Some free themes are available in both wpcom and wporg. However, the themes endpoint won't return
+// the retired themes on wpcom so we're not able to filter them out from the search result. The
+// number of this kind of theme is not too many, so hard-code the list here to hide those themes
+// instead of querying them one by one when showing the search result.
+// See https://github.com/Automattic/wp-calypso/issues/77991
+export const RETIRED_THEME_SLUGS_SET = new Set( [ 'blank-canvas' ] );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/77991

## Proposed Changes

* Avoid showing the retired themes from the search result if those themes are also available in wporg

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/9972746e-6210-47d6-89ea-b5a4a8b20c71) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6891c427-5e77-494f-b840-0f3439be42c6) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Search “blank canvas”
* Ensure you won't see 2 blank canvas theme as one of them is retired.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
