### PR TITLE
Assembler - Adding clarity with premium badge and free and premium fonts and styles titles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -31,7 +31,6 @@ const ScreenColorPalettes = ( {
 				description={ translate(
 					'Choose from our curated color palettes when you upgrade to the Premium plan or above.'
 				) }
-				isPremium
 				onBack={ onBack }
 			/>
 			<div className="screen-container__body">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
@@ -31,7 +31,6 @@ const ScreenFontPairings = ( {
 				description={ translate(
 					'Choose from our curated font pairings when you upgrade to the Premium plan or above.'
 				) }
-				isPremium
 				onBack={ onBack }
 			/>
 			<div className="screen-container__body">

--- a/packages/design-picker/src/components/premium-badge/index.tsx
+++ b/packages/design-picker/src/components/premium-badge/index.tsx
@@ -12,6 +12,7 @@ interface Props {
 	tooltipClassName?: string;
 	tooltipPosition?: string;
 	isPremiumThemeAvailable?: boolean;
+	shouldCompactWithAnimation?: boolean;
 	shouldHideIcon?: boolean;
 	shouldHideTooltip?: boolean;
 	focusOnShow?: boolean;
@@ -24,6 +25,7 @@ const PremiumBadge: FunctionComponent< Props > = ( {
 	tooltipClassName,
 	tooltipPosition = 'bottom left',
 	isPremiumThemeAvailable,
+	shouldCompactWithAnimation,
 	shouldHideIcon,
 	shouldHideTooltip,
 	focusOnShow,
@@ -42,12 +44,22 @@ const PremiumBadge: FunctionComponent< Props > = ( {
 
 	const divRef = useRef( null );
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
+	const [ isHovered, setIsHovered ] = useState( false );
 	return (
 		<div
-			className={ classNames( 'premium-badge', className ) }
+			className={ classNames( 'premium-badge', className, {
+				'premium-badge__compact-animation': shouldCompactWithAnimation,
+				'premium-badge--compact': shouldCompactWithAnimation && ! isHovered,
+			} ) }
 			ref={ divRef }
-			onMouseEnter={ () => setIsPopoverVisible( true ) }
-			onMouseLeave={ () => setIsPopoverVisible( false ) }
+			onMouseEnter={ () => {
+				setIsPopoverVisible( true );
+				setIsHovered( true );
+			} }
+			onMouseLeave={ () => {
+				setIsPopoverVisible( false );
+				setIsHovered( false );
+			} }
 		>
 			{ ! shouldHideIcon && (
 				<>
@@ -55,7 +67,7 @@ const PremiumBadge: FunctionComponent< Props > = ( {
 					<Gridicon className="premium-badge__logo" icon="star" size={ 14 } />
 				</>
 			) }
-			<span>{ labelText || __( 'Premium' ) }</span>
+			<span className="premium-badge__label">{ labelText || __( 'Premium' ) }</span>
 			{ ! shouldHideTooltip && (
 				<Popover
 					className={ classNames( 'premium-badge__popover', tooltipClassName ) }

--- a/packages/design-picker/src/components/premium-badge/style.scss
+++ b/packages/design-picker/src/components/premium-badge/style.scss
@@ -23,16 +23,30 @@
 	}
 
 	&.premium-badge__compact-animation {
-		transition: all 0.2s ease-out;
+		position: relative;
+		padding: 0 10px 0 25px;
+		cursor: default;
+
+		&,
+		.premium-badge__logo {
+			transition-property: all;
+			transition-duration: 0.1s;
+			transition-timing-function: ease-out;
+		}
+
+		.premium-badge__logo {
+			position: absolute;
+			left: 7px;
+			width: 14px;
+			height: 14px;
+		}
 
 		&.premium-badge--compact {
-			width: 20px;
-			height: 20px;
-			padding: 0;
-			justify-content: center;
+			padding: 0 0 0 20px;
 
 			.premium-badge__logo {
-				margin: -1px 0 0;
+				left: 3px;
+				margin: 0;
 			}
 
 			.premium-badge__label {

--- a/packages/design-picker/src/components/premium-badge/style.scss
+++ b/packages/design-picker/src/components/premium-badge/style.scss
@@ -22,6 +22,26 @@
 		fill: currentColor;
 	}
 
+	&.premium-badge__compact-animation {
+		transition: all 0.2s ease-out;
+
+		&.premium-badge--compact {
+			width: 20px;
+			height: 20px;
+			padding: 0;
+			justify-content: center;
+
+			.premium-badge__logo {
+				margin: -1px 0 0;
+			}
+
+			.premium-badge__label {
+				width: 0;
+				overflow: hidden;
+			}
+		}
+	}
+
 	.components-tooltip .components-popover__content {
 		border-radius: 4px;
 		margin: 8px;

--- a/packages/design-picker/src/components/premium-badge/style.scss
+++ b/packages/design-picker/src/components/premium-badge/style.scss
@@ -39,6 +39,7 @@
 			left: 7px;
 			width: 14px;
 			height: 14px;
+			margin: 0;
 		}
 
 		&.premium-badge--compact {
@@ -46,7 +47,6 @@
 
 			.premium-badge__logo {
 				left: 3px;
-				margin: 0;
 			}
 
 			.premium-badge__label {

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -1,3 +1,4 @@
+import { PremiumBadge } from '@automattic/design-picker';
 import {
 	__unstableComposite as Composite,
 	__unstableUseCompositeState as useCompositeState,
@@ -55,7 +56,7 @@ const ColorPaletteVariation = ( {
 			aria-label={
 				translate( 'Color: %s', {
 					comment: 'Aria label for color preview buttons',
-					args: colorPaletteVariation.title ?? translate( 'Default' ),
+					args: colorPaletteVariation.title ?? translate( 'Free style' ),
 				} ) as string
 			}
 		>
@@ -82,25 +83,33 @@ const ColorPaletteVariations = ( {
 		<Composite
 			{ ...composite }
 			role="listbox"
-			className="color-palette-variations"
 			aria-label={ translate( 'Color palette variations' ) }
 		>
-			<ColorPaletteVariation
-				key="base"
-				colorPaletteVariation={ base }
-				isActive={ ! selectedColorPaletteVariation }
-				composite={ composite }
-				onSelect={ () => onSelect( null ) }
-			/>
-			{ colorPaletteVariations.map( ( colorPaletteVariation, index ) => (
+			<h3 className="global-styles-variation__title">{ translate( 'Free styles' ) }</h3>
+			<div className="color-palette-variations">
 				<ColorPaletteVariation
-					key={ index }
-					colorPaletteVariation={ colorPaletteVariation }
-					isActive={ colorPaletteVariation.title === selectedColorPaletteVariation?.title }
+					key="base"
+					colorPaletteVariation={ { ...base, title: translate( 'Free style' ) } }
+					isActive={ ! selectedColorPaletteVariation }
 					composite={ composite }
-					onSelect={ () => onSelect( colorPaletteVariation ) }
+					onSelect={ () => onSelect( null ) }
 				/>
-			) ) }
+			</div>
+			<h3 className="global-styles-variation__title">
+				{ translate( 'Premium styles' ) }
+				<PremiumBadge shouldHideTooltip shouldCompactWithAnimation />
+			</h3>
+			<div className="color-palette-variations">
+				{ colorPaletteVariations.map( ( colorPaletteVariation, index ) => (
+					<ColorPaletteVariation
+						key={ index }
+						colorPaletteVariation={ colorPaletteVariation }
+						isActive={ colorPaletteVariation.title === selectedColorPaletteVariation?.title }
+						composite={ composite }
+						onSelect={ () => onSelect( colorPaletteVariation ) }
+					/>
+				) ) }
+			</div>
 		</Composite>
 	);
 };

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -85,7 +85,7 @@ const ColorPaletteVariations = ( {
 			role="listbox"
 			aria-label={ translate( 'Color palette variations' ) }
 		>
-			<h3 className="global-styles-variation__title">{ translate( 'Free styles' ) }</h3>
+			<h3 className="global-styles-variation__title">{ translate( 'Free style' ) }</h3>
 			<div className="color-palette-variations">
 				<ColorPaletteVariation
 					key="base"

--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -4,10 +4,24 @@
 	grid-template-columns: repeat(3, 1fr);
 	width: 100%;
 	box-sizing: border-box;
+	margin: 14px -2px 26px;
 
 	.global-styles-variation-container__iframe {
 		max-height: 47px;
 	}
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+}
+
+.global-styles-variation__title {
+	display: flex;
+	color: var(--color-neutral-100);
+	font-size: $font-body-small;
+	font-weight: 500;
+	letter-spacing: -0.15px;
+	line-height: 1.4;
 }
 
 .global-styles-variation__item {

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -1,3 +1,4 @@
+import { PremiumBadge } from '@automattic/design-picker';
 import {
 	__unstableComposite as Composite,
 	__unstableUseCompositeState as useCompositeState,
@@ -55,7 +56,7 @@ const FontPairingVariation = ( {
 			aria-label={
 				translate( 'Font: %s', {
 					comment: 'Aria label for font preview buttons',
-					args: fontPairingVariation.title ?? translate( 'Default' ),
+					args: fontPairingVariation.title ?? translate( 'Free font' ),
 				} ) as string
 			}
 		>
@@ -82,25 +83,33 @@ const FontPairingVariations = ( {
 		<Composite
 			{ ...composite }
 			role="listbox"
-			className="font-pairing-variations"
 			aria-label={ translate( 'Font pairing variations' ) }
 		>
-			<FontPairingVariation
-				key="base"
-				fontPairingVariation={ base }
-				isActive={ ! selectedFontPairingVariation }
-				composite={ composite }
-				onSelect={ () => onSelect( null ) }
-			/>
-			{ fontPairingVariations.map( ( fontPairingVariation, index ) => (
+			<h3 className="global-styles-variation__title">{ translate( 'Free fonts' ) }</h3>
+			<div className="font-pairing-variations">
 				<FontPairingVariation
-					key={ index }
-					fontPairingVariation={ fontPairingVariation }
-					isActive={ fontPairingVariation.title === selectedFontPairingVariation?.title }
+					key="base"
+					fontPairingVariation={ { ...base, title: translate( 'Free font' ) } }
+					isActive={ ! selectedFontPairingVariation }
 					composite={ composite }
-					onSelect={ () => onSelect( fontPairingVariation ) }
+					onSelect={ () => onSelect( null ) }
 				/>
-			) ) }
+			</div>
+			<h3 className="global-styles-variation__title">
+				{ translate( 'Premium fonts' ) }
+				<PremiumBadge shouldHideTooltip shouldCompactWithAnimation />
+			</h3>
+			<div className="font-pairing-variations">
+				{ fontPairingVariations.map( ( fontPairingVariation, index ) => (
+					<FontPairingVariation
+						key={ index }
+						fontPairingVariation={ fontPairingVariation }
+						isActive={ fontPairingVariation.title === selectedFontPairingVariation?.title }
+						composite={ composite }
+						onSelect={ () => onSelect( fontPairingVariation ) }
+					/>
+				) ) }
+			</div>
 		</Composite>
 	);
 };

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -85,7 +85,7 @@ const FontPairingVariations = ( {
 			role="listbox"
 			aria-label={ translate( 'Font pairing variations' ) }
 		>
-			<h3 className="global-styles-variation__title">{ translate( 'Free fonts' ) }</h3>
+			<h3 className="global-styles-variation__title">{ translate( 'Free font' ) }</h3>
 			<div className="font-pairing-variations">
 				<FontPairingVariation
 					key="base"

--- a/packages/global-styles/src/components/font-pairing-variations/style.scss
+++ b/packages/global-styles/src/components/font-pairing-variations/style.scss
@@ -4,9 +4,14 @@
 	grid-template-columns: repeat(1, 1fr);
 	width: 100%;
 	box-sizing: border-box;
+	margin: 14px -2px 26px;
 
 	.global-styles-variation-container__iframe {
 		max-height: 80px;
+	}
+
+	&:last-child {
+		margin-bottom: 0;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/75156

## Proposed Changes

* Add feature compact animation to premium badge
* Remove premium badge from fonts and styles screens
* Add font and styles title and premium compact animated badge

### Animated compact premium badge

https://github.com/Automattic/wp-calypso/assets/1881481/675d9ac5-8a5d-4a15-be54-4bf7cb291f85

### Fonts

|BEFORE|AFTER|
|--|--|
|<img width="351" alt="Screenshot 2566-06-16 at 19 26 21" src="https://github.com/Automattic/wp-calypso/assets/1881481/ee6f9388-d894-4523-b477-b6d66f3285b5">|<img width="351" alt="Screenshot 2566-06-16 at 19 25 13" src="https://github.com/Automattic/wp-calypso/assets/1881481/5288630e-0b95-4f6a-848a-4bfa1bd53008">|

### Styles

|BEFORE|AFTER|
|--|--|
|<img width="348" alt="Screenshot 2566-06-16 at 19 26 07" src="https://github.com/Automattic/wp-calypso/assets/1881481/181ddf33-162e-4876-84f1-a7168f581064">|<img width="347" alt="Screenshot 2566-06-16 at 19 25 51" src="https://github.com/Automattic/wp-calypso/assets/1881481/0ee85b37-6bcf-49ce-903e-6a279f079484">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3`
* Verify there are titles for Free and Premium fonts and styles
* Verify the premium badge is on premium fonts and styles
* Verify Free and Premium fonts and styles work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->
- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
