### PR TITLE
Assembler - UX - Disable fixed viewport for breakpoint 1280px

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -2,6 +2,7 @@ import { PatternRenderer } from '@automattic/block-renderer';
 import { Button, DeviceSwitcher } from '@automattic/components';
 import { useStyle } from '@automattic/global-styles';
 import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { Icon, layout } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -57,6 +58,7 @@ const PatternLargePreview = ( {
 		'--pattern-large-preview-block-gap': blockGap,
 		'--pattern-large-preview-background': backgroundColor,
 	} as CSSProperties );
+	const isWideViewport = useViewportMatch( 'wide', '<' );
 
 	const goToSelectHeaderPattern = () => {
 		navigator.goTo( NAVIGATOR_PATHS.HEADER );
@@ -186,7 +188,7 @@ const PatternLargePreview = ( {
 			isShowDeviceSwitcherToolbar
 			isShowFrameBorder
 			isShowFrameShadow={ false }
-			isFixedViewport={ !! hasSelectedPattern }
+			isFixedViewport={ !! hasSelectedPattern && ! isWideViewport }
 			frameRef={ frameRef }
 			onDeviceChange={ ( device ) => {
 				recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PREVIEW_DEVICE_CLICK, { device } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78239

## Proposed Changes

*  Disable fixed viewport for breakpoint 1280px

Just for testing. This solution is not making the UX better. WDYT?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler
* Resize the window to 1280px

**Window 1280px**

|BEFORE|AFTER|
|--|--|
|<img width="1281" alt="Screenshot 2566-06-15 at 19 12 56" src="https://github.com/Automattic/wp-calypso/assets/1881481/728da5f7-59f8-438b-b71e-e930d2a7ecc9">|<img width="1278" alt="Screenshot 2566-06-15 at 19 12 41" src="https://github.com/Automattic/wp-calypso/assets/1881481/084200b3-e62c-41e7-9ef6-fa9e712206e0">|

**Window 960px**

|BEFORE|AFTER|
|--|--|
|<img width="959" alt="Screenshot 2566-06-15 at 19 31 35" src="https://github.com/Automattic/wp-calypso/assets/1881481/64a11b57-52b9-4e04-90fc-c0fd06565fbd">|<img width="957" alt="Screenshot 2566-06-15 at 19 13 35" src="https://github.com/Automattic/wp-calypso/assets/1881481/74efcf0d-ab5e-4ed5-8926-ef3190665ddd">|




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
