### PR TITLE
Subscribers: fix REST API (rest/v1.1) call

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -3,7 +3,6 @@ import wpcom from 'calypso/lib/wp';
 
 const querySubscribersTotals = ( siteId: number | null ): Promise< any > => {
 	return wpcom.req.get( {
-		method: 'GET',
 		path: `/sites/${ siteId }/stats/followers`,
 	} );
 };

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -2,29 +2,17 @@ import { useQueries } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
 const querySubscribersTotals = ( siteId: number | null ): Promise< any > => {
-	return wpcom.req.get(
-		{
-			method: 'GET',
-			apiNamespace: 'rest/v1.1',
-			path: `/sites/${ siteId }/stats/followers`,
-		},
-		{
-			http_envelope: 1,
-		}
-	);
+	return wpcom.req.get( {
+		method: 'GET',
+		path: `/sites/${ siteId }/stats/followers`,
+	} );
 };
 
 const queryMore = ( siteId: number | null ): Promise< any > => {
-	return wpcom.req.get(
-		{
-			method: 'GET',
-			apiNamespace: 'wpcom/v2',
-			path: `/sites/${ siteId }/subscribers/counts`,
-		},
-		{
-			http_envelope: 1,
-		}
-	);
+	return wpcom.req.get( {
+		apiNamespace: 'wpcom/v2',
+		path: `/sites/${ siteId }/subscribers/counts`,
+	} );
 };
 
 const selectSubscribers = ( payload: {
@@ -69,14 +57,14 @@ export default function useSubscribersTotalsQueries( siteId: number | null ) {
 
 	return {
 		data: {
-			total_email: queries[ 0 ]?.data?.total_email || 0,
-			total_wpcom: queries[ 0 ]?.data?.total_wpcom || 0,
+			total_email: queries[ 0 ]?.data?.total_email,
+			total_wpcom: queries[ 0 ]?.data?.total_wpcom,
 			total_email_free:
 				queries[ 0 ]?.data?.total_email !== undefined &&
 				queries[ 1 ]?.data?.total_email_paid !== undefined
 					? queries[ 0 ]?.data?.total_email - queries[ 1 ]?.data?.total_email_paid
-					: 0,
-			total_email_paid: queries[ 1 ]?.data?.total_email_paid || 0,
+					: queries[ 0 ]?.data?.total_email,
+			total_email_paid: queries[ 1 ]?.data?.total_email_paid,
 		},
 		isLoading: queries.some( ( result ) => result.isLoading ),
 		isError: queries.some( ( result ) => result.isError ),

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -28,7 +28,11 @@ function useSubscriberHighlights( siteId: number | null ) {
 
 	if ( isLoading || isError ) {
 		// Nulling the count values makes the count comparison card render a '-' instead of a '0'.
-		highlights.map( ( h ) => ( h.count = null ) );
+		highlights.map( ( h ) => {
+			if ( ! h.count && h.count !== 0 ) {
+				h.count = null;
+			}
+		} );
 	}
 	return highlights;
 }


### PR DESCRIPTION
## Proposed Changes

- Fixes the call to Rest API (rest/v1.1). We don't have to pass the envelope options, as on wpcom it's already using enveloped mode, the parameter of which actually would be [automatically added](https://github.com/Automattic/wp-calypso/blob/8af266b9829a0bd2011d1cff1016146f02285693/packages/wpcom-xhr-request/src/index.js#LL246C2-L246C2).
- It also removes the default value 0 for followers, because the value could actually be zero and at the same time there are some errors (because there are two queries!).
- Default free email subscriber number to email subscriber number if paid is undefined (it is currently the case for Odyssey, because it’s not yet supported. )

cc @grzegorz-cp

## Testing Instructions

#### Calypso

* Open Live branch
* Open Subscribers page
* Ensure Highlights card shows the right numbers

#### Odyssey

* Build the branch for Odyssey
    * `STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Build Jetpack if necessary
    * `jetpack build plugins/jetpack`
* Open `/wp-admin/admin.php?page=stats`.
* Open Subscribers page
* Ensure only Paid Subscribers shows a `-` (not supported)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
