### PR TITLE
update tos link for akismet checkout

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { isAkismetProduct } from '@automattic/calypso-products';
 import { useStripe, useStripeSetupIntentId } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { Card, Gridicon } from '@automattic/components';
@@ -89,6 +90,8 @@ export default function PaymentMethodSelector( {
 		error: setupIntentError,
 	} = useStripeSetupIntentId();
 	const currentlyAssignedPaymentMethodId = getPaymentMethodIdFromPayment( purchase?.payment );
+
+	const isAkismetPurchase = purchase ? isAkismetProduct( purchase ) : false;
 
 	const showRedirectMessage = useCallback( () => {
 		reduxDispatch( infoNotice( translate( 'Redirecting to payment partner…' ) ) );
@@ -209,7 +212,7 @@ export default function PaymentMethodSelector( {
 				<div className="payment-method-selector__terms">
 					<Gridicon icon="info-outline" size={ 18 } />
 					<p>
-						<TosText />
+						<TosText isAkismetPurchase={ isAkismetPurchase } />
 					</p>
 				</div>
 

--- a/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
@@ -1,13 +1,8 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import type { FC } from 'react';
 
-interface TosTextProps {
-	isAkismetPurchase: boolean;
-}
-
-const TosText: FC< TosTextProps > = ( { isAkismetPurchase } ) => {
+export default function TosText( isAkismetPurchase: boolean ) {
 	const translate = useTranslate();
 	return (
 		<>
@@ -37,6 +32,4 @@ const TosText: FC< TosTextProps > = ( { isAkismetPurchase } ) => {
 			) }
 		</>
 	);
-};
-
-export default TosText;
+}

--- a/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
@@ -1,9 +1,13 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import type { FC } from 'react';
 
-export default function TosText() {
+interface TosTextProps {
+	isAkismetPurchase: boolean;
+}
+
+const TosText: FC< TosTextProps > = ( { isAkismetPurchase } ) => {
 	const translate = useTranslate();
 	return (
 		<>
@@ -14,7 +18,7 @@ export default function TosText() {
 						tosLink: (
 							<a
 								href={
-									isAkismetCheckout()
+									isAkismetPurchase
 										? localizeUrl( 'https://akismet.com/tos/' )
 										: localizeUrl( 'https://wordpress.com/tos/' )
 								}
@@ -33,4 +37,6 @@ export default function TosText() {
 			) }
 		</>
 	);
-}
+};
+
+export default TosText;

--- a/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
@@ -1,5 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
 export default function TosText() {
@@ -12,7 +13,11 @@ export default function TosText() {
 					components: {
 						tosLink: (
 							<a
-								href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+								href={
+									isAkismetCheckout()
+										? localizeUrl( 'https://akismet.com/tos/' )
+										: localizeUrl( 'https://wordpress.com/tos/' )
+								}
 								target="_blank"
 								rel="noopener noreferrer"
 							/>

--- a/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
@@ -2,7 +2,11 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
-export default function TosText( isAkismetPurchase: boolean ) {
+interface TosTextProps {
+	isAkismetPurchase: boolean;
+}
+
+export default function TosText( { isAkismetPurchase }: TosTextProps ) {
 	const translate = useTranslate();
 	return (
 		<>

--- a/client/my-sites/checkout/composite-checkout/components/terms-of-service.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/terms-of-service.tsx
@@ -1,7 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import TosText from 'calypso/me/purchases/manage-purchase/payment-method-selector/tos-text';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 
@@ -36,7 +36,7 @@ export const TermsOfService = ( {
 
 		// Don't show the extended ToS notice for one-time purchases or gifts
 		if ( ! isGiftPurchase && hasRenewableSubscription ) {
-			message = <TosText />;
+			message = <TosText isAkismetPurchase={ isAkismetCheckout() } />;
 		}
 
 		return message;

--- a/client/my-sites/checkout/composite-checkout/components/terms-of-service.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/terms-of-service.tsx
@@ -1,6 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import TosText from 'calypso/me/purchases/manage-purchase/payment-method-selector/tos-text';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 
@@ -21,7 +22,11 @@ export const TermsOfService = ( {
 			components: {
 				link: (
 					<a
-						href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+						href={
+							isAkismetCheckout()
+								? localizeUrl( 'https://akismet.com/tos/' )
+								: localizeUrl( 'https://wordpress.com/tos/' )
+						}
 						target="_blank"
 						rel="noopener noreferrer"
 					/>


### PR DESCRIPTION
## Proposed Changes

* Link to Akismet TOS in Akismet checkout

## Testing Instructions

* Go to the Calypso live link or check this branch out locally
* Go to `/checkout/akismet/ak_personal_yearly:-q-36`
* Make sure the Terms of Service link links to the Akismet TOS (https://akismet.com/tos/)
![image](https://github.com/Automattic/wp-calypso/assets/65001528/aea16266-6e26-499e-ac1a-02b345fa2b44)
* Go to `/checkout/jetpack/jetpack_backup_t1_yearly` and make sure it goes to the regular wordpress TOS (https://wordpress.com/tos/)
![image](https://github.com/Automattic/wp-calypso/assets/65001528/f84f6fce-4ea8-4dd9-9f0a-1740be6879b2)
* Purchase an Akismet product
* Find the product in `/me/purchases` and edit the payment option for it
* Make sure the link that is render is the Akismet TOS
![image](https://github.com/Automattic/wp-calypso/assets/65001528/e1325c64-e217-4d19-aa21-a954faa7137e)
* Open up a different purchase and edit it's payment option to make sure it is still the wordpress TOS

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
