### PR TITLE
Subscription Management: Hide Manage Purchases button for free subscribers on individual site subscription page

### DIFF
--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
@@ -246,14 +246,16 @@ const SiteSubscriptionDetails = ( {
 					</div>
 
 					<div className="site-subscription-page__button-container">
-						<Button
-							className="site-subscription-page__manage-button"
-							isPrimary
-							href="/me/purchases"
-							disabled={ unsubscribing }
-						>
-							{ translate( 'Manage purchases' ) }
-						</Button>
+						{ paymentPlans && !! paymentPlans.length && (
+							<Button
+								className="site-subscription-page__manage-button"
+								isPrimary
+								href="/me/purchases"
+								disabled={ unsubscribing }
+							>
+								{ translate( 'Manage purchases' ) }
+							</Button>
+						) }
 						<Button
 							className="site-subscription-page__unsubscribe-button"
 							onClick={ () => confirmUnsubscribe( { blogId, url } ) }

--- a/client/landing/subscriptions/components/site-subscription-page/styles.scss
+++ b/client/landing/subscriptions/components/site-subscription-page/styles.scss
@@ -146,9 +146,12 @@
 		margin: 64px 0 32px;
 	}
 
+	.site-subscription-page__manage-button {
+		margin-right: 10px;
+	}
+
 	.site-subscription-page__unsubscribe-button {
 		border: 1px solid $studio-gray-20;
-		margin-left: 10px;
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78276

## Proposed Changes

* Hide Manage Purchases button for free subscribers on individual site subscription page

## Testing Instructions

* Apply this PR to your local env
* Go to http://calypso.localhost:3000/subscriptions
* Click on a site that you have free subscription
* Check if the individual site subscription page has only the Cancel subscription button
* Check for regressions, go to a site with paid subscription and verify if the Manage purchases button appears

<img width="633" alt="Screenshot 2023-06-15 at 12 20 29" src="https://github.com/Automattic/wp-calypso/assets/3113712/c90664db-a908-43b5-b2be-673974904c82">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
