### PR TITLE
Format views/likes/comments in BlazePress' mobile version

### DIFF
--- a/client/my-sites/promote-post-i2/components/post-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/post-item/index.tsx
@@ -47,9 +47,9 @@ export default function PostItem( { post }: Props ) {
 		<PostRelativeTimeStatus showPublishedStatus={ false } post={ post } showGridIcon={ false } />
 	);
 
-	const viewCount = 1232424; // post?.monthly_view_count ?? 0;
-	const likeCount = 21231; // post?.like_count ?? 0;
-	const commentCount = 1213; // post?.comment_count ?? 0;
+	const viewCount = post?.monthly_view_count ?? 0;
+	const likeCount = post?.like_count ?? 0;
+	const commentCount = post?.comment_count ?? 0;
 
 	const mobileStatsSeparator = <span className="blazepress-mobile-stats-mid-dot">&#183;</span>;
 

--- a/client/my-sites/promote-post-i2/components/post-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/post-item/index.tsx
@@ -7,6 +7,7 @@ import resizeImageUrl from 'calypso/lib/resize-image-url';
 import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
 import { getPostType } from 'calypso/my-sites/promote-post/utils';
 import useOpenPromoteWidget from '../../hooks/use-open-promote-widget';
+import { formatNumber } from '../../utils';
 
 export type BlazablePost = {
 	ID: number;
@@ -46,9 +47,9 @@ export default function PostItem( { post }: Props ) {
 		<PostRelativeTimeStatus showPublishedStatus={ false } post={ post } showGridIcon={ false } />
 	);
 
-	const viewCount = post?.monthly_view_count ?? 0;
-	const likeCount = post?.like_count ?? 0;
-	const commentCount = post?.comment_count ?? 0;
+	const viewCount = 1232424; // post?.monthly_view_count ?? 0;
+	const likeCount = 21231; // post?.like_count ?? 0;
+	const commentCount = 1213; // post?.comment_count ?? 0;
 
 	const mobileStatsSeparator = <span className="blazepress-mobile-stats-mid-dot">&#183;</span>;
 
@@ -97,20 +98,22 @@ export default function PostItem( { post }: Props ) {
 				</div>
 				<div className="post-item__post-data-row post-item__post-data-row-mobile">
 					<div className="post-item__stats-mobile">
-						{
-							// translators: %d is number of post's views
-							sprintf( _n( '%d view', '%d views', viewCount ), viewCount )
-						}
+						{ sprintf(
+							// translators: %s is number of post's views
+							_n( '%s view', '%s views', viewCount ),
+							formatNumber( viewCount )
+						) }
 						{ mobileStatsSeparator }
 						{
-							// translators: %d is number of post's likes
-							sprintf( _n( '%d like', '%d likes', likeCount ), likeCount )
+							// translators: %s is number of post's likes
+							sprintf( _n( '%s like', '%s likes', likeCount ), formatNumber( likeCount ) )
 						}
 						{ mobileStatsSeparator }
-						{
-							// translators: %d is number of post's comments
-							sprintf( _n( '%d comment', '%d comments', commentCount ), commentCount )
-						}
+						{ sprintf(
+							// translators: %s is number of post's comments
+							_n( '%s comment', '%s comments', commentCount ),
+							formatNumber( commentCount )
+						) }
 					</div>
 					<div className="post-item__actions-mobile">
 						<a href={ post.post_url } className="post-item__view-link">
@@ -130,9 +133,9 @@ export default function PostItem( { post }: Props ) {
 
 			<td className="post-item__post-type">{ getPostType( post.type ) }</td>
 			<td className="post-item__post-publish-date">{ postDate }</td>
-			<td className="post-item__post-views">{ viewCount }</td>
-			<td className="post-item__post-likes">{ likeCount }</td>
-			<td className="post-item__post-comments">{ commentCount }</td>
+			<td className="post-item__post-views">{ formatNumber( viewCount ) }</td>
+			<td className="post-item__post-likes">{ formatNumber( likeCount ) }</td>
+			<td className="post-item__post-comments">{ formatNumber( commentCount ) }</td>
 			<td className="post-item__post-view">
 				<a href={ post.post_url } className="post-item__view-link">
 					{ __( 'View' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [the comment](https://github.com/Automattic/wp-calypso/pull/77909#discussion_r1224382301)

## Proposed Changes

* We want to format numbers of view, likes, and comments on "Ready to Blaze" tab within BlazePress (both desktop and mobile)

### Desktop
<img width="1057" alt="Screenshot 2023-06-14 at 15 03 45" src="https://github.com/Automattic/wp-calypso/assets/115007291/8146f4a2-0363-48fd-96fe-4501d30a8d22">

### Mobile
<img width="595" alt="Screenshot 2023-06-14 at 15 03 18" src="https://github.com/Automattic/wp-calypso/assets/115007291/01754aad-cc54-46f5-90d7-de4a8867e41a">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch in your local dev environment
* Build assets (`yarn && yarn start`)
* Open [http://calypso.localhost:3000/advertising/http://calypso.localhost:3000/advertising/YOUR-SITE-HERE/posts](http://calypso.localhost:3000/advertising/http://calypso.localhost:3000/advertising/)
* Make sure you have views/likes/comments for your posts or pages
* If there are no posts/pages with stats, you can fake stats by putting numbers like [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/promote-post-i2/components/post-item/index.tsx#L49) in the code below in:
```php
const viewCount = 1232424; // post?.monthly_view_count ?? 0;
const likeCount = 21231; // post?.like_count ?? 0;
const commentCount = 1213; // post?.comment_count ?? 0;
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

## For translators

This PR has changes in the following strings:
- In '%s view' / '%s views' – `%s` is the formatted number of views
- `'%s like'` / `'%s likes'` – `%s` is the formatted number of likes
- '%s comment' / '%s comments' – `%s` is the formatted number of comments

<img width="595" alt="Screenshot 2023-06-14 at 15 03 18" src="https://github.com/Automattic/wp-calypso/assets/115007291/01754aad-cc54-46f5-90d7-de4a8867e41a">