### PR TITLE
Plans 2023: Bound comparison grid title cell text with max width

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
@@ -4,7 +4,7 @@ import { PropsWithChildren, useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 
 const HoverAreaContainer = styled.span`
-	max-width: 240;
+	max-width: 240px;
 `;
 
 const StyledTooltip = styled( Tooltip )`

--- a/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
@@ -4,7 +4,7 @@ import { PropsWithChildren, useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 
 const HoverAreaContainer = styled.span`
-	max-width: 240px;
+	max-width: 220px;
 `;
 
 const StyledTooltip = styled( Tooltip )`

--- a/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
@@ -3,7 +3,9 @@ import { TranslateResult } from 'i18n-calypso';
 import { PropsWithChildren, useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 
-const HoverAreaContainer = styled.span``;
+const HoverAreaContainer = styled.span`
+	max-width: 240;
+`;
 
 const StyledTooltip = styled( Tooltip )`
 	&.tooltip.popover .popover__inner {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78061 and https://github.com/Automattic/martech/issues/1824 and p1686391762900559-slack-CV2TX2PAN

## Proposed Changes

* Add max-width to comparison grid title cells to prevent odd text flow with jetpack icon

## Screenshots

### Before
![Screenshot 2023-06-08 at 23 43 31](https://github.com/Automattic/wp-calypso/assets/5414230/df392fc9-2514-4dfe-bee3-c7533ad40de1)

### After
<img width="477" alt="Screenshot 2023-06-13 at 11 58 40 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/a5b69040-fa82-43e2-bedd-13610ed06ef9">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this branch and run `yarn` and `yarn start` if needed. 
2. Navigate to the 2023 pricing grid in onboarding http://calypso.localhost:3000/start/plans
3. Verify that the jetpack icon for the comparison grid title cells isn't misaligned
4. Navigate to the 2023 pricing grid in the plans page http://calypso.localhost:3000/plans/{SITE_SLUG}
5. Repeat step 3

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?