### PR TITLE
Hosting onboarding: reuse "I am a developer" copy from /me

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -51,6 +51,7 @@ import {
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
+import { getIAmDeveloperCopy } from 'calypso/me/profile/get-i-am-a-developer-copy';
 import { isP2Flow } from 'calypso/signup/utils';
 import { recordTracksEventWithClientId } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
@@ -949,16 +950,7 @@ class SignupForm extends Component {
 					this.setState( { isDevAccount } );
 				} }
 			>
-				{ preventWidows(
-					translate(
-						"{{strong}}I'm a developer.{{/strong}} Boost my WordPress.com experience and give me early access to developer features",
-						{
-							components: {
-								strong: <span className="signup-form__is-dev-account-strong" />,
-							},
-						}
-					)
-				) }
+				{ preventWidows( getIAmDeveloperCopy( translate ) ) }
 			</SelectCardCheckbox>
 		);
 	}

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -119,6 +119,10 @@
 .signup-form__is-dev-account-checkbox {
 	margin-bottom: 48px;
 
+	@include break-large {
+		width: fit-content;
+	}
+
 	// The SelectCardCheckbox label is flex by default, which is good for badges, but makes
 	// the <strong> section of the label it's own block and not wrap nicely with the rest
 	// of the label.

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -127,10 +127,6 @@
 	}
 }
 
-.signup-form__is-dev-account-strong {
-	font-weight: 500;
-}
-
 // Replace recaptcha badge with ToS text and space
 // everything out a little more.
 @media ( max-width: 660px ) {

--- a/client/me/profile/get-i-am-a-developer-copy.tsx
+++ b/client/me/profile/get-i-am-a-developer-copy.tsx
@@ -1,0 +1,11 @@
+import { translate } from 'i18n-calypso';
+
+export const getIAmDeveloperCopy = ( translateFunction: typeof translate ) =>
+	translateFunction(
+		'{{strong}}I am a developer.{{/strong}} Make my WordPress.com experience more powerful and grant me early access to developer features.',
+		{
+			components: {
+				strong: <strong />,
+			},
+		}
+	);

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -1,7 +1,7 @@
 import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import classnames from 'classnames';
-import { localize, translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -24,8 +24,8 @@ import ProfileLinks from 'calypso/me/profile-links';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
+import { getIAmDeveloperCopy } from './get-i-am-a-developer-copy';
 import UpdatedGravatarString from './updated-gravatar-string';
-
 import './style.scss';
 
 class Profile extends Component {
@@ -145,14 +145,7 @@ class Profile extends Component {
 								disabled={ this.props.isFetchingUserSettings }
 								checked={ this.props.getSetting( 'is_dev_account' ) }
 								onChange={ this.toggleIsDevAccount }
-								label={ translate(
-									'{{spanLead}}I am a developer.{{/spanLead}} Make my WordPress.com experience more powerful and grant me early access to developer features.',
-									{
-										components: {
-											spanLead: <strong />,
-										},
-									}
-								) }
+								label={ getIAmDeveloperCopy( this.props.translate ) }
 							/>
 						</FormFieldset>
 


### PR DESCRIPTION
## Proposed Changes

During the CfT, it was related that using "Boost" my experience might be misleading because of Jetpack Boost. Let's reword it. It's better to use the same wording that exists in `/me`.

## Testing Instructions

Check that the wording is different on `/start/hosting` and that the copy is shared between this page and `/me`.

| `trunk` | This PR |
| ------- | -------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/ee7503a7-ccc3-4702-9d63-2f0cc7661daf) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/0ebb460d-a2fc-416a-9464-97019cc20653) |
