### PR TITLE
Hosting onboarding: Remove "start with free" link from `/setup/new-hosted-site` flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -220,6 +220,10 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			return;
 		}
 
+		if ( isNewHostedSiteCreationFlow( flowName ) ) {
+			return translate( 'Welcome to the best place for your WordPress website.' );
+		}
+
 		if ( ! hideFreePlan ) {
 			return translate(
 				`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Removes the "start with free" link from the plans sub heading

When the free plan is in the plans grid we don't need it to appear as a hyperlink in the sub heading too.

We made this change in the Hosting onboarding i1 project, this just ensures the same behaviour in i2. I copied the exact same text over from i1 too, although maybe we should change it up. Saying "Welcome ..." might not be right now that this flow is used for your 2nd or 3rd site too.

**With `?hosting-flow=true`**
![CleanShot 2023-06-14 at 17 51 57@2x](https://github.com/Automattic/wp-calypso/assets/1500769/d5de02ed-d8eb-4765-9e7d-e5118636c70a)

**Without `?hosting-flow=true`**
![CleanShot 2023-06-14 at 17 52 10@2x](https://github.com/Automattic/wp-calypso/assets/1500769/63af94d4-08cf-411a-869c-60dac9934640)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the `/setup/new-hosted-site?hosting-flow=true`
* Test the `/setup/new-hosted-site`
* Test other flows are unchanged like `/setup/link-in-bio`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
