### PR TITLE
Use the right order for using _n for clicks and impressions

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -84,7 +84,7 @@ export default function CampaignItem( props: Props ) {
 		if ( impressions_total > 0 ) {
 			statElements[ statElements.length ] = sprintf(
 				// translators: %s is formatted number of views
-				_n( '%s impressions', '%s impression', impressions_total ),
+				_n( '%s impression', '%s impressions', impressions_total ),
 				formatNumber( impressions_total )
 			);
 		}
@@ -92,7 +92,7 @@ export default function CampaignItem( props: Props ) {
 		if ( clicks_total > 0 ) {
 			statElements[ statElements.length ] = sprintf(
 				// translators: %s is formatted number of clicks
-				_n( '%s clicks', '%s click', clicks_total ),
+				_n( '%s click', '%s clicks', clicks_total ),
 				formatNumber( clicks_total )
 			);
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes
* Use the right order for `_n` function parameters for clicks and impressions

<img width="377" alt="Screenshot 2023-06-13 at 21 51 55" src="https://github.com/Automattic/wp-calypso/assets/115007291/c3152092-b968-41d1-9530-5b3fc4126a50">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch in your local dev environment
* Build assets (`yarn && yarn start`)
* Pretend you have impressions and clicks by editing `clicks_total` and `impressions_total` default values [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/promote-post-i2/components/campaign-item/index.tsx#L55-L57) like this:
<img width="581" alt="image" src="https://github.com/Automattic/wp-calypso/assets/115007291/f75d4c09-68e9-424e-ab26-a55c7ed55298">

* Open campaigns [page](http://calypso.localhost:3000/advertising/) (`http://calypso.localhost:3000/advertising/YOUR-SITE-URL/campaigns`)
* Change your screen to smaller than `782px`
* Make sure you see correct form for your numbers like: 
  - `9,223` impressions · `111` clicks, or
  - `1` impressions · `1` click

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
