### PR TITLE
Subscription Management: Show new unsubscribe modal for individual subscriptions page

### DIFF
--- a/client/components/confirm-modal/README.md
+++ b/client/components/confirm-modal/README.md
@@ -12,6 +12,7 @@ import ConfirmModal from './ConfirmModal';
 
 The ConfirmModal component accepts the following props:
 
+- `isVisible`: Whether the modal is visible or not.
 - `cancelButtonLabel` (optional): Label or content for the cancel button.
 - `confirmButtonLabel` (optional): Label or content for the confirm button.
 - `text` (optional): Additional text to display in the modal.
@@ -23,6 +24,7 @@ The ConfirmModal component accepts the following props:
 
 ```jsx
 <ConfirmModal
+  isVisible={isVisible}
   cancelButtonLabel="Cancel"
   confirmButtonLabel="Confirm"
   text="Are you sure you want to proceed?"

--- a/client/components/confirm-modal/README.md
+++ b/client/components/confirm-modal/README.md
@@ -1,0 +1,35 @@
+# ConfirmModal Component
+
+The ConfirmModal component is a reusable component that provides a confirmation dialog with customizable buttons and text.
+
+## Usage
+
+Import the ConfirmModal component in your project:
+
+```jsx
+import ConfirmModal from './ConfirmModal';
+```
+
+The ConfirmModal component accepts the following props:
+
+- `cancelButtonLabel` (optional): Label or content for the cancel button.
+- `confirmButtonLabel` (optional): Label or content for the confirm button.
+- `text` (optional): Additional text to display in the modal.
+- `title`: Title of the confirmation modal.
+- `onCancel`: Callback function to handle the cancel button click event.
+- `onConfirm`: Callback function to handle the confirm button click event.
+
+## Example usage:
+
+```jsx
+<ConfirmModal
+  cancelButtonLabel="Cancel"
+  confirmButtonLabel="Confirm"
+  text="Are you sure you want to proceed?"
+  title="Confirmation"
+  onCancel={handleCancel}
+  onConfirm={handleConfirm}
+/>
+```
+
+Make sure to define the `handleCancel` and `handleConfirm` functions in your code to handle the respective button click events.

--- a/client/components/confirm-modal/README.md
+++ b/client/components/confirm-modal/README.md
@@ -20,7 +20,7 @@ The ConfirmModal component accepts the following props:
 - `onCancel`: Callback function to handle the cancel button click event.
 - `onConfirm`: Callback function to handle the confirm button click event.
 
-## Example usage:
+## Example usage
 
 ```jsx
 <ConfirmModal

