### PR TITLE
Jetpack Pro Dashboard: integrate verify phone number verification code API to the downtime monitoring 

### DIFF
--- a/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
@@ -18,11 +18,11 @@ const useFetchMonitorVerfiedContacts = ( isPartnerOAuthTokenLoaded: boolean ) =>
 		select: ( contacts: MonitorContactsResponse ) => {
 			return {
 				emails: contacts?.emails
-					.filter( ( email ) => email.verified )
+					?.filter( ( email ) => email.verified )
 					.map( ( email ) => email.email_address ),
-				phoneNumbers: contacts.sms_numbers
-					.filter( ( sms ) => sms.verified )
-					.map( ( sms ) => `${ sms.country_numeric_code }${ sms.sms_number }` ), // Add country code to phone number
+				phoneNumbers: contacts?.sms_numbers
+					?.filter( ( sms ) => sms.verified )
+					.map( ( sms ) => sms.sms_number ),
 			};
 		},
 		enabled: isPartnerOAuthTokenLoaded && isMultipleEmailEnabled,

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/index.tsx
@@ -14,6 +14,7 @@ export default function ConfigureSMSNotification( {
 	toggleModal,
 	recordEvent,
 	allPhoneItems,
+	verifiedPhoneNumber,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -30,6 +31,7 @@ export default function ConfigureSMSNotification( {
 					recordEvent={ recordEvent }
 					key={ item.phoneNumberFull }
 					item={ item }
+					showVerifiedBadge={ item.phoneNumberFull === verifiedPhoneNumber }
 				/>
 			) ) }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -174,10 +174,8 @@ export default function PhoneNumberEditor( {
 		if ( phoneItem?.verificationCode ) {
 			verifyPhoneNumber.mutate( {
 				type: 'sms',
-				value: phoneItem.phoneNumber,
+				value: `${ phoneItem.countryNumericCode }${ phoneItem.phoneNumber }`,
 				verification_code: Number( phoneItem.verificationCode ),
-				country_code: phoneItem.countryCode,
-				country_numeric_code: phoneItem.countryNumericCode,
 			} );
 		}
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -130,7 +130,8 @@ export default function PhoneNumberEditor( {
 	const handleRequestVerificationCode = () => {
 		requestVerificationCode.mutate( {
 			type: 'sms',
-			value: Number( phoneItem.phoneNumber ),
+			value: `${ phoneItem.countryNumericCode }${ phoneItem.phoneNumber }`,
+			number: phoneItem.phoneNumber,
 			site_ids: sites?.map( ( site ) => site.blog_id ) ?? [],
 			country_code: phoneItem.countryCode,
 			country_numeric_code: phoneItem.countryNumericCode,

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/sms-item-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/sms-item-content.tsx
@@ -16,6 +16,7 @@ interface Props {
 	item: StateMonitorSettingsSMS;
 	toggleModal?: ( item?: StateMonitorSettingsSMS, action?: AllowedMonitorContactActions ) => void;
 	recordEvent?: ( action: string, params?: object ) => void;
+	showVerifiedBadge?: boolean;
 }
 
 const EVENT_NAMES = {
@@ -24,7 +25,12 @@ const EVENT_NAMES = {
 	verify: 'downtime_monitoring_sms_number_verify_click',
 };
 
-export default function SMSItemContent( { item, toggleModal, recordEvent }: Props ) {
+export default function SMSItemContent( {
+	item,
+	toggleModal,
+	recordEvent,
+	showVerifiedBadge,
+}: Props ) {
 	const translate = useTranslate();
 	const [ isOpen, setIsOpen ] = useState( false );
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
@@ -66,7 +72,7 @@ export default function SMSItemContent( { item, toggleModal, recordEvent }: Prop
 						<Badge type="warning">{ translate( 'Pending' ) }</Badge>
 					</span>
 				) }
-				{ isVerified && (
+				{ showVerifiedBadge && isVerified && (
 					<span className="configure-contact-info__verification-status">
 						<Badge type="success">{ translate( 'Verified' ) }</Badge>
 					</span>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
@@ -55,8 +55,6 @@ export function useValidateVerificationCode(): {
 			const newEmailItem = { email_address: params.value, verified: data.verified };
 			const newSMSItem = {
 				sms_number: params.value,
-				country_code: params.country_code,
-				country_numeric_code: params.country_numeric_code,
 				verified: data.verified,
 			};
 
@@ -83,8 +81,7 @@ export function useValidateVerificationCode(): {
 					sms_numbers: [
 						...oldContacts.sms_numbers.filter(
 							( sms: { sms_number: string; country_numeric_code: string } ) =>
-								`${ sms.country_numeric_code }${ sms.sms_number }` !==
-								`${ params.country_numeric_code }${ params.value }` // Add the country code to the number
+								sms.sms_number !== params.value
 						),
 						newSMSItem,
 					],

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
@@ -80,8 +80,7 @@ export function useValidateVerificationCode(): {
 					// Replace if it exists, otherwise add it
 					sms_numbers: [
 						...oldContacts.sms_numbers.filter(
-							( sms: { sms_number: string; country_numeric_code: string } ) =>
-								sms.sms_number !== params.value
+							( sms: { sms_number: string } ) => sms.sms_number !== params.value
 						),
 						newSMSItem,
 					],

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
@@ -51,10 +51,20 @@ export function useValidateVerificationCode(): {
 		// Optimistically update the contacts
 		queryClient.setQueryData( queryKey, ( oldContacts: any ) => {
 			const type = params.type;
+
+			const newEmailItem = { email_address: params.value, verified: data.verified };
+			const newSMSItem = {
+				sms_number: params.value,
+				country_code: params.country_code,
+				country_numeric_code: params.country_numeric_code,
+				verified: data.verified,
+			};
+
 			if ( ! oldContacts ) {
 				// If there are no contacts, create a new object
 				return {
-					emails: [ { email_address: params.value, verified: data.verified } ],
+					...( type === 'email' && { emails: [ newEmailItem ] } ),
+					...( type === 'sms' && { sms_numbers: [ newSMSItem ] } ),
 				};
 			}
 			return {
@@ -65,7 +75,18 @@ export function useValidateVerificationCode(): {
 						...oldContacts.emails.filter(
 							( email: { email_address: string } ) => email.email_address !== params.value
 						),
-						{ email_address: params.value, verified: data.verified },
+						newEmailItem,
+					],
+				} ),
+				...( type === 'sms' && {
+					// Replace if it exists, otherwise add it
+					sms_numbers: [
+						...oldContacts.sms_numbers.filter(
+							( sms: { sms_number: string; country_numeric_code: string } ) =>
+								`${ sms.country_numeric_code }${ sms.sms_number }` !==
+								`${ params.country_numeric_code }${ params.value }` // Add the country code to the number
+						),
+						newSMSItem,
 					],
 				} ),
 			};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -319,8 +319,10 @@ export type AllowedMonitorContactActions = 'add' | 'verify' | 'edit' | 'remove';
 
 export interface RequestVerificationCodeParams {
 	type: 'email' | 'sms';
-	value: string | number;
+	value: string;
 	site_ids: Array< number >;
+	// For SMS contacts
+	number?: string;
 	country_code?: string;
 	country_numeric_code?: string;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -326,9 +326,11 @@ export interface RequestVerificationCodeParams {
 }
 
 export interface ValidateVerificationCodeParams {
-	type: 'email';
+	type: 'email' | 'sms';
 	value: string;
 	verification_code: number;
+	country_code?: string;
+	country_numeric_code?: string;
 }
 
 export interface MonitorContactsResponse {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -331,8 +331,6 @@ export interface ValidateVerificationCodeParams {
 	type: 'email' | 'sms';
 	value: string;
 	verification_code: number;
-	country_code?: string;
-	country_numeric_code?: string;
 }
 
 export interface MonitorContactsResponse {


### PR DESCRIPTION
Related to 1204774821045518-as-1204793234816314

## Proposed Changes

This PR implements API integration with the UI to verify the phone number

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Apply this patch D113560-code and sandbox the public API.
2. Run `git checkout add/implement-verify-phone-number-in-downtime-monitoring` and `yarn start-jetpack-cloud` or open the Jetpack live link.
3. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
4. Enable monitor if not enabled already.
5. Click on the clock icon next to the monitor toggle.
6. Click the `+ Add phone number` button -> Enter all the details -> Click `Verify` 
7. Enter a random(wrong) verification code and verify the below error is shown.

<img width="473" alt="Screenshot 2023-06-15 at 5 28 55 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0bf74749-ee55-4117-9132-939bf6dc33ab">

8. Follow the instruction - D113560-code how to get the verification code and enter the verification code.
9. Verify that the entered phone number is verified and added to the list of phone numbers. 

<img width="472" alt="Screenshot 2023-06-15 at 5 35 35 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0a3c72a0-cb68-4e54-8200-267d44b25e6d">

10. Click `Save` to save the changes.
11. Go to any other site -> Repeat steps 4 & 5.
12. Click the `+ Add email address` button -> Try entering the same phone number which you have verified previously -> It should be directly added to the list without asking for you to enter the verification code again, and the "Verified" badge is shown only for 10 sec.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?