### PR TITLE
Site transfers: Add new keep_admin_access toggle

### DIFF
--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -50,6 +50,11 @@ const Title = styled.h2( {
 	marginBottom: '1em',
 } );
 
+const ToggleContainer = styled.div( {
+	marginTop: '2em',
+	marginBottom: '2em',
+} );
+
 const Text = styled.p( {
 	marginBottom: '0.5em !important',
 } );
@@ -61,6 +66,43 @@ const List = styled.ul( {
 const ListItem = styled.li( {
 	marginBottom: '0.25em',
 } );
+
+const AdminCard = ( {
+	siteOwner,
+	onToggle,
+	checked,
+}: {
+	siteOwner?: string;
+	onToggle: ( checked: boolean ) => void;
+	checked: boolean;
+} ) => {
+	const translate = useTranslate();
+	return (
+		<>
+			<Title>{ translate( 'Admin access' ) }</Title>
+			<Text>
+				{ createInterpolateElement(
+					sprintf(
+						// translators: siteOwner is the user that the site is going to transfer to
+						translate(
+							'When you transfer a site you can keep or decline administrator rights. By declining, you’ll lose access to the site unless <strong>%(siteOwner)s</strong> gives you new permissions.'
+						),
+						{ siteOwner }
+					),
+					{ strong: <Strong /> }
+				) }
+			</Text>
+			<ToggleContainer>
+				<FormToggleControl
+					disabled={ false }
+					label={ translate( 'Keep me as an administrator on this site.' ) }
+					checked={ checked }
+					onChange={ () => onToggle( ! checked ) }
+				/>
+			</ToggleContainer>
+		</>
+	);
+};
 
 const DomainsCard = ( {
 	domains,
@@ -81,7 +123,7 @@ const DomainsCard = ( {
 						{ createInterpolateElement(
 							sprintf(
 								// translators: siteSlug is the current site slug, siteOwner is the user that the site is going to
-								// transer to
+								// transfer to
 								translate(
 									'The domain name <strong>%(siteSlug)s</strong> will be transferred to <strong>%(siteOwner)s</strong> and will remain working on the site.'
 								),
@@ -137,7 +179,7 @@ const UpgradesCard = ( {
 					{ createInterpolateElement(
 						sprintf(
 							// translators: siteSlug is the current site slug, siteOwner is the user that the site is going to
-							// transer to
+							// transfer to
 							translate(
 								'Your paid upgrades on <strong>%(siteSlug)s</strong> will be transferred to <strong>%(siteOwner)s</strong> and will remain with the site.'
 							),
@@ -167,7 +209,7 @@ const ContentAndOwnershipCard = ( {
 					{ createInterpolateElement(
 						sprintf(
 							// translators: siteSlug is the current site slug, siteOwner is the user that the site is going to
-							// transer to
+							// transfer to
 							translate(
 								'You’ll be removed as owner of <strong>%(siteSlug)s</strong> and <strong>%(siteOwner)s</strong> will be the new owner from now on.'
 							),
@@ -180,20 +222,7 @@ const ContentAndOwnershipCard = ( {
 					{ createInterpolateElement(
 						sprintf(
 							// translators: siteSlug is the current site slug, siteOwner is the user that the site is going to
-							// transer to
-							translate(
-								'You will not be able to access <strong>%(siteSlug)s</strong> unless allowed by <strong>%(siteOwner)s</strong>.'
-							),
-							{ siteSlug, siteOwner }
-						),
-						{ strong: <Strong /> }
-					) }
-				</ListItem>
-				<ListItem>
-					{ createInterpolateElement(
-						sprintf(
-							// translators: siteSlug is the current site slug, siteOwner is the user that the site is going to
-							// transer to
+							// transfer to
 							translate(
 								'Your posts on <strong>%(siteSlug)s</strong> will be transferred to <strong>%(siteOwner)s</strong> and will no longer be authored by your account.'
 							),
@@ -216,6 +245,7 @@ const StartSiteOwnerTransfer = ( {
 	onSiteTransferError,
 	translate,
 }: Props ) => {
+	const [ confirmAdminToggle, setConfirmAdminToggle ] = useState( true );
 	const [ confirmFirstToggle, setConfirmFirstToggle ] = useState( false );
 	const [ confirmSecondToggle, setConfirmSecondToggle ] = useState( false );
 	const [ confirmThirdToggle, setConfirmThirdToggle ] = useState( false );
@@ -247,7 +277,7 @@ const StartSiteOwnerTransfer = ( {
 		if ( ! siteOwner ) {
 			return;
 		}
-		startSiteOwnerTransfer( { newSiteOwner: siteOwner } );
+		startSiteOwnerTransfer( { newSiteOwner: siteOwner, keepAdminAccess: confirmAdminToggle } );
 	};
 
 	const startSiteTransferForm = (
@@ -323,6 +353,11 @@ const StartSiteOwnerTransfer = ( {
 					domains={ customDomains }
 					siteOwner={ siteOwner }
 					siteSlug={ selectedSiteSlug }
+				/>
+				<AdminCard
+					siteOwner={ siteOwner }
+					onToggle={ setConfirmAdminToggle }
+					checked={ confirmAdminToggle }
 				/>
 				{ ! startSiteTransferSuccess && startSiteTransferForm }
 			</SiteOwnerTransferActionPanelBody>

--- a/client/my-sites/site-settings/site-owner-transfer/use-start-site-owner-transfer.ts
+++ b/client/my-sites/site-settings/site-owner-transfer/use-start-site-owner-transfer.ts
@@ -4,6 +4,7 @@ import wp from 'calypso/lib/wp';
 
 interface MutationVariables {
 	newSiteOwner: string;
+	keepAdminAccess: boolean;
 }
 
 interface MutationResponse {
@@ -19,20 +20,18 @@ export const useStartSiteOwnerTransfer = (
 	siteId: number | null,
 	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
-	const mutation = useMutation(
-		async ( { newSiteOwner }: MutationVariables ) => {
+	const mutation = useMutation( {
+		mutationFn: async ( { newSiteOwner, keepAdminAccess }: MutationVariables ) => {
 			return wp.req.post(
 				{
 					path: `/sites/${ siteId }/site-owner-transfer`,
 					apiNamespace: 'wpcom/v2',
 				},
-				{ new_site_owner: newSiteOwner }
+				{ new_site_owner: newSiteOwner, keep_admin_access: keepAdminAccess }
 			);
 		},
-		{
-			...options,
-		}
-	);
+		...options,
+	} );
 
 	const { mutate, isLoading } = mutation;
 


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/2579

## Proposed Changes

Adds a toggle to keep the current site owner as an administrator on the site when they initiate a site transfer:

<img width="837" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/2ed3952f-55f8-4597-8b1c-29b223faf467">

## Testing Instructions

1. Sandbox `public-api.wordpress.com` and apply D113745-code
2. Create a new Personal site and add another user to it as an administrator.
3. Navigate to General Settings -> Transfer site, leave the 'Keep me as an administrator on this site.' checked, and transfer the site to another user.
4. Verify your original user was kept as an administrator on the site.
5. As the second user, navigate to General Settings -> Transfer site, uncheck 'Keep me as an administrator on this site.', and transfer the site back to the original user.
6. Verify the second user was removed from the site.
7. Create a new Business site, take it Atomic, and add the second user as an administrator.
8. Repeat the Transfer site steps and verify the expected behavior.