### PR TITLE
Domain upsell preview: fix preview for RTL languages

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -5,6 +5,7 @@ import { useDomainSuggestions } from '@automattic/domain-picker/src';
 import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useMemo } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useState } from 'react';
@@ -188,8 +189,13 @@ export function RenderDomainUpsell( {
 			  );
 
 	const domainNameSVG = (
-		<svg viewBox="0 0 40 18" id="map" direction="ltr">
-			<text x="-115" y="15">
+		<svg viewBox="0 0 40 18" id="map">
+			<text
+				x={ isRTL() ? 115 : -115 }
+				y="15"
+				textAnchor={ isRTL() ? 'end' : 'start' }
+				direction="ltr"
+			>
 				{ domainSuggestionName.length > 34
 					? `${ domainSuggestionName.slice( 0, 32 ) }...`
 					: domainSuggestionName }

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -188,7 +188,7 @@ export function RenderDomainUpsell( {
 			  );
 
 	const domainNameSVG = (
-		<svg viewBox="0 0 40 18" id="map">
+		<svg viewBox="0 0 40 18" id="map" direction="ltr">
 			<text x="-115" y="15">
 				{ domainSuggestionName.length > 34
 					? `${ domainSuggestionName.slice( 0, 32 ) }...`

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -68,3 +68,12 @@ body .customer-home__layout .domain-upsell__card {
 	}
 
 }
+
+html[dir="rtl"] {
+	.domain-upsell-illustration {
+		&,
+		text {
+			transform: scale(-1, 1);
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/77760#pullrequestreview-1464475269

## Proposed Changes

* When using an RTL language, force the `svg` to use `direction="ltr"` so its positioning is still valid. 

| Staging | This branch |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/6851384/f399ce64-4df0-498f-89ea-6440071739a4) | 
<img width="652" alt="Screenshot 2566-06-16 at 16 05 01" src="https://github.com/Automattic/wp-calypso/assets/6851384/c98af88f-6507-426e-9e05-ccd1b03445f4"> |

This seems like a good fix, even though the full preview should ideally be flipped when it RTL mode. Doing that is easy enough using `translate: scale( -1, 1 );`, but it looks weird because we use a LTR language for the domain name. If a reviewer wants to add a commit to force the domain name to be right aligned but in LTR mode, i.e. `      youngkid8.com` then go for it:

![image](https://github.com/Automattic/wp-calypso/assets/6851384/7ed63f0e-37a1-4945-8f18-74175a303447)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On trunk, using an existing site without a custom domain, go to `/home`
* Change the language to an RTL like Hebrew. Observe that the domain name is out of position
* Repeat the above steps on this branch and see the full domain name is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
