### PR TITLE
Revert "Hide the GA promo banner for now until the translation is finished"

### DIFF
--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -78,11 +78,9 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	const showYoastPromo =
 		! useSelector( isBlockDismissed( EVENT_YOAST_PROMO_DISMISS ) ) && ! jetpackNonAtomic;
 
-	// TODO: remove the false here once the translation is done
 	const showGoogleAnalyticsPromo =
 		! useSelector( isBlockDismissed( EVENT_GOOGLE_ANALYTICS_BANNER_DISMISS ) ) &&
-		( isFreePlan( currentPlanSlug ) || isPersonalPlan( currentPlanSlug ) ) &&
-		false;
+		( isFreePlan( currentPlanSlug ) || isPersonalPlan( currentPlanSlug ) );
 
 	const viewEvents = useMemo( () => {
 		const events = [];


### PR DESCRIPTION
Reverts Automattic/wp-calypso#77999 since now the translation has been done.