### PR TITLE
Adds the campaign stats to the Advertising campaign list

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -148,9 +148,8 @@ export default function CampaignItem( props: Props ) {
 				{ getCampaignEndText( moment, campaign.status, campaign.end_date ) }
 			</td>
 			<td className="campaign-item__budget">{ budgetString }</td>
-			{ /* TODO: Return these columns back when backend is ready to provide the data */ }
-			{ /* <td className="campaign-item__impressions">{ formatNumber( impressions_total ) }</td> */ }
-			{ /* <td className="campaign-item__clicks">{ formatNumber( clicks_total ) }</td> */ }
+			<td className="campaign-item__impressions">{ formatNumber( impressions_total ) }</td>
+			<td className="campaign-item__clicks">{ formatNumber( clicks_total ) }</td>
 			<td className="campaign-item__action">
 				{ campaignContainsData && <Button href={ openCampaignURL } isLink icon={ chevronRight } /> }
 			</td>

--- a/client/my-sites/promote-post-i2/components/campaigns-table/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/index.tsx
@@ -57,14 +57,14 @@ export default function CampaignsTable( props: Props ) {
 			key: 'budget',
 			title: translate( 'Budget' ),
 		},
-		/* { TODO: Return these columns when backend is ready to populate the data
+		{
 			key: 'impressions',
 			title: translate( 'Impressions' ),
 		},
 		{
 			key: 'clicks',
 			title: translate( 'Clicks' ),
-		}, */
+		},
 		{
 			key: 'action',
 			title: '',

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -3,13 +3,14 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { Campaign } from 'calypso/data/promote-post/types';
 import useCampaignsQueryPaged from 'calypso/data/promote-post/use-promote-post-campaigns-query-paged';
+import useCampaignsStatsQuery from 'calypso/data/promote-post/use-promote-post-campaigns-stats-query';
 import useCreditBalanceQuery from 'calypso/data/promote-post/use-promote-post-credit-balance-query';
 import usePostsQueryPaged from 'calypso/data/promote-post/use-promote-post-posts-query-paged';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -17,7 +18,7 @@ import CampaignsList from 'calypso/my-sites/promote-post-i2/components/campaigns
 import PostsList from 'calypso/my-sites/promote-post-i2/components/posts-list';
 import PromotePostTabBar from 'calypso/my-sites/promote-post-i2/components/promoted-post-filter';
 import { SearchOptions } from 'calypso/my-sites/promote-post-i2/components/search-bar';
-import { getPagedBlazeSearchData } from 'calypso/my-sites/promote-post-i2/utils';
+import { getPagedBlazeSearchData, unifyCampaigns } from 'calypso/my-sites/promote-post-i2/utils';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import CreditBalance from './components/credit-balance';
@@ -88,9 +89,15 @@ export default function PromotedPosts( { tab }: Props ) {
 		'',
 	] );
 
-	const { has_more_pages: campaignsHasMorePages, items: campaigns } = getPagedBlazeSearchData(
+	const { has_more_pages: campaignsHasMorePages, items: pagedCampaigns } = getPagedBlazeSearchData(
 		'campaigns',
 		campaignsData
+	);
+
+	const { data: campaignsStatsData } = useCampaignsStatsQuery( selectedSiteId ?? 0 );
+	const campaigns = useMemo(
+		() => unifyCampaigns( pagedCampaigns as Campaign[], campaignsStatsData ),
+		[ pagedCampaigns, campaignsStatsData ]
 	);
 
 	const { total_items: totalCampaignsUnfiltered } = getPagedBlazeSearchData(

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
-import { Campaign } from 'calypso/data/promote-post/types';
+import { Campaign, CampaignStats } from 'calypso/data/promote-post/types';
 import {
 	PagedBlazeContentData,
 	PagedBlazeSearchResponse,
@@ -213,3 +213,23 @@ export function getAdvertisingDashboardPath( path: string ) {
 	const pathPrefix = config( 'advertising_dashboard_path_prefix' ) || '/advertising';
 	return `${ pathPrefix }${ path }`;
 }
+
+/**
+ * Unifies the campaign list with the stats list
+ *
+ * @param {Campaign[]} campaigns List of campaigns
+ * @param {CampaignStats[]} campaignsStats List of campaign stats
+ * @returns A unified list of campaign with the stats
+ */
+export const unifyCampaigns = (
+	campaigns: Campaign[] = [],
+	campaignsStats: CampaignStats[] = []
+) => {
+	return campaigns.map( ( campaign ) => {
+		const stats = campaignsStats.find( ( cs ) => cs.campaign_id === campaign.campaign_id );
+		return {
+			...campaign,
+			...( stats ? stats : {} ),
+		};
+	} );
+};


### PR DESCRIPTION
Related to SELFSERVE-554

We are not showing the stats of a campaign in the new Advertising redesign because the backend cannot send that information because of a performance issue. While we discussed what approach to fix the backend, I am changing to use the same endpoint we use in prod to get the stats.

## Proposed Changes

Change the Advertising page to call the `/stats` endpoint to get the campaign's stats. This is a temporary solution until we fix the backend. I made the code as easy as possible to remove in the future.

This is how the page looks now with the new stats:
![Screenshot 2023-06-13 at 17 29 43](https://github.com/Automattic/wp-calypso/assets/1258162/3badc349-855d-485b-94fa-77b5080bbe7b)

![Screenshot 2023-06-13 at 17 42 17](https://github.com/Automattic/wp-calypso/assets/1258162/0992a4af-32ec-4211-aa0c-c3e9cfee493e)

## Testing Instructions

* Open the Live preview
* Click on Tools->Advertising
* Click on Campaigns in the navigation bar
* Verify that the new columns impressions and clicks are displayed
* Shrink your screen and verify that the impressions an clicks are displayed correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
