### PR TITLE
VideoPress onboarding: Fix styling and site options input

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/videopress-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/videopress-site-options.tsx
@@ -66,9 +66,9 @@ export const VideoPressSiteOptions = ( { navigation }: Pick< StepProps, 'navigat
 
 		switch ( inputName ) {
 			case 'siteTitle':
-				return setSiteTitle( event.currentTarget.value.trim() );
+				return setSiteTitle( event.currentTarget.value );
 			case 'tagline':
-				return setTagline( event.currentTarget.value.trim() );
+				return setTagline( event.currentTarget.value );
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -107,13 +107,15 @@ body.is-videopress-stepper {
 			}
 
 			button.is-primary,
-			button.launchpad__checklist-primary-button {
+			button.launchpad__checklist-primary-button,
+			button.checklist-item__checklist-primary-button {
 				color: $videopress-theme-background-color;
 				background-color: $videopress-theme-yellow;
 				border-color: $videopress-theme-yellow;
 			}
 
-			button.launchpad__checklist-primary-button[disabled] {
+			button.launchpad__checklist-primary-button[disabled],
+			button.checklist-item__checklist-primary-button[disabled] {
 				color: var(--studio-gray-30);
 				background-color: rgba(255, 255, 255, 0.1);
 				border-color: rgba(255, 255, 255, 0.1);
@@ -181,7 +183,14 @@ body.is-videopress-stepper {
 			}
 		}
 
-		.launchpad__checklist-item {
+		.checklist-item__task:nth-last-child(2) {
+			.checklist-item__task-content {
+				border-bottom: none;
+			}
+		}
+
+		.launchpad__checklist-item,
+		.checklist-item__task-content {
 			color: $videopress-theme-base-text-color;
 			border-bottom: 1px solid rgba(255, 255, 255, 0.2);
 
@@ -192,11 +201,13 @@ body.is-videopress-stepper {
 			}
 
 			&[disabled] {
-				.launchpad__checklist-item-text {
+				.launchpad__checklist-item-text,
+				.checklist-item__text {
 					color: $videopress-theme-header-subtitle-text-color;
 				}
 
-				.launchpad__checklist-item-checkmark {
+				.launchpad__checklist-item-checkmark,
+				.checklist-item__checkmark {
 					fill: $videopress-theme-header-subtitle-text-color;
 				}
 			}
@@ -242,15 +253,18 @@ body.is-videopress-stepper {
 			}
 		}
 
-		.launchpad__checklist-item-chevron {
+		.launchpad__checklist-item-chevron,
+		.checklist-item__chevron {
 			align-self: center;
 		}
 
-		.launchpad__task.pending .launchpad__checklist-item {
+		.launchpad__task.pending .launchpad__checklist-item,
+		.checklist-item__task.pending .checklist-item__task-content {
 			padding-left: 44px;
 		}
 
-		.launchpad__task.pending .launchpad__checklist-item-chevron {
+		.launchpad__task.pending .launchpad__checklist-item-chevron,
+		.checklist-item__task.pending .checklist-item__chevron {
 			color: #fff;
 			fill: #fff;
 		}
@@ -264,12 +278,23 @@ body.is-videopress-stepper {
 		.launchpad__task.completed.enabled:hover .launchpad__checklist-item-text,
 		.launchpad__task.completed.enabled:hover .launchpad__checklist-item-checkmark,
 		.button.launchpad__checklist-item:hover:not([disabled]),
-		.button.launchpad__checklist-item:focus:not([disabled]) {
+		.button.launchpad__checklist-item:focus:not([disabled]),
+		.checklist-item__task.pending:hover .checklist-item__task-content:not([disabled]) .checklist-item__text,
+		.checklist-item__task.pending .checklist-item__task-content:not([disabled]) > a:focus .checklist-item__text,
+		.checklist-item__task.pending:hover .checklist-item__task-content:not([disabled]) .checklist-item__chevron,
+		.checklist-item__task.pending:hover .checklist-item__task-content:not([disabled]) .checklist-item__checkmark,
+		.checklist-item__task.pending > a:focus .checklist-item__task-content:not([disabled]) .checklist-item__chevron,
+		.checklist-item__task.pending > a:focus .checklist-item__task-content:not([disabled]) .checklist-item__checkmark,
+		.checklist-item__task.completed.enabled:hover .checklist-item__text,
+		.checklist-item__task.completed.enabled:hover .checklist-item__checkmark,
+		.button.checklist-item__task-content:hover:not([disabled]),
+		.button.checklist-item__task-content:focus:not([disabled]) {
 			color: $videopress-theme-yellow;
 			fill: $videopress-theme-yellow;
 		}
 
-		.launchpad__task.completed.enabled {
+		.launchpad__task.completed.enabled,
+		.checklist-item__task.completed.enabled {
 			&:hover {
 				.badge {
 					background-color: $videopress-theme-yellow;
@@ -278,11 +303,13 @@ body.is-videopress-stepper {
 				}
 			}
 
-			.launchpad__checklist-item-text {
+			.launchpad__checklist-item-text,
+			.checklist-item__text {
 				color: $videopress-theme-header-subtitle-text-color;
 			}
 
-			.launchpad__checklist-item-checkmark {
+			.launchpad__checklist-item-checkmark,
+			.checklist-item__checkmark {
 				fill: $videopress-theme-header-subtitle-text-color;
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* fix css styling on VideoPress onboarding flow after classname changes to "launchpad checklist" items
* fix trimming that was occurring in the `onchange` event for the site options page (cc @zaguiini incase you were trying to fix an issue that I should address some other way with the addition of `.trim()` in the `onchange` event here)
* css class names were added instead of edited incase the checklist class name change that prompted these changes are reverted in the future (just trying to be proactive about not needing to address this again)

<img width="436" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4081020/ebb5c0e7-8591-42e6-bb62-0c4698603ace">

<img width="435" alt="SCR-20230613-pidc" src="https://github.com/Automattic/wp-calypso/assets/4081020/d0f235d5-e5c0-4dc4-8f9e-ee0529db4711">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* pull pr and `yarn && yarn start` OR use one of the prebuild images on the PR
* visit `/setup/videopress`
* Follow steps until Site Options
* Ensure you are allowed to type a space while typing in the site name and description fields
* continue through the flow, pay and then stop at the Launchpad
* Ensure the colours match the designs
* proceed to upload a video (click the checklist item for `Upload your first video`, edit an existing video in the editor and upload a video. Then press `Update` in the editor)
* In the celebration modal click "Return to launchpad" (or equivalent button -- I don't remember the text exactly 😄 )
* if you were using local testing url, edit the URL to return to `calypso.localhost:3000` otherwise you are probably currently looking at the staging site, not this branch
* When you return to the dashboard, ensure that the Launch button is VideoPress yellow and not blue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
