### PR TITLE
eslint-plugin-calypso: Fix spread operator error

### DIFF
--- a/packages/eslint-plugin-wpcalypso/lib/rules/i18n-no-variables.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/i18n-no-variables.js
@@ -42,6 +42,10 @@ const rule = ( module.exports = function ( context ) {
 
 	function validateOptions( options ) {
 		return options.properties.every( function ( property ) {
+			if ( property.type === 'SpreadElement' ) {
+				return;
+			}
+
 			const key = property.key.name;
 
 			// `options.original` can be a string value to be validated in this


### PR DESCRIPTION
## Proposed Changes

This PR resolves an error with the `fix/spread-element-i18n-no-variables` custom rule where it fails when attempting to lint a `translate()` call that has a spread element used in its `args`. 

## Testing Instructions

* Cherry-pick this in #78292
* Run `yarn run lint:js` and verify it works well and is able to complete the lint process.