### PR TITLE
Enable premium design choices and style variations

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -587,7 +587,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		const selectStyle = () => {
 			if (
 				shouldLimitGlobalStyles &&
-				! isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug )
+				! isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug ) &&
+				! isDesignFirstFlow
 			) {
 				unlockPremiumGlobalStyles();
 			} else {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -128,17 +128,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			}
 		}
 
-		if ( isDesignFirstFlow ) {
-			allDesigns.designs = allDesigns.designs.filter( ( design ) => design.is_premium === false );
-
-			allDesigns.designs = allDesigns.designs.map( ( design ) => {
-				design.style_variations = design.style_variations?.filter( ( variation ) =>
-					isDefaultGlobalStylesVariationSlug( variation.slug )
-				);
-				return design;
-			} );
-		}
-
 		return allDesigns;
 	};
 
@@ -187,10 +176,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const { data: selectedDesignDetails } = useStarterDesignBySlug( selectedDesign?.slug || '', {
 		enabled: isPreviewingDesign && selectedDesignHasStyleVariations,
 	} );
-
-	if ( isDesignFirstFlow && selectedDesignDetails?.style_variations ) {
-		selectedDesignDetails.style_variations = [];
-	}
 
 	const selectedStyleVariation = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedStyleVariation(),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -346,10 +346,14 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			);
 		}
 
-		recordTracksEvent( 'calypso_signup_design_upgrade_modal_show', {
-			theme: selectedDesign?.slug,
-		} );
-		setShowUpgradeModal( true );
+		if ( isDesignFirstFlow ) {
+			// tofix
+		} else {
+			recordTracksEvent( 'calypso_signup_design_upgrade_modal_show', {
+				theme: selectedDesign?.slug,
+			} );
+			setShowUpgradeModal( true );
+		}
 	}
 
 	function closeUpgradeModal() {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -130,7 +130,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 		if ( isDesignFirstFlow ) {
 			allDesigns.designs = allDesigns.designs.filter(
-				( design ) => design.is_bundled_with_woo_commerce === false
+				( design ) => design.is_premium === false && design.is_bundled_with_woo_commerce === false
 			);
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -128,6 +128,12 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			}
 		}
 
+		if ( isDesignFirstFlow ) {
+			allDesigns.designs = allDesigns.designs.filter(
+				( design ) => design.is_bundled_with_woo_commerce === false
+			);
+		}
+
 		return allDesigns;
 	};
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2650

## Proposed Changes

* Reverts select parts of https://github.com/Automattic/wp-calypso/pull/77568 to re-enable paid designs and style variations (probably need the filter part back to do woo)
* Leaves the blog category hard selected

TODO:

- [x] Premium blog themes and custom styles can be selected
- [x] Woocommerce themes remain hidden
- [ ] There is NO modal prompt about upgrading when selecting a premium theme or custom style
- [ ] There is NO immediate checkout when a premium theme or custom style is selected
- [x] There IS a label on the premium theme or custom style showing the plan that is required for that theme or style
- [ ] The user can select a Premium theme or custom style without impediment
- [ ] Once the user reaches the Plans step in the Launchpad (or by selecting a paid domain), any plans that do not support the theme or style they selected (such a free) are hidden from the user.

## Testing Instructions

* [x] New user or one with existing sites deleted
* [x] Visit http://calypso.localhost:3000/setup/blog
* [x] Click through to setting a design
* [ ] You should be able to select a premium theme without being shown a modal
* [ ] ... and be taken back to the launch pad without being taken through the checkout.
* [x] You should be able to select a non default global style variation on a free theme without being shown a modal 
* [x] ... and be taken back to the launch pad without being taken through the checkout.
* [ ] Selecting a plan after choosing a paid design will only show paid plan options

Before

![Screenshot 2023-06-14 at 16-50-33 Pick a design — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/4f236780-8105-4de1-8ff5-cce9f32f10ff)


After 

![Screenshot 2023-06-15 at 15-05-51 Pick a design — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/be675dbb-4880-452c-9be1-adfdbbdacfd7)
