### PR TITLE
Subscription Management: Add cross-portal compatible Link component and fix title cell styling.

### DIFF
--- a/client/landing/subscriptions/components/link/index.ts
+++ b/client/landing/subscriptions/components/link/index.ts
@@ -1,0 +1,1 @@
+export { default as Link } from './link';

--- a/client/landing/subscriptions/components/link/link.tsx
+++ b/client/landing/subscriptions/components/link/link.tsx
@@ -1,0 +1,19 @@
+import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
+import {
+	useSubscriptionManagerContext,
+	SubscriptionsPortal,
+} from '../subscription-manager-context';
+
+type LinkProps = Omit< RouterLinkProps, 'to' > &
+	Omit< React.HTMLProps< HTMLAnchorElement >, 'ref' > & { active?: boolean };
+
+const Link: React.FunctionComponent< LinkProps > = ( { active = false, ...props } ) => {
+	const { portal } = useSubscriptionManagerContext();
+
+	if ( active || portal === SubscriptionsPortal ) {
+		return <RouterLink to={ props.href || '' } { ...props } />;
+	}
+	return <a { ...props }></a>;
+};
+
+export default Link;

--- a/client/landing/subscriptions/components/link/link.tsx
+++ b/client/landing/subscriptions/components/link/link.tsx
@@ -7,7 +7,7 @@ import {
 type LinkProps = Omit< RouterLinkProps, 'to' > &
 	Omit< React.HTMLProps< HTMLAnchorElement >, 'ref' > & { active?: boolean };
 
-const Link: React.FunctionComponent< LinkProps > = ( { active = false, ...props } ) => {
+const Link = ( { active = false, ...props }: LinkProps ) => {
 	const { portal } = useSubscriptionManagerContext();
 
 	if ( active || portal === SubscriptionsPortal ) {

--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
@@ -177,32 +177,30 @@ const SiteRow = ( {
 
 	return ! isDeleted ? (
 		<li className="row" role="row">
-			<div className="title-cell" role="cell">
-				<Link className="name" href={ siteTitleUrl }>
+			<span className="title-cell" role="cell">
+				<Link className="title-icon" href={ siteTitleUrl }>
 					<SiteIcon iconUrl={ site_icon } size={ 40 } siteName={ name } />
 				</Link>
-				<div className="vertical-stack">
-					<div className="horizontal-stack">
-						<Link className="name" href={ siteTitleUrl }>
-							{ name }
-						</Link>
+				<span className="title-column">
+					<Link className="title-name" href={ siteTitleUrl }>
+						{ name }
 						{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
 						{ !! is_paid_subscription && (
 							<span className="paid-label">
 								{ translate( 'Paid', { context: 'Label for a paid subscription plan' } ) }
 							</span>
 						) }
-					</div>
+					</Link>
 					<a
-						className="url"
+						className="title-url"
 						{ ...( url && { href: url } ) }
 						rel="noreferrer noopener"
 						target="_blank"
 					>
 						{ hostname }
 					</a>
-				</div>
-			</div>
+				</span>
+			</span>
 			<span className="date-cell" role="cell">
 				<TimeSince
 					date={

--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
@@ -1,15 +1,19 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
-import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import TimeSince from 'calypso/components/time-since';
 import { successNotice } from 'calypso/state/notices/actions';
+import { Link } from '../link';
 import { SiteSettingsPopover } from '../settings';
 import { SiteIcon } from '../site-icon';
-import { useSubscriptionManagerContext } from '../subscription-manager-context';
+import {
+	useSubscriptionManagerContext,
+	ReaderPortal,
+	SubscriptionsPortal,
+} from '../subscription-manager-context';
 
 const useDeliveryFrequencyLabel = ( deliveryFrequencyValue?: Reader.EmailDeliveryFrequency ) => {
 	const translate = useTranslate();
@@ -55,7 +59,6 @@ const SelectedNewPostDeliveryMethods = ( {
 };
 
 type SiteRowProps = Reader.SiteSubscription & {
-	onSiteTitleClick: () => void;
 	successNotice: typeof successNotice;
 };
 
@@ -68,7 +71,6 @@ const SiteRow = ( {
 	delivery_methods,
 	is_wpforteams_site,
 	is_paid_subscription,
-	onSiteTitleClick,
 	isDeleted,
 	successNotice,
 }: SiteRowProps ) => {
@@ -113,6 +115,17 @@ const SiteRow = ( {
 	};
 
 	const { portal } = useSubscriptionManagerContext();
+
+	const siteTitleUrl = useMemo( () => {
+		if ( portal === ReaderPortal ) {
+			// TODO: This should be feed_ID but we will address it separately
+			return `/read/feeds/${ blog_ID }`;
+		}
+
+		if ( portal === SubscriptionsPortal ) {
+			return `/subscriptions/site/${ blog_ID }`;
+		}
+	}, [ blog_ID, portal ] );
 
 	const handleNotifyMeOfNewPostsChange = ( send_posts: boolean ) => {
 		// Update post notification settings
@@ -165,16 +178,14 @@ const SiteRow = ( {
 	return ! isDeleted ? (
 		<li className="row" role="row">
 			<div className="title-cell" role="cell">
-				<Button
-					icon={ <SiteIcon iconUrl={ site_icon } siteName={ name } /> }
-					iconSize={ 40 }
-					onClick={ onSiteTitleClick }
-				/>
+				<Link className="name" href={ siteTitleUrl }>
+					<SiteIcon iconUrl={ site_icon } size={ 40 } siteName={ name } />
+				</Link>
 				<div className="vertical-stack">
 					<div className="horizontal-stack">
-						<Button className="name" onClick={ onSiteTitleClick }>
+						<Link className="name" href={ siteTitleUrl }>
 							{ name }
-						</Button>
+						</Link>
 						{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
 						{ !! is_paid_subscription && (
 							<span className="paid-label">

--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-subscriptions-list.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-subscriptions-list.tsx
@@ -4,11 +4,7 @@ import { Notice, NoticeType } from '../notice';
 import SiteRow from './site-row';
 import { useSiteSubscriptionsManager } from './site-subscriptions-manager-context';
 
-type SiteSubscriptionsListProps = {
-	onSiteTitleClick: ( blogId: number | string ) => void;
-};
-
-const SiteSubscriptionsList = ( { onSiteTitleClick }: SiteSubscriptionsListProps ) => {
+const SiteSubscriptionsList = () => {
 	const translate = useTranslate();
 	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 	const { filterOption, siteSubscriptionsQueryResult, searchTerm } = useSiteSubscriptionsManager();
@@ -58,11 +54,7 @@ const SiteSubscriptionsList = ( { onSiteTitleClick }: SiteSubscriptionsListProps
 				<span className="actions-cell" role="columnheader" />
 			</li>
 			{ subscriptions.map( ( siteSubscription ) => (
-				<SiteRow
-					key={ `sites.siteRow.${ siteSubscription.ID }` }
-					onSiteTitleClick={ () => onSiteTitleClick( siteSubscription.blog_ID ) }
-					{ ...siteSubscription }
-				/>
+				<SiteRow key={ `sites.siteRow.${ siteSubscription.ID }` } { ...siteSubscription } />
 			) ) }
 		</ul>
 	);

--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -1,7 +1,6 @@
 import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
-import { useNavigate } from 'react-router';
 import { Notice, NoticeType } from 'calypso/landing/subscriptions/components/notice';
 import SiteSubscriptionsList from './site-subscriptions-list';
 import ListActionsBar from './site-subscriptions-list-actions-bar';
@@ -52,14 +51,11 @@ SiteSubscriptionsManager.ListActionsBar = ListActionsBar;
 SiteSubscriptionsManager.List = SiteSubscriptionsList;
 
 export default () => {
-	const navigate = useNavigate();
 	return (
 		<SiteSubscriptionsManagerProvider>
 			<SiteSubscriptionsManager>
 				<SiteSubscriptionsManager.ListActionsBar />
-				<SiteSubscriptionsManager.List
-					onSiteTitleClick={ ( blogId ) => navigate( `/subscriptions/site/${ blogId }` ) }
-				/>
+				<SiteSubscriptionsManager.List />
 			</SiteSubscriptionsManager>
 		</SiteSubscriptionsManagerProvider>
 	);

--- a/client/landing/subscriptions/components/site-subscriptions-manager/styles.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/styles.scss
@@ -46,6 +46,7 @@
 			.title-icon {
 				display: flex;
 				flex: 0;
+				min-width: 40px;
 			}
 
 			.title-column {

--- a/client/landing/subscriptions/components/site-subscriptions-manager/styles.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/styles.scss
@@ -41,84 +41,55 @@
 				align-items: center;
 				flex: 1.83;
 				min-width: 0;
+			}
 
-				> button,
-				> a {
-					flex: 0;
+			.title-icon {
+				display: flex;
+				flex: 0;
+			}
+
+			.title-column {
+				display: flex;
+				flex-direction: column;
+				min-width: 0;
+				padding-left: 12px;
+			}
+
+			.title-name {
+				font-weight: 600;
+				font-size: $font-code;
+				line-height: 22px;
+				color: $studio-gray-100;
+				letter-spacing: -0.24px;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+				overflow: hidden;
+				padding-right: 10px;
+
+				&:hover {
+					text-decoration: underline;
 				}
 
-				.components-button svg {
-					fill: var(--color-text-subtle);
+				.p2-label {
+					@extend %p2-label;
 				}
 
-				.components-button.has-icon {
-					padding: 0;
-					margin: 0;
-					min-width: 40px;
-					min-height: 40px;
-
-					@media (max-width: $break-small) {
-						display: none;
-					}
+				.paid-label {
+					@extend %paid-label;
 				}
+			}
 
-				.vertical-stack {
-					display: flex;
-					flex-direction: column;
-					min-width: 0;
-					padding-left: 12px;
+			.title-url {
+				font-weight: 400;
+				font-size: $font-body-extra-small;
+				line-height: 18px;
+				color: $studio-gray-40;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+				overflow: hidden;
 
-					@media (max-width: $break-small) {
-						padding-left: 0;
-					}
-
-					.horizontal-stack {
-						align-items: center;
-						overflow: hidden;
-						white-space: nowrap;
-
-						.name {
-							display: inline-block;
-							padding: 0 10px 0 0;
-							max-width: 100%;
-							color: $studio-gray-100;
-							font-weight: 600;
-							font-size: $font-code;
-							line-height: 22px;
-							letter-spacing: -0.24px;
-							overflow: hidden;
-							text-overflow: ellipsis;
-							white-space: nowrap;
-
-							&:hover {
-								text-decoration: underline;
-							}
-						}
-
-						.p2-label {
-							vertical-align: text-top;
-							@extend %p2-label;
-						}
-
-						.paid-label {
-							vertical-align: text-top;
-							@extend %paid-label;
-						}
-					}
-
-					.url {
-						font-weight: 400;
-						font-size: $font-body-extra-small;
-						line-height: 18px;
-						color: $studio-gray-40;
-						text-overflow: ellipsis;
-						white-space: nowrap;
-						overflow: hidden;
-
-						&:hover {
-							text-decoration: underline;
-						}
-					}
+				&:hover {
+					text-decoration: underline;
 				}
 			}
 

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -34,7 +34,7 @@ const SiteSubscriptionsManager = () => {
 					<ExternalSiteSubscriptionsManager>
 						<ExternalSiteSubscriptionsManager.ListActionsBar />
 						<RecommendedSites />
-						<ExternalSiteSubscriptionsManager.List onSiteTitleClick={ () => undefined } />
+						<ExternalSiteSubscriptionsManager.List />
 					</ExternalSiteSubscriptionsManager>
 				</SiteSubscriptionsManagerProvider>
 			</Main>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/78328
Fixes https://github.com/Automattic/wp-calypso/issues/78331

## Proposed Changes

* Introduce a new `<Link>` component that works with both calypso router & react-router-dom.
  * This removes the need for `onSiteTitleClick()`.
* Migrate the links in Sites list to use `<Link>` component.
* Restore the old HTML structure for the title cell in Sites list with a bit of markup & styling clean-up.
  * This fixes the whitespace regression around the title icon and title name introduced in the [reader refactor PR](https://github.com/Automattic/wp-calypso/pull/77553).

## Testing Instructions

**Test standalone routing:**
 * Go to `/subscriptions/sites`.
 * Check if everything in the title cell renders properly.
 * Click on title icon and title name should take you to the individual site subscription page.

**Test reader routing:**
 * Go to `/read/subscriptions`.
 * Check if everything in the title cell renders properly.
 * Click on title icon and title name should take you to `/read/feeds/<broken_id>`.
   * Currently it leads to the wrong place. But as long as the URL on the address bar is correct, this is fine.
 

**Before:**
<img width="393" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/7e78bef8-0fa1-40a2-9657-d58b15551851">

**After:**
<img width="357" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/2b281753-473c-4c3f-b048-a51aae708977">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
