### PR TITLE
Sites: Don't show 'Domains and DNS' link for Jetpack sites

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -436,7 +436,7 @@ export const SitesEllipsisMenu = ( {
 							{ __( 'Privacy settings' ) }
 						</MenuItemLink>
 					) }
-					{ hasCustomDomain && (
+					{ hasCustomDomain && ! isNotAtomicJetpack( site ) && (
 						<MenuItemLink
 							href={ `/domains/manage/${ site.slug }/dns/${ site.slug }` }
 							onClick={ () =>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/77980

## Proposed Changes

Prevents the 'Domains and DNS' link from appearing for non-Atomic Jetpack sites.

### Before

<img width="1548" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/6ea91644-9c84-4f28-80dc-2d4d19fda4e4">

### After

<img width="1559" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/9b7abf1c-8c10-4f36-b6c2-5c914d1d3044">

## Testing Instructions

1. Create a Jurassic Ninja site and connect it to WordPress.com
2. Verify the 'Domains and DNS' link doesn't appear for the Jurassic Ninja site.
3. Verify the 'Domains and DNS' link still appears for an Atomic site with a mapped domain.