### PR TITLE
Enable public reader search in production.

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -692,13 +692,6 @@ function wpcomPages( app ) {
 			next();
 		}
 	} );
-	app.get( '/read/search', function ( req, res, next ) {
-		if ( ! req.context.isLoggedIn && calypsoEnv === 'production' ) {
-			res.redirect( 'https://en.search.wordpress.com/?q=' + encodeURIComponent( req.query.q ) );
-		} else {
-			next();
-		}
-	} );
 
 	app.get( '/plans', function ( req, res, next ) {
 		if ( ! req.context.isLoggedIn ) {


### PR DESCRIPTION
Part of pe7F0s-Ti-p2


I already deactivated this redirect in other environments in https://github.com/Automattic/wp-calypso/pull/78154, this PR completely removes the code that would redirect the /read/search page to en.search.wordpress.com

### Testing instructions
N/A as this only affects production