### PR TITLE
Subscription Management: Fix sort dropdown not right aligned.

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-subscriptions-list-actions-bar.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-subscriptions-list-actions-bar.tsx
@@ -34,7 +34,7 @@ const ListActionsBar = () => {
 			/>
 
 			<SelectDropdown
-				className="subscriptions-manager__filter-control subscriptions-manager__list-actions-bar-spacer"
+				className="subscriptions-manager__filter-control list-actions-bar-spacer"
 				options={ filterOptions }
 				onSelect={ ( selectedOption: Option< Reader.SiteSubscriptionsFilterBy > ) =>
 					setFilterOption( selectedOption.value )


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/78129

## Proposed Changes

* Fix sort dropdown not right aligned.

## Testing Instructions

* Go to `/subscriptions/sites`
* The sort dropdown should display on the right.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
