### PR TITLE
Blog onboarding: Complete checkout before launch

### DIFF
--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -1,7 +1,6 @@
 import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
-import { DESIGN_FIRST_FLOW, replaceProductsInCart } from '@automattic/onboarding';
-import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useSelector } from 'react-redux';
@@ -64,13 +63,7 @@ const designFirst: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
 		const siteSlug = useSiteSlug();
-		const { getDomainCartItem, getPlanCartItem } = useSelect(
-			( select ) => ( {
-				getDomainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem,
-				getPlanCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem,
-			} ),
-			[]
-		);
+
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
 		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
 		const state = useSelect(
@@ -151,11 +144,6 @@ const designFirst: Flow = {
 
 						const currentSiteSlug = String( providedDependencies?.domainName ?? siteSlug );
 
-						await replaceProductsInCart(
-							currentSiteSlug as string,
-							[ getPlanCartItem() ].filter( Boolean ) as MinimalRequestCartProduct[]
-						);
-
 						return window.location.assign(
 							`/setup/design-first/launchpad?siteSlug=${ currentSiteSlug }`
 						);
@@ -174,14 +162,6 @@ const designFirst: Flow = {
 						await updateLaunchpadSettings( siteSlug, {
 							checklist_statuses: { plan_completed: true },
 						} );
-					}
-					if ( providedDependencies?.goToCheckout ) {
-						const items = [ getPlanCartItem(), getDomainCartItem() ].filter(
-							Boolean
-						) as MinimalRequestCartProduct[];
-
-						// Always replace items in the cart so we can remove old plan/domain items.
-						await replaceProductsInCart( siteSlug as string, items );
 					}
 					return navigate( 'launchpad' );
 				case 'setup-blog':

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -51,6 +51,10 @@ const designFirst: Flow = {
 				asyncComponent: () => import( './internals/steps-repository/launchpad' ),
 			},
 			{
+				slug: 'site-launch',
+				asyncComponent: () => import( './internals/steps-repository/site-launch' ),
+			},
+			{
 				slug: 'celebration-step',
 				asyncComponent: () => import( './internals/steps-repository/celebration-step' ),
 			},
@@ -77,7 +81,6 @@ const designFirst: Flow = {
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );
-			const returnUrl = `/setup/design-first/celebration-step?siteSlug=${ siteSlug }`;
 
 			switch ( currentStep ) {
 				case 'site-creation-step':
@@ -112,19 +115,11 @@ const designFirst: Flow = {
 							// Remove the site_intent.
 							setIntentOnSite( providedDependencies?.siteSlug, '' ),
 						] );
-
-						// If the user launched their site with a plan or domain in their cart, redirect them to
-						// checkout before sending them home.
-						if ( getPlanCartItem() || getDomainCartItem() ) {
-							const encodedReturnUrl = encodeURIComponent( returnUrl );
-
-							return window.location.assign(
-								`/checkout/${ encodeURIComponent(
-									( siteSlug as string ) ?? ''
-								) }?redirect_to=${ encodedReturnUrl }`
-							);
-						}
-						return window.location.replace( returnUrl );
+						return navigate( 'celebration-step' );
+					}
+					if ( providedDependencies?.goToCheckout ) {
+						// Do nothing and wait for checkout redirect
+						return;
 					}
 					return navigate( 'launchpad' );
 				}
@@ -197,6 +192,8 @@ const designFirst: Flow = {
 					}
 					return navigate( 'launchpad' );
 				case 'launchpad':
+					return navigate( 'processing' );
+				case 'site-launch':
 					return navigate( 'processing' );
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -72,9 +72,10 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 
 	const { title, launchTitle, subtitle } = getLaunchpadTranslations( flow );
 
