### PR TITLE
Checkout: fix upgrade credit display arg

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -801,12 +801,12 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 	if ( isMonthlyProduct( product ) ) {
 		return (
 			<>
-				{ translate( 'Upgrade Credit: %(discount)s applied in first month only', {
+				{ translate( 'Upgrade Credit: %(upgradeCredit)s applied in first month only', {
 					comment:
 						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
 						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
 					args: {
-						discount: formatCurrency( upgradeCredit, product.currency, {
+						upgradeCredit: formatCurrency( upgradeCredit, product.currency, {
 							isSmallestUnit: true,
 							stripZeros: true,
 						} ),
@@ -819,12 +819,12 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 	if ( isYearly( product ) ) {
 		return (
 			<>
-				{ translate( 'Upgrade Credit: %(discount)s applied in first year only', {
+				{ translate( 'Upgrade Credit: %(upgradeCredit)s applied in first year only', {
 					comment:
 						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
 						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
 					args: {
-						discount: formatCurrency( upgradeCredit, product.currency, {
+						upgradeCredit: formatCurrency( upgradeCredit, product.currency, {
 							isSmallestUnit: true,
 							stripZeros: true,
 						} ),

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -801,12 +801,12 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 	if ( isMonthlyProduct( product ) ) {
 		return (
 			<>
-				{ translate( 'Upgrade Credit: %(upgradeCredit)s applied in first month only', {
+				{ translate( 'Upgrade Credit: %(discount)s applied in first month only', {
 					comment:
 						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
 						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
 					args: {
-						upgradeCredit: formatCurrency( upgradeCredit, product.currency, {
+						discount: formatCurrency( upgradeCredit, product.currency, {
 							isSmallestUnit: true,
 							stripZeros: true,
 						} ),
@@ -819,7 +819,7 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 	if ( isYearly( product ) ) {
 		return (
 			<>
-				{ translate( 'Upgrade Credit: %(upgradeCredit)s applied in first year only', {
+				{ translate( 'Upgrade Credit: %(discount)s applied in first year only', {
 					comment:
 						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
 						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77855

## Proposed Changes

* Small fix to the changes added via #77855. This PR fixes the argument name passed to the `translate` function which displays the available upgrade credit.

| Before | After |
|--------|--------|
|<img width="578" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/07643b80-36db-4f75-9af7-14395d868ed7">|<img width="593" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/aa363609-d1ad-419c-a674-5272aa995719">| 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/<site slug>` for a site with a paid plan.
* Click on any of the available Upgrade buttons to upgrade to a higher plan.
* Confirm that the available upgrade credit is displayed correctly on the checkout screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
