### PR TITLE
Site Assembler - Pattern Inserter - Show to users that a pattern was already added

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -623,6 +623,7 @@ const PatternAssembler = ( {
 						onSelect={ onSelect }
 						recordTracksEvent={ recordTracksEvent }
 						onTogglePatternPanelList={ setIsPatternPanelListOpen }
+						sections={ sections }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -623,7 +623,7 @@ const PatternAssembler = ( {
 						onSelect={ onSelect }
 						recordTracksEvent={ recordTracksEvent }
 						onTogglePatternPanelList={ setIsPatternPanelListOpen }
-						sections={ sections }
+						selectedPatterns={ sections }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
@@ -9,16 +9,16 @@ type PatternListPanelProps = {
 	categories: Category[];
 	selectedCategory: string | null;
 	patternsMapByCategory: { [ key: string ]: Pattern[] };
-	sections: Pattern[];
+	selectedPatterns: Pattern[];
 };
 
 const PatternListPanel = ( {
 	onSelect,
 	selectedPattern,
+	selectedPatterns,
 	selectedCategory,
 	categories,
 	patternsMapByCategory,
-	sections,
 }: PatternListPanelProps ) => {
 	const categoryPatterns = selectedCategory ? patternsMapByCategory[ selectedCategory ] : [];
 
@@ -39,7 +39,7 @@ const PatternListPanel = ( {
 				patterns={ categoryPatterns }
 				onSelect={ onSelect }
 				selectedPattern={ selectedPattern }
-				sections={ sections }
+				selectedPatterns={ selectedPatterns }
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
@@ -9,6 +9,7 @@ type PatternListPanelProps = {
 	categories: Category[];
 	selectedCategory: string | null;
 	patternsMapByCategory: { [ key: string ]: Pattern[] };
+	sections: Pattern[];
 };
 
 const PatternListPanel = ( {
@@ -17,6 +18,7 @@ const PatternListPanel = ( {
 	selectedCategory,
 	categories,
 	patternsMapByCategory,
+	sections,
 }: PatternListPanelProps ) => {
 	const categoryPatterns = selectedCategory ? patternsMapByCategory[ selectedCategory ] : [];
 
@@ -37,6 +39,7 @@ const PatternListPanel = ( {
 				patterns={ categoryPatterns }
 				onSelect={ onSelect }
 				selectedPattern={ selectedPattern }
+				sections={ sections }
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -22,11 +22,11 @@ interface PatternListRendererProps {
 	patterns: Pattern[];
 	shownPatterns: Pattern[];
 	selectedPattern: Pattern | null;
+	selectedPatterns?: Pattern[];
 	activeClassName: string;
 	emptyPatternText?: string;
 	composite?: Record< string, unknown >;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
-	sections?: Pattern[];
 }
 
 const PLACEHOLDER_HEIGHT = 100;
@@ -95,11 +95,11 @@ const PatternListRenderer = ( {
 	patterns,
 	shownPatterns,
 	selectedPattern,
+	selectedPatterns,
 	activeClassName,
 	emptyPatternText,
 	composite,
 	onSelect,
-	sections,
 }: PatternListRendererProps ) => {
 	return (
 		<>
@@ -120,7 +120,7 @@ const PatternListRenderer = ( {
 					className={ classnames( 'pattern-list-renderer__pattern-list-item', {
 						[ activeClassName ]:
 							pattern.ID === selectedPattern?.ID ||
-							sections?.find( ( { ID } ) => ID === pattern.ID ),
+							selectedPatterns?.find( ( { ID } ) => ID === pattern.ID ),
 					} ) }
 					isFirst={ index === 0 }
 					isShown={ shownPatterns.includes( pattern ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -26,6 +26,7 @@ interface PatternListRendererProps {
 	emptyPatternText?: string;
 	composite?: Record< string, unknown >;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
+	sections?: Pattern[];
 }
 
 const PLACEHOLDER_HEIGHT = 100;
@@ -98,6 +99,7 @@ const PatternListRenderer = ( {
 	emptyPatternText,
 	composite,
 	onSelect,
+	sections,
 }: PatternListRendererProps ) => {
 	return (
 		<>
@@ -116,7 +118,9 @@ const PatternListRenderer = ( {
 					key={ `${ index }-${ pattern.ID }` }
 					pattern={ pattern }
 					className={ classnames( 'pattern-list-renderer__pattern-list-item', {
-						[ activeClassName ]: pattern.ID === selectedPattern?.ID,
+						[ activeClassName ]:
+							pattern.ID === selectedPattern?.ID ||
+							sections?.find( ( { ID } ) => ID === pattern.ID ),
 					} ) }
 					isFirst={ index === 0 }
 					isShown={ shownPatterns.includes( pattern ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -12,6 +12,7 @@ type PatternSelectorProps = {
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 	selectedPattern: Pattern | null;
 	emptyPatternText?: string;
+	sections?: Pattern[];
 };
 
 const PatternSelector = ( {
@@ -19,6 +20,7 @@ const PatternSelector = ( {
 	onSelect,
 	selectedPattern,
 	emptyPatternText,
+	sections,
 }: PatternSelectorProps ) => {
 	const translate = useTranslate();
 	const shownPatterns = useAsyncList( patterns );
@@ -41,6 +43,7 @@ const PatternSelector = ( {
 						activeClassName="pattern-selector__block-list--selected-pattern"
 						composite={ composite }
 						onSelect={ onSelect }
+						sections={ sections }
 					/>
 				</Composite>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -11,16 +11,16 @@ type PatternSelectorProps = {
 	patterns: Pattern[];
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 	selectedPattern: Pattern | null;
+	selectedPatterns?: Pattern[];
 	emptyPatternText?: string;
-	sections?: Pattern[];
 };
 
 const PatternSelector = ( {
 	patterns = [],
 	onSelect,
 	selectedPattern,
+	selectedPatterns,
 	emptyPatternText,
-	sections,
 }: PatternSelectorProps ) => {
 	const translate = useTranslate();
 	const shownPatterns = useAsyncList( patterns );
@@ -39,11 +39,11 @@ const PatternSelector = ( {
 						patterns={ patterns }
 						shownPatterns={ shownPatterns }
 						selectedPattern={ selectedPattern }
+						selectedPatterns={ selectedPatterns }
 						emptyPatternText={ emptyPatternText }
 						activeClassName="pattern-selector__block-list--selected-pattern"
 						composite={ composite }
 						onSelect={ onSelect }
-						sections={ sections }
 					/>
 				</Composite>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -28,9 +28,9 @@ interface Props {
 	) => void;
 	replacePatternMode: boolean;
 	selectedPattern: Pattern | null;
+	selectedPatterns: Pattern[];
 	recordTracksEvent: ( name: string, eventProperties: any ) => void;
 	onTogglePatternPanelList?: ( isOpen: boolean ) => void;
-	sections: Pattern[];
 }
 
 const ScreenCategoryList = ( {
@@ -40,9 +40,9 @@ const ScreenCategoryList = ( {
 	replacePatternMode,
 	onSelect,
 	selectedPattern,
+	selectedPatterns,
 	recordTracksEvent,
 	onTogglePatternPanelList,
-	sections,
 }: Props ) => {
 	const translate = useTranslate();
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
@@ -141,9 +141,9 @@ const ScreenCategoryList = ( {
 					onSelect( 'section', selectedPattern, selectedCategory )
 				}
 				selectedPattern={ selectedPattern }
+				selectedPatterns={ selectedPatterns }
 				selectedCategory={ selectedCategory }
 				categories={ categories }
-				sections={ sections }
 				patternsMapByCategory={ patternsMapByCategory }
 			/>
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -30,6 +30,7 @@ interface Props {
 	selectedPattern: Pattern | null;
 	recordTracksEvent: ( name: string, eventProperties: any ) => void;
 	onTogglePatternPanelList?: ( isOpen: boolean ) => void;
+	sections: Pattern[];
 }
 
 const ScreenCategoryList = ( {
@@ -41,6 +42,7 @@ const ScreenCategoryList = ( {
 	selectedPattern,
 	recordTracksEvent,
 	onTogglePatternPanelList,
+	sections,
 }: Props ) => {
 	const translate = useTranslate();
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
@@ -141,6 +143,7 @@ const ScreenCategoryList = ( {
 				selectedPattern={ selectedPattern }
 				selectedCategory={ selectedCategory }
 				categories={ categories }
+				sections={ sections }
 				patternsMapByCategory={ patternsMapByCategory }
 			/>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #76175

## Proposed Changes

* Mark sections selected with a dark border

|BEFORE|AFTER|
|---|---|
|<img width="1375" alt="Screenshot 2566-06-16 at 20 51 43" src="https://github.com/Automattic/wp-calypso/assets/1881481/64dde4f5-02a6-4f02-9cb7-8af045865ebc">|<img width="1372" alt="Screenshot 2566-06-16 at 20 51 13" src="https://github.com/Automattic/wp-calypso/assets/1881481/e5aaf17a-2a6e-42e3-893d-714c3cc73ec4">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3`
* Add patterns
* Verify the selected patterns have a dark border

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