-	const { getPlanCartItem } = useSelect(
+	const { getPlanCartItem, getDomainCartItem } = useSelect(
 		( select ) => ( {
 			getPlanCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem,
+			getDomainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem,
 		} ),
 		[]
 	);
@@ -91,7 +92,8 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 			flow,
 			isEmailVerified,
 			checklistStatuses,
-			getPlanCartItem()?.product_slug ?? null
+			getPlanCartItem(),
+			getDomainCartItem()
 		);
 
 	const currentTask = enhancedTasks?.filter( ( task ) => task.completed ).length;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -10,7 +10,9 @@ import {
 	isDesignFirstFlow,
 	isNewsletterFlow,
 	isStartWritingFlow,
+	replaceProductsInCart,
 } from '@automattic/onboarding';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { ExternalLink } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -44,7 +46,8 @@ export function getEnhancedTasks(
 	flow: string | null = '',
 	isEmailVerified = false,
 	checklistStatuses: LaunchpadStatuses = {},
-	planCartProductSlug?: string | null
+	planCartItem?: MinimalRequestCartProduct | null,
+	domainCartItem?: MinimalRequestCartProduct | null
 ) {
 	if ( ! tasks ) {
 		return [];
@@ -53,7 +56,8 @@ export function getEnhancedTasks(
 	const enhancedTaskList: Task[] = [];
 
 	const productSlug =
-		( isBlogOnboardingFlow( flow ) ? planCartProductSlug : null ) ?? site?.plan?.product_slug;
+		( isBlogOnboardingFlow( flow ) ? planCartItem?.product_slug : null ) ??
+		site?.plan?.product_slug;
 
 	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
 
@@ -342,20 +346,32 @@ export function getEnhancedTasks(
 									! setupBlogCompleted ) ) ||
 							( isDesignFirstFlow( flow ) &&
 								( ! planCompleted || ! domainUpsellCompleted || ! setupBlogCompleted ) ),
-						actionDispatch: () => {
+						actionDispatch: async () => {
 							if ( site?.ID ) {
-								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );
-								const { launchSite } = dispatch( SITE_STORE );
+								// If user selected products during onboarding, update cart and redirect to checkout
+								const onboardingCartItems = [ planCartItem, domainCartItem ].filter(
+									Boolean
+								) as MinimalRequestCartProduct[];
+								if ( onboardingCartItems.length ) {
+									await replaceProductsInCart( siteSlug as string, onboardingCartItems );
+									return window.location.assign(
+										`/checkout/${ encodeURIComponent(
+											( siteSlug as string ) ?? ''
+										) }?cancel_to=/home&redirect_to=/some-new-launch-step`
+									);
+								}
+								// const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );
+								// const { launchSite } = dispatch( SITE_STORE );
 
-								setPendingAction( async () => {
-									setProgressTitle( __( 'Launching blog' ) );
-									await launchSite( site.ID );
+								// setPendingAction( async () => {
+								// 	setProgressTitle( __( 'Launching blog' ) );
+								// 	await launchSite( site.ID );
 
-									// Waits for half a second so that the loading screen doesn't flash away too quickly
-									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									recordTaskClickTracksEvent( flow, task.completed, task.id );
-									return { blogLaunched: true, siteSlug };
-								} );
+								// 	// Waits for half a second so that the loading screen doesn't flash away too quickly
+								// 	await new Promise( ( res ) => setTimeout( res, 500 ) );
+								// 	recordTaskClickTracksEvent( flow, task.completed, task.id );
+								// 	return { blogLaunched: true, siteSlug };
+								// } );
 
 								submit?.();
 							}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-launch/index.tsx
@@ -7,6 +7,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { urlToSlug } from 'calypso/lib/url';
 import type { StepProps } from '../../types';
 // import './style.scss';
 interface SiteLaunchStepProps extends StepProps {
@@ -27,8 +28,8 @@ const SiteLaunchStep: React.FC< SiteLaunchStepProps > = function ( props ) {
 		if ( site?.ID ) {
 			setPendingAction( async () => {
 				await launchSite( site.ID );
-				await new Promise( ( res ) => setTimeout( res, 2000 ) );
-				return { blogLaunched: true };
+				await new Promise( ( res ) => setTimeout( res, 1000 ) );
+				return { blogLaunched: true, siteSlug: urlToSlug( site.URL ) };
 			} );
 			submit?.();
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-launch/index.tsx
@@ -1,0 +1,62 @@
+import { StepContainer } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { StepProps } from '../../types';
+// import './style.scss';
+interface SiteLaunchStepProps extends StepProps {
+	title?: string;
+	subtitle?: string;
+}
+
+const SiteLaunchStep: React.FC< SiteLaunchStepProps > = function ( props ) {
+	const { submit } = props.navigation;
+
+	const { __ } = useI18n();
+
+	const site = useSite();
+	const { launchSite } = useDispatch( SITE_STORE );
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+
+	const callLaunchSite = async () => {
+		if ( site?.ID ) {
+			setPendingAction( async () => {
+				await launchSite( site.ID );
+				await new Promise( ( res ) => setTimeout( res, 2000 ) );
+				return { blogLaunched: true };
+			} );
+			submit?.();
+		}
+	};
+
+	useEffect( () => {
+		callLaunchSite();
+	}, [ site ] );
+
+	return (
+		<>
+			<DocumentHead title={ __( 'Processing' ) } />
+			<StepContainer
+				shouldHideNavButtons={ true }
+				hideFormattedHeader={ true }
+				stepName="processing-step"
+				stepContent={
+					<>
+						<div className="processing-step">
+							<h1 className="processing-step__progress-step">{ __( 'Launching blog' ) }</h1>
+							<LoadingEllipsis />
+						</div>
+					</>
+				}
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
+	);
+};
+
+export default SiteLaunchStep;

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -1,7 +1,6 @@
 import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
-import { START_WRITING_FLOW, replaceProductsInCart } from '@automattic/onboarding';
-import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
@@ -50,6 +49,10 @@ const startWriting: Flow = {
 				asyncComponent: () => import( './internals/steps-repository/launchpad' ),
 			},
 			{
+				slug: 'site-launch',
+				asyncComponent: () => import( './internals/steps-repository/site-launch' ),
+			},
+			{
 				slug: 'celebration-step',
 				asyncComponent: () => import( './internals/steps-repository/celebration-step' ),
 			},
@@ -59,13 +62,6 @@ const startWriting: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
 		const siteSlug = useSiteSlug();
-		const { getDomainCartItem, getPlanCartItem } = useSelect(
-			( select ) => ( {
-				getDomainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem,
-				getPlanCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem,
-			} ),
-			[]
-		);
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
 		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
 		const state = useSelect(
@@ -76,7 +72,6 @@ const startWriting: Flow = {
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );
-			const returnUrl = `/setup/start-writing/celebration-step?siteSlug=${ siteSlug }`;
 
 			switch ( currentStep ) {
 				case 'site-creation-step':
@@ -99,24 +94,17 @@ const startWriting: Flow = {
 						);
 					}
 
-					// If the user's site has just been launched.
-					if ( providedDependencies?.blogLaunched && providedDependencies?.siteSlug ) {
-						// Remove the site_intent.
+					if ( providedDependencies?.blogLaunched ) {
+						// Remove the site_intent so that it doesn't affect the editor.
 						await setIntentOnSite( providedDependencies?.siteSlug, '' );
-
-						// If the user launched their site with a plan or domain in their cart, redirect them to
-						// checkout before sending them home.
-						if ( getPlanCartItem() || getDomainCartItem() ) {
-							const encodedReturnUrl = encodeURIComponent( returnUrl );
-
-							return window.location.assign(
-								`/checkout/${ encodeURIComponent(
-									( siteSlug as string ) ?? ''
-								) }?redirect_to=${ encodedReturnUrl }`
-							);
-						}
-						return window.location.replace( returnUrl );
+						return navigate( 'celebration-step' );
 					}
+
+					if ( providedDependencies?.goToCheckout ) {
+						// Do nothing and wait for checkout redirect
+						return;
+					}
+
 					return navigate( 'launchpad' );
 				}
 				case 'domains':
@@ -147,11 +135,6 @@ const startWriting: Flow = {
 
 						const currentSiteSlug = String( providedDependencies?.domainName ?? siteSlug );
 
-						await replaceProductsInCart(
-							currentSiteSlug as string,
-							[ getPlanCartItem() ].filter( Boolean ) as MinimalRequestCartProduct[]
-						);
-
 						return window.location.assign(
 							`/setup/start-writing/launchpad?siteSlug=${ currentSiteSlug }`
 						);
@@ -171,14 +154,6 @@ const startWriting: Flow = {
 							checklist_statuses: { plan_completed: true },
 						} );
 					}
-					if ( providedDependencies?.goToCheckout ) {
-						const items = [ getPlanCartItem(), getDomainCartItem() ].filter(
-							Boolean
-						) as MinimalRequestCartProduct[];
-
-						// Always replace items in the cart so we can remove old plan/domain items.
-						await replaceProductsInCart( siteSlug as string, items );
-					}
 					return navigate( 'launchpad' );
 				case 'setup-blog':
 					if ( siteSlug ) {
@@ -188,6 +163,8 @@ const startWriting: Flow = {
 					}
 					return navigate( 'launchpad' );
 				case 'launchpad':
+					return navigate( 'processing' );
+				case 'site-launch':
 					return navigate( 'processing' );
 			}
 		}

--- a/client/landing/stepper/hooks/use-checkout.ts
+++ b/client/landing/stepper/hooks/use-checkout.ts
@@ -12,6 +12,7 @@ interface GoToCheckoutProps {
 	siteSlug: string;
 	destination: string;
 	plan?: string;
+	cancelDestination?: string;
 }
 
 const useCheckout = () => {
@@ -21,11 +22,12 @@ const useCheckout = () => {
 		siteSlug,
 		destination,
 		plan,
+		cancelDestination,
 	}: GoToCheckoutProps ) => {
 		const relativeCurrentPath = window.location.href.replace( window.location.origin, '' );
 		const params = new URLSearchParams( {
 			redirect_to: destination,
-			cancel_to: relativeCurrentPath,
+			cancel_to: cancelDestination || relativeCurrentPath,
 			signup: '1',
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2379

## Proposed Changes

### When clicking on "Launch your blog"

User doesn't select anything that costs money
* Launch the site

User selects a plan/domain
* Go to checkout
  * If user leaves cart (empty cart/leave items), redirect back to launchpad
* Launch the site and show celebration screen

Code changes:
* Added a `/site-launch` step
* Removed adding things to cart when user selects domain/plan -> everything is updated to cart when they press "Launch your blog"
* Go to checkout if there are items in the cart

(Please ignore the layout breaking for now as they are not related to this PR)

https://github.com/Automattic/wp-calypso/assets/6586048/444e11f7-01b1-4b96-99c2-f58c84ad9c9f


TODO:

- [ ] Manual test for `design-first` flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/start-writing` with a new account or account with 0 sites
* Go through the launchpad and test around the scenarios mentioned above
* Try to break it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
