### PR TITLE
Site Transfers: Update language to communicate site owner is kept as an administrator

### DIFF
--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -182,7 +182,7 @@ const ContentAndOwnershipCard = ( {
 							// translators: siteSlug is the current site slug, siteOwner is the user that the site is going to
 							// transer to
 							translate(
-								'You will not be able to access <strong>%(siteSlug)s</strong> unless allowed by <strong>%(siteOwner)s</strong>.'
+								'You will remain as an administrator on <strong>%(siteSlug)s</strong>, unless removed by <strong>%(siteOwner)s</strong>.'
 							),
 							{ siteSlug, siteOwner }
 						),
@@ -195,7 +195,7 @@ const ContentAndOwnershipCard = ( {
 							// translators: siteSlug is the current site slug, siteOwner is the user that the site is going to
 							// transer to
 							translate(
-								'Your posts on <strong>%(siteSlug)s</strong> will be transferred to <strong>%(siteOwner)s</strong> and will no longer be authored by your account.'
+								'Your posts on <strong>%(siteSlug)s</strong> will remain with your account, unless they are transferred to <strong>%(siteOwner)s</strong>.'
 							),
 							{ siteSlug, siteOwner }
 						),


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/2579

## Proposed Changes

Updates the language on the Site Transfer confirmation screen to clarify that the original site owner will be kept as an administrator.

### Before

<img width="814" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/b70334b3-3339-4ab8-9a79-87af857e1b02">

### After

<img width="797" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/081229ef-5ccf-4ce3-a321-7b32dd9370b9">

## Testing Instructions

1. Navigate to General Settings -> Site transfer and verify the language appears as expected.