### PR TITLE
Stats: Consider user's role when showing the dashboard

### DIFF
--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -87,11 +87,18 @@ class JetpackSiteStats extends Component {
 			onChange = handleAutosavingToggle( name );
 		}
 
+		// Admin users should always be able to access stats, so we don't want to enable the toggle for them.
+		const isAdminToggleForStatsVisibilitySection = name === 'roles_administrator';
+
 		return (
 			<ToggleControl
-				checked={ checked }
+				checked={ checked || isAdminToggleForStatsVisibilitySection }
 				disabled={
-					isRequestingSettings || isSavingSettings || moduleUnavailable || ! statsModuleActive
+					isRequestingSettings ||
+					isSavingSettings ||
+					moduleUnavailable ||
+					! statsModuleActive ||
+					isAdminToggleForStatsVisibilitySection
 				}
 				onChange={ onChange }
 				key={ name }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -383,9 +383,13 @@ class StatsSite extends Component {
 			<EmptyContent
 				illustration={ illustration404 }
 				title={ translate( 'Looking for stats?' ) }
-				line={ translate(
-					'Enable Jetpack Stats to see detailed information about your traffic, likes, comments, and subscribers.'
-				) }
+				line={
+					<p>
+						{ translate(
+							'Enable Jetpack Stats to see detailed information about your traffic, likes, comments, and subscribers.'
+						) }
+					</p>
+				}
 				action={ translate( 'Enable Jetpack Stats' ) }
 				actionCallback={ this.enableStatsModule }
 			/>
@@ -402,9 +406,14 @@ class StatsSite extends Component {
 			<EmptyContent
 				illustration={ illustration404 }
 				title={ translate( 'Looking for stats?' ) }
-				line={ translate(
-					'You have insufficient permissions for viewing the Jetpack Stats dashboard. Please contact your site administrator for access.'
-				) }
+				line={
+					<p>
+						<div>
+							{ translate( "We're sorry, but you do not have permission to access this page." ) }
+						</div>
+						<div>{ translate( "Please contact your site's administrator for access." ) }</div>
+					</p>
+				}
 			/>
 		);
 	}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -487,7 +487,7 @@ export default connect(
 		//       If the user's role is missing from the site's stats dashboard access allowlist (fetched via getJetpackSettings.role),
 		//       then it should be reflected in the user's view_stats capability.
 		const canUserViewStats =
-			! isOdysseyStats && ( canUserManageOptions || canCurrentUser( state, siteId, 'view_stats' ) );
+			isOdysseyStats || ( canUserManageOptions || canCurrentUser( state, siteId, 'view_stats' ) );
 
 		return {
 			canUserViewStats,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -487,7 +487,7 @@ export default connect(
 		//       If the user's role is missing from the site's stats dashboard access allowlist (fetched via getJetpackSettings.role),
 		//       then it should be reflected in the user's view_stats capability.
 		const canUserViewStats =
-			isOdysseyStats || ( canUserManageOptions || canCurrentUser( state, siteId, 'view_stats' ) );
+			isOdysseyStats || canUserManageOptions || canCurrentUser( state, siteId, 'view_stats' );
 
 		return {
 			canUserViewStats,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -392,6 +392,7 @@ class StatsSite extends Component {
 	}
 
 	componentDidMount() {
+		// TODO: Migrate to a query component pattern (i.e. <QueryStatsModuleSettings siteId={siteId} />).
 		this.props.requestModuleSettings( this.props.siteId );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/31358

## Proposed Changes

* Ensure that administrators can always access the stats dashboard.
* Check the user's capabilities before prompting them to enable the Jetpack Stats module.
* Check the user's capabilities before rendering the Jetpack Stats dashboard.

Note that **the `view_stats` capability is currently bugged** in the backend for Atomic sites and **ignores the configured allowlist for accessing the stats dashboard**. Once this is fixed in the backend, everything should work as expected on Calypso.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Tools > Marketing > Traffic Section
> <img width="257" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/f3c28aa1-d9d2-475d-b756-19426574753b">

* Navigate to `/marketing/traffic/:siteSlug` and expand the "Jetpack Stats" section. You'll need to use an Atomic site for these settings to appear.
* Ensure that the "Administrator" toggle in the "Allow stats reports to be viewed by" is checked and disabled.

### Jetpack Stats as an Administrator
* Navigate to `/stats/day/:siteSlug` on an atomic site with an admin user and ensure it works as expected.

### Jetpack Stats as an Non-Administrator
* Repeat the above using a non-admin user **with permission** to view the dashboard. Ensure the page works as expected.
* Repeat the above using a non-admin user **without permission** to view the dashboard. Unfortunately, user capabilities are currently not working as expected here, and you will be able to access the stats dashboard.

### Jetpack Stats as a Non-Administrator while the module is disabled
* Navigate to `/marketing/traffic/:siteSlug`and disable "Jetpack Stats" section using an admin user.

> <img width="697" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/9c5213ad-5d1a-420f-b38c-bb6e7e534fe8">

* Navigate to `/stats/day/:siteSlug` as a non-admin user. Ensure that you see a message saying you cannot access Jetpack Stats.

> <img width="963" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/500b5024-1d06-45c7-9e17-de4e641b0918">

* Repeat the above using an admin user. Ensure you see a page prompting you to enable the Jetpack Stats module.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
