### PR TITLE
Manually set linker for Akismet Personal purchases

### DIFF
--- a/client/lib/analytics/ga.js
+++ b/client/lib/analytics/ga.js
@@ -5,6 +5,7 @@ import {
 	fireGoogleAnalyticsPageView,
 	fireGoogleAnalyticsEvent,
 } from 'calypso/lib/analytics/ad-tracking';
+import isAkismetCheckout from '../akismet/is-akismet-checkout';
 import { mayWeTrackByTracker } from './tracker-buckets';
 
 const gaDebug = debug( 'calypso:analytics:ga' );
@@ -17,6 +18,19 @@ function initialize() {
 			send_page_view: false,
 			...getGoogleAnalyticsDefaultConfig(),
 		};
+
+		// We enable custom cross-domain linking only for Akismet checkouts
+		if ( isAkismetCheckout() ) {
+			const queryParams = new URLSearchParams( location.search );
+			const gl = queryParams.get( '_gl' );
+
+			// If we have a _gl query param, cross-domain linking is done automatically
+			if ( ! gl ) {
+				// Setting cross-domain manually: https://support.google.com/analytics/answer/10071811?hl=en#zippy=%2Cmanual-setup
+				params.client_id = queryParams.get( '_gl_cid' );
+				params.session_id = queryParams.get( '_gl_sid' );
+			}
+		}
 
 		gaDebug( 'parameters:', params );
 


### PR DESCRIPTION
Related to:
- D113584-code
- D113583-code

## Proposed Changes

* Set `client_id` and `session_id` in ga4 config when `_gl` param is not provided (following instructions to set up cross-domain linker manually: https://support.google.com/analytics/answer/10071811?hl=en#zippy=%2Cmanual-setup)

## Testing Instructions

* Checkout the PR and run `yarn start`
* Go to `calypso.localhost:3000?flags=cookie-banner,ad-tracking`
* Accept cookie banner if necessary (EU region)
* Enable marketing debug logs (`localStorage.setItem( 'debug', 'calypso:analytics:*' );` in console)
* Open link: http://calypso.localhost:3000/checkout/akismet/ak_personal_yearly:-q-12?flags=ad-tracking&_gl_cid=123456789&_gl_sid=987654321
* Ensure that `calypso:analytics:ga parameters` object has correct `client_id` (_gl_cid) and `session_id` (_gl_sid)