### PR TITLE
Subscription Management: Restrict localed path only for external users.

### DIFF
--- a/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
@@ -21,14 +21,16 @@ type SubscriptionManagerTab = {
 
 const getPath = ( subpath: string ) => `/subscriptions/${ subpath }`;
 
-const getPathWithLocale = ( subpath: string, locale: string ) =>
-	getPath( subpath ) + ( locale !== 'en' ? '/' + locale : '' );
+// Localed path only applies for external users, WPCOM users inherits locale from user's language settings.
+const getPathWithLocale = ( subpath: string, locale: string, isLoggedIn: boolean ) =>
+	getPath( subpath ) + ( ! isLoggedIn && locale !== 'en' ? '/' + locale : '' );
 
 const useTabs = (): SubscriptionManagerTab[] => {
 	const navigate = useNavigate();
 	const { pathname } = useLocation();
 	const translate = useTranslate();
 	const locale = useLocale();
+	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 	const { data: counts } = SubscriptionManager.useSubscriptionsCountQuery();
 
 	return useMemo( () => {
@@ -37,32 +39,32 @@ const useTabs = (): SubscriptionManagerTab[] => {
 				id: 'sites',
 				label: translate( 'Sites' ),
 				count: counts?.blogs || undefined,
-				onClick: () => navigate( getPathWithLocale( 'sites', locale ) ),
+				onClick: () => navigate( getPathWithLocale( 'sites', locale, isLoggedIn ) ),
 				selected: pathname.startsWith( getPath( 'sites' ) ),
 			},
 			{
 				id: 'comments',
 				label: translate( 'Comments' ),
 				count: undefined, // temporarily disable inaccurate comments count
-				onClick: () => navigate( getPathWithLocale( 'comments', locale ) ),
+				onClick: () => navigate( getPathWithLocale( 'comments', locale, isLoggedIn ) ),
 				selected: pathname.startsWith( getPath( 'comments' ) ),
 			},
 			{
 				id: 'pending',
 				label: translate( 'Pending' ),
 				count: counts?.pending || undefined,
-				onClick: () => navigate( getPathWithLocale( 'pending', locale ) ),
+				onClick: () => navigate( getPathWithLocale( 'pending', locale, isLoggedIn ) ),
 				selected: pathname.startsWith( getPath( 'pending' ) ),
 				hide: ! counts?.pending && ! pathname.includes( 'pending' ),
 			},
 			{
 				id: 'settings',
 				label: translate( 'Settings' ),
-				onClick: () => navigate( getPathWithLocale( 'settings', locale ) ),
+				onClick: () => navigate( getPathWithLocale( 'settings', locale, isLoggedIn ) ),
 				selected: pathname.startsWith( getPath( 'settings' ) ),
 			},
 		];
-	}, [ counts?.blogs, counts?.pending, locale, navigate, pathname, translate ] );
+	}, [ counts?.blogs, counts?.pending, locale, isLoggedIn, navigate, pathname, translate ] );
 };
 
 const TabsSwitcher = () => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/78130

## Proposed Changes

* Localed path only applies for external users. Logged-in users inherits locale from user's language settings.
* Context: The locale url fragment is added when redirecting from email links.

## Testing Instructions

* As an external user, go to `/subscriptions/sites/nl`. 
  * Switch between tabs, the locale url fragment should be preserved.
* As a logged-in user, go to `/subscriptions/sites/nl`.
  * You will notice that the language `nl` is not used as it is inheriting from your user's language settings.
  * Switch between tabs, the locale url fragment should disappear.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
