### PR TITLE
Flaky E2E: update the Calypso SSR spec.

### DIFF
--- a/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
@@ -7,21 +7,18 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Server-side Rendering' ), function () {
+describe( 'Server-side Rendering', function () {
 	let page: Page;
-
-	beforeAll( async () => {
-		page = await browser.newPage();
-	} );
 
 	describe.each( [ 'log-in', 'themes', 'theme/twentytwentythree' ] )(
 		'Check SSR endoint: %s',
 		function ( endpoint ) {
-			it( 'Navigate to $endpoint', async function () {
-				await page.goto( DataHelper.getCalypsoURL( endpoint ), { timeout: 20 * 1000 } );
+			beforeEach( async () => {
+				page = await browser.newPage();
 			} );
 
-			it( `SSR is present for ${ endpoint }`, async function () {
+			it( `Check SSR: ${ endpoint }`, async function () {
+				await page.goto( DataHelper.getCalypsoURL( endpoint ), { timeout: 20 * 1000 } );
 				await page.locator( '#wpcom[data-calypso-ssr="true"]' ).waitFor( { timeout: 15 * 1000 } );
 			} );
 		}

--- a/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
@@ -14,18 +14,16 @@ describe( DataHelper.createSuiteTitle( 'Server-side Rendering' ), function () {
 		page = await browser.newPage();
 	} );
 
-	describe.each`
-		endpoint
-		${ 'log-in' }
-		${ 'themes' }
-		${ 'theme/twentytwentythree' }
-	`( 'Check SSR endoint: $endpoint', function ( { endpoint } ) {
-		it( 'Navigate to $endpoint', async function () {
-			await page.goto( endpoint, { timeout: 20 * 1000 } );
-		} );
+	describe.each( [ 'log-in', 'themes', 'theme/twentytwentythree' ] )(
+		'Check SSR endoint: %s',
+		function ( endpoint ) {
+			it( 'Navigate to $endpoint', async function () {
+				await page.goto( DataHelper.getCalypsoURL( endpoint ), { timeout: 20 * 1000 } );
+			} );
 
-		it( 'SSR is present for $endpoint', async function () {
-			await page.locator( '#wpcom[data-calypso-ssr="true"]' ).waitFor( { timeout: 15 * 1000 } );
-		} );
-	} );
+			it( `SSR is present for ${ endpoint }`, async function () {
+				await page.locator( '#wpcom[data-calypso-ssr="true"]' ).waitFor( { timeout: 15 * 1000 } );
+			} );
+		}
+	);
 } );

--- a/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
@@ -1,6 +1,5 @@
 /**
- * @group calypso-pr
- * @group kpi
+ * @group calypso-loop
  */
 
 import { DataHelper } from '@automattic/calypso-e2e';
@@ -15,13 +14,18 @@ describe( DataHelper.createSuiteTitle( 'Server-side Rendering' ), function () {
 		page = await browser.newPage();
 	} );
 
-	it.each`
+	describe.each`
 		endpoint
-		${ DataHelper.getCalypsoURL( 'log-in' ) }
-		${ DataHelper.getCalypsoURL( 'themes' ) }
-		${ DataHelper.getCalypsoURL( 'theme/twentytwenty' ) }
-	`( 'Check endpoint: $endpoint', async function ( { endpoint } ) {
-		await page.goto( endpoint, { waitUntil: 'domcontentloaded' } );
-		await page.locator( '#wpcom[data-calypso-ssr="true"]' ).waitFor( { timeout: 15 * 1000 } );
+		${ 'log-in' }
+		${ 'themes' }
+		${ 'theme/twentytwentythree' }
+	`( 'Check SSR endoint: $endpoint', function ( { endpoint } ) {
+		it( 'Navigate to $endpoint', async function () {
+			await page.goto( endpoint, { timeout: 20 * 1000 } );
+		} );
+
+		it( 'SSR is present for $endpoint', async function () {
+			await page.locator( '#wpcom[data-calypso-ssr="true"]' ).waitFor( { timeout: 15 * 1000 } );
+		} );
 	} );
 } );

--- a/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
@@ -1,5 +1,5 @@
 /**
- * @group calypso-loop
+ * @group calypso-pr
  */
 
 import { DataHelper } from '@automattic/calypso-e2e';


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78186.

## Proposed Changes

This PR updates the Calypso SSR spec to be less flaky.

Key changes:
- each page now loads in its own tab.
- test step title is fixed instead of being variable with the container name.

Still unknown:
- whether these tests are necessary or even useful. Thread: p1686819783199949-slack-C7YPUHBB2

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)

Revised spec managed to pass 100 iterations.
<img width="792" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6549265/8b27bd6f-d01c-484d-927c-b91da497eb0e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?