### PR TITLE
Subscribers: Move import notice above button

### DIFF
--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -504,6 +504,8 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 					{ renderEmptyFormValidationMsg() }
 
+					{ showCsvUpload && ! includesHandledError() && renderImportCsvDisclaimerMsg() }
+
 					<NextButton
 						type="submit"
 						className="add-subscriber__form-submit-btn"
@@ -519,7 +521,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 							</button>
 						</div>
 					) }
-					{ showCsvUpload && ! includesHandledError() && renderImportCsvDisclaimerMsg() }
 				</form>
 			</div>
 		</div>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -358,7 +358,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						sprintf(
 							/* translators: the first string variable shows CTA button name */
 							translate(
-								'By clicking "%s", you represent that you\'ve obtained the appropriate consent to email each person. <Button>Learn more</Button>.'
+								'By clicking "%s," you represent that you\'ve obtained the appropriate consent to email each person. <Button>Learn more</Button>.'
 							),
 							submitBtnName
 						),


### PR DESCRIPTION
## Proposed Changes

This PR moves the import notice above the submit button in the AddSubscribers form component. This came up as feedback here from legal team: pdtkmj-pL-p2#comment-2689 and p1686769367064479-slack-C052XEUUBL4

I've also moved the comma inside the quote, again based on feedback in the first link above.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch and run yarn and yarn start if needed. 
* Start a new newsletter site at http://calypso.localhost:3000/setup/newsletter/intro
* Proceed to the subscribers step.
* Type a valid email into one of the fields, and confirm that the `By clicking "Add and continue", you represent that you've obtained the appropriate consent to email each person.` notice appears above, and not below, the `Add and continue` button.
* As this is a generic component, we should also test in other places. Go to `http://calypso.localhost:3000/people/add-subscribers/YOURSITEDOMAIN`, click to add subscribers, and agin enter an email. Confirm the loads as expected above the submit button. 

**Onboarding screen should look like:**

<img width="395" alt="Screenshot on 2023-06-14 at 14-44-22" src="https://github.com/Automattic/wp-calypso/assets/21228350/1b9a50be-fc2d-45ab-a4a9-f196844d0b57">

**Backend user/subscribers screen should look like:**

<img width="728" alt="Screenshot on 2023-06-14 at 14-42-57" src="https://github.com/Automattic/wp-calypso/assets/21228350/e226d236-be8a-4f55-8f24-50c38aea7a55">

