### PR TITLE
Migrate away from deprecated react types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -117,7 +117,30 @@ module.exports = {
 					'return-await': 'off',
 					semi: 'off',
 					'space-before-function-paren': 'off',
-
+					'@typescript-eslint/ban-types': [
+						'error',
+						{
+							types: {
+								ReactText: {
+									message:
+										"It's deprecated, so we don't want new uses. Inline the required type (such as string or number) instead.",
+								},
+								[ 'React.ReactText' ]: {
+									message:
+										"It's deprecated, so we don't want new uses. Inline the required type (such as string or number) instead.",
+								},
+								ReactChild: {
+									message:
+										"It's deprecated, so we don't want new uses. Prefer types like ReactElement, string, or number instead. If the type should be nullable, use ReactNode.",
+								},
+								[ 'React.ReactChild' ]: {
+									message:
+										"It's deprecated, so we don't want new uses. Prefer types like ReactElement, string, or number instead. If the type should be nullable, use ReactNode.",
+								},
+							},
+							extendDefaults: true,
+						},
+					],
 					'@typescript-eslint/explicit-function-return-type': 'off',
 					'@typescript-eslint/explicit-member-accessibility': 'off',
 					'@typescript-eslint/no-unused-vars': [ 'error', { ignoreRestSiblings: true } ],

--- a/.yarn/patches/@types-react-npm-17.0.39-b4ac1f7bfe.patch
+++ b/.yarn/patches/@types-react-npm-17.0.39-b4ac1f7bfe.patch
@@ -1,0 +1,13 @@
+diff --git a/index.d.ts b/index.d.ts
+index 2d617bcb6e6d378d99a89fdf37fd632eb9fa325b..094587a884e2dc28be3f2cfb77bb1089dd64e476 100755
+--- a/index.d.ts
++++ b/index.d.ts
+@@ -236,7 +236,7 @@ declare namespace React {
+      * @deprecated Use either `ReactNode[]` if you need an array or `Iterable<ReactNode>` if its passed to a host component.
+      */
+     interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
+-    type ReactFragment = {} | Iterable<ReactNode>;
++    type ReactFragment = Iterable<ReactNode>;
+     type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null | undefined;
+ 
+     //

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -148,7 +148,7 @@ export const EligibilityWarnings = ( {
 
 	const monthlyCost = useSelector( ( state ) =>
 		getProductDisplayCost( state, PLAN_BUSINESS_MONTHLY )
-	);
+	) as string;
 
 	return (
 		<div className={ classes }>

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -5,7 +5,7 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import page from 'page';
-import { ReactChild } from 'react';
+import { ReactElement } from 'react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import EligibilityWarnings from '..';
@@ -14,7 +14,7 @@ jest.mock( 'page', () => ( {
 	redirect: jest.fn(),
 } ) );
 
-function renderWithStore( element: ReactChild, initialState: Record< string, unknown > ) {
+function renderWithStore( element: ReactElement, initialState: Record< string, unknown > ) {
 	const store = createStore( ( state ) => state, initialState );
 	return {
 		...render( <Provider store={ store }>{ element }</Provider> ),

--- a/client/blocks/importer/components/importer-drag/config.tsx
+++ b/client/blocks/importer/components/importer-drag/config.tsx
@@ -66,7 +66,7 @@ export function getImportDragConfig( importer: Importer, supportLinkModal?: bool
 			),
 		},
 	};
-	const importerData = importerConfig()[ importer ];
+	const importerData = importerConfig( {} )[ importer ];
 
 	importerData.title = translate( 'Import content from %(importerName)s', {
 		...options,

--- a/client/blocks/importer/wordpress/import-everything/confirm-upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm-upgrade-plan.tsx
@@ -33,12 +33,13 @@ export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
 	const plan = getPlan( planType );
 	const planId = plan?.getProductId();
 	const [ visibleFeaturesNum, setVisibleFeatureNum ] = useState( initialFeaturesNumber );
-	let features: React.ReactChild[] = [];
-	if ( plan && 'getPlanCompareFeatures' in plan ) {
-		features = ( plan?.getPlanCompareFeatures?.() || [] )
-			.map( ( feature: string ) => getFeatureByKey( feature )?.getTitle() || '' )
-			.filter( ( x: string | React.ReactChild ) => x );
-	}
+
+	const features =
+		plan && 'getPlanCompareFeatures' in plan
+			? ( plan?.getPlanCompareFeatures?.() || [] )
+					.map( ( feature: string ) => getFeatureByKey( feature )?.getTitle() )
+					.filter( ( x ) => x )
+			: [];
 
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const rawPrice = useSelector( ( state ) => getPlanRawPrice( state, planId as number, true ) );

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
@@ -39,7 +39,7 @@ export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props
 							'Migrating themes, plugins, users, and settings requires a %(plan)s plan',
 							{
 								args: {
-									plan: plan?.getTitle(),
+									plan: plan?.getTitle() ?? '',
 								},
 							}
 						) }

--- a/client/components/activity-card-list/visible-days-limit-upsell/index.tsx
+++ b/client/components/activity-card-list/visible-days-limit-upsell/index.tsx
@@ -56,7 +56,7 @@ const VisibleDaysLimitUpsell: React.FC< OwnProps > = ( { cardClassName } ) => {
 
 	const upsellRef = useTrackUpsellView( siteId );
 
-	if ( ! Number.isInteger( visibleDays ) ) {
+	if ( visibleDays == null || ! Number.isInteger( visibleDays ) ) {
 		return null;
 	}
 
@@ -81,7 +81,7 @@ const VisibleDaysLimitUpsell: React.FC< OwnProps > = ( { cardClassName } ) => {
 							'Restore backups older than %(retentionDays)d day',
 							'Restore backups older than %(retentionDays)d days',
 							{
-								count: visibleDays as number,
+								count: visibleDays,
 								args: { retentionDays: visibleDays },
 							}
 						)
@@ -93,7 +93,7 @@ const VisibleDaysLimitUpsell: React.FC< OwnProps > = ( { cardClassName } ) => {
 							'Your activity log spans more than %(retentionDays)d day. Upgrade your backup storage to access activity older than %(retentionDays)d day.',
 							'Your activity log spans more than %(retentionDays)d days. Upgrade your backup storage to access activity older than %(retentionDays)d days.',
 							{
-								count: visibleDays as number,
+								count: visibleDays,
 								args: { retentionDays: visibleDays },
 							}
 						)

--- a/client/components/advanced-credentials/host-info.ts
+++ b/client/components/advanced-credentials/host-info.ts
@@ -1,10 +1,4 @@
-import { translate, TranslateResult } from 'i18n-calypso';
-import { ReactChild } from 'react';
-
-export interface LinkAndInfo {
-	info?: TranslateResult;
-	link?: string | TranslateResult;
-}
+import { translate } from 'i18n-calypso';
 
 enum InfoTypes {
 	Text = 'Text',
@@ -16,23 +10,23 @@ enum InfoTypes {
 
 export interface Text {
 	type: InfoTypes.Text;
-	text: ReactChild;
+	text: string;
 }
 
 export interface Link {
 	type: InfoTypes.Link;
-	text: ReactChild;
+	text: string;
 	link: string;
 }
 
 export interface UnorderedList {
 	type: InfoTypes.UnorderedList;
-	items: ReactChild[];
+	items: string[];
 }
 
 export interface OrderedList {
 	type: InfoTypes.OrderedList;
-	items: ReactChild[];
+	items: string[];
 }
 
 export interface Line {

--- a/client/components/advanced-credentials/host-selection/index.tsx
+++ b/client/components/advanced-credentials/host-selection/index.tsx
@@ -34,7 +34,7 @@ function useHostingProviderGuessQuery( siteId: SiteId ) {
 const HostSelection: FunctionComponent = () => {
 	const isMobile = useMobileBreakpoint();
 	const siteId = useSelector( getSelectedSiteId ) as SiteId;
-	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 

--- a/client/components/advanced-credentials/verification/index.tsx
+++ b/client/components/advanced-credentials/verification/index.tsx
@@ -76,7 +76,7 @@ const Verification: FunctionComponent< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 
-	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
 	const siteId = useSelector( getSelectedSiteId );
 	const updateError = useSelector( ( state ) => getJetpackCredentialsUpdateError( state, siteId ) );
 	const updateProgress = useSelector( ( state ) =>

--- a/client/components/backup-retention-management/use-upsell-info.ts
+++ b/client/components/backup-retention-management/use-upsell-info.ts
@@ -17,7 +17,7 @@ import useItemPrice from 'calypso/my-sites/plans/jetpack-plans/use-item-price';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import type { SelectorProductWithStorage } from 'calypso/components/backup-storage-space/usage-warning/use-upsell-slug';
-
+import type { TranslateResult } from 'i18n-calypso';
 /**
  * This hook is inspired in `calypso/components/backup-storage-space/usage-warning/use-upsell-slug`.
  * The main difference is that this hook returns the best storage addon according to the space needed
@@ -36,7 +36,7 @@ export default (
 	const additionalBytesNeeded = currentSize * retentionDays - storageLimitBytes;
 
 	const upsellSlug = useMemo( () => {
-		const ADD_ON_STORAGE_MAP: Record< string, React.ReactChild > = {
+		const ADD_ON_STORAGE_MAP: Record< string, TranslateResult > = {
 			[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_10GB_MONTHLY ]: TEN_GIGABYTES,
 			[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_100GB_MONTHLY ]: HUNDRED_GIGABYTES,
 			[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_1TB_MONTHLY ]: ONE_TERABYTES,

--- a/client/components/backup-storage-space/usage-warning/action-button.tsx
+++ b/client/components/backup-storage-space/usage-warning/action-button.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import classnames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 import { StorageUsageLevelName } from 'calypso/state/rewind/storage/types';
 import useStorageStatusText from './use-storage-status-text';
@@ -10,7 +10,7 @@ type OwnProps = {
 	usageLevel: StorageUsageLevelName;
 	href?: string;
 	upsellSlug: SelectorProduct | null;
-	storage: React.ReactChild;
+	storage: TranslateResult;
 	onClick?: React.MouseEventHandler;
 	price: JSX.Element;
 	daysOfBackupsSaved: number;

--- a/client/components/backup-storage-space/usage-warning/use-upsell-slug.ts
+++ b/client/components/backup-storage-space/usage-warning/use-upsell-slug.ts
@@ -23,9 +23,10 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getRewindBytesAvailable, getRewindBytesUsed } from 'calypso/state/rewind/selectors';
 import type { Purchase } from 'calypso/lib/purchases/types';
+import type { TranslateResult } from 'i18n-calypso';
 
 export type SelectorProductWithStorage = SelectorProduct & {
-	storage: React.ReactChild;
+	storage: TranslateResult;
 };
 
 const UPGRADEABLE_STORAGE_PRODUCT_SLUGS_T1 = [
@@ -67,7 +68,7 @@ export default ( siteId: number ) => {
 	const bytesUsed = useSelector( ( state ) => getRewindBytesUsed( state, siteId ) );
 
 	const upsellSlug = useMemo( () => {
-		const ADD_ON_STORAGE_MAP: Record< string, React.ReactChild > = {
+		const ADD_ON_STORAGE_MAP: Record< string, TranslateResult > = {
 			[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_10GB_MONTHLY ]: TEN_GIGABYTES,
 			[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_100GB_MONTHLY ]: HUNDRED_GIGABYTES,
 			[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_1TB_MONTHLY ]: ONE_TERABYTES,

--- a/client/components/confirm-modal/index.tsx
+++ b/client/components/confirm-modal/index.tsx
@@ -1,13 +1,13 @@
 import { Button } from '@automattic/components';
 import { Modal } from '@wordpress/components';
 import './styles.scss';
-import { useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 
 type ConfirmModalProps = {
 	isVisible: boolean;
-	cancelButtonLabel?: string | React.ReactChild;
-	confirmButtonLabel?: string | React.ReactChild;
-	text?: string | React.ReactChild;
+	cancelButtonLabel?: TranslateResult;
+	confirmButtonLabel?: TranslateResult;
+	text?: TranslateResult;
 	title: string;
 	onCancel: () => void;
 	onConfirm: () => void;

--- a/client/components/feature-item/README.md
+++ b/client/components/feature-item/README.md
@@ -14,5 +14,5 @@ function render() {
 
 ## Props
 
-- `header` (`ReactChild`) - The string rendered in the title of the component.
-- `children` (`ReactChild`) - The content to be rendered inside the item.
+- `header` (`ReactNode`) - The content rendered in the title of the component.
+- `children` (`ReactNode`) - The content to be rendered inside the item.

--- a/client/components/feature-item/index.tsx
+++ b/client/components/feature-item/index.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
-import { ReactChild } from 'react';
+import type { ReactNode } from 'react';
 
 import './style.scss';
 
 interface FeatureItemProps {
-	header: ReactChild;
-	children: ReactChild;
+	header: ReactNode;
+	children: ReactNode;
 	dark?: boolean;
 }
 

--- a/client/components/forms/form-section-heading/index.jsx
+++ b/client/components/forms/form-section-heading/index.jsx
@@ -6,7 +6,7 @@ import './style.scss';
  *
  * @param {Object} props Component props
  * @param {string=} props.className optional extra CSS class(es) to be added to the component
- * @param {import('react').ReactChild=} props.children react element props that must contain some children
+ * @param {import('react').ReactNode=} props.children react element props that must contain some children
  * @param {Object=} props.otherProps react element props that must contain some children
  * @returns {import('react').ReactElement} React component
  */

--- a/client/components/jetpack/jetpack-product-info/coming-soon-list.tsx
+++ b/client/components/jetpack/jetpack-product-info/coming-soon-list.tsx
@@ -1,8 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, ReactChild } from 'react';
+import { FunctionComponent, ReactNode } from 'react';
 
 type Props = {
-	items: ReactChild[];
+	items: ReactNode[];
 };
 
 const JetpackProductInfoComingSoonList: FunctionComponent< Props > = ( { items } ) => {

--- a/client/components/jetpack/jetpack-product-info/index.tsx
+++ b/client/components/jetpack/jetpack-product-info/index.tsx
@@ -1,5 +1,5 @@
-import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, ReactChild } from 'react';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
 import { useIncludedProductDescriptionMap } from 'calypso/components/jetpack/jetpack-product-info/hooks/use-included-product-description-map';
 import { PricingBreakdown } from 'calypso/my-sites/plans/jetpack-plans/product-store/pricing-breakdown';
 import getProductIcon from 'calypso/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon';
@@ -18,7 +18,7 @@ type JetpackProductInfoProps = {
 	product: SelectorProduct;
 	showPricingBreakdown?: boolean;
 	siteId?: number;
-	title: string | ReactChild;
+	title: TranslateResult;
 };
 
 const JetpackProductInfo: FunctionComponent< JetpackProductInfoProps > = ( {

--- a/client/components/jetpack/jetpack-product-info/regular-list.tsx
+++ b/client/components/jetpack/jetpack-product-info/regular-list.tsx
@@ -1,7 +1,7 @@
-import { FunctionComponent, ReactChild } from 'react';
+import { FunctionComponent, ReactNode } from 'react';
 
 type Props = {
-	items: ReactChild[];
+	items: ReactNode[];
 };
 
 const JetpackProductInfoRegularList: FunctionComponent< Props > = ( { items } ) => {

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -69,7 +69,7 @@ function LicensingPromptDialog( { siteId }: Props ) {
 	const instructions = (
 		<>
 			<b>
-				{ hasOneDetachedLicense
+				{ hasOneDetachedLicense && detachedUserLicense?.product
 					? translate(
 							'You have a %(productName)s license available. You can activate it now if you want.',
 							{

--- a/client/components/jetpack/scan-badge/index.tsx
+++ b/client/components/jetpack/scan-badge/index.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress } ) => {
 	const translate = useTranslate();
-	const hasProgressPercentage = Number.isFinite( progress );
+	const hasProgressPercentage = progress != null && Number.isFinite( progress );
 
 	if ( ! numberOfThreatsFound && ! hasProgressPercentage ) {
 		return null;

--- a/client/components/jetpack/threat-item-header/index.tsx
+++ b/client/components/jetpack/threat-item-header/index.tsx
@@ -31,9 +31,11 @@ const getThreatMessage = ( threat: Threat ) => {
 
 	switch ( getThreatType( threat ) ) {
 		case 'core':
-			return translate( 'Vulnerable WordPress version: %s', {
-				args: [ version ?? 'unknown' ],
-			} );
+			return version
+				? translate( 'Vulnerable WordPress version: %s', {
+						args: [ version ],
+				  } )
+				: translate( 'Vulnerable WordPress version.' );
 
 		case 'core_file':
 			return translate( 'Infected core file: %s', {

--- a/client/components/jetpack/threat-item-header/index.tsx
+++ b/client/components/jetpack/threat-item-header/index.tsx
@@ -32,7 +32,7 @@ const getThreatMessage = ( threat: Threat ) => {
 	switch ( getThreatType( threat ) ) {
 		case 'core':
 			return translate( 'Vulnerable WordPress version: %s', {
-				args: [ version ],
+				args: [ version ?? 'unknown' ],
 			} );
 
 		case 'core_file':
@@ -72,7 +72,7 @@ const getThreatMessage = ( threat: Threat ) => {
 					count: Object.keys( threat.rows ).length,
 					args: {
 						threatCount: Object.keys( threat.rows ).length,
-						threatTable: threat.table,
+						threatTable: threat.table as string,
 					},
 				}
 			);

--- a/client/components/jetpack/threat-item/utils.ts
+++ b/client/components/jetpack/threat-item/utils.ts
@@ -31,7 +31,7 @@ export const getThreatMessage = ( threat: Threat ): string | TranslateResult => 
 	switch ( getThreatType( threat ) ) {
 		case 'core':
 			return translate( 'The installed version of WordPress (%s) has a known vulnerability.', {
-				args: [ version ],
+				args: [ version ?? 'unknown' ],
 			} );
 
 		case 'core_file':
@@ -71,7 +71,7 @@ export const getThreatMessage = ( threat: Threat ): string | TranslateResult => 
 					count: Object.keys( threat.rows ).length,
 					args: {
 						threatCount: Object.keys( threat.rows ).length,
-						threatTable: threat.table,
+						threatTable: threat.table as string,
 					},
 				}
 			);

--- a/client/components/jetpack/threat-item/utils.ts
+++ b/client/components/jetpack/threat-item/utils.ts
@@ -30,9 +30,11 @@ export const getThreatMessage = ( threat: Threat ): string | TranslateResult => 
 
 	switch ( getThreatType( threat ) ) {
 		case 'core':
-			return translate( 'The installed version of WordPress (%s) has a known vulnerability.', {
-				args: [ version ?? 'unknown' ],
-			} );
+			return version
+				? translate( 'The installed version of WordPress (%s) has a known vulnerability.', {
+						args: [ version ],
+				  } )
+				: translate( 'The installed version of WordPress has a known vulnerability.' );
 
 		case 'core_file':
 			return translate( 'Compromised WordPress core file: %s', {

--- a/client/components/link-card/README.md
+++ b/client/components/link-card/README.md
@@ -23,8 +23,8 @@ function render() {
 ## Props
 
 - `background` (`string`) - A background color variable name.
-- `label` (`ReactChild`) - The string rendered in the top card with the smaller size, it can also be a component.
-- `title` (`ReactChild`) - The string rendered in the middle of the card with the larger size, it can also be a component.
-- `cta` (`ReactChild`) - The string rendered in the bottom of the card with the middle size, it can also be a component.
+- `label` (`ReactNode`) - The string rendered in the top card with the smaller size, it can also be a component.
+- `title` (`ReactNode`) - The string rendered in the middle of the card with the larger size, it can also be a component.
+- `cta` (`ReactNode`) - The string rendered in the bottom of the card with the middle size, it can also be a component.
 - `url` (`string`) - The url the component points to.
 - `onClick` (`() => void`) - The callback called when the card is clicked.

--- a/client/components/link-card/index.tsx
+++ b/client/components/link-card/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { ReactChild } from 'react';
+import { ReactNode } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 
 import './style.scss';
@@ -9,10 +9,10 @@ interface LinkCardContainerProps {
 	border?: string;
 }
 interface LinkCardProps {
-	label?: ReactChild;
-	title: ReactChild;
+	label?: ReactNode;
+	title: ReactNode;
 	titleMarginBottom?: string;
-	cta?: ReactChild;
+	cta?: ReactNode;
 	background?: string;
 	border?: string;
 	url: string;

--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -1,11 +1,8 @@
 import { JETPACK_PRODUCTS_LIST } from '@automattic/calypso-products';
-import { translate } from 'i18n-calypso';
+import { TranslateResult, translate } from 'i18n-calypso';
 import { DOWNGRADEABLE_PLANS_FROM_PLAN } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
 import type { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
-import type { ReactChild } from 'react';
-
-type TranslateReturnType = ReactChild | string;
 
 export interface CancellationReasonBase {
 	/**
@@ -16,7 +13,7 @@ export interface CancellationReasonBase {
 	/**
 	 * A string that will be displayed to the user.
 	 */
-	label: TranslateReturnType;
+	label: TranslateResult;
 
 	/**
 	 * Whether this option is disabled.
@@ -28,7 +25,7 @@ export interface CancellationReason extends CancellationReasonBase {
 	/**
 	 * placeholder text for the additional input
 	 */
-	textPlaceholder?: TranslateReturnType;
+	textPlaceholder?: TranslateResult;
 
 	/**
 	 * Default value for the sub category select
@@ -38,7 +35,7 @@ export interface CancellationReason extends CancellationReasonBase {
 	/**
 	 * Default label for the sub category select
 	 */
-	selectLabel?: TranslateReturnType;
+	selectLabel?: TranslateResult;
 
 	/**
 	 * Options for the sub category select

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -277,7 +277,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 							'But we’d love to see you stick around to build on what you started. ' +
 							'How about a free month of your %(currentPlan)s plan subscription to continue building your site?',
 						{
-							args: { planName: getPlan( purchase.productSlug )?.getTitle() },
+							args: { planName: getPlan( purchase.productSlug )?.getTitle() ?? '' },
 						}
 					) }
 				</Upsell>

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -21,7 +21,7 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 import type { TranslateResult } from 'i18n-calypso';
 
 type UpsellProps = {
-	children: React.ReactChild;
+	children?: React.ReactNode;
 	image: string;
 	title: TranslateResult;
 	acceptButtonText: TranslateResult;

--- a/client/components/marketing-survey/cancel-purchase-form/to-select-options.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/to-select-options.ts
@@ -1,9 +1,7 @@
-import type { ReactChild } from 'react';
-
-type TranslateReturnType = ReactChild | string;
+import { TranslateResult } from 'i18n-calypso';
 
 type OptionLike = {
-	label: TranslateReturnType;
+	label: TranslateResult;
 	value: string | number;
 };
 

--- a/client/components/section-header/README.md
+++ b/client/components/section-header/README.md
@@ -34,7 +34,7 @@ This is the base component and acts as a wrapper for a section's (a list of card
 ### Props
 
 - `className` - _optional_ (string|object) Classes to be added to the rendered component.
-- `label` - _optional_ (string|ReactChild) The text to be displayed in the header.
+- `label` - _optional_ (string|ReactElement) The text to be displayed in the header.
 
 ## General guidelines
 

--- a/client/components/section/README.md
+++ b/client/components/section/README.md
@@ -14,6 +14,6 @@ function render() {
 
 ## Props
 
-- `header` (`ReactChild`) - The header string or a component to render as the header.
-- `children` (`ReactChild | ReactChild[]`) - The content to be rendered inside the section.
+- `header` (`string | ReactElement`) - The header string or a component to render as the header.
+- `children` (`ReactNode`) - The content to be rendered inside the section.
 - `dark?` (`boolean`) - Makes the background of the section dark.

--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled';
-import { ReactChild } from 'react';
+import { ReactElement, ReactNode } from 'react';
 
 import './style.scss';
 
 interface SectionProps {
-	header: ReactChild;
-	subheader?: ReactChild;
-	children: ReactChild | ReactChild[];
+	header: string | ReactElement;
+	subheader?: string | ReactElement;
+	children: ReactNode;
 	dark?: boolean;
 }
 

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -2,18 +2,18 @@ import { TranslateResult } from 'i18n-calypso';
 import * as React from 'react';
 
 export type ThankYouNextStepProps = {
-	stepCta?: React.ReactNode | React.ReactFragment;
-	stepSection?: TranslateResult | React.ReactElement;
-	stepDescription?: TranslateResult | React.ReactElement;
+	stepCta?: React.ReactNode;
+	stepSection?: TranslateResult;
+	stepDescription?: TranslateResult;
 	stepKey: string;
 	stepTitle?: TranslateResult;
 	stepIcon?: React.ReactNode;
 };
 
 export type ThankYouNoticeProps = {
-	noticeTitle: React.ReactNode | React.ReactFragment;
+	noticeTitle: React.ReactNode;
 	noticeIcon?: string;
-	noticeIconCustom?: React.ReactNode | React.ReactFragment;
+	noticeIconCustom?: React.ReactNode;
 };
 
 export type ThankYouSectionProps = {

--- a/client/data/emails/use-add-email-forward-mutation.tsx
+++ b/client/data/emails/use-add-email-forward-mutation.tsx
@@ -167,7 +167,7 @@ export default function useAddEmailForwardMutation(
 				{
 					args: {
 						emailAddress: variables.mailbox,
-						message: error,
+						message: error as string,
 					},
 					components: noticeComponents,
 				}

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/hooks.tsx
@@ -1,4 +1,4 @@
-import { useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState, useContext, RefObject } from 'react';
 import acceptDialog from 'calypso/lib/accept';
 import {
@@ -15,7 +15,7 @@ import type { Site } from '../sites-overview/types';
 
 const dialogContent = (
 	heading: string,
-	description: string,
+	description: TranslateResult,
 	action: ( accepted: boolean ) => void
 ) => {
 	const content = (

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/hooks.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactChild, useCallback, useEffect, useState, useContext, RefObject } from 'react';
+import { useCallback, useEffect, useState, useContext, RefObject } from 'react';
 import acceptDialog from 'calypso/lib/accept';
 import {
 	useJetpackAgencyDashboardRecordTrackEvent,
@@ -14,8 +14,8 @@ import {
 import type { Site } from '../sites-overview/types';
 
 const dialogContent = (
-	heading: ReactChild,
-	description: ReactChild,
+	heading: string,
+	description: string,
 	action: ( accepted: boolean ) => void
 ) => {
 	const content = (

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/hooks.tsx
@@ -50,7 +50,7 @@ export function useHandleToggleMonitor( selectedSites: Array< Site >, isLargeScr
 		( activate: boolean ) => {
 			const heading = activate ? translate( 'Resume Monitor' ) : translate( 'Pause Monitor' );
 			const monitorAction = activate ? translate( 'resume' ) : translate( 'pause' );
-			const siteCountText = getSiteCountText( selectedSites );
+			const siteCountText = getSiteCountText( selectedSites ) as string;
 			const content =
 				selectedSites.length > 1
 					? translate( 'You are about to %(monitorAction)s the monitor for %(siteCountText)s.', {
@@ -109,7 +109,7 @@ export function useHandleResetNotification(
 			strong: <strong />,
 		};
 
-		const siteCountText = getSiteCountText( selectedSites );
+		const siteCountText = getSiteCountText( selectedSites ) as string;
 
 		const content =
 			selectedSites.length > 1

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -2,8 +2,8 @@ import { Button } from '@automattic/components';
 import { Modal } from '@wordpress/components';
 import classNames from 'classnames';
 import emailValidator from 'email-validator';
-import { useTranslate } from 'i18n-calypso';
-import { ReactChild, useCallback, useContext, useEffect, useState, useMemo } from 'react';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useCallback, useContext, useEffect, useState, useMemo } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -59,7 +59,7 @@ export default function EmailAddressEditor( {
 		id: '',
 	} );
 	const [ resendCodeClicked, setResendCodeClicked ] = useState< boolean >( false );
-	const [ helpText, setHelpText ] = useState< ReactChild | undefined >( undefined );
+	const [ helpText, setHelpText ] = useState< TranslateResult | undefined >( undefined );
 
 	const { verifiedContacts } = useContext( DashboardDataContext );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { Modal } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState, useContext, useEffect, ReactChild, useMemo } from 'react';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useCallback, useState, useContext, useEffect, useMemo } from 'react';
 import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -54,7 +54,7 @@ export default function PhoneNumberEditor( {
 
 	const countriesList = useSelector( ( state ) => getCountries( state, 'sms' ) ?? [] );
 
-	const [ helpText, setHelpText ] = useState< ReactChild | undefined >( undefined );
+	const [ helpText, setHelpText ] = useState< TranslateResult | undefined >( undefined );
 	const [ showCodeVerification, setShowCodeVerification ] = useState< boolean >( false );
 	const [ validationStatus, setValidationStatus ] = useState< {
 		isValid: boolean;

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactChild, useState, useRef } from 'react';
+import { ReactNode, useState, useRef } from 'react';
 import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Tooltip from 'calypso/components/tooltip';
@@ -17,7 +17,7 @@ interface Props {
 	site: Site;
 	status: AllowedStatusTypes | string;
 	settings: MonitorSettings | undefined;
-	tooltip: ReactChild | undefined;
+	tooltip: ReactNode;
 	tooltipId: string;
 	siteError: boolean;
 	isLargeScreen?: boolean;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
@@ -1,14 +1,14 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
-import type { ReactChild } from 'react';
+import type { ReactNode } from 'react';
 
 const CALYPSO_MASTERBAR_HEIGHT = 47;
 
 interface Props {
 	pageTitle: string;
 	showStickyContent: boolean;
-	content: ReactChild;
+	content: ReactNode;
 }
 
 export default function SiteContentHeader( { content, pageTitle, showStickyContent }: Props ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -9,7 +9,6 @@ import { useToggleActivateMonitor } from '../../hooks';
 import { getMonitorDowntimeText } from '../utils';
 import ExpandedCard from './expanded-card';
 import type { Site } from '../types';
-import type { ReactChild } from 'react';
 
 interface Props {
 	hasMonitor: boolean;
@@ -32,7 +31,7 @@ const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
 		const { date, status, downtime_in_minutes } = data;
 
 		let className = 'site-expanded-content__chart-bar-no-data';
-		let tooltipLabel: ReactChild = 'No data';
+		let tooltipLabel = 'No data';
 
 		if ( status === 'up' ) {
 			className = 'site-expanded-content__chart-bar-is-uptime';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -1,12 +1,10 @@
-import type { ReactChild } from 'react';
-
 // All types based on which the data is populated on the agency dashboard table rows
 export type AllowedTypes = 'site' | 'stats' | 'boost' | 'backup' | 'scan' | 'monitor' | 'plugin';
 
 // Site column object which holds key and title of each column
 export type SiteColumns = Array< {
 	key: AllowedTypes;
-	title: ReactChild;
+	title: string;
 	className?: string;
 	isExpandable?: boolean;
 	isSortable?: boolean;
@@ -102,26 +100,26 @@ export interface BoostNode {
 export interface BackupNode {
 	type: AllowedTypes;
 	status: AllowedStatusTypes;
-	value: ReactChild;
+	value: string;
 }
 
 export interface ScanNode {
 	type: AllowedTypes;
 	status: AllowedStatusTypes;
-	value: ReactChild;
+	value: string;
 	threats: number;
 }
 
 interface PluginNode {
 	type: AllowedTypes;
 	status: AllowedStatusTypes;
-	value: ReactChild;
+	value: string;
 	updates: number;
 }
 export interface MonitorNode {
 	type: AllowedTypes;
 	status: AllowedStatusTypes;
-	value: ReactChild;
+	value: string;
 	error?: boolean;
 	settings?: MonitorSettings;
 }
@@ -140,12 +138,12 @@ export interface SiteData {
 
 export interface RowMetaData {
 	row: {
-		value: Site | SiteStats | BoostData | ReactChild;
+		value: Site | SiteStats | BoostData | string;
 		status: AllowedStatusTypes;
 	};
 	link: string;
 	isExternalLink: boolean;
-	tooltip: ReactChild | undefined;
+	tooltip?: string;
 	tooltipId: string;
 	siteDown?: boolean;
 	eventName: string | undefined;
@@ -163,7 +161,7 @@ export type StatusEventNames = {
 };
 
 export type StatusTooltip = {
-	[ key in AllowedStatusTypes ]?: ReactChild;
+	[ key in AllowedStatusTypes ]?: string;
 };
 
 export type AllowedActionTypes =

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -615,7 +615,7 @@ export const DASHBOARD_LICENSE_TYPES: { [ key: string ]: AllowedTypes } = {
 	BACKUP: 'backup',
 };
 
-export const getMonitorDowntimeText = ( downtime: number | undefined ) => {
+export const getMonitorDowntimeText = ( downtime: number | undefined ): string => {
 	if ( ! downtime ) {
 		return translate( 'Downtime' );
 	}
@@ -637,7 +637,7 @@ export const getMonitorDowntimeText = ( downtime: number | undefined ) => {
 			time: time.trim(),
 		},
 		comment: '%(time) is the downtime, e.g. "2d 5h 30m", "5h 30m", "55m"',
-	} );
+	} ) as string;
 };
 
 export const DASHBOARD_PREFERENCE_NAMES = {

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -6,11 +6,10 @@ import { useSelector } from 'calypso/state';
 import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { ReactChild } from 'react';
 
 import './style.scss';
 
-function getStepClassName( currentStep: number, step: number ): any {
+function getStepClassName( currentStep: number, step: number ): string {
 	return classnames( {
 		'step-current': currentStep === step,
 		'step-next': currentStep < step,
@@ -38,7 +37,7 @@ type StepKey = 'issueLicense' | 'addPaymentMethod' | 'assignLicense';
 
 interface Step {
 	key: StepKey;
-	label: ReactChild | null;
+	label: string;
 }
 
 interface Props {

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactChild, useCallback, useState, useMemo, ChangeEvent, useEffect } from 'react';
+import { useCallback, useState, useMemo, ChangeEvent, useEffect } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -40,7 +40,7 @@ interface Props {
 		postalCode?: string;
 		state?: string;
 	};
-	submitLabel: ReactChild;
+	submitLabel: string;
 }
 
 export default function CompanyDetailsForm( {

--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -326,8 +326,8 @@ export function useIssueMultipleLicenses(
 				.filter( ( license ) => license );
 
 			if ( assignedLicenses.length > 0 ) {
-				const initialLicenseList = assignedLicenses.slice( 0, -1 );
-				const lastLicenseItem = assignedLicenses.slice( -1 )[ 0 ];
+				const initialLicenseList = assignedLicenses.slice( 0, -1 ) as string[];
+				const lastLicenseItem = assignedLicenses.slice( -1 )[ 0 ] as string;
 
 				const commaCharacter = translate( ',', {
 					comment:

--- a/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/index.tsx
@@ -48,7 +48,7 @@ export default function OnboardingWidget( { isLicensesPage }: { isLicensesPage?:
 			description: translate(
 				'Manage features and monitor your clients’ sites by adding them to your Jetpack Pro Dashboard. To do so, connect the sites to Jetpack using your {{strong}}%(userEmail)s{{/strong}} user account.',
 				{
-					args: { userEmail: user?.email },
+					args: { userEmail: user?.email ?? '' },
 					components: {
 						strong: <strong />,
 					},

--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -24,6 +24,11 @@ export default function Prices() {
 		const userYearlyProduct = Object.values( userProducts ).find(
 			( p ) => p.product_id === product.product_id
 		);
+
+		if ( userYearlyProduct === undefined ) {
+			return null;
+		}
+
 		const userMonthlyProduct =
 			userYearlyProduct &&
 			Object.values( userProducts ).find(
@@ -57,9 +62,9 @@ export default function Prices() {
 					<div>
 						{ translate( '%(price)s/month', {
 							args: {
-								price:
-									userMonthlyProduct &&
-									formatCurrency( userMonthlyProduct.cost, 'USD', currencyFormatOptions ),
+								price: userMonthlyProduct
+									? formatCurrency( userMonthlyProduct.cost, 'USD', currencyFormatOptions )
+									: translate( 'unknown' ),
 							},
 						} ) }
 					</div>

--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -29,6 +29,9 @@ export default function Prices() {
 			return null;
 		}
 
+		const dailyAgencyPrice = ( product.amount * 12 ) / 365;
+		const dailyUserYearlyPrice = userYearlyProduct.cost / 365;
+
 		const userMonthlyProduct =
 			userYearlyProduct &&
 			Object.values( userProducts ).find(
@@ -36,10 +39,9 @@ export default function Prices() {
 					p.billing_product_slug === userYearlyProduct.billing_product_slug &&
 					p.product_term === 'month'
 			);
-
-		const dailyAgencyPrice = ( product.amount * 12 ) / 365;
-		const dailyUserMonthlyPrice = userMonthlyProduct ? ( userMonthlyProduct.cost * 12 ) / 365 : 0;
-		const dailyUserYearlyPrice = userYearlyProduct ? userYearlyProduct.cost / 365 : 0;
+		const dailyUserMonthlyPrice = userMonthlyProduct
+			? ( userMonthlyProduct.cost * 12 ) / 365
+			: undefined;
 
 		return (
 			<tr key={ product.product_id }>
@@ -48,26 +50,28 @@ export default function Prices() {
 					<LicenseBundleCardDescription product={ product } />
 				</td>
 				<td>
-					<div className="prices__mobile-description">
-						<div>{ translate( 'Jetpack.com Pricing' ) }</div>
-						<span className="prices__th-detail">{ translate( 'billed monthly' ) }</span>
-					</div>
-					<div>
-						{ translate( '%(price)s/day', {
-							args: {
-								price: formatCurrency( dailyUserMonthlyPrice, 'USD', currencyFormatOptions ),
-							},
-						} ) }
-					</div>
-					<div>
-						{ translate( '%(price)s/month', {
-							args: {
-								price: userMonthlyProduct
-									? formatCurrency( userMonthlyProduct.cost, 'USD', currencyFormatOptions )
-									: translate( 'unknown' ),
-							},
-						} ) }
-					</div>
+					{ userMonthlyProduct && dailyUserMonthlyPrice && (
+						<>
+							<div className="prices__mobile-description">
+								<div>{ translate( 'Jetpack.com Pricing' ) }</div>
+								<span className="prices__th-detail">{ translate( 'billed monthly' ) }</span>
+							</div>
+							<div>
+								{ translate( '%(price)s/day', {
+									args: {
+										price: formatCurrency( dailyUserMonthlyPrice, 'USD', currencyFormatOptions ),
+									},
+								} ) }
+							</div>
+							<div>
+								{ translate( '%(price)s/month', {
+									args: {
+										price: formatCurrency( userMonthlyProduct.cost, 'USD', currencyFormatOptions ),
+									},
+								} ) }
+							</div>
+						</>
+					) }
 				</td>
 				<td>
 					<div className="prices__mobile-description">

--- a/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
@@ -78,7 +78,7 @@ export default function UnassignLicenseDialog( {
 					'Unassigning this license means that the site {{bold}}%(siteUrl)s{{/bold}} will no longer have access to {{bold}}%(product)s{{/bold}}. Once this action is completed, you will be able to assign the license to another site. You will continue to be billed.',
 					{
 						components: { bold: <strong /> },
-						args: { siteUrl, product },
+						args: { siteUrl: siteUrl ?? '', product },
 					}
 				) }
 				&nbsp;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/index.tsx
@@ -25,6 +25,8 @@ const BlogIntent: Step = function BlogIntent() {
 		[]
 	);
 
+	const username = currentUser?.display_name ?? currentUser?.username;
+
 	return (
 		<>
 			<DocumentHead title={ translate( 'Create your blog' ) } />
@@ -37,9 +39,11 @@ const BlogIntent: Step = function BlogIntent() {
 				stepContent={
 					<div className="blogger-intent__container">
 						<h2 className="blogger-intent__heading">
-							{ translate( "Let's start your blog, %(username)s!", {
-								args: { username: currentUser?.display_name || currentUser?.username },
-							} ) }
+							{ username
+								? translate( "Let's start your blog, %(username)s!", {
+										args: { username },
+								  } )
+								: translate( "Let's start your blog!" ) }
 						</h2>
 						<div className="blogger-intent__content">
 							<div className="blogger-intent__row">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
@@ -2,7 +2,7 @@
 import { Button, FormInputValidation } from '@automattic/components';
 import { TextControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { Dispatch, FormEvent, ReactChild, SetStateAction, useEffect } from 'react';
+import { Dispatch, FormEvent, ReactNode, SetStateAction, useEffect } from 'react';
 import { ForwardedAutoresizingFormTextarea } from 'calypso/blocks/comments/autoresizing-form-textarea';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -36,7 +36,7 @@ interface SetupFormProps {
 	translatedText?: TranslatedStrings;
 	isLoading?: boolean;
 	isSubmitError?: boolean;
-	children?: ReactChild | ReactChild[];
+	children?: ReactNode;
 }
 
 const SetupForm = ( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/types.ts
@@ -2,6 +2,6 @@ import { Onboard } from '@automattic/data-stores';
 
 export type Goal = {
 	key: Onboard.SiteGoal;
-	title: React.ReactChild | string;
+	title: string;
 	isPremium?: boolean;
 };

--- a/client/landing/subscriptions/components/sort-controls/sort-controls.tsx
+++ b/client/landing/subscriptions/components/sort-controls/sort-controls.tsx
@@ -22,8 +22,8 @@ const SortControls: < T extends string >( props: SortControlsProps< T > ) => Rea
 } ) => {
 	const translate = useTranslate();
 	const sortingLabel = useMemo(
-		() => options.find( ( option ) => option.value === value )?.label,
-		[ options, value ]
+		() => options.find( ( option ) => option.value === value )?.label ?? translate( 'unknown' ),
+		[ options, value, translate ]
 	);
 
 	return (

--- a/client/landing/subscriptions/components/sort-controls/sort-controls.tsx
+++ b/client/landing/subscriptions/components/sort-controls/sort-controls.tsx
@@ -22,9 +22,13 @@ const SortControls: < T extends string >( props: SortControlsProps< T > ) => Rea
 } ) => {
 	const translate = useTranslate();
 	const sortingLabel = useMemo(
-		() => options.find( ( option ) => option.value === value )?.label ?? translate( 'unknown' ),
-		[ options, value, translate ]
+		() => options.find( ( option ) => option.value === value )?.label,
+		[ options, value ]
 	);
+
+	if ( ! sortingLabel ) {
+		throw new Error( 'In SortControl, props.value must exist in props.options.' );
+	}
 
 	return (
 		<Dropdown

--- a/client/layout/powered-by-wp-footer/index.tsx
+++ b/client/layout/powered-by-wp-footer/index.tsx
@@ -19,9 +19,9 @@ export default function PoweredByWPFooter( { clientTitle }: Props ) {
 		);
 	}
 
-	function renderPoweredByWPWithClientTitle() {
-		const wording = translate( '%(clientTitle)s is powered by <logo/> WordPress.com', {
-			args: { clientTitle },
+	function renderPoweredByWPWithClientTitle( title: string ) {
+		const wording = translate( '%(title)s is powered by <logo/> WordPress.com', {
+			args: { title },
 			comment:
 				"'clientTitle' is the name of the app that uses WordPress.com Connect (e.g. 'Crowdsignal' or 'Gravatar')",
 		} ) as string;
@@ -34,7 +34,7 @@ export default function PoweredByWPFooter( { clientTitle }: Props ) {
 	return (
 		<footer className="powered-by-wp-footer">
 			<div className="powered-by-wp-footer__info">
-				{ clientTitle ? renderPoweredByWPWithClientTitle() : renderPoweredByWP() }
+				{ clientTitle ? renderPoweredByWPWithClientTitle( clientTitle ) : renderPoweredByWP() }
 			</div>
 		</footer>
 	);

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -20,12 +20,11 @@ import { transferStatus, type as domainTypes, gdprConsentStatus } from './consta
 import type { ResponseDomain } from './types';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { CalypsoDispatch } from 'calypso/state/types';
-import type { I18N } from 'i18n-calypso';
-import type { ReactChild } from 'react';
+import type { I18N, TranslateResult } from 'i18n-calypso';
 
-export type ResolveDomainStatusReturn =
+type ResolveDomainStatusReturn =
 	| {
-			statusText: ReactChild | Array< ReactChild >;
+			statusText: TranslateResult;
 			statusClass:
 				| 'status-error'
 				| 'status-warning'
@@ -33,10 +32,10 @@ export type ResolveDomainStatusReturn =
 				| 'status-success'
 				| 'status-neutral'
 				| 'status-premium';
-			status: ReactChild;
+			status: TranslateResult;
 			icon: 'info' | 'verifying' | 'check_circle' | 'cached' | 'cloud_upload' | 'download_done';
 			listStatusWeight?: number;
-			noticeText?: ReactChild | Array< ReactChild > | null;
+			noticeText?: TranslateResult | Array< TranslateResult > | null;
 	  }
 	| Record< string, never >;
 

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -24,7 +24,7 @@ import type { I18N, TranslateResult } from 'i18n-calypso';
 
 type ResolveDomainStatusReturn =
 	| {
-			statusText: TranslateResult;
+			statusText: TranslateResult | TranslateResult[];
 			statusClass:
 				| 'status-error'
 				| 'status-warning'
@@ -346,7 +346,6 @@ export function resolveDomainStatus(
 						},
 						args: {
 							expiryDate: moment.utc( domain.expiry ).format( 'LL' ),
-							renewCta,
 						},
 					}
 				);

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -32,11 +32,7 @@ interface ImporterConfigArgs {
 	isJetpack?: boolean;
 }
 
-function getConfig(
-	args: ImporterConfigArgs = { siteTitle: '', isAtomic: false, isJetpack: false }
-): {
-	[ key: string ]: ImporterConfig;
-} {
+function getConfig( { siteTitle = '', isAtomic = false, isJetpack = false } ): ImporterConfigMap {
 	let importerConfig: ImporterConfigMap = {};
 
 	importerConfig.wordpress = {
@@ -48,7 +44,7 @@ function getConfig(
 		description: translate(
 			'Import posts, pages, and media from a WordPress export\u00A0file to {{b}}%(siteTitle)s{{/b}}.',
 			{
-				args,
+				args: { siteTitle },
 				components: {
 					b: <strong />,
 				},
@@ -84,7 +80,7 @@ function getConfig(
 			{
 				args: {
 					importerName: 'Blogger',
-					siteTitle: args.siteTitle,
+					siteTitle,
 				},
 				components: {
 					b: <strong />,
@@ -121,7 +117,7 @@ function getConfig(
 			'Import posts, tags, images, and videos ' +
 				'from a Medium export file to {{b}}%(siteTitle)s{{/b}}.',
 			{
-				args,
+				args: { siteTitle },
 				components: {
 					b: <strong />,
 				},
@@ -158,7 +154,7 @@ function getConfig(
 			{
 				args: {
 					importerName: 'Substack',
-					siteTitle: args.siteTitle,
+					siteTitle,
 				},
 				components: {
 					b: <strong />,
@@ -205,7 +201,7 @@ function getConfig(
 			{
 				args: {
 					importerName: 'Squarespace',
-					siteTitle: args.siteTitle,
+					siteTitle,
 				},
 				components: {
 					b: <strong />,
@@ -241,7 +237,7 @@ function getConfig(
 		description: translate(
 			'Import posts, pages, and media from your Wix.com site to {{b}}%(siteTitle)s{{/b}}.',
 			{
-				args,
+				args: { siteTitle },
 				components: {
 					b: <strong />,
 				},
@@ -262,12 +258,12 @@ function getConfig(
 	const hasUnifiedImporter = config.isEnabled( 'importer/unified' );
 
 	// For Jetpack sites, we don't support migration as destination, so we remove the override here.
-	if ( hasUnifiedImporter && args.isJetpack && ! args.isAtomic ) {
+	if ( hasUnifiedImporter && isJetpack && ! isAtomic ) {
 		delete importerConfig.wordpress.overrideDestination;
 	}
 
 	// For atomic sites filter out all importers except the WordPress ones if the Unified Importer is disabled.
-	if ( ! hasUnifiedImporter && args.isAtomic ) {
+	if ( ! hasUnifiedImporter && isAtomic ) {
 		importerConfig = { wordpress: importerConfig.wordpress };
 	}
 

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -1,12 +1,12 @@
 import config from '@automattic/calypso-config';
-import { translate } from 'i18n-calypso';
+import { TranslateResult, translate } from 'i18n-calypso';
 import { filter, orderBy, values } from 'lodash';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
 export interface ImporterOptionalURL {
-	title: React.ReactChild;
-	description: React.ReactChild;
-	invalidDescription: React.ReactChild;
+	title: TranslateResult;
+	description: TranslateResult;
+	invalidDescription: TranslateResult;
 }
 
 export interface ImporterConfig {
@@ -15,8 +15,8 @@ export interface ImporterConfig {
 	type: 'file' | 'url';
 	title: string;
 	icon: string;
-	description: React.ReactChild;
-	uploadDescription: React.ReactChild;
+	description: TranslateResult;
+	uploadDescription: TranslateResult;
 	weight: number;
 	overrideDestination?: string;
 	optionalUrl?: ImporterOptionalURL;

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -852,7 +852,7 @@ export function purchaseType( purchase: Purchase ) {
 	if ( isGSuiteOrGoogleWorkspace( purchase ) ) {
 		return i18n.translate( 'Mailboxes and Productivity Tools at %(domain)s', {
 			args: {
-				domain: purchase.meta,
+				domain: purchase.meta as string,
 			},
 		} );
 	}
@@ -860,7 +860,7 @@ export function purchaseType( purchase: Purchase ) {
 	if ( isTitanMail( purchase ) ) {
 		return i18n.translate( 'Mailboxes at %(domain)s', {
 			args: {
-				domain: purchase.meta,
+				domain: purchase.meta as string,
 			},
 		} );
 	}

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -24,7 +24,7 @@ import {
 import { formatCurrency } from '@automattic/format-currency';
 import { encodeProductForUrl } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
-import i18n from 'i18n-calypso';
+import i18n, { TranslateResult } from 'i18n-calypso';
 import moment from 'moment';
 import page from 'page';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -39,7 +39,6 @@ import type {
 	MembershipSubscriptionsSite,
 } from 'calypso/lib/purchases/types';
 import type { CalypsoDispatch } from 'calypso/state/types';
-import type { ReactChild } from 'react';
 
 const debug = debugFactory( 'calypso:purchases' );
 
@@ -239,7 +238,7 @@ export function getName( purchase: Purchase ): string {
 	return purchase.productName;
 }
 
-export function getDisplayName( purchase: Purchase ): ReactChild | string | undefined {
+export function getDisplayName( purchase: Purchase ): TranslateResult {
 	const jetpackProductsDisplayNames = getJetpackProductsDisplayNames();
 	if ( jetpackProductsDisplayNames[ purchase.productSlug ] ) {
 		return jetpackProductsDisplayNames[ purchase.productSlug ];

--- a/client/lib/validation/types.ts
+++ b/client/lib/validation/types.ts
@@ -1,7 +1,5 @@
-import type { ReactChild } from 'react';
-
 export interface ValidationError {
-	message: ReactChild;
+	message: string;
 }
 
 export type validator< T > = ( data: T ) => null | ValidationError;

--- a/client/me/account/account-email-field.tsx
+++ b/client/me/account/account-email-field.tsx
@@ -88,7 +88,7 @@ const AccountEmailValidationNotice = ( {
 					settingName: 'user_email',
 					unsavedUserSettings,
 					userSettings,
-				} ),
+				} ) as string,
 			},
 		} );
 	}
@@ -119,7 +119,7 @@ const AccountEmailPendingEmailChangeNotice = ( {
 		settingName: 'new_user_email',
 		unsavedUserSettings,
 		userSettings,
-	} );
+	} ) as string;
 
 	const hasCustomDomainRegistration = domainsList.some( ( domain ) => {
 		return domainTypes.REGISTERED === domain.type;

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -283,7 +283,7 @@ function UserVatDetails( { transaction }: { transaction: BillingTransaction } ) 
 			<br />
 			{ translate( 'VAT #: %(vatCountry)s %(vatId)s', {
 				args: {
-					vatCountry: vatDetails.country,
+					vatCountry: vatDetails.country ?? '',
 					vatId: vatDetails.id,
 				},
 				comment: 'This is the user-supplied VAT number, format "UK 553557881".',

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -943,7 +943,7 @@ class ManagePurchase extends Component<
 					'with {{strong}}%(domain)s{{/strong}}, making it easier to remember and easier to share.',
 				{
 					args: {
-						domain: purchase.meta,
+						domain: purchase.meta as string,
 						wpcom_url: purchase.domain,
 					},
 					components: {
@@ -980,7 +980,7 @@ class ManagePurchase extends Component<
 								count: purchase.purchaseRenewalQuantity,
 								args: {
 									numberOfMailboxes: purchase.purchaseRenewalQuantity,
-									domain: purchase.meta,
+									domain: purchase.meta as string,
 								},
 							}
 						) }
@@ -993,7 +993,10 @@ class ManagePurchase extends Component<
 		if ( isDIFMProduct( purchase ) ) {
 			const difmTieredPurchaseDetails = getDIFMTieredPurchaseDetails( purchase );
 			if ( difmTieredPurchaseDetails && ( difmTieredPurchaseDetails.extraPageCount ?? 0 ) > 0 ) {
-				const { extraPageCount, numberOfIncludedPages } = difmTieredPurchaseDetails;
+				// We know there are some pages due to the above check.
+				const extraPageCount = difmTieredPurchaseDetails.extraPageCount as number;
+				const numberOfIncludedPages = difmTieredPurchaseDetails.numberOfIncludedPages as number;
+
 				return (
 					<>
 						{ numberOfIncludedPages === 1
@@ -1181,7 +1184,7 @@ class ManagePurchase extends Component<
 								<div className="manage-purchase__contact-partner">
 									{ translate( 'Please contact your site host %(partnerName)s for details', {
 										args: {
-											partnerName: getPartnerName( purchase ),
+											partnerName: getPartnerName( purchase ) ?? '',
 										},
 									} ) }
 								</div>

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -445,7 +445,7 @@ class PurchaseNotice extends Component<
 				expiry: expiry.fromNow(),
 				earliestOtherExpiry: earliestOtherExpiringPurchase
 					? moment( earliestOtherExpiringPurchase.expiryDate ).fromNow()
-					: null,
+					: '',
 			},
 			components: {
 				link: (

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -48,7 +48,7 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 									count: extraPageCount,
 									args: {
 										extraPageCount,
-										costOfExtraPages,
+										costOfExtraPages: costOfExtraPages as string,
 									},
 								}
 							) }

--- a/client/me/purchases/pre-cancellation-dialog/index.tsx
+++ b/client/me/purchases/pre-cancellation-dialog/index.tsx
@@ -139,8 +139,16 @@ export const PreCancellationDialog = ( {
 	 * Instantiate site's variables.
 	 */
 	const siteName = site.name ?? '';
-	const productSlug = site.plan?.product_slug;
-	const planLabel = site.plan?.product_name_short;
+
+	// This component doesn't make sense if a plan doesn't exist!
+	const plan = site.plan;
+	if ( ! plan ) {
+		return null;
+	}
+
+	const productSlug = plan.product_slug;
+	const planLabel = plan.product_name_short;
+
 	const isComingSoon = site.is_coming_soon;
 	const isPrivate = site.is_private;
 	const launchedStatus = site.launch_status === 'launched' ? true : false;
@@ -246,7 +254,7 @@ export const PreCancellationDialog = ( {
 						<FormattedHeader
 							brandFont
 							headerText={ translate( 'Are you sure you want to cancel your %(label)s plan?', {
-								args: { label: planLabel ?? '' },
+								args: { label: planLabel },
 							} ) }
 							align="left"
 						/>

--- a/client/me/purchases/pre-cancellation-dialog/index.tsx
+++ b/client/me/purchases/pre-cancellation-dialog/index.tsx
@@ -246,7 +246,7 @@ export const PreCancellationDialog = ( {
 						<FormattedHeader
 							brandFont
 							headerText={ translate( 'Are you sure you want to cancel your %(label)s plan?', {
-								args: { label: planLabel },
+								args: { label: planLabel ?? '' },
 							} ) }
 							align="left"
 						/>

--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -9,16 +9,16 @@ import type { AddOnMeta } from '../hooks/use-add-ons';
 
 export interface Props {
 	actionPrimary?: {
-		text: string | React.ReactChild;
+		text: string;
 		handler: ( productSlug: string, quantity?: number ) => void;
 	};
 	actionSecondary?: {
-		text: string | React.ReactChild;
+		text: string;
 		handler: ( productSlug: string ) => void;
 	};
 	useAddOnAvailabilityStatus?: ( addOnMeta: AddOnMeta ) => {
 		available: boolean;
-		text?: string | React.ReactChild;
+		text?: string;
 	};
 	highlightFeatured: boolean;
 	addOnMeta: AddOnMeta;

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -3,7 +3,7 @@ import {
 	PRODUCT_WPCOM_UNLIMITED_THEMES,
 	PRODUCT_1GB_SPACE,
 } from '@automattic/calypso-products';
-import { useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
 import { filterTransactions } from 'calypso/me/purchases/billing-history/filter-transactions';
 import { useSelector } from 'calypso/state';
@@ -27,10 +27,10 @@ export interface AddOnMeta {
 	featureSlugs?: string[] | null;
 	icon: JSX.Element;
 	featured?: boolean; // irrelevant to "featureSlugs"
-	name: string | React.ReactChild | null;
+	name: string | null;
 	quantity?: number;
-	description: string | React.ReactChild | null;
-	displayCost: string | React.ReactChild | null;
+	description: string | null;
+	displayCost: TranslateResult | null;
 	purchased?: boolean;
 }
 

--- a/client/my-sites/backup/clone-flow/step-progress/index.tsx
+++ b/client/my-sites/backup/clone-flow/step-progress/index.tsx
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { ReactChild } from 'react';
 
 import './style.scss';
 
@@ -35,7 +34,7 @@ type StepKey = 'destination' | 'clonePoint' | 'configure';
 
 interface Step {
 	key: StepKey;
-	label: ReactChild | null;
+	label: string;
 }
 
 interface Props {

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer.tsx
@@ -31,7 +31,7 @@ const domainTransferThankYouProps = ( {
 						{
 							components: { i: <i /> },
 							args: {
-								email,
+								email: email as string,
 							},
 						}
 					),

--- a/client/my-sites/checkout/checkout-thank-you/gift/gift-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/gift/gift-thank-you.tsx
@@ -94,7 +94,7 @@ export default function GiftThankYou( { site }: { site: number | string } ) {
 						width: '63px',
 					} }
 					thankYouTitle={ translate( 'All done! Thank you for supporting %(siteName)s.', {
-						args: { siteName },
+						args: { siteName: siteName ?? translate( 'this website' ) },
 					} ) }
 					thankYouHeaderBody={
 						<div className="gift-thank-you__header-body">

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-thank-you.tsx
@@ -75,8 +75,8 @@ const JetpackCheckoutThankYou: FunctionComponent< Props > = ( {
 					>
 						{ translate( '%(productName)s was added to your site %(siteName)s.', {
 							args: {
-								productName,
-								siteName,
+								productName: productName as string, // We know this exists via hasProductInfo
+								siteName: siteName ?? '',
 							},
 						} ) }
 					</p>

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
@@ -40,7 +40,7 @@ const LicensingActivationThankYouCompleted: FC< Props > = ( {
 		return subscriptionTransferSucceeded
 			? translate( `Your %(productName)s is active! %(celebrationEmoji)s`, {
 					args: {
-						productName: hasProductInfo ? productName : 'subscription',
+						productName: hasProductInfo ? ( productName as string ) : 'subscription',
 						celebrationEmoji: String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */,
 					},
 			  } )

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -152,7 +152,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 								strong: <strong />,
 							},
 							args: {
-								productName,
+								productName: productName as string,
 								selectedSite: urlToSlug( selectedSite ),
 								incompatibleProductName,
 							},
@@ -171,7 +171,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 								a: <a href={ manualActivationUrl } />,
 							},
 							args: {
-								productName,
+								productName: productName as string,
 								selectedSite: urlToSlug( selectedSite ),
 							},
 						}
@@ -281,7 +281,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 						<br />
 						{ translate( 'Select the site you want %(productName)s on:', {
 							args: {
-								productName,
+								productName: productName as string,
 							},
 						} ) }
 					</p>

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
@@ -38,7 +38,7 @@ const LicensingActivationInstructions: FC< JetpackLicenseKeyProps > = ( {
 			/>
 			<LicensingActivation
 				title={ translate( 'Activate your %(productName)s plan', {
-					args: { productName },
+					args: { productName: productName ?? '' },
 				} ) }
 				footerImage={ licensingActivationPluginBanner }
 				isLoading={ isProductListFetching }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/index.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { ReactChild } from 'react';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
@@ -53,7 +52,7 @@ const MasterbarStyled = ( {
 	showContact = true,
 }: {
 	onClick: () => void;
-	backText: ReactChild;
+	backText: string;
 	canGoBack: boolean;
 	contact?: JSX.Element | null;
 	showContact?: boolean;

--- a/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
@@ -5,14 +5,13 @@ import { useMemo } from 'react';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { TranslateResult } from 'i18n-calypso';
-import type { ReactChild } from 'react';
 interface Props {
 	responseCart: ResponseCart;
 	headerText?: TranslateResult;
 }
 
 interface NextStepsStep {
-	text: ReactChild;
+	text: TranslateResult;
 	icon: JSX.Element;
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/country-select-menu.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/country-select-menu.tsx
@@ -1,8 +1,8 @@
-import { useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import FormCountrySelect from 'calypso/components/forms/form-country-select';
 import FormFieldAnnotation from 'calypso/my-sites/checkout/composite-checkout/components/form-field-annotation';
 import type { CountryListItem } from '@automattic/wpcom-checkout';
-import type { HTMLProps, ReactChild } from 'react';
+import type { HTMLProps } from 'react';
 
 export default function CountrySelectMenu( {
 	onChange,
@@ -15,7 +15,7 @@ export default function CountrySelectMenu( {
 	onChange: HTMLProps< HTMLSelectElement >[ 'onChange' ];
 	isDisabled?: boolean;
 	isError?: boolean;
-	errorMessage?: ReactChild;
+	errorMessage?: TranslateResult;
 	currentValue: HTMLProps< HTMLSelectElement >[ 'value' ];
 	countriesList: CountryListItem[];
 } ) {

--- a/client/my-sites/checkout/composite-checkout/components/form-field-annotation.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/form-field-annotation.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
-import type { FunctionComponent, ReactChild } from 'react';
+import { TranslateResult } from 'i18n-calypso';
+import type { FunctionComponent } from 'react';
 
 type FormFieldWrapperProps = {
 	isError: boolean;
@@ -49,7 +50,7 @@ type FormFieldAnnotationProps = {
 	// Semantic props
 	labelText: string;
 	normalDescription?: string;
-	errorDescription?: ReactChild;
+	errorDescription?: TranslateResult;
 
 	// Functional props
 	isError?: boolean; // default false
@@ -115,7 +116,7 @@ type RenderedDescriptionProps = {
 	descriptionText?: string;
 	descriptionId?: string;
 	isError?: boolean;
-	errorMessage?: ReactChild;
+	errorMessage?: TranslateResult;
 };
 
 type DescriptionProps = {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -135,20 +135,19 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	const productBillingTermInMonths = variant.productBillingTermInMonths;
 	const isIntroductoryOffer = introCount > 0;
 	const translate = useTranslate();
-	const billingTermInYears = () => {
-		if ( productBillingTermInMonths > 12 ) {
-			return productBillingTermInMonths / 12;
-		}
-		return null;
-	};
 
 	const translatedIntroOfferDetails = () => {
 		const args = {
 			formattedCurrentPrice,
 			formattedPriceBeforeDiscounts,
-			billingTermInYears: billingTermInYears(),
 			introCount,
 		};
+		// Add billing term in years for multi-year plans. (Only to be used when productBillingTermInMonths > 12)
+		const multiYearArgs = {
+			...args,
+			billingTermInYears: productBillingTermInMonths / 12,
+		};
+
 		//generic introductory offer to catch unexpected offer terms
 		if (
 			( introTerm !== 'month' && introTerm !== 'year' ) ||
@@ -178,11 +177,11 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 				return introTerm === 'month'
 					? translate(
 							'%(formattedCurrentPrice)s first month then %(formattedPriceBeforeDiscounts)s per %(billingTermInYears)s years',
-							{ args }
+							{ args: multiYearArgs }
 					  )
 					: translate(
 							'%(formattedCurrentPrice)s first year then %(formattedPriceBeforeDiscounts)s per %(billingTermInYears)s years',
-							{ args }
+							{ args: multiYearArgs }
 					  );
 				// translation example: $1 first month then $2 per 2 years
 			} else if ( productBillingTermInMonths === 12 ) {
@@ -210,13 +209,13 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 					? preventWidows(
 							translate(
 								'%(formattedCurrentPrice)s first %(introCount)s months then %(formattedPriceBeforeDiscounts)s per %(billingTermInYears)s years',
-								{ args }
+								{ args: multiYearArgs }
 							)
 					  )
 					: preventWidows(
 							translate(
 								'%(formattedCurrentPrice)s for first %(introCount)s years then %(formattedPriceBeforeDiscounts)s per %(billingTermInYears)s years',
-								{ args }
+								{ args: multiYearArgs }
 							)
 					  );
 				// translation example: $1 first 3 months then $2 per 2 years

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -22,7 +22,7 @@ import type {
 	ManagedContactDetails,
 	ManagedValue,
 } from '@automattic/wpcom-checkout';
-import type { ChangeEvent } from 'react';
+import type { ChangeEvent, ReactElement } from 'react';
 
 const GridRow = styled.div`
 	display: -ms-grid;
@@ -69,7 +69,7 @@ export default function TaxFields( {
 			: {};
 	const isVatSupported = config.isEnabled( 'checkout/vat-form' ) && allowVat;
 
-	const fields: JSX.Element[] = [
+	const fields: ReactElement[] = [
 		<CountrySelectMenu
 			onChange={ ( event: ChangeEvent< HTMLSelectElement > ) => {
 				onChange(

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -351,7 +351,7 @@ function useAddRenewalItems( {
 					translate(
 						"I tried and failed to create products matching the identifier '%(productAlias)s'",
 						{
-							args: { productAlias },
+							args: { productAlias: productAlias as string },
 						}
 					)
 				),
@@ -440,7 +440,7 @@ function useAddProductFromSlug( {
 					translate(
 						"I tried and failed to create products matching the identifier '%(productAlias)s'",
 						{
-							args: { productAlias: productAliasFromUrl },
+							args: { productAlias: productAliasFromUrl as string },
 						}
 					)
 				),

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -351,7 +351,7 @@ function useAddRenewalItems( {
 					translate(
 						"I tried and failed to create products matching the identifier '%(productAlias)s'",
 						{
-							args: { productAlias: productAlias as string },
+							args: { productAlias: productAlias ?? '' },
 						}
 					)
 				),
@@ -440,7 +440,7 @@ function useAddProductFromSlug( {
 					translate(
 						"I tried and failed to create products matching the identifier '%(productAlias)s'",
 						{
-							args: { productAlias: productAliasFromUrl as string },
+							args: { productAlias: productAliasFromUrl ?? '' },
 						}
 					)
 				),

--- a/client/my-sites/domains/domain-management/edit/card/renew-button/index.tsx
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/index.tsx
@@ -7,7 +7,6 @@ import { useDispatch } from 'calypso/state';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
-import type { ReactChild } from 'react';
 
 import './style.scss';
 
@@ -16,7 +15,7 @@ type RenewButtonProps = {
 	selectedSite: SiteDetails;
 	subscriptionId: number;
 	compact?: boolean;
-	customLabel?: ReactChild;
+	customLabel?: string;
 	disabled?: boolean;
 	primary?: boolean;
 	redemptionProduct?: ProductListItem;
@@ -54,7 +53,7 @@ function RenewButton( {
 	}
 
 	const buttonClasses = classNames( 'renew-button', { 'is-loading': loading } );
-	let buttonLabel: ReactChild;
+	let buttonLabel;
 	if ( reactivate ) {
 		buttonLabel = translate( 'Reactivate for {{strong}}%(price)s{{/strong}}', {
 			components: { strong: <strong /> },

--- a/client/my-sites/domains/domain-management/list/domain-only-upsell-carousel.tsx
+++ b/client/my-sites/domains/domain-management/list/domain-only-upsell-carousel.tsx
@@ -1,7 +1,7 @@
 import { Card, Button, Gridicon } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import moment from 'moment';
-import { useEffect, useState, useRef, ReactChild } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { connect } from 'react-redux';
 import addEmailImage from 'calypso/assets/images/domains/add-email.svg';
 import createSiteImage from 'calypso/assets/images/domains/create-site.svg';
@@ -133,10 +133,10 @@ const DomainOnlyUpsellCarousel = ( props: DomainOnlyUpsellCarouselProps ) => {
 	}: {
 		actionUrl: string;
 		imageUrl: string;
-		title: ReactChild;
-		subtitle: ReactChild;
+		title: TranslateResult;
+		subtitle: TranslateResult;
 		ref: React.MutableRefObject< null >;
-		buttonLabel: ReactChild;
+		buttonLabel: string;
 		cardName: string;
 		cardNoticeType: UpsellCardNoticeType;
 		eventTrackViewName: string;

--- a/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
@@ -26,7 +26,7 @@ const DnsRecordItem = ( { dnsRecord, selectedDomainName }: DnsRecordItemProps ) 
 				return translate( '%(data)s with priority %(aux)d', {
 					args: {
 						data,
-						aux,
+						aux: aux as number,
 					},
 					comment: '%(data)s is a hostname',
 				} );
@@ -35,9 +35,9 @@ const DnsRecordItem = ( { dnsRecord, selectedDomainName }: DnsRecordItemProps ) 
 				return translate( '%(target)s:%(port)d, with priority %(aux)d and weight %(weight)d', {
 					args: {
 						target,
-						port,
-						aux,
-						weight,
+						port: port as number,
+						aux: aux as number,
+						weight: weight as number,
 						comment: '%(target)s is a hostname',
 					},
 				} );

--- a/client/my-sites/email/email-non-domain-owner-message/index.tsx
+++ b/client/my-sites/email/email-non-domain-owner-message/index.tsx
@@ -96,7 +96,7 @@ export const EmailNonDomainOwnerMessage = ( props: EmailNonDomainOwnerMessagePro
 		},
 		args: {
 			ownerUserName,
-			selectedDomainName: domain?.name,
+			selectedDomainName: domain?.name ?? '',
 		},
 	};
 

--- a/client/my-sites/email/email-pricing-notice/index.tsx
+++ b/client/my-sites/email/email-pricing-notice/index.tsx
@@ -24,7 +24,7 @@ function getNoticeMessage(
 ): TranslateResult {
 	const translateArgs = {
 		args: {
-			price: mailboxPurchaseCost?.text,
+			price: mailboxPurchaseCost?.text as string,
 		},
 		components: {
 			strong: <strong />,

--- a/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
@@ -28,8 +28,8 @@ const SalePriceWithInterval = ( {
 	standardPrice,
 }: {
 	intervalLength: IntervalLength;
-	salePrice: string | null;
-	standardPrice: string | null;
+	salePrice: string;
+	standardPrice: string;
 } ) => {
 	const translateArguments = {
 		args: {
@@ -70,7 +70,7 @@ const StandardPriceWithInterval = ( {
 	standardPrice,
 }: {
 	intervalLength: IntervalLength;
-	standardPrice: string | null;
+	standardPrice: string;
 } ) => {
 	const translateArguments = {
 		args: { standardPrice },

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -118,13 +118,13 @@ const GoogleWorkspacePrice = ( {
 					{ isEligibleForIntroductoryOffer
 						? translate( 'Extra %(discount)d%% off', {
 								args: {
-									discount: product?.sale_coupon?.discount,
+									discount: product?.sale_coupon?.discount as number,
 								},
 								comment: "%(discount)d is a numeric discount percentage (e.g. '40')",
 						  } )
 						: translate( 'Limited time: %(discount)d%% off', {
 								args: {
-									discount: product?.sale_coupon?.discount,
+									discount: product?.sale_coupon?.discount as number,
 								},
 								comment: "%(discount)d is a numeric discount percentage (e.g. '40')",
 						  } ) }

--- a/client/my-sites/email/email-providers-comparison/price/price-information.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/price-information.tsx
@@ -71,7 +71,7 @@ export const FreeTrialPriceInformation = ( {
 
 	const translateArguments = {
 		args: {
-			firstRenewalPrice: getFirstRenewalPrice( product, currencyCode ?? '' ),
+			firstRenewalPrice: getFirstRenewalPrice( product, currencyCode ?? '' ) as string,
 			standardPrice: formatCurrency( product.cost ?? 0, currencyCode ?? '', { stripZeros: true } ),
 		},
 		comment:

--- a/client/my-sites/email/form/mailboxes/components/test/list.tsx
+++ b/client/my-sites/email/form/mailboxes/components/test/list.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import nock from 'nock';
-import { ReactChild } from 'react';
+import { ReactElement } from 'react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import {
@@ -16,7 +16,7 @@ import { useGetDefaultFieldLabelText } from 'calypso/my-sites/email/form/mailbox
 import { FIELD_MAILBOX } from 'calypso/my-sites/email/form/mailboxes/constants';
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 
-function renderWithStore( element: ReactChild ) {
+function renderWithStore( element: ReactElement ) {
 	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 	const store = createStore( ( state ) => state, { ui: { selectedSiteId: 1 } } );
 	return {

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -69,7 +69,7 @@ const GoogleSaleBanner = ( { domains }: GoogleSaleBannerProps ) => {
 	// Verify that we have a percentage discount
 	if (
 		! hasDiscount( googleWorkspaceProduct ) ||
-		( ! googleWorkspaceProduct?.sale_coupon?.discount ?? null )
+		! googleWorkspaceProduct?.sale_coupon?.discount
 	) {
 		return null;
 	}

--- a/client/my-sites/hosting/github/deployment-card/deployment-status-explanation.tsx
+++ b/client/my-sites/hosting/github/deployment-card/deployment-status-explanation.tsx
@@ -1,7 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactChild } from 'react';
 import { useDeploymentLogsURL } from './use-deployment-logs-url';
 
 interface DeploymentStatusBadgeProps {
@@ -24,12 +23,11 @@ export const DeploymentStatusExplanation = ( {
 
 	const translate = useTranslate();
 
-	let message: ReactChild = '';
-
 	if ( ! deploymentLogsUrl ) {
 		return null;
 	}
 
+	let message;
 	if ( status === 'failed' ) {
 		message = translate(
 			'Failed to build. Please {{a}}check the logs{{/a}} for more information.',

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -270,9 +270,11 @@ export default function DIFMLanding( {
 		}
 	}, [ isFAQSectionOpen ] );
 
-	const planTitle = isEnabled( 'plans/pro-plan' )
-		? getPlan( PLAN_WPCOM_PRO )?.getTitle()
-		: getPlan( PLAN_PREMIUM )?.getTitle();
+	const planTitle = (
+		isEnabled( 'plans/pro-plan' )
+			? getPlan( PLAN_WPCOM_PRO )?.getTitle()
+			: getPlan( PLAN_PREMIUM )?.getTitle()
+	) as string; // It's guaranteed that getPlan will return a plan object when passing a valid plan slug, but the types aren't strong enough.
 
 	const headerText = translate(
 		'Let us build your site for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
@@ -530,7 +532,7 @@ export default function DIFMLanding( {
 									'Although revisions aren’t included with this service, you will be able to edit all content of the site using the WordPress editor. You will be able to change images, edit text, and also add additional pages and posts. You could even try a new theme for a different look, and you will still have the professionally designed page layouts. Your %(planTitle)s plan comes with access to live chat and priority email support, so you can always contact support if you need help customizing your new site or have questions about this service.',
 									{
 										args: {
-											planTitle: planTitle ?? '',
+											planTitle: planTitle,
 										},
 									}
 								) }

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -312,7 +312,7 @@ export default function DIFMLanding( {
 				'{{sup}}*{{/sup}}One time fee, plus an additional purchase of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
 				{
 					args: {
-						plan: planTitle,
+						plan: planTitle ?? '',
 						freePages: 5,
 					},
 					components: {
@@ -461,7 +461,7 @@ export default function DIFMLanding( {
 									{
 										args: {
 											displayCost,
-											planTitle,
+											planTitle: planTitle ?? '',
 										},
 									}
 								) }
@@ -530,7 +530,7 @@ export default function DIFMLanding( {
 									'Although revisions aren’t included with this service, you will be able to edit all content of the site using the WordPress editor. You will be able to change images, edit text, and also add additional pages and posts. You could even try a new theme for a different look, and you will still have the professionally designed page layouts. Your %(planTitle)s plan comes with access to live chat and priority email support, so you can always contact support if you need help customizing your new site or have questions about this service.',
 									{
 										args: {
-											planTitle,
+											planTitle: planTitle ?? '',
 										},
 									}
 								) }

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -63,18 +63,18 @@ function WebsiteContentSubmissionPending( { primaryDomain, siteId, siteSlug }: P
 				/>
 			),
 		},
-		args: {
-			contentSubmissionDueDate: contentSubmissionDueDate
-				? moment( contentSubmissionDueDate ).format( 'MMMM Do, YYYY' )
-				: null,
-		},
 	};
 
 	const lineText = contentSubmissionDueDate
 		? translate(
 				'Click the button below to provide the content we need to build your site by %(contentSubmissionDueDate)s.{{br}}{{/br}}' +
 					'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
-				lineTextTranslateOptions
+				{
+					...lineTextTranslateOptions,
+					args: {
+						contentSubmissionDueDate: moment( contentSubmissionDueDate ).format( 'MMMM Do, YYYY' ),
+					},
+				}
 		  )
 		: translate(
 				'Click the button below to provide the content we need to build your site.{{br}}{{/br}}' +

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -94,7 +94,7 @@ function Subscribers( props: Props ) {
 							'You have %(number)d subscriber',
 							'You have %(number)d subscribers',
 							{
-								args: { number: subscribersTotal },
+								args: { number: subscribersTotal as number },
 								count: subscribersTotal as number,
 							}
 						) }
@@ -154,7 +154,7 @@ function Subscribers( props: Props ) {
 					<NoResults
 						image="/calypso/images/people/mystery-person.svg"
 						text={ translate( 'No results found for {{em}}%(searchTerm)s{{/em}}', {
-							args: { searchTerm: search },
+							args: { searchTerm: search as string },
 							components: { em: <em /> },
 						} ) }
 					/>

--- a/client/my-sites/people/team-invite/index.tsx
+++ b/client/my-sites/people/team-invite/index.tsx
@@ -56,7 +56,7 @@ function TeamInvite( props: Props ) {
 				<PageViewTracker path="/people/new/:site" title="People > Invite People" />
 				<HeaderCake onClick={ goBack }>
 					{ translate( 'Add team members to %(sitename)s', {
-						args: { sitename: site.name ?? '' },
+						args: { sitename: site.name ?? translate( 'this site' ) },
 					} ) }
 				</HeaderCake>
 				<PeopleSectionAddNav selectedFilter="team" />
@@ -76,7 +76,7 @@ function TeamInvite( props: Props ) {
 
 			<HeaderCake onClick={ goBack }>
 				{ translate( 'Add team members to %(sitename)s', {
-					args: { sitename: site.name as string },
+					args: { sitename: site.name ?? translate( 'this site' ) },
 				} ) }
 			</HeaderCake>
 

--- a/client/my-sites/people/team-invite/index.tsx
+++ b/client/my-sites/people/team-invite/index.tsx
@@ -56,7 +56,7 @@ function TeamInvite( props: Props ) {
 				<PageViewTracker path="/people/new/:site" title="People > Invite People" />
 				<HeaderCake onClick={ goBack }>
 					{ translate( 'Add team members to %(sitename)s', {
-						args: { sitename: site.name },
+						args: { sitename: site.name ?? '' },
 					} ) }
 				</HeaderCake>
 				<PeopleSectionAddNav selectedFilter="team" />
@@ -76,7 +76,7 @@ function TeamInvite( props: Props ) {
 
 			<HeaderCake onClick={ goBack }>
 				{ translate( 'Add team members to %(sitename)s', {
-					args: { sitename: site.name },
+					args: { sitename: site.name as string },
 				} ) }
 			</HeaderCake>
 

--- a/client/my-sites/people/team-invite/sso-notice.tsx
+++ b/client/my-sites/people/team-invite/sso-notice.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactChild, ReactChildren } from 'react';
+import { ReactNode } from 'react';
 import FeatureExample from 'calypso/components/feature-example';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
@@ -8,7 +8,7 @@ import { activateModule } from 'calypso/state/jetpack/modules/actions';
 
 interface Props {
 	siteId: number;
-	children?: ReactChild | ReactChildren;
+	children?: ReactNode;
 }
 export default function SsoNotice( props: Props ) {
 	const translate = useTranslate();

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -47,7 +47,7 @@ function TeamMembers( props: Props ) {
 		}
 
 		return translate( 'You have %(number)d team member', 'You have %(number)d team members', {
-			args: { number: membersTotal, searchTerm: search },
+			args: { number: membersTotal as number, searchTerm: search as string },
 			count: membersTotal as number,
 		} );
 	}
@@ -108,7 +108,7 @@ function TeamMembers( props: Props ) {
 					<NoResults
 						image="/calypso/images/people/mystery-person.svg"
 						text={ translate( 'No results found for {{em}}%(searchTerm)s{{/em}}', {
-							args: { searchTerm: search },
+							args: { searchTerm: search as string },
 							components: { em: <em /> },
 						} ) }
 					/>

--- a/client/my-sites/plans-comparison/plans-comparison-action.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-action.tsx
@@ -36,8 +36,12 @@ type TranslateFunc = ReturnType< typeof useTranslate >;
 function getButtonText( props: Partial< Props >, translate: TranslateFunc ): TranslateResult {
 	const { isCurrentPlan, plan } = props;
 
-	const planTitle = plan?.getTitle();
-	const planSlug = plan?.getStoreSlug() || '';
+	if ( ! plan ) {
+		return translate( 'Start' );
+	}
+
+	const planTitle = plan.getTitle();
+	const planSlug = plan.getStoreSlug();
 
 	if ( [ PLAN_WPCOM_PRO, PLAN_WPCOM_PRO_MONTHLY ].includes( planSlug ) ) {
 		return 'en' === i18n.getLocaleSlug() || i18n.hasTranslation( 'Choose Pro' )
@@ -53,10 +57,8 @@ function getButtonText( props: Partial< Props >, translate: TranslateFunc ): Tra
 		return props.canPurchase ? translate( 'Manage plan' ) : translate( 'View plan' );
 	}
 
-	return translate( 'Start with %(plan)s', {
-		args: {
-			plan: planTitle ?? '',
-		},
+	return translate( 'Start with %(planTitle)s', {
+		args: { planTitle },
 	} );
 }
 

--- a/client/my-sites/plans-comparison/plans-comparison-action.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-action.tsx
@@ -55,7 +55,7 @@ function getButtonText( props: Partial< Props >, translate: TranslateFunc ): Tra
 
 	return translate( 'Start with %(plan)s', {
 		args: {
-			plan: planTitle,
+			plan: planTitle ?? '',
 		},
 	} );
 }

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -194,7 +194,7 @@ export function FreePlanPaidDomainDialog( {
 								translate( 'Get %(planTitle)s - %(planPrice)s/month', {
 									comment: 'Eg: Get Personal - $4/month',
 									args: {
-										planTitle,
+										planTitle: planTitle as string,
 										planPrice: formatCurrency(
 											planPrices.discountedRawPrice || planPrices.rawPrice,
 											currencyCode,

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
@@ -67,7 +67,7 @@ const ECommerceTrialBanner = ( props: ECommerceTrialBannerProps ) => {
 									count: eCommerceTrialDaysLeftToDisplay,
 									args: {
 										daysLeft: eCommerceTrialDaysLeftToDisplay,
-										expirationdate: readableExpirationDate,
+										expirationdate: readableExpirationDate as string,
 									},
 								}
 						  ) }

--- a/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-get-product-card-data.ts
+++ b/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-get-product-card-data.ts
@@ -114,7 +114,9 @@ export const useGetMonthlyBackupsCardData = (): StorageUpgradeGetter => {
 			const features = {
 				items: [
 					{
-						text: translate( '%(storageAmount)s backup storage', { args: { storageAmount } } ),
+						text: translate( '%(storageAmount)s backup storage', {
+							args: { storageAmount: storageAmount as string },
+						} ),
 						slug: 'jetpack-backup-storage',
 					},
 					{
@@ -166,7 +168,9 @@ export const useGetYearlyBackupsCardData = (): StorageUpgradeGetter => {
 			const features = {
 				items: [
 					{
-						text: translate( '%(storageAmount)s backup storage', { args: { storageAmount } } ),
+						text: translate( '%(storageAmount)s backup storage', {
+							args: { storageAmount: storageAmount as string },
+						} ),
 						slug: 'jetpack-backup-storage',
 						isHighlighted: true,
 					},
@@ -202,7 +206,7 @@ export const useGetYearlyBackupsCardData = (): StorageUpgradeGetter => {
 				buttonLabel,
 				description: translate(
 					'Go back in time and recover all your information for up to a year, with %(storageAmount)s storage space.',
-					{ args: { storageAmount } }
+					{ args: { storageAmount: storageAmount as string } }
 				),
 				features,
 				disclaimer: getDisclaimer( product?.productSlug as string, features.items ),

--- a/client/my-sites/plans/jetpack-plans/upsell/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/upsell/index.tsx
@@ -175,7 +175,7 @@ const JetpackUpsellPage: React.FC< Props > = ( {
 						<h1 className="jetpack-upsell__heading">
 							{ translate( 'Nice choice, we added %(productName)s to your cart.', {
 								args: {
-									productName,
+									productName: productName as string,
 								},
 							} ) }
 							<br />
@@ -251,7 +251,7 @@ const JetpackUpsellPage: React.FC< Props > = ( {
 								>
 									{ translate( 'Upgrade to %(productName)s', {
 										args: {
-											productName: upsellName,
+											productName: upsellName as string,
 										},
 									} ) }
 								</Button>
@@ -262,7 +262,7 @@ const JetpackUpsellPage: React.FC< Props > = ( {
 								>
 									{ translate( 'No thanks, proceed with %(productName)s', {
 										args: {
-											productName,
+											productName: productName as string,
 										},
 									} ) }
 								</a>

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -147,7 +147,7 @@ export const PlanUSPS: React.FC< Props > = ( {
 		case PLAN_PERSONAL_MONTHLY:
 			planText = translate( 'Included in the Personal plan (%(cost)s/%(periodicity)s):', {
 				args: {
-					cost: planDisplayCost,
+					cost: planDisplayCost as string,
 					periodicity: periodicityLabel,
 				},
 			} );
@@ -156,7 +156,7 @@ export const PlanUSPS: React.FC< Props > = ( {
 		case PLAN_BUSINESS_MONTHLY:
 			planText = translate( 'Included in the Business plan (%(cost)s/%(periodicity)s):', {
 				args: {
-					cost: planDisplayCost,
+					cost: planDisplayCost as string,
 					periodicity: periodicityLabel,
 				},
 			} );

--- a/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
@@ -68,23 +68,18 @@ export default function UpdatePlugins( { plugins, isWpCom }: Props ): ReactEleme
 	}
 
 	function updateAllPluginsNotice() {
-		let pluginName;
-		const hasOnePlugin = pluginUpdateCount === 1;
+		let heading = translate( 'Update %(pluginUpdateCount)d plugins', {
+			args: { pluginUpdateCount },
+		} );
 
-		if ( hasOnePlugin ) {
+		if ( pluginUpdateCount === 1 ) {
 			const [ { name, slug } ] = pluginsWithUpdates;
-			pluginName = name || slug;
+			heading = translate( 'Update %(pluginName)s', { args: { pluginName: name || slug } } );
 		}
 
 		const dialogOptions = {
 			additionalClassNames: 'plugins__confirmation-modal',
 		};
-
-		const heading = hasOnePlugin
-			? translate( 'Update %(pluginName)s', { args: { pluginName } } )
-			: translate( 'Update %(pluginUpdateCount)d plugins', {
-					args: { pluginUpdateCount },
-			  } );
 
 		acceptDialog(
 			getPluginActionDailogMessage( allSites, pluginsWithUpdates, heading, 'update' ),

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -23,7 +23,7 @@ const UnsubscribeModal = ( { subscriber, onCancel, onConfirm }: UnsubscribeModal
 		text: translate(
 			'Are you sure you want to remove %s from your list? They will no longer receive new notifications from your site.',
 			{
-				args: [ subscriber?.display_name ],
+				args: [ subscriber?.display_name as string ],
 				comment: "%s is the subscriber's public display name",
 			}
 		),
@@ -36,7 +36,7 @@ const UnsubscribeModal = ( { subscriber, onCancel, onConfirm }: UnsubscribeModal
 		text: translate(
 			'To remove %s from your list, you’ll need to cancel their paid subscription first.',
 			{
-				args: [ subscriber?.display_name ],
+				args: [ subscriber?.display_name as string ],
 				comment: "%s is the subscriber's public display name",
 			}
 		),

--- a/client/signup/accordion-form/form-components.tsx
+++ b/client/signup/accordion-form/form-components.tsx
@@ -2,7 +2,7 @@ import { FormInputValidation } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Icon } from '@wordpress/icons';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { ChangeEvent, ChangeEventHandler, ReactChild } from 'react';
+import { ChangeEvent, ChangeEventHandler, ReactNode } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -145,13 +145,7 @@ interface TextInputFieldProps {
 	onChange?: ( event: ChangeEvent< HTMLInputElement > ) => void;
 }
 
-export function LabelBlock( {
-	inputName,
-	children,
-}: {
-	inputName?: string;
-	children: ReactChild | ReactChild[];
-} ) {
+export function LabelBlock( { inputName, children }: { inputName?: string; children: ReactNode } ) {
 	return (
 		<LabelContainer>
 			<Label htmlFor={ inputName }>{ children }</Label>

--- a/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
+++ b/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
@@ -105,8 +105,8 @@ function SiteDeleteConfirmationDialog( {
 										strong: <strong />,
 									},
 									args: {
-										siteTitle,
-										siteAddress: siteDomain,
+										siteTitle: siteTitle ?? '',
+										siteAddress: siteDomain ?? '',
 									},
 								}
 							) }

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -54,12 +54,11 @@ export default function NewOrExistingSiteStep( props: Props ) {
 		'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}} plus an additional purchase of the %(plan)s plan.',
 		{
 			args: {
-				displayCost,
+				displayCost: displayCost as string,
 				fulfillmentDays: 4,
-				plan:
-					props.flowName === 'do-it-for-me-store'
-						? getPlan( PLAN_BUSINESS )?.getTitle()
-						: getPlan( PLAN_PREMIUM )?.getTitle(),
+				plan: ( props.flowName === 'do-it-for-me-store'
+					? getPlan( PLAN_BUSINESS )?.getTitle()
+					: getPlan( PLAN_PREMIUM )?.getTitle() ) as string,
 			},
 			components: {
 				PriceWrapper: isLoading ? <Placeholder /> : <strong />,

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -388,7 +388,7 @@ function DIFMPagePicker( props: StepProps ) {
 							),
 					},
 					args: {
-						freePageCount: difmTieredPriceDetails?.numberOfIncludedPages,
+						freePageCount: difmTieredPriceDetails?.numberOfIncludedPages as number,
 						extraPagePrice: formatCurrency(
 							difmTieredPriceDetails?.perExtraPagePrice ?? 0,
 							effectiveCurrencyCode ?? '',
@@ -413,7 +413,7 @@ function DIFMPagePicker( props: StepProps ) {
 							),
 					},
 					args: {
-						freePageCount: difmTieredPriceDetails?.numberOfIncludedPages,
+						freePageCount: difmTieredPriceDetails?.numberOfIncludedPages as number,
 						extraPagePrice: formatCurrency(
 							difmTieredPriceDetails?.perExtraPagePrice ?? 0,
 							effectiveCurrencyCode ?? '',

--- a/client/signup/steps/page-picker/use-cart-for-difm.tsx
+++ b/client/signup/steps/page-picker/use-cart-for-difm.tsx
@@ -69,7 +69,7 @@ function getDIFMPriceBreakdownSubLabel( {
 				<>
 					{ translate( 'Service: %(productCost)s one-time fee', {
 						args: {
-							productCost: formattedOneTimeFee,
+							productCost: formattedOneTimeFee as string,
 						},
 					} ) }
 					<br></br>

--- a/client/signup/steps/site-options/site-options.tsx
+++ b/client/signup/steps/site-options/site-options.tsx
@@ -1,7 +1,7 @@
 import { Button, FormInputValidation } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import React, { ReactChild, useState } from 'react';
+import React, { useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -15,10 +15,10 @@ interface Props {
 	defaultSiteTitle: string;
 	defaultTagline: string;
 	defaultSearchTerms?: string;
-	siteTitleLabel: ReactChild;
-	siteTitleExplanation?: ReactChild;
-	taglineExplanation?: ReactChild;
-	searchTermsExplanation?: ReactChild;
+	siteTitleLabel: TranslateResult;
+	siteTitleExplanation?: TranslateResult;
+	taglineExplanation?: TranslateResult;
+	searchTermsExplanation?: TranslateResult;
 	isSiteTitleRequired?: boolean;
 	isTaglineRequired?: boolean;
 	acceptSearchTerms?: boolean;

--- a/package.json
+++ b/package.json
@@ -309,7 +309,11 @@
 		"@wordpress/interface@^4.8.0": "patch:@wordpress/interface@npm%3A4.8.0#./.yarn/patches/@wordpress-interface-npm-4.8.0-8a39ad37cf.patch",
 		"@wordpress/data-controls": "2.22.0",
 		"@wordpress/element": "4.20.0",
-		"node-abi": "3.35.0"
+		"node-abi": "3.35.0",
+		"@types/react@*": "patch:@types/react@npm%3A17.0.39#./.yarn/patches/@types-react-npm-17.0.39-b4ac1f7bfe.patch",
+		"@types/react@^17.0.39": "patch:@types/react@npm%3A17.0.39#./.yarn/patches/@types-react-npm-17.0.39-b4ac1f7bfe.patch",
+		"@types/react@>=16.9.0": "patch:@types/react@npm%3A17.0.39#./.yarn/patches/@types-react-npm-17.0.39-b4ac1f7bfe.patch",
+		"@types/react@^17.0.37": "patch:@types/react@npm%3A17.0.39#./.yarn/patches/@types-react-npm-17.0.39-b4ac1f7bfe.patch"
 	},
 	"packageManager": "yarn@3.2.3",
 	"dependenciesMeta": {

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -5,7 +5,7 @@ import {
 	__unstablePresetDuotoneFilter as PresetDuotoneFilter,
 } from '@wordpress/block-editor';
 import { useResizeObserver, useRefEffect } from '@wordpress/compose';
-import React, { useMemo, useState, useContext } from 'react';
+import React, { useMemo, useState, useContext, ReactNode } from 'react';
 import { BLOCK_MAX_HEIGHT } from '../constants';
 import useParsedAssets from '../hooks/use-parsed-assets';
 import loadScripts from '../utils/load-scripts';
@@ -15,7 +15,7 @@ import type { RenderedStyle } from '../types';
 import './block-renderer-container.scss';
 
 interface BlockRendererContainerProps {
-	children: React.ReactChild;
+	children: ReactNode;
 	styles?: RenderedStyle[];
 	scripts?: string;
 	inlineCss?: string;

--- a/packages/components/src/component-swapper/index.tsx
+++ b/packages/components/src/component-swapper/index.tsx
@@ -1,5 +1,5 @@
 import { useBreakpoint } from '@automattic/viewport-react';
-import React, { ReactChild, useEffect } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 
 const ComponentSwapper = ( {
 	className,
@@ -9,7 +9,7 @@ const ComponentSwapper = ( {
 	onSwap,
 	children,
 }: {
-	children?: ReactChild[];
+	children?: ReactNode;
 	breakpoint: string;
 	breakpointActiveComponent: React.Component | React.ReactElement;
 	breakpointInactiveComponent: React.Component | React.ReactElement;

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -29,7 +29,7 @@ export default function AnnualHighlightCards( {
 
 	const header = (
 		<h3 className="highlight-cards-heading">
-			{ Number.isFinite( year )
+			{ year != null && Number.isFinite( year )
 				? translate( '%(year)s in review', { args: { year } } )
 				: translate( 'Year in review' ) }{ ' ' }
 			{ titleHref ? (

--- a/packages/components/src/responsive-toolbar-group/README.md
+++ b/packages/components/src/responsive-toolbar-group/README.md
@@ -17,7 +17,7 @@ import Discover from 'calypso/my-sites/plugins/categories/responsive-toolbar-gro
 
 ## Props
 
-- `children`[ReactChild]: A group of react components to be rendered.
+- `children`[ReactNode]: A group of react components to be rendered.
 - `className`[string]: A classname to add to the ToolBarGroupComponent. (optional).
 - `hideRatio`[number]: The ratio in chich the components are considered to be hidden ([take a look at the IntersectionObserver docs](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#thresholds)) (optional).
 - `showRatio`[number]: The ratio in chich the components are considered to be shown ([take a look at the IntersectionObserver docs](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#thresholds)) (optional).

--- a/packages/components/src/responsive-toolbar-group/dropdown-group.tsx
+++ b/packages/components/src/responsive-toolbar-group/dropdown-group.tsx
@@ -2,7 +2,7 @@ import { ToolbarGroup, ToolbarButton, Dropdown, MenuItem, MenuGroup } from '@wor
 import { Icon, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { ReactChild, useCallback, useEffect, useRef, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
 import './style.scss';
 
@@ -19,7 +19,7 @@ export default function DropdownGroup( {
 	onClick = () => null,
 	initialActiveIndex = -1,
 }: {
-	children: ReactChild[];
+	children: ReactNode[];
 	className?: string;
 	hideRatio?: number;
 	showRatio?: number;

--- a/packages/components/src/responsive-toolbar-group/index.tsx
+++ b/packages/components/src/responsive-toolbar-group/index.tsx
@@ -1,6 +1,6 @@
 import { useBreakpoint } from '@automattic/viewport-react';
 import classnames from 'classnames';
-import { ReactChild } from 'react';
+import { ReactNode } from 'react';
 import DropdownGroup from './dropdown-group';
 import SwipeGroup from './swipe-group';
 
@@ -18,7 +18,7 @@ const ResponsiveToolbarGroup = ( {
 	hrefList = [],
 	forceSwipe = false,
 }: {
-	children: ReactChild[];
+	children: ReactNode[];
 	className?: string;
 	hideRatio?: number;
 	showRatio?: number;

--- a/packages/components/src/responsive-toolbar-group/swipe-group.tsx
+++ b/packages/components/src/responsive-toolbar-group/swipe-group.tsx
@@ -1,6 +1,6 @@
 import { ToolbarGroup, ToolbarButton as BaseToolbarButton } from '@wordpress/components';
 import classnames from 'classnames';
-import { ReactChild, useState, useRef, useEffect } from 'react';
+import { ReactNode, useState, useRef, useEffect } from 'react';
 import type { Button } from '@wordpress/components';
 
 import './style.scss';
@@ -16,7 +16,7 @@ export default function SwipeGroup( {
 	initialActiveIndex = -1,
 	hrefList = [],
 }: {
-	children: ReactChild[];
+	children: ReactNode[];
 	className?: string;
 	onClick?: ( index: number ) => void;
 	initialActiveIndex?: number;

--- a/packages/data-stores/src/contextual-help/contextual-help.tsx
+++ b/packages/data-stores/src/contextual-help/contextual-help.tsx
@@ -4,8 +4,8 @@ import { RESULT_TOUR, RESULT_VIDEO } from './constants';
 export type LinksForSection = {
 	readonly link: string;
 	post_id?: number;
-	readonly title: React.ReactChild;
-	readonly description?: React.ReactChild;
+	readonly title: string;
+	readonly description?: string;
 	readonly intent?: string;
 	icon?: string;
 };

--- a/packages/help-center/src/components/help-center-notice.tsx
+++ b/packages/help-center/src/components/help-center-notice.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 function getResponses( siteName?: string ) {
-	const responses: Record< AnalysisReport[ 'result' ], React.ReactChild > = {
+	const responses: Record< AnalysisReport[ 'result' ], React.ReactElement | string > = {
 		NOT_OWNED_BY_USER: (
 			<p>
 				{ sprintf(

--- a/packages/help-center/src/components/index.d.ts
+++ b/packages/help-center/src/components/index.d.ts
@@ -128,7 +128,7 @@ declare module 'calypso/state/inline-help/selectors/get-admin-help-results' {
 }
 
 declare module 'calypso/lib/formatting' {
-	export const decodeEntities: ( text: string | React.ReactChild ) => string;
+	export const decodeEntities: ( text: string ) => string;
 	export const preventWidows: ( text: string, wordsToKeep?: number ) => string;
 }
 

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -41,7 +41,7 @@ export interface FeatureFlags {
 
 export interface SearchResult {
 	link: string;
-	title: string | React.ReactChild;
+	title: string;
 	content?: string;
 	icon?: string;
 	post_id?: number;

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -3,7 +3,7 @@
 
 import * as React from 'react';
 
-type LocaleData = Record< string, any >;
+type LocaleData = Record< string, unknown >;
 type NormalizedTranslateArgs =
 	| ( TranslateOptions & { original: string } )
 	| ( TranslateOptions & {
@@ -12,7 +12,11 @@ type NormalizedTranslateArgs =
 			count: number;
 	  } );
 
-export type Substitution = string | number | React.ReactFragment;
+// This type represents things that React can render, but which also exist. (E.g.
+// not nullable, not undefined, etc.)
+type ExistingReactNode = React.ReactElement | string | number;
+
+export type Substitution = ExistingReactNode;
 
 export type Substitutions =
 	| Substitution
@@ -25,7 +29,7 @@ export interface ComponentInterpolations {
 
 export interface TranslateOptions {
 	/**
-	 * Arguments you would pass into sprintf to be run against the text for string substitution.
+	 * Arguments you would pass into sprintf to be run against the text for string substitution. Each substitution must exist. Iff a substitution shouldn't exist in some cases, pass an empty string to make the substitution explicit.
 	 */
 	args?: Substitutions;
 
@@ -56,7 +60,7 @@ export type TranslateOptionsPluralText = TranslateOptionsPlural & { textOnly: tr
 
 // Translate hooks, like component interpolation or highlighting untranslated strings,
 // force us to declare the return type as a generic React node, not as just string.
-export type TranslateResult = React.ReactChild;
+export type TranslateResult = ExistingReactNode;
 
 export interface NumberFormatOptions {
 	decimals?: number;
@@ -65,21 +69,30 @@ export interface NumberFormatOptions {
 }
 
 export type TranslateHook = (
-	translation: React.ReactChild,
+	translation: ExistingReactNode,
 	options: NormalizedTranslateArgs
-) => React.ReactChild;
+) => ExistingReactNode;
 
 export type ComponentUpdateHook = ( ...args: any ) => any;
 
 export type EventListener = ( ...payload: any ) => any;
 
 export interface I18N {
-	translate( options: DeprecatedTranslateOptions ): React.ReactChild;
+	/**
+	 * Translate a string.
+	 *
+	 * @example translate( "Hello, %(name)s", { args: { name: "World" } } );
+	 * @param original The original string to translate.
+	 * @param options Options for the translation. Note that substutions must exist.
+	 * If a substitution really should result in a blank string, pass an empty
+	 * string to make that explicit.
+	 */
+	translate( options: DeprecatedTranslateOptions ): ExistingReactNode;
 	translate( original: string ): string;
-	translate( original: string ): React.ReactChild;
-	translate( original: string, options: TranslateOptions ): React.ReactChild;
+	translate( original: string ): ExistingReactNode;
+	translate( original: string, options: TranslateOptions ): ExistingReactNode;
 	translate( original: string, options: TranslateOptionsText ): string;
-	translate( original: string, plural: string, options: TranslateOptionsPlural ): React.ReactChild;
+	translate( original: string, plural: string, options: TranslateOptionsPlural ): ExistingReactNode;
 	translate( original: string, plural: string, options: TranslateOptionsPluralText ): string;
 
 	numberFormat( number: number, numberOfDecimalPlaces: number ): string;

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -29,7 +29,7 @@ export interface ComponentInterpolations {
 
 export interface TranslateOptions {
 	/**
-	 * Arguments you would pass into sprintf to be run against the text for string substitution. Each substitution must exist. Iff a substitution shouldn't exist in some cases, pass an empty string to make the substitution explicit.
+	 * Arguments you would pass into `sprintf` to be run against the text for string substitution. Each substitution must exist. If a substitution shouldn't exist in some cases, pass an empty string to make the substitution explicit.
 	 */
 	args?: Substitutions;
 

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -1,7 +1,7 @@
 import { WordPressLogo, JetpackLogo, WooCommerceWooLogo } from '@automattic/components';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
-import { ReactChild, ReactElement } from 'react';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { ReactElement } from 'react';
 import ActionButtons from '../action-buttons';
 import StepNavigationLink from '../step-navigation-link';
 import VideoPressLogo from '../videopress-logo';
@@ -19,9 +19,9 @@ interface Props {
 	hideNext?: boolean;
 	skipButtonAlign?: 'top' | 'bottom';
 	skipHeadingText?: string;
-	backLabelText?: string | ReactChild;
-	skipLabelText?: string | ReactChild;
-	nextLabelText?: string | ReactChild;
+	backLabelText?: TranslateResult;
+	skipLabelText?: TranslateResult;
+	nextLabelText?: TranslateResult;
 	formattedHeader?: ReactElement;
 	hideFormattedHeader?: boolean;
 	headerImageUrl?: string;

--- a/packages/onboarding/src/step-navigation-link/index.tsx
+++ b/packages/onboarding/src/step-navigation-link/index.tsx
@@ -1,13 +1,12 @@
 import { Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
-import { ReactChild } from 'react';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import './style.scss';
 
 interface Props {
 	direction: 'back' | 'forward';
 	handleClick?: () => void;
-	label?: string | ReactChild;
+	label?: TranslateResult;
 	hasBackIcon?: boolean;
 	hasForwardIcon?: boolean;
 	primary?: boolean;

--- a/packages/sites/src/use-sites-list-grouping.tsx
+++ b/packages/sites/src/use-sites-list-grouping.tsx
@@ -18,7 +18,7 @@ export const siteLaunchStatusGroupValues = [
 export type GroupableSiteLaunchStatuses = ( typeof siteLaunchStatusGroupValues )[ number ];
 
 export interface Status {
-	title: React.ReactChild;
+	title: string;
 	name: GroupableSiteLaunchStatuses;
 	count: number;
 	hiddenCount: number;

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -752,7 +752,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 	const isDomainMapping = productSlug === 'domain_map';
 
 	if ( ( isDomainRegistration || isDomainMapping ) && product.months_per_bill_period === 12 ) {
-		const premiumLabel = product.extra?.premium ? translate( 'Premium' ) : null;
+		const premiumLabel = product.extra?.premium ? translate( 'Premium' ) : '';
 
 		return (
 			<>

--- a/packages/wpcom-template-parts/src/types.ts
+++ b/packages/wpcom-template-parts/src/types.ts
@@ -13,7 +13,7 @@ export interface FooterProps {
 	onLanguageChange?: React.ChangeEventHandler< HTMLSelectElement >;
 	isLoggedIn?: boolean;
 	currentRoute?: string;
-	additionalCompanyLinks?: React.ReactChild | null;
+	additionalCompanyLinks?: React.ReactNode;
 }
 export interface PureFooterProps extends FooterProps {
 	localizeUrl?: ReturnType< typeof useLocalizeUrl >;


### PR DESCRIPTION
## Proposed Changes
React 18 includes fixes and changes for certain React types. Notably, `ReactFragment` is changing from `{} | Iterable<ReactNode>` to simply `Iterable<ReactNode>`. Additionally, the `ReactChild` and `ReactText` types have been deprecated.

The first change is big because it makes `ReactFragment` much narrower -- so types which used to be accepted now aren't.

The core place this impacts us is the translation function, which relied on `ReactFragment` before. With the `{}` type, that means the `translation` function currently accepts substitutions which might not exist. We don't want that behavior; we only want to accept substitutions which do exist.

Since this requires a lot of changes, I propose we separate it from #77046 and work on it here:

1. We can patch `@types/react` to simply remove `{}` on `ReactFragment`. This lets us get the biggest part of the upgrade in the repo more quickly. (We'll remove this after #77046 is merged.)
2. Ban `ReactChild` and `ReactText` across the repo to prevent new uses.
3. Migrate away from `ReactChild` and `ReactText`
4. Fix type issues associated with all these changes

## Testing Instructions

Typecheck should pass. Most changes should be to types.
