### PR TITLE
Stepper: fix the signup completion event.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -7,7 +7,6 @@ import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
-import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
@@ -41,7 +40,6 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		data: { launchpad_screen: launchpadScreenOption, checklist: launchpadChecklist } = {},
 	} = useLaunchpad( siteSlug, siteIntentOption );
 
-	const recordSignupComplete = useRecordSignupComplete( flow );
 	const dispatch = useDispatch();
 	const { saveSiteSettings } = useWPDispatch( SITE_STORE );
 	const isLoggedIn = useSelector( isUserLoggedIn );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -87,10 +87,9 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 
 	useEffect( () => {
 		if ( siteSlug && site && localStorage.getItem( 'launchpad_siteSlug' ) !== siteSlug ) {
-			recordSignupComplete();
 			localStorage.setItem( 'launchpad_siteSlug', siteSlug );
 		}
-	}, [ recordSignupComplete, siteSlug, site ] );
+	}, [ siteSlug, site ] );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useInterval } from 'calypso/lib/interval';
@@ -42,6 +43,8 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
 	const [ hasActionSuccessfullyRun, setHasActionSuccessfullyRun ] = useState( false );
 	const [ destinationState, setDestinationState ] = useState( {} );
+
+	const recordSignupComplete = useRecordSignupComplete( flow );
 
 	useInterval( () => {
 		setCurrentMessageIndex( ( s ) => ( s + 1 ) % loadingMessages.length );
@@ -95,14 +98,15 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ action ] );
 
-	// When the hasActionSuccessfullyRun flag turns on, run submit().
+	// When the hasActionSuccessfullyRun flag turns on, run submit() and fire the sign-up completion event.
 	useEffect( () => {
 		if ( hasActionSuccessfullyRun ) {
+			recordSignupComplete();
 			submit?.( destinationState, ProcessingResult.SUCCESS );
 		}
 		// A change in submit() doesn't cause this effect to rerun.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ hasActionSuccessfullyRun ] );
+	}, [ hasActionSuccessfullyRun, recordSignupComplete ] );
 
 	const getSubtitle = () => {
 		return props.subtitle || loadingMessages[ currentMessageIndex ]?.subtitle;

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -39,7 +39,7 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 		const domainProductSlug =
 			domainCartItem &&
 			isDomainRegistration( domainCartItem ) &&
-			( domainCartItem.product_slug === '' ? undefined : domainCarItem.product_slug );
+			( domainCartItem.product_slug === '' ? undefined : domainCartItem.product_slug );
 		const hasCartItems = Boolean( domainProductSlug || planCartItem ); // see the function `dependenciesContainCartItem()
 
 		// TBD:

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -18,7 +18,7 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 		return {
 			siteCount: ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.site_count,
 			domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
-			planCartItem: ( select( ONBOARD_STORE ) as OnboardSelct ).getPlanCartItem(),
+			planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
 		};
 	}, [] );
 
@@ -38,7 +38,9 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 		// This behavior worths a revisit. It's also why we can't check hasCartItems as simply as domainCartItem || planCartItem
 		const domainProductSlug =
 			domainCartItem &&
-			isDomainRegistration( domainCartItem ) &&
+			// FIXME:
+			// the current shopping cart types don't include one for a domain product. We should add one and remove the `any` here
+			isDomainRegistration( domainCartItem as any ) &&
 			( domainCartItem.product_slug === '' ? undefined : domainCartItem.product_slug );
 		const hasCartItems = Boolean( domainProductSlug || planCartItem ); // see the function `dependenciesContainCartItem()
 

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -1,37 +1,55 @@
+import {
+	isDomainRegistration,
+	isDomainTransfer,
+	isDomainMapping,
+} from '@automattic/calypso-products';
 import { useSelect } from '@wordpress/data';
 import { useCallback } from 'react';
-import { USER_STORE } from 'calypso/landing/stepper/stores';
+import { USER_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordSignupComplete } from 'calypso/lib/analytics/signup';
 import { useSite } from './use-site';
