### PR TITLE
Limited Global Styles: Skip E2E test for Atomic sites

### DIFF
--- a/test/e2e/specs/fse/fse__limited-global-styles.ts
+++ b/test/e2e/specs/fse/fse__limited-global-styles.ts
@@ -2,8 +2,9 @@
  * @group gutenberg
  */
 
-import { TestAccount, FullSiteEditorPage } from '@automattic/calypso-e2e';
+import { envVariables, TestAccount, FullSiteEditorPage } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
+import { skipDescribeIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
@@ -12,8 +13,12 @@ declare const browser: Browser;
  * style variations (eg. Twenty Twenty-Three).
  *
  * @see https://github.com/Automattic/wp-calypso/issues/78107
+ *
+ * We skip Atomic sites because they are not affected by Limited Global Styles.
+ *
+ * @see https://github.com/Automattic/wp-calypso/pull/71333#issuecomment-1592490057
  */
-describe( 'Site Editor: Limited Global Styles', function () {
+skipDescribeIf( envVariables.TEST_ON_ATOMIC )( 'Site Editor: Limited Global Styles', function () {
 	let page: Page;
 	let fullSiteEditorPage: FullSiteEditorPage;
 	let testAccount: TestAccount;


### PR DESCRIPTION
## Proposed Changes

Prevents the Limited Global Styles E2E test from running on Atomic sites since they always full access to Global Styles.

See https://github.com/Automattic/wp-calypso/pull/71333#issuecomment-1592490057

## Testing Instructions

Unsure! I think this cannot be manually tested?

