### PR TITLE
Hosting onboarding i2: remove feature flag

### DIFF
--- a/client/lib/paths/use-add-new-site-url.tsx
+++ b/client/lib/paths/use-add-new-site-url.tsx
@@ -19,7 +19,7 @@ export const useAddNewSiteUrl = ( queryParameters: Record< string, Primitive > )
 		// eslint-disable-next-line no-nested-ternary
 		isJetpackCloud()
 			? config( 'jetpack_connect_url' )
-			: ( isDevAccount || isInHostingFlow ) && config.isEnabled( 'hosting-onboarding-i2' )
+			: isDevAccount || isInHostingFlow
 			? '/setup/new-hosted-site'
 			: config( 'signup_url' )
 	);

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -21,9 +21,7 @@ export function generateFlows( {
 	const flows = [
 		{
 			name: HOSTING_LP_FLOW,
-			steps: isEnabled( 'hosting-onboarding-i2' )
-				? [ 'user-hosting' ]
-				: [ 'plans-hosting', 'user-hosting', 'domains' ],
+			steps: [ 'user-hosting' ],
 			destination: getHostingFlowDestination,
 			description:
 				'Create an account and a blog and give the user the option of adding a domain and plan to the cart.',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	BLANK_CANVAS_DESIGN,
 	PREMIUM_THEME,
@@ -199,7 +198,7 @@ function getHostingFlowDestination( { siteId } ) {
 	return addQueryArgs(
 		{
 			'new-site': siteId,
-			'hosting-flow': isEnabled( 'hosting-onboarding-i2' ) ? true : null,
+			'hosting-flow': true,
 		},
 		'/sites'
 	);

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -147,7 +147,7 @@ export function generateSteps( {
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 				isPasswordless: true,
-				showIsDevAccountCheckbox: config.isEnabled( 'hosting-onboarding-i2' ),
+				showIsDevAccountCheckbox: true,
 			},
 		},
 

--- a/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
+++ b/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
@@ -14,8 +13,6 @@ export const useSitesDashboardImportSiteUrl = (
 			source: TRACK_SOURCE_NAME,
 			...additionalParameters,
 		},
-		isDevAccount && isEnabled( 'hosting-onboarding-i2' )
-			? '/setup/import-hosted-site'
-			: '/start/import'
+		isDevAccount ? '/setup/import-hosted-site' : '/start/import'
 	);
 };

--- a/config/development.json
+++ b/config/development.json
@@ -74,7 +74,6 @@
 		"help": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,
-		"hosting-onboarding-i2": true,
 		"hosting/datacenter-picker": true,
 		"i18n/community-translator": false,
 		"i18n/empathy-mode": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,7 +42,6 @@
 		"happychat": false,
 		"help": true,
 		"home/layout-dev": true,
-		"hosting-onboarding-i2": false,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/unified": true,

--- a/config/production.json
+++ b/config/production.json
@@ -48,7 +48,6 @@
 		"happychat": false,
 		"help": true,
 		"help/gpt-response": true,
-		"hosting-onboarding-i2": false,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/unified": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -56,7 +56,6 @@
 		"help": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,
-		"hosting-onboarding-i2": true,
 		"hosting/datacenter-picker": true,
 		"i18n/translation-scanner": true,
 		"importers/substack": true,


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/2359.

## Proposed Changes

Farewell, Hosting onboarding i2. This PR removes the feature flag and its references, enabling all features in production.

This is blocked by D113819-code. Please only merge this PR once that diff is landed.

## Testing Instructions

Check that the new `/hosting` flow is still working in the scope that we worked on in the past 6 weeks.