### PR TITLE
Manage Connection: Remove dependency on Happy Chat

### DIFF
--- a/client/my-sites/site-settings/manage-connection/ownership-information.jsx
+++ b/client/my-sites/site-settings/manage-connection/ownership-information.jsx
@@ -1,63 +1,50 @@
 import { Gridicon } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
+import { createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import HappychatButton from 'calypso/components/happychat/button';
-import HappychatConnection from 'calypso/components/happychat/connection-connected';
-import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
-import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 
-const OwnershipInformation = ( { isChatActive, isChatAvailable, translate } ) => (
-	<FormFieldset className="manage-connection__formfieldset has-divider is-top-only">
-		<div className="manage-connection__ownership-info">
-			<Gridicon
-				icon="info-outline"
-				size={ 24 }
-				className="manage-connection__ownership-info-icon"
-			/>
+const OwnershipInformation = () => {
+	const { __ } = useI18n();
+	const strongElement = { strong: <strong /> };
 
-			<div className="manage-connection__ownership-info-text">
-				<FormSettingExplanation>
-					{ translate(
-						'{{strong}}Site owners{{/strong}} are users who have connected Jetpack to WordPress.com.',
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
-					) }
-					<br />
-					{ translate(
-						'{{strong}}Plan purchasers{{/strong}} are users who purchased a paid plan for the site.',
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
-					) }
-				</FormSettingExplanation>
-				<FormSettingExplanation>
-					{ translate(
-						'Usually these are the same person, but sometimes they can differ. E.g., developers may be ' +
-							'a Site owner, because they set up the website and connected Jetpack to WordPress.com and ' +
-							'their clients may be Plan purchasers who use their billing information to purchase the plan ' +
-							'for the site.'
-					) }
-				</FormSettingExplanation>
+	return (
+		<FormFieldset className="manage-connection__formfieldset has-divider is-top-only">
+			<div className="manage-connection__ownership-info">
+				<Gridicon
+					icon="info-outline"
+					size={ 24 }
+					className="manage-connection__ownership-info-icon"
+				/>
 
-				<HappychatConnection />
-				{ ( isChatActive || isChatAvailable ) && (
+				<div className="manage-connection__ownership-info-text">
 					<FormSettingExplanation>
-						<HappychatButton>{ translate( 'Need help? Chat with us' ) }</HappychatButton>
+						{ createInterpolateElement(
+							__(
+								'<strong>Site owners</strong> are users who have connected Jetpack to WordPress.com.'
+							),
+							strongElement
+						) }
+						<br />
+						{ createInterpolateElement(
+							__(
+								'<strong>Plan purchasers</strong> are users who purchased a paid plan for the site.'
+							),
+							strongElement
+						) }
 					</FormSettingExplanation>
-				) }
+					<FormSettingExplanation>
+						{ __(
+							'Usually these are the same person, but sometimes they can differ. E.g., developers may be ' +
+								'a Site owner, because they set up the website and connected Jetpack to WordPress.com and ' +
+								'their clients may be Plan purchasers who use their billing information to purchase the plan ' +
+								'for the site.'
+						) }
+					</FormSettingExplanation>
+				</div>
 			</div>
-		</div>
-	</FormFieldset>
-);
+		</FormFieldset>
+	);
+};
 
-export default connect( ( state ) => ( {
-	isChatAvailable: isHappychatAvailable( state ),
-	isChatActive: hasActiveHappychatSession( state ),
-} ) )( localize( OwnershipInformation ) );
+export default OwnershipInformation;


### PR DESCRIPTION
Introduced 5 years ago in https://github.com/Automattic/wp-calypso/pull/25749 Removing the HappychatButton as part of clean-up: pdm0RZ-BU-p2

Opted to simply remove the button altogether. It was generic and if the user needs help, there's the Help Center always available.

## Proposed Changes

* Remove HappychatButton from `/settings/manage-connection`

## Testing Instructions

- Grab a site with a Jetpack connection (but one that is *not* Atomic).
- The connection can be broken, as long as it's a Jetpack site you should be able to manually navigate to: `/settings/manage-connection/DOMAIN`, replace `DOMAIN` with your Jetpack site's domain.

The part we're interested in:
<img width="740" alt="Screenshot 2023-06-14 at 13 56 54" src="https://github.com/Automattic/wp-calypso/assets/3392497/4f33bc52-7743-44d0-b355-57a4a7a957d2">

Before there was a link to chat, if chat was available:
![68747470733a2f2f636c6475702e636f6d2f456f47413353734865712e706e67](https://github.com/Automattic/wp-calypso/assets/3392497/94da4706-a77d-451d-b735-303586d2c07a)
