### PR TITLE
BackupBrowser: View files button in backup page

### DIFF
--- a/client/components/activity-card/index.tsx
+++ b/client/components/activity-card/index.tsx
@@ -19,7 +19,7 @@ import type { Activity } from './types';
 
 import './style.scss';
 
-const useToggleContent = (): [ boolean, () => void ] => {
+export const useToggleContent = (): [ boolean, () => void ] => {
 	const [ isVisible, setVisible ] = useState( false );
 
 	const toggle = () => {

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -1,5 +1,4 @@
 import { Gridicon } from '@automattic/components';
-import { Icon, file as fileIcon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import * as React from 'react';
@@ -9,11 +8,7 @@ import missingCredentialsIcon from 'calypso/components/jetpack/daily-backup-stat
 import PopoverMenu from 'calypso/components/popover-menu';
 import { getActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
-import {
-	backupContentsPath,
-	backupDownloadPath,
-	backupRestorePath,
-} from 'calypso/my-sites/backup/paths';
+import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
@@ -22,6 +17,7 @@ import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-pr
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteSlug, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import { Activity } from '../types';
+import ViewFilesButton from './buttons/view-files-button';
 import downloadIcon from './download-icon.svg';
 
 type SingleSiteOwnProps = {
@@ -103,16 +99,7 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 						</div>
 					</div>
 				) }
-				<Button
-					borderless
-					compact
-					isPrimary={ false }
-					href={ backupContentsPath( siteSlug, rewindId ) }
-					className="toolbar__view-files-button"
-				>
-					<Icon icon={ fileIcon } className="toolbar__view-files-button-icon" size={ 18 } />
-					<span className="toolbar__view-files-button-text">{ translate( 'View files' ) }</span>
-				</Button>
+				<ViewFilesButton siteSlug={ siteSlug } rewindId={ rewindId } />
 				<Button
 					borderless
 					compact

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import { Icon, file as fileIcon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import * as React from 'react';
@@ -8,7 +9,11 @@ import missingCredentialsIcon from 'calypso/components/jetpack/daily-backup-stat
 import PopoverMenu from 'calypso/components/popover-menu';
 import { getActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
-import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
+import {
+	backupContentsPath,
+	backupDownloadPath,
+	backupRestorePath,
+} from 'calypso/my-sites/backup/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
@@ -98,6 +103,16 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 						</div>
 					</div>
 				) }
+				<Button
+					borderless
+					compact
+					isPrimary={ false }
+					href={ backupContentsPath( siteSlug, rewindId ) }
+					className="toolbar__view-files-button"
+				>
+					<Icon icon={ fileIcon } className="toolbar__view-files-button-icon" size={ 18 } />
+					<span className="toolbar__view-files-button-text">{ translate( 'View files' ) }</span>
+				</Button>
 				<Button
 					borderless
 					compact

--- a/client/components/activity-card/toolbar/buttons/view-files-button.tsx
+++ b/client/components/activity-card/toolbar/buttons/view-files-button.tsx
@@ -1,0 +1,39 @@
+import config from '@automattic/calypso-config';
+import { Icon, file as fileIcon } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import Button from 'calypso/components/forms/form-button';
+import { backupContentsPath } from 'calypso/my-sites/backup/paths';
+
+type ViewFilesButtonProps = {
+	siteSlug: string;
+	rewindId: string;
+	isPrimary?: boolean;
+};
+
+const ViewFilesButton: FunctionComponent< ViewFilesButtonProps > = ( {
+	siteSlug,
+	rewindId,
+	isPrimary = false,
+} ) => {
+	const translate = useTranslate();
+
+	if ( ! config.isEnabled( 'jetpack/backup-contents-page' ) ) {
+		return null;
+	}
+
+	return (
+		<Button
+			borderless
+			compact
+			isPrimary={ isPrimary }
+			href={ backupContentsPath( siteSlug, rewindId ) }
+			className="toolbar__view-files-button"
+		>
+			<Icon icon={ fileIcon } className="toolbar__view-files-button-icon" size={ 18 } />
+			<span className="toolbar__view-files-button-text">{ translate( 'View files' ) }</span>
+		</Button>
+	);
+};
+
+export default ViewFilesButton;

--- a/client/components/activity-card/toolbar/style.scss
+++ b/client/components/activity-card/toolbar/style.scss
@@ -54,18 +54,23 @@
 	justify-content: left;
 }
 
-.toolbar__download-button.is-borderless {
-	margin: 0.8rem;
-	border-radius: 0;
-	border-top: 1px solid #e4e4e6;
-	margin-bottom: 0.5rem;
-	padding-top: 0.8rem;
-	display: flex;
-	justify-content: left;
-	font-size: 0.875rem;
+.toolbar__download-button,
+.toolbar__view-files-button {
+	&.is-borderless {
+		margin: 0.8rem;
+		border-radius: 0;
+		border-top: 1px solid #e4e4e6;
+		margin-bottom: 0.5rem;
+		padding-top: 0.8rem;
+		display: flex;
+		justify-content: left;
+		align-items: center;
+		font-size: 0.875rem;
+	}
 }
 
-.toolbar__download-button-icon {
+.toolbar__download-button-icon,
+.toolbar__view-files-button-icon {
 	margin-right: 0.6rem;
 }
 

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -116,6 +116,7 @@ const DailyBackupStatus = ( {
 				deltas={ deltas }
 				selectedDate={ selectedDate }
 				lastBackupAttemptOnDate={ lastBackupAttemptOnDate }
+				availableActions={ [ 'rewind' ] }
 			/>
 		) : (
 			<BackupFailed backup={ backup } />

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryRewindBackups from 'calypso/components/data/query-rewind-backups';
 import QueryRewindPolicies from 'calypso/components/data/query-rewind-policies';
+import config from '@automattic/calypso-config';
 import BackupWarnings from 'calypso/components/jetpack/backup-warnings/backup-warnings';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { Interval, EVERY_SECOND } from 'calypso/lib/interval';
@@ -116,7 +117,9 @@ const DailyBackupStatus = ( {
 				deltas={ deltas }
 				selectedDate={ selectedDate }
 				lastBackupAttemptOnDate={ lastBackupAttemptOnDate }
-				availableActions={ [ 'rewind' ] }
+				{ ...( config.isEnabled( 'jetpack/backup-contents-page' )
+					? { availableActions: [ 'rewind' ] }
+					: {} ) }
 			/>
 		) : (
 			<BackupFailed backup={ backup } />

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import PropTypes from 'prop-types';
@@ -5,7 +6,6 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryRewindBackups from 'calypso/components/data/query-rewind-backups';
 import QueryRewindPolicies from 'calypso/components/data/query-rewind-policies';
-import config from '@automattic/calypso-config';
 import BackupWarnings from 'calypso/components/jetpack/backup-warnings/backup-warnings';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { Interval, EVERY_SECOND } from 'calypso/lib/interval';

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import ActivityCard from 'calypso/components/activity-card';
+import { default as ActivityCard, useToggleContent } from 'calypso/components/activity-card';
+import { default as Toolbar } from 'calypso/components/activity-card/toolbar';
 import ExternalLink from 'calypso/components/external-link';
 import BackupWarningRetry from 'calypso/components/jetpack/backup-warnings/backup-warning-retry';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -59,12 +60,25 @@ const BackupSuccessful = ( {
 
 	const multiSiteInfoLink = `https://jetpack.com/redirect?source=jetpack-support-backup&anchor=does-jetpack-backup-support-multisite`;
 
+	const [ showContent, toggleShowContent ] = useToggleContent();
+
 	return (
 		<>
 			<div className="status-card__message-head">
 				<img src={ cloudIcon } alt="" role="presentation" />
 				<div className="status-card__hide-mobile">
 					{ isToday ? translate( 'Latest backup' ) : translate( 'Latest backup on this day' ) }
+				</div>
+
+				<div className="status-card__toolbar">
+					<Toolbar
+						siteId={ siteId }
+						activity={ backup }
+						isContentExpanded={ showContent }
+						onToggleContent={ toggleShowContent }
+						availableActions={ [ 'download', 'rewind', 'view' ] }
+						onClickClone={ onClickClone }
+					/>
 				</div>
 			</div>
 			<div className="status-card__hide-desktop">

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { default as ActivityCard, useToggleContent } from 'calypso/components/activity-card';
@@ -70,16 +71,18 @@ const BackupSuccessful = ( {
 					{ isToday ? translate( 'Latest backup' ) : translate( 'Latest backup on this day' ) }
 				</div>
 
-				<div className="status-card__toolbar">
-					<Toolbar
-						siteId={ siteId }
-						activity={ backup }
-						isContentExpanded={ showContent }
-						onToggleContent={ toggleShowContent }
-						availableActions={ [ 'download', 'rewind', 'view' ] }
-						onClickClone={ onClickClone }
-					/>
-				</div>
+				{ config.isEnabled( 'jetpack/backup-contents-page' ) && (
+					<div className="status-card__toolbar">
+						<Toolbar
+							siteId={ siteId }
+							activity={ backup }
+							isContentExpanded={ showContent }
+							onToggleContent={ toggleShowContent }
+							availableActions={ [ 'download', 'rewind', 'view' ] }
+							onClickClone={ onClickClone }
+						/>
+					</div>
+				) }
 			</div>
 			<div className="status-card__hide-desktop">
 				<div className="status-card__title">{ displayDate }</div>

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -44,6 +44,17 @@
 		font-weight: 600;
 	}
 
+	.status-card__toolbar {
+		margin-left: auto;
+
+		.activity-card__toolbar--reverse {
+			margin-left: 0;
+			border-top: 0;
+			position: initial;
+			padding-top: 0;
+		}
+	}
+
 	@include breakpoint-deprecated( ">660px" ) {
 		display: flex;
 		font-weight: 600;


### PR DESCRIPTION
## Proposed Changes
* Add `Actions (+)` toolbar on daily successful backup card.
* Add new `View files` button on `Actions (+)` toolbar and make it navigate to the new backup contents page introduced in #77767

## Screenshots
| Before | After |
|---|---|
| <img width="731" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/a17f5209-2d4c-49c2-918a-885fe9286073"> | <img width="819" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/614e0bb9-593b-49b6-8f9a-9b635f07b09b"> |

## Testing Instructions
* Checkout this branch
* Start your local environment using `yarn start-jetpack-cloud`
* Select one of your sites with a Jetpack VaultPress Backup plan
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* You should see the `Actions (+)` toolbar as described in the above screenshot. Click on it.
* Click on `View files` and it should redirect you to the backup contents page, where you can explore the new file browser UI introduced in #77947

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
