### PR TITLE
Reader: Fix YouTube autoplay not triggering when an autoplay iframe is inserted as a response to a thumbnail click

### DIFF
--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -78,6 +78,12 @@ const getAutoplayIframe = ( iframe ) => {
 		} else {
 			autoplayIframe.src += '&autoplay=1';
 		}
+
+		// ?autoplay=1 is no longer sufficient for YouTube - we also need to add autoplay to the allow attribute.
+		const allow = ( autoplayIframe.allow || '' ).split( /\s*;\s*/g );
+		allow.push( 'autoplay' );
+		autoplayIframe.setAttribute( 'allow', allow.filter( ( s ) => s.length > 0 ).join( '; ' ) );
+
 		return autoplayIframe.outerHTML;
 	}
 	return null;


### PR DESCRIPTION
Related to p1HpG7-lfW-p2#comment-64019

Clicking on a featured video thumbnail in reader injects an autoplay iframe of the video but at some point YouTube has started requiring that `allow="autoplay"` is present on the iframe for autoplay to work. This means that for YouTube videos, 2 clicks are required in order to start playing a video (see the before and after at the bottom).

## Proposed Changes

* Reader: Fix YouTube autoplay not triggering when an autoplay iframe is inserted as a response to a thumbnail click.

## Testing Instructions

- Follow this blog so it shows up in your reader: https://atanasvideofeedblog.wordpress.com/
- Open up the blog's feed before checking out this patch: http://calypso.localhost:3000/read/feeds/143404674
- Click on the first YouTube post's featured video thumbnail with a play button - it should be replaced with a YouTube embed but that embed will require a second click for it to start playing.
- Checkout this PR's branch and refresh - the second click should no longer be required in order to play the video.

Before:

https://github.com/Automattic/wp-calypso/assets/22746396/abe09f37-e16e-4e58-b4fc-cc1175fc11a2

After:

https://github.com/Automattic/wp-calypso/assets/22746396/f89f3ad4-2566-4bce-854a-491fc0a45270

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?