### PR TITLE
remove redirect to en.search.wordpress.com

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -692,6 +692,13 @@ function wpcomPages( app ) {
 			next();
 		}
 	} );
+	app.get( '/read/search', function ( req, res, next ) {
+		if ( ! req.context.isLoggedIn && calypsoEnv === 'production' ) {
+			res.redirect( 'https://en.search.wordpress.com/?q=' + encodeURIComponent( req.query.q ) );
+		} else {
+			next();
+		}
+	} );
 
 	app.get( '/plans', function ( req, res, next ) {
 		if ( ! req.context.isLoggedIn ) {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -391,7 +391,9 @@ function setUpLoggedInRoute( req, res, next ) {
 				if ( req.path === '/' && req.query ) {
 					const searchParam = req.query.s || req.query.q;
 					if ( searchParam ) {
-						res.redirect( '/read/search?q=' + encodeURIComponent( searchParam ) );
+						res.redirect(
+							'https://wordpress.com/read/search?q=' + encodeURIComponent( searchParam )
+						);
 						return;
 					}
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -391,12 +391,7 @@ function setUpLoggedInRoute( req, res, next ) {
 				if ( req.path === '/' && req.query ) {
 					const searchParam = req.query.s || req.query.q;
 					if ( searchParam ) {
-						res.redirect(
-							'https://' +
-								req.context.lang +
-								'.search.wordpress.com/?q=' +
-								encodeURIComponent( searchParam )
-						);
+						res.redirect( '/read/search?q=' + encodeURIComponent( searchParam ) );
 						return;
 					}
 
@@ -691,15 +686,6 @@ function wpcomPages( app ) {
 	app.get( '/discover', function ( req, res, next ) {
 		if ( ! req.context.isLoggedIn ) {
 			res.redirect( config( 'discover_logged_out_redirect_url' ) );
-		} else {
-			next();
-		}
-	} );
-
-	// redirect logged-out searches to en.search.wordpress.com
-	app.get( '/read/search', function ( req, res, next ) {
-		if ( ! req.context.isLoggedIn && calypsoEnv !== 'development' ) {
-			res.redirect( 'https://en.search.wordpress.com/?q=' + encodeURIComponent( req.query.q ) );
 		} else {
 			next();
 		}

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1016,17 +1016,6 @@ describe( 'main app', () => {
 		} );
 	} );
 
-	describe( 'Route /read/search', () => {
-		it( 'redirects to public search for anonymous users', async () => {
-			const { response } = await app.run( {
-				request: { url: '/read/search', query: { q: 'my query' } },
-			} );
-			expect( response.redirect ).toHaveBeenCalledWith(
-				'https://en.search.wordpress.com/?q=my%20query'
-			);
-		} );
-	} );
-
 	describe( 'Route /plans', () => {
 		it( 'redirects to login if the request is for jetpack', async () => {
 			const { response } = await app.run( {
@@ -1203,7 +1192,7 @@ describe( 'main app', () => {
 				} );
 
 				expect( response.redirect ).toHaveBeenCalledWith(
-					'https://en.search.wordpress.com/?q=my%20search'
+					'https://wordpress.com/read/search?q=my%20search'
 				);
 			} );
 
@@ -1218,7 +1207,7 @@ describe( 'main app', () => {
 				} );
 
 				expect( response.redirect ).toHaveBeenCalledWith(
-					'https://en.search.wordpress.com/?q=my%20search'
+					'https://wordpress.com/read/search?q=my%20search'
 				);
 			} );
 


### PR DESCRIPTION
Removes redirect so that /read/search will be open to the public.

There is also code that redirects `/?q=$query`. I wasn't able to test this redirection because there are other redirects that seem to intercept it first and redirect the user to their site homepage or to `/devdocs/start` for logged out users or `wordpress.com/$lang/` for logged out non-en users.

for production wordpress.com there may or may not be other redirects in the nginx layer.

#### Testing instructions
in an incognito window /read/search should now be accessible.