### PR TITLE
Plans: Remove dependency on HappychatButton in HappinessSupport

### DIFF
--- a/client/blocks/product-purchase-features-list/happiness-support-card.jsx
+++ b/client/blocks/product-purchase-features-list/happiness-support-card.jsx
@@ -5,8 +5,7 @@ export const HappinessSupportCard = ( {
 	isJetpack,
 	isJetpackFreePlan,
 	isPlaceholder,
-	liveChatButtonEventName,
-	showLiveChatButton,
+	contactButtonEventName,
 } ) => (
 	<div className="product-purchase-features-list__item">
 		<HappinessSupport
@@ -14,8 +13,7 @@ export const HappinessSupportCard = ( {
 			isJetpack={ isJetpack }
 			isJetpackFreePlan={ isJetpackFreePlan }
 			isPlaceholder={ isPlaceholder }
-			showLiveChatButton={ showLiveChatButton }
-			liveChatButtonEventName={ liveChatButtonEventName }
+			contactButtonEventName={ contactButtonEventName }
 		/>
 	</div>
 );

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -72,8 +72,7 @@ export class ProductPurchaseFeaturesList extends Component {
 			<Fragment>
 				<HappinessSupportCard
 					isPlaceholder={ isPlaceholder }
-					showLiveChatButton
-					liveChatButtonEventName="calypso_livechat_my_plan_ecommerce"
+					contactButtonEventName="calypso_livechat_my_plan_ecommerce"
 				/>
 				{ ! isMonthlyPlan && (
 					<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
@@ -125,8 +124,7 @@ export class ProductPurchaseFeaturesList extends Component {
 			<Fragment>
 				<HappinessSupportCard
 					isPlaceholder={ isPlaceholder }
-					showLiveChatButton
-					liveChatButtonEventName="calypso_livechat_my_plan_business"
+					contactButtonEventName="calypso_livechat_my_plan_business"
 				/>
 				{ ! isMonthlyPlan && (
 					<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
@@ -225,8 +223,7 @@ export class ProductPurchaseFeaturesList extends Component {
 			<Fragment>
 				<HappinessSupportCard
 					isPlaceholder={ isPlaceholder }
-					showLiveChatButton
-					liveChatButtonEventName="calypso_livechat_my_plan_pro"
+					contactButtonEventName="calypso_livechat_my_plan_pro"
 				/>
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				{ canActivateWordadsInstant && <MonetizeSite selectedSite={ selectedSite } /> }
@@ -332,8 +329,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<HappinessSupportCard
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isPlaceholder={ isPlaceholder }
-					showLiveChatButton
-					liveChatButtonEventName="calypso_livechat_my_plan_jetpack_professsional"
+					contactButtonEventName="calypso_livechat_my_plan_jetpack_professsional"
 				/>
 			</Fragment>
 		);
@@ -352,8 +348,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<HappinessSupportCard
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isPlaceholder={ isPlaceholder }
-					showLiveChatButton
-					liveChatButtonEventName="calypso_livechat_my_plan_jetpack_security"
+					contactButtonEventName="calypso_livechat_my_plan_jetpack_security"
 				/>
 			</Fragment>
 		);
@@ -372,8 +367,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<HappinessSupportCard
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isPlaceholder={ isPlaceholder }
-					showLiveChatButton
-					liveChatButtonEventName="calypso_livechat_my_plan_jetpack_complete"
+					contactButtonEventName="calypso_livechat_my_plan_jetpack_complete"
 				/>
 			</Fragment>
 		);

--- a/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
+++ b/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
@@ -321,20 +321,18 @@ describe( '<HappinessSupportCard isJetpackFreePlan', () => {
 } );
 
 describe( '<HappinessSupportCard isEligibleForLiveChat', () => {
-	test.each( [
-		PLAN_BUSINESS,
-		PLAN_BUSINESS_2_YEARS,
-		PLAN_JETPACK_BUSINESS,
-		PLAN_JETPACK_BUSINESS_MONTHLY,
-	] )( `Should be eligible for live chat for %s`, ( plan ) => {
-		const props = {
-			plan: plan,
-			isPlaceholder: false,
-			selectedSite: {
-				plan: { product_slug: plan },
-			},
-		};
-		render( <ProductPurchaseFeaturesList { ...props } /> );
-		expect( screen.getByRole( 'link', { name: /ask a question/i } ) ).toBeVisible();
-	} );
+	test.each( [ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS, PLAN_JETPACK_BUSINESS_MONTHLY ] )(
+		`Should be eligible for live chat for %s`,
+		( plan ) => {
+			const props = {
+				plan: plan,
+				isPlaceholder: false,
+				selectedSite: {
+					plan: { product_slug: plan },
+				},
+			};
+			render( <ProductPurchaseFeaturesList { ...props } /> );
+			expect( screen.getByRole( 'button', { name: /ask a question/i } ) ).toBeVisible();
+		}
+	);
 } );

--- a/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
+++ b/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
@@ -321,18 +321,20 @@ describe( '<HappinessSupportCard isJetpackFreePlan', () => {
 } );
 
 describe( '<HappinessSupportCard isEligibleForLiveChat', () => {
-	test.each( [ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS, PLAN_JETPACK_BUSINESS_MONTHLY ] )(
-		`Should be eligible for live chat for %s`,
-		( plan ) => {
-			const props = {
-				plan: plan,
-				isPlaceholder: false,
-				selectedSite: {
-					plan: { product_slug: plan },
-				},
-			};
-			render( <ProductPurchaseFeaturesList { ...props } /> );
-			expect( screen.getByRole( 'button', { name: /ask a question/i } ) ).toBeVisible();
-		}
-	);
+	test.each( [
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	] )( `Should be eligible for live chat for %s`, ( plan ) => {
+		const props = {
+			plan: plan,
+			isPlaceholder: false,
+			selectedSite: {
+				plan: { product_slug: plan },
+			},
+		};
+		render( <ProductPurchaseFeaturesList { ...props } /> );
+		expect( screen.getByRole( 'button', { name: /ask a question/i } ) ).toBeVisible();
+	} );
 } );

--- a/client/components/happiness-support/README.md
+++ b/client/components/happiness-support/README.md
@@ -1,6 +1,6 @@
 # Happiness Support
 
-This component renders a card presenting our support resources, including links to the support form and documentation. It can also render a button to open a Live chat window if the prop `showLiveChatButton` is `true`.
+This component renders a card presenting our support resources, including links to the support form and documentation.
 
 ## Usage
 
@@ -8,13 +8,7 @@ This component renders a card presenting our support resources, including links 
 import HappinessSupport from 'calypso/components/happiness-support';
 
 export default () => {
-	return (
-		<HappinessSupport
-			isJetpack
-			liveChatButtonEventName="calypso_chat_button_clicked"
-			showLiveChatButton
-		/>
-	);
+	return <HappinessSupport isJetpack contactButtonEventName="calypso_chat_button_clicked" />;
 };
 ```
 
@@ -22,5 +16,4 @@ export default () => {
 
 - _isJetpack_ (boolean) – Indicates that the Happiness Support card is related to a Jetpack Plan.
 - _isJetpackFreePlan_ (boolean) – Indicates that the Happiness Support card is related to a Jetpack Free Plan.
-- _liveChatButtonEventName_ (string) – event name that will be recorded when the `HappychatButton` is clicked.
-- _showLiveChatButton_ (boolean) – Whether to show a `HappychatButton` instead of the support link `Button`
+- _contactButtonEventName_ (string) – event name that will be recorded when the contact button/link is clicked.

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -6,17 +6,10 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import supportImage from 'calypso/assets/images/illustrations/dotcom-support.svg';
-import HappychatButton from 'calypso/components/happychat/button';
-import HappychatConnection from 'calypso/components/happychat/connection-connected';
+import SupportButton from 'calypso/components/support-button';
 import { preventWidows } from 'calypso/lib/formatting';
-import {
-	CALYPSO_CONTACT,
-	JETPACK_CONTACT_SUPPORT,
-	JETPACK_SUPPORT,
-	SUPPORT_ROOT,
-} from 'calypso/lib/url/support';
+import { JETPACK_CONTACT_SUPPORT, JETPACK_SUPPORT, SUPPORT_ROOT } from 'calypso/lib/url/support';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 
 import './style.scss';
 
@@ -25,19 +18,17 @@ export class HappinessSupport extends Component {
 		isJetpack: PropTypes.bool,
 		isJetpackFreePlan: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
-		liveChatButtonEventName: PropTypes.string,
-		showLiveChatButton: PropTypes.bool,
+		contactButtonEventName: PropTypes.string,
 	};
 
 	static defaultProps = {
 		isJetpack: false,
 		isJetpackFreePlan: false,
-		showLiveChatButton: false,
 	};
 
-	onLiveChatButtonClick = () => {
-		if ( this.props.liveChatButtonEventName ) {
-			this.props.recordTracksEvent( this.props.liveChatButtonEventName );
+	onContactButtonClick = () => {
+		if ( this.props.contactButtonEventName ) {
+			this.props.recordTracksEvent( this.props.contactButtonEventName );
 		}
 	};
 
@@ -67,53 +58,39 @@ export class HappinessSupport extends Component {
 	}
 
 	getSupportButtons() {
-		const { isJetpackFreePlan, liveChatAvailable, showLiveChatButton } = this.props;
-
-		if ( isJetpackFreePlan ) {
-			return (
-				<div className="happiness-support__buttons">
-					{ this.renderSupportButton() }
-					{ this.renderContactButton() }
-				</div>
-			);
-		}
+		const { isJetpack } = this.props;
 
 		return (
 			<div className="happiness-support__buttons">
-				{ showLiveChatButton && <HappychatConnection /> }
-				{ showLiveChatButton && liveChatAvailable
-					? this.renderLiveChatButton()
-					: this.renderContactButton() }
+				{ isJetpack ? this.renderJetpackContactButton() : this.renderHelpCenterButton() }
 				{ this.renderSupportButton() }
 			</div>
 		);
 	}
 
-	renderContactButton() {
-		let url = CALYPSO_CONTACT;
-		let target = '';
-
-		if ( this.props.isJetpack ) {
-			url = JETPACK_CONTACT_SUPPORT;
-			target = '_blank';
-		}
-
+	renderJetpackContactButton() {
 		return (
-			<Button href={ url } target={ target } className="happiness-support__contact-button">
+			<Button
+				href={ JETPACK_CONTACT_SUPPORT }
+				target="_blank"
+				onClick={ this.onContactButtonClick }
+				className="happiness-support__contact-button"
+			>
 				{ this.props.translate( 'Ask a question' ) }
 			</Button>
 		);
 	}
 
-	renderLiveChatButton() {
+	renderHelpCenterButton() {
 		return (
-			<HappychatButton
-				borderless={ false }
-				onClick={ this.onLiveChatButtonClick }
+			<SupportButton
+				isLink={ false }
+				onClick={ this.onContactButtonClick }
 				className="happiness-support__livechat-button"
+				skipToContactOptions
 			>
 				{ this.props.translate( 'Ask a question' ) }
-			</HappychatButton>
+			</SupportButton>
 		);
 	}
 
@@ -167,9 +144,4 @@ export class HappinessSupport extends Component {
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		liveChatAvailable: isHappychatAvailable( state ),
-	} ),
-	{ recordTracksEvent }
-)( localize( HappinessSupport ) );
+export default connect( null, { recordTracksEvent } )( localize( HappinessSupport ) );

--- a/client/components/support-button/index.tsx
+++ b/client/components/support-button/index.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
+import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import type { FC } from 'react';
@@ -18,11 +19,12 @@ const SupportButton: FC< Props > = ( {
 	skipToContactOptions = false,
 } ) => {
 	const { __ } = useI18n();
+	const { url } = useStillNeedHelpURL();
 	const { setInitialRoute, setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	function handleClick() {
 		if ( skipToContactOptions ) {
-			setInitialRoute( '/contact-options' );
+			setInitialRoute( url );
 		}
 		setShowHelpCenter( true );
 		recordTracksEvent( 'calypso_support_button_click', {

--- a/client/components/support-button/index.tsx
+++ b/client/components/support-button/index.tsx
@@ -1,0 +1,40 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@automattic/components';
+import { HelpCenter } from '@automattic/data-stores';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import type { FC } from 'react';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+type Props = {
+	isLink?: boolean;
+	skipToContactOptions?: boolean;
+};
+
+const SupportButton: FC< Props > = ( {
+	isLink = true,
+	children,
+	skipToContactOptions = false,
+} ) => {
+	const { __ } = useI18n();
+	const { setInitialRoute, setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
+
+	function handleClick() {
+		if ( skipToContactOptions ) {
+			setInitialRoute( '/contact-options' );
+		}
+		setShowHelpCenter( true );
+		recordTracksEvent( 'calypso_support_button_click', {
+			skip_to_contact_options: skipToContactOptions,
+		} );
+	}
+
+	return (
+		<Button borderless={ isLink } onClick={ handleClick }>
+			{ children || __( 'Contact support' ) }
+		</Button>
+	);
+};
+
+export default SupportButton;

--- a/client/my-sites/checkout/checkout-thank-you/difm/difm-lite-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/difm/difm-lite-thank-you.tsx
@@ -44,8 +44,7 @@ export default function DIFMLiteThankYou() {
 			<Card className="difm-lite-thank-you__feature">
 				<HappinessSupport
 					isJetpack={ false }
-					liveChatButtonEventName="calypso_plans_autoconfig_chat_initiated"
-					showLiveChatButton={ true }
+					contactButtonEventName="calypso_plans_autoconfig_chat_initiated"
 				/>
 			</Card>
 		</Card>

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -56,7 +56,6 @@ import {
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
 import { recordStartTransferClickInThankYou } from 'calypso/state/domains/actions';
-import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import {
 	getPlugins as getInstalledPlugins,
@@ -124,7 +123,6 @@ export interface CheckoutThankYouProps {
 
 export interface CheckoutThankYouConnectedProps {
 	isProductsListFetching: boolean;
-	isHappychatEligible: boolean | null;
 	receipt: ReceiptState;
 	gsuiteReceipt: ReceiptState | null;
 	sitePlans: SitesPlansResult;
@@ -463,8 +461,7 @@ export class CheckoutThankYou extends Component<
 	};
 
 	render() {
-		const { translate, isHappychatEligible, email, domainOnlySiteFlow, selectedFeature } =
-			this.props;
+		const { translate, email, domainOnlySiteFlow, selectedFeature } = this.props;
 		let purchases: ReceiptPurchase[] = [];
 		let failedPurchases = [];
 		let wasJetpackPlanPurchased = false;
@@ -628,8 +625,7 @@ export class CheckoutThankYou extends Component<
 					<Card className="checkout-thank-you__footer">
 						<HappinessSupport
 							isJetpack={ wasJetpackPlanPurchased }
-							liveChatButtonEventName="calypso_plans_autoconfig_chat_initiated"
-							showLiveChatButton={ isHappychatEligible }
+							contactButtonEventName="calypso_plans_autoconfig_chat_initiated"
 						/>
 					</Card>
 				) }
@@ -835,7 +831,6 @@ export default connect(
 
 		return {
 			isProductsListFetching: isProductsListFetching( state ),
-			isHappychatEligible: isHappychatUserEligible( state ),
 			receipt: getReceiptById( state, props.receiptId ),
 			gsuiteReceipt: props.gsuiteReceiptId ? getReceiptById( state, props.gsuiteReceiptId ) : null,
 			sitePlans: getPlansBySite( state, props.selectedSite ),


### PR DESCRIPTION
Switch to using SupportButton instead which opens Help Center.

Part of efforts to sunset Happy Chat and remove all references: pdm0RZ-BU-p2

## Proposed Changes

* Update `HappinessSupport` component to not depend on `HappychatButton`. Instead, it should depend on Help Center via`SupportButton`.
* This also simplifies the setup - the clients should not check themselves if chat is available, if the chat option should be enabled, etc.

## Testing Instructions

Test in `/plans/my-plan`:

<img width="1154" alt="Screenshot 2023-06-16 at 10 47 24" src="https://github.com/Automattic/wp-calypso/assets/3392497/3c696d53-7488-4fe4-be80-82e21609c870">

Verify the links work as expected:
 - Ask a question should open Help Center with the contact options.
 - Support documentation should open a new tab with support docs.

Test in checkout thank-you page (it shows up at the very end):
<img width="799" alt="Screenshot 2023-06-16 at 10 48 19" src="https://github.com/Automattic/wp-calypso/assets/3392497/cd799a34-f005-4502-af56-1df7f7106cb7">

Same as above.

Make sure you also test with a Jetpack plan/purchase. In which case, the Ask a question link should go to `https://jetpack.com/contact-support/?rel=support`. And the support docs one to `https://jetpack.com/support/`.