### PR TITLE
Revert "Anchor cleanup: remove from stepper"

### DIFF
--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -1,0 +1,117 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import DesignSetup from './internals/steps-repository/design-setup';
+import ErrorStep from './internals/steps-repository/error-step';
+import { redirect } from './internals/steps-repository/import/util';
+import LoginStep from './internals/steps-repository/login';
+import PodcastTitleStep from './internals/steps-repository/podcast-title';
+import ProcessingStep from './internals/steps-repository/processing-step';
+import {
+	AssertConditionState,
+	type AssertConditionResult,
+	type Flow,
+	type ProvidedDependencies,
+} from './internals/types';
+import type { SiteSelect } from '@automattic/data-stores';
+
+export function isAnchorFmFlow() {
+	const sanitizePodcast = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
+	const anchorPodcast = new URLSearchParams( window.location.search ).get( 'anchor_podcast' );
+
+	return Boolean( sanitizePodcast( anchorPodcast || '' ) );
+}
+
+const anchorFmFlow: Flow = {
+	name: 'anchor-fm',
+
+	useSteps() {
+		if ( isEnabled( 'anchor/sunset-integration' ) ) {
+			return [ { slug: 'error', component: ErrorStep } ];
+		}
+		return [
+			{ slug: 'login', component: LoginStep },
+			{ slug: 'podcastTitle', component: PodcastTitleStep },
+			{ slug: 'designSetup', component: DesignSetup },
+			{ slug: 'processing', component: ProcessingStep },
+			{ slug: 'error', component: ErrorStep },
+		];
+	},
+
+	useAssertConditions(): AssertConditionResult {
+		const { setSiteSetupError } = useDispatch( SITE_STORE );
+		const { __ } = useI18n();
+
+		if ( isEnabled( 'anchor/sunset-integration' ) ) {
+			const error = __( 'Anchor.fm Discontinuation Notice' );
+			const message = __(
+				"We're sorry to inform you that the Anchor.fm integration with WordPress.com is being discontinued. As a result, you may have encountered an error while setting up your site. We apologize for any inconvenience. Please contact our support team for assistance or return to Anchor.fm to continue managing your podcast."
+			);
+			setSiteSetupError( error, message );
+		}
+		return { state: AssertConditionState.SUCCESS };
+	},
+
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
+		const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
+		const siteSlugParam = useSiteSlugParam();
+
+		if ( isEnabled( 'anchor/sunset-integration' ) ) {
+			return {};
+		}
+
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, 'anchor-fm', flowName, currentStep );
+			const siteSlug = siteSlugParam || getNewSite()?.site_slug;
+
+			switch ( currentStep ) {
+				case 'login':
+					return navigate( 'podcastTitle' );
+				case 'podcastTitle':
+					return navigate( 'designSetup' );
+				case 'designSetup':
+					return navigate( 'processing' );
+				case 'processing':
+					return redirect( `/page/${ siteSlug }/home` );
+			}
+		}
+
+		const goBack = () => {
+			switch ( currentStep ) {
+				case 'designSetup':
+					return navigate( 'podcastTitle' );
+				default:
+					return navigate( 'podcastTitle' );
+			}
+		};
+
+		const goNext = () => {
+			const siteSlug = siteSlugParam || getNewSite()?.site_slug;
+
+			switch ( currentStep ) {
+				case 'login':
+					return navigate( 'podcastTitle' );
+				case 'podcastTitle':
+					return navigate( 'designSetup' );
+				case 'designSetup':
+					return navigate( 'processing' );
+				case 'processing':
+					return redirect( `/page/${ siteSlug }/home` );
+				default:
+					return navigate( 'podcastTitle' );
+			}
+		};
+
+		const goToStep = ( step: string ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};
+
+export default anchorFmFlow;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -75,6 +75,7 @@ button {
 .patterns,
 .link-in-bio-setup,
 .link-in-bio-post-setup,
+.anchor-fm,
 .subscribers,
 .ecommerce,
 .wooexpress,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-design-picker.tsx
@@ -1,0 +1,140 @@
+import DesignPicker from '@automattic/design-picker';
+import { useLocale } from '@automattic/i18n-utils';
+import { StepContainer } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
+import { useNewSiteVisibility } from 'calypso/landing/stepper/hooks/use-selected-plan';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useDispatch as useReduxDispatch } from 'calypso/state';
+import { setActiveTheme } from 'calypso/state/themes/actions';
+import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../../../../stores';
+import { ANCHOR_FM_THEMES } from './anchor-fm-themes';
+import { STEP_NAME } from './constants';
+import type { Step } from '../../types';
+import './style.scss';
+import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
+import type { Design } from '@automattic/design-picker';
+
+const AnchorFmDesignPicker: Step = ( { navigation, flow } ) => {
+	const { goBack, submit, goToStep } = navigation;
+	const translate = useTranslate();
+	const locale = useLocale();
+	const reduxDispatch = useReduxDispatch();
+	const { setPendingAction, createSite } = useDispatch( ONBOARD_STORE );
+	const { setDesignOnSite } = useDispatch( SITE_STORE );
+	const selectedDesign = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
+		[]
+	);
+	const { anchorPodcastId, anchorEpisodeId, anchorSpotifyUrl } = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getState(),
+		[]
+	);
+
+	const visibility = useNewSiteVisibility();
+
+	const currentUser = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+		[]
+	);
+	const newUser = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).getNewUser(),
+		[]
+	);
+	const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
+
+	const pickDesign = ( _selectedDesign: Design | undefined = selectedDesign ) => {
+		if ( ! _selectedDesign ) {
+			return;
+		}
+
+		setPendingAction( async () => {
+			if ( ! currentUser && ! newUser ) {
+				return;
+			}
+
+			let user = '';
+			if ( currentUser ) {
+				user = currentUser.username;
+			} else if ( newUser ) {
+				user = newUser.username as string;
+			}
+
+			await createSite( {
+				username: user,
+				languageSlug: locale,
+				bearerToken: undefined,
+				visibility,
+				anchorFmPodcastId: anchorPodcastId,
+				anchorFmEpisodeId: anchorEpisodeId,
+				anchorFmSpotifyUrl: anchorSpotifyUrl,
+			} );
+
+			const newSite = getNewSite();
+
+			if ( ! newSite || ! newSite.site_slug ) {
+				return;
+			}
+
+			return setDesignOnSite( newSite.site_slug, _selectedDesign ).then( ( theme: ActiveTheme ) =>
+				reduxDispatch( setActiveTheme( newSite.blogid, theme ) )
+			);
+		} );
+
+		recordTracksEvent( 'calypso_signup_design_type_submit', {
+			flow,
+			intent: 'anchor-fm',
+			design_type: _selectedDesign.design_type,
+		} );
+
+		submit?.();
+	};
+
+	useEffect( () => {
+		if ( ! currentUser && ! newUser ) {
+			//Go to login
+			goToStep?.( 'login' );
+		}
+	}, [ currentUser, newUser ] );
+
+	return (
+		<StepContainer
+			stepName={ STEP_NAME }
+			hideSkip
+			skipButtonAlign="top"
+			hideFormattedHeader
+			backLabelText="Back"
+			stepContent={
+				<DesignPicker
+					designs={ ANCHOR_FM_THEMES as Design[] }
+					theme="light"
+					locale={ locale }
+					onSelect={ pickDesign }
+					isGridMinimal
+					highResThumbnails
+					hideFullScreenPreview
+					recommendedCategorySlug={ null }
+					anchorHeading={
+						<FormattedHeader
+							className="anchor-fm-design-picker__header"
+							id="step-header"
+							headerText={ translate( 'Choose a design' ) }
+							subHeaderText={ translate(
+								'Pick a homepage layout for your podcast site. You can customize or change it later.'
+							) }
+							align="left"
+						/>
+					}
+				/>
+			}
+			recordTracksEvent={ recordTracksEvent }
+			goNext={ () => submit?.() }
+			goBack={ goBack }
+		/>
+	);
+};
+
+export default AnchorFmDesignPicker;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-themes.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-themes.ts
@@ -1,0 +1,52 @@
+import type { Design } from '@automattic/design-picker';
+
+/*
+ * Anchor.fm themes are not actual themes as we understand them.
+ * They're built at site setup from specialized Headstart annotations
+ * using existing themes `spearhead` and `mayland`.
+ * Therefore we hard-code their data since it's not available via the themes API.
+ */
+export const ANCHOR_FM_THEMES: Design[] = [
+	{
+		title: 'Gilbert',
+		slug: 'gilbert',
+		template: 'gilbert',
+		theme: 'spearhead',
+		fonts: {
+			headings: 'Roboto',
+			base: 'Roboto',
+		},
+		is_premium: false,
+		features: [ 'anchorfm' ],
+		categories: [],
+		design_type: 'anchor-fm',
+	},
+	{
+		title: 'Hannah',
+		slug: 'hannah',
+		template: 'hannah',
+		theme: 'mayland',
+		fonts: {
+			headings: 'Raleway',
+			base: 'Cabin',
+		},
+		is_premium: false,
+		features: [ 'anchorfm' ],
+		categories: [],
+		design_type: 'anchor-fm',
+	},
+	{
+		title: 'Riley',
+		slug: 'riley',
+		template: 'riley',
+		theme: 'spearhead',
+		fonts: {
+			headings: 'Raleway',
+			base: 'Cabin',
+		},
+		is_premium: false,
+		features: [ 'anchorfm' ],
+		categories: [],
+		design_type: 'anchor-fm',
+	},
+];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
+import AnchorFmDesignPicker from './anchor-fm-design-picker';
 import UnifiedDesignPicker from './unified-design-picker';
 import type { Step } from '../../types';
 
