### PR TITLE
Launchpad: Set the correct checklist slug

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -14,9 +14,10 @@ interface LaunchpadKeepBuildingProps {
 
 const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.Element => {
 	const translate = useTranslate();
+	const checklistSlug = 'keep-building';
 	const {
 		data: { checklist },
-	} = useLaunchpad( siteSlug );
+	} = useLaunchpad( siteSlug, checklistSlug );
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
@@ -36,7 +37,7 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 					/>
 				</div>
 			</div>
-			<Launchpad siteSlug={ siteSlug } />
+			<Launchpad siteSlug={ siteSlug } checklistSlug={ checklistSlug } />
 		</div>
 	);
 };


### PR DESCRIPTION
## Proposed Changes

* Start using the right checklist in the Launchpad component (in the customer home)

## Testing Instructions

* Open the customer home and see if the right checklist is shown

![image](https://github.com/Automattic/wp-calypso/assets/3801502/1c7c266b-b4aa-4951-bed1-b2f7b57508ef)
