### PR TITLE
Make all backend messages undismissable

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-page/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-page/index.tsx
@@ -33,7 +33,7 @@ export default function CampaignItemPage( props: Props ) {
 
 	if ( isError ) {
 		return (
-			<Notice status="is-error" icon="mention">
+			<Notice status="is-error" icon="mention" showDismiss={ false }>
 				{ noCampaignListMessage }
 			</Notice>
 		);

--- a/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx
@@ -57,7 +57,12 @@ export default function CampaignsList( props: Props ) {
 
 	if ( isError && hasLocalUser ) {
 		return (
-			<Notice className="promote-post-i2__aux-wrapper" status="is-error" icon="mention">
+			<Notice
+				className="promote-post-i2__aux-wrapper"
+				status="is-error"
+				icon="mention"
+				showDismiss={ false }
+			>
 				{ fetchErrorListMessage }
 			</Notice>
 		);

--- a/client/my-sites/promote-post-i2/components/posts-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/posts-list/index.tsx
@@ -58,7 +58,12 @@ export default function PostsList( props: Props ) {
 
 	if ( isError && hasLocalUser ) {
 		return (
-			<Notice className="promote-post-i2__aux-wrapper" status="is-error" icon="mention">
+			<Notice
+				className="promote-post-i2__aux-wrapper"
+				status="is-error"
+				icon="mention"
+				showDismiss={ false }
+			>
 				{ fetchErrorListMessage }
 			</Notice>
 		);


### PR DESCRIPTION
Related to #

- Remove the close in the <notice> components used in BlazePress since we're not handling them in any form

![image](https://github.com/Automattic/wp-calypso/assets/43957544/527c0e88-7ce4-4e2b-8967-b5913582a15c)

## Testing Instructions

- go to the campaigns section in blazepress
- Block the campaigns call. You can do it in Chrome Devtools

<img width="1263" alt="image" src="https://github.com/Automattic/wp-calypso/assets/43957544/9cdfeae0-c723-4675-b9e4-5bc3801d8f3a">

- Reload the webpage, it should display the error without a closing button

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
