### PR TITLE
Assembler - Sidenav - Checklist feature

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -563,7 +563,11 @@ const PatternAssembler = ( {
 						recordTracksEvent={ recordTracksEvent }
 						surveyDismissed={ surveyDismissed }
 						setSurveyDismissed={ setSurveyDismissed }
-						hasSections={ !! sections.length }
+						hasSections={ Boolean( sections.length ) }
+						hasHeader={ Boolean( header ) }
+						hasFooter={ Boolean( footer ) }
+						hasColor={ Boolean( colorVariation ) }
+						hasFont={ Boolean( fontVariation ) }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/index.tsx
@@ -5,7 +5,7 @@ import {
 	FlexItem,
 } from '@wordpress/components';
 import { isRTL } from '@wordpress/i18n';
-import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
+import { Icon, chevronLeft, chevronRight, check } from '@wordpress/icons';
 import classnames from 'classnames';
 import './style.scss';
 
@@ -15,6 +15,8 @@ interface Props {
 	icon?: JSX.Element;
 	children: JSX.Element;
 	onClick?: () => void;
+	checklist?: boolean;
+	checked?: boolean;
 }
 
 const GenericButton = ( { icon, children, ...props }: Props ) => {
@@ -25,7 +27,7 @@ const GenericButton = ( { icon, children, ...props }: Props ) => {
 			<Item { ...props }>
 				<HStack justify="space-between">
 					<HStack justify="flex-start">
-						<Icon icon={ icon } size={ 24 } />
+						<Icon className="navigator-button__icon" icon={ icon } size={ 24 } />
 						<FlexItem>{ children }</FlexItem>
 					</HStack>
 					<Icon icon={ forwardIcon } size={ 24 } />
@@ -44,10 +46,24 @@ const GenericButton = ( { icon, children, ...props }: Props ) => {
 	);
 };
 
-export const NavigationButtonAsItem = ( { className, ...props }: Props ) => {
+const ChecklistButton = ( { icon, children, className, checked, ...props }: Props ) => {
+	return (
+		<GenericButton
+			{ ...props }
+			icon={ checked ? check : icon }
+			className={ classnames( className, {
+				'navigator-button__checklist-item--checked': checked,
+			} ) }
+		>
+			{ children }
+		</GenericButton>
+	);
+};
+
+export const NavigationButtonAsItem = ( { className, checklist, ...props }: Props ) => {
 	return (
 		<NavigatorButton
-			as={ GenericButton }
+			as={ checklist ? ChecklistButton : GenericButton }
 			className={ classnames( 'navigator-button', className ) }
 			{ ...props }
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/index.tsx
@@ -15,7 +15,6 @@ interface Props {
 	icon?: JSX.Element;
 	children: JSX.Element | string;
 	onClick?: () => void;
-	checklist?: boolean;
 	checked?: boolean;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/index.tsx
@@ -13,22 +13,27 @@ interface Props {
 	path: string;
 	className?: string;
 	icon?: JSX.Element;
-	children: JSX.Element;
+	children: JSX.Element | string;
 	onClick?: () => void;
 	checklist?: boolean;
 	checked?: boolean;
 }
 
-const GenericButton = ( { icon, children, ...props }: Props ) => {
+const GenericButton = ( { icon, children, className, checked, ...props }: Props ) => {
 	const forwardIcon = isRTL() ? chevronLeft : chevronRight;
 
 	if ( icon ) {
 		return (
-			<Item { ...props }>
+			<Item
+				{ ...props }
+				className={ classnames( className, {
+					'navigator-button__checklist-item--checked': checked,
+				} ) }
+			>
 				<HStack justify="space-between">
 					<HStack justify="flex-start">
-						<Icon className="navigator-button__icon" icon={ icon } size={ 24 } />
-						<FlexItem>{ children }</FlexItem>
+						<Icon className="navigator-button__icon" icon={ checked ? check : icon } size={ 24 } />
+						<FlexItem className="navigator-button__text">{ children }</FlexItem>
 					</HStack>
 					<Icon icon={ forwardIcon } size={ 24 } />
 				</HStack>
@@ -46,24 +51,10 @@ const GenericButton = ( { icon, children, ...props }: Props ) => {
 	);
 };
 
-const ChecklistButton = ( { icon, children, className, checked, ...props }: Props ) => {
-	return (
-		<GenericButton
-			{ ...props }
-			icon={ checked ? check : icon }
-			className={ classnames( className, {
-				'navigator-button__checklist-item--checked': checked,
-			} ) }
-		>
-			{ children }
-		</GenericButton>
-	);
-};
-
-export const NavigationButtonAsItem = ( { className, checklist, ...props }: Props ) => {
+export const NavigationButtonAsItem = ( { className, ...props }: Props ) => {
 	return (
 		<NavigatorButton
-			as={ checklist ? ChecklistButton : GenericButton }
+			as={ GenericButton }
 			className={ classnames( 'navigator-button', className ) }
 			{ ...props }
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/style.scss
@@ -36,15 +36,24 @@
 		}
 
 		&__checklist-item--checked {
-			color: var(--studio-gray-30);
-
-			&:hover,
-			&:focus-visible {
+			&:focus {
 				color: var(--studio-gray-100);
 			}
 
+			.navigator-button__text {
+				line-height: 24px;
+			}
+
 			.navigator-button__icon {
-				fill: var(--studio-gray-30);
+				fill: var(--studio-gray-100);
+			}
+
+			&:hover,
+			&:focus-visible {
+				color: var(--studio-blue-50);
+				.navigator-button__icon {
+					fill: var(--studio-blue-50);
+				}
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/style.scss
@@ -34,6 +34,19 @@
 		&:active {
 			background-color: var(--studio-blue-0);
 		}
+
+		&__checklist-item--checked {
+			color: var(--studio-gray-30);
+
+			&:hover,
+			&:focus-visible {
+				color: var(--studio-gray-100);
+			}
+
+			.navigator-button__icon {
+				fill: var(--studio-gray-30);
+			}
+		}
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -115,7 +115,7 @@ const ScreenMain = ( {
 							aria-label={ translate( 'Header' ) }
 							onClick={ () => onSelect( 'header' ) }
 						>
-							<span className="pattern-layout__list-item-text">{ translate( 'Header' ) }</span>
+							{ translate( 'Header' ) }
 						</NavigationButtonAsItem>
 						<NavigationButtonAsItem
 							checklist
@@ -125,7 +125,7 @@ const ScreenMain = ( {
 							aria-label={ translate( 'Homepage' ) }
 							onClick={ () => onSelect( 'section' ) }
 						>
-							<span className="pattern-layout__list-item-text">{ translate( 'Homepage' ) }</span>
+							{ translate( 'Homepage' ) }
 						</NavigationButtonAsItem>
 						<NavigationButtonAsItem
 							checklist
@@ -135,7 +135,7 @@ const ScreenMain = ( {
 							aria-label={ translate( 'Footer' ) }
 							onClick={ () => onSelect( 'footer' ) }
 						>
-							<span className="pattern-layout__list-item-text">{ translate( 'Footer' ) }</span>
+							{ translate( 'Footer' ) }
 						</NavigationButtonAsItem>
 					</NavigatorItemGroup>
 					<NavigatorItemGroup title={ translate( 'Style' ) }>
@@ -148,10 +148,9 @@ const ScreenMain = ( {
 								aria-label={ translate( 'Colors' ) }
 								onClick={ () => onSelect( 'color-palettes' ) }
 							>
-								<span className="pattern-layout__list-item-text">{ translate( 'Colors' ) }</span>
+								{ translate( 'Colors' ) }
 							</NavigationButtonAsItem>
 							<NavigationButtonAsItem
-								key="font-pairings"
 								checklist
 								checked={ hasFont }
 								path={ NAVIGATOR_PATHS.FONT_PAIRINGS }
@@ -159,7 +158,7 @@ const ScreenMain = ( {
 								aria-label={ translate( 'Fonts' ) }
 								onClick={ () => onSelect( 'font-pairings' ) }
 							>
-								<span className="pattern-layout__list-item-text">{ translate( 'Fonts' ) }</span>
+								{ translate( 'Fonts' ) }
 							</NavigationButtonAsItem>
 						</>
 					</NavigatorItemGroup>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -25,6 +25,10 @@ interface Props {
 	surveyDismissed: boolean;
 	setSurveyDismissed: ( dismissed: boolean ) => void;
 	hasSections: boolean;
+	hasHeader: boolean;
+	hasFooter: boolean;
+	hasColor: boolean;
+	hasFont: boolean;
 }
 
 const ScreenMain = ( {
@@ -34,6 +38,10 @@ const ScreenMain = ( {
 	surveyDismissed,
 	setSurveyDismissed,
 	hasSections,
+	hasHeader,
+	hasFooter,
+	hasColor,
+	hasFont,
 }: Props ) => {
 	const translate = useTranslate();
 	const [ disabled, setDisabled ] = useState( true );
@@ -100,6 +108,8 @@ const ScreenMain = ( {
 				<HStack direction="column" alignment="top" spacing="4">
 					<NavigatorItemGroup title={ translate( 'Layout' ) }>
 						<NavigationButtonAsItem
+							checklist
+							checked={ hasHeader }
 							path={ NAVIGATOR_PATHS.HEADER }
 							icon={ header }
 							aria-label={ translate( 'Header' ) }
@@ -108,6 +118,8 @@ const ScreenMain = ( {
 							<span className="pattern-layout__list-item-text">{ translate( 'Header' ) }</span>
 						</NavigationButtonAsItem>
 						<NavigationButtonAsItem
+							checklist
+							checked={ hasSections }
 							path={ hasSections ? NAVIGATOR_PATHS.SECTION : NAVIGATOR_PATHS.SECTION_PATTERNS }
 							icon={ layout }
 							aria-label={ translate( 'Homepage' ) }
@@ -116,6 +128,8 @@ const ScreenMain = ( {
 							<span className="pattern-layout__list-item-text">{ translate( 'Homepage' ) }</span>
 						</NavigationButtonAsItem>
 						<NavigationButtonAsItem
+							checklist
+							checked={ hasFooter }
 							path={ NAVIGATOR_PATHS.FOOTER }
 							icon={ footer }
 							aria-label={ translate( 'Footer' ) }
@@ -127,6 +141,8 @@ const ScreenMain = ( {
 					<NavigatorItemGroup title={ translate( 'Style' ) }>
 						<>
 							<NavigationButtonAsItem
+								checklist
+								checked={ hasColor }
 								path={ NAVIGATOR_PATHS.COLOR_PALETTES }
 								icon={ color }
 								aria-label={ translate( 'Colors' ) }
@@ -135,6 +151,9 @@ const ScreenMain = ( {
 								<span className="pattern-layout__list-item-text">{ translate( 'Colors' ) }</span>
 							</NavigationButtonAsItem>
 							<NavigationButtonAsItem
+								key="font-pairings"
+								checklist
+								checked={ hasFont }
 								path={ NAVIGATOR_PATHS.FONT_PAIRINGS }
 								icon={ typography }
 								aria-label={ translate( 'Fonts' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -108,7 +108,6 @@ const ScreenMain = ( {
 				<HStack direction="column" alignment="top" spacing="4">
 					<NavigatorItemGroup title={ translate( 'Layout' ) }>
 						<NavigationButtonAsItem
-							checklist
 							checked={ hasHeader }
 							path={ NAVIGATOR_PATHS.HEADER }
 							icon={ header }
@@ -118,7 +117,6 @@ const ScreenMain = ( {
 							{ translate( 'Header' ) }
 						</NavigationButtonAsItem>
 						<NavigationButtonAsItem
-							checklist
 							checked={ hasSections }
 							path={ hasSections ? NAVIGATOR_PATHS.SECTION : NAVIGATOR_PATHS.SECTION_PATTERNS }
 							icon={ layout }
@@ -128,7 +126,6 @@ const ScreenMain = ( {
 							{ translate( 'Homepage' ) }
 						</NavigationButtonAsItem>
 						<NavigationButtonAsItem
-							checklist
 							checked={ hasFooter }
 							path={ NAVIGATOR_PATHS.FOOTER }
 							icon={ footer }
@@ -141,7 +138,6 @@ const ScreenMain = ( {
 					<NavigatorItemGroup title={ translate( 'Style' ) }>
 						<>
 							<NavigationButtonAsItem
-								checklist
 								checked={ hasColor }
 								path={ NAVIGATOR_PATHS.COLOR_PALETTES }
 								icon={ color }
@@ -151,7 +147,6 @@ const ScreenMain = ( {
 								{ translate( 'Colors' ) }
 							</NavigationButtonAsItem>
 							<NavigationButtonAsItem
-								checklist
 								checked={ hasFont }
 								path={ NAVIGATOR_PATHS.FONT_PAIRINGS }
 								icon={ typography }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/75156

## Proposed Changes

* Added new props `checklist` and `checked` to the component `<NavigationButtonAsItem>`
* The screens must be completed by choosing an item (header, footer, sections, font, color) to become checked ☑️
* The non-checked styles remain the same

https://github.com/Automattic/wp-calypso/assets/1881481/a1e999aa-b9c4-4cd5-acd8-edaa3de09ee7

**Updated screenshots**
| NO CHECKED| CHECKED | + HOVER | + FOCUS |
|--|--|--|--|
|<img width="331" alt="Screenshot 2566-06-15 at 11 20 27" src="https://github.com/Automattic/wp-calypso/assets/1881481/a237508a-670c-41aa-8d19-94f3de994334">|<img width="339" alt="Screenshot 2566-06-15 at 11 19 19" src="https://github.com/Automattic/wp-calypso/assets/1881481/51b4db9a-4b67-4907-b651-5e02f738f3a0">|<img width="333" alt="Screenshot 2566-06-15 at 11 19 31" src="https://github.com/Automattic/wp-calypso/assets/1881481/80e57d45-58b8-4275-a53b-1216d5477245">|<img width="339" alt="Screenshot 2566-06-15 at 11 20 02" src="https://github.com/Automattic/wp-calypso/assets/1881481/95f23cd6-0924-4f52-b22c-91ff9ab1bc8f">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3`
* Verify the navigator button icons change to a checkmark when users choose an item from each screen 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
