### PR TITLE
chore: add notice on top of FSE: Limited Global Styles spec about checking for the theme.

### DIFF
--- a/test/e2e/specs/fse/fse__limited-global-styles.ts
+++ b/test/e2e/specs/fse/fse__limited-global-styles.ts
@@ -2,12 +2,18 @@
  * @group gutenberg
  */
 
-import { DataHelper, TestAccount, FullSiteEditorPage } from '@automattic/calypso-e2e';
+import { TestAccount, FullSiteEditorPage } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Site Editor: Limited Global Styles' ), function () {
+/**
+ * Note: test user for this spec requires the use of FSE theme with
+ * style variations (eg. Twenty Twenty-Three).
+ *
+ * @see https://github.com/Automattic/wp-calypso/issues/78107
+ */
+describe( 'Site Editor: Limited Global Styles', function () {
 	let page: Page;
 	let fullSiteEditorPage: FullSiteEditorPage;
 	let testAccount: TestAccount;


### PR DESCRIPTION
Fixes #78107.

## Proposed Changes

This PR adds a debug notice as the first step to check when the spec permafails.

## Testing Instructions

Nothing required, text change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
