### PR TITLE
Partner Portal: Implement UI to show discounts for licenses in the partner portal

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -8,6 +8,7 @@ import page from 'page';
 import { useContext, useEffect, useState, useMemo, createRef } from 'react';
 import Count from 'calypso/components/count';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -292,13 +293,16 @@ export default function SitesOverview() {
 									},
 								} }
 							>
-								<SiteContent
-									data={ data }
-									isLoading={ isLoading }
-									currentPage={ currentPage }
-									isFavoritesTab={ isFavoritesTab }
-									ref={ containerRef }
-								/>
+								<>
+									<QueryProductsList type="jetpack" currency="USD" />
+									<SiteContent
+										data={ data }
+										isLoading={ isLoading }
+										currentPage={ currentPage }
+										isFavoritesTab={ isFavoritesTab }
+										ref={ containerRef }
+									/>
+								</>
 							</DashboardDataContext.Provider>
 						) }
 					</div>

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import { useIssueMultipleLicenses } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import LicenseBundleCard from 'calypso/jetpack-cloud/sections/partner-portal/license-bundle-card';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
@@ -154,6 +155,7 @@ export default function IssueMultipleLicensesForm( {
 
 			{ ! isLoadingProducts && (
 				<>
+					<QueryProductsList type="jetpack" currency="USD" />
 					<div className="issue-multiple-licenses-form__top">
 						<p className="issue-multiple-licenses-form__description">
 							{ selectedSiteDomain

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -8,6 +7,7 @@ import { APIProductFamilyProduct } from '../../../../state/partner-portal/types'
 import { useProductDescription } from '../hooks';
 import LicenseLightbox from '../license-lightbox';
 import LicenseLightboxLink from '../license-lightbox-link';
+import ProductPriceWithDiscount from '../primary/product-price-with-discount-info';
 import { getProductTitle } from '../utils';
 
 import './style.scss';
@@ -63,15 +63,8 @@ export default function LicenseBundleCard( props: Props ) {
 
 				<div className="license-bundle-card__footer">
 					<div className="license-bundle-card__pricing">
-						<div className="license-bundle-card__price">
-							{ formatCurrency( product.amount, product.currency ) }
-						</div>
-						<div className="license-bundle-card__price-interval">
-							{ product.price_interval === 'day' && translate( '/USD per license per day' ) }
-							{ product.price_interval === 'month' && translate( '/USD per license per month' ) }
-						</div>
+						<ProductPriceWithDiscount product={ product } />
 					</div>
-
 					<Button
 						primary
 						className="license-bundle-card__select-license"

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/style.scss
@@ -77,23 +77,6 @@
 	}
 }
 
-.license-bundle-card__price {
-	margin-bottom: 0.25rem;
-	font-size: 1.25rem;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 1.5rem;
-	font-weight: 600;
-	color: var(--studio-gray-80);
-
-	@include break-xlarge {
-		font-size: 1.5rem;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 1.75rem;
-		font-weight: 700;
-		color: var(--studio-black);
-	}
-}
-
 .license-bundle-card__footer {
 	display: flex;
 	justify-content: space-between;
@@ -104,14 +87,6 @@
 		flex-direction: column;
 		align-items: flex-start;
 	}
-}
-
-.license-bundle-card__price-interval {
-	font-size: 0.75rem;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 0.875rem;
-	font-weight: 400;
-	color: var(--studio-gray-60);
 }
 
 .license-bundle-card__select-license {

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-payment-plan.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-payment-plan.tsx
@@ -1,7 +1,7 @@
-import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import ProductPriceWithDiscount from '../primary/product-price-with-discount-info';
 
 type Props = {
 	product: APIProductFamilyProduct;
@@ -9,18 +9,13 @@ type Props = {
 
 const LicenseLightboxPaymentPlan: FunctionComponent< Props > = ( { product } ) => {
 	const translate = useTranslate();
+
 	return (
 		<div className="license-lightbox__payment-plan">
 			<h3 className="license-lightbox__payment-plan-title">{ translate( 'Payment plan:' ) }</h3>
 
 			<div className="license-lightbox__pricing">
-				<span className="license-lightbox__pricing-amount">
-					{ formatCurrency( product.amount, product.currency ) }
-				</span>
-				<span className="license-lightbox__pricing-interval">
-					{ product.price_interval === 'day' && translate( '/USD per license per day' ) }
-					{ product.price_interval === 'month' && translate( '/USD per license per month' ) }
-				</span>
+				<ProductPriceWithDiscount product={ product } />
 			</div>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
@@ -10,18 +10,6 @@
 	margin-block-end: 8px;
 }
 
-.license-lightbox__pricing-amount {
-	display: inline-block;
-	font-size: 1.5rem;
-	font-weight: 700;
-	margin-inline-end: 4px;
-}
-
-.license-lightbox__pricing-interval {
-	font-size: 0.75rem;
-	font-weight: 400;
-}
-
 .license-lightbox__cta-button {
 	margin-block-start: 1rem;
 	margin-block-end: 0;

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -1,5 +1,4 @@
 import { Gridicon } from '@automattic/components';
-import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
@@ -9,6 +8,7 @@ import { APIProductFamilyProduct } from '../../../../state/partner-portal/types'
 import { useProductDescription } from '../hooks';
 import LicenseLightbox from '../license-lightbox';
 import LicenseLightboxLink from '../license-lightbox-link';
+import ProductPriceWithDiscount from '../primary/product-price-with-discount-info';
 import { getProductTitle } from '../utils';
 
 import './style.scss';
@@ -124,13 +124,7 @@ export default function LicenseProductCard( props: Props ) {
 						</div>
 
 						<div className="license-product-card__pricing">
-							<div className="license-product-card__price">
-								{ formatCurrency( product.amount, product.currency ) }
-							</div>
-							<div className="license-product-card__price-interval">
-								{ product.price_interval === 'day' && translate( '/USD per license per day' ) }
-								{ product.price_interval === 'month' && translate( '/USD per license per month' ) }
-							</div>
+							<ProductPriceWithDiscount product={ product } />
 						</div>
 					</div>
 				</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -241,29 +241,3 @@
 		@include license-product-card-block__pricing;
 	}
 }
-
-.license-product-card__price {
-	margin-bottom: 0.25rem;
-	font-size: 1.25rem;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 1.5rem;
-	font-weight: 600;
-	color: var(--studio-gray-80);
-
-	@include break-xlarge {
-		margin-bottom: 0.5rem;
-		font-size: 1.5rem;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 1.75rem;
-		font-weight: 700;
-		color: var(--studio-black);
-	}
-}
-
-.license-product-card__price-interval {
-	font-size: 0.75rem;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 0.875rem;
-	font-weight: 400;
-	color: var(--studio-gray-60);
-}

--- a/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
@@ -1,0 +1,81 @@
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { getProductsList } from 'calypso/state/products-list/selectors';
+
+import './style.scss';
+
+interface Props {
+	product: APIProductFamilyProduct;
+}
+
+export default function ProductPriceWithDiscount( { product }: Props ) {
+	const translate = useTranslate();
+
+	const userProducts = useSelector( ( state ) => getProductsList( state ) );
+	const productCost = product?.amount || 0;
+
+	const isDailyPricing = product.price_interval === 'day';
+
+	const discountInfo: {
+		actualCost: string;
+		discountedCost: string;
+		discountPercentage: number;
+	} = {
+		actualCost: '',
+		discountedCost: formatCurrency( productCost, product.currency ),
+		discountPercentage: 0,
+	};
+	if ( Object.keys( userProducts ).length && product ) {
+		const yearlyProduct = Object.values( userProducts ).find(
+			( prod ) => prod.product_id === product.product_id
+		);
+		const monthlyProduct =
+			yearlyProduct &&
+			Object.values( userProducts ).find(
+				( p ) =>
+					p.billing_product_slug === yearlyProduct.billing_product_slug &&
+					p.product_term === 'month'
+			);
+		if ( monthlyProduct ) {
+			const actualCost = isDailyPricing ? monthlyProduct.cost / 365 : monthlyProduct.cost;
+			const discountedCost = actualCost - productCost;
+			discountInfo.discountPercentage = ! productCost
+				? 100
+				: Math.round( ( discountedCost / actualCost ) * 100 );
+			discountInfo.actualCost = formatCurrency( actualCost, product.currency );
+		}
+	}
+
+	return (
+		<div>
+			<div className="product-price-with-discount__price">
+				{ discountInfo.discountedCost }
+				{
+					// Display discount info only if there is a discount
+					discountInfo.discountPercentage > 0 && (
+						<>
+							<span className="product-price-with-discount__price-discount">
+								{ translate( 'Save %(discountPercentage)s%', {
+									args: {
+										discountPercentage: discountInfo.discountPercentage,
+									},
+								} ) }
+							</span>
+							<div>
+								<span className="product-price-with-discount__price-old">
+									{ discountInfo.actualCost }
+								</span>
+							</div>
+						</>
+					)
+				}
+			</div>
+			<div className="product-price-with-discount__price-interval">
+				{ isDailyPricing && translate( '/USD per license per day' ) }
+				{ product.price_interval === 'month' && translate( '/USD per license per month' ) }
+			</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/style.scss
@@ -1,0 +1,35 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.product-price-with-discount__price {
+	font-size: 1.25rem;
+	font-weight: 600;
+	color: var(--studio-gray-80);
+	line-height: 1;
+
+	.product-price-with-discount__price-old {
+		text-decoration: line-through;
+		font-weight: 400;
+		font-size: 1rem;
+	}
+
+	.product-price-with-discount__price-discount {
+		margin-inline-start: 8px;
+		font-size: 1rem;
+		font-weight: 500;
+		color: var(--studio-jetpack-green-50);
+	}
+
+	@include break-xlarge {
+		font-size: 1.5rem;
+		font-weight: 700;
+		color: var(--studio-black);
+	}
+}
+
+.product-price-with-discount__price-interval {
+	font-size: 0.75rem;
+	font-weight: 400;
+	color: var(--studio-gray-60);
+	line-height: 2;
+}


### PR DESCRIPTION
Related to 1202619025189113-as-1204821647785930

## Proposed Changes

This PR implements UI to show old prices and discount percentages in

- Product card
- Bundle card
- Pricing lightbox

#### Testing Instructions

**Instructions**

1. Run `git checkout add/show-agency-product-discount-for-products` and `yarn start-jetpack-cloud` or open the Jetpack live link.
2. Open http://jetpack.cloud.localhost:3000/
3. Click on the **Licensing** top nav -> Click on **Issue New License** button -> Verify that you can now see the old price, new price, and the discount percentages on both product and bundle cards as shown below

<img width="1064" alt="Screenshot 2023-06-15 at 1 35 14 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5ab4aedb-7caf-464d-a3f0-c00fcaded6da">

<img width="839" alt="Screenshot 2023-06-15 at 1 35 39 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e84e95f3-6fef-4973-ab27-a483ae87193b">

4. Click on the `More about <product>` link and verify you can see the product discount info as shown below.

<img width="1070" alt="Screenshot 2023-06-15 at 1 35 51 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/15e6136c-c00a-4263-94b2-10b503d95ebe">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?