### PR TITLE
Updates the promote-post/redesign-i2 flag until stage

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -98,7 +98,7 @@
 		"post-list/qr-code-link": false,
 		"pre-cancellation-modal": false,
 		"press-this": true,
-		"promote-post/redesign-i2": false,
+		"promote-post/redesign-i2": true,
 		"promote-post/widget-i2": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -111,7 +111,7 @@
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": true,
 		"press-this": true,
-		"promote-post/redesign-i2": false,
+		"promote-post/redesign-i2": true,
 		"promote-post/widget-i2": true,
 		"pre-cancellation-modal": false,
 		"publicize-preview": true,

--- a/config/test.json
+++ b/config/test.json
@@ -81,7 +81,7 @@
 		"plugins/ssr-landing": true,
 		"post-list/qr-code-link": false,
 		"press-this": true,
-		"promote-post/redesign-i2": false,
+		"promote-post/redesign-i2": true,
 		"promote-post/widget-i2": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -125,7 +125,7 @@
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": true,
 		"press-this": true,
-		"promote-post/redesign-i2": false,
+		"promote-post/redesign-i2": true,
 		"promote-post/widget-i2": true,
 		"pre-cancellation-modal": false,
 		"publicize-preview": true,


### PR DESCRIPTION
Related to the Advertising Dashboard redesign project

## Proposed Changes

* Raise the `promote-post/redesign-i2` until stage (not in prod yet)

## Testing Instructions

Code review! 

Then, open the Live preview link, go to Tools->Advertising and check that you are on the redesigned page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
