### PR TITLE
Plans 2023: hide free plan when premium theme selected in with-theme flow

### DIFF
--- a/client/signup/steps/plans-theme-preselected/index.tsx
+++ b/client/signup/steps/plans-theme-preselected/index.tsx
@@ -35,14 +35,14 @@ function getHidePlanPropsBasedOnSignupDependencies(
 		signupDependencies.themeType === MARKETPLACE_THEME ||
 		signupDependencies.themeType === WOOCOMMERCE_THEME
 	) {
-		return { hidePremiumPlan: true, hidePersonalPlan: true };
+		return { hidePremiumPlan: true, hidePersonalPlan: true, hideFreePlan: true };
 	}
 
 	/**
 	 * Premium themes: Display Premium, Business and eCommerce
 	 */
 	if ( signupDependencies.themeType === PREMIUM_THEME ) {
-		return { hidePersonalPlan: true };
+		return { hidePersonalPlan: true, hideFreePlan: true };
 	}
 
 	return {};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/78165

## Proposed Changes

The free plan should not be visible in the plans grid when in `with-theme` flow and a premium theme is selected. 
- Passes the missing `hideFreePlan` property to plans grid when a premium theme is selected.

### Media

with premium theme:

**Before**

<img width="500" alt="Screenshot 2023-06-14 at 1 20 38 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/39bc4a69-d447-4c18-a1ab-fcc4fcf891eb">

**After**

<img width="500" alt="Screenshot 2023-06-14 at 1 20 08 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/5c453816-1d7e-4a50-b3dc-5a292c58d406">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/start/with-theme?theme=yuga&premium=true&theme_type=premium` and ensure "Free" plan is not visible in the grid.
- Go to `start/with-theme?theme=yuga&premium=false&theme_type=free` and ensure "Free" plan is visible in the grid.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
