### PR TITLE
Subscribers Page: Update Unsubscribe Modal text

### DIFF
--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -28,7 +28,13 @@ const UnsubscribeModal = ( { subscriber, onClose }: UnsubscribeModalProps ) => {
 		: translate( 'Remove subscriber', { context: 'Confirm Unsubscribe subscriber button text.' } );
 
 	const confirmMessage = subscriberHasPlans
-		? translate( 'To remove this subscriber, you’ll need to cancel their paid subscription first.' )
+		? translate(
+				'To remove %s from your list, you’ll need to cancel their paid subscription first.',
+				{
+					args: [ subscriber?.display_name ],
+					comment: "%s is the subscriber's public display name",
+				}
+		  )
 		: translate(
 				'Are you sure you want to remove %s from your list? They will no longer receive new notifications from your site.',
 				{


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/77733

## Proposed Changes

* Update Unsubscribe Modal text, for context see p1686845084370769/1686778769.332109-slack-C02TCEHP3HA

## Testing Instructions

* Apply this PR to your local env
* Go to http://calypso.localhost:3000/subscribers/{site-slug}?flags=subscribers-page
* Using a paid subscriber, click on Unsubscribe
* Verify if the modal is displayed with the updated message

<img width="583" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/42b57ecf-fbfd-48a6-9621-7a8180cb9273">
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?