### PR TITLE
wpcom-proxy-request: Bump major and release

### DIFF
--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wpcom-proxy-request",
-	"version": "6.0.0",
+	"version": "7.0.0",
 	"description": "Proxied cookie-authenticated REST API requests to WordPress.com.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
@@ -34,9 +34,7 @@
 	],
 	"types": "types",
 	"scripts": {
-		"clean": "rm -rf dist",
-		"build": "transpile",
-		"prepack": "yarn run clean && yarn run build"
+		"prepack": "Echo 'no need to prepack vanilla JS package'"
 	},
 	"dependencies": {
 		"debug": "^4.3.3",


### PR DESCRIPTION
This changes `wpcom-proxy-request` version to 7.0.0 and releases. This is because the types are currently outdated in the released version (it's 3 years old). 