### PR TITLE
CI: remove variable from filepath of Jetpack E2E VCS trigger.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -212,10 +212,8 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpack
 
 				// Trigger only when changes are made to the Jetpack staging directories in our WPCOM connection
 				triggerRules = """
-					+:root=wpcom:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/sun/**
-					+:root=wpcom:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/moon/**
-					+:root=wpcom:%WPCOM_JETPACK_PLUGIN_PATH%/sun/**
-					+:root=wpcom:%WPCOM_JETPACK_PLUGIN_PATH%/moon/**
+					+:root=wpcom:**/sun/**
+					+:root=wpcom:**/moon/**
 				""".trimIndent()
 			}
 		} else {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/75308, https://github.com/Automattic/wp-calypso/pull/77400.

## Proposed Changes

This PR removes the use of TeamCity variables from the filepath of the VCS trigger for the Jetpack E2E build configurations:
- Jetpack E2E Tests [wpcom-staging] (desktop)
- Jetpack E2E Tests [wpcom-staging] (mobile)

The reason being that we aren't actually sure if the TeamCity variables ("% strings") work in the file path of a VCS trigger. 

<img width="494" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6549265/0cdf03e6-6c42-4509-aee4-fc32d20ba8cb">

Because we're already exposing to the public that there are two folders named "sun" and "moon" each and we want to trigger a Jetpack E2E build when any of these change, surrounding the "sun/moon" subdir with a wildcard does not expose any new information. 

## Testing Instructions

As long as TeamCity does not complain of configuration issues, we are good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
