### PR TITLE
Assembler - UX - Close patterns panel after click to add a pattern

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -44,10 +44,10 @@ const ScreenCategoryList = ( {
 	onTogglePatternPanelList,
 }: Props ) => {
 	const translate = useTranslate();
+	const firstCategory = categories[ 0 ];
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
 	const categoriesInOrder = useCategoriesOrder( categories );
 	const composite = useCompositeState( { orientation: 'vertical' } );
-	const firstCategory = categories[ 0 ];
 	const isWideViewport = useViewportMatch( 'wide', '<' );
 
 	const trackEventCategoryClick = ( name: string ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -47,6 +47,7 @@ const ScreenCategoryList = ( {
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
 	const categoriesInOrder = useCategoriesOrder( categories );
 	const composite = useCompositeState( { orientation: 'vertical' } );
+	const firstCategory = categories[ 0 ];
 	const isWideViewport = useViewportMatch( 'wide', '<' );
 
 	const trackEventCategoryClick = ( name: string ) => {
@@ -56,6 +57,9 @@ const ScreenCategoryList = ( {
 	};
 
 	useEffect( () => {
+		// Open first category with a delay to avoid the top position flickering
+		setTimeout( () => setSelectedCategory( firstCategory?.name ?? null ), 200 );
+
 		// Notify the pattern panel list is open and closed
 		onTogglePatternPanelList?.( true );
 		return () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -5,6 +5,7 @@ import {
 	__unstableUseCompositeState as useCompositeState,
 	__unstableCompositeItem as CompositeItem,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { Icon, chevronRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -43,10 +44,10 @@ const ScreenCategoryList = ( {
 	onTogglePatternPanelList,
 }: Props ) => {
 	const translate = useTranslate();
-	const firstCategory = categories[ 0 ];
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
 	const categoriesInOrder = useCategoriesOrder( categories );
 	const composite = useCompositeState( { orientation: 'vertical' } );
+	const isWideViewport = useViewportMatch( 'wide', '<' );
 
 	const trackEventCategoryClick = ( name: string ) => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_CATEGORY_LIST_CATEGORY_CLICK, {
@@ -55,9 +56,6 @@ const ScreenCategoryList = ( {
 	};
 
 	useEffect( () => {
-		// Open first category with a delay to avoid the top position flickering
-		setTimeout( () => setSelectedCategory( firstCategory?.name ?? null ), 200 );
-
 		// Notify the pattern panel list is open and closed
 		onTogglePatternPanelList?.( true );
 		return () => {
@@ -141,9 +139,13 @@ const ScreenCategoryList = ( {
 				</NavigatorBackButton>
 			</div>
 			<PatternListPanel
-				onSelect={ ( selectedPattern: Pattern | null ) =>
-					onSelect( 'section', selectedPattern, selectedCategory )
-				}
+				onSelect={ ( selectedPattern: Pattern | null ) => {
+					onSelect( 'section', selectedPattern, selectedCategory );
+					if ( isWideViewport ) {
+						onTogglePatternPanelList?.( false );
+						setSelectedCategory( null );
+					}
+				} }
 				selectedPattern={ selectedPattern }
 				selectedCategory={ selectedCategory }
 				categories={ categories }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78239

## Proposed Changes

*  When the window width is 1280px or less, close the patterns panel after click to add a pattern

### TODO
- Keep the scroll position per category

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Resize the window to less than 1280px
* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3`
* Add a pattern to verify that the patterns panel closes on click

**Window 960px**

|BEFORE|AFTER|
|--|--|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/c90ea929-a6d1-4c80-89c4-443ef84c39ce">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/fa76a918-309d-4eab-8c69-d999eed2dd70">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