-import type { UserSelect } from '@automattic/data-stores';
+import type { UserSelect, OnboardSelect } from '@automattic/data-stores';
 
 export const useRecordSignupComplete = ( flow: string | null ) => {
 	const site = useSite();
 	const siteId = site?.ID || null;
 	const theme = site?.options?.theme_slug || '';
-	const siteCount = useSelect(
-		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
-		[]
-	)?.site_count;
+	const { domainCartItem, planCartItem, siteCount } = useSelect( ( select ) => {
+		return {
+			siteCount: ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.site_count,
+			domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
+			planCartItem: ( select( ONBOARD_STORE ) as OnboardSelct ).getPlanCartItem(),
+		};
+	}, [] );
 
 	return useCallback( () => {
+		// FIXME: once moving to the Stepper verion of User step,
+		// wire the value of `isNewUser()` from the user store.
+		const isNewUser = ! siteCount;
+
+		// FIXME:
+		// currently it's impossible to derive this data since it requires
+		// the length of registration, so I use isNewUser here as an approximation
+		const isNew7DUserSite = isNewUser;
+
 		recordSignupComplete(
 			{
 				flow,
-				siteId: siteId,
-				isNewUser: ! siteCount,
-				hasCartItems: false,
-				isNew7DUserSite: '',
+				siteId,
+				isNewUser,
+				hasCartItems: domainCartItem !== null || planCartItem !== null,
+				isNew7DUserSite,
 				theme,
 				intent: flow,
 				startingPoint: flow,
 				isBlankCanvas: theme?.includes( 'blank-canvas' ),
-				domainProductSlug: '',
-				planProductSlug: '',
-				isMapping: false,
-				isTransfer: false,
+				domainProductSlug:
+					domainCartItem && isDomainRegistration( domainCartItem ) && domainCartItem.product_slug,
+				planProductSlug: planCartItem && planCartItem.product_slug,
+				isMapping: domainCartItem && isDomainMapping( domainCartItem ),
+				isTransfer: domainCartItem && isDomainTransfer( domainCartItem ),
 			},
 			true
 		);
-	}, [ flow, siteId, siteCount, theme ] );
+	}, [ flow, siteId, siteCount, theme, domainCartItem, planCartItem ] );
 };

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -32,24 +32,35 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 		// the length of registration, so I use isNewUser here as an approximation
 		const isNew7DUserSite = isNewUser;
 
-		recordSignupComplete(
-			{
-				flow,
-				siteId,
-				isNewUser,
-				hasCartItems: domainCartItem !== null || planCartItem !== null,
-				isNew7DUserSite,
-				theme,
-				intent: flow,
-				startingPoint: flow,
-				isBlankCanvas: theme?.includes( 'blank-canvas' ),
-				domainProductSlug:
-					domainCartItem && isDomainRegistration( domainCartItem ) && domainCartItem.product_slug,
-				planProductSlug: planCartItem && planCartItem.product_slug,
-				isMapping: domainCartItem && isDomainMapping( domainCartItem ),
-				isTransfer: domainCartItem && isDomainTransfer( domainCartItem ),
-			},
-			true
-		);
+		// FIXME:
+		// the domain store considers a free domain a domain registration and will populate a domainCartItem object.
+		// Thus the only way to check whether it's a free domain for now is whether domainCarItem is undefined or the product_slug is an empty string.
+		// This behavior worths a revisit. It's also why we can't check hasCartItems as simply as domainCartItem || planCartItem
+		const domainProductSlug =
+			domainCartItem &&
+			isDomainRegistration( domainCartItem ) &&
+			( domainCartItem.product_slug === '' ? undefined : domainCarItem.product_slug );
+		const hasCartItems = Boolean( domainProductSlug || planCartItem ); // see the function `dependenciesContainCartItem()
+
+		// TBD:
+		// When there is no plan put in the cart, `planCartItem` is `null` instead of `undefined` like domainCartItem.
+		// It worths a investigation of whether the both should behave the same so this code can be simplified.
+		const planProductSlug = planCartItem !== null ? planCartItem.product_slug : undefined;
+
+		recordSignupComplete( {
+			flow,
+			siteId,
+			isNewUser,
+			hasCartItems,
+			isNew7DUserSite,
+			theme,
+			intent: flow,
+			startingPoint: flow,
+			isBlankCanvas: theme?.includes( 'blank-canvas' ),
+			planProductSlug,
+			domainProductSlug,
+			isMapping: domainCartItem && isDomainMapping( domainCartItem ),
+			isTransfer: domainCartItem && isDomainTransfer( domainCartItem ),
+		} );
 	}, [ flow, siteId, siteCount, theme, domainCartItem, planCartItem ] );
 };

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -67,7 +67,7 @@ export const useLoginUrl = ( params: {
 			}
 		} );
 
-	nonEmptyQueryParameters.push( [ 'toStepper', true ] );
+	nonEmptyQueryParameters.push( [ 'toStepper', 'true' ] );
 
 	return addQueryArgs( loginPath, Object.fromEntries( nonEmptyQueryParameters ) );
 };

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -67,5 +67,7 @@ export const useLoginUrl = ( params: {
 			}
 		} );
 
