### PR TITLE
Odyssey Stats Widget: Fix affected WP Admin notice styles on atomic sites

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -6,9 +6,9 @@
 	}
 }
 
-// Since styles of the component Notice should be imported before this file,
-// we can override the styles without more hierarchy for higher specificity.
-.notice {
+// Since the component `Notice` styles affect the WP Admin notice styles,
+// we need to restore by overriding them except for `.wpcomsh-notice` on Atomic sites.
+.notice:not(.wpcomsh-notice) {
 	display: block;
 	width: auto;
 	background: var(--studio-white);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#31375](https://github.com/Automattic/jetpack/issues/31375)

## Proposed Changes

The [previous change](https://github.com/Automattic/wp-calypso/pull/71954) before https://github.com/Automattic/wp-calypso/pull/76310 is to fix affected notice styles by Odyssey Stats on Jurassic Ninja sites, which would break existing WP Admin notice styling on Atomic sites.

* Adjust notice styles overriding aside from WP Admin on Atomic sites since adding distinguishable class names for JN sites is challenging.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### JN sites
* Spin up a Jurassic Ninja site.
* Follow `Option 2` of `PCYsg-Pp7-p2#option-2` to verify changes on the site.
* Ensure the JN welcome notice looks as previously.
* Ensure the dashboard widget `WordPress Events and News` looks reasonable.

##### Atomic sites
* Spin up an Atomic site.
* Follow `Option 2` of `PCYsg-Pp7-p2#option-2` to verify changes on the site.
* Follow the [steps to reproduce the issue](https://github.com/Automattic/jetpack/issues/31375).
* Ensure the Atomic WP Admin notice works well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
