### PR TITLE
Launchpad: sort task list

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -34,8 +34,13 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 
-	const tasksWithActions = ( tasks: Task[] ) => {
-		return tasks.map( ( task: Task ) => {
+	const sortedTasksWithActions = ( tasks: Task[] ) => {
+		const completedTasks = tasks.filter( ( task: Task ) => task.completed );
+		const incompleteTasks = tasks.filter( ( task: Task ) => ! task.completed );
+
+		const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
+
+		return sortedTasks.map( ( task: Task ) => {
 			let actionDispatch;
 
 			switch ( task.id ) {
@@ -93,7 +98,7 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 			<Launchpad
 				siteSlug={ siteSlug }
 				checklistSlug={ checklistSlug }
-				taskFilter={ tasksWithActions }
+				taskFilter={ sortedTasksWithActions }
 			/>
 		</div>
 	);

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -19,16 +19,12 @@ const Launchpad = ( {
 	const { isFetchedAfterMount, data } = launchpadData;
 
 	const originalTasks = data.checklist || [];
-	const tasks: Task[] | null = taskFilter ? taskFilter( originalTasks ) : originalTasks;
+	const tasks = taskFilter ? taskFilter( originalTasks ) : originalTasks;
 
-	const completedTasks = tasks?.filter( ( task: Task ) => task.completed );
-	const incompleteTasks = tasks?.filter( ( task: Task ) => ! task.completed );
-
-	const sortedTasks = [ ...( completedTasks || [] ), ...( incompleteTasks || [] ) ];
 	return (
 		<div className="launchpad__checklist-wrapper">
 			{ isFetchedAfterMount ? (
-				<Checklist tasks={ sortedTasks } makeLastTaskPrimaryAction={ makeLastTaskPrimaryAction } />
+				<Checklist tasks={ tasks } makeLastTaskPrimaryAction={ makeLastTaskPrimaryAction } />
 			) : (
 				<Checklist.Placeholder />
 			) }

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -19,12 +19,16 @@ const Launchpad = ( {
 	const { isFetchedAfterMount, data } = launchpadData;
 
 	const originalTasks = data.checklist || [];
-	const tasks = taskFilter ? taskFilter( originalTasks ) : originalTasks;
+	const tasks: Task[] | null = taskFilter ? taskFilter( originalTasks ) : originalTasks;
 
+	const completedTasks = tasks?.filter( ( task: Task ) => task.completed );
+	const incompleteTasks = tasks?.filter( ( task: Task ) => ! task.completed );
+
+	const sortedTasks = [ ...( completedTasks || [] ), ...( incompleteTasks || [] ) ];
 	return (
 		<div className="launchpad__checklist-wrapper">
 			{ isFetchedAfterMount ? (
-				<Checklist tasks={ tasks } makeLastTaskPrimaryAction={ makeLastTaskPrimaryAction } />
+				<Checklist tasks={ sortedTasks } makeLastTaskPrimaryAction={ makeLastTaskPrimaryAction } />
 			) : (
 				<Checklist.Placeholder />
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Sorts the task lists always putting the completed items on top.

Closes https://github.com/Automattic/wp-calypso/issues/78197

| Before  | After |
| ------------- | ------------- |
| <img width="708" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/7bd87af5-c896-4f63-bcd7-256fcb9e3693">| <img width="713" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/e6e19fcd-0084-4837-ba88-109c063d36ba">  |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the task list component and verify that the completed items are on top.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
