### PR TITLE
Stepper: Extract the login URL constructing code into an utility function

### DIFF
--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -1,4 +1,3 @@
-import { useLocale, useLocalizeUrl } from '@automattic/i18n-utils';
 import { useFlowProgress, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -14,7 +13,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
-import { getLoginPath } from '../utils/path';
+import { useLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
@@ -85,14 +84,11 @@ const newsletter: Flow = {
 			flowName,
 		} );
 		setStepProgress( flowProgress );
-		const locale = useLocale();
-		const localizeUrl = useLocalizeUrl();
-
-		const logInUrl = localizeUrl(
-			getLoginPath( `/setup/${ flowName }/newsletterSetup`, 'Newsletter', flowName ),
-			locale,
-			userIsLoggedIn
-		);
+		const logInUrl = useLoginUrl( {
+			flowName,
+			redirectTo: `/setup/${ flowName }/newsletterSetup`,
+			pageTitle: 'Newsletter',
+		} );
 
 		// Unless showing intro step, send non-logged-in users to account screen.
 		if ( ! isLoadingIntroScreen && ! userIsLoggedIn ) {

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -1,4 +1,4 @@
-import { useLocale } from '@automattic/i18n-utils';
+import { useLocale, useLocalizeUrl } from '@automattic/i18n-utils';
 import { useFlowProgress, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -14,6 +14,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
+import { getLoginPath } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
@@ -85,16 +86,17 @@ const newsletter: Flow = {
 		} );
 		setStepProgress( flowProgress );
 		const locale = useLocale();
+		const localizeUrl = useLocalizeUrl();
 
-		const getStartUrl = () => {
-			return locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Newsletter&redirect_to=/setup/${ flowName }/newsletterSetup`
-				: `/start/account/user?variationName=${ flowName }&pageTitle=Newsletter&redirect_to=/setup/${ flowName }/newsletterSetup`;
-		};
+		const logInUrl = localizeUrl(
+			getLoginPath( `/setup/${ flowName }/newsletterSetup`, 'Newsletter', flowName ),
+			locale,
+			userIsLoggedIn
+		);
 
 		// Unless showing intro step, send non-logged-in users to account screen.
 		if ( ! isLoadingIntroScreen && ! userIsLoggedIn ) {
-			window.location.assign( getStartUrl() );
+			window.location.assign( logInUrl );
 		}
 
 		// trigger guides on step movement, we don't care about failures or response
@@ -111,7 +113,6 @@ const newsletter: Flow = {
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
-			const logInUrl = getStartUrl();
 
 			switch ( _currentStep ) {
 				case 'intro':

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -44,23 +44,28 @@ export function useLangRouteParam() {
 	return match?.params.lang;
 }
 
-export const useLoginUrl = ( {
-	flowName,
-	redirectTo,
-	pageTitle,
-}: {
-	flowName: string;
-	redirectTo: string;
-	pageTitle: string;
+export const useLoginUrl = ( params: {
+	flowName?: string;
+	redirectTo?: string;
+	pageTitle?: string;
 } ): string => {
 	const locale = useLocale();
 
 	const loginPath =
 		locale && locale !== 'en' ? `/start/account/user/${ locale }` : `/start/account/user`;
 
-	return addQueryArgs( loginPath, {
-		redirect_to: redirectTo,
-		variationName: flowName,
-		pageTitle: pageTitle,
-	} );
+	const nonEmptyQueryParameters = Object.entries( params )
+		.filter( ( [ , value ] ) => value )
+		.map( ( [ key, value ] ) => {
+			switch ( key ) {
+				case 'redirectTo':
+					return [ 'redirect_to', value ];
+				case 'flowName':
+					return [ 'variationName', value ];
+				default:
+					return [ key, value ];
+			}
+		} );
+
+	return addQueryArgs( loginPath, Object.fromEntries( nonEmptyQueryParameters ) );
 };

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -1,5 +1,6 @@
 import { Plans } from '@automattic/data-stores';
 import languages from '@automattic/languages';
+import { addQueryArgs } from '@wordpress/url';
 import { useMatch } from 'react-router-dom';
 
 const plansPaths = Plans.plansSlugs;
@@ -41,3 +42,16 @@ export function useLangRouteParam() {
 	const match = useMatch( path );
 	return match?.params.lang;
 }
+
+export const getLoginPath = (
+	redirectTo: string,
+	pageTitle = '',
+	variationName = '',
+	loginPath = '/start/account/user'
+): string => {
+	return addQueryArgs( loginPath, {
+		redirect_to: redirectTo,
+		variationName,
+		pageTitle,
+	} );
+};

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -1,4 +1,5 @@
 import { Plans } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
 import { addQueryArgs } from '@wordpress/url';
 import { useMatch } from 'react-router-dom';
@@ -43,15 +44,23 @@ export function useLangRouteParam() {
 	return match?.params.lang;
 }
 
-export const getLoginPath = (
-	redirectTo: string,
-	pageTitle = '',
-	variationName = '',
-	loginPath = '/start/account/user'
-): string => {
+export const useLoginUrl = ( {
+	flowName,
+	redirectTo,
+	pageTitle,
+}: {
+	flowName: string;
+	redirectTo: string;
+	pageTitle: string;
+} ): string => {
+	const locale = useLocale();
+
+	const loginPath =
+		locale && locale !== 'en' ? `/start/account/user/${ locale }` : `/start/account/user`;
+
 	return addQueryArgs( loginPath, {
 		redirect_to: redirectTo,
-		variationName,
-		pageTitle,
+		variationName: flowName,
+		pageTitle: pageTitle,
 	} );
 };


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/growth-foundations#70 , which is a refactor that will make the subsequent works easier to maintain.

## Proposed Changes

This PR extracts the repetitive login URL constructing code into an utility function so. Also, it applies `useLocalizeUrl()` hook to alter the URL according to the locale in a more standardized way(see https://github.com/Automattic/wp-calypso/blob/trunk/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx#L24 for an example usage).

The PR chooses the Newsletter flow as the 1st use case. Once it is approved, the same will be propagated into all the other tailored flows.

## Testing Instructions

The Newsletter flow should work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
