### PR TITLE
Theme showcase: De-emphasize WP.org classic themes

### DIFF
--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -127,6 +127,7 @@ export function fetchThemesList( options = {} ) {
 		// Return an `author` object containing `user_nicename` and `display_name` attrs.
 		// This is for consistency with WP.com, which always returns the display name as `author`.
 		'request[fields][extended_author]': true,
+		'request[fields][tags]': true,
 		'request[search]': search,
 		'request[page]': page,
 		'request[per_page]:': number,

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -166,25 +166,22 @@ export function interlaceThemes( wpComThemes, wpOrgThemes, searchTerm, isLastPag
 
 	// 3. WP.org themes (only if the list of WP.com themes has reached the last page).
 	if ( isEnabled( 'themes/interlaced-dotorg-themes' ) && isLastPage ) {
+		const restWpOrgThemes = matchingTheme
+			? wpOrgThemes.filter( ( theme ) => theme.id !== matchingTheme.id )
+			: wpOrgThemes;
+
 		// 3.1. WP.org block themes.
-		const restWpOrgBlockThemes = validWpOrgThemes.filter(
-			( theme ) =>
-				theme.id !== matchingTheme?.id &&
-				theme.taxonomies?.theme_feature?.some(
-					( feature ) => feature?.slug === 'full-site-editing'
-				)
+		const restWpOrgBlockThemes = restWpOrgThemes.filter( ( theme ) =>
+			theme.taxonomies?.theme_feature?.some( ( feature ) => feature?.slug === 'full-site-editing' )
 		);
 		interlacedThemes.push( ...restWpOrgBlockThemes );
 
-		// 3.2 WP.org classic themes.
-		const restWpOrgClassicThemes = validWpOrgThemes.filter(
+		// 3.2. WP.org classic themes.
+		const restWpOrgClassicThemes = restWpOrgThemes.filter(
 			( theme ) =>
-				theme.id !== matchingTheme?.id &&
-				( ! theme.taxonomies ||
-					! theme.taxonomies.theme_feature ||
-					theme.taxonomies.theme_feature.every(
-						( feature ) => feature?.slug !== 'full-site-editing'
-					) )
+				! theme.taxonomies ||
+				! theme.taxonomies.theme_feature ||
+				theme.taxonomies.theme_feature.every( ( feature ) => feature?.slug !== 'full-site-editing' )
 		);
 		interlacedThemes.push( ...restWpOrgClassicThemes );
 	}

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -166,23 +166,25 @@ export function interlaceThemes( wpComThemes, wpOrgThemes, searchTerm, isLastPag
 
 	// 3. WP.org themes (only if the list of WP.com themes has reached the last page).
 	if ( isEnabled( 'themes/interlaced-dotorg-themes' ) && isLastPage ) {
-		const restWpOrgThemes = matchingTheme
-			? wpOrgThemes.filter( ( theme ) => theme.id !== matchingTheme.id )
-			: wpOrgThemes;
+		const restWpOrgBlockThemes = [];
+		const restWpOrgClassicThemes = [];
 
-		// 3.1. WP.org block themes.
-		const restWpOrgBlockThemes = restWpOrgThemes.filter( ( theme ) =>
-			theme.taxonomies?.theme_feature?.some( ( feature ) => feature?.slug === 'full-site-editing' )
-		);
+		validWpOrgThemes.forEach( ( theme ) => {
+			if ( theme.id === matchingTheme?.id ) {
+				return;
+			}
+			if (
+				theme.taxonomies?.theme_feature?.some(
+					( feature ) => feature?.slug === 'full-site-editing'
+				)
+			) {
+				restWpOrgBlockThemes.push( theme );
+			} else {
+				restWpOrgClassicThemes.push( theme );
+			}
+		} );
+
 		interlacedThemes.push( ...restWpOrgBlockThemes );
-
-		// 3.2. WP.org classic themes.
-		const restWpOrgClassicThemes = restWpOrgThemes.filter(
-			( theme ) =>
-				! theme.taxonomies ||
-				! theme.taxonomies.theme_feature ||
-				theme.taxonomies.theme_feature.every( ( feature ) => feature?.slug !== 'full-site-editing' )
-		);
 		interlacedThemes.push( ...restWpOrgClassicThemes );
 	}
 

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -121,6 +121,7 @@ export function getSubjectsFromTermTable( filterToTermTable ) {
  * - If the search term has an exact match (either a WP.com or a WP.org theme), that theme is the first result.
  * - WP.com themes are prioritized over WP.org themes.
  * - Retired WP.org themes or duplicate WP.org themes (those that are also WP.com themes) are excluded.
+ * - WP.org block themes are prioritized over WP.org classic themes.
  *
  * @param wpComThemes List of WP.com themes.
  * @param wpOrgThemes List of WP.org themes.
@@ -148,20 +149,45 @@ export function interlaceThemes( wpComThemes, wpOrgThemes, searchTerm, isLastPag
 		  )
 		: [];
 
-	const matchingTheme = wpComThemes.find( isMatchingTheme );
+	const interlacedThemes = [];
+
+	// 1. Exact match.
+	const matchingTheme =
+		wpComThemes.find( isMatchingTheme ) || validWpOrgThemes.find( isMatchingTheme );
+	if ( matchingTheme ) {
+		interlacedThemes.push( matchingTheme );
+	}
+
+	// 2. WP.com themes.
 	const restWpComThemes = matchingTheme
 		? wpComThemes.filter( ( theme ) => theme.id !== matchingTheme.id )
 		: wpComThemes;
-	const matchingWpOrgTheme = validWpOrgThemes.find( isMatchingTheme );
-	const restWpOrgThemes = matchingWpOrgTheme
-		? validWpOrgThemes.filter( ( theme ) => theme.id !== matchingWpOrgTheme.id )
-		: validWpOrgThemes;
+	interlacedThemes.push( ...restWpComThemes );
 
-	return [
-		...( matchingTheme ? [ matchingTheme ] : [] ),
-		...( matchingWpOrgTheme ? [ matchingWpOrgTheme ] : [] ),
-		...restWpComThemes,
-		// Include WP.org themes after the last page of WP.com themes.
-		...( isEnabled( 'themes/interlaced-dotorg-themes' ) && isLastPage ? restWpOrgThemes : [] ),
-	];
+	// 3. WP.org themes (only if the list of WP.com themes has reached the last page).
+	if ( isEnabled( 'themes/interlaced-dotorg-themes' ) && isLastPage ) {
+		// 3.1. WP.org block themes.
+		const restWpOrgBlockThemes = validWpOrgThemes.filter(
+			( theme ) =>
+				theme.id !== matchingTheme?.id &&
+				theme.taxonomies?.theme_feature?.some(
+					( feature ) => feature?.slug === 'full-site-editing'
+				)
+		);
+		interlacedThemes.push( ...restWpOrgBlockThemes );
+
+		// 3.2 WP.org classic themes.
+		const restWpOrgClassicThemes = validWpOrgThemes.filter(
+			( theme ) =>
+				theme.id !== matchingTheme?.id &&
+				( ! theme.taxonomies ||
+					! theme.taxonomies.theme_feature ||
+					theme.taxonomies.theme_feature.every(
+						( feature ) => feature?.slug !== 'full-site-editing'
+					) )
+		);
+		interlacedThemes.push( ...restWpOrgClassicThemes );
+	}
+
+	return interlacedThemes;
 }

--- a/client/my-sites/themes/test/helpers.js
+++ b/client/my-sites/themes/test/helpers.js
@@ -34,5 +34,23 @@ describe( 'helpers', () => {
 			const interlacedThemes = interlaceThemes( wpComThemes, wpOrgThemes, 'wporg-theme-2', true );
 			expect( interlacedThemes[ 0 ] ).toEqual( { id: 'wporg-theme-2' } );
 		} );
+
+		test( 'prioritizes WP.org block themes over WP.org classic themes', () => {
+			const wpOrgClassicAndBlockThemes = [
+				{ id: 'wporg-classic-theme' },
+				{
+					id: 'wporg-block-theme',
+					taxonomies: { theme_feature: [ { slug: 'full-site-editing' } ] },
+				},
+			];
+			const interlacedThemes = interlaceThemes(
+				wpComThemes,
+				wpOrgClassicAndBlockThemes,
+				'test',
+				true
+			);
+			expect( interlacedThemes[ 2 ].id ).toEqual( 'wporg-block-theme' );
+			expect( interlacedThemes[ 3 ].id ).toEqual( 'wporg-classic-theme' );
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2747

## Proposed Changes

De-emphasize the WP.org classic themes in the theme showcase by moving them to the bottom of the results.

Before | Astra
--- | ---
<img width="1421" alt="Screenshot 2023-06-15 at 15 38 42" src="https://github.com/Automattic/wp-calypso/assets/1233880/3dfcc92a-cd89-482c-82fd-d2cf4c7b8f10"> | <img width="1404" alt="Screenshot 2023-06-15 at 15 38 13" src="https://github.com/Automattic/wp-calypso/assets/1233880/f8896c43-cf43-408d-9705-6d5d32280fa6">

Note: The code of the interlacing logic has been rewritten to improve its readability. 

## Testing Instructions

- Use the Calypso live link below.
- Go to Appearance > Themes.
- Enter a search term that produces results that include WP.org block themes and WP.org classic themes (e.g. Hotel).
- Make sure WP.org block themes (e.g. Elevated Lite, Strategist FSE) are prioritized over WP.org classic themes (e.g. Entr, Avantex).
