### PR TITLE
Reader: Add featured video support for VideoPress blocks

### DIFF
--- a/client/lib/get-video-id.js
+++ b/client/lib/get-video-id.js
@@ -1,0 +1,11 @@
+import _getEmbedMetadata from 'get-video-id';
+
+/**
+ * Wrapper for the get-video-id library in order to make sure that video.wordpress.com videos are
+ * considered videopress.com videos. Ideally this would be fixed upstream but the library's last
+ * commit at the time of writing is almost a year old ... and it's HACK week ;)
+ */
+export default function getEmbedMetadata( url ) {
+	// Fake the video domain for video.wordpress.com to look like videopress.com so the external library recognizes it.
+	return _getEmbedMetadata( url.replace( 'video.wordpress', 'videopress' ) );
+}

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -1,7 +1,7 @@
 /* eslint-disable jsdoc/no-undefined-types */
 
-import getEmbedMetadata from 'get-video-id';
 import { map, compact, includes, some, filter } from 'lodash';
+import getEmbedMetadata from 'calypso/lib/get-video-id';
 import { READER_CONTENT_WIDTH } from 'calypso/state/reader/posts/sizes';
 import { iframeIsAllowed, maxWidthPhotonishURL, deduceImageWidthAndHeight } from './utils';
 
@@ -70,6 +70,7 @@ const detectImage = ( image ) => {
 const getAutoplayIframe = ( iframe ) => {
 	const KNOWN_SERVICES = [ 'youtube', 'vimeo', 'videopress' ];
 	const metadata = getEmbedMetadata( iframe.src );
+
 	if ( metadata && includes( KNOWN_SERVICES, metadata.service ) ) {
 		const autoplayIframe = iframe.cloneNode();
 		if ( autoplayIframe.src.indexOf( '?' ) === -1 ) {
@@ -90,7 +91,15 @@ const getEmbedType = ( iframe ) => {
 		if ( ! node.className ) {
 			continue;
 		}
+
+		// Match elements like <span class="embed-youtube"><iframe ... /></span>
 		matches = node.className.match( /\bembed-([-a-zA-Z0-9_]+)\b/ );
+		if ( matches ) {
+			return matches[ 1 ];
+		}
+
+		// Match elements like <figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress">...</figure>
+		matches = node.className.match( /\bis-provider-([-a-zA-Z0-9_]+)\b/ );
 		if ( matches ) {
 			return matches[ 1 ];
 		}

--- a/client/state/reader/thumbnails/actions.js
+++ b/client/state/reader/thumbnails/actions.js
@@ -1,6 +1,6 @@
 import debugModule from 'debug';
-import getEmbedMetadata from 'get-video-id';
 import { get } from 'lodash';
+import getEmbedMetadata from 'calypso/lib/get-video-id';
 import { READER_THUMBNAIL_RECEIVE } from 'calypso/state/reader/action-types';
 
 import 'calypso/state/reader/init';


### PR DESCRIPTION
Related to p1HpG7-lfW-p2#comment-64019

The solution is hacky and it would be ideal for there to be a fix upstream but if we're looking for a quick and dirty fix for now this should do. The root cause is that `get-video-id` does not recognize videos hosted on video.wordpress.com as VideoPress videos.

## Proposed Changes

* Reader: Add support for featured video media hosted on video.wordpress.com, not just videopress.com.

## Testing Instructions

1. Follow this blog so it shows up in your reader: https://atanasvideofeedblog.wordpress.com/
2. Open up the blog's feed before checking out this patch: http://calypso.localhost:3000/read/feeds/143404674
3. You should see the screenshot marked as BEFORE - the second post will be missing it's featured video.
4. Checkout this PR's branch and refresh - the second video will now show its featured video content as seen in the AFTER screenshot.

The video in the test post was added by uploading a video file directly into the block editor.

| BEFORE | AFTER |
| - | - |
| ![Screen Shot 2023-06-14 at 18 02 32](https://github.com/Automattic/wp-calypso/assets/22746396/d02a1275-756f-4fc8-8d67-38363ea2567d) | ![Screen Shot 2023-06-14 at 18 00 04](https://github.com/Automattic/wp-calypso/assets/22746396/784c4949-f584-41ef-9566-c408f4ca81c9) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?