### PR TITLE
Hide ThankYouModal when redirecting to `/marketplace/thank-you`

### DIFF
--- a/client/my-sites/themes/test/thanks-modal.jsx
+++ b/client/my-sites/themes/test/thanks-modal.jsx
@@ -8,7 +8,11 @@ import { createReduxStore } from 'calypso/state';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
 import { setStore } from 'calypso/state/redux-store';
 import { receiveSite } from 'calypso/state/sites/actions';
-import { receiveTheme, themeActivated } from 'calypso/state/themes/actions';
+import {
+	receiveTheme,
+	themeActivated,
+	showAutoLoadingHomepageWarning,
+} from 'calypso/state/themes/actions';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import ThanksModal from '../thanks-modal';
 
@@ -90,6 +94,27 @@ describe( 'thanks-modal', () => {
 
 				expect( editSiteCallToAction ).toBeInTheDocument();
 				expect( editSiteCallToAction.closest( 'a' ) ).toHaveAttribute( 'href', encodedURL );
+			} );
+		} );
+	} );
+
+	describe( 'when activating an FSE AND Dotcom theme', () => {
+		test( 'does not display the modal since it will redirect to `/marketplace/thank-you`', async () => {
+			const store = setupStore( {
+				theme: {
+					...defaultTheme,
+					taxonomies: {
+						theme_feature: [ fseThemeFeature ],
+					},
+				},
+			} );
+			store.dispatch( showAutoLoadingHomepageWarning( defaultTheme.id ) );
+
+			render( <TestComponent store={ store } /> );
+
+			await waitFor( () => {
+				const editSiteCallToAction = screen.queryByText( 'Customize site' );
+				expect( editSiteCallToAction ).not.toBeInTheDocument();
 			} );
 		} );
 	} );

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -23,7 +23,9 @@ import {
 	isActivatingTheme,
 	isInstallingTheme,
 	isWpcomTheme,
+	getPreActivateThemeId,
 } from 'calypso/state/themes/selectors';
+import { shouldRedirectToThankYouPage } from 'calypso/state/themes/selectors/should-show-thank-you-page';
 import { themeHasAutoLoadingHomepage } from 'calypso/state/themes/selectors/theme-has-auto-loading-homepage';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { trackClick } from './helpers';
