### PR TITLE
Avoid the menu to pop when mobile view

### DIFF
--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -41,6 +41,26 @@
 	background-color: transparent;
 }
 
+// Grabbed from wp-calypso/client/my-sites/sidebar/style.scss
+@media screen and ( max-width: 660px ) {
+	.theme-default {
+		// client/layout/style.scss
+		.layout__content {
+			min-height: initial;
+		}
+
+		.focus-content:not(.has-no-sidebar) .layout__content {
+			padding: 47px 0 0;
+		}
+
+		// client/layout/sidebar/style.scss
+		.sidebar {
+			position: absolute;
+			padding-bottom: 120px;
+		}
+	}
+}
+
 body.is-section-promote-post-i2 {
 	.layout__content {
 		position: relative;


### PR DESCRIPTION
When opening blazepress in mobile you can notice some scrolling coming from the menu. By analyzing the "posts" section which doesn't display this effect I noticed some CSS class we were missing to include. I've added it in our CSS file so it's isolated of the rest of the codebase

## Proposed Changes
- Added fix from "posts" CSS stylesheet into blazepress to avoid the sidebar to pop when opening blazepress in mobile

## Testing Instructions
- Open blazepress in mobile. You shouldn't see the menu moving to the left.


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
