### PR TITLE
Site picker: Confirm modal: update target site slug

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -77,7 +77,7 @@ const SitePickerStep: Step = function SitePickerStep( { navigation, flow } ) {
 					),
 					{
 						sourceSite: sourceSiteSlug,
-						targetSite: destinationSite?.slug,
+						targetSite: destinationSite?.slug.replace( /\b\.wordpress\.com/, '.wpcomstaging.com' ),
 					}
 				) }
 			</p>


### PR DESCRIPTION
Related to #78226

## Proposed Changes

* Updated selected site slug; Replaced `.wordpress.com` domain with `.wpcomstaging.com`.

<img width="484" alt="Screenshot 2023-06-15 at 14 45 12" src="https://github.com/Automattic/wp-calypso/assets/1241413/3aeb66e8-fe8f-45a1-96ae-ff2504014934">

## Testing Instructions

* Go to `/setup/import-focused/sitePicker?from={JN_SLUG}`
* Select a simple site
* Check if the confirmation modal has `wpcomstaging.com` for the target selected site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