@@ -64,6 +66,12 @@ class ThanksModal extends Component {
 	}
 
 	static getDerivedStateFromProps( nextProps, prevState ) {
+		if ( nextProps.shouldRedirectToThankYouPage ) {
+			return {
+				isVisible: false,
+				wasInstalling: false,
+			};
+		}
 		if ( nextProps.isInstalling || nextProps.isActivating || nextProps.hasActivated ) {
 			return {
 				isVisible: true,
@@ -347,6 +355,8 @@ const ConnectedThanksModal = connect(
 				  )
 				: getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId, isFSEActive );
 
+		const installingThemeId = getPreActivateThemeId( state );
+
 		return {
 			siteId,
 			siteUrl,
@@ -358,6 +368,7 @@ const ConnectedThanksModal = connect(
 				siteId
 			),
 			shouldEditHomepageWithGutenberg,
+			shouldRedirectToThankYouPage: shouldRedirectToThankYouPage( state, installingThemeId ),
 			detailsUrl: getThemeDetailsUrl( state, currentThemeId, siteId ),
 			customizeUrl,
 			forumUrl: getThemeForumUrl( state, currentThemeId, siteId ),

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -25,7 +25,7 @@ import {
 	isWpcomTheme,
 	getPreActivateThemeId,
 } from 'calypso/state/themes/selectors';
-import { shouldRedirectToThankYouPage } from 'calypso/state/themes/selectors/should-show-thank-you-page';
+import { shouldRedirectToThankYouPage } from 'calypso/state/themes/selectors/should-redirect-to-thank-you-page';
 import { themeHasAutoLoadingHomepage } from 'calypso/state/themes/selectors/theme-has-auto-loading-homepage';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { trackClick } from './helpers';

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -23,7 +23,6 @@ import {
 	isActivatingTheme,
 	isInstallingTheme,
 	isWpcomTheme,
-	getPreActivateThemeId,
 } from 'calypso/state/themes/selectors';
 import { shouldRedirectToThankYouPage } from 'calypso/state/themes/selectors/should-redirect-to-thank-you-page';
 import { themeHasAutoLoadingHomepage } from 'calypso/state/themes/selectors/theme-has-auto-loading-homepage';
@@ -355,7 +354,7 @@ const ConnectedThanksModal = connect(
 				  )
 				: getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId, isFSEActive );
 
-		const installingThemeId = getPreActivateThemeId( state );
+		const activatingThemeId = state.themes.activationRequests?.themeId;
 
 		return {
 			siteId,
@@ -368,7 +367,7 @@ const ConnectedThanksModal = connect(
 				siteId
 			),
 			shouldEditHomepageWithGutenberg,
-			shouldRedirectToThankYouPage: shouldRedirectToThankYouPage( state, installingThemeId ),
+			shouldRedirectToThankYouPage: shouldRedirectToThankYouPage( state, activatingThemeId ),
 			detailsUrl: getThemeDetailsUrl( state, currentThemeId, siteId ),
 			customizeUrl,
 			forumUrl: getThemeForumUrl( state, currentThemeId, siteId ),

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -16,7 +16,7 @@ import {
 	isExternallyManagedTheme,
 } from 'calypso/state/themes/selectors';
 import 'calypso/state/themes/init';
-import { shouldRedirectToThankYouPage } from '../selectors/should-show-thank-you-page';
+import { shouldRedirectToThankYouPage } from 'calypso/state/themes/selectors/should-redirect-to-thank-you-page';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -14,10 +14,9 @@ import {
 	themeHasAutoLoadingHomepage,
 	wasAtomicTransferDialogAccepted,
 	isExternallyManagedTheme,
-	doesThemeBundleSoftwareSet,
 } from 'calypso/state/themes/selectors';
-
 import 'calypso/state/themes/init';
+import { shouldRedirectToThankYouPage } from '../selectors/should-show-thank-you-page';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -85,8 +84,6 @@ export function activate(
 		 *
 		 * Currently a feature flag check is also being applied.
 		 */
-		const isExternallyManaged = isExternallyManagedTheme( getState(), themeId );
-		const isWooTheme = doesThemeBundleSoftwareSet( getState(), themeId );
 		const isDotComTheme = !! getTheme( getState(), 'wpcom', themeId );
 		const siteSlug = getSiteSlug( getState(), siteId );
 		const dispatchActivateAction = activateOrInstallThenActivate(
@@ -97,12 +94,7 @@ export function activate(
 			keepCurrentHomepage
 		);
 
-		if (
-			isEnabled( 'themes/display-thank-you-page' ) &&
-			isDotComTheme &&
-			! isWooTheme &&
-			! isExternallyManaged
-		) {
+		if ( shouldRedirectToThankYouPage( getState(), themeId ) ) {
 			dispatchActivateAction( dispatch, getState );
 
 			return page( `/marketplace/thank-you/${ siteSlug }?themes=${ themeId }` );

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -100,11 +100,16 @@ export const activeThemes = withSchemaValidation( activeThemesSchema, ( state = 
 export function activationRequests( state = {}, action ) {
 	switch ( action.type ) {
 		case THEME_ACTIVATE:
+			return {
+				...state,
+				[ action.siteId ]: true,
+				themeId: action.themeId,
+			};
 		case THEME_ACTIVATE_SUCCESS:
 		case THEME_ACTIVATE_FAILURE:
 			return {
 				...state,
-				[ action.siteId ]: THEME_ACTIVATE === action.type,
+				[ action.siteId ]: false,
 			};
 	}
 

--- a/client/state/themes/selectors/should-redirect-to-thank-you-page.js
+++ b/client/state/themes/selectors/should-redirect-to-thank-you-page.js
@@ -1,6 +1,6 @@
 import 'calypso/state/themes/init';
 
-import { getTheme, doesThemeBundleSoftwareSet, isExternallyManagedTheme } from '../selectors';
+import { getTheme, doesThemeBundleSoftwareSet, isExternallyManagedTheme } from '.';
 
 /**
  * Returns whether it should redirect to thank you page

--- a/client/state/themes/selectors/should-show-thank-you-page.js
+++ b/client/state/themes/selectors/should-show-thank-you-page.js
@@ -1,0 +1,18 @@
+import 'calypso/state/themes/init';
+
+import { getTheme, doesThemeBundleSoftwareSet, isExternallyManagedTheme } from '../selectors';
+
+/**
+ * Returns whether it should redirect to thank you page
+ * after to activate a theme.
+ *
+ * @param {Object} state
+ * @param {string} themeId
+ * @returns {boolean}
+ */
+export function shouldRedirectToThankYouPage( state, themeId ) {
+	const isWooTheme = doesThemeBundleSoftwareSet( state, themeId );
+	const isDotComTheme = !! getTheme( state, 'wpcom', themeId );
+	const isExternallyManaged = isExternallyManagedTheme( state, themeId );
+	return isDotComTheme && ! isWooTheme && ! isExternallyManaged;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -196,7 +196,6 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/display-thank-you-page": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/interlaced-dotorg-themes": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -134,7 +134,6 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/display-thank-you-page": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,

--- a/config/production.json
+++ b/config/production.json
@@ -160,7 +160,6 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/display-thank-you-page": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -152,7 +152,6 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/display-thank-you-page": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -165,7 +165,6 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/display-thank-you-page": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/interlaced-dotorg-themes": true,
 		"themes/premium": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/77881, https://github.com/Automattic/dotcom-forge/issues/2222

## Proposed Changes

Hide ThankYouModal when redirecting to `/marketplace/thank-you`. This is a follow-up for https://github.com/Automattic/wp-calypso/pull/77881#issuecomment-1584287672.

Note that we still need ThankYouModal for themes that do not redirect to the `/marketplace/thank-you` page after activation (See `Activating without redirects` in Testing Instructions).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the Theme Showcase page (`/themes/<your-site>`)
- Select a theme
- Activate the theme

Activating with a redirect to `/marketplace/thank-you`

https://github.com/Automattic/wp-calypso/assets/5287479/9ecb0dab-1429-48c7-8afe-65c1392129d6

Activating without redirects (try it with one of the partner themes)

https://github.com/Automattic/wp-calypso/assets/5287479/fcc75d0b-195a-4c2e-8eb8-58a36b509e2f

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

## Other resources

- https://github.com/Automattic/wp-calypso/pull/75546
- https://github.com/Automattic/wp-calypso/pull/75763
- https://miro.com/app/board/uXjVPsA5uiI=/
- paYJgx-2Rv-p2#comment-3102