### PR TITLE
eslint: fix `@tanstack/query` eslint violations in `state/(agency-dashboard|partner-portal)`

### DIFF
--- a/client/state/jetpack-agency-dashboard/hooks/use-request-contact-verification-code.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-request-contact-verification-code.ts
@@ -22,8 +22,8 @@ function mutationRequestVerificationCode(
 export default function useRequestContactVerificationCode< TContext = unknown >(
 	options?: UseMutationOptions< APIResponse, APIError, RequestVerificationCodeParams, TContext >
 ): UseMutationResult< APIResponse, APIError, RequestVerificationCodeParams, TContext > {
-	return useMutation< APIResponse, APIError, RequestVerificationCodeParams, TContext >(
-		mutationRequestVerificationCode,
-		options
-	);
+	return useMutation< APIResponse, APIError, RequestVerificationCodeParams, TContext >( {
+		...options,
+		mutationFn: mutationRequestVerificationCode,
+	} );
 }

--- a/client/state/jetpack-agency-dashboard/hooks/use-resend-contact-verification-code.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-resend-contact-verification-code.ts
@@ -22,8 +22,8 @@ function mutationResendVerificationCode(
 export default function useResendVerificationCodeMutation< TContext = unknown >(
 	options?: UseMutationOptions< APIResponse, APIError, ResendVerificationCodeParams, TContext >
 ): UseMutationResult< APIResponse, APIError, ResendVerificationCodeParams, TContext > {
-	return useMutation< APIResponse, APIError, ResendVerificationCodeParams, TContext >(
-		mutationResendVerificationCode,
-		options
-	);
+	return useMutation< APIResponse, APIError, ResendVerificationCodeParams, TContext >( {
+		...options,
+		mutationFn: mutationResendVerificationCode,
+	} );
 }

--- a/client/state/jetpack-agency-dashboard/hooks/use-toggle-activate-monitor-mutation.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-toggle-activate-monitor-mutation.ts
@@ -19,8 +19,8 @@ function mutationToggleActivateMonitor( {
 export default function useToggleActivateMonitorMutation< TContext = unknown >(
 	options?: UseMutationOptions< APIResponse, APIError, ToggleActivateMonitorArgs, TContext >
 ): UseMutationResult< APIResponse, APIError, ToggleActivateMonitorArgs, TContext > {
-	return useMutation< APIResponse, APIError, ToggleActivateMonitorArgs, TContext >(
-		mutationToggleActivateMonitor,
-		options
-	);
+	return useMutation< APIResponse, APIError, ToggleActivateMonitorArgs, TContext >( {
+		...options,
+		mutationFn: mutationToggleActivateMonitor,
+	} );
 }

--- a/client/state/jetpack-agency-dashboard/hooks/use-update-monitor-settings-mutation.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-update-monitor-settings-mutation.ts
@@ -20,8 +20,8 @@ function mutationUpdateMonitorSettings( {
 export default function useUpdateMonitorSettingsMutation< TContext = unknown >(
 	options?: UseMutationOptions< APIResponse, APIError, UpdateMonitorSettingsArgs, TContext >
 ): UseMutationResult< APIResponse, APIError, UpdateMonitorSettingsArgs, TContext > {
-	return useMutation< APIResponse, APIError, UpdateMonitorSettingsArgs, TContext >(
-		mutationUpdateMonitorSettings,
-		options
-	);
+	return useMutation< APIResponse, APIError, UpdateMonitorSettingsArgs, TContext >( {
+		...options,
+		mutationFn: mutationUpdateMonitorSettings,
+	} );
 }

--- a/client/state/jetpack-agency-dashboard/hooks/use-validate-contact-verification-code.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-validate-contact-verification-code.ts
@@ -23,8 +23,8 @@ function mutationValidateVerificationCode(
 export default function useValidateVerificationCodeMutation< TContext = unknown >(
 	options?: UseMutationOptions< APIResponse, APIError, ValidateVerificationCodeParams, TContext >
 ): UseMutationResult< APIResponse, APIError, ValidateVerificationCodeParams, TContext > {
-	return useMutation< APIResponse, APIError, ValidateVerificationCodeParams, TContext >(
-		mutationValidateVerificationCode,
-		options
-	);
+	return useMutation< APIResponse, APIError, ValidateVerificationCodeParams, TContext >( {
+		...options,
+		mutationFn: mutationValidateVerificationCode,
+	} );
 }

--- a/client/state/partner-portal/licenses/hooks/use-assign-license-mutation.ts
+++ b/client/state/partner-portal/licenses/hooks/use-assign-license-mutation.ts
@@ -21,8 +21,8 @@ function mutationAssignLicense( {
 export default function useAssignLicenseMutation< TContext = unknown >(
 	options?: UseMutationOptions< APILicense, Error, MutationAssignLicenseVariables, TContext >
 ): UseMutationResult< APILicense, Error, MutationAssignLicenseVariables, TContext > {
-	return useMutation< APILicense, Error, MutationAssignLicenseVariables, TContext >(
-		mutationAssignLicense,
-		options
-	);
+	return useMutation< APILicense, Error, MutationAssignLicenseVariables, TContext >( {
+		...options,
+		mutationFn: mutationAssignLicense,
+	} );
 }

--- a/client/state/partner-portal/licenses/hooks/use-issue-license-mutation.ts
+++ b/client/state/partner-portal/licenses/hooks/use-issue-license-mutation.ts
@@ -17,8 +17,8 @@ function mutationIssueLicense( { product }: MutationIssueLicenseVariables ): Pro
 export default function useIssueLicenseMutation< TContext = unknown >(
 	options?: UseMutationOptions< APILicense, APIError, MutationIssueLicenseVariables, TContext >
 ): UseMutationResult< APILicense, APIError, MutationIssueLicenseVariables, TContext > {
-	return useMutation< APILicense, APIError, MutationIssueLicenseVariables, TContext >(
-		mutationIssueLicense,
-		options
-	);
+	return useMutation< APILicense, APIError, MutationIssueLicenseVariables, TContext >( {
+		...options,
+		mutationFn: mutationIssueLicense,
+	} );
 }

--- a/client/state/partner-portal/licenses/hooks/use-revoke-license-mutation.ts
+++ b/client/state/partner-portal/licenses/hooks/use-revoke-license-mutation.ts
@@ -20,8 +20,8 @@ function mutationRevokeLicense( {
 export default function useRevokeLicenseMutation< TContext = unknown >(
 	options?: UseMutationOptions< APILicense, Error, MutationRevokeLicenseVariables, TContext >
 ): UseMutationResult< APILicense, Error, MutationRevokeLicenseVariables, TContext > {
-	return useMutation< APILicense, Error, MutationRevokeLicenseVariables, TContext >(
-		mutationRevokeLicense,
-		options
-	);
+	return useMutation< APILicense, Error, MutationRevokeLicenseVariables, TContext >( {
+		...options,
+		mutationFn: mutationRevokeLicense,
+	} );
 }

--- a/client/state/partner-portal/licenses/hooks/use-tos-consent-mutation.ts
+++ b/client/state/partner-portal/licenses/hooks/use-tos-consent-mutation.ts
@@ -14,5 +14,8 @@ function mutationTOSConsent(): Promise< APIPartner > {
 export default function useTOSConsentMutation< TVariables = void, TContext = unknown >(
 	options?: UseMutationOptions< APIPartner, Error, TVariables, TContext >
 ): UseMutationResult< APIPartner, Error, TVariables, TContext > {
-	return useMutation< APIPartner, Error, TVariables, TContext >( mutationTOSConsent, options );
+	return useMutation< APIPartner, Error, TVariables, TContext >( {
+		...options,
+		mutationFn: mutationTOSConsent,
+	} );
 }

--- a/client/state/partner-portal/licenses/hooks/use-unassign-license-mutation.ts
+++ b/client/state/partner-portal/licenses/hooks/use-unassign-license-mutation.ts
@@ -20,8 +20,8 @@ function mutationUnassignLicense( {
 export default function useUnassignLicenseMutation< TContext = unknown >(
 	options?: UseMutationOptions< APILicense, Error, MutationUnassignLicenseVariables, TContext >
 ): UseMutationResult< APILicense, Error, MutationUnassignLicenseVariables, TContext > {
-	return useMutation< APILicense, Error, MutationUnassignLicenseVariables, TContext >(
-		mutationUnassignLicense,
-		options
-	);
+	return useMutation< APILicense, Error, MutationUnassignLicenseVariables, TContext >( {
+		...options,
+		mutationFn: mutationUnassignLicense,
+	} );
 }

--- a/client/state/partner-portal/partner/hooks/use-create-partner-mutation.ts
+++ b/client/state/partner-portal/partner/hooks/use-create-partner-mutation.ts
@@ -24,8 +24,8 @@ function createPartner( details: PartnerDetailsPayload ): Promise< APIPartner > 
 export default function useCreatePartnerMutation< TContext = unknown >(
 	options?: UseMutationOptions< APIPartner, APIError, PartnerDetailsPayload, TContext >
 ): UseMutationResult< APIPartner, APIError, PartnerDetailsPayload, TContext > {
-	return useMutation< APIPartner, APIError, PartnerDetailsPayload, TContext >(
-		createPartner,
-		options
-	);
+	return useMutation< APIPartner, APIError, PartnerDetailsPayload, TContext >( {
+		...options,
+		mutationFn: createPartner,
+	} );
 }

--- a/client/state/partner-portal/partner/hooks/use-update-company-details-mutation.ts
+++ b/client/state/partner-portal/partner/hooks/use-update-company-details-mutation.ts
@@ -24,8 +24,8 @@ function updateCompanyDetails( details: CompanyDetailsPayload ): Promise< APIPar
 export default function useUpdateCompanyDetailsMutation< TContext = unknown >(
 	options?: UseMutationOptions< APIPartner, APIError, CompanyDetailsPayload, TContext >
 ): UseMutationResult< APIPartner, APIError, CompanyDetailsPayload, TContext > {
-	return useMutation< APIPartner, APIError, CompanyDetailsPayload, TContext >(
-		updateCompanyDetails,
-		options
-	);
+	return useMutation< APIPartner, APIError, CompanyDetailsPayload, TContext >( {
+		...options,
+		mutationFn: updateCompanyDetails,
+	} );
 }


### PR DESCRIPTION
Related to #77787

## Proposed Changes

PR fixes a bunch of `@tanstack/query` eslint violations in `client/state/jetpack-agency-dashboard` and `client/state/partner-portal`.

This is a follow up to #78118. I missed there are a bunch more mutations related to the agency dashboard/partner portal. I wonder if those mutations should be moved to `client/data` as well.

## Testing Instructions

You need an agency partner account for being able to go through these testing instructions. Test these by starting Jetpack Cloud locally (`yarn start-jetpack-cloud`) or using the provided link in the comment below.

1. Go to `/dashboard` and verify you're able to toggle monitoring on/off and adjust settings (by clicking the clock next to the toggle)
2. Go to `/partner-portal/billing` and verify you're able to issue new licenses and revoke existing ones
3. I think for the last one you should go through the agency signup flow (go to `/agency/signup`)

In general I think verifying the code changes are good is sufficient.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
