### PR TITLE
Hosting Onboarding i2: Ensure all users in the hosting flow are offered a WoA plan

### DIFF
--- a/client/lib/paths/use-add-new-site-url.tsx
+++ b/client/lib/paths/use-add-new-site-url.tsx
@@ -3,17 +3,23 @@ import { useSelector } from 'react-redux';
 import { Primitive } from 'utility-types';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { addQueryArgs } from 'calypso/lib/url';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import type { AppState } from 'calypso/types';
 
 export const useAddNewSiteUrl = ( queryParameters: Record< string, Primitive > ) => {
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
+
+	const isInHostingFlow = useSelector(
+		( state: AppState ) => getInitialQueryArguments( state )?.[ 'hosting-flow' ] === 'true'
+	);
 
 	return addQueryArgs(
 		queryParameters,
 		// eslint-disable-next-line no-nested-ternary
 		isJetpackCloud()
 			? config( 'jetpack_connect_url' )
-			: isDevAccount && config.isEnabled( 'hosting-onboarding-i2' )
+			: ( isDevAccount || isInHostingFlow ) && config.isEnabled( 'hosting-onboarding-i2' )
 			? '/setup/new-hosted-site'
 			: config( 'signup_url' )
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

Changes the new site CTA so that all users who have come from the LOHP go through the `/setup/new-hosted-site` flow.

After this change
- all devs will always use the `/setup/new-hosted-site` flow, even if sometimes they will be able to pick any plan
- all users who landed on the `/hosting` LOHP will use the `/setup/new-hosted-site` flow, but in this case it will always just show the two WoA compatible plans.

I believe this change is appropriate because users the features we're advertising on the LOHP are WoA related, and so it shouldn't really matter whether they tick the dev checkbox or not.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
