### PR TITLE
Fix entering decimal (.) for Earn payment plans on Safari

### DIFF
--- a/client/components/forms/form-currency-input/index.jsx
+++ b/client/components/forms/form-currency-input/index.jsx
@@ -64,7 +64,6 @@ function FormCurrencyInput( {
 	return (
 		<FormTextInputWithAffixes
 			{ ...props }
-			type="number"
 			className={ classes }
 			prefix={ prefix }
 			suffix={ suffix }

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -187,7 +187,9 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	};
 	const handlePriceChange = ( event ) => {
 		const value = parseFloat( event.currentTarget.value );
-		setCurrentPrice( value );
+		if ( ! isNaN( value ) ) {
+			setCurrentPrice( event.currentTarget.value );
+		}
 	};
 	const handlePayWhatYouWant = ( newValue ) => setEditedPayWhatYouWant( newValue );
 	const handleMultiplePerUser = ( newValue ) => setEditedMultiplePerUser( newValue );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #77926.

## Proposed Changes

* Change the currency input field type from number to text.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up development environment. If testing against sandboxed store I had to:
   * disable proxy
   * on sandbox: `sudo global-http enable` (and answer all the prompts)
* Using Safari, navigate to http://calypso.localhost:3000/earn/payments-plans/neffffearn.wordpress.com#add-newsletter-payment-plan (your URL might be slightly different depending on the site you test against)
* Try entering different values into the currency field.  After this change invalid values are preserved in the field, but the save is not enabled until the value is valid.

<video src="https://github.com/Automattic/wp-calypso/assets/6354169/fc623ad8-fec1-4f53-89c1-4913656671d2">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
