### PR TITLE
Format stats if we receive -1 on them (which means is invalid)

### DIFF
--- a/client/my-sites/promote-post-i2/components/post-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/post-item/index.tsx
@@ -133,9 +133,9 @@ export default function PostItem( { post }: Props ) {
 
 			<td className="post-item__post-type">{ getPostType( post.type ) }</td>
 			<td className="post-item__post-publish-date">{ postDate }</td>
-			<td className="post-item__post-views">{ formatNumber( viewCount ) }</td>
-			<td className="post-item__post-likes">{ formatNumber( likeCount ) }</td>
-			<td className="post-item__post-comments">{ formatNumber( commentCount ) }</td>
+			<td className="post-item__post-views">{ formatNumber( viewCount, true ) }</td>
+			<td className="post-item__post-likes">{ formatNumber( likeCount, true ) }</td>
+			<td className="post-item__post-comments">{ formatNumber( commentCount, true ) }</td>
 			<td className="post-item__post-view">
 				<a href={ post.post_url } className="post-item__view-link">
 					{ __( 'View' ) }

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -165,8 +165,8 @@ export const getCampaignEstimatedImpressions = ( displayDeliveryEstimate: string
 	return `${ ( +minEstimate ).toLocaleString() } - ${ ( +maxEstimate ).toLocaleString() }`;
 };
 
-export const formatNumber = ( number: number ) => {
-	if ( ! number ) {
+export const formatNumber = ( number: number, onlyPositives = false ): string => {
+	if ( ! number || ( onlyPositives && number < 0 ) ) {
 		return '-';
 	}
 	return number.toLocaleString();


### PR DESCRIPTION
We now receive a -1 in likes or stats if this information is disabled by the blog. This quick patch lets the formatNumber function we use in blazepress to discern by only positive numbers

## Proposed Changes
- Adds "-" whenever we get a -1 in "like_view" or stats

## Testing Instructions
- Create a jetpack site (jurassic.ninja and connect it to jetpack). It should have likes disabled. Go to calypso, select this site and check if you see "-" in like count instead of -1

![image](https://github.com/Automattic/wp-calypso/assets/43957544/bced2d89-5f78-43e8-abee-f2d4613e07f3)

![image](https://github.com/Automattic/wp-calypso/assets/43957544/99712795-61db-45a5-9380-f02da7af2c8b)

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
