### PR TITLE
Assembler - UX improvements together

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 @import "./keyframes";
 
 .pattern-large-preview {
@@ -14,6 +16,10 @@
 
 	.pattern-assembler__pattern-panel-list--is-open & {
 		margin-inline-start: 365px;
+
+		@include break-wide {
+			margin-inline-start: 360px;
+		}
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -17,7 +17,7 @@
 	.pattern-assembler__pattern-panel-list--is-open & {
 		margin-inline-start: 365px;
 
-		@include break-wide {
+		@media ( max-width: $break-wide ) {
 			margin-inline-start: 360px;
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -2,6 +2,7 @@ import { PatternRenderer } from '@automattic/block-renderer';
 import { Button, DeviceSwitcher } from '@automattic/components';
 import { useStyle } from '@automattic/global-styles';
 import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { Icon, layout } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -57,6 +58,7 @@ const PatternLargePreview = ( {
 		'--pattern-large-preview-block-gap': blockGap,
 		'--pattern-large-preview-background': backgroundColor,
 	} as CSSProperties );
+	const isWideViewport = useViewportMatch( 'wide', '<' );
 
 	const goToSelectHeaderPattern = () => {
 		navigator.goTo( NAVIGATOR_PATHS.HEADER );
@@ -186,7 +188,7 @@ const PatternLargePreview = ( {
 			isShowDeviceSwitcherToolbar
 			isShowFrameBorder
 			isShowFrameShadow={ false }
-			isFixedViewport={ !! hasSelectedPattern }
+			isFixedViewport={ !! hasSelectedPattern && ! isWideViewport }
 			frameRef={ frameRef }
 			onDeviceChange={ ( device ) => {
 				recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PREVIEW_DEVICE_CLICK, { device } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -19,7 +19,7 @@
 	scrollbar-gutter: stable;
 	font-family: "SF Pro Text", $sans;
 
-	@include break-wide {
+	@media ( max-width: $break-wide ) {
 		margin-inline-start: 300px;
 		width: 340px;
 		padding: 20px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/variables.scss";
 
 .pattern-list-panel__wrapper {
@@ -16,6 +18,11 @@
 	transform: translateX(0);
 	scrollbar-gutter: stable;
 	font-family: "SF Pro Text", $sans;
+
+	@include break-wide {
+		margin-inline-start: 300px;
+		padding: 20px;
+	}
 }
 
 .pattern-list-panel__title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -21,6 +21,7 @@
 
 	@include break-wide {
 		margin-inline-start: 300px;
+		width: 340px;
 		padding: 20px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -44,10 +44,10 @@ const ScreenCategoryList = ( {
 	onTogglePatternPanelList,
 }: Props ) => {
 	const translate = useTranslate();
+	const firstCategory = categories[ 0 ];
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
 	const categoriesInOrder = useCategoriesOrder( categories );
 	const composite = useCompositeState( { orientation: 'vertical' } );
-	const firstCategory = categories[ 0 ];
 	const isWideViewport = useViewportMatch( 'wide', '<' );
 
 	const trackEventCategoryClick = ( name: string ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -47,6 +47,7 @@ const ScreenCategoryList = ( {
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
 	const categoriesInOrder = useCategoriesOrder( categories );
 	const composite = useCompositeState( { orientation: 'vertical' } );
+	const firstCategory = categories[ 0 ];
 	const isWideViewport = useViewportMatch( 'wide', '<' );
 
 	const trackEventCategoryClick = ( name: string ) => {
@@ -56,6 +57,9 @@ const ScreenCategoryList = ( {
 	};
 
 	useEffect( () => {
+		// Open first category with a delay to avoid the top position flickering
+		setTimeout( () => setSelectedCategory( firstCategory?.name ?? null ), 200 );
+
 		// Notify the pattern panel list is open and closed
 		onTogglePatternPanelList?.( true );
 		return () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -5,6 +5,7 @@ import {
 	__unstableUseCompositeState as useCompositeState,
 	__unstableCompositeItem as CompositeItem,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { Icon, chevronRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -43,10 +44,10 @@ const ScreenCategoryList = ( {
 	onTogglePatternPanelList,
 }: Props ) => {
 	const translate = useTranslate();
-	const firstCategory = categories[ 0 ];
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
 	const categoriesInOrder = useCategoriesOrder( categories );
 	const composite = useCompositeState( { orientation: 'vertical' } );
+	const isWideViewport = useViewportMatch( 'wide', '<' );
 
 	const trackEventCategoryClick = ( name: string ) => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_CATEGORY_LIST_CATEGORY_CLICK, {
@@ -55,9 +56,6 @@ const ScreenCategoryList = ( {
 	};
 
 	useEffect( () => {
-		// Open first category with a delay to avoid the top position flickering
-		setTimeout( () => setSelectedCategory( firstCategory?.name ?? null ), 200 );
-
 		// Notify the pattern panel list is open and closed
 		onTogglePatternPanelList?.( true );
 		return () => {
@@ -141,9 +139,13 @@ const ScreenCategoryList = ( {
 				</NavigatorBackButton>
 			</div>
 			<PatternListPanel
-				onSelect={ ( selectedPattern: Pattern | null ) =>
-					onSelect( 'section', selectedPattern, selectedCategory )
-				}
+				onSelect={ ( selectedPattern: Pattern | null ) => {
+					onSelect( 'section', selectedPattern, selectedCategory );
+					if ( isWideViewport ) {
+						onTogglePatternPanelList?.( false );
+						setSelectedCategory( null );
+					}
+				} }
 				selectedPattern={ selectedPattern }
 				selectedCategory={ selectedCategory }
 				categories={ categories }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -43,7 +43,6 @@ const ScreenCategoryList = ( {
 	onTogglePatternPanelList,
 }: Props ) => {
 	const translate = useTranslate();
-	const firstCategory = categories[ 0 ];
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
 	const categoriesInOrder = useCategoriesOrder( categories );
 	const composite = useCompositeState( { orientation: 'vertical' } );
@@ -55,11 +54,6 @@ const ScreenCategoryList = ( {
 	};
 
 	useEffect( () => {
-		// Open first category with a delay to avoid the top position flickering
-		setTimeout( () => setSelectedCategory( firstCategory?.name ?? null ), 200 );
-
-		// Notify the pattern panel list is open and closed
-		onTogglePatternPanelList?.( true );
 		return () => {
 			onTogglePatternPanelList?.( false );
 		};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -46,7 +46,7 @@ $font-family: "SF Pro Text", $sans;
 		z-index: 2;
 		overflow-x: visible;
 
-		@include break-wide {
+		@media ( max-width: $break-wide ) {
 			width: 300px;
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/variables";
 @import "./keyframes";
 
@@ -43,6 +45,10 @@ $font-family: "SF Pro Text", $sans;
 		position: relative;
 		z-index: 2;
 		overflow-x: visible;
+
+		@include break-wide {
+			width: 300px;
+		}
 	}
 
 	/**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.scss
@@ -8,7 +8,7 @@
 		cursor: default;
 		border: 0;
 		box-shadow: none;
-		padding-right: 52px;
+		padding-right: 52px !important;
 	}
 
 	.banner__info .banner__title {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78239

## Proposed Changes
Merging the following issues together for testing.

* For all window sizes, don't open first pattern category initially. https://github.com/Automattic/wp-calypso/pull/78257
* When the window width is 1280px or less:
  * Reduce sidebar width and patterns panel padding. https://github.com/Automattic/wp-calypso/pull/78265
  * Close the patterns panel after click to add a pattern. https://github.com/Automattic/wp-calypso/pull/78256

@lucasmendes-design this PR is for testing the changes [mentioned](https://github.com/Automattic/wp-calypso/pull/77962#issuecomment-1591692260) in previous discussions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Resize the window to less than 1280px
* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3`
* Click Homepage and verify the first category is not open initially
* Verify the reduced width and padding makes the large preview slightly wider
* Add a pattern to verify that the patterns panel closes on click

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
