### PR TITLE
JP Pro dashboard: Redirect user to dashboard page after Agency signup.

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -6,7 +6,7 @@ import CardHeading from 'calypso/components/card-heading';
 import CompanyDetailsForm from 'calypso/jetpack-cloud/sections/partner-portal/company-details-form';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { formatApiPartner } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-import { partnerPortalBasePath } from 'calypso/lib/jetpack/paths';
+import { dashboardPath } from 'calypso/lib/jetpack/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
@@ -69,7 +69,7 @@ export default function AgencySignupForm() {
 	// Redirect the user if they are already a partner or the form was submitted successfully.
 	useEffect( () => {
 		if ( partner ) {
-			page.redirect( partnerPortalBasePath() );
+			page.redirect( dashboardPath() );
 		}
 	} );
 


### PR DESCRIPTION
It was identified that ~50% of our sign-ups are not reaching the Pro Dashboard. Currently, after the user submits the signup form, the page redirects to `/partner-portal/licenses`.

One of the ideas to improve this is to immediately redirect the users to the Dashboard screen after submitting the signup form.

Related to 1202619025189113-as-1204806328858503


## Proposed Changes

This PR updates the signup page to redirect to the dashboard after submitting the form.

## Testing Instructions
* Run git checkout `update/agency-signup-redirect-to-dashboard` and `yarn start-jetpack-cloud`
* Open the Incognito window (Chrome browser) and go to http://jetpack.cloud.localhost:3000/agency/signup
* Create a new WordPress account and connect it to Jetpack.
* Fill up the Agency signup form and press submit
* Confirm that the page redirects to `/dashboard`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
