### PR TITLE
Subscribers Page: Add "Unsubscribe" confirm dialog

### DIFF
--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { SectionContainer } from 'calypso/components/section';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getEarnPageUrl } from '../../helpers';
 import './styles.scss';
 
 type GrowYourAudienceCardProps = {
@@ -65,7 +66,7 @@ const GrowYourAudience = () => {
 						'Allow your readers to support your work with paid subscriptions, gated content, or tips.'
 					) }
 					title={ translate( 'Start earning' ) }
-					url={ `https://wordpress.com/earn/${ selectedSiteSlug }` }
+					url={ getEarnPageUrl( selectedSiteSlug ) }
 				/>
 			</div>
 		</SectionContainer>

--- a/client/my-sites/subscribers/components/subscriber-list/subscriber-list.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/subscriber-list.tsx
@@ -1,7 +1,8 @@
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, translate } from 'i18n-calypso';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import { Subscriber } from '../../types';
 import { SubscriberRow } from './subscriber-row';
+import accept from 'calypso/lib/accept';
 import './styles.scss';
 
 type SubscriberListProps = {
@@ -9,6 +10,38 @@ type SubscriberListProps = {
 };
 
 const noop = () => undefined;
+
+const unsubscribe = ( subscriber: Subscriber ) => {
+	const subscriberHasPlans = !! subscriber?.plans?.length;
+	const confirmButtonLabel = subscriberHasPlans
+		? translate( 'Manage', { context: 'Navigate to the Earns page button text.' } )
+		: translate( 'Unsubscribe', { context: 'Confirm Unsubscribe subscriber button text.' } );
+
+	const confirmMessage = subscriberHasPlans
+		? translate(
+				'Looks like you’re trying to remove a paid subscriber %s. You’ll need to remove their paid subscription to continue.',
+				{ args: [ subscriber.display_name ], comment: "%s is the subscriber's public display name" }
+		  )
+		: translate(
+				'Are you sure you want to remove %s from your subscribers? They will no longer receive any notifications from your site.',
+				{ args: [ subscriber.display_name ], comment: "%s is the subscriber's public display name" }
+		  );
+
+	accept(
+		<div>
+			<p>{ confirmMessage }</p>
+		</div>,
+		( accepted: boolean ) => {
+			if ( accepted ) {
+				// todo: run mutation that removes the subscriber depedning on if they have plans or not. If they are a paid subscriber, navigate to the Earns page.
+				// todo: maybe track the action
+			} else {
+				// todo: maybe track the action
+			}
+		},
+		confirmButtonLabel
+	);
+};
 
 export const SubscriberList = ( { subscribers }: SubscriberListProps ) => {
 	const translate = useTranslate();
@@ -37,7 +70,7 @@ export const SubscriberList = ( { subscribers }: SubscriberListProps ) => {
 					key={ subscriber.subscription_id }
 					subscriber={ subscriber }
 					onView={ noop }
-					onUnsubscribe={ noop }
+					onUnsubscribe={ () => unsubscribe( subscriber ) }
 				/>
 			) ) }
 		</ul>

