### PR TITLE
Onboarding / launchpad header and page width css fixes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -100,7 +100,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 			<StepContainer
 				stepName="launchpad"
 				goNext={ navigation.goNext }
-				isWideLayout={ true }
+				isFullLayout={ true }
 				skipLabelText={ translate( 'Skip to dashboard' ) }
 				skipButtonAlign="bottom"
 				hideBack={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -6,7 +6,7 @@
 // This is styling common parts of stepper page
 .launchpad {
 	.flow-progress,
-	.step-container__header {
+	.step-container .step-container__header {
 		display: none;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/78071

## Proposed Changes

* Add specificity to override display:block from the onboarding package
* Switch launchpad step layout to full page width from wide.

## Testing Instructions

* User with no sites
* Visit http://calypso.localhost:3000/setup/blog and go through to the design page.
* You should no longer see the page header title after a hard refresh (hot reloading / some build orders can mask the issue)
* Width of the page should now match after screenshot
* Repeat for /setup/start-writing
* Repeat /setup/free flows. 
* Repeat for /start that I think lands back on launchpad after your site is setup.

Before
![Screenshot 2023-06-14 at 16-28-39 Almost ready to launch — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/9ec382d6-5c23-4c66-b7ef-7dac1dad6f6b)

After
![Screenshot 2023-06-14 at 16-39-02 Almost ready to launch — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/05e346e7-f00a-4f36-8ae6-815bdf97a54b)