+	nonEmptyQueryParameters.push( [ 'toStepper', true ] );
+
 	return addQueryArgs( loginPath, Object.fromEntries( nonEmptyQueryParameters ) );
 };

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -33,11 +33,13 @@ export function generateFlows( {
 			steps: [ 'user' ],
 			destination: getRedirectDestination,
 			description: 'Create an account without a blog.',
-			lastModified: '2020-08-12',
+			lastModified: '2023-06-16',
 			get pageTitle() {
 				return translate( 'Create an account' );
 			},
 			showRecaptcha: true,
+			providesDependenciesInQuery: [ 'toStepper' ],
+			optionalDependenciesInQuery: [ 'toStepper' ],
 		},
 		{
 			name: 'business',

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -496,27 +496,33 @@ class Signup extends Component {
 			intent,
 			startingPoint,
 		};
-		debug( 'Tracking signup completion.', debugProps );
 
-		recordSignupComplete( {
-			flow: this.props.flowName,
-			siteId,
-			isNewUser,
-			hasCartItems,
-			planProductSlug: hasCartItems && cartItem !== null ? cartItem.product_slug : undefined,
-			domainProductSlug:
-				undefined !== domainItem && domainItem.is_domain_registration
-					? domainItem.product_slug
-					: undefined,
-			isNew7DUserSite,
-			// Record the following values so that we can know the user completed which branch under the hero flow
-			theme: selectedDesign?.theme,
-			intent,
-			startingPoint,
-			isBlankCanvas: isBlankCanvasDesign( dependencies.selectedDesign ),
-			isMapping: domainItem && isDomainMapping( domainItem ),
-			isTransfer: domainItem && isDomainTransfer( domainItem ),
-		} );
+		// In case of the flow just serves as a bridge to a Stepper flow, do not fire
+		// the signup completion event. Theoretically speaking this can be applied to other scenarios,
+		// but it's not recommended outside of this, hence the name toStepper. See Automattic/growth-foundations#72 for more context.
+		if ( ! dependencies.toStepper ) {
+			debug( 'Tracking signup completion.', debugProps );
+
+			recordSignupComplete( {
+				flow: this.props.flowName,
+				siteId,
+				isNewUser,
+				hasCartItems,
+				planProductSlug: hasCartItems && cartItem !== null ? cartItem.product_slug : undefined,
+				domainProductSlug:
+					undefined !== domainItem && domainItem.is_domain_registration
+						? domainItem.product_slug
+						: undefined,
+				isNew7DUserSite,
+				// Record the following values so that we can know the user completed which branch under the hero flow
+				theme: selectedDesign?.theme,
+				intent,
+				startingPoint,
+				isBlankCanvas: isBlankCanvasDesign( dependencies.selectedDesign ),
+				isMapping: domainItem && isDomainMapping( domainItem ),
+				isTransfer: domainItem && isDomainTransfer( domainItem ),
+			} );
+		}
 	};
 
 	handleDestination( dependencies, destination ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/growth-foundations#70, and is based on https://github.com/Automattic/wp-calypso/pull/78323.

## Proposed Changes

This PR improves the signup completion event issues discussed in the linked issue above. Namely:

* There are two `calypso_signup_completion` fired, one from the classic signup framework, `/start/account`, and one from the Stepper itself.
* The `calyspo_signup_completion` event from Stepper is not complete. 
* It's not correct to fire the signup completion event on Launchpad, since it's not really part of the signup flow. The users who haven't launched their sites can always see it the 1st thing clicking on the "home" button.

Since [the parent PR](https://github.com/Automattic/wp-calypso/pull/78323) uses the Newsletter flow as the updated case, the fix for the doubled `calypso_signup_completion` only works for the Newsletter flow for now. The other fixes apply to all the tailored flows.

Note that, in case of completing the signup completion event, this PR only fills the purchase info that's most relevant to the linked Growth Foundation issue. Filling in the other fields is intentionally left out as follow-ups.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### The doubled signup completion event

* Follow the instruction in [the analytics lib README](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/analytics/README.md#L13) and enable the console debugging message, i.e. calling `localStorage.setItem('debug', 'calypso:analytics*');`. Since there will be redirection, make sure to enable "preserve log" for your browser console.
* Go to the Newsletter flow, `/setup/newsletter`
* Complete the user step, and make sure that there is no `calypso_signup_complete` event.
* Cherry-pick some other flows and do the same and note that there is still `calypso_signup_complete` event fired as expected, since they are not updated yet.

#### The more completed signup completion event and its timing

In general:

1. Go through the Newsletter flow til the end of the processing step
2. Make sure `calypso_signup_complete` event is fired with expected value. 
3. Confirm Launchpad no longer fires the signup completion event.

Note that the console message tends to be truncated in this case, so I'd reommend to observe it from the Network tab instead, e.g.
<img width="655" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/24b32e62-be79-45c8-b1cb-5dc9d53524eb">

Combinations worth trying and the values to pay attention to:

* A free domain + Free plan -> `hasCartItem`: false, no `plan_product_slug` and no `domain_product_slug` fields.
* A paid domain + Free plan (since it is currently allowed on this flow, it still worth examining) -> `hasCartItem`: true, has `domain_product_slug`, no `plan_product_slug`
* A paid domain + a paid plan -> `hasCartItem`: true, `plan_product_slug` and `domain_product_slug` should be populated as expected. 

Note that it's not possible to test out the domain mapping and the domain transfer case yet. The best for now is to compare it to the original code: https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/main.jsx#L501.

#### Misc.

Cherry-pick a few other tailored flows, e.g. link in bio, and confirm the section of "The more completed signup completion event and its timing" also works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
