### PR TITLE
Stats E2E: fix flaky Insights test

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -27,7 +27,7 @@ export class StatsPage {
 	 */
 	async clickTab( name: StatsTabs ): Promise< void > {
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			const dismissModalButton = await this.page.getByRole( 'button', { name: 'Got it' } );
+			const dismissModalButton = this.page.getByRole( 'button', { name: 'Got it' } );
 			await dismissModalButton.click();
 			await dismissModalButton.waitFor( { state: 'hidden' } );
 		}

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -27,7 +27,7 @@ export class StatsPage {
 	 */
 	async clickTab( name: StatsTabs ): Promise< void > {
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			const dismissModalButton = this.page.getByRole( 'button', { name: 'Got it' } );
+			const dismissModalButton = await this.page.getByRole( 'button', { name: 'Got it' } );
 			await dismissModalButton.click();
 			await dismissModalButton.waitFor( { state: 'hidden' } );
 		}

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -1,5 +1,6 @@
 import { Page } from 'playwright';
 import { clickNavTab } from '../../element-helper';
+import envVariables from '../../env-variables';
 
 export type StatsTabs = 'Traffic' | 'Insights' | 'Store';
 
@@ -19,25 +20,17 @@ export class StatsPage {
 	}
 
 	/**
-	 * Suppresses the tooltips that blocks the nav menu.
-	 */
-	async suppressTooltips() {
-		await this.page.evaluate(
-			"window.localStorage.setItem('notices_dismissed__traffic_page_highlights_module_settings', '1')"
-		);
-		await this.page.evaluate(
-			"window.localStorage.setItem('notices_dismissed__traffic_page_settings', '1')"
-		);
-	}
-
-	/**
 	 * Given a string, click on the tab name on the page.
 	 *
 	 * @param {StatsTabs} name Name of the tab to click.
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickTab( name: StatsTabs ): Promise< void > {
-		await this.suppressTooltips();
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			const dismissModalButton = this.page.getByRole( 'button', { name: 'Got it' } );
+			await dismissModalButton.click();
+			await dismissModalButton.waitFor( { state: 'hidden' } );
+		}
 		await clickNavTab( this.page, name );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -26,11 +26,13 @@ export class StatsPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickTab( name: StatsTabs ): Promise< void > {
-		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			const dismissModalButton = this.page.getByRole( 'button', { name: 'Got it' } );
-			await dismissModalButton.click();
-			await dismissModalButton.waitFor( { state: 'hidden' } );
-		}
+		try {
+			if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+				const dismissModalButton = this.page.getByRole( 'button', { name: 'Got it' } );
+				await dismissModalButton.click( { timeout: 3000 } );
+				await dismissModalButton.waitFor( { state: 'hidden' } );
+			}
+		} catch ( e ) {}
 		await clickNavTab( this.page, name );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -16,11 +16,16 @@ export class StatsPage {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
-		// Surppress notices.
-		this.page.evaluate(
+	}
+
+	/**
+	 * Suppresses the tooltips that blocks the nav menu.
+	 */
+	async suppressTooltips() {
+		await this.page.evaluate(
 			"window.localStorage.setItem('notices_dismissed__traffic_page_highlights_module_settings', '1')"
 		);
-		this.page.evaluate(
+		await this.page.evaluate(
 			"window.localStorage.setItem('notices_dismissed__traffic_page_settings', '1')"
 		);
 	}
@@ -32,6 +37,7 @@ export class StatsPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickTab( name: StatsTabs ): Promise< void > {
+		await this.suppressTooltips();
 		await clickNavTab( this.page, name );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -1,6 +1,5 @@
 import { Page } from 'playwright';
 import { clickNavTab } from '../../element-helper';
-import envVariables from '../../env-variables';
 
 export type StatsTabs = 'Traffic' | 'Insights' | 'Store';
 
@@ -26,13 +25,12 @@ export class StatsPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickTab( name: StatsTabs ): Promise< void > {
-		try {
-			if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-				const dismissModalButton = this.page.getByRole( 'button', { name: 'Got it' } );
-				await dismissModalButton.click( { timeout: 3000 } );
-				await dismissModalButton.waitFor( { state: 'hidden' } );
-			}
-		} catch ( e ) {}
+		const dismissModalButton = this.page.getByRole( 'button', { name: 'Got it' } );
+
+		if ( ( await dismissModalButton.count() ) > 0 ) {
+			await dismissModalButton.click();
+			await dismissModalButton.waitFor( { state: 'hidden' } );
+		}
 		await clickNavTab( this.page, name );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/78304.

## Proposed Changes

Slack: p1686898631504189-slack-C1A1EKDGQ

<strike>`page.evaluate` is async and we'll need to wait for calls to finish.</strike>

Dismiss tooltip before clicking nav item.

## Testing Instructions

* Ensure there's no failed E2E tests caused by the PR

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?