### PR TITLE
Site transfer: add administrators dropdown

### DIFF
--- a/client/my-sites/site-settings/site-owner-transfer/choose-user-loading-placeholder.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/choose-user-loading-placeholder.tsx
@@ -1,0 +1,27 @@
+import { LoadingPlaceholder } from '@automattic/components';
+import styled from '@emotion/styled';
+
+const Root = styled.div( {
+	display: 'flex',
+	gap: '1em',
+	flexDirection: 'column',
+} );
+
+const ButtonPlaceholder = styled( LoadingPlaceholder )( {
+	width: '100px',
+	height: '32px',
+} );
+
+const LoadingPlaceholderStyled = styled( LoadingPlaceholder )( {
+	height: '1.7em',
+} );
+
+export function ChooseUserLoadingPlaceholder() {
+	return (
+		<Root>
+			<LoadingPlaceholderStyled />
+			<LoadingPlaceholderStyled />
+			<ButtonPlaceholder />
+		</Root>
+	);
+}

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -35,6 +35,16 @@ const ErrorText = styled.p( {
 	fontSize: '100%',
 } );
 
+const AdministratorsExplanation = styled( FormSettingExplanation )( {
+	a: {
+		color: 'var(--studio-gray-50)',
+		textDecoration: 'underline',
+		'&:hover': {
+			color: 'var(--studio-gray-80)',
+		},
+	},
+} );
+
 const SiteOwnerTransferEligibility = ( {
 	siteId,
 	siteSlug,
@@ -114,7 +124,7 @@ const SiteOwnerTransferEligibility = ( {
 						<ErrorText>{ siteTransferEligibilityError }</ErrorText>
 					</Error>
 				) }
-				<FormSettingExplanation>
+				<AdministratorsExplanation>
 					{ translate(
 						'If you don`t see the new owner in the list, {{linkToUsers}} add them as an administrator {{/linkToUsers}}',
 						{
@@ -123,7 +133,7 @@ const SiteOwnerTransferEligibility = ( {
 							},
 						}
 					) }
-				</FormSettingExplanation>
+				</AdministratorsExplanation>
 			</FormFieldset>
 
 			<ButtonStyled

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -110,7 +110,7 @@ const SiteOwnerTransferEligibility = ( {
 	const currentUser = useSelector( getCurrentUser );
 	const { administrators, isLoading } = useAdministrators( {
 		siteId,
-		excludeUserIDs: [ currentUser?.ID as number ],
+		excludeUserEmails: [ currentUser?.email as string ],
 	} );
 
 	if ( isLoading ) {

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -151,7 +151,7 @@ const SiteOwnerTransferEligibility = ( {
 				) }
 				<AdministratorsExplanation>
 					{ translate(
-						'If you don`t see the new owner in the list, {{linkToUsers}} add them as an administrator {{/linkToUsers}}',
+						'If you don’t see the new owner in the list, {{linkToUsers}} add them as an administrator.{{/linkToUsers}}',
 						{
 							components: {
 								linkToUsers: <a href={ addUsersHref } />,

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -45,6 +45,26 @@ const AdministratorsExplanation = styled( FormSettingExplanation )( {
 	},
 } );
 
+function NoAdministrators( { href, siteSlug }: { href: string; siteSlug: string } ) {
+	const translate = useTranslate();
+	return (
+		<>
+			<p>
+				{ translate(
+					'To transfer ownership of {{strong}}%(siteSlug)s{{/strong}} to another user, first add them as an administrator of the site.',
+					{
+						args: { siteSlug },
+						components: { strong: <Strong /> },
+					}
+				) }
+			</p>
+			<ButtonStyled primary type="submit" href={ href }>
+				{ translate( 'Manage team members' ) }
+			</ButtonStyled>
+		</>
+	);
+}
+
 const SiteOwnerTransferEligibility = ( {
 	siteId,
 	siteSlug,
@@ -85,11 +105,16 @@ const SiteOwnerTransferEligibility = ( {
 		checkSiteTransferEligibility( { newSiteOwner: tempSiteOwner } );
 	};
 
+	const addUsersHref = '/people/team/' + siteSlug;
 	const currentUser = useSelector( getCurrentUser );
 	const { administrators } = useAdministrators( {
 		siteId,
 		excludeUserIDs: [ currentUser?.ID as number ],
 	} );
+
+	if ( ! administrators || administrators.length === 0 ) {
+		return <NoAdministrators href={ addUsersHref } siteSlug={ siteSlug } />;
+	}
 
 	return (
 		<form onSubmit={ handleFormSubmit }>
@@ -112,7 +137,7 @@ const SiteOwnerTransferEligibility = ( {
 					value={ tempSiteOwner }
 				>
 					<option value="">{ translate( 'Select administrator' ) }</option>
-					{ administrators?.map( ( user ) => (
+					{ administrators.map( ( user ) => (
 						<option key={ user.ID } value={ user.email }>
 							{ `${ user.login } (${ user.email })` }
 						</option>
@@ -129,7 +154,7 @@ const SiteOwnerTransferEligibility = ( {
 						'If you don`t see the new owner in the list, {{linkToUsers}} add them as an administrator {{/linkToUsers}}',
 						{
 							components: {
-								linkToUsers: <a href={ '/people/team/' + siteSlug } />,
+								linkToUsers: <a href={ addUsersHref } />,
 							},
 						}
 					) }

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -8,6 +8,7 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { ChooseUserLoadingPlaceholder } from './choose-user-loading-placeholder';
 import { useAdministrators } from './use-administrators';
 import { useCheckSiteTransferEligibility } from './use-check-site-transfer-eligibility';
 
@@ -107,10 +108,14 @@ const SiteOwnerTransferEligibility = ( {
 
 	const addUsersHref = '/people/team/' + siteSlug;
 	const currentUser = useSelector( getCurrentUser );
-	const { administrators } = useAdministrators( {
+	const { administrators, isLoading } = useAdministrators( {
 		siteId,
 		excludeUserIDs: [ currentUser?.ID as number ],
 	} );
+
+	if ( isLoading ) {
+		return <ChooseUserLoadingPlaceholder />;
+	}
 
 	if ( ! administrators || administrators.length === 0 ) {
 		return <NoAdministrators href={ addUsersHref } siteSlug={ siteSlug } />;

--- a/client/my-sites/site-settings/site-owner-transfer/use-administrators.ts
+++ b/client/my-sites/site-settings/site-owner-transfer/use-administrators.ts
@@ -1,0 +1,42 @@
+import useUsersQuery from 'calypso/data/users/use-users-query';
+
+interface User {
+	ID: number;
+	login: string;
+	email: string;
+	linked_user_ID: number;
+}
+
+interface Page {
+	found: number;
+	users: User[];
+}
+
+interface UserResponse {
+	pages: Page[];
+}
+
+interface UseAdministratorsParams {
+	siteId: number;
+	excludeUserIDs?: number[];
+}
+
+export function useAdministrators( { siteId, excludeUserIDs }: UseAdministratorsParams ) {
+	const queryResult = useUsersQuery(
+		siteId,
+		{ role: 'administrator' },
+		{
+			select: ( data: UserResponse ) => {
+				const users = data?.pages?.[ 0 ]?.users || [];
+				if ( excludeUserIDs ) {
+					return users.filter( ( user ) => ! excludeUserIDs.includes( user.linked_user_ID ) );
+				}
+				return users;
+			},
+		}
+	);
+	return {
+		...queryResult,
+		administrators: queryResult.data as unknown as User[],
+	};
+}

--- a/client/my-sites/site-settings/site-owner-transfer/use-administrators.ts
+++ b/client/my-sites/site-settings/site-owner-transfer/use-administrators.ts
@@ -18,18 +18,19 @@ interface UserResponse {
 
 interface UseAdministratorsParams {
 	siteId: number;
-	excludeUserIDs?: number[];
+	excludeUserEmails?: string[];
 }
 
-export function useAdministrators( { siteId, excludeUserIDs }: UseAdministratorsParams ) {
+export function useAdministrators( { siteId, excludeUserEmails }: UseAdministratorsParams ) {
 	const queryResult = useUsersQuery(
 		siteId,
 		{ role: 'administrator' },
 		{
 			select: ( data: UserResponse ) => {
 				const users = data?.pages?.[ 0 ]?.users || [];
-				if ( excludeUserIDs ) {
-					return users.filter( ( user ) => ! excludeUserIDs.includes( user.linked_user_ID ) );
+				// We filter by email instead of user.ID to support simple and atomic sites.
+				if ( excludeUserEmails ) {
+					return users.filter( ( user ) => ! excludeUserEmails.includes( user.email ) );
 				}
 				return users;
 			},

--- a/client/my-sites/site-settings/site-owner-transfer/use-administrators.ts
+++ b/client/my-sites/site-settings/site-owner-transfer/use-administrators.ts
@@ -4,7 +4,7 @@ interface User {
 	ID: number;
 	login: string;
 	email: string;
-	linked_user_ID: number;
+	linked_user_ID?: number | false;
 }
 
 interface Page {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Solves https://github.com/Automattic/dotcom-forge/issues/2757

## Proposed Changes

* Display administrators dropdown instead of text input.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In any site, go to `/settings/general/${siteSlug}`
* Click on `Transfer your site`
* Observe the new dropdown
* Continue the process and confirm the site was successfully transferred.

## Screenshots:

**Choose administrator**

| **Before** | **After** |
|---|---|
| <img width="1269" alt="Screenshot 2023-06-16 at 11 16 44" src="https://github.com/Automattic/wp-calypso/assets/779993/ba42f5af-ca0b-4276-a1a8-a5317d722794"> | <img width="1265" alt="Screenshot 2023-06-16 at 11 16 33" src="https://github.com/Automattic/wp-calypso/assets/779993/05b5e805-5700-44ac-bc72-becbb5077edf"> |

**No administrator**
<img width="1265" alt="Screenshot 2023-06-16 at 11 14 19" src="https://github.com/Automattic/wp-calypso/assets/779993/388c4900-c1e0-46fa-bd32-bbb32f4be984">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
