### PR TITLE
Help Center: wrap close callback with useCallback

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -5,7 +5,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { Button, Fill } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import cx from 'classnames';
 import { useSelector } from 'react-redux';
@@ -45,6 +45,8 @@ function HelpCenterContent() {
 		return () => clearTimeout( timeout );
 	}, [] );
 
+	const closeCallback = useCallback( () => setShowHelpCenter( false ), [ setShowHelpCenter ] );
+
 	const content = (
 		<>
 			<Button
@@ -75,7 +77,7 @@ function HelpCenterContent() {
 					<PinnedItems scope="core/edit-widgets">{ content }</PinnedItems>
 				</>
 			) }
-			<HelpCenter handleClose={ () => setShowHelpCenter( false ) } />
+			<HelpCenter handleClose={ closeCallback } />
 		</>
 	);
 }


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/78234

## Proposed Changes

* In the Help Center, we have the following effect the prepares the portal for the Help Center
```js
useEffect( () => {
	const classes = [ 'help-center' ];
	portalParent.classList.add( ...classes );

	return () => {
		document.body.removeChild( portalParent );
		handleClose(); // <------ this is the key
	};
}, [ portalParent, handleClose ] );
```
This means whenever `handleClose` changes, the effect will re-run and `handleClose` will be called to clean up the last side effects. This worked totally fine because this value never changed. I'm not sure why, but probably due to Gutenberg update, the `registerPlugin` is calling `render` more than once.

And inside render we have this line, this means `handleClose`'s value will change with every render.
```jsx
			<HelpCenter handleClose={ () => setShowHelpCenter( false ) } />
```

Wrapping it with `useCallback` fixed it.

## Testing Instructions

1. Cd into `apps/editing-toolkit`.
2. run `yarn dev --sync`.
3. Sandbox a site.
4. Go to the editor of that site.
5. Verify that the Help Center opens.