--- a/client/my-sites/subscribers/components/subscriber-list/subscriber-list.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/subscriber-list.tsx
@@ -1,50 +1,19 @@
-import { useTranslate, translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
-import accept from 'calypso/lib/accept';
 import { Subscriber } from '../../types';
 import { SubscriberRow } from './subscriber-row';
 import './styles.scss';
 
 type SubscriberListProps = {
 	subscribers: Subscriber[];
+	onUnsubscribe: ( subscriber: Subscriber ) => void;
 };
 
 const noop = () => undefined;
 
-const unsubscribe = ( subscriber: Subscriber ) => {
-	const subscriberHasPlans = !! subscriber?.plans?.length;
-	const confirmButtonLabel = subscriberHasPlans
-		? translate( 'Manage', { context: 'Navigate to the Earns page button text.' } )
-		: translate( 'Unsubscribe', { context: 'Confirm Unsubscribe subscriber button text.' } );
-
-	const confirmMessage = subscriberHasPlans
-		? translate(
-				'Looks like you’re trying to remove a paid subscriber %s. You’ll need to remove their paid subscription to continue.',
-				{ args: [ subscriber.display_name ], comment: "%s is the subscriber's public display name" }
-		  )
-		: translate(
-				'Are you sure you want to remove %s from your subscribers? They will no longer receive any notifications from your site.',
-				{ args: [ subscriber.display_name ], comment: "%s is the subscriber's public display name" }
-		  );
-
-	accept(
-		<div>
-			<p>{ confirmMessage }</p>
-		</div>,
-		( accepted: boolean ) => {
-			if ( accepted ) {
-				// todo: run mutation that removes the subscriber depedning on if they have plans or not. If they are a paid subscriber, navigate to the Earns page.
-				// todo: maybe track the action
-			} else {
-				// todo: maybe track the action
-			}
-		},
-		confirmButtonLabel
-	);
-};
-
-export const SubscriberList = ( { subscribers }: SubscriberListProps ) => {
+export const SubscriberList = ( { subscribers, onUnsubscribe }: SubscriberListProps ) => {
 	const translate = useTranslate();
+
 	return (
 		<ul className="subscriber-list" role="table">
 			<li className="row header" role="row">
@@ -70,7 +39,7 @@ export const SubscriberList = ( { subscribers }: SubscriberListProps ) => {
 					key={ subscriber.subscription_id }
 					subscriber={ subscriber }
 					onView={ noop }
-					onUnsubscribe={ () => unsubscribe( subscriber ) }
+					onUnsubscribe={ onUnsubscribe }
 				/>
 			) ) }
 		</ul>

--- a/client/my-sites/subscribers/components/subscriber-list/subscriber-list.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/subscriber-list.tsx
@@ -1,8 +1,8 @@
 import { useTranslate, translate } from 'i18n-calypso';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import accept from 'calypso/lib/accept';
 import { Subscriber } from '../../types';
 import { SubscriberRow } from './subscriber-row';
-import accept from 'calypso/lib/accept';
 import './styles.scss';
 
 type SubscriberListProps = {

--- a/client/my-sites/subscribers/components/unsubscribe-modal/index.ts
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/index.ts
@@ -1,0 +1,2 @@
+export { default as UnsubscribeModal } from './unsubscribe-modal';
+export { UnsubscribeActionType } from './unsubscribe-modal';

--- a/client/my-sites/subscribers/components/unsubscribe-modal/styles.scss
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/styles.scss
@@ -1,0 +1,31 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+
+.unsubscribe-modal {
+	.components-modal__frame {
+		max-width: 563px;
+	}
+
+	.components-modal__header {
+		border-bottom-color: $studio-gray-0;
+		padding: 18px 24px;
+
+		.components-modal__header-heading {
+			font-size: $font-body;
+		}
+	}
+
+	.components-modal__content {
+		padding: 0 24px 24px;
+
+		p {
+			margin-top: 24px;
+		}
+	}
+
+	.unsubscribe-modal__buttons {
+		display: flex;
+		justify-content: flex-end;
+		gap: 10px;
+	}
+}

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -4,7 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { Subscriber } from '../../types';
 import './styles.scss';
 
-enum UnsubscribeActionType {
+export enum UnsubscribeActionType {
 	Cancel = 'cancel',
 	Manage = 'manage',
 	Unsubscribe = 'unsubscribe',
@@ -77,5 +77,4 @@ const UnsubscribeModal = ( { subscriber, onClose }: UnsubscribeModalProps ) => {
 	);
 };
 
-export { UnsubscribeActionType };
 export default UnsubscribeModal;

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -1,0 +1,81 @@
+import { Button } from '@automattic/components';
+import { Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { Subscriber } from '../../types';
+import './styles.scss';
+
+enum UnsubscribeActionType {
+	Cancel = 'cancel',
+	Manage = 'manage',
+	Unsubscribe = 'unsubscribe',
+}
+
+type UnsubscribeModalProps = {
+	subscriber?: Subscriber;
+	onClose: ( action: UnsubscribeActionType, subscriber?: Subscriber ) => void;
+};
+
+const UnsubscribeModal = ( { subscriber, onClose }: UnsubscribeModalProps ) => {
+	const translate = useTranslate();
+	const subscriberHasPlans = !! subscriber?.plans?.length;
+
+	const title = subscriberHasPlans
+		? translate( 'Remove paid subscriber' )
+		: translate( 'Remove free subscriber' );
+
+	const confirmButtonLabel = subscriberHasPlans
+		? translate( 'Manage paid subscribers', { context: 'Navigate to the Earns page button text.' } )
+		: translate( 'Unsubscribe', { context: 'Confirm Unsubscribe subscriber button text.' } );
+
+	const confirmMessage = subscriberHasPlans
+		? translate( 'To remove this subscriber, you’ll need to cancel their paid subscription first.' )
+		: translate(
+				'Are you sure you want to remove %s from your subscribers? They will no longer receive any notifications from your site.',
+				{
+					args: [ subscriber?.display_name ],
+					comment: "%s is the subscriber's public display name",
+				}
+		  );
+
+	const confirmActionType = subscriberHasPlans
+		? UnsubscribeActionType.Manage
+		: UnsubscribeActionType.Unsubscribe;
+
+	const onCloseHandler = ( action?: string ) => {
+		if ( action === UnsubscribeActionType.Unsubscribe ) {
+			onClose( UnsubscribeActionType.Unsubscribe, subscriber );
+		} else if ( action === UnsubscribeActionType.Manage ) {
+			onClose( UnsubscribeActionType.Manage, subscriber );
+		} else {
+			onClose( UnsubscribeActionType.Cancel );
+		}
+	};
+
+	if ( ! subscriber ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			overlayClassName="unsubscribe-modal"
+			title={ title }
+			onRequestClose={ () => onCloseHandler( UnsubscribeActionType.Cancel ) }
+		>
+			<p>{ confirmMessage }</p>
+			<div className="unsubscribe-modal__buttons">
+				<Button
+					className="unsubscribe-modal__cancel"
+					onClick={ () => onCloseHandler( UnsubscribeActionType.Cancel ) }
+				>
+					{ translate( 'Cancel' ) }
+				</Button>
+				<Button onClick={ () => onCloseHandler( confirmActionType ) } primary>
+					{ confirmButtonLabel }
+				</Button>
+			</div>
+		</Modal>
+	);
+};
+
+export { UnsubscribeActionType };
+export default UnsubscribeModal;

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -25,12 +25,12 @@ const UnsubscribeModal = ( { subscriber, onClose }: UnsubscribeModalProps ) => {
 
 	const confirmButtonLabel = subscriberHasPlans
 		? translate( 'Manage paid subscribers', { context: 'Navigate to the Earns page button text.' } )
-		: translate( 'Unsubscribe', { context: 'Confirm Unsubscribe subscriber button text.' } );
+		: translate( 'Remove subscriber', { context: 'Confirm Unsubscribe subscriber button text.' } );
 
 	const confirmMessage = subscriberHasPlans
 		? translate( 'To remove this subscriber, you’ll need to cancel their paid subscription first.' )
 		: translate(
-				'Are you sure you want to remove %s from your subscribers? They will no longer receive any notifications from your site.',
+				'Are you sure you want to remove %s from your list? They will no longer receive new notifications from your site.',
 				{
 					args: [ subscriber?.display_name ],
 					comment: "%s is the subscriber's public display name",

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -1,3 +1,10 @@
+const URL_PREFIX = 'https://wordpress.com';
+
+const getEarnPageUrl = ( siteSlug: string | null ) => `${ URL_PREFIX }/earn/${ siteSlug ?? '' }`;
+
+const getEarnPaymentsPageUrl = ( siteSlug: string | null ) =>
+	`${ URL_PREFIX }/earn/payments/${ siteSlug ?? '' }`;
+
 const getSubscribersCacheKey = (
 	siteId: number | null,
 	currentPage?: number,
@@ -13,12 +20,9 @@ const getSubscribersCacheKey = (
 	return cacheKey;
 };
 
-const getEarnPageUrl = ( siteSlug: string | null ) =>
-	`https://wordpress.com/earn/${ siteSlug ?? '' }`;
-
 const sanitizeInt = ( intString: string ) => {
 	const parsedInt = parseInt( intString, 10 );
 	return ! Number.isNaN( parsedInt ) && parsedInt > 0 ? parsedInt : undefined;
 };
 
-export { getSubscribersCacheKey, getEarnPageUrl, sanitizeInt };
+export { getEarnPageUrl, getEarnPaymentsPageUrl, getSubscribersCacheKey, sanitizeInt };

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -13,9 +13,12 @@ const getSubscribersCacheKey = (
 	return cacheKey;
 };
 
+const getEarnPageUrl = ( siteSlug: string | null ) =>
+	`https://wordpress.com/earn/${ siteSlug ?? '' }`;
+
 const sanitizeInt = ( intString: string ) => {
 	const parsedInt = parseInt( intString, 10 );
 	return ! Number.isNaN( parsedInt ) && parsedInt > 0 ? parsedInt : undefined;
 };
 
-export { getSubscribersCacheKey, sanitizeInt };
+export { getSubscribersCacheKey, getEarnPageUrl, sanitizeInt };

--- a/client/my-sites/subscribers/hooks/index.ts
+++ b/client/my-sites/subscribers/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as usePagination } from './use-pagination';
+export { default as useUnsubscribeModal } from './use-unsubscribe-modal';

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { UnsubscribeActionType } from '../components/unsubscribe-modal';
+import { getEarnPageUrl } from '../helpers';
+import { useSubscriberRemoveMutation } from '../mutations';
+import { Subscriber } from '../types';
+
+const useUnsubscribeModal = ( siteId: number | null, currentPage: number ) => {
+	const [ currentSubscriber, setCurrentSubscriber ] = useState< Subscriber >();
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const { mutate } = useSubscriberRemoveMutation( siteId, currentPage );
+
+	const onClickUnsubscribe = ( subscriber: Subscriber ) => {
+		setCurrentSubscriber( subscriber );
+	};
+
+	const onCloseModal = ( action: UnsubscribeActionType, subscriber?: Subscriber ) => {
+		if ( action === UnsubscribeActionType.Manage ) {
+			window.open( getEarnPageUrl( selectedSiteSlug ), '_blank' );
+		} else if ( action === UnsubscribeActionType.Unsubscribe && subscriber ) {
+			mutate( subscriber );
+		}
+
+		setCurrentSubscriber( undefined );
+	};
+
+	// Reset current subscriber on unmount
+	useEffect( () => {
+		return () => {
+			setCurrentSubscriber( undefined );
+		};
+	}, [] );
+
+	return {
+		currentSubscriber,
+		onClickUnsubscribe,
+		onCloseModal,
+	};
+};
+
+export default useUnsubscribeModal;

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { UnsubscribeActionType } from '../components/unsubscribe-modal';
-import { getEarnPageUrl } from '../helpers';
+import { getEarnPaymentsPageUrl } from '../helpers';
 import { useSubscriberRemoveMutation } from '../mutations';
 import { Subscriber } from '../types';
 
@@ -17,7 +17,7 @@ const useUnsubscribeModal = ( siteId: number | null, currentPage: number ) => {
 
 	const onCloseModal = ( action: UnsubscribeActionType, subscriber?: Subscriber ) => {
 		if ( action === UnsubscribeActionType.Manage ) {
-			window.open( getEarnPageUrl( selectedSiteSlug ), '_blank' );
+			window.open( getEarnPaymentsPageUrl( selectedSiteSlug ), '_blank' );
 		} else if ( action === UnsubscribeActionType.Unsubscribe && subscriber ) {
 			mutate( subscriber );
 		}

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -9,7 +9,8 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { EmptyListView } from './components/empty-list-view';
 import { GrowYourAudience } from './components/grow-your-audience';
 import { SubscriberList } from './components/subscriber-list/subscriber-list';
-import { usePagination } from './hooks';
+import { UnsubscribeModal } from './components/unsubscribe-modal';
+import { usePagination, useUnsubscribeModal } from './hooks';
 import { useSubscribersQuery } from './queries';
 import './styles.scss';
 
@@ -29,6 +30,10 @@ export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
 	} = result && result.data ? result : initialState;
 	const { isFetching } = result;
 	const { pageClickCallback } = usePagination( page, pageChanged, isFetching );
+	const { currentSubscriber, onClickUnsubscribe, onCloseModal } = useUnsubscribeModal(
+		selectedSiteId,
+		page
+	);
 
 	const navigationItems: Item[] = [
 		{
@@ -66,7 +71,7 @@ export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
 							<span className="subscribers__title">{ translate( 'Total' ) }</span>{ ' ' }
 							<span className="subscribers__subscriber-count">{ total }</span>
 						</div>
-						<SubscriberList subscribers={ subscribers } />
+						<SubscriberList subscribers={ subscribers } onUnsubscribe={ onClickUnsubscribe } />
 					</>
 				) : (
 					<EmptyListView />
@@ -82,6 +87,8 @@ export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
 			</section>
 
 			{ !! total && <GrowYourAudience /> }
+
+			<UnsubscribeModal subscriber={ currentSubscriber } onClose={ onCloseModal } />
 		</Main>
 	);
 };

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -3,7 +3,7 @@ import wpcom from 'calypso/lib/wp';
 import { getSubscribersCacheKey } from '../helpers';
 import type { SubscriberEndpointResponse, Subscriber } from '../types';
 
-const useSubscriberRemoveMutation = ( siteId: number, currentPage: number ) => {
+const useSubscriberRemoveMutation = ( siteId: number | null, currentPage: number ) => {
 	const queryClient = useQueryClient();
 
 	return useMutation( {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/77733
Closes https://github.com/Automattic/wp-calypso/issues/77734

## Proposed Changes

* Create UnsubscribeModal component and useUnsubscribeModal hook
* Apply modal to Subscribers page

## Testing Instructions

* Apply this PR to your local env
* Go to http://calypso.localhost:3000/subscribers/{site-slug}?flags=subscribers-page
* Click the actions menu of a Free Subscriber row and click on Unsubscribe
* Verify if the modal is displayed as expected
* Click on Unsubscribe and verify if the list is updated
* Click the actions menu of a Paid Subscriber row and click on Unsubscribe
* Verify if the modal is displayed as expected
* Click on Manage paid subscribers and check if the earns page is opened on a new tab

<img width="608" alt="Screenshot 2023-06-14 at 17 34 55" src="https://github.com/Automattic/wp-calypso/assets/3113712/fb23582a-6a40-4387-9480-030996c348bc">

<img width="580" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/004b6c2a-d85e-4ec6-964a-94edb543be97">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