@@ -11,6 +12,14 @@ const DesignSetup: Step = ( props ) => {
 
 	const headerText = translate( 'Pick a design' );
 
+	if ( 'anchor-fm' === props.flow ) {
+		return (
+			<>
+				<DocumentHead title={ headerText } />
+				<AnchorFmDesignPicker { ...props } />
+			</>
+		);
+	}
 	return (
 		<>
 			<DocumentHead title={ headerText } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -56,6 +56,12 @@ $design-button-primary-color: rgb(17, 122, 201);
 			flex-grow: 1;
 			text-align: start;
 
+			&.anchor-fm-design-picker__header {
+				flex-basis: 100%;
+				margin-top: 80px;
+				margin-bottom: 64px;
+			}
+
 			.formatted-header__title {
 				@include onboarding-font-recoleta;
 				color: $gray-100;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -1,3 +1,5 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
@@ -13,7 +15,7 @@ const WarningsOrHoldsSection = styled.div`
 	margin-top: 40px;
 `;
 
-const ErrorStep: Step = function ErrorStep( { navigation } ) {
+const ErrorStep: Step = function ErrorStep( { navigation, flow } ) {
 	const { goBack, goNext } = navigation;
 	const { __ } = useI18n();
 	const siteDomains = useSiteDomains();
@@ -25,14 +27,39 @@ const ErrorStep: Step = function ErrorStep( { navigation } ) {
 		domain = siteDomains[ 0 ].domain;
 	}
 
-	const defaultBodyText = __(
-		'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
-	);
+	const defaultBodyText =
+		flow !== 'anchor-fm'
+			? __(
+					'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
+			  )
+			: __(
+					'It looks like something went wrong while setting up your site. Return to Anchor or continue with site creation.'
+			  );
 
 	const headerText = siteSetupError?.error || __( "We've hit a snag" );
 	const bodyText = siteSetupError?.message || defaultBodyText;
 
 	const getContent = () => {
+		if ( flow === 'anchor-fm' ) {
+			const secondaryAction = isEnabled( 'anchor/sunset-integration' ) ? (
+				<Button className="error-step__link" borderless href="/help/contact">
+					{ __( 'Contact support' ) }
+				</Button>
+			) : (
+				<Button className="error-step__link" borderless href="https://anchor.fm">
+					{ __( 'Back to Anchor.fm' ) }
+				</Button>
+			);
+			return (
+				<WarningsOrHoldsSection>
+					<Button className="error-step__button" href="/start" primary>
+						{ __( 'Continue' ) }
+					</Button>
+					{ secondaryAction }
+				</WarningsOrHoldsSection>
+			);
+		}
+
 		return (
 			<WarningsOrHoldsSection>
 				<SupportCard domain={ domain } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-post-setup/test/lib/fixtures.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-post-setup/test/lib/fixtures.ts
@@ -133,6 +133,7 @@ export const defaultSiteDetails: SiteDetails = {
 		is_wpforteams_site: false,
 		p2_hub_blog_id: null,
 		is_cloud_eligible: false,
+		anchor_podcast: false,
 		was_created_with_blank_canvas_design: false,
 		videopress_storage_used: 0,
 		is_difm_lite_in_progress: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/lib/fixtures.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/lib/fixtures.ts
@@ -135,6 +135,7 @@ export const defaultSiteDetails: SiteDetails = {
 		is_wpforteams_site: false,
 		p2_hub_blog_id: null,
 		is_cloud_eligible: false,
+		anchor_podcast: false,
 		was_created_with_blank_canvas_design: false,
 		videopress_storage_used: 0,
 		is_difm_lite_in_progress: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/login/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/login/index.tsx
@@ -1,0 +1,349 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import config from '@automattic/calypso-config';
+import { Button, FormInputValidation } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { StepContainer } from '@automattic/onboarding';
+import { TextControl, ExternalLink } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
+import { useEffect, useState } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import { useAnchorFmParams } from 'calypso/landing/stepper/hooks/use-anchor-fm-params';
+import useDetectMatchingAnchorSite from 'calypso/landing/stepper/hooks/use-detect-matching-anchor-site';
+import { useIsAnchorFm } from 'calypso/landing/stepper/hooks/use-is-anchor-fm';
+import { ONBOARD_STORE, USER_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
+import {
+	recordOnboardingError,
+	initGoogleRecaptcha,
+	recordGoogleRecaptchaAction,
+} from 'calypso/landing/stepper/utils/analytics';
+import { useLangRouteParam } from 'calypso/landing/stepper/utils/path';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+import type { UserSelect } from '@automattic/data-stores';
+import type { FormEvent } from 'react';
+import './style.scss';
+
+const LoginStep: Step = function LoginStep( { navigation } ) {
+	const { submit, goToStep } = navigation;
+	const { __ } = useI18n();
+	const currentUser = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+		[]
+	);
+	const userIsLoggedIn = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+		[]
+	);
+	//Check to see if there is a site with a matching anchor podcast ID
+	const isLookingUpMatchingAnchorSites = useDetectMatchingAnchorSite();
+	const { setSiteSetupError } = useDispatch( SITE_STORE );
+	const { setAnchorPodcastId, setAnchorEpisodeId, setAnchorSpotifyUrl } =
+		useDispatch( ONBOARD_STORE );
+	const { isAnchorFmPodcastIdError } = useAnchorFmParams();
+	const [ recaptchaClientId, setRecaptchaClientId ] = useState< number >();
+	const { createAccount } = useDispatch( USER_STORE );
+	const isFetchingNewUser = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).isFetchingNewUser(),
+		[]
+	);
+	const newUserError = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).getNewUserError(),
+		[]
+	);
+	const lang = useLangRouteParam();
+	const isMobile = useViewportMatch( 'small', '<' );
+	const { anchorFmPodcastId, anchorFmEpisodeId, anchorFmSpotifyUrl } = useAnchorFmParams();
+	const isAnchorFmSignup = useIsAnchorFm();
+	const [ emailVal, setEmailVal ] = useState( '' );
+	const [ passwordVal, setPasswordVal ] = useState( '' );
+
+	const submitAnchorDeps = () => {
+		const providedDependencies = {
+			anchorFmPodcastId,
+			anchorFmEpisodeId,
+			anchorFmSpotifyUrl,
+		};
+
+		setAnchorPodcastId( ! isAnchorFmPodcastIdError ? anchorFmPodcastId : null );
+		setAnchorEpisodeId( anchorFmEpisodeId );
+		setAnchorSpotifyUrl( anchorFmSpotifyUrl );
+		submit?.( providedDependencies );
+	};
+
+	const handleSubmit = async ( event: FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+
+		let recaptchaToken;
+		let recaptchaError;
+
+		if ( typeof recaptchaClientId === 'number' ) {
+			recaptchaToken = await recordGoogleRecaptchaAction(
+				recaptchaClientId,
+				'calypso/signup/formSubmit'
+			);
+
+			if ( ! recaptchaToken ) {
+				recaptchaError = 'recaptcha_failed';
+			}
+		} else {
+			recaptchaError = 'recaptcha_didnt_load';
+		}
+
+		const result = await createAccount( {
+			email: emailVal,
+			'g-recaptcha-error': recaptchaError,
+			'g-recaptcha-response': recaptchaToken || undefined,
+			password: passwordVal,
+			signup_flow_name: 'gutenboarding',
+			locale: lang,
+			extra: { username_hint: null, is_anchor_fm_signup: isAnchorFmSignup },
+			is_passwordless: false,
+		} );
+
+		if ( result.ok ) {
+			submitAnchorDeps();
+		} else {
+			recordOnboardingError( {
+				step: 'account_creation',
+				error: result.newUserError.error || 'signup_form_new_user_error',
+			} );
+		}
+	};
+
+	const localizedTosLink = localizeUrl( 'https://wordpress.com/tos/' );
+
+	const tos = createInterpolateElement(
+		__( 'By creating an account you agree to our <link_to_tos>Terms of Service</link_to_tos>.' ),
+		{
+			link_to_tos: <ExternalLink href={ localizedTosLink } />,
+		}
+	);
+
+	// translators: English wording comes from Google: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed
+	const recaptcha_text = __(
+		'This site is protected by reCAPTCHA and the Google <link_to_policy>Privacy Policy</link_to_policy> and <link_to_tos>Terms of Service</link_to_tos> apply.'
+	);
+	const recaptcha_tos = createInterpolateElement( recaptcha_text, {
+		link_to_policy: <ExternalLink href="https://policies.google.com/privacy" />,
+		link_to_tos: <ExternalLink href="https://policies.google.com/terms" />,
+	} );
+
+	let errorMessage: string | undefined;
+	if ( newUserError ) {
+		switch ( newUserError.error ) {
+			case 'already_taken':
+			case 'already_active':
+			case 'email_exists':
+			case 'email_reserved':
+				errorMessage = __( 'An account with this email address already exists.' );
+				break;
+			case 'email_invalid':
+				errorMessage = __( 'Please enter a valid email address.' );
+				break;
+			case 'email_cant_be_used_to_signup':
+				errorMessage = __(
+					'You cannot use that email address to signup. We are having problems with them blocking some of our email. Please use another email provider.'
+				);
+				break;
+			case 'email_not_allowed':
+				errorMessage = __( 'Sorry, that email address is not allowed!' );
+				break;
+			case 'password_invalid':
+				errorMessage = newUserError.message;
+				break;
+			default:
+				errorMessage = __(
+					'Sorry, something went wrong when trying to create your account. Please try again.'
+				);
+				break;
+		}
+	}
+
+	const langFragment = lang ? `/${ lang }` : '';
+
+	const addAnchorQueryParts = ( url: string ): string => {
+		const queryParts = {
+			anchor_podcast: anchorFmPodcastId,
+			anchor_episode: anchorFmEpisodeId,
+			spotify_url: anchorFmSpotifyUrl,
+		};
+		for ( const [ k, v ] of Object.entries( queryParts ) ) {
+			if ( v ) {
+				url += `&${ k }=${ encodeURIComponent( v ) }`;
+			}
+		}
+		return url;
+	};
+
+	let loginRedirectUrl = window.location.origin + '/setup';
+	loginRedirectUrl += `/login?new`;
+	loginRedirectUrl = addAnchorQueryParts( loginRedirectUrl );
+	loginRedirectUrl = encodeURIComponent( loginRedirectUrl );
+
+	let signupUrl = `/setup/login?signup`;
+	signupUrl = addAnchorQueryParts( signupUrl );
+	signupUrl = encodeURIComponent( signupUrl );
+
+	const loginUrl = `/log-in/new${ langFragment }?redirect_to=${ loginRedirectUrl }&signup_url=${ signupUrl }`;
+
+	const form = (
+		<form className="login__form" onSubmit={ handleSubmit }>
+			<FormFieldset className="login__fieldset">
+				<TextControl
+					value={ emailVal }
+					disabled={ isFetchingNewUser }
+					type="email"
+					onChange={ setEmailVal }
+					placeholder={ __( 'Email address' ) }
+					required
+					autoFocus={ ! isMobile } // eslint-disable-line jsx-a11y/no-autofocus
+				/>
+
+				<TextControl
+					value={ passwordVal }
+					disabled={ isFetchingNewUser }
+					type="password"
+					autoComplete="new-password"
+					onChange={ setPasswordVal }
+					placeholder={ __( 'Password' ) }
+					required
+				/>
+
+				{ errorMessage && (
+					<FormInputValidation className="login__error-notice" isError text={ errorMessage } />
+				) }
+
+				<div className="login__footer">
+					<p className="login__login-link">
+						<span>{ __( 'Already have an account?' ) }</span>{ ' ' }
+						<Button className="login__link" plain href={ loginUrl }>
+							{ __( 'Log in' ) }
+						</Button>
+					</p>
+
+					<p className="login__link login__terms-of-service-link">{ tos }</p>
+
+					<Button
+						type="submit"
+						className="login__submit-button"
+						primary
+						disabled={ isFetchingNewUser }
+					>
+						{ __( 'Create account' ) }
+					</Button>
+
+					<p className="login__link login__terms-of-service-link login__recaptcha_tos">
+						{ recaptcha_tos }
+					</p>
+				</div>
+			</FormFieldset>
+		</form>
+	);
+	const stepContent = (
+		<div>
+			<div className="login__anchor-body">
+				<h1 className="login__title">{ __( 'Create your podcast site with WordPress.com' ) }</h1>
+				<div className="login__anchor-subheading">
+					<p>{ __( 'Create a WordPress.com account and start creating your free site.' ) }</p>
+				</div>
+
+				<div className="login__anchor-row">
+					{ /* Left Column: Contains Form */ }
+					<div className="login__anchor-col">
+						<div className="login__anchor-col-container is-left-col">{ form }</div>
+					</div>
+
+					<div className="login__anchor-separator" aria-hidden="true" role="presentation" />
+
+					{ /* Right Column: Contains Marketing Text */ }
+					<div className="login__anchor-col">
+						<div className="login__anchor-col-container is-right-col">
+							<div className="login__anchor-col-right-group">
+								<div className="login__anchor-right-heading">
+									{ __(
+										'Turn your listeners into customers with the marketing power of a website'
+									) }
+								</div>
+								<div>
+									<ul className="login__anchor-list">
+										<li> { __( 'Create forms and mailing lists' ) } </li>
+										<li> { __( 'Accept Payments and sell merchandise' ) } </li>
+										<li> { __( 'Built-in SEO and social tools' ) } </li>
+									</ul>
+								</div>
+							</div>
+
+							<div className="login__anchor-col-right-group">
+								<div className="login__anchor-right-heading">
+									{ __( 'Increase your audience with episode transcriptions' ) }
+								</div>
+								<div>
+									<ul className="login__anchor-list">
+										<li> { __( 'Add transcriptions to episode pages' ) } </li>
+										<li> { __( 'Customizable templates built for podcasts' ) } </li>
+										<li> { __( 'Add images, videos, and text formatting' ) } </li>
+									</ul>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div id="g-recaptcha"></div>
+		</div>
+	);
+
+	/*
+	 * If we have a current user and they're logged in,
+	 * proceed to the next step; no need to log in.
+	 */
+	useEffect( () => {
+		if ( currentUser && userIsLoggedIn ) {
+			submitAnchorDeps();
+		}
+	}, [ currentUser, userIsLoggedIn ] );
+
+	useEffect( () => {
+		if ( isAnchorFmPodcastIdError ) {
+			const error = __( "We're sorry!" );
+			const message = __(
+				"We're unable to locate your podcast. Return to Anchor or continue with site creation."
+			);
+			setSiteSetupError( error, message );
+			return goToStep?.( 'error' );
+		}
+	}, [ isAnchorFmPodcastIdError ] );
+
+	useEffect( () => {
+		initGoogleRecaptcha( 'g-recaptcha', config( 'google_recaptcha_site_key' ) ).then(
+			( clientId ) => {
+				if ( clientId === null ) {
+					return;
+				}
+				setRecaptchaClientId( clientId );
+			}
+		);
+	}, [ setRecaptchaClientId ] );
+
+	//If we're still checking for matching Anchor sites, don't show the form
+	if ( isLookingUpMatchingAnchorSites ) {
+		return <div />;
+	}
+
+	return (
+		<StepContainer
+			stepName="login-step"
+			hideBack
+			hideSkip
+			hideNext
+			stepContent={ stepContent }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default LoginStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/login/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/login/style.scss
@@ -1,0 +1,275 @@
+@import "@automattic/onboarding/styles/variables";
+@import "@automattic/calypso-color-schemes/src/calypso-color-schemes";
+@import "@automattic/onboarding/styles/mixins";
+
+$design-button-primary-color: var(--color-primary);
+$design-button-primary-hover-color: var(--color-primary-60);
+
+.step-container.login-step {
+
+	.login__submit-button {
+		background: $design-button-primary-color;
+		border-color: $design-button-primary-color;
+		padding: 9px 48px;
+		border-radius: 4px;
+		font-weight: 500;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05) !important;
+
+		&:hover,
+		&:focus {
+			background: $design-button-primary-hover-color;
+			border-color: $design-button-primary-hover-color;
+		}
+	}
+
+	.login__title {
+		@include onboarding-heading-text-mobile;
+		text-align: center;
+
+		@include break-mobile {
+			@include onboarding-heading-text;
+		}
+	}
+
+	.login__body {
+		position: relative;
+		padding: 44px 20px 0;
+		text-align: center;
+
+		@include break-mobile {
+			padding: 0 20px 20px;
+			position: absolute;
+			top: 25%;
+			left: 50%;
+			width: 100%;
+			max-width: 540px;
+			transform: translateX(-50%);
+		}
+	}
+
+	.login__legend {
+		padding-bottom: 42px;
+
+		& > p {
+			@include onboarding-large-text;
+			color: var(--studio-gray-40);
+		}
+	}
+
+	.login__fieldset {
+		border: 0;
+		margin: 0;
+		outline: 0;
+		padding: 0;
+		vertical-align: baseline;
+	}
+
+	.components-text-control__input {
+		padding: 18px 14px;
+		font-size: $font-body;
+		line-height: 17px;
+		border-radius: 0;
+		border: 1px solid var(--studio-gray-10);
+		box-sizing: border-box;
+		width: 100%;
+		max-width: 100%;
+
+		&::placeholder {
+			@include onboarding-medium-text;
+		}
+
+		@include break-mobile {
+			@include onboarding-medium-text;
+			max-width: 400px;
+		}
+	}
+
+	.login__error-notice {
+		max-width: 400px;
+		margin: 10px auto;
+
+		.components-notice__content {
+			margin: 0;
+		}
+	}
+
+	.login__login-link {
+		@include onboarding-medium-text;
+		margin: 4px 0 29px;
+		color: var(--color-text-subtle);
+
+		.login__link {
+			@include onboarding-medium-text;
+			color: var(--color-text-subtle);
+		}
+
+		a {
+			text-decoration: underline;
+		}
+	}
+
+	.login__link,
+	.login__link a {
+		@include onboarding-medium-text;
+		color: var(--color-text-subtle);
+	}
+
+	.login__link a {
+		text-decoration: underline;
+	}
+
+	.login__terms-of-service-link {
+		@include onboarding-medium-text;
+		text-align: center;
+		color: var(--color-text-subtle);
+		margin: 15px auto 20px;
+		max-width: 400px;
+
+		a {
+			text-decoration: underline;
+		}
+	}
+
+	.login__recaptcha_tos {
+		margin: 20px auto 15px;
+
+		@include break-small {
+			display: none;
+		}
+	}
+
+	// override spacing between input fields
+	.components-base-control .components-base-control__field {
+		margin-bottom: 10px;
+	}
+
+	//// Anchor Specific ////
+
+	// 1024 wide container
+	.login__anchor-body {
+		position: relative;
+		padding: 44px 20px 0;
+		text-align: center;
+
+		@include break-small {
+			padding: 64px 20px 0;
+		}
+
+		@include break-medium {
+			padding: 0 20px 20px;
+			left: 50%;
+			width: 100%;
+			max-width: 1024px;
+			transform: translateX(-50%);
+		}
+	}
+
+	// "Create a WordPress.com account.." under main header
+	.login__anchor-subheading {
+		padding-bottom: 64px;
+
+		& > p {
+			@include onboarding-large-text;
+			color: var(--color-text-subtle);
+		}
+	}
+
+	// Flexbox Row used for 2 column layout
+	.login__anchor-row {
+		// One column for small displays
+		display: block;
+
+		// Two column for medium and larger
+		@include break-medium {
+			display: flex;
+		}
+
+		flex-direction: row;
+		flex-wrap: wrap;
+		width: 100%;
+	}
+
+	// Flexbox Col used for 2 column layout
+	.login__anchor-col {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		flex-basis: 100%;
+		justify-content: center;
+	}
+
+	// Thin line between Flexbox Cols
+	.login__anchor-separator {
+		background: var(--studio-gray-5);
+		width: 0;
+
+		@include break-medium {
+			width: 1px;
+		}
+	}
+
+	// Container of left+right columns
+	.login__anchor-col-container {
+		padding-left: 0.5rem;
+		padding-right: 0.5rem;
+
+		@include break-small {
+			padding-left: 1rem;
+			padding-right: 1rem;
+		}
+
+		@include break-medium {
+			padding-left: 2rem;
+			padding-right: 2rem;
+		}
+
+		@include break-large {
+			padding-left: 4rem;
+			padding-right: 4rem;
+		}
+
+		&.is-right-col {
+			text-align: left;
+			margin-top: 3rem;
+
+			@include break-medium {
+				margin-top: 0;
+			}
+		}
+	}
+
+	// Div grouping together right heading "Turn your listeners.." with bullet points
+	.login__anchor-col-right-group {
+		margin-bottom: 2em;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	// Right heading like "Turn your listeners.."
+	.login__anchor-right-heading {
+		font-size: 1.25rem;
+		margin-bottom: 0.5rem;
+	}
+
+	// UL with Right bullet points
+	ul.login__anchor-list {
+		list-style: disc inside;
+		color: var(--studio-gray-70);
+		font-size: 0.875rem;
+
+		& > li {
+			margin-bottom: 0.5rem;
+		}
+	}
+
+	.grecaptcha-badge {
+		visibility: hidden;
+
+		@include break-small {
+			visibility: visible;
+		}
+	}
+}
+

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
@@ -1,0 +1,128 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { Button } from '@automattic/components';
+import { StepContainer } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { Icon } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
+import { useState, useRef, useEffect } from 'react';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormInput from 'calypso/components/forms/form-text-input';
+import usePodcastTitle from 'calypso/landing/stepper/hooks/use-podcast-title';
+import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
+import getTextWidth from 'calypso/landing/stepper/utils/get-text-width';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { tip } from 'calypso/signup/icons';
+import type { Step } from '../../types';
+import type { OnboardSelect, UserSelect } from '@automattic/data-stores';
+import './style.scss';
+
+const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
+	const { goBack, submit, goToStep } = navigation;
+	const { __ } = useI18n();
+
+	const PodcastTitleForm: React.FC = () => {
+		//Get the podcast title from the API
+		const podcastTitle = usePodcastTitle();
+		const { siteTitle } = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getState(),
+			[]
+		);
+		const currentUser = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+			[]
+		);
+		const newUser = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).getNewUser(),
+			[]
+		);
+		const hasSiteTitle = siteTitle.length > 0;
+		const { setSiteTitle } = useDispatch( ONBOARD_STORE );
+		const [ formTouched, setFormTouched ] = useState( false );
+
+		useEffect( () => {
+			if ( ! currentUser && ! newUser ) {
+				//Go to login
+				goToStep?.( 'login' );
+			}
+		}, [ currentUser, newUser ] );
+
+		/*
+		 * If we don't have a custom title in the store and we haven't touched the form input,
+		 * use the podcast title from the API
+		 */
+		useEffect( () => {
+			if ( podcastTitle && ! hasSiteTitle && ! formTouched ) {
+				// Set initial site title to podcast title
+				setSiteTitle( podcastTitle );
+			}
+		}, [ setSiteTitle, hasSiteTitle, podcastTitle ] );
+
+		const inputRef = useRef< HTMLInputElement >();
+		const underlineWidth = getTextWidth( ( siteTitle as string ) || '', inputRef.current );
+
+		const handleSubmit = ( siteTitle: string ) => {
+			const providedDependencies = {
+				siteTitle,
+			};
+			setSiteTitle( siteTitle );
+			submit?.( providedDependencies );
+		};
+
+		const handleChange = ( event: React.FormEvent< HTMLInputElement > ) => {
+			setFormTouched( true );
+			setSiteTitle( event.currentTarget.value );
+		};
+
+		return (
+			<form
+				className="podcast-title__form"
+				onSubmit={ () => {
+					handleSubmit?.( siteTitle );
+				} }
+			>
+				<div
+					className={ classNames( 'podcast-title__input-wrapper', { 'is-touched': formTouched } ) }
+				>
+					<FormLabel htmlFor="podcast-title">{ __( 'My podcast is called' ) }</FormLabel>
+					<div className="podcast-title__explanation">
+						<FormInput
+							id="podcast-title"
+							inputRef={ inputRef }
+							value={ siteTitle }
+							onChange={ handleChange }
+							placeholder="At the Fork"
+						/>
+						<div
+							className={ classNames( 'podcast-title__underline', {
+								'is-empty': ! ( siteTitle as string )?.length,
+							} ) }
+							style={ { width: underlineWidth || '100%' } }
+						/>
+						<FormSettingExplanation>
+							<Icon className="podcast-title__form-icon" icon={ tip } size={ 20 } />
+							{ __( "Don't worry, you can change it later." ) }
+						</FormSettingExplanation>
+					</div>
+				</div>
+				<Button className="podcast-title__submit-button" type="submit" primary>
+					{ __( 'Continue' ) }
+				</Button>
+			</form>
+		);
+	};
+
+	return (
+		<StepContainer
+			stepName="podcast-title-step"
+			goBack={ goBack }
+			hideBack
+			isFullLayout
+			stepContent={ <PodcastTitleForm /> }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default PodcastTitleStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/style.scss
@@ -1,0 +1,146 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+$design-button-primary-color: var(--color-primary);
+$design-button-primary-hover-color: var(--color-primary-60);
+$input-max-width: 448px;
+
+.podcast-title__form {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	position: relative;
+	padding: 64px 20px 0;
+	text-align: center;
+
+	@include break-medium {
+		padding: 64px;
+	}
+
+	@include break-large {
+		padding: 20px;
+		top: 24vh;
+		left: 50%;
+		width: 100%;
+		max-width: 1024px;
+		transform: translateX(-50%);
+	}
+
+	.podcast-title__input-wrapper {
+		display: flex;
+		flex-direction: column;
+		margin-bottom: 40px;
+		text-align: left;
+
+		@include break-large {
+			flex-direction: row;
+			flex-wrap: nowrap;
+		}
+
+		&.is-touched .form-setting-explanation {
+			opacity: 1;
+			transition-delay: 3s;
+		}
+	}
+
+	.podcast-title__explanation {
+		display: flex;
+		flex-direction: column;
+		input[type="text"] {
+			@include break-medium {
+				font-size: 4rem; /* stylelint-disable-line scales/font-sizes */
+			}
+			padding: 0;
+			border: 0;
+			line-height: 1;
+		}
+
+	}
+
+	input[type="text"],
+	label {
+		@extend .wp-brand-font;
+		font-size: 2rem;
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		line-height: 1.4em;
+
+		@include break-medium {
+			font-size: 4rem; /* stylelint-disable-line scales/font-sizes */
+		}
+
+		&::placeholder {
+			color: var(--color-text-subtle);
+		}
+	}
+
+	label {
+		white-space: nowrap;
+		margin-right: 12px;
+	}
+
+	input[type="text"] {
+		border: none;
+		display: inline-block;
+		flex: 1;
+		letter-spacing: -0.4px;
+		line-height: 57px;
+		height: auto;
+		padding: 0;
+		width: 100%;
+		max-width: 100%;
+
+		&:focus {
+			box-shadow: none;
+		}
+
+		@include break-large {
+			max-width: $input-max-width;
+		}
+	}
+
+	.form-setting-explanation {
+		display: flex;
+		align-items: center;
+		margin: 16px 0;
+		font-style: normal;
+		color: var(--color-text-subtle);
+		opacity: 0;
+		transition: opacity 0.2s ease-in-out;
+
+		.podcast-title__form-icon {
+			margin-right: 8px;
+		}
+	}
+
+	.podcast-title__submit-button {
+		background: $design-button-primary-color;
+		border-color: $design-button-primary-color;
+		padding: 9px 48px;
+		border-radius: 4px;
+		font-weight: 500;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05) !important;
+
+		&:hover,
+		&:focus {
+			background: $design-button-primary-hover-color;
+			border-color: $design-button-primary-hover-color;
+		}
+	}
+
+	.podcast-title__underline {
+		height: 2px;
+		background: currentColor;
+		margin-top: -5px;
+		max-width: 100%;
+
+		&.is-empty {
+			max-width: 310px;
+			background: var(--color-text-subtle);
+		}
+
+		@include break-large {
+			margin-top: -12px;
+			max-width: $input-max-width;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -29,7 +29,8 @@
 }
 
 .import-focused .step-container__content,
-.site-setup.processing .step-container__content {
+.site-setup.processing .step-container__content,
+.anchor-fm.processing .step-container__content {
 	width: 100%;
 }
 

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -13,6 +13,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 	'site-setup': () =>
 		import( /* webpackChunkName: "site-setup-flow" */ '../declarative-flow/site-setup-flow' ),
 
+	'anchor-fm-flow': () =>
+		import( /* webpackChunkName: "anchor-fm-flow" */ '../declarative-flow/anchor-fm-flow' ),
+
 	'copy-site': () =>
 		import( /* webpackChunkName: "copy-site-flow" */ '../declarative-flow/copy-site' ),
 

--- a/client/landing/stepper/hooks/test/use-anchor-fm-params.tsx
+++ b/client/landing/stepper/hooks/test/use-anchor-fm-params.tsx
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { MemoryRouter as Router } from 'react-router-dom';
+import { useAnchorFmParams } from '../use-anchor-fm-params';
+
+describe( 'use-anchor-fm-params tests', () => {
+	const RouteWrapper: React.FC = ( props: { children?: React.ReactNode; path: string } ) => (
+		<Router initialEntries={ [ props.path ] }>{ props.children }</Router>
+	);
+
+	test( 'Returns anchor podcast ID', async () => {
+		const { result } = renderHook( () => useAnchorFmParams(), {
+			wrapper: RouteWrapper,
+			initialProps: { path: '?anchor_podcast=e1fab2c' },
+		} );
+		expect( result.current.anchorFmPodcastId ).toEqual( 'e1fab2c' );
+	} );
+
+	test( 'Returns episode ID', async () => {
+		const { result } = renderHook( () => useAnchorFmParams(), {
+			wrapper: RouteWrapper,
+			initialProps: { path: '?anchor_episode=12345' },
+		} );
+		expect( result.current.anchorFmEpisodeId ).toEqual( '12345' );
+	} );
+
+	test( 'Returns new site flag value', async () => {
+		const { result } = renderHook( () => useAnchorFmParams(), {
+			wrapper: RouteWrapper,
+			initialProps: { path: '?anchor_is_new_site=true' },
+		} );
+		expect( result.current.anchorFmIsNewSite ).toEqual( 'true' );
+	} );
+
+	test( 'Returns Spotify URL', async () => {
+		const { result } = renderHook( () => useAnchorFmParams(), {
+			wrapper: RouteWrapper,
+			initialProps: { path: '?spotify_url=https://wordpress.com' },
+		} );
+		expect( result.current.anchorFmSpotifyUrl ).toEqual( 'https://wordpress.com' );
+	} );
+
+	test( 'Returns an error for malformed podcast ID', () => {
+		const { result } = renderHook( () => useAnchorFmParams(), {
+			wrapper: RouteWrapper,
+			initialProps: { path: '?anchor_podcast=zzz' },
+		} );
+		expect( result.current.isAnchorFmPodcastIdError ).toEqual( true );
+	} );
+} );

--- a/client/landing/stepper/hooks/test/use-is-anchor-fm.tsx
+++ b/client/landing/stepper/hooks/test/use-is-anchor-fm.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { MemoryRouter as Router } from 'react-router-dom';
+import { useIsAnchorFm } from '../use-is-anchor-fm';
+
+describe( 'use-is-anchor-fm tests', () => {
+	const RouteWrapper = ( props: { children?: React.ReactNode; path: string } ) => (
+		<Router initialEntries={ [ props.path ] } initialIndex={ 0 }>
+			{ props.children }
+		</Router>
+	);
+
+	test( 'Returns true for a valid podcast ID', () => {
+		const { result } = renderHook( () => useIsAnchorFm(), {
+			wrapper: RouteWrapper,
+			initialProps: { path: '?anchor_podcast=eb12e6c' },
+		} );
+		expect( result.current ).toEqual( true );
+	} );
+
+	test( 'Returns false for an invalid podcast ID', () => {
+		const { result } = renderHook( () => useIsAnchorFm(), {
+			wrapper: RouteWrapper,
+			initialProps: { path: '?anchor_podcast=mmm' },
+		} );
+		expect( result.current ).toEqual( false );
+	} );
+} );

--- a/client/landing/stepper/hooks/test/use-podcast-title.ts
+++ b/client/landing/stepper/hooks/test/use-podcast-title.ts
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import usePodcastTitle from '../use-podcast-title';
+import * as hook from '../use-podcast-title';
+
+jest.mock( '../use-podcast-title' );
+
+describe( 'use-podcast-title test', () => {
+	test( 'Returns the correct title from the response', () => {
+		const spy = jest.spyOn( hook, 'default' ).mockReturnValue( 'My Podcast Title' );
+		const title = renderHook( () => usePodcastTitle() );
+
+		expect( spy ).toHaveBeenCalled();
+		expect( title.result.current ).toBe( 'My Podcast Title' );
+
+		spy.mockRestore();
+	} );
+} );

--- a/client/landing/stepper/hooks/use-anchor-fm-params.ts
+++ b/client/landing/stepper/hooks/use-anchor-fm-params.ts
@@ -1,0 +1,82 @@
+import { isAnchorPodcastIdValid } from './use-is-anchor-fm';
+import useParameter from './use-parameter';
+
+export interface AnchorFmParams {
+	anchorFmPodcastId: string | null;
+	anchorFmEpisodeId: string | null;
+	anchorFmSpotifyUrl: string | null;
+	anchorFmSite: string | null;
+	anchorFmPost: string | null;
+	anchorFmIsNewSite: string | null;
+	isAnchorFmPodcastIdError: boolean;
+}
+export function useAnchorFmParams(): AnchorFmParams {
+	const sanitizePodcast = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
+	const anchorFmPodcastId = useParameter( {
+		queryParamName: 'anchor_podcast',
+		locationStateParamName: 'anchorFmPodcastId',
+		sanitize: sanitizePodcast,
+	} );
+	const isAnchorFmPodcastIdError =
+		anchorFmPodcastId !== null && ! isAnchorPodcastIdValid( anchorFmPodcastId );
+
+	// Allow all characters allowed in urls
+	// Reserved characters: !*'();:@&=+$,/?#[]
+	// Unreserved: A-Za-z0-9_.~-    (possibly % as a part of percent-encoding)
+	const sanitizeEpisode = ( id: string ) => id.replace( /[^A-Za-z0-9_.\-~%]/g, '' );
+	const anchorFmEpisodeId = useParameter( {
+		queryParamName: 'anchor_episode',
+		locationStateParamName: 'anchorFmEpisodeId',
+		sanitize: sanitizeEpisode,
+	} );
+
+	// Allow all characters allowed in urls
+	// Reserved characters: !*'();:@&=+$,/?#[]
+	// Unreserved: A-Za-z0-9_.~-    (possibly % as a part of percent-encoding)
+	const sanitizeShowUrl = ( id: string ) =>
+		id.replace( /[^A-Za-z0-9_.\-~%!*'();:@&=+$,/?#[\]]/g, '' );
+	const anchorFmSpotifyUrl = useParameter( {
+		queryParamName: 'spotify_url',
+		locationStateParamName: 'anchorFmSpotifyUrl',
+		sanitize: sanitizeShowUrl,
+	} );
+
+	// "site" and "post" are strings consisting of digits only. Example URL:
+	// http://wordpress.com/new?site=181129564&post=5&anchor_podcast=22b6608
+	// We store them as strings for consistency with the other param types
+	// and simplicity in code and type signatures.
+	const sanitizeNumberParam = ( id: string ) => id.replace( /^\D+$/g, '' );
+	const anchorFmSite = useParameter( {
+		queryParamName: 'site',
+		locationStateParamName: 'anchorFmSite',
+		sanitize: sanitizeNumberParam,
+	} );
+	const anchorFmPost = useParameter( {
+		queryParamName: 'post',
+		locationStateParamName: 'anchorFmPost',
+		sanitize: sanitizeNumberParam,
+	} );
+
+	// anchorFmIsNewSite:
+	// Indicates the backend has told us we need to make a new site and
+	// we don't need to query it anymore.
+	// If we start with "/new?anchor_podcast=abcdef0", the backend might say there's
+	// no matching site and redirect us to "/new?anchor_podcast=abcdef0&anchor_episode=1234-123456&anchor_is_new_site=true",
+	// because it found the last episode and wanted to pass that information to us.
+	// In this case, we don't need to ask the backend again after restarting gutenboarding.
+	const anchorFmIsNewSite = useParameter( {
+		queryParamName: 'anchor_is_new_site',
+		locationStateParamName: 'anchorFmIsNewSite',
+		sanitize: ( flag: string ) => ( flag === 'true' ? 'true' : 'false' ),
+	} );
+
+	return {
+		anchorFmPodcastId,
+		isAnchorFmPodcastIdError,
+		anchorFmEpisodeId,
+		anchorFmSpotifyUrl,
+		anchorFmSite,
+		anchorFmPost,
+		anchorFmIsNewSite,
+	};
+}

--- a/client/landing/stepper/hooks/use-detect-matching-anchor-site.ts
+++ b/client/landing/stepper/hooks/use-detect-matching-anchor-site.ts
@@ -1,0 +1,76 @@
+import { useSelect } from '@wordpress/data';
+import { useState, useEffect } from 'react';
+import wpcom from 'calypso/lib/wp';
+import { USER_STORE } from '../stores';
+import { useAnchorFmParams } from './use-anchor-fm-params';
+import { useIsAnchorFm } from './use-is-anchor-fm';
+import type { UserSelect } from '@automattic/data-stores';
+
+interface AnchorEndpointResult {
+	location: string | false;
+}
+
+// useDetectMatchingAnchorSite:
+// If I'm making a new site and anchor parameters are available, check wpcom backend to
+// see if there's already a site that belongs to me that matches these parameters.
+// If it's found, redirect the browser to it
+export default function useDetectMatchingAnchorSite(): boolean {
+	const {
+		anchorFmPodcastId,
+		anchorFmEpisodeId,
+		anchorFmSpotifyUrl,
+		anchorFmSite,
+		anchorFmPost,
+		anchorFmIsNewSite,
+	} = useAnchorFmParams();
+	const isAnchorFm = useIsAnchorFm();
+	const currentUserExists = useSelect(
+		( select ) => !! ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+		[]
+	);
+	const [ isLoading, setIsLoading ] = useState( !! ( isAnchorFm && currentUserExists ) );
+
+	useEffect( () => {
+		// Must be a logged-in user on anchor FM to check
+		if ( ! isAnchorFm || ! currentUserExists || anchorFmIsNewSite ) {
+			setIsLoading( false );
+			return;
+		}
+
+		setIsLoading( true );
+
+		// construct query object from entries that are not null or undefined
+		const query = Object.fromEntries(
+			[
+				[ 'podcast', anchorFmPodcastId ],
+				[ 'episode', anchorFmEpisodeId ],
+				[ 'spotify_url', anchorFmSpotifyUrl ],
+				[ 'site', anchorFmSite ],
+				[ 'post', anchorFmPost ],
+			].filter( ( [ , value ] ) => value != null )
+		);
+
+		wpcom.req
+			.get( { path: '/anchor', apiNamespace: 'wpcom/v2' }, query )
+			.then( ( result: AnchorEndpointResult ) => {
+				if ( result.location ) {
+					window.location.href = result.location;
+				} else {
+					setIsLoading( false );
+				}
+			} )
+			.catch( () => {
+				setIsLoading( false );
+			} );
+	}, [
+		isAnchorFm,
+		currentUserExists,
+		anchorFmPodcastId,
+		anchorFmEpisodeId,
+		anchorFmSpotifyUrl,
+		anchorFmSite,
+		anchorFmPost,
+		anchorFmIsNewSite,
+	] );
+	return isLoading;
+}

--- a/client/landing/stepper/hooks/use-is-anchor-fm.ts
+++ b/client/landing/stepper/hooks/use-is-anchor-fm.ts
@@ -1,0 +1,10 @@
+import { useAnchorFmParams } from './use-anchor-fm-params';
+
+export function isAnchorPodcastIdValid( anchorFmPodcastId: string | null ): boolean {
+	return Boolean( anchorFmPodcastId && anchorFmPodcastId.match( /^[0-9a-f]{7,8}$/i ) );
+}
+
+export function useIsAnchorFm(): boolean {
+	const { anchorFmPodcastId } = useAnchorFmParams();
+	return isAnchorPodcastIdValid( anchorFmPodcastId );
+}

--- a/client/landing/stepper/hooks/use-parameter.ts
+++ b/client/landing/stepper/hooks/use-parameter.ts
@@ -1,0 +1,50 @@
+import { useLocation } from 'react-router-dom';
+
+export interface StateType {
+	anchorFmPodcastId?: string;
+	anchorFmEpisodeId?: string;
+	anchorFmSpotifyUrl?: string;
+	anchorFmSite?: string;
+	anchorFmPost?: string;
+	anchorFmIsNewSite?: string;
+}
+export type StateKeyType = keyof StateType;
+
+/*
+ useParameter is an internal helper for finding a value that comes from either a query string, or location state.
+ For example, when a user hits http://calypso.localhost:3000/new?anchor_podcast=40a166a8
+ We grab that anchor_podcast value, and store it in location state to keep as we move along the states.
+ It's called "anchor_podcast" in the query string above, but "anchorFmPodcastId" above.
+  Calling this function like so:
+  useParameter({
+    queryParamName: 'anchor_podcast',
+    locationStateParamName: 'anchorFmPodcastId',
+  })
+  Looks for the value first in location state, then if it can't be found, looks in the query parameter.
+*/
+interface UseParameterType {
+	queryParamName: string;
+	locationStateParamName: StateKeyType;
+	sanitize: ( arg0: string ) => string;
+}
+
+export default function useParameter( {
+	queryParamName,
+	locationStateParamName,
+	sanitize,
+}: UseParameterType ): string | null {
+	const { state: locationState, search } = useLocation();
+
+	// Use location state if available
+	const locationStateParamValue = locationState?.[ locationStateParamName ];
+	if ( locationState && locationStateParamValue ) {
+		return sanitize( locationStateParamValue );
+	}
+
+	// Fall back to looking in query param
+	const queryParamValue = new URLSearchParams( search ).get( queryParamName );
+	if ( queryParamValue ) {
+		return sanitize( queryParamValue );
+	}
+	return null;
+}

--- a/client/landing/stepper/hooks/use-podcast-title.ts
+++ b/client/landing/stepper/hooks/use-podcast-title.ts
@@ -1,0 +1,39 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from 'react';
+import { useAnchorFmParams } from './use-anchor-fm-params';
+
+export default function usePodcastTitle(): string | null {
+	const { anchorFmPodcastId } = useAnchorFmParams();
+	const [ siteTitle, setSiteTitle ] = useState( '' );
+	interface PodcastDetails {
+		title?: string;
+	}
+
+	useEffect( () => {
+		let isMounted = true;
+
+		if ( ! anchorFmPodcastId ) {
+			return;
+		}
+
+		// Fetch podcast title from /podcast-details endpoint
+		apiFetch< PodcastDetails >( {
+			path: `https://public-api.wordpress.com/wpcom/v2/podcast-details?url=https://anchor.fm/s/${ encodeURIComponent(
+				anchorFmPodcastId
+			) }/podcast/rss&_fields=title`,
+		} )
+			.then( ( response ) => {
+				if ( response?.title && isMounted ) {
+					setSiteTitle( response.title );
+				}
+			} )
+			.catch( () => {
+				isMounted && setSiteTitle( '' );
+			} );
+		return () => {
+			isMounted = false;
+		}; //Cleanup when we've finished mounting
+	}, [ anchorFmPodcastId ] );
+
+	return siteTitle;
+}

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -25,6 +25,7 @@ import { createQueryClient } from 'calypso/state/query-client';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
 import { requestSites } from 'calypso/state/sites/actions';
+import { isAnchorFmFlow } from './declarative-flow/anchor-fm-flow';
 import { FlowRenderer } from './declarative-flow/internals';
 import 'calypso/components/environment-badge/style.scss';
 import 'calypso/assets/stylesheets/style.scss';
@@ -44,6 +45,10 @@ function initializeCalypsoUserStore( reduxStore: any, user: CurrentUser ) {
 }
 
 function determineFlow() {
+	if ( isAnchorFmFlow() ) {
+		return availableFlows[ 'anchor-fm-flow' ];
+	}
+
 	const flowNameFromPathName = window.location.pathname.split( '/' )[ 2 ];
 
 	return availableFlows[ flowNameFromPathName ] || availableFlows[ 'site-setup' ];


### PR DESCRIPTION
Reverts Automattic/wp-calypso#77406

Caused issues at `/setup/newsletter` flow:

- Color dropdown cut
- Font in description input
- On localhost also page isn't centered anymore

**Prod**
<img src="https://github.com/Automattic/wp-calypso/assets/87168/6cedbc1b-65cb-489f-b121-fe4704f531c1" width="500"/>

**Localhost**
<img width="1986" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/e6eb81fb-4315-4595-9012-78b7029fedfd">


**Reverting fixes:**

<img width="500" alt="Screenshot 2023-06-16 at 13 41 36" src="https://github.com/Automattic/wp-calypso/assets/87168/99d9aa17-101a-4b23-8d57-2fda066d789c">
