### PR TITLE
Add setup-container selector to force rule application

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-blog/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-blog/styles.scss
@@ -3,7 +3,7 @@
 $font-family: "SF Pro Text", $sans;
 
 .setup-blog {
-	.step-container__content {
+	.step-container .step-container__content {
 		display: flex;
 		justify-content: center;
 		margin-bottom: 30px;
@@ -14,7 +14,7 @@ $font-family: "SF Pro Text", $sans;
 		text-transform: none;
 	}
 
-	.step-container__header {
+	.step-container .step-container__header {
 		margin-bottom: 32px;
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/78071

Context p1686782827094329-slack-CKZHG0QCR

## Proposed Changes

* Adds .step-container to ensure css rules gets applied correctly in development environments.

## Testing Instructions

* User with no sites
* Visit http://calypso.localhost:3000/setup/design-first clicking through to setting a site name
* Form should be centered on the screen.

Before/After
![Screenshot 2023-06-15 at 13-09-29 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/9b0d2351-21cf-4fea-b597-0ef154230632)

![Screenshot 2023-06-15 at 13-09-44 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/eb7dad46-2c28-475d-ac55-56398b69e9b5)