### PR TITLE
Try get sites in discover

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -52,6 +52,7 @@ import PostPlaceholder from './post-placeholder';
 import ReaderListFollowedSites from './reader-list-followed-sites';
 import './style.scss';
 import ReaderDiscoverSidebar from 'calypso/reader/stream/reader-discover-sidebar';
+import { getReaderRecommendedSites } from 'calypso/state/reader/recommended-sites/selectors';
 
 const WIDE_DISPLAY_CUTOFF = 900;
 const GUESSED_POST_HEIGHT = 600;
@@ -463,7 +464,7 @@ class ReaderStream extends Component {
 	};
 
 	render() {
-		const { translate, forcePlaceholders, lastPage, streamHeader, streamKey, tag, tags } =
+		const { translate, forcePlaceholders, lastPage, streamHeader, streamKey, tag, tags, sites } =
 			this.props;
 		const wideDisplay = this.props.width > WIDE_DISPLAY_CUTOFF;
 		let { items, isRequesting } = this.props;
@@ -523,7 +524,7 @@ class ReaderStream extends Component {
 			} else if ( isSearchPage ) {
 				sidebarContent = <ReaderSearchSidebar items={ items } />;
 			} else if ( isDiscoverPage ) {
-				sidebarContent = <ReaderDiscoverSidebar items={ [] } />;
+				sidebarContent = <ReaderDiscoverSidebar items={ sites } />;
 			} else {
 				sidebarContent = <ReaderListFollowedSites path={ path } />;
 			}
@@ -600,6 +601,8 @@ export default connect(
 		const selectedPost = getPostByKey( state, stream.selected );
 		const streamKeySuffix = streamKey?.substring( streamKey?.indexOf( ':' ) + 1 );
 
+		const recommendedSites = getReaderRecommendedSites( state, 'seed?' ) || [];
+
 		return {
 			blockedSites: getBlockedSites( state ),
 			items: getTransformedStreamItems( state, {
@@ -619,6 +622,7 @@ export default connect(
 			primarySiteId: getPrimarySiteId( state ),
 			tag: streamKeySuffix,
 			tags: getReaderTags( state ),
+			sites: recommendedSites,
 		};
 	},
 	{

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -9,7 +9,7 @@ import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { READER_STREAMS_PAGE_REQUEST } from 'calypso/state/reader/action-types';
 import { receivePosts } from 'calypso/state/reader/posts/actions';
 import { receivePage, receiveUpdates } from 'calypso/state/reader/streams/actions';
-import { receiveSites } from 'calypso/state/sites/actions';
+import { receiveRecommendedSites } from 'calypso/state/reader/recommended-sites/actions';
 
 const noop = () => {};
 
@@ -360,10 +360,9 @@ export function handlePage( action, data ) {
 		actions.push( receivePosts( streamPosts ) );
 		actions.push( receivePage( { streamKey, query, streamItems, pageHandle, gap } ) );
 		if ( streamSites.length > 0 ) {
-			actions.push( receiveSites( streamSites ) );
+			actions.push( receiveRecommendedSites( { seed: 'seed?', sites: streamSites } ) );
 		}
 	}
-	console.log( 'actions', actions );
 
 	return actions;
 }

--- a/client/state/reader/recommended-sites/reducer.js
+++ b/client/state/reader/recommended-sites/reducer.js
@@ -13,6 +13,10 @@ import { combineReducers, keyedReducer } from 'calypso/state/utils';
 export const items = keyedReducer( 'seed', ( state = [], action ) => {
 	switch ( action.type ) {
 		case READER_RECOMMENDED_SITES_RECEIVE:
+			console.log( 'receiving', action.payload );
+			// This seems to be removing results we would want (in my end its reducing from 2 to 1
+			// and they dont have the same feedId)
+			console.log( uniqBy( state.concat( action.payload.sites ), 'feedId' ) );
 			return uniqBy( state.concat( action.payload.sites ), 'feedId' );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

for discussion, just messing around with ideas how to move https://github.com/Automattic/wp-calypso/pull/78137 forward.

## Proposed Changes

* 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
