### PR TITLE
Reader: only use layout overrides in `is-section-reader`

### DIFF
--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -35,7 +35,7 @@
 	}
 }
 
-.has-no-sidebar .layout__content {
+.is-section-reader.has-no-sidebar .layout__content {
 	padding-left: 24px;
 	padding-right: 24px;
 	max-width: 1140px;
@@ -52,7 +52,7 @@
 }
 
 // to match other reader pages.
-.layout:not(.has-no-sidebar) .tags__main {
+.is-section-reader .layout:not(.has-no-sidebar) .tags__main {
 	padding: 30px 20px;
 	max-width: 600px;
 	margin: 0 auto;


### PR DESCRIPTION
The styles added in #73464 for the logged-out `/tags` page can apply to any page if the user has already visited the Reader (and loaded the styles). This can both break intentionally full-width layouts (like the one in #77353) and result in unexpected bugs when a page implicitly relies on the max-width (or lack thereof). 

This PR makes them specific to `.is-section-reader`.

**To test:**
- logged-out, visit calypso.localhost:3000/tags and verify that the sidebar-less `.layout_content` has `max-width: 1140px`
- navigate around and verify that the styling of the pages looks correct
- logged-in, visit calypso.localhost:3000/tags and verify that the `.layout_content` has `max-width: 600px`
- navigate around and verify that the styling of the pages looks correct