### PR TITLE
agency-dashboard: fix a few `@tanstack/eslint-plugin-query` violations

### DIFF
--- a/client/data/agency-dashboard/use-fetch-monitor-data.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-data.ts
@@ -7,7 +7,7 @@ import wpcom from 'calypso/lib/wp';
 
 const useFetchMonitorData = ( siteId: number, period: AllowedMonitorPeriods ) => {
 	return useQuery( {
-		queryKey: [ 'jetpack-monitor-uptime', siteId ],
+		queryKey: [ 'jetpack-monitor-uptime', siteId, period ],
 		queryFn: () =>
 			wpcom.req.get(
 				{

--- a/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
@@ -8,27 +8,25 @@ const isMultipleEmailEnabled = isEnabled(
 );
 
 const useFetchMonitorVerfiedContacts = ( isPartnerOAuthTokenLoaded: boolean ) => {
-	return useQuery(
-		[ 'monitor_notification_contacts' ],
-		() =>
+	return useQuery( {
+		queryKey: [ 'monitor_notification_contacts' ],
+		queryFn: () =>
 			wpcomJpl.req.get( {
 				path: '/jetpack-agency/contacts',
 				apiNamespace: 'wpcom/v2',
 			} ),
-		{
-			select: ( contacts: MonitorContactsResponse ) => {
-				return {
-					emails: contacts?.emails
-						.filter( ( email ) => email.verified )
-						.map( ( email ) => email.email_address ),
-					phoneNumbers: contacts.sms_numbers
-						.filter( ( sms ) => sms.verified )
-						.map( ( sms ) => `${ sms.country_numeric_code }${ sms.sms_number }` ), // Add country code to phone number
-				};
-			},
-			enabled: isPartnerOAuthTokenLoaded && isMultipleEmailEnabled,
-		}
-	);
+		select: ( contacts: MonitorContactsResponse ) => {
+			return {
+				emails: contacts?.emails
+					.filter( ( email ) => email.verified )
+					.map( ( email ) => email.email_address ),
+				phoneNumbers: contacts.sms_numbers
+					.filter( ( sms ) => sms.verified )
+					.map( ( sms ) => `${ sms.country_numeric_code }${ sms.sms_number }` ), // Add country code to phone number
+			};
+		},
+		enabled: isPartnerOAuthTokenLoaded && isMultipleEmailEnabled,
+	} );
 };
 
 export default useFetchMonitorVerfiedContacts;

--- a/client/data/agency-dashboard/use-toggle-favourite-site-mutation.ts
+++ b/client/data/agency-dashboard/use-toggle-favourite-site-mutation.ts
@@ -25,8 +25,8 @@ function mutationToggleFavoriteSite( {
 export default function useToggleFavoriteSiteMutation< TContext = unknown >(
 	options: UseMutationOptions< APIToggleFavorite, APIError, ToggleFavoriteOptions, TContext >
 ): UseMutationResult< APIToggleFavorite, APIError, ToggleFavoriteOptions, TContext > {
-	return useMutation< APIToggleFavorite, APIError, ToggleFavoriteOptions, TContext >(
-		mutationToggleFavoriteSite,
-		options
-	);
+	return useMutation< APIToggleFavorite, APIError, ToggleFavoriteOptions, TContext >( {
+		...options,
+		mutationFn: mutationToggleFavoriteSite,
+	} );
 }


### PR DESCRIPTION
Related to #77787 

## Proposed Changes

PR fixes violations of `@tanstack/eslint-plugin-query` recommended rules in `client/data/agency-dashboard` (see related issue mentioned above).

## Testing Instructions

You need an agency partner account for being able to go through these testing instructions. Test these by starting Jetpack Cloud locally (`yarn start-jetpack-cloud`) or using the provided link in the comment below.

1. Go to `/dashboard` and verify you see a request to `/wpcom/v2/jetpack-agency/contacts`
2. Verify you're able to (un-)fav a site by clicking on the star icon on the first column of each entry

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
