### PR TITLE
Reader: use correct editor url for sharing posts

### DIFF
--- a/client/state/selectors/should-load-gutenframe.js
+++ b/client/state/selectors/should-load-gutenframe.js
@@ -1,8 +1,17 @@
+import { isJetpackSite } from '@automattic/data-stores/src/site/selectors';
 import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
 import { getPreferredEditorView } from 'calypso/state/selectors/get-preferred-editor-view';
+import isSSOEnabled from 'calypso/state/sites/selectors/is-sso-enabled';
 
-export const shouldLoadGutenframe = ( state, siteId, postType = 'post' ) =>
-	isEligibleForGutenframe( state, siteId ) &&
-	getPreferredEditorView( state, siteId, postType ) === 'default';
+export const shouldLoadGutenframe = ( state, siteId, postType = 'post' ) => {
+	if ( isJetpackSite( state, siteId ) && ! isSSOEnabled( state, siteId ) ) {
+		return false;
+	}
+
+	return (
+		isEligibleForGutenframe( state, siteId ) &&
+		getPreferredEditorView( state, siteId, postType ) === 'default'
+	);
+};
 
 export default shouldLoadGutenframe;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/78014

## Proposed Changes

* Update the `shouldLoadGutenframe` selector to account for Jetpack sites that don't support SSO and so can't use Gutenframe
* Determine the correct editor url for a site when sharing a post from Reader, so we don't have to take the extra time for Gutenframe to redirect.

Combined, this fixes an issue with Jetpack sites that don't support SSO, when sharing a post from Reader.

## Testing Instructions

- Set up an Atomic or Jetpack site and turn off SSO from the Jetpack settings
- Go to `/read` and click on the Share arrow below a post
- Select the non-SSO site
- Verify that you end up with a new post on the selected site that has an embed link to the post from Reader
