### PR TITLE
Fix the entire credentials page for every viewport size

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
@@ -56,13 +56,6 @@
 				width: 240px;
 			}
 
-			@include break-xlarge {
-				margin-inline-end: 0;
-				position: absolute;
-				inset-inline-end: -85px;
-				width: 250px;
-			}
-
 			h3 {
 				font-weight: 500;
 				font-size: 1rem;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Originally, the design for the credentials page during a migration flow would only center the form. The credentials helper menu would be placed next to the centered form. 

It has been decided that it would be better to center the entire page, not just the form.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start a migration via the onboarding flow.
- When you arrive on the 'You are ready to migrate' page, click on 'provide the server credentials' and verify that the page is entirely centered as in the screenshot below:

<img width="1127" alt="Screenshot 2566-06-16 at 15 25 37" src="https://github.com/Automattic/wp-calypso/assets/10244734/0270fb73-f693-4776-a842-8bcdf4e22579">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
