### PR TITLE
BackupBrowser: Truncate file and directory names

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -73,6 +73,9 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 		return <Icon icon={ isOpen ? chevronDown : chevronRight } />;
 	};
 
+	const labelIsTruncated = item.name.length > 30;
+	const label = labelIsTruncated ? `${ item.name.slice( 0, 30 ) }…` : item.name;
+
 	return (
 		<div className="file-browser-node">
 			{ isRoot ? null : (
@@ -80,8 +83,10 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 					icon={ renderExpandIcon }
 					className="file-browser-node__title has-icon"
 					onClick={ handleClick }
+					showTooltip={ labelIsTruncated }
+					label={ item.name }
 				>
-					<FileTypeIcon type={ item.type } /> { item.name }
+					<FileTypeIcon type={ item.type } /> { label }
 				</Button>
 			) }
 

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -2,6 +2,7 @@ import { Button, Icon } from '@wordpress/components';
 import { chevronDown, chevronRight } from '@wordpress/icons';
 import { FunctionComponent, useCallback, useState } from 'react';
 import FileTypeIcon from './file-type-icon';
+import { useTruncatedFileName } from './hooks';
 import { FileBrowserItem } from './types';
 import { useBackupContentsQuery } from './use-backup-contents-query';
 
@@ -73,8 +74,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 		return <Icon icon={ isOpen ? chevronDown : chevronRight } />;
 	};
 
-	const labelIsTruncated = item.name.length > 30;
-	const label = labelIsTruncated ? `${ item.name.slice( 0, 30 ) }…` : item.name;
+	const [ label, isLabelTruncated ] = useTruncatedFileName( item.name, 30 );
 
 	return (
 		<div className="file-browser-node">
@@ -83,7 +83,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 					icon={ renderExpandIcon }
 					className="file-browser-node__title has-icon"
 					onClick={ handleClick }
-					showTooltip={ labelIsTruncated }
+					showTooltip={ isLabelTruncated }
 					label={ item.name }
 				>
 					<FileTypeIcon type={ item.type } /> { label }

--- a/client/my-sites/backup/backup-contents-page/file-browser/hooks.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/hooks.ts
@@ -1,0 +1,17 @@
+import { getFileExtension } from 'calypso/lib/media/utils/get-file-extension';
+
+type TruncatedFileNameResult = [ string, boolean ];
+
+export const useTruncatedFileName = (
+	name: string,
+	maxLength: number
+): TruncatedFileNameResult => {
+	const isTruncated = name.length > maxLength;
+	const extension = getFileExtension( name ) || '';
+	const basename = name.replace( `.${ extension }`, '' );
+	const truncatedName = isTruncated
+		? `${ basename.slice( 0, maxLength - 3 - extension.length ) }...${ extension }`
+		: name;
+
+	return [ truncatedName, isTruncated ];
+};

--- a/client/my-sites/backup/backup-contents-page/file-browser/test/hooks.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/test/hooks.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { getFileExtension } from 'calypso/lib/media/utils/get-file-extension';
+import { useTruncatedFileName } from '../hooks';
+
+describe( 'useTruncatedFileName', () => {
+	test( 'returns original name when name length is less than max length', () => {
+		const { result } = renderHook( () =>
+			useTruncatedFileName( 'this-is-a-very-long-filename', 30 )
+		);
+
+		expect( result.current[ 0 ] ).toBe( 'this-is-a-very-long-filename' );
+		expect( result.current[ 1 ] ).toBe( false );
+	} );
+
+	test( 'returns truncated name when name length exceeds max length with extension', () => {
+		const { result } = renderHook( () =>
+			useTruncatedFileName( 'this-is-a-very-long-filename.mp3', 30 )
+		);
+
+		const expectedTruncatedName = 'this-is-a-very-long-file...mp3';
+		expect( result.current[ 0 ] ).toBe( expectedTruncatedName );
+		expect( result.current[ 1 ] ).toBe( true );
+	} );
+
+	test( 'returns truncated name when name length exceeds max length without extension', () => {
+		const { result } = renderHook( () =>
+			useTruncatedFileName( 'this-is-a-very-very-very-long-filename', 30 )
+		);
+
+		const expectedTruncatedName = 'this-is-a-very-very-very-lo...';
+		expect( result.current[ 0 ] ).toBe( expectedTruncatedName );
+		expect( result.current[ 1 ] ).toBe( true );
+	} );
+
+	test( 'truncated name should maintain file extension if exists', () => {
+		const { result } = renderHook( () =>
+			useTruncatedFileName( 'this-is-a-very-long-filename.mp3', 30 )
+		);
+
+		const extension = getFileExtension( result.current[ 0 ] );
+		expect( extension ).toBe( 'mp3' );
+	} );
+
+	test( 'truncated name should have no extension when original name has no extension', () => {
+		const { result } = renderHook( () =>
+			useTruncatedFileName( 'this-is-a-very-very-very-long-filename', 30 )
+		);
+
+		const extension = getFileExtension( result.current[ 0 ] );
+		expect( extension ).toBe( '' );
+	} );
+} );

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -11,10 +11,13 @@
 
 	&__body {
 		border-top: 1px solid var(--studio-gray-5);
+		overflow-x: scroll;
 		padding-top: 30px;
 	}
 
 	.file-browser-node {
+		min-width: max-content;
+
 		&__loading {
 			&.placeholder {
 				height: 26px;
@@ -24,9 +27,19 @@
 		}
 
 		&__contents {
+			display: flex;
+			flex-direction: column;
+			overflow-x: auto;
+			background-color: #fff;
+
 			&:not(:first-child) {
 				padding-left: 26px;
 			}
+		}
+
+		.file-browser-node__title {
+			white-space: nowrap;
+			overflow: hidden;
 		}
 
 		.components-button.has-icon.has-text svg {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77947

## Proposed Changes

* Truncate file and directory names longer than 30 characters.
  * Include file extension when truncated.
* Add a tooltip with the full name when the name is truncated.
* Add horizontal scroll the directory tree has many items opened.

## Screenshots

<img width="922" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/98ea8829-2ff4-4ab2-b2e7-a2cb9eb0b849">


## Testing Instructions
If you already have a site with a backup that includes a file with a long name (> 30 chars), you could proceed with the following steps. Otherwise, I will suggest adding a site with a long name, queue a backup and then try the next steps.

* Checkout this branch
* Start your local environment using `yarn start-jetpack-cloud`
* Select one of your sites with a Jetpack VaultPress Backup plan
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Copy the link from the `Download Backup` button and replace `download` with `contents` and navigate to that page.
* You should see a page similar to the one shared above.
* Look for your file (or files) with long names. They should be truncated, and a tooltip should be displayed when you put the mouse pointer on it.

Note: to reproduce the horizontal scroll, you could try to resize the screen or create nested directories in your site (similar to the screenshot shared above).

### Unit tests

```yarn run test-client client/my-sites/backup/backup-contents-page/file-browser/test```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
