### PR TITLE
Fix budget left in blazepress redesign & remove missing support link

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query-new.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query-new.ts
@@ -29,7 +29,7 @@ export type CampaignResponse = {
 		clickthrough_rate: number;
 		duration_days: number;
 		total_budget: number;
-		total_budget_left: number;
+		budget_left: number;
 		total_budget_used: number;
 		display_delivery_estimate: string;
 		visits_total: number;

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -597,10 +597,12 @@ export default function CampaignItemDetails( props: Props ) {
 								<div className="campaign-item-details__support-heading">
 									{ translate( 'Support articles' ) }
 								</div>
+								{ /*
+								commented out until we get the link
 								<Button className="is-link campaign-item-details__support-effective-ad-doc">
 									{ translate( 'What makes an effective ad?' ) }
 									<Gridicon icon="external" size={ 16 } />
-								</Button>
+								</Button>*/ }
 
 								<InlineSupportLink
 									className="is-link components-button campaign-item-details__support-link"

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -90,7 +90,7 @@ export default function CampaignItemDetails( props: Props ) {
 		clicks_total,
 		clickthrough_rate,
 		duration_days,
-		total_budget_left,
+		budget_left,
 		total_budget,
 		total_budget_used,
 		visits_total = 0,
@@ -115,7 +115,7 @@ export default function CampaignItemDetails( props: Props ) {
 	const ctrFormatted = clickthrough_rate ? `${ clickthrough_rate.toFixed( 2 ) }%` : '-';
 	const durationFormatted = getCampaignDurationFormatted( start_date, end_date );
 	const totalBudgetFormatted = `$${ formatCents( total_budget || 0 ) }`;
-	const totalBudgetLeftFormatted = `$${ formatCents( total_budget_left || 0 ) } ${ __( 'left' ) }`;
+	const totalBudgetLeftFormatted = `$${ formatCents( budget_left || 0 ) } ${ __( 'left' ) }`;
 	const overallSpendingFormatted = `$${ formatCents( total_budget_used || 0 ) }`;
 	const deliveryEstimateFormatted = getCampaignEstimatedImpressions( display_delivery_estimate );
 	const campaignTitleFormatted = title || __( 'Untitled' );


### PR DESCRIPTION
Related to #
- Changed "budget_left" to use the current accessor from the DSP: Now it displays the same info that in the campaigns table:
![image](https://github.com/Automattic/wp-calypso/assets/43957544/6dd266df-b046-46a4-96a6-d372ff8aca85)

![image](https://github.com/Automattic/wp-calypso/assets/43957544/27957dee-1ba4-4f2a-8928-5e3142c3ada4)


- Remove missing link from support section: "what makes an ad effective" until we get this page
![image](https://github.com/Automattic/wp-calypso/assets/43957544/57905ec1-ec7d-4009-9be3-c7f453f83bd7)


## Testing Instructions

- Go to any campaign and check that you cannot see the support link "what makes an ad effective"
-  Check if the "left" label displays the correct amount coming from the campaigns table

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