--- a/client/components/confirm-modal/index.tsx
+++ b/client/components/confirm-modal/index.tsx
@@ -4,6 +4,7 @@ import './styles.scss';
 import { useTranslate } from 'i18n-calypso';
 
 type ConfirmModalProps = {
+	isVisible: boolean;
 	cancelButtonLabel?: string | React.ReactChild;
 	confirmButtonLabel?: string | React.ReactChild;
 	text?: string | React.ReactChild;
@@ -13,6 +14,7 @@ type ConfirmModalProps = {
 };
 
 const ConfirmModal = ( {
+	isVisible,
 	cancelButtonLabel,
 	confirmButtonLabel,
 	text,
@@ -21,6 +23,10 @@ const ConfirmModal = ( {
 	onConfirm,
 }: ConfirmModalProps ) => {
 	const translate = useTranslate();
+
+	if ( ! isVisible ) {
+		return null;
+	}
 
 	return (
 		<Modal overlayClassName="confirm-modal" title={ title } onRequestClose={ onCancel }>

--- a/client/components/confirm-modal/index.tsx
+++ b/client/components/confirm-modal/index.tsx
@@ -1,0 +1,40 @@
+import { Button } from '@automattic/components';
+import { Modal } from '@wordpress/components';
+import './styles.scss';
+import { useTranslate } from 'i18n-calypso';
+
+type ConfirmModalProps = {
+	cancelButtonLabel?: string | React.ReactChild;
+	confirmButtonLabel?: string | React.ReactChild;
+	text?: string | React.ReactChild;
+	title: string;
+	onCancel: () => void;
+	onConfirm: () => void;
+};
+
+const ConfirmModal = ( {
+	cancelButtonLabel,
+	confirmButtonLabel,
+	text,
+	title,
+	onCancel,
+	onConfirm,
+}: ConfirmModalProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<Modal overlayClassName="confirm-modal" title={ title } onRequestClose={ onCancel }>
+			{ text && <p>{ text }</p> }
+			<div className="confirm-modal__buttons">
+				<Button className="confirm-modal__cancel" onClick={ onCancel }>
+					{ cancelButtonLabel ?? translate( 'Cancel' ) }
+				</Button>
+				<Button onClick={ onConfirm } primary>
+					{ confirmButtonLabel ?? translate( 'Confirm' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+};
+
+export default ConfirmModal;

--- a/client/components/confirm-modal/styles.scss
+++ b/client/components/confirm-modal/styles.scss
@@ -20,6 +20,7 @@
 
 		p {
 			margin-top: 24px;
+			margin-bottom: 24px;
 		}
 	}
 

--- a/client/components/confirm-modal/styles.scss
+++ b/client/components/confirm-modal/styles.scss
@@ -1,7 +1,7 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
 
-.unsubscribe-modal {
+.confirm-modal {
 	.components-modal__frame {
 		max-width: 563px;
 	}
@@ -23,7 +23,7 @@
 		}
 	}
 
-	.unsubscribe-modal__buttons {
+	.confirm-modal__buttons {
 		display: flex;
 		justify-content: flex-end;
 		gap: 10px;

--- a/client/landing/subscriptions/components/cancel-paid-subscription-modal/cancel-paid-subscription-modal.tsx
+++ b/client/landing/subscriptions/components/cancel-paid-subscription-modal/cancel-paid-subscription-modal.tsx
@@ -1,0 +1,31 @@
+import { useTranslate } from 'i18n-calypso';
+import ConfirmModal from 'calypso/components/confirm-modal';
+
+type CancelPaidSubscriptionModalProps = {
+	isVisible: boolean;
+	onCancel: () => void;
+	onConfirm: () => void;
+};
+
+const CancelPaidSubscriptionModal = ( {
+	isVisible,
+	onCancel,
+	onConfirm,
+}: CancelPaidSubscriptionModalProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<ConfirmModal
+			isVisible={ isVisible }
+			confirmButtonLabel={ translate( 'Manage purchases' ) }
+			text={ translate(
+				'Looks like you’re trying to cancel a paid subscription. To do so, you’ll need to cancel the subscription plan first.'
+			) }
+			title={ translate( 'Cancel paid subscription' ) }
+			onCancel={ onCancel }
+			onConfirm={ onConfirm }
+		/>
+	);
+};
+
+export default CancelPaidSubscriptionModal;

--- a/client/landing/subscriptions/components/cancel-paid-subscription-modal/index.ts
+++ b/client/landing/subscriptions/components/cancel-paid-subscription-modal/index.ts
@@ -1,0 +1,1 @@
+export { default as CancelPaidSubscriptionModal } from './cancel-paid-subscription-modal';

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
@@ -8,6 +8,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import TimeSince from 'calypso/components/time-since';
 import { Notice, NoticeState, NoticeType } from 'calypso/landing/subscriptions/components/notice';
 import { SiteIcon } from 'calypso/landing/subscriptions/components/site-icon';
+import { CancelPaidSubscriptionModal } from '../cancel-paid-subscription-modal';
 import {
 	PaymentPlan,
 	SiteSubscriptionDetailsProps,
@@ -31,6 +32,7 @@ const SiteSubscriptionDetails = ( {
 	const translate = useTranslate();
 	const localeSlug = useLocale();
 	const [ notice, setNotice ] = useState< NoticeState | null >( null );
+	const [ showUnsubscribeModal, setShowUnsubscribeModal ] = useState( false );
 
 	const {
 		mutate: subscribe,
@@ -44,16 +46,6 @@ const SiteSubscriptionDetails = ( {
 		isSuccess: unsubscribed,
 		error: unsubscribeError,
 	} = SubscriptionManager.useSiteUnsubscribeMutation( blogId );
-
-	const confirmUnsubscribe = ( { blogId, url }: { blogId: string; url: string } ) => {
-		if (
-			confirm(
-				'You currently have paid subscriptions with this site. Paid subscriptions must be cancelled separately by clicking the Manage Subscriptions button or going to https://wordpress.com/me/purchases.\n\nPress OK to proceed with unsubscribing from the site.\nPress Cancel to go back.'
-			)
-		) {
-			unsubscribe( { blog_id: blogId, url } );
-		}
-	};
 
 	const [ paymentPlans, setPaymentPlans ] = useState< PaymentPlan[] >( [] );
 
@@ -90,6 +82,19 @@ const SiteSubscriptionDetails = ( {
 			setPaymentPlans( newPaymentPlans );
 		}
 	}, [ paymentDetails ] );
+
+	const onClickCancelSubscriptionButton = () => {
+		if ( paymentPlans && !! paymentPlans.length ) {
+			setShowUnsubscribeModal( true );
+		} else {
+			unsubscribe( { blog_id: blogId, url } );
+		}
+	};
+
+	const onConfirmCancelSubscription = () => {
+		window.open( '/me/purchases', '_blank' );
+		setShowUnsubscribeModal( false );
+	};
 
 	const subscriberCountText = subscriberCount
 		? translate( '%s subscriber', '%s subscribers', {
@@ -258,7 +263,7 @@ const SiteSubscriptionDetails = ( {
 						) }
 						<Button
 							className="site-subscription-page__unsubscribe-button"
-							onClick={ () => confirmUnsubscribe( { blogId, url } ) }
+							onClick={ onClickCancelSubscriptionButton }
 							disabled={ unsubscribing }
 						>
 							{ translate( 'Cancel subscription' ) }
@@ -266,6 +271,12 @@ const SiteSubscriptionDetails = ( {
 					</div>
 				</>
 			) }
+
+			<CancelPaidSubscriptionModal
+				isVisible={ showUnsubscribeModal }
+				onCancel={ () => setShowUnsubscribeModal( false ) }
+				onConfirm={ onConfirmCancelSubscription }
+			/>
 		</>
 	);
 };

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -47,12 +47,9 @@ const UnsubscribeModal = ( { subscriber, onCancel, onConfirm }: UnsubscribeModal
 		? paidSubscriberProps
 		: freeSubscriberProps;
 
-	if ( ! subscriber ) {
-		return null;
-	}
-
 	return (
 		<ConfirmModal
+			isVisible={ !! subscriber }
 			confirmButtonLabel={ confirmButtonLabel }
 			text={ text }
 			title={ title }

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -15,27 +15,30 @@ const useUnsubscribeModal = ( siteId: number | null, currentPage: number ) => {
 		setCurrentSubscriber( subscriber );
 	};
 
-	const onCloseModal = ( action: UnsubscribeActionType, subscriber?: Subscriber ) => {
+	const resetSubscriber = () => {
+		setCurrentSubscriber( undefined );
+	};
+
+	const onConfirmModal = ( action: UnsubscribeActionType, subscriber?: Subscriber ) => {
 		if ( action === UnsubscribeActionType.Manage ) {
 			window.open( getEarnPaymentsPageUrl( selectedSiteSlug ), '_blank' );
 		} else if ( action === UnsubscribeActionType.Unsubscribe && subscriber ) {
 			mutate( subscriber );
 		}
 
-		setCurrentSubscriber( undefined );
+		resetSubscriber();
 	};
 
 	// Reset current subscriber on unmount
 	useEffect( () => {
-		return () => {
-			setCurrentSubscriber( undefined );
-		};
+		return resetSubscriber;
 	}, [] );
 
 	return {
 		currentSubscriber,
 		onClickUnsubscribe,
-		onCloseModal,
+		onConfirmModal,
+		resetSubscriber,
 	};
 };
 

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -30,10 +30,8 @@ export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
 	} = result && result.data ? result : initialState;
 	const { isFetching } = result;
 	const { pageClickCallback } = usePagination( page, pageChanged, isFetching );
-	const { currentSubscriber, onClickUnsubscribe, onCloseModal } = useUnsubscribeModal(
-		selectedSiteId,
-		page
-	);
+	const { currentSubscriber, onClickUnsubscribe, onConfirmModal, resetSubscriber } =
+		useUnsubscribeModal( selectedSiteId, page );
 
 	const navigationItems: Item[] = [
 		{
@@ -88,7 +86,11 @@ export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
 
 			{ !! total && <GrowYourAudience /> }
 
-			<UnsubscribeModal subscriber={ currentSubscriber } onClose={ onCloseModal } />
+			<UnsubscribeModal
+				subscriber={ currentSubscriber }
+				onCancel={ resetSubscriber }
+				onConfirm={ onConfirmModal }
+			/>
 		</Main>
 	);
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78250

## Proposed Changes

* Extract the modal layout to ConfirmModal component
* Apply the ConfirmModal to the UnsubscribeModal component
* Create a new modal CancelPaidSubscriptionModal
* Apply the CancelPaidSubscriptionModal to the Individual Subscription page

## Testing Instructions

* Apply this PR to your local env
* Go to http://calypso.localhost:3000/subscriptions/sites
* Open a free subscription
* Click on "Cancel subscription"
* You should be unsubscribed right away
* Open a paid subscription
* Click on "Cancel subscription"
* You should see the modal below
* Click on "Manage purchases"
* You should be redirected to `/me/purchases`

<img width="581" alt="Screenshot 2023-06-15 at 20 23 49" src="https://github.com/Automattic/wp-calypso/assets/3113712/e0896c64-073d-40b2-9f30-f62b09d85668">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
