### PR TITLE
Use browser language for logged out users

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -8,6 +8,7 @@ import {
 	isTranslatedIncompletely,
 	isDefaultLocale,
 	getLanguageSlugs,
+	getLanguage,
 } from '@automattic/i18n-utils';
 import bodyParser from 'body-parser';
 import cookieParser from 'cookie-parser';
@@ -297,7 +298,16 @@ function setUpLoggedOutRoute( req, res, next ) {
 		};
 	}
 	const acceptLang = req.get( 'Accept-Language' )?.split( ',' )[ 0 ];
-	req.context.lang = acceptLang || req.context.lang;
+
+	const language = getLanguage( acceptLang );
+
+	if ( language ) {
+		req.context.lang = language.langSlug;
+		req.context.store.dispatch( {
+			type: LOCALE_SET,
+			localeSlug: language.langSlug,
+		} );
+	}
 
 	Promise.all( setupRequests )
 		.then( () => {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -296,6 +296,8 @@ function setUpLoggedOutRoute( req, res, next ) {
 			subscriptionManagementSubkey: req.cookies.subkey,
 		};
 	}
+	const acceptLang = req.get( 'Accept-Language' )?.split( ',' )[ 0 ];
+	req.context.lang = acceptLang || req.context.lang;
 
 	Promise.all( setupRequests )
 		.then( () => {

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,5 +1,4 @@
 import warn from '@wordpress/warning';
-import i18n from 'i18n-calypso';
 import { random, map, includes, get } from 'lodash';
 import { keyForPost } from 'calypso/reader/post-key';
 import XPostHelper from 'calypso/reader/xpost-helper';
@@ -212,14 +211,13 @@ export function requestPage( action ) {
 	const fetchCount = pageHandle ? PER_FETCH : INITIAL_FETCH;
 	// eslint-disable-next-line no-extra-boolean-cast
 	const number = !! gap ? PER_GAP : fetchCount;
-	const lang = i18n.getLocaleVariant() || i18n.getLocaleSlug();
 	return http( {
 		method: 'GET',
 		path: path( { ...action.payload } ),
 		apiVersion,
 		query: isPoll
-			? pollQuery( [], { lang, ...algorithm } )
-			: query( { ...pageHandle, ...algorithm, number, lang }, action.payload ),
+			? pollQuery( [], { ...algorithm } )
+			: query( { ...pageHandle, ...algorithm, number }, action.payload ),
 		onSuccess: action,
 		onFailure: action,
 	} );

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,4 +1,5 @@
 import warn from '@wordpress/warning';
+import i18n from 'i18n-calypso';
 import { random, map, includes, get } from 'lodash';
 import { keyForPost } from 'calypso/reader/post-key';
 import XPostHelper from 'calypso/reader/xpost-helper';
@@ -9,7 +10,6 @@ import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { READER_STREAMS_PAGE_REQUEST } from 'calypso/state/reader/action-types';
 import { receivePosts } from 'calypso/state/reader/posts/actions';
 import { receivePage, receiveUpdates } from 'calypso/state/reader/streams/actions';
-
 const noop = () => {};
 
 /**
@@ -212,14 +212,14 @@ export function requestPage( action ) {
 	const fetchCount = pageHandle ? PER_FETCH : INITIAL_FETCH;
 	// eslint-disable-next-line no-extra-boolean-cast
 	const number = !! gap ? PER_GAP : fetchCount;
-
+	const lang = i18n.getLocaleVariant() || i18n.getLocaleSlug();
 	return http( {
 		method: 'GET',
 		path: path( { ...action.payload } ),
 		apiVersion,
 		query: isPoll
-			? pollQuery( [], { ...algorithm } )
-			: query( { ...pageHandle, ...algorithm, number }, action.payload ),
+			? pollQuery( [], { lang, ...algorithm } )
+			: query( { ...pageHandle, ...algorithm, number, lang }, action.payload ),
 		onSuccess: action,
 		onFailure: action,
 	} );

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -9,6 +9,7 @@ import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { READER_STREAMS_PAGE_REQUEST } from 'calypso/state/reader/action-types';
 import { receivePosts } from 'calypso/state/reader/posts/actions';
 import { receivePage, receiveUpdates } from 'calypso/state/reader/streams/actions';
+
 const noop = () => {};
 
 /**
@@ -211,6 +212,7 @@ export function requestPage( action ) {
 	const fetchCount = pageHandle ? PER_FETCH : INITIAL_FETCH;
 	// eslint-disable-next-line no-extra-boolean-cast
 	const number = !! gap ? PER_GAP : fetchCount;
+
 	return http( {
 		method: 'GET',
 		path: path( { ...action.payload } ),

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -101,7 +101,9 @@ export function getMappedLanguageSlug( langSlug: string | undefined ) {
 	if ( langSlug === 'no' ) {
 		return 'nb';
 	}
-
+	if ( langSlug === 'zh' ) {
+		return 'zh-cn';
+	}
 	return langSlug;
 }
 
@@ -123,7 +125,7 @@ export function getLanguageRouteParam( name = 'lang', optional = true ) {
  * @returns {Object | undefined} An object containing the locale data or undefined.
  */
 export function getLanguage( langSlug: string | undefined ): Language | undefined {
-	langSlug = getMappedLanguageSlug( langSlug );
+	langSlug = getMappedLanguageSlug( langSlug?.toLowerCase() );
 	if ( langSlug && localeRegex.test( langSlug ) ) {
 		// Find for the langSlug first. If we can't find it, split it and find its parent slug.
 		// Please see the comment above `localeRegex` to see why we can split by - or _ and find the parent slug.


### PR DESCRIPTION
As part of opening up the reader to the public, we would like to be able to localize logged out pages for non-en users. project thread: pe7F0s-Ti-p2

For logged in pages, the user's localeSlug is used to set the lang in the calypso server [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/server/pages/index.js#L383)

For logged out pages, we can take the lang from the sent `Accept-Language` header. The header is split to take the first language in case multiple languages exist.

I found that the search endpoint /v1.2/read/search/ already uses the `Accept-Language` header so no change was necessary on the backend.

Note that this can affect the logged in interface language when testing on localhost because of an existing limitation with how the server detects whether the user is logged in or not. On localhost, the `wordpress_logged_in` cookie does not exist so the *setUpLogged**Out**Route* code path is invoked even if the user is logged **in**. Therefore on localhost, this change makes the users browser locale overwrite their interface language. 

Testing:
Set your browser language to a mag-16 language.
In an incognito window, open the `/read/search` page or a `/tag/$tag` page
The page should be rendered in your preferred language.
Test language selection is still based on interface language for logged in users (except on localhost)