### PR TITLE
Switch yarn frozen lockfile to immutable flag

### DIFF
--- a/.github/workflows/editing-toolkit-plugin.yml
+++ b/.github/workflows/editing-toolkit-plugin.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile # Not needed when restoring from cache.
+        run: yarn install --immutable # Not needed when restoring from cache.
 
       - name: Build packages
         if: steps.cache.outputs.cache-hit == 'true'

--- a/bin/install-if-no-packages.js
+++ b/bin/install-if-no-packages.js
@@ -3,7 +3,7 @@ const fs = require( 'fs' );
 
 if ( ! fs.existsSync( 'node_modules' ) ) {
 	console.log( 'No "node_modules" present, installing dependencies…' );
-	const installResult = spawnSync( 'yarn', [ 'install', '--frozen-lockfile' ], {
+	const installResult = spawnSync( 'yarn', [ 'install', '--immutable' ], {
 		shell: true,
 		stdio: 'inherit',
 		env: { ...process.env },

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -7,7 +7,7 @@ WordPress.com for Desktop is an [Electron](https://github.com/atom/electron) wra
 The steps marked _Production\*_ can be omitted but should be taken when building the production version of the app.
 
 1. Clone the Calypso repository locally
-1. Install all root level dependencies with `yarn` or `yarn install --frozen-lockfile`
+1. Install all root level dependencies with `yarn`
 1. Export the environment variables:
    - _Production\*_: `CONFIG_ENV` (set to `release`)
    - _Production\*_: `CALYPSO_SECRETS_ENCRYPTION_KEY` (it's a secret!)

--- a/docs/lockfile.md
+++ b/docs/lockfile.md
@@ -13,5 +13,5 @@ Yarn will automattically generate and update the lock file whenever `yarn`, `yar
 To verify that the new `yarn.lock` works:
 
 - Run `yarn run distclean` to delete local `node_modules`
-- Run `yarn install --frozen-lockfile`
+- Run `yarn install --immutable`
 - Verify that Calypso works as expected and that tests pass

--- a/test/e2e/docs/setup.md
+++ b/test/e2e/docs/setup.md
@@ -9,9 +9,9 @@
 <!-- TOC -->
 
 - [Setup](#setup)
-    - [Regular setup](#regular-setup)
-    - [Apple Silicon emulated x86_64](#apple-silicon-emulated-x86_64)
-    - [Apple Silicon arm64](#apple-silicon-arm64)
+  - [Regular setup](#regular-setup)
+  - [Apple Silicon emulated x86_64](#apple-silicon-emulated-x86_64)
+  - [Apple Silicon arm64](#apple-silicon-arm64)
 
 <!-- /TOC -->
 
@@ -65,7 +65,7 @@ arch -x86_64 npm install yarn
 7. install all dependencies from repo root:
 
 ```
-arch -x86_64 yarn install --frozen-lockfile
+arch -x86_64 yarn install --immutable
 ```
 
 At any point, run `arch` to verify whether shell is running with Rosetta 2 emulation.


### PR DESCRIPTION
Yarn frozen lockfile has been deprecated -- this just tweaks everywhere we mentioned it to use `--immutable` instead, which does the same thing. (I think in the current version of yarn, frozen lockfile is just an alias for that until it's removed.)