### PR TITLE
Hosting Onboarding: Ensure refund periods are promoted in `/setup/new-hosted-site` flow

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -14,6 +14,8 @@ import {
 	isJetpackProduct,
 	isJetpackPlan,
 	isAkismetProduct,
+	planHasFeature,
+	WPCOM_FEATURES_ATOMIC,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
@@ -167,10 +169,14 @@ function CheckoutSummaryFeaturesWrapper( props: {
 } ) {
 	const { siteId, nextDomainIsFree } = props;
 	const signupFlowName = getSignupCompleteFlowName();
-	const shouldUseFlowFeatureList =
-		isNewsletterOrLinkInBioFlow( signupFlowName ) || isAHostingFlow( signupFlowName );
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
+	const planHasHostingFeature = responseCart.products.some( ( product ) =>
+		planHasFeature( product.product_slug, WPCOM_FEATURES_ATOMIC )
+	);
+	const shouldUseFlowFeatureList =
+		isNewsletterOrLinkInBioFlow( signupFlowName ) ||
+		( isAHostingFlow( signupFlowName ) && planHasHostingFeature );
 	const giftSiteSlug = responseCart.gift_details?.receiver_blog_slug;
 
 	if ( responseCart.is_gift_purchase && giftSiteSlug ) {

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -22,7 +22,7 @@ import {
 	FormStatus,
 	useFormStatus,
 } from '@automattic/composite-checkout';
-import { isNewsletterOrLinkInBioFlow, isHostingFlow } from '@automattic/onboarding';
+import { isNewsletterOrLinkInBioFlow, isAHostingFlow } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	getCouponLineItemFromCart,
@@ -168,7 +168,7 @@ function CheckoutSummaryFeaturesWrapper( props: {
 	const { siteId, nextDomainIsFree } = props;
 	const signupFlowName = getSignupCompleteFlowName();
 	const shouldUseFlowFeatureList =
-		isNewsletterOrLinkInBioFlow( signupFlowName ) || isHostingFlow( signupFlowName );
+		isNewsletterOrLinkInBioFlow( signupFlowName ) || isAHostingFlow( signupFlowName );
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const giftSiteSlug = responseCart.gift_details?.receiver_blog_slug;
@@ -399,7 +399,7 @@ function CheckoutSummaryFlowFeaturesList( { flowName }: { flowName: string } ) {
 					</CheckoutSummaryFeaturesListItem>
 				);
 			} ) }
-			{ isHostingFlow( flowName ) && (
+			{ isAHostingFlow( flowName ) && (
 				<CheckoutSummaryRefundWindows cart={ responseCart } highlight />
 			) }
 		</CheckoutSummaryFeaturesListWrapper>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -24,7 +24,7 @@ import {
 	FormStatus,
 	useFormStatus,
 } from '@automattic/composite-checkout';
-import { isNewsletterOrLinkInBioFlow, isAHostingFlow } from '@automattic/onboarding';
+import { isNewsletterOrLinkInBioFlow, isAnyHostingFlow } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	getCouponLineItemFromCart,
@@ -176,7 +176,7 @@ function CheckoutSummaryFeaturesWrapper( props: {
 	);
 	const shouldUseFlowFeatureList =
 		isNewsletterOrLinkInBioFlow( signupFlowName ) ||
-		( isAHostingFlow( signupFlowName ) && planHasHostingFeature );
+		( isAnyHostingFlow( signupFlowName ) && planHasHostingFeature );
 	const giftSiteSlug = responseCart.gift_details?.receiver_blog_slug;
 
 	if ( responseCart.is_gift_purchase && giftSiteSlug ) {
@@ -405,7 +405,7 @@ function CheckoutSummaryFlowFeaturesList( { flowName }: { flowName: string } ) {
 					</CheckoutSummaryFeaturesListItem>
 				);
 			} ) }
-			{ isAHostingFlow( flowName ) && (
+			{ isAnyHostingFlow( flowName ) && (
 				<CheckoutSummaryRefundWindows cart={ responseCart } highlight />
 			) }
 		</CheckoutSummaryFeaturesListWrapper>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -35,7 +35,7 @@ import {
 	WooLogo,
 } from '@automattic/components';
 import {
-	isAHostingFlow,
+	isAnyHostingFlow,
 	isLinkInBioFlow,
 	isNewsletterFlow,
 	isBlogOnboardingFlow,
@@ -724,7 +724,7 @@ export class PlanFeatures2023Grid extends Component<
 	maybeRenderRefundNotice( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
 		const { translate, flowName } = this.props;
 
-		if ( ! isAHostingFlow( flowName ) ) {
+		if ( ! isAnyHostingFlow( flowName ) ) {
 			return false;
 		}
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -736,17 +736,19 @@ export class PlanFeatures2023Grid extends Component<
 					className="plan-features-2023-grid__table-item"
 					isMobile={ options?.isMobile }
 				>
-					<div
-						className={ `plan-features-2023-grid__refund-notice ${ getPlanClass(
-							planProperties.planName
-						) }` }
-					>
-						{ translate( 'Refundable within %(dayCount)s days. No questions asked.', {
-							args: {
-								dayCount: planProperties.billingPeriod === 365 ? 14 : 7,
-							},
-						} ) }
-					</div>
+					{ ! isFreePlan( planProperties.planName ) && (
+						<div
+							className={ `plan-features-2023-grid__refund-notice ${ getPlanClass(
+								planProperties.planName
+							) }` }
+						>
+							{ translate( 'Refundable within %(dayCount)s days. No questions asked.', {
+								args: {
+									dayCount: planProperties.billingPeriod === 365 ? 14 : 7,
+								},
+							} ) }
+						</div>
+					) }
 				</Container>
 			) );
 	}

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -35,7 +35,7 @@ import {
 	WooLogo,
 } from '@automattic/components';
 import {
-	isHostingFlow,
+	isAHostingFlow,
 	isLinkInBioFlow,
 	isNewsletterFlow,
 	isBlogOnboardingFlow,
@@ -724,7 +724,7 @@ export class PlanFeatures2023Grid extends Component<
 	maybeRenderRefundNotice( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
 		const { translate, flowName } = this.props;
 
-		if ( ! isHostingFlow( flowName ) ) {
+		if ( ! isAHostingFlow( flowName ) ) {
 			return false;
 		}
 

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1076,6 +1076,14 @@ body.is-section-signup.is-white-signup,
 	font-size: $font-body-extra-small;
 	line-height: 16px;
 
+	&.is-personal-plan {
+		color: var(--studio-blue-60);
+	}
+
+	&.is-premium-plan {
+		color: #004687;
+	}
+
 	&.is-business-plan {
 		color: #7f54b3;
 	}

--- a/client/my-sites/plan-features-comparison/util.ts
+++ b/client/my-sites/plan-features-comparison/util.ts
@@ -2,7 +2,7 @@ import { IncompleteWPcomPlan } from '@automattic/calypso-products';
 import {
 	NEWSLETTER_FLOW,
 	isLinkInBioFlow,
-	isHostingFlow,
+	isAHostingFlow,
 	isNewsletterOrLinkInBioFlow,
 	isBlogOnboardingFlow,
 } from '@automattic/onboarding';
@@ -16,7 +16,7 @@ const linkInBioFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
 };
 
 const hostingFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
-	return isHostingFlow( flowName ) && plan.getHostingSignupFeatures?.( plan.term );
+	return isAHostingFlow( flowName ) && plan.getHostingSignupFeatures?.( plan.term );
 };
 
 const blogOnboardingFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {

--- a/client/my-sites/plan-features-comparison/util.ts
+++ b/client/my-sites/plan-features-comparison/util.ts
@@ -2,7 +2,7 @@ import { IncompleteWPcomPlan } from '@automattic/calypso-products';
 import {
 	NEWSLETTER_FLOW,
 	isLinkInBioFlow,
-	isAHostingFlow,
+	isAnyHostingFlow,
 	isNewsletterOrLinkInBioFlow,
 	isBlogOnboardingFlow,
 } from '@automattic/onboarding';
@@ -16,7 +16,7 @@ const linkInBioFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
 };
 
 const hostingFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
-	return isAHostingFlow( flowName ) && plan.getHostingSignupFeatures?.( plan.term );
+	return isAnyHostingFlow( flowName ) && plan.getHostingSignupFeatures?.( plan.term );
 };
 
 const blogOnboardingFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,4 +1,4 @@
-import { VIDEOPRESS_FLOW, isWithThemeFlow, isHostingFlow } from '@automattic/onboarding';
+import { VIDEOPRESS_FLOW, isWithThemeFlow, isHostingSignupFlow } from '@automattic/onboarding';
 import { isTailoredSignupFlow } from '@automattic/onboarding/src';
 import { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
@@ -611,7 +611,7 @@ class DomainsStep extends Component {
 		);
 	};
 
-	isHostingFlow = () => isHostingFlow( this.props.flowName );
+	isHostingFlow = () => isHostingSignupFlow( this.props.flowName );
 
 	getSubHeaderText() {
 		const { flowName, isAllDomains, stepSectionName, isReskinned, translate } = this.props;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -68,7 +68,7 @@ export const isTailoredSignupFlow = ( flowName: string | null ) => {
 	);
 };
 
-export const isHostingFlow = ( flowName: string | null ) => {
+export const isHostingSignupFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && HOSTING_LP_FLOW === flowName );
 };
 
@@ -78,6 +78,13 @@ export const isNewHostedSiteCreationFlow = ( flowName: string | null ) => {
 
 export const isTransferringHostedSiteCreationFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && TRANSFERRING_HOSTED_SITE_FLOW === flowName );
+};
+
+export const isAHostingFlow = ( flowName: string | null ) => {
+	return Boolean(
+		flowName &&
+			[ HOSTING_LP_FLOW, NEW_HOSTED_SITE_FLOW, TRANSFERRING_HOSTED_SITE_FLOW ].includes( flowName )
+	);
 };
 
 export const isMigrationFlow = ( flowName: string | null ) => {

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -80,7 +80,7 @@ export const isTransferringHostedSiteCreationFlow = ( flowName: string | null ) 
 	return Boolean( flowName && TRANSFERRING_HOSTED_SITE_FLOW === flowName );
 };
 
-export const isAHostingFlow = ( flowName: string | null ) => {
+export const isAnyHostingFlow = ( flowName: string | null ) => {
 	return Boolean(
 		flowName &&
 			[ HOSTING_LP_FLOW, NEW_HOSTED_SITE_FLOW, TRANSFERRING_HOSTED_SITE_FLOW ].includes( flowName )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

We introduced some modifications in the hosting onboarding i1 project which emphasised the refund window. We don't want to lose those changes in this iteration of the flow pet6gk-qP-p2

The PR also takes the opportunity to refactor some of our function names now that the overall hosting flow is technically made up of multiple sub-flows.

* Renames `isHostingFlow` to `isHostingSignupFlow` to disambiguate it from the other "hosting" flows we have now
* Create a new `isAHostingFlow` function which returns true for any of the "hosting" flows. This name feels pretty clumsy to me but I couldn't come up with anything better. **Suggestions welcome!!**
* Ensure the pricing grid shows the refund window for any hosting flow
* Ensure the checkout feature list shows hosting related features (e.g. SSH etc.)
* Ensure the checkout feature list emphasises the refund window for any hosting flow

The naming is still a little confusing to me, because the `/setup/new-hosted-site` flow is now used for non-"hosted" site creation too. Which is why there's an extra check in the checkout code before showing the hosted features in the checklist.

Note that the plans step in `/setup/new-hosted-site` shows the refund window under the non-WoA plans too. Nothing wrong with that, and probably good for symmetry. But just noting that this wasn't something that happened before because i1 didn't show these plans.
![CleanShot 2023-06-14 at 16 31 51@2x](https://github.com/Automattic/wp-calypso/assets/1500769/105b31de-f6e7-4262-aa91-d97c42bc1300)

![CleanShot 2023-06-14 at 16 37 55@2x](https://github.com/Automattic/wp-calypso/assets/1500769/3826298b-da4d-4012-84c7-fa9f303b2c2f)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With `hosting-onboarding-i2` flag disabled
   * `/start/hosting`
   * Domain step should still be skippable and have custom copy about "your next project"
   * Plans step still emphasises refund window
   * Checkout shows hosting features and the refund window is bold
* With `hosting-onboarding-i2` flag enabled
   * `/setup/new-hosted-site`
   * Plans step now emphasises refund window
   * Choose the Business plan
      * Checkout shows hosting features and the refund window is bold
   * Choose a plan lower than Business
      * Checkout doesn't show hosting features

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?