### PR TITLE
Launchpad: Add drive traffic task

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -1,6 +1,7 @@
 import { CircularProgressBar } from '@automattic/components';
 import { useLaunchpad } from '@automattic/data-stores';
 import { Launchpad, Task } from '@automattic/launchpad';
+import { isMobile } from '@automattic/viewport';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -57,6 +58,15 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 					actionDispatch = () => {
 						recordTaskClickTracksEvent( task );
 						window.location.assign( `/domains/add/${ siteSlug }` );
+					};
+					break;
+				case 'drive_traffic':
+					actionDispatch = () => {
+						recordTaskClickTracksEvent( task.completed, task.id );
+						const url = isMobile()
+							? `/marketing/connections/${ siteSlug }`
+							: `/marketing/connections/${ siteSlug }?tour=marketingConnectionsTour`;
+						window.location.assign( url );
 					};
 					break;
 			}

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -62,7 +62,7 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 					break;
 				case 'drive_traffic':
 					actionDispatch = () => {
-						recordTaskClickTracksEvent( task.completed, task.id );
+						recordTaskClickTracksEvent( task );
 						const url = isMobile()
 							? `/marketing/connections/${ siteSlug }`
 							: `/marketing/connections/${ siteSlug }?tour=marketingConnectionsTour`;

--- a/client/my-sites/marketing/connections/connections.jsx
+++ b/client/my-sites/marketing/connections/connections.jsx
@@ -1,4 +1,6 @@
+import { useLaunchpad, updateLaunchpadSettings } from '@automattic/data-stores';
 import { localize } from 'i18n-calypso';
+import { useEffect } from 'react';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import QueryP2Connections from 'calypso/components/data/query-p2-connections';
@@ -9,8 +11,25 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import SharingServicesGroup from './services-group';
 
-const SharingConnections = ( { translate, isP2Hub, siteId } ) => {
+const SharingConnections = ( { translate, isP2Hub, siteId, siteSlug } ) => {
 	useRequestSiteChecklistTaskUpdate( siteId, CHECKLIST_KNOWN_TASKS.POST_SHARING_ENABLED );
+
+	const { data: { checklist: launchpadChecklist } = {} } = useLaunchpad(
+		siteSlug,
+		'keep-building'
+	);
+
+	useEffect( () => {
+		const driveTrafficTask = launchpadChecklist?.find(
+			( task ) => task.id === 'drive_traffic' && task.completed === false
+		);
+		if ( driveTrafficTask ) {
+			// Mark the task as done
+			updateLaunchpadSettings( siteSlug, {
+				checklist_statuses: { drive_traffic: true },
+			} );
+		}
+	}, [ launchpadChecklist ] );
 
 	return (
 		<div className="connections__sharing-settings connections__sharing-connections">

--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -84,7 +84,9 @@ export const connections = ( context, next ) => {
 		);
 	}
 
-	context.contentComponent = createElement( SharingConnections, { isP2Hub, siteId } );
+	const siteSlug = getSiteSlug( state, siteId );
+
+	context.contentComponent = createElement( SharingConnections, { isP2Hub, siteId, siteSlug } );
 
 	next();
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/77809

## Proposed Changes

This PR adds the client side part of the drive traffic task. It adds a drive_traffic action to the Launchpad that redirects the user to `/marketing/connections` when it's clicked. It will mark the task as done on the server when the `/marketing/connections` component is rendered.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply [this PR](https://github.com/Automattic/jetpack/pull/31377) in your sandbox.
* Sandbox `public-api`.
* Go to a site home to see the Launchpad.
* Verify you see the `Drive traffic to your site` task.
* Click on it.
* Verify you are redirected to `/marketing/connections` and the tooltip is shown.
* Go back to the sites home and verify the task is marked as complete.
* Unsandbox `public-api`.
* Verify the task is not show and that navigation to `/marketing/connections` does not trigger an error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
