### PR TITLE
useFollowersQuery: Raise the maximum amount of followers fetched to 10K

### DIFF
--- a/client/data/followers/use-followers-query.js
+++ b/client/data/followers/use-followers-query.js
@@ -2,7 +2,7 @@ import { uniqueBy } from '@automattic/js-utils';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-const MAX_FOLLOWERS = 10; // means pages (= 1000 followers);
+const MAX_FOLLOWERS = 100; // means pages (= 10000 followers);
 const defaults = {
 	max: 100,
 };


### PR DESCRIPTION
## Proposed Changes

* The followers page uses an infinite query to fetch. It has a safeguard to stop fetching after 10 pages (of 100 subscribers each). This PR raises this limit to 100 pages.

It might be beneficial to also update the API endpoint to allow for larger pages, but this can be done later.

Discussion: p1686132835044129-slack-C03TY6J1A 

## Testing Instructions

1. Apply this PR
2. Go to `http://calypso.localhost:3000/people/subscribers/<siteid>`
3. Confirm that this still works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?