### PR TITLE
Editor tracking - only redefine redux actions when necessary.

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -887,6 +887,10 @@ const REDUX_TRACKING = {
  */
 const EVENT_TYPES = [ 'keyup', 'click' ];
 
+// Store original and rewritten redux actions locally so we can return the same references when
+// needed.
+const rewrittenActions = {};
+const originalActions = {};
 // Registering tracking handlers.
 if (
 	undefined === window ||
@@ -903,12 +907,10 @@ if (
 			const actions = { ...registry.dispatch( namespaceName ) };
 			const trackers = REDUX_TRACKING[ namespaceName ];
 
-			// Store rewrittenActions so we can return the same reference when the store updates.
+			// Initialize namespace level objects if not yet done.
 			if ( ! rewrittenActions[ namespaceName ] ) {
 				rewrittenActions[ namespaceName ] = {};
 			}
-			// Store originalActions so we can determine if these ever change and we need to update
-			// the corresponding item in rewrittenActions.
 			if ( ! originalActions[ namespaceName ] ) {
 				originalActions[ namespaceName ] = {};
 			}
@@ -983,6 +985,3 @@ if (
 		}
 	);
 }
-
-const rewrittenActions = {};
-const originalActions = {};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1686677477797309-slack-CBTN58FTJ and https://github.com/Automattic/wp-calypso/issues/78131  and https://github.com/Automattic/wp-calypso/issues/66092 

## Proposed Changes

For editor tracking via redux actions: This saves the updated action with tracking functionality locally, and returns that when the registry updates and the original action has not changed. Also stores the original action for reference to determine the need for rewriting later.

Previously, the action was rewritten with an anonymous function every time which could cause some odd edge cases like seen in linked issues above. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* patch this wpcom-block-editor build
* sandbox public-api, widgets, and a gutenberg-edge stickered test site
* test and verify this issue doesn't happen https://github.com/Automattic/wp-calypso/issues/78131 
* verify editor tracking events still works as expected
* Verify gutenberg functionality continues to work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?