### PR TITLE
Theme showcase: Include WP.org themes

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -7,7 +7,7 @@ import { Icon, addTemplate, brush, cloudUpload } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
 import PropTypes from 'prop-types';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import Theme from 'calypso/components/theme';
@@ -17,7 +17,7 @@ import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { upsellCardDisplayed as upsellCardDisplayedAction } from 'calypso/state/themes/actions';
-import { DEFAULT_THEME_QUERY, RETIRED_THEME_SLUGS_SET } from 'calypso/state/themes/constants';
+import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -101,26 +101,7 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 		window.location.assign( destinationUrl );
 	};
 
-	const matchingWpOrgThemes = useMemo( () => {
-		const themeSlugs = props.themes.map( ( theme ) => theme.id );
-
-		return (
-			props.wpOrgThemes?.filter(
-				( wpOrgTheme ) =>
-					! themeSlugs.includes( wpOrgTheme?.id?.toLowerCase() ) && // Avoid duplicate themes. Some free themes are available in both wpcom and wporg.
-					! RETIRED_THEME_SLUGS_SET.has( wpOrgTheme?.id?.toLowerCase() ) && // Avoid retired themes.
-					( wpOrgTheme?.name?.toLowerCase() === props.searchTerm.toLowerCase() ||
-						wpOrgTheme?.id?.toLowerCase() === props.searchTerm.toLowerCase() )
-			) || []
-		);
-	}, [ props.wpOrgThemes, props.searchTerm, props.themes ] );
-
-	const themes = useMemo(
-		() => [ ...props.themes, ...matchingWpOrgThemes ],
-		[ props.themes, matchingWpOrgThemes ]
-	);
-
-	if ( ! props.loading && themes.length === 0 ) {
+	if ( ! props.loading && props.themes.length === 0 ) {
 		return (
 			<Empty
 				isFSEActive={ props.isFSEActive }
@@ -142,14 +123,14 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 
 	return (
 		<div className="themes-list" ref={ themesListRef }>
-			{ themes.map( ( theme, index ) => (
+			{ props.themes.map( ( theme, index ) => (
 				<ThemeBlock key={ 'theme-block' + index } theme={ theme } index={ index } { ...props } />
 			) ) }
 			{ /* Don't show second upsell nudge when less than 6 rows are present.
 				 Second plan upsell at 7th row is implemented through CSS. */ }
 			{ showSecondUpsellNudge && SecondUpsellNudge }
 			{ /* The Pattern Assembler CTA will display on the 9th row and the behavior is controlled by CSS */ }
-			{ isPatternAssemblerCTAEnabled && tabFilter !== 'my-themes' && themes.length > 0 && (
+			{ isPatternAssemblerCTAEnabled && tabFilter !== 'my-themes' && props.themes.length > 0 && (
 				<PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } />
 			) }
 			{ props.loading && <LoadingPlaceholders placeholderCount={ props.placeholderCount } /> }
@@ -160,7 +141,6 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 
 ThemesList.propTypes = {
 	themes: PropTypes.array.isRequired,
-	wpOrgThemes: PropTypes.array,
 	loading: PropTypes.bool.isRequired,
 	recordTracksEvent: PropTypes.func.isRequired,
 	fetchNextPage: PropTypes.func.isRequired,
@@ -190,7 +170,6 @@ ThemesList.defaultProps = {
 	loading: false,
 	searchTerm: '',
 	themes: [],
-	wpOrgThemes: [],
 	recordTracksEvent: noop,
 	fetchNextPage: noop,
 	placeholderCount: DEFAULT_THEME_QUERY.number,

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -130,6 +130,7 @@ export function fetchThemesList( options = {} ) {
 		'request[search]': search,
 		'request[page]': page,
 		'request[per_page]:': number,
+		'request[browse]': 'popular',
 	};
 
 	return getRequest( WPORG_THEMES_ENDPOINT, query );

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -116,7 +116,11 @@ export function getSubjectsFromTermTable( filterToTermTable ) {
 }
 
 /**
- * Interlace WP.com themes with WP.org themes.
+ * Interlace WP.com themes with WP.org themes according to the logic below:
+ * - WP.org themes are only included if there is a search term.
+ * - If the search term has an exact match (either a WP.com or a WP.org theme), that theme is the first result.
+ * - WP.com themes are prioritized over WP.org themes.
+ * - Retired WP.org themes or duplicate WP.org themes (those that are also WP.com themes) are excluded.
  *
  * @param wpComThemes List of WP.com themes.
  * @param wpOrgThemes List of WP.org themes.
@@ -134,12 +138,15 @@ export function interlaceThemes( wpComThemes, wpOrgThemes, searchTerm, isLastPag
 		);
 	};
 
+	const includeWpOrgThemes = !! searchTerm;
 	const wpComThemesSlugs = wpComThemes.map( ( theme ) => theme.id );
-	const validWpOrgThemes = wpOrgThemes.filter(
-		( theme ) =>
-			! wpComThemesSlugs.includes( theme?.id?.toLowerCase() ) && // Avoid duplicate themes. Some free themes are available in both wpcom and wporg.
-			! RETIRED_THEME_SLUGS_SET.has( theme?.id?.toLowerCase() ) // Avoid retired themes.
-	);
+	const validWpOrgThemes = includeWpOrgThemes
+		? wpOrgThemes.filter(
+				( theme ) =>
+					! wpComThemesSlugs.includes( theme?.id?.toLowerCase() ) && // Avoid duplicate themes. Some free themes are available in both wpcom and wporg.
+					! RETIRED_THEME_SLUGS_SET.has( theme?.id?.toLowerCase() ) // Avoid retired themes.
+		  )
+		: [];
 
 	const matchingTheme = wpComThemes.find( isMatchingTheme );
 	const restWpComThemes = matchingTheme

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -125,6 +125,9 @@ export function getSubjectsFromTermTable( filterToTermTable ) {
  */
 export function interlaceThemes( wpComThemes, wpOrgThemes, searchTerm, isLastPage ) {
 	const isMatchingTheme = ( theme ) => {
+		if ( ! searchTerm ) {
+			return false;
+		}
 		return (
 			theme.name?.toLowerCase() === searchTerm?.toLowerCase() ||
 			theme.id?.toLowerCase() === searchTerm?.toLowerCase()

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -121,7 +121,7 @@ export function getSubjectsFromTermTable( filterToTermTable ) {
  * @param wpComThemes List of WP.com themes.
  * @param wpOrgThemes List of WP.org themes.
  * @param searchTerm Search term.
- * @param isLastPage Whether the list of WP.com has reached the last page.
+ * @param isLastPage Whether the list of WP.com themes has reached the last page.
  */
 export function interlaceThemes( wpComThemes, wpOrgThemes, searchTerm, isLastPage ) {
 	const isMatchingTheme = ( theme ) => {
@@ -154,7 +154,7 @@ export function interlaceThemes( wpComThemes, wpOrgThemes, searchTerm, isLastPag
 		...( matchingTheme ? [ matchingTheme ] : [] ),
 		...( matchingWpOrgTheme ? [ matchingWpOrgTheme ] : [] ),
 		...restWpComThemes,
-		// Include WP.org themes after the last page of the default themes.
+		// Include WP.org themes after the last page of WP.com themes.
 		...( isEnabled( 'themes/interlaced-dotorg-themes' ) && isLastPage ? restWpOrgThemes : [] ),
 	];
 }

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { isMagnificentLocale, addLocaleToPath } from '@automattic/i18n-utils';
 import { mapValues } from 'lodash';
 import titlecase from 'to-title-case';
@@ -151,6 +152,6 @@ export function interlaceThemes( wpComThemes, wpOrgThemes, searchTerm, isLastPag
 		...( matchingWpOrgTheme ? [ matchingWpOrgTheme ] : [] ),
 		...restWpComThemes,
 		// Include WP.org themes after the last page of the default themes.
-		...( isLastPage ? restWpOrgThemes : [] ),
+		...( isEnabled( 'themes/interlaced-dotorg-themes' ) && isLastPage ? restWpOrgThemes : [] ),
 	];
 }

--- a/client/my-sites/themes/search-themes-tracks.js
+++ b/client/my-sites/themes/search-themes-tracks.js
@@ -1,5 +1,5 @@
 import { usePrevious } from '@wordpress/compose';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isRequestingThemesForQuery, prependThemeFilterKeys } from 'calypso/state/themes/selectors';
@@ -16,31 +16,6 @@ function useThemeSearchDetails( query ) {
 	return { search, searchTaxonomies, searchTerm, searchTermHasChanged };
 }
 
-function useThemeSearchResults( search, themes, wporgThemes ) {
-	const themesCount = themes.length;
-	const wporgThemesCount = wporgThemes.length;
-	const totalCount = themesCount + wporgThemesCount;
-
-	// In some cases, we don't show all themes that match a search.
-	// For example, when there are no WPCOM results, we only show WPORG themes
-	// whose names are an exact match for the search.
-	// @see https://github.com/Automattic/wp-calypso/pull/69461
-	const actualCount = useMemo( () => {
-		if ( themesCount > 0 || ! search ) {
-			return themesCount;
-		}
-
-		const matchingWporgThemes = wporgThemes.filter(
-			( theme ) =>
-				theme?.name?.toLowerCase() === search.toLowerCase() ||
-				theme?.id?.toLowerCase() === search.toLowerCase()
-		);
-		return matchingWporgThemes.length;
-	}, [ search, themesCount, wporgThemes ] );
-
-	return { actualCount, themesCount, totalCount, wporgThemesCount };
-}
-
 function useIsRequestingThemes( query ) {
 	const isRequesting = useSelector(
 		( state ) =>
@@ -53,14 +28,11 @@ function useIsRequestingThemes( query ) {
 	return { isRequesting, prevIsRequesting };
 }
 
-export default function SearchThemesTracks( { query = {}, themes = [], wporgThemes = [] } ) {
+export default function SearchThemesTracks( { query = {}, themes = [] } ) {
 	const { search, searchTaxonomies, searchTerm, searchTermHasChanged } =
 		useThemeSearchDetails( query );
-	const { actualCount, themesCount, totalCount, wporgThemesCount } = useThemeSearchResults(
-		search,
-		themes,
-		wporgThemes
-	);
+	const themesCount = themes.length;
+
 	const { isRequesting, prevIsRequesting } = useIsRequestingThemes( query );
 
 	const dispatch = useDispatch();
@@ -70,10 +42,7 @@ export default function SearchThemesTracks( { query = {}, themes = [], wporgThem
 		search_term: searchTerm.trim(),
 		search_taxonomies: searchTaxonomies.trim(),
 		tier: query.tier,
-		result_count: totalCount,
-		actual_count: actualCount,
-		wpcom_result_count: themesCount,
-		wporg_result_count: wporgThemesCount,
+		result_count: themesCount,
 	} );
 
 	useEffect( () => {
@@ -85,7 +54,7 @@ export default function SearchThemesTracks( { query = {}, themes = [], wporgThem
 		// If the count is immediately valued after a search, the query is retrieving
 		// results already available in the Redux store, skipping the remote fetches.
 		// We can just record the event straight away.
-		if ( searchTermHasChanged && ! isRequesting && actualCount > 0 ) {
+		if ( searchTermHasChanged && ! isRequesting && themesCount > 0 ) {
 			dispatch( recordSearchEvent );
 			return;
 		}
@@ -95,7 +64,7 @@ export default function SearchThemesTracks( { query = {}, themes = [], wporgThem
 			dispatch( recordSearchEvent );
 		}
 	}, [
-		actualCount,
+		themesCount,
 		dispatch,
 		isRequesting,
 		prevIsRequesting,

--- a/client/my-sites/themes/test/helpers.js
+++ b/client/my-sites/themes/test/helpers.js
@@ -5,8 +5,8 @@ describe( 'helpers', () => {
 		const wpComThemes = [ { id: 'wpcom-theme-1' }, { id: 'wpcom-theme-2' } ];
 		const wpOrgThemes = [ { id: 'wporg-theme-1' }, { id: 'wporg-theme-2' } ];
 
-		test( 'prioritizes WP.com themes over WP.org themes', () => {
-			const interlacedThemes = interlaceThemes( wpComThemes, wpOrgThemes, null, true );
+		test( 'includes WP.org themes after WP.com themes when searching a term', () => {
+			const interlacedThemes = interlaceThemes( wpComThemes, wpOrgThemes, 'test', true );
 			expect( interlacedThemes ).toEqual( [
 				{ id: 'wpcom-theme-1' },
 				{ id: 'wpcom-theme-2' },
@@ -15,17 +15,22 @@ describe( 'helpers', () => {
 			] );
 		} );
 
+		test( 'does not include WP.org themes when not searching a term', () => {
+			const interlacedThemes = interlaceThemes( wpComThemes, wpOrgThemes, null, true );
+			expect( interlacedThemes ).toEqual( [ { id: 'wpcom-theme-1' }, { id: 'wpcom-theme-2' } ] );
+		} );
+
 		test( 'does not include WP.org themes if the last page of WP.com themes has not been reached', () => {
 			const interlacedThemes = interlaceThemes( wpComThemes, wpOrgThemes, 'test', false );
 			expect( interlacedThemes ).toEqual( [ { id: 'wpcom-theme-1' }, { id: 'wpcom-theme-2' } ] );
 		} );
 
-		test( 'returns exact matching WP.com theme as first result', async () => {
+		test( 'returns exact matching WP.com theme as first result', () => {
 			const interlacedThemes = interlaceThemes( wpComThemes, wpOrgThemes, 'wpcom-theme-2', true );
 			expect( interlacedThemes[ 0 ] ).toEqual( { id: 'wpcom-theme-2' } );
 		} );
 
-		test( 'returns exact matching WP.org theme as first result', async () => {
+		test( 'returns exact matching WP.org theme as first result', () => {
 			const interlacedThemes = interlaceThemes( wpComThemes, wpOrgThemes, 'wporg-theme-2', true );
 			expect( interlacedThemes[ 0 ] ).toEqual( { id: 'wporg-theme-2' } );
 		} );

--- a/client/my-sites/themes/test/helpers.js
+++ b/client/my-sites/themes/test/helpers.js
@@ -1,0 +1,33 @@
+import { interlaceThemes } from 'calypso/my-sites/themes/helpers';
+
+describe( 'helpers', () => {
+	describe( 'interlaceThemes', () => {
+		const wpComThemes = [ { id: 'wpcom-theme-1' }, { id: 'wpcom-theme-2' } ];
+		const wpOrgThemes = [ { id: 'wporg-theme-1' }, { id: 'wporg-theme-2' } ];
+
+		test( 'prioritizes WP.com themes over WP.org themes', () => {
+			const interlacedThemes = interlaceThemes( wpComThemes, wpOrgThemes, null, true );
+			expect( interlacedThemes ).toEqual( [
+				{ id: 'wpcom-theme-1' },
+				{ id: 'wpcom-theme-2' },
+				{ id: 'wporg-theme-1' },
+				{ id: 'wporg-theme-2' },
+			] );
+		} );
+
+		test( 'does not include WP.org themes if the last page of WP.com themes has not been reached', () => {
+			const interlacedThemes = interlaceThemes( wpComThemes, wpOrgThemes, 'test', false );
+			expect( interlacedThemes ).toEqual( [ { id: 'wpcom-theme-1' }, { id: 'wpcom-theme-2' } ] );
+		} );
+
+		test( 'returns exact matching WP.com theme as first result', async () => {
+			const interlacedThemes = interlaceThemes( wpComThemes, wpOrgThemes, 'wpcom-theme-2', true );
+			expect( interlacedThemes[ 0 ] ).toEqual( { id: 'wpcom-theme-2' } );
+		} );
+
+		test( 'returns exact matching WP.org theme as first result', async () => {
+			const interlacedThemes = interlaceThemes( wpComThemes, wpOrgThemes, 'wporg-theme-2', true );
+			expect( interlacedThemes[ 0 ] ).toEqual( { id: 'wporg-theme-2' } );
+		} );
+	} );
+} );

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -226,7 +226,7 @@ class ThemesSelection extends Component {
 	};
 
 	getThemes = () => {
-		const { themes, wpOrgThemes, query, isLastPage } = this.props;
+		const { themes, wpOrgThemes, isLastPage } = this.props;
 
 		const themeSlugs = themes.map( ( theme ) => theme.id );
 		const validWpOrgThemes = wpOrgThemes.filter(
@@ -248,8 +248,8 @@ class ThemesSelection extends Component {
 			...( matchingTheme ? [ matchingTheme ] : [] ),
 			...( matchingWpOrgTheme ? [ matchingWpOrgTheme ] : [] ),
 			...restThemes,
-			// Only include WP.org themes when searching a term and after all previous themes are visible.
-			...( query.search && isLastPage ? restWpOrgThemes : [] ),
+			// Include WP.org themes after the last page of the default themes.
+			...( isLastPage ? restWpOrgThemes : [] ),
 		];
 	};
 
@@ -369,7 +369,7 @@ export const ConnectedThemesSelection = connect(
 
 		const themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [];
 
-		const includeWpOrgThemes = forceWpOrgSearch && sourceSiteId !== 'wporg';
+		const includeWpOrgThemes = forceWpOrgSearch && sourceSiteId !== 'wporg' && search; // Only display WP.org themes when searching a term.
 		const wpOrgQuery = { ...query, page: 1 }; // We limit the WP.org themes to one page only.
 		const wpOrgThemes = includeWpOrgThemes
 			? getThemesForQueryIgnoringPage( state, 'wporg', wpOrgQuery ) || []

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -226,7 +226,8 @@ class ThemesSelection extends Component {
 			siteId,
 			tabFilter,
 			isLastPage,
-			includeWpOrgThemes,
+			isRequesting,
+			shouldFetchWpOrgThemes,
 			wpOrgQuery,
 			wpOrgThemes,
 		} = this.props;
@@ -236,7 +237,7 @@ class ThemesSelection extends Component {
 		return (
 			<div className="themes__selection">
 				<QueryThemes query={ query } siteId={ source } />
-				{ includeWpOrgThemes && <QueryThemes query={ wpOrgQuery } siteId="wporg" /> }
+				{ shouldFetchWpOrgThemes && <QueryThemes query={ wpOrgQuery } siteId="wporg" /> }
 				<ThemesList
 					upsellUrl={ upsellUrl }
 					upsellBanner={ upsellBanner }
@@ -253,7 +254,7 @@ class ThemesSelection extends Component {
 					isActive={ this.props.isThemeActive }
 					getPrice={ this.props.getPremiumThemePrice }
 					isInstalling={ this.props.isInstallingTheme }
-					loading={ this.props.isRequesting }
+					loading={ isRequesting }
 					emptyContent={ this.props.emptyContent }
 					placeholderCount={ this.props.placeholderCount }
 					bookmarkRef={ this.props.bookmarkRef }
@@ -261,7 +262,13 @@ class ThemesSelection extends Component {
 					searchTerm={ query.search }
 					tabFilter={ tabFilter }
 				/>
-				<SearchThemesTracks query={ query } themes={ interlacedThemes } />
+				<SearchThemesTracks
+					query={ query }
+					interlacedThemes={ interlacedThemes }
+					wpComThemes={ themes }
+					wpOrgThemes={ wpOrgThemes }
+					isRequesting={ isRequesting }
+				/>
 			</div>
 		);
 	}
@@ -335,9 +342,9 @@ export const ConnectedThemesSelection = connect(
 
 		const themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [];
 
-		const includeWpOrgThemes = forceWpOrgSearch && sourceSiteId !== 'wporg' && search; // Only request/include WP.org themes when searching a term.
+		const shouldFetchWpOrgThemes = forceWpOrgSearch && sourceSiteId !== 'wporg' && !! search; // Only fetch WP.org themes when searching a term.
 		const wpOrgQuery = { ...query, page: 1 }; // We limit the WP.org themes to one page only.
-		const wpOrgThemes = includeWpOrgThemes
+		const wpOrgThemes = shouldFetchWpOrgThemes
 			? getThemesForQueryIgnoringPage( state, 'wporg', wpOrgQuery ) || []
 			: [];
 
@@ -350,7 +357,7 @@ export const ConnectedThemesSelection = connect(
 			isRequesting:
 				isCustomizedThemeListLoading ||
 				isRequestingThemesForQuery( state, sourceSiteId, query ) ||
-				( includeWpOrgThemes && isRequestingThemesForQuery( state, 'wporg', wpOrgQuery ) ),
+				( shouldFetchWpOrgThemes && isRequestingThemesForQuery( state, 'wporg', wpOrgQuery ) ),
 			isLastPage: isThemesLastPageForQuery( state, sourceSiteId, query ),
 			isLoggedIn: isUserLoggedIn( state ),
 			isThemeActive: bindIsThemeActive( state, siteId ),
@@ -363,7 +370,7 @@ export const ConnectedThemesSelection = connect(
 			getPremiumThemePrice: bindGetPremiumThemePrice( state, siteId ),
 			getThemeDetailsUrl: bindGetThemeDetailsUrl( state, siteId ),
 			filterString: prependThemeFilterKeys( state, query.filter ),
-			includeWpOrgThemes,
+			shouldFetchWpOrgThemes,
 			wpOrgQuery,
 			wpOrgThemes,
 		};

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -220,8 +220,8 @@ class ThemesSelection extends Component {
 	isMatchingTheme = ( theme ) => {
 		const { query } = this.props;
 		return (
-			theme.name?.toLowerCase() === query.search.toLowerCase() ||
-			theme.id?.toLowerCase() === query.search.toLowerCase()
+			theme.name?.toLowerCase() === query.search?.toLowerCase() ||
+			theme.id?.toLowerCase() === query.search?.toLowerCase()
 		);
 	};
 

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -335,7 +335,7 @@ export const ConnectedThemesSelection = connect(
 
 		const themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [];
 
-		const includeWpOrgThemes = forceWpOrgSearch && sourceSiteId !== 'wporg' && search; // Only display WP.org themes when searching a term.
+		const includeWpOrgThemes = forceWpOrgSearch && sourceSiteId !== 'wporg' && search; // Only request/include WP.org themes when searching a term.
 		const wpOrgQuery = { ...query, page: 1 }; // We limit the WP.org themes to one page only.
 		const wpOrgThemes = includeWpOrgThemes
 			? getThemesForQueryIgnoringPage( state, 'wporg', wpOrgQuery ) || []

--- a/config/development.json
+++ b/config/development.json
@@ -200,6 +200,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": true,
 		"themes/display-thank-you-page-for-woo": true,
+		"themes/interlaced-dotorg-themes": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": true,
 		"themes/theme-switch-persist-template": false,

--- a/config/test.json
+++ b/config/test.json
@@ -105,6 +105,7 @@
 		"stats/subscribers-section": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": false,
+		"themes/interlaced-dotorg-themes": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -169,6 +169,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": true,
 		"themes/display-thank-you-page-for-woo": true,
+		"themes/interlaced-dotorg-themes": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2744
Fixes https://github.com/Automattic/dotcom-forge/issues/2745
Fixes https://github.com/Automattic/dotcom-forge/issues/2746
Fixes https://github.com/Automattic/dotcom-forge/issues/2748
Fixes https://github.com/Automattic/dotcom-forge/issues/2749

## Proposed Changes

- Includes the 100 most popular WP.org themes in the theme showcase when searching a term (gated behind the `themes/interlaced-dotorg-themes` feature flag).
- Results are interlaced with WP.com themes according to this logic:
  - If the search term has an exact match, that theme is the first result, regardless of its WP.com or WP.org origin.
  - WP.com themes take first place over WP.org themes.
  - Retired WP.org themes or duplicate WP.org themes (those that are also WP.com themes) are excluded.

**Examples**

<table><tr><td>
<img width="600" alt="Screenshot 2023-06-14 at 13 17 39" src="https://github.com/Automattic/wp-calypso/assets/1233880/3c48e1a5-0b14-4206-83fc-3b87e85663da"></td><td>
<img width="600" alt="Screenshot 2023-06-14 at 13 18 00" src="https://github.com/Automattic/wp-calypso/assets/1233880/1922a957-7e8a-44b3-b530-9a98a2d608eb"></td></tr><tr><td>
<img width="600" alt="Screenshot 2023-06-14 at 13 18 14" src="https://github.com/Automattic/wp-calypso/assets/1233880/dd668a65-45f0-4af9-986e-2164fb1d57b0"></td><td>
<img width="600" alt="Screenshot 2023-06-14 at 13 18 28" src="https://github.com/Automattic/wp-calypso/assets/1233880/2f6d835e-823b-4ae7-8b8f-151511b6ff76"></td></tr></table>


## Testing Instructions

- Use the Calypso live link below.
- Go to Appearance > Themes.
- Scroll down to the bottom and make sure that WP.org themes don't show up.
- Enter a search theme such that matches a WP.com theme (e.g. Disco)
- Make sure that the WP.com theme is the first result.
- Make sure that WP.com themes are next.
- Make sure that WP.org themes are included at the end.
- Enter a search theme such that matches a WP.org theme (e.g. Astra).
- Make sure that the WP.org theme is the first result.
- Make sure that WP.com themes are next.
- Make sure that WP.org themes are included at the end.
- Make sure there are no regressions for Atomic and Jetpack sites.
- Make sure there are no regressions while logged out.
- Make sure WP.org themes are not interlaced when the `themes/interlaced-dotorg-themes` feature flag is disabled (add the `?flags=-themes/interlaced-dotorg-themes` query param).
