### PR TITLE
Add pre-emptive translations for congrats page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/remove-after-traslated/new-congrats-translations.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/remove-after-traslated/new-congrats-translations.jsx
@@ -77,6 +77,7 @@ const translations = [
 		}
 	),
 	translate( 'Use the plugins' ),
+	translate( 'Plugin guide' ),
 
 	// Plan / Annual / Without custom domain selected or included in the cart
 	translate( 'Get the best out of your site' ),
@@ -162,6 +163,7 @@ const translations = [
 	translate( 'Say hello to your new email address' ),
 	translate( 'All set! Now it’s time to update your contact details.' ),
 	translate( 'Go to inbox' ),
+	translate( 'Manage email' ),
 	translate( 'Manage your email and site from anywhere' ),
 	translate(
 		'The Jetpack mobile app for iOS and Android makes managing your email, domain, and website even simpler.'

--- a/client/my-sites/checkout/checkout-thank-you/remove-after-traslated/new-congrats-translations.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/remove-after-traslated/new-congrats-translations.jsx
@@ -46,7 +46,7 @@ const translations = [
 	translate( 'Your site looks stunning with its new theme. Take a look or start styling it up.' ),
 	translate( 'Customize the theme' ),
 	translate( 'Visit site' ),
-	translate( 'Solve anything with yout go-to theme resource' ),
+	translate( 'Solve anything with your go-to theme resource' ),
 	translate(
 		'Take a look at our comprehensive support documentation and learn more about themes.'
 	),
@@ -125,7 +125,7 @@ const translations = [
 	// Plan monthly or annual with custom domain for plans below Business
 	translate( 'A site refresh' ),
 	translate(
-		'A new look and feel can help you stand our from the crowd. Get a new theme and make an impression.'
+		'A new look and feel can help you stand out from the crowd. Get a new theme and make an impression.'
 	),
 	translate( '{{a}}Find your new theme{{/a}}', {
 		components: {

--- a/client/my-sites/checkout/checkout-thank-you/remove-after-traslated/new-congrats-translations.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/remove-after-traslated/new-congrats-translations.jsx
@@ -1,0 +1,196 @@
+import { translate } from 'i18n-calypso';
+
+const translations = [
+	// Paid theme
+	translate( 'Unveil the wow factor' ),
+	translate(
+		`All set! Activate the %(themeName)s theme and take your site's style to the next level.`,
+		{
+			args: {
+				themeName: 'Livro',
+			},
+		}
+	),
+	translate( '%(themeName)s theme', {
+		args: {
+			themeName: 'Livro',
+		},
+	} ),
+	translate( 'Available until %(date)s', {
+		args: {
+			savingsValue: 'June 30, 2022',
+		},
+	} ),
+	translate( 'Activate theme' ),
+	translate( 'Need help setting up your theme?' ),
+	translate(
+		'Check out our support documentation for step-by-step instructions and expert guidance on your theme set up.'
+	),
+	translate( '{{a}}Get set up support{{/a}}', {
+		components: {
+			a: <a href=" https://wordpress.com/support/themes/set-up-your-theme/" />,
+		},
+	} ),
+	translate( 'Your go-to theme resource' ),
+	translate(
+		'Take a look at our comprehensive support documentation and learn more about themes.'
+	),
+	translate( '{{a}}Learn more about themes{{/a}}', {
+		components: {
+			a: <a href="https://wordpress.com/support/themes/" />,
+		},
+	} ),
+
+	// Free theme
+	translate( 'Way to make an impression' ),
+	translate( 'Your site looks stunning with its new theme. Take a look or start styling it up.' ),
+	translate( 'Customize the theme' ),
+	translate( 'Visit site' ),
+	translate( 'Solve anything with yout go-to theme resource' ),
+	translate(
+		'Take a look at our comprehensive support documentation and learn more about themes.'
+	),
+
+	// Paid single plugin
+	translate( 'Your site, more powerful than ever' ),
+	translate( 'Use the plugin' ),
+	translate( 'Manage plugin' ),
+	translate( 'Need help setting your plugin up?' ),
+	translate(
+		'Check out our support documentation for step-by-step instructions and expert guidance on your plugin set up.'
+	),
+	translate( '{{a}}Plugin setup guide{{/a}}', {
+		components: {
+			a: <a href="https://wordpress.com/support/plugins/use-your-plugins/" />,
+		},
+	} ),
+	translate( 'All-in-one plugin documentation' ),
+	translate( `Unlock your plugin's potential with our comprehensive support documentation.` ),
+	translate( 'Plugin documentation' ),
+
+	// Paid multiple plugin
+	translate(
+		'All set! Time to put your new plugin to work and take your site further.',
+		'All set! Time to put your new plugins to work and take your site further.',
+		{
+			count: 2,
+		}
+	),
+	translate( 'Use the plugins' ),
+
+	// Plan / Annual / Without custom domain selected or included in the cart
+	translate( 'Get the best out of your site' ),
+	translate( 'All set! Start exploring the features included with your %(plan)s plan', {
+		args: {
+			plan: translate( 'Free' ),
+		},
+	} ),
+	translate( '%(plan)s plan', {
+		args: {
+			plan: translate( 'Free' ),
+		},
+		comment: `Shows which plan the user is on. For example, "Free plan"`,
+	} ),
+	translate( `Let’s work on the site` ),
+	translate( 'Manage plan' ),
+	translate( 'Claim your free domain ' ),
+	translate(
+		'Easy to remember. Easy to share. And free for your first year. Help people find you with a personalized site address.'
+	),
+	translate( '{{a}}Claim custom domain{{/a}}', {
+		components: {
+			a: <a href="https://wordpress.com/domains/add/" />,
+		},
+	} ),
+	translate( 'Everything you need to know' ),
+	translate( 'Explore our support guides and find an answer to every question.' ),
+	translate( '{{a}}Explore support resources{{/a}}', {
+		components: {
+			a: <a href="https://wordpress.com/support/" />,
+		},
+	} ),
+
+	// Plan monthly or annual with custom domain for Business plans and above
+	translate( 'There’s a plugin for that' ),
+	translate(
+		'With 54,000+ plugins and apps, you’ll never outgrow your website. If you can think of it, there’s a plugin to make it happen.'
+	),
+	translate( '{{a}}Discover plugins{{/a}}', {
+		components: {
+			a: <a href="https://wordpress.com/plugins/" />,
+		},
+	} ),
+
+	// Plan monthly or annual with custom domain for plans below Business
+	translate( 'A site refresh' ),
+	translate(
+		'A new look and feel can help you stand our from the crowd. Get a new theme and make an impression.'
+	),
+	translate( '{{a}}Find your new theme{{/a}}', {
+		components: {
+			a: <a href="https://wordpress.com/themes/" />,
+		},
+	} ),
+
+	// Domains
+	translate( 'Your own corner of the web' ),
+	translate(
+		'All set! We’re just setting up your new domain so you can start spreading the word.'
+	),
+	translate( 'Share site' ),
+	translate( 'Site copied' ),
+	translate( 'Dive into domain essentials' ),
+	translate(
+		'Check out our support documentation for step-by-step instructions and expert guidance on your domain set up.'
+	),
+	translate( '{{a}}Master the domain basics{{/a}}', {
+		components: {
+			a: <a href="https://wordpress.com/support/domains/" />,
+		},
+	} ),
+	translate( 'Your go-to domain resource' ),
+	translate(
+		'Dive into our comprehensive support documentation to learn the basics of domains, from registration to management.'
+	),
+	translate( '{{a}}Domain support resources{{/a}}', {
+		components: {
+			a: <a href="https://wordpress.com/support/category/domains-and-email/" />,
+		},
+	} ),
+
+	// Email (titan)
+	translate( 'Say hello to your new email address' ),
+	translate( 'All set! Now it’s time to update your contact details.' ),
+	translate( 'Go to inbox' ),
+	translate( 'Manage your email and site from anywhere' ),
+	translate(
+		'The Jetpack mobile app for iOS and Android makes managing your email, domain, and website even simpler.'
+	),
+	translate( 'Get the app' ),
+	translate( 'Email questions? We have the answers' ),
+	translate(
+		'Explore our comprehensive support guides and find solutions to all your email-related questions.'
+	),
+	translate( '{{a}}Email support resources{{/a}}', {
+		components: {
+			a: <a href="https://wordpress.com/support/category/domains-and-email/email/" />,
+		},
+	} ),
+
+	// Generic
+	translate( 'Great choices!' ),
+	translate( 'All set! Ready to take your site even further?' ),
+];
+
+const CongratsTranslations = () => (
+	<>
+		{ translations.map( ( string ) => (
+			<div>{ string }</div>
+		) ) }
+	</>
+);
+
+export const testCongratsTranslations = ( context, next ) => {
+	context.primary = <CongratsTranslations />;
+	next();
+};

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -8,6 +8,7 @@ import {
 } from 'calypso/controller';
 import { recordSiftScienceUser } from 'calypso/lib/siftscience';
 import { loggedInSiteSelection, noSite, siteSelection } from 'calypso/my-sites/controller';
+import { testCongratsTranslations } from './checkout-thank-you/remove-after-traslated/new-congrats-translations';
 import {
 	checkout,
 	checkoutAkismetSiteless,
@@ -131,6 +132,8 @@ export default function () {
 	// The no-site post-checkout route is for purchases not tied to a site so do
 	// not include the `siteSelection` middleware.
 	page( '/checkout/gift/thank-you/:site', giftThankYou, makeLayout, clientRender );
+
+	page( '/checkout/thank-you/translations', testCongratsTranslations, makeLayout, clientRender );
 
 	page(
 		'/checkout/thank-you/no-site/pending/:orderId',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2717

> **Note**
> We won't be merging the PR. We will close it when **all translations live somewhere in the code.**

## Proposed Changes

* Added translations for congrats page and a testing route to render it for easy review.

Example congrats page
<img width="1480" alt="Theme congrats NEW" src="https://github.com/Automattic/wp-calypso/assets/6586048/e281efa4-e25b-4ac8-8857-8067c0e30878">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can check the translations at `/checkout/thank-you/translations`
* See if everything reads alright, no typos and such
* Check the links

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
