### PR TITLE
Remove/happychat jetpack rewind activity log

### DIFF
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -15,7 +15,6 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
-import HappychatButton from 'calypso/components/happychat/button';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { disconnect } from 'calypso/state/jetpack/connection/actions';
 import {
@@ -206,10 +205,6 @@ class DisconnectJetpack extends PureComponent {
 		page( `/activity-log/${ this.props.siteSlug }` );
 	};
 
-	trackTryRewindHelp = () => {
-		this.props.recordTracksEvent( 'calypso_disconnect_jetpack_try_rewind_help' );
-	};
-
 	render() {
 		const {
 			disconnectHref,
@@ -285,10 +280,6 @@ class DisconnectJetpack extends PureComponent {
 					</p>
 					<div className="disconnect-jetpack__try-rewind-button-wrap">
 						<Button onClick={ this.handleTryRewind }>{ translate( 'Restore site' ) }</Button>
-						<HappychatButton borderless={ false } onClick={ this.trackTryRewindHelp } primary>
-							<Gridicon icon="chat" size={ 18 } />
-							{ translate( 'Get help' ) }
-						</HappychatButton>
 					</div>
 				</Card>
 			),

--- a/client/my-sites/activity/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/error-banner.jsx
@@ -1,15 +1,13 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import HappychatButton from 'calypso/components/happychat/button';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import {
 	dismissRewindBackupProgress,
 	dismissRewindRestoreProgress as dismissRewindRestoreProgressAction,
 } from 'calypso/state/activity-log/actions';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ActivityLogBanner from './index';
 
 class ErrorBanner extends PureComponent {
@@ -54,15 +52,7 @@ class ErrorBanner extends PureComponent {
 			: this.props.dismissDownloadError( this.props.siteId, this.props.downloadId );
 
 	render() {
-		const {
-			errorCode,
-			failureReason,
-			timestamp,
-			translate,
-			downloadId,
-			trackHappyChatBackup,
-			trackHappyChatRestore,
-		} = this.props;
+		const { errorCode, failureReason, timestamp, translate, downloadId } = this.props;
 		const strings =
 			typeof downloadId === 'undefined'
 				? {
@@ -101,15 +91,6 @@ class ErrorBanner extends PureComponent {
 				<Button primary onClick={ this.handleClickRestart }>
 					{ translate( 'Try again' ) }
 				</Button>
-				<HappychatButton
-					className="activity-log-banner__happychat-button"
-					onClick={
-						typeof downloadId === 'undefined' ? trackHappyChatRestore : trackHappyChatBackup
-					}
-				>
-					<Gridicon icon="chat" />
-					<span>{ translate( 'Get help' ) }</span>
-				</HappychatButton>
 			</ActivityLogBanner>
 		);
 	}
@@ -118,6 +99,4 @@ class ErrorBanner extends PureComponent {
 export default connect( null, {
 	dismissRewindRestoreProgress: dismissRewindRestoreProgressAction,
 	dismissDownloadError: dismissRewindBackupProgress,
-	trackHappyChatBackup: () => recordTracksEvent( 'calypso_activitylog_error_banner_backup' ),
-	trackHappyChatRestore: () => recordTracksEvent( 'calypso_activitylog_error_banner_restore' ),
 } )( localize( ErrorBanner ) );

--- a/client/my-sites/activity/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/success-banner.jsx
@@ -1,10 +1,9 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import HappychatButton from 'calypso/components/happychat/button';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import {
@@ -68,17 +67,8 @@ class SuccessBanner extends PureComponent {
 		} );
 
 	render() {
-		const {
-			applySiteOffset,
-			moment,
-			siteUrl,
-			timestamp,
-			translate,
-			backupUrl,
-			context,
-			trackHappyChatBackup,
-			trackHappyChatRestore,
-		} = this.props;
+		const { applySiteOffset, moment, siteUrl, timestamp, translate, backupUrl, context } =
+			this.props;
 		const date = applySiteOffset( moment( ms( timestamp ) ) ).format( 'LLLL' );
 		const params = backupUrl
 			? {
@@ -98,7 +88,6 @@ class SuccessBanner extends PureComponent {
 							{ translate( 'Download' ) }
 						</Button>
 					),
-					trackHappyChat: trackHappyChatBackup,
 			  }
 			: {
 					title:
@@ -125,7 +114,6 @@ class SuccessBanner extends PureComponent {
 							{ translate( 'View site' ) }
 						</Button>
 					),
-					trackHappyChat: trackHappyChatRestore,
 			  };
 		return (
 			<ActivityLogBanner
@@ -144,13 +132,6 @@ class SuccessBanner extends PureComponent {
 							{ translate( 'Thanks, got it!' ) }
 						</Button>
 					) }
-					<HappychatButton
-						className="activity-log-banner__happychat-button"
-						onClick={ params.trackHappyChat }
-					>
-						<Gridicon icon="chat" />
-						<span>{ translate( 'Get help' ) }</span>
-					</HappychatButton>
 				</div>
 			</ActivityLogBanner>
 		);
@@ -166,9 +147,6 @@ export default compose(
 			dismissRestoreProgress: dismissRewindRestoreProgress,
 			dismissBackupProgress: dismissRewindBackupProgress,
 			recordTracksEvent: recordTracksEvent,
-			trackHappyChatBackup: () => recordTracksEvent( 'calypso_activitylog_success_banner_backup' ),
-			trackHappyChatRestore: () =>
-				recordTracksEvent( 'calypso_activitylog_success_banner_restore' ),
 		}
 	),
 	localize,

--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -1,16 +1,12 @@
 import { Button, Card, Gridicon } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
+import { useI18n } from '@wordpress/react-i18n';
 import ExternalLink from 'calypso/components/external-link';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
-import HappychatButton from 'calypso/components/happychat/button';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ActivityIcon from '../activity-log-item/activity-icon';
 
 import './style.scss';
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 const ActivityLogConfirmDialog = ( {
 	children,
 	confirmTitle,
@@ -22,84 +18,74 @@ const ActivityLogConfirmDialog = ( {
 	onSettingsChange,
 	supportLink,
 	title,
-	translate,
-	happychatEvent,
-} ) => (
-	<div className="activity-log-item activity-log-item__restore-confirm">
-		<div className="activity-log-item__type">
-			<ActivityIcon activityIcon={ icon } />
+} ) => {
+	const { __ } = useI18n();
+
+	return (
+		<div className="activity-log-item activity-log-item__restore-confirm">
+			<div className="activity-log-item__type">
+				<ActivityIcon activityIcon={ icon } />
+			</div>
+			<Card className="activity-log-item__card">
+				<h5 className="activity-log-confirm-dialog__title">{ title }</h5>
+
+				<div className="activity-log-confirm-dialog__highlight">{ children }</div>
+
+				<div className="activity-log-confirm-dialog__partial-restore-settings">
+					<p>
+						{ notice
+							? __( 'Choose the items you wish to restore:' )
+							: __( 'Choose the items you wish to include in the download:' ) }
+					</p>
+					<FormLabel>
+						<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
+						{ __( 'WordPress Themes' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="plugins" onChange={ onSettingsChange } defaultChecked />
+						{ __( 'WordPress Plugins' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="uploads" onChange={ onSettingsChange } defaultChecked />
+						{ __( 'Media Uploads' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="roots" onChange={ onSettingsChange } defaultChecked />
+						{ __( 'WordPress Root (includes wp-config.php and any non-WordPress files)' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="contents" onChange={ onSettingsChange } defaultChecked />
+						{ __( 'WP-Content Directory (excluding themes, plugins, and uploads)' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
+						{ __( 'Site Database (SQL)' ) }
+					</FormLabel>
+				</div>
+
+				{ notice && (
+					<div className="activity-log-confirm-dialog__notice">
+						<Gridicon icon="notice" />
+						<span className="activity-log-confirm-dialog__notice-content">{ notice }</span>
+					</div>
+				) }
+
+				<div className="activity-log-confirm-dialog__button-wrap">
+					<div className="activity-log-confirm-dialog__primary-actions">
+						<Button onClick={ onClose }>{ __( 'Cancel' ) }</Button>
+						<Button primary disabled={ disableButton } onClick={ onConfirm }>
+							{ confirmTitle }
+						</Button>
+					</div>
+					<div className="activity-log-confirm-dialog__secondary-actions">
+						<ExternalLink icon href={ supportLink }>
+							{ __( 'More info' ) }
+						</ExternalLink>
+					</div>
+				</div>
+			</Card>
 		</div>
-		<Card className="activity-log-item__card">
-			<h5 className="activity-log-confirm-dialog__title">{ title }</h5>
-
-			<div className="activity-log-confirm-dialog__highlight">{ children }</div>
-
-			<div className="activity-log-confirm-dialog__partial-restore-settings">
-				<p>
-					{ notice
-						? translate( 'Choose the items you wish to restore:' )
-						: translate( 'Choose the items you wish to include in the download:' ) }
-				</p>
-				<FormLabel>
-					<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
-					{ translate( 'WordPress Themes' ) }
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox name="plugins" onChange={ onSettingsChange } defaultChecked />
-					{ translate( 'WordPress Plugins' ) }
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox name="uploads" onChange={ onSettingsChange } defaultChecked />
-					{ translate( 'Media Uploads' ) }
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox name="roots" onChange={ onSettingsChange } defaultChecked />
-					{ translate( 'WordPress Root (includes wp-config.php and any non-WordPress files)' ) }
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox name="contents" onChange={ onSettingsChange } defaultChecked />
-					{ translate( 'WP-Content Directory (excluding themes, plugins, and uploads)' ) }
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
-					{ translate( 'Site Database (SQL)' ) }
-				</FormLabel>
-			</div>
-
-			{ notice && (
-				<div className="activity-log-confirm-dialog__notice">
-					<Gridicon icon="notice" />
-					<span className="activity-log-confirm-dialog__notice-content">{ notice }</span>
-				</div>
-			) }
-
-			<div className="activity-log-confirm-dialog__button-wrap">
-				<div className="activity-log-confirm-dialog__primary-actions">
-					<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
-					<Button primary disabled={ disableButton } onClick={ onConfirm }>
-						{ confirmTitle }
-					</Button>
-				</div>
-				<div className="activity-log-confirm-dialog__secondary-actions">
-					<ExternalLink icon href={ supportLink } onClick={ () => {} }>
-						{ translate( 'More info' ) }
-					</ExternalLink>
-					<HappychatButton
-						className="activity-log-confirm-dialog__more-info-link"
-						onClick={ happychatEvent }
-					>
-						<Gridicon icon="chat" />
-						<span>{ translate( 'Any Questions?' ) }</span>
-					</HappychatButton>
-				</div>
-			</div>
-		</Card>
-	</div>
-);
-/* eslint-enable wpcalypso/jsx-classname-namespace */
-
-const mapDispatchToProps = {
-	happychatEvent: () => recordTracksEvent( 'calypso_activitylog_confirm_dialog' ),
+	);
 };
 
-export default connect( null, mapDispatchToProps )( localize( ActivityLogConfirmDialog ) );
+export default ActivityLogConfirmDialog;

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import { Fragment, Component } from 'react';
 import { connect } from 'react-redux';
 import FoldableCard from 'calypso/components/foldable-card';
-import HappychatButton from 'calypso/components/happychat/button';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
 import scrollTo from 'calypso/lib/scroll-to';
@@ -200,13 +199,11 @@ class ActivityLogItem extends Component {
 		} = this.props;
 
 		switch ( activityName ) {
-			case 'rewind__scan_result_found':
-				return this.renderHelpAction();
 			case 'rewind__backup_error':
-				return 'bad_credentials' === activityMeta.errorCode
-					? this.renderFixCredsAction()
-					: this.renderHelpAction();
+				return 'bad_credentials' === activityMeta.errorCode && this.renderFixCredsAction();
 		}
+
+		return null;
 	}
 
 	renderCloneAction = () => {
@@ -283,24 +280,6 @@ class ActivityLogItem extends Component {
 			</div>
 		);
 	};
-
-	/**
-	 * Displays a button for users to get help. Tracks button click.
-	 *
-	 * @returns {Object} Get help button.
-	 */
-	renderHelpAction = () => (
-		<HappychatButton
-			className="activity-log-item__help-action"
-			borderless={ false }
-			onClick={ this.handleTrackHelp }
-		>
-			<Gridicon icon="chat" size={ 18 } />
-			{ this.props.translate( 'Get help' ) }
-		</HappychatButton>
-	);
-
-	handleTrackHelp = () => this.props.trackHelp( this.props.activity.activityName );
 
 	/**
 	 * Displays a button to take users to enter credentials.
@@ -485,10 +464,6 @@ const mapDispatchToProps = ( dispatch, { activity: { activityId }, siteId } ) =>
 			)
 		)
 	),
-	trackHelp: ( activityName ) =>
-		dispatch(
-			recordTracksEvent( 'calypso_activitylog_event_get_help', { activity_name: activityName } )
-		),
 	trackAddCreds: () => dispatch( recordTracksEvent( 'calypso_activitylog_event_add_credentials' ) ),
 	trackFixCreds: () => dispatch( recordTracksEvent( 'calypso_activitylog_event_fix_credentials' ) ),
 } );


### PR DESCRIPTION
Part of efforts to sunset Happy Chat and remove all references: pdm0RZ-BU-p2

## Proposed Changes

* Remove `HappychatButton` from Activity Log-related pages. This was introduced 6 years ago in https://github.com/Automattic/wp-calypso/issues/20475. It's not the best user experience to just drop them in chat as a band-aid for missing proper error messages and guidance in the UI. So let's remove it and think of ways of better supporting them in that context. Looking at the related Tracks events, those buttons were either not used at all or very rarely.

## Testing Instructions

- Go to `/activity-log/` on your Atomic and/or Jetpack site, make sure it's rendering correctly, without links to chat.

<img width="975" alt="Screenshot 2023-06-14 at 14 26 18" src="https://github.com/Automattic/wp-calypso/assets/3392497/0adb2539-e1d3-41f9-98c7-b029df89d412">
