### PR TITLE
BackupBrowser: Fix backup browser zebra striping on sub-nodes

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -1,5 +1,6 @@
 import { Button, Icon } from '@wordpress/components';
 import { chevronDown, chevronRight } from '@wordpress/icons';
+import classNames from 'classnames';
 import { FunctionComponent, useCallback, useState } from 'react';
 import FileTypeIcon from './file-type-icon';
 import { FileBrowserItem } from './types';
@@ -10,6 +11,7 @@ interface FileBrowserNodeProps {
 	path: string;
 	siteId: number;
 	rewindId: number;
+	isAlternate: boolean; // This decides if the node will have a background color or not
 }
 
 const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
@@ -17,6 +19,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 	path,
 	siteId,
 	rewindId,
+	isAlternate,
 } ) => {
 	const isRoot = path === '/';
 	const hasChildren = item.hasChildren;
@@ -49,7 +52,11 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 
 		// @TODO: Add a message when the API fails to fetch
 		if ( isSuccess ) {
+			let childIsAlternate = isAlternate;
+
 			return backupFiles.map( ( item ) => {
+				childIsAlternate = ! childIsAlternate;
+
 				return (
 					<FileBrowserNode
 						key={ item.name }
@@ -57,6 +64,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 						path={ `${ path }${ item.name }/` }
 						siteId={ siteId }
 						rewindId={ rewindId }
+						isAlternate={ childIsAlternate }
 					/>
 				);
 			} );
@@ -73,8 +81,10 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 		return <Icon icon={ isOpen ? chevronDown : chevronRight } />;
 	};
 
+	const nodeClassName = classNames( 'file-browser-node', { 'is-alternate': isAlternate } );
+
 	return (
-		<div className="file-browser-node">
+		<div className={ nodeClassName }>
 			{ isRoot ? null : (
 				<Button
 					icon={ renderExpandIcon }

--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -14,7 +14,15 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( { siteId, rewindId 
 		hasChildren: true,
 	};
 
-	return <FileBrowserNode siteId={ siteId } rewindId={ rewindId } item={ rootItem } path="/" />;
+	return (
+		<FileBrowserNode
+			siteId={ siteId }
+			rewindId={ rewindId }
+			item={ rootItem }
+			path="/"
+			isAlternate={ true }
+		/>
+	);
 };
 
 export default FileBrowser;

--- a/client/my-sites/backup/backup-contents-page/file-browser/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/util.ts
@@ -93,10 +93,10 @@ export const parseBackupContentsData = ( payload: BackupLsResponse ): FileBrowse
 		}
 
 		// If 'sort' field doesn't exist in either, then 'dir' types come first
-		if ( a.type === 'dir' && b.type !== 'dir' ) {
+		if ( a.hasChildren === true && b.hasChildren !== true ) {
 			return -1;
 		}
-		if ( b.type === 'dir' && a.type !== 'dir' ) {
+		if ( b.hasChildren === true && a.hasChildren !== true ) {
 			return 1;
 		}
 

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -24,6 +24,8 @@
 		}
 
 		&__contents {
+			background-color: #fff;
+
 			&:not(:first-child) {
 				padding-left: 26px;
 			}
@@ -39,14 +41,8 @@
 			height: 32px;
 		}
 
-		&:not(:first-child) {
-			&:nth-child(even) {
-				background-color: var(--studio-gray-0);
-			}
-
-			&:nth-child(odd) {
-				background-color: #fff;
-			}
+		.is-alternate {
+			background-color: var(--studio-gray-0);
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Add a `isAlternate` prop to `FileBrowserNode` that will help us to decide which node will have a colored background and which not. Any time a new `FileBrowserNode` child is created, it will toggle the flag. This way, sub-nodes will start with a different background color than their parents.
* Sort items by `hasChildren` instead of by `type === 'dir'`. This way it will sort plugins and themes as well.

## Screenshots
| Change | Screenshot before | Screenshot after |
|---|---|---|
| Zebra striping | <img width="652" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/b5000c9c-5a91-4d43-8021-8a78d435710f"> | <img width="645" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/e8334c44-0b69-4d1b-94bd-b9183629b651"> |
| Sort items | <img width="614" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/281165ec-7934-46e6-9160-5e15207c9f85"> | <img width="618" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/4ea03336-1dc7-4856-899f-e217b287dc24"> |

## Known issues
There might be cases where the last item in a directory will have the same background as the next upper level element.

## Testing Instructions
* Start a Jetpack Cloud live branch.
* Select one of your sites with a Jetpack VaultPress Backup plan
* Navigate to VaultPress Backup page
* Add `?flags=jetpack/backup-contents-page` at the end of the URL and refresh the page.
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* On the daily backup card, click on `Actions (+)` and then click on `View files`.
* You should see a page similar to the one shared above.
* Ensure that the first item inside a directory starts with a background different from its parent.
* Also validate that `wp-content/plugins` and `wp-content/themes` are sorted as the image shared above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
