### PR TITLE
eslint: fix remaining `@tanstack/query/prefer-query-object-syntax` violations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -539,6 +539,5 @@ module.exports = {
 		// @TODO remove these lines once we fixed the warnings so
 		// they'll become errors for new code added to the codebase
 		'@tanstack/query/exhaustive-deps': 'warn',
-		'@tanstack/query/prefer-query-object-syntax': 'warn',
 	},
 };

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -58,7 +58,10 @@ const emptyVatDetails = {};
 
 export default function useVatDetails(): VatDetailsManager {
 	const queryClient = useQueryClient();
-	const query = useQuery< VatDetails, FetchError >( [ 'vat-details' ], fetchVatDetails );
+	const query = useQuery< VatDetails, FetchError >( {
+		queryKey: [ 'vat-details' ],
+		queryFn: fetchVatDetails,
+	} );
 	const mutation = useMutation< VatDetails, UpdateError, VatDetails >( {
 		mutationFn: setVatDetails,
 		onSuccess: ( data ) => {

--- a/client/my-sites/site-settings/site-owner-transfer/use-check-site-transfer-eligibility.ts
+++ b/client/my-sites/site-settings/site-owner-transfer/use-check-site-transfer-eligibility.ts
@@ -20,6 +20,7 @@ export const useCheckSiteTransferEligibility = (
 	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const mutation = useMutation( {
+		...options,
 		mutationFn: async ( { newSiteOwner }: MutationVariables ) =>
 			wp.req.post(
 				{
@@ -28,7 +29,6 @@ export const useCheckSiteTransferEligibility = (
 				},
 				{ new_site_owner: newSiteOwner }
 			),
-		...options,
 	} );
 
 	const { mutate, isLoading } = mutation;

--- a/client/my-sites/site-settings/site-owner-transfer/use-check-site-transfer-eligibility.ts
+++ b/client/my-sites/site-settings/site-owner-transfer/use-check-site-transfer-eligibility.ts
@@ -19,8 +19,8 @@ export const useCheckSiteTransferEligibility = (
 	siteId: number | null,
 	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
-	const mutation = useMutation(
-		async ( { newSiteOwner }: MutationVariables ) =>
+	const mutation = useMutation( {
+		mutationFn: async ( { newSiteOwner }: MutationVariables ) =>
 			wp.req.post(
 				{
 					path: `/sites/${ siteId }/site-owner-transfer/eligibility`,
@@ -28,10 +28,8 @@ export const useCheckSiteTransferEligibility = (
 				},
 				{ new_site_owner: newSiteOwner }
 			),
-		{
-			...options,
-		}
-	);
+		...options,
+	} );
 
 	const { mutate, isLoading } = mutation;
 

--- a/client/my-sites/site-settings/site-owner-transfer/use-start-site-owner-transfer.ts
+++ b/client/my-sites/site-settings/site-owner-transfer/use-start-site-owner-transfer.ts
@@ -19,8 +19,8 @@ export const useStartSiteOwnerTransfer = (
 	siteId: number | null,
 	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
-	const mutation = useMutation(
-		async ( { newSiteOwner }: MutationVariables ) => {
+	const mutation = useMutation( {
+		mutationFn: async ( { newSiteOwner }: MutationVariables ) => {
 			return wp.req.post(
 				{
 					path: `/sites/${ siteId }/site-owner-transfer`,
@@ -29,10 +29,8 @@ export const useStartSiteOwnerTransfer = (
 				{ new_site_owner: newSiteOwner }
 			);
 		},
-		{
-			...options,
-		}
-	);
+		...options,
+	} );
 
 	const { mutate, isLoading } = mutation;
 

--- a/client/my-sites/site-settings/site-owner-transfer/use-start-site-owner-transfer.ts
+++ b/client/my-sites/site-settings/site-owner-transfer/use-start-site-owner-transfer.ts
@@ -20,6 +20,7 @@ export const useStartSiteOwnerTransfer = (
 	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const mutation = useMutation( {
+		...options,
 		mutationFn: async ( { newSiteOwner }: MutationVariables ) => {
 			return wp.req.post(
 				{
@@ -29,7 +30,6 @@ export const useStartSiteOwnerTransfer = (
 				{ new_site_owner: newSiteOwner }
 			);
 		},
-		...options,
 	} );
 
 	const { mutate, isLoading } = mutation;


### PR DESCRIPTION
Related to #77787 

## Proposed Changes

PR fixes remaining violations of the `@tanstack/query/prefer-query-object-syntax` found throughout the Calypso repo. Additionally we're adjusting the eslint config to error in case of violations of this rule.

## Testing Instructions

I think a code review should be sufficient but if you want to double-check these are the flows which need testing:

* Go to your billing history and verify VAT details (if provided) show up correctly
* Attempt to transfer a site to a user who is an administrator of your site, verify that process works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
