### PR TITLE
Don't set cookie based on setting

### DIFF
--- a/client/lib/analytics/utils/use-do-not-sell.ts
+++ b/client/lib/analytics/utils/use-do-not-sell.ts
@@ -1,24 +1,15 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import cookie from 'cookie';
 import { useCallback, useEffect, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { useDispatch } from 'react-redux';
 import { saveUserSettings } from 'calypso/state/user-settings/actions';
 import isRegionInCcpaZone from './is-region-in-ccpa-zone';
-import { getTrackingPrefs, refreshCountryCodeCookieGdpr, setTrackingPrefs } from '.';
-
-const ADVERTISING_OPT_OUT_USER_SETTINGS_KEY = 'advertising_targeting_opt_out';
+import { refreshCountryCodeCookieGdpr, setTrackingPrefs } from '.';
 
 export default () => {
 	const [ shouldSeeDoNotSell, setShouldSeeDoNotSell ] = useState( false );
 	const [ isDoNotSell, setIsDoNotSell ] = useState( false );
 	const dispatch = useDispatch();
-
-	// TODO: this assumes this hook being used in a state where user settings have already been loaded
-	// We could potentially add a conditional query to load settings here for good measure
-	const userHasOptedOutOfAdvertising = useSelector( ( state ) => {
-		return getUserSetting( state, ADVERTISING_OPT_OUT_USER_SETTINGS_KEY ) ?? false;
-	} );
 
 	useEffect( () => {
 		const controller = new AbortController();
@@ -36,15 +27,6 @@ export default () => {
 
 		return () => controller.abort();
 	}, [ setShouldSeeDoNotSell ] );
-
-	useEffect( () => {
-		if ( userHasOptedOutOfAdvertising !== null ) {
-			// If the user settings show that the user has opted out of advertising, set the advertising bucket to false
-			setTrackingPrefs( { ok: true, buckets: { advertising: ! userHasOptedOutOfAdvertising } } );
-		}
-		// We set initial `isDoNotSell` via hook to make sure it run only on client side (when SSR)
-		setIsDoNotSell( ! getTrackingPrefs().buckets.advertising );
-	}, [ userHasOptedOutOfAdvertising ] );
 
 	const setUserAdvertisingOptOut = useCallback(
 		( isOptedOut: boolean ) => {

--- a/client/lib/analytics/utils/use-do-not-sell.ts
+++ b/client/lib/analytics/utils/use-do-not-sell.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { saveUserSettings } from 'calypso/state/user-settings/actions';
 import isRegionInCcpaZone from './is-region-in-ccpa-zone';
-import { refreshCountryCodeCookieGdpr, setTrackingPrefs } from '.';
+import { getTrackingPrefs, refreshCountryCodeCookieGdpr, setTrackingPrefs } from '.';
 
 export default () => {
 	const [ shouldSeeDoNotSell, setShouldSeeDoNotSell ] = useState( false );
@@ -27,6 +27,11 @@ export default () => {
 
 		return () => controller.abort();
 	}, [ setShouldSeeDoNotSell ] );
+
+	useEffect( () => {
+		// We set initial `isDoNotSell` via hook to make sure it run only on client side (when SSR)
+		setIsDoNotSell( ! getTrackingPrefs().buckets.advertising );
+	}, [] );
 
 	const setUserAdvertisingOptOut = useCallback(
 		( isOptedOut: boolean ) => {


### PR DESCRIPTION
## Proposed Changes

* This diff stops setting the user tracking prefs cookie using the saved user setting.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You'll need to temporarily enable the cookie-banner feature on the development environment. You can do this by editing config/development.json before starting Calypso OR by adding the `?flags=cookie-banner` query parameter.
* Navigate to /me/privacy
* In order to see the "Do not sell" setting, you will need to change your "country" and "region" cookies
* Set your "country" cookie to "US" and "region" cookie to "california"
* Refresh the privacy page and you should see the "Do not sell setting"

![Screenshot 2023-06-13 at 10 07 56 AM](https://github.com/Automattic/wp-calypso/assets/18016357/a8eb96ed-3466-4d6e-8cab-d8326c680215)

* Toggle the setting on, confirm that your user settings are updated as mentioned in D100729-code
* Now, delete your `sensitive_pixel_options` cookie
* Reload the page, confirm that the toggle is OFF after deleting the cookie.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?