### PR TITLE
Launchpad: Add tracks event for task list view on Customer Home

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -2,13 +2,13 @@ import { CircularProgressBar } from '@automattic/components';
 import { useLaunchpad } from '@automattic/data-stores';
 import { Launchpad, Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
-import { useEffect } from 'react';
 
 function recordTaskClickTracksEvent( is_completed: boolean, task_id: string ) {
 	recordTracksEvent( 'calypso_launchpad_task_clicked', {

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -8,6 +8,7 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
+import { useEffect } from 'react';
 
 function recordTaskClickTracksEvent( is_completed: boolean, task_id: string ) {
 	recordTracksEvent( 'calypso_launchpad_task_clicked', {
@@ -26,6 +27,17 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 	const {
 		data: { checklist },
 	} = useLaunchpad( siteSlug, checklistSlug );
+
+	const taskIds = checklist?.map( ( task: Task ) => task.id ).join( ', ' ) || false;
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_launchpad_task_list_view', {
+			checklist_slug: checklistSlug,
+			context: 'customer-home',
+			tasks: taskIds,
+			// @todo: Add `is_completed` once we've added it to the API endpoint.
+		} );
+	}, [] );
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;


### PR DESCRIPTION
Related to #77616

## Proposed Changes

* Add a Tracks event `calypso_launchpad_task_list_view` with the following properties when the task list is shown in Customer Home:

* Task list slug/ID - `checklist_slug: "keep-building"`
* Included tasks - `tasks: "task-slug-1, task-slug-2, task-slug-3, etc."` -- this is a concatenated string of task IDs since we can't log nested properties, or false if no tasks exist.
* Surrounding context (where the task list was shown) - `context: "customer-home"`

## Testing Instructions

* Switch to this PR
* Navigate to `/home` on a site with the Keep Building task list
* Confirm you see the tracks event fire with the above properties, like so:

<img width="1379" alt="Screen Shot 2023-06-14 at 12 49 46 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/9172cab8-1dfe-4c3d-95f2-387054127e8c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
