### PR TITLE
Assembler - UX - Reduce sidebar width and panel padding for wide breakpoint

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -15,10 +15,10 @@
 	transition: margin-inline-start 0.2s ease-out;
 
 	.pattern-assembler__pattern-panel-list--is-open & {
-		margin-inline-start: 365px;
+		margin-inline-start: 360px;
 
-		@media ( max-width: $break-wide ) {
-			margin-inline-start: 360px;
+		@include break-wide {
+			margin-inline-start: 365px;
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 @import "./keyframes";
 
 .pattern-large-preview {
@@ -14,6 +16,10 @@
 
 	.pattern-assembler__pattern-panel-list--is-open & {
 		margin-inline-start: 365px;
+
+		@include break-wide {
+			margin-inline-start: 360px;
+		}
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -17,7 +17,7 @@
 	.pattern-assembler__pattern-panel-list--is-open & {
 		margin-inline-start: 365px;
 
-		@include break-wide {
+		@media ( max-width: $break-wide ) {
 			margin-inline-start: 360px;
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -19,7 +19,7 @@
 	scrollbar-gutter: stable;
 	font-family: "SF Pro Text", $sans;
 
-	@include break-wide {
+	@media ( max-width: $break-wide ) {
 		margin-inline-start: 300px;
 		width: 340px;
 		padding: 20px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -6,11 +6,11 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-	margin-inline-start: 348px;
-	width: 348px;
+	margin-inline-start: 300px;
+	width: 340px;
+	padding: 20px;
 	background: var(--studio-gray-0);
 	border-left: 1px solid rgba(0, 0, 0, 0.03);
-	padding: 24px;
 	max-height: 100vh;
 	min-height: 100vh;
 	overflow-y: auto;
@@ -19,10 +19,10 @@
 	scrollbar-gutter: stable;
 	font-family: "SF Pro Text", $sans;
 
-	@media ( max-width: $break-wide ) {
-		margin-inline-start: 300px;
-		width: 340px;
-		padding: 20px;
+	@include break-wide {
+		margin-inline-start: 348px;
+		width: 348px;
+		padding: 24px;
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/variables.scss";
 
 .pattern-list-panel__wrapper {
@@ -16,6 +18,11 @@
 	transform: translateX(0);
 	scrollbar-gutter: stable;
 	font-family: "SF Pro Text", $sans;
+
+	@include break-wide {
+		margin-inline-start: 300px;
+		padding: 20px;
+	}
 }
 
 .pattern-list-panel__title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -21,6 +21,7 @@
 
 	@include break-wide {
 		margin-inline-start: 300px;
+		width: 340px;
 		padding: 20px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -37,7 +37,7 @@ $font-family: "SF Pro Text", $sans;
 	.pattern-assembler__sidebar {
 		display: flex;
 		flex-direction: column;
-		width: 348px;
+		width: 300px;
 		height: 100vh;
 		box-sizing: border-box;
 		padding: 110px 32px 32px;
@@ -46,8 +46,8 @@ $font-family: "SF Pro Text", $sans;
 		z-index: 2;
 		overflow-x: visible;
 
-		@media ( max-width: $break-wide ) {
-			width: 300px;
+		@include break-wide {
+			width: 348px;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -46,7 +46,7 @@ $font-family: "SF Pro Text", $sans;
 		z-index: 2;
 		overflow-x: visible;
 
-		@include break-wide {
+		@media ( max-width: $break-wide ) {
 			width: 300px;
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/variables";
 @import "./keyframes";
 
@@ -43,6 +45,10 @@ $font-family: "SF Pro Text", $sans;
 		position: relative;
 		z-index: 2;
 		overflow-x: visible;
+
+		@include break-wide {
+			width: 300px;
+		}
 	}
 
 	/**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.scss
@@ -8,7 +8,7 @@
 		cursor: default;
 		border: 0;
 		box-shadow: none;
-		padding-right: 52px;
+		padding-right: 52px !important;
 	}
 
 	.banner__info .banner__title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.scss
@@ -4,11 +4,15 @@
 	background: #f0f7fc;
 	margin: 16px 0;
 
-	&.banner.card {
+	&.banner.card.is-dismissible {
 		cursor: default;
 		border: 0;
 		box-shadow: none;
-		padding-right: 52px !important;
+
+		// Overwrite .banner.card padding without !important
+		@media (min-width: 481px) {
+			padding-right: 52px;
+		}
 	}
 
 	.banner__info .banner__title {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78239

## Proposed Changes

*  When the window width is 1280px or less, reduce sidebar width and patterns panel padding 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Resize the window to less than 1280px
* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3`
* Verify the reduced width and padding makes the large preview slightly wider

**Window 960px**

|BEFORE|AFTER|
|--|--|
|<img width="961" alt="Screenshot 2566-06-15 at 20 56 33" src="https://github.com/Automattic/wp-calypso/assets/1881481/c9bc0698-2633-4194-9a88-574a1a902df0">|<img width="960" alt="Screenshot 2566-06-15 at 21 09 46" src="https://github.com/Automattic/wp-calypso/assets/1881481/5569fd96-ca91-4ee7-b174-85b1d279e888">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
