### PR TITLE
Import: redirect users to sitePicker step on import failed for migration plugin flow

### DIFF
--- a/client/blocks/importer/types.ts
+++ b/client/blocks/importer/types.ts
@@ -18,6 +18,7 @@ export type StepNavigator = {
 	goToWpAdminWordPressPluginPage?: () => void;
 	navigate?: ( path: string ) => void;
 	goToAddDomainPage?: () => void;
+	goToSitePickerPage?: () => void;
 };
 
 export interface ImportError {

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -66,10 +66,15 @@ export class ImportEverything extends SectionMigrate {
 	};
 
 	resetMigration = () => {
-		const { stepNavigator } = this.props;
+		const { stepNavigator, isMigrateFromWp } = this.props;
 
 		this.requestMigrationReset( this.props.targetSiteId ).finally( () => {
-			stepNavigator?.goToImportCapturePage?.();
+			if ( isMigrateFromWp ) {
+				stepNavigator?.goToSitePickerPage?.();
+			} else {
+				stepNavigator?.goToImportCapturePage?.();
+			}
+
 			/**
 			 * Note this migrationStatus is local, thus the setState vs setMigrationState.
 			 * Call to updateFromAPI will update both local and non-local state.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
@@ -96,6 +96,10 @@ export function useStepNavigator(
 		} );
 	}
 
+	function goToSitePickerPage() {
+		navigation.goToStep?.( `sitePicker?from=${ fromSite }` );
+	}
+
 	return {
 		supportLinkModal: false,
 		goToIntentPage,
@@ -106,6 +110,7 @@ export function useStepNavigator(
 		goToWpAdminImportPage,
 		goToWpAdminWordPressPluginPage,
 		goToAddDomainPage,
+		goToSitePickerPage,
 		navigate: ( path ) => navigator( path ),
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78228

## Proposed Changes

* Redirect users to sitePicker step if user faced import failed from the migration plugin flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a JN site and start a migration
* Spin up another JN site and use same WordPress.com site for the target site
* You'll see import failed after you start a migration because it's in the middle of another migration
* Click try again button and see if you gets redirected to the sitePicker step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
