### PR TITLE
Add scroll in filter for mobile view

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaigns-filter/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-filter/index.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import { useRef } from 'react';
 import SegmentedControl from 'calypso/components/segmented-control';
 
 export type CampaignsFilterType = 'all' | 'active' | 'created' | 'finished' | 'rejected';
@@ -11,39 +12,60 @@ interface Props {
 export default function CampaignsFilter( props: Props ) {
 	const translate = useTranslate();
 
+	// Smooth horizontal scrolling on mobile views
+	const tabsRef = useRef< { [ key: string ]: HTMLSpanElement | null } >( {} );
+	const onTabClick = ( key: string ) => {
+		tabsRef.current[ key ]?.scrollIntoView( {
+			behavior: 'smooth',
+			block: 'nearest',
+			inline: 'center',
+		} );
+	};
+
 	const { handleChangeFilter, campaignsFilter } = props;
+
+	const handleChange = ( type: CampaignsFilterType ) => {
+		onTabClick( type );
+		handleChangeFilter( type );
+	};
+
+	const options = [
+		{
+			value: 'all',
+			label: translate( 'All' ),
+			selectedCondition: campaignsFilter === 'all' || ! campaignsFilter,
+		},
+		{
+			value: 'active',
+			label: translate( 'Active', { context: 'comment status' } ),
+		},
+		{
+			value: 'created',
+			label: translate( 'In moderation', { context: 'comment status' } ),
+		},
+		{
+			value: 'finiasdasdd',
+			label: translate( 'Completed', { context: 'comment status' } ),
+		},
+		{
+			value: 'rejected',
+			label: translate( 'Rejected', { context: 'comment status' } ),
+		},
+	];
+
 	return (
 		<SegmentedControl compact primary>
-			<SegmentedControl.Item
-				selected={ campaignsFilter === 'all' || ! campaignsFilter }
-				onClick={ () => handleChangeFilter( 'all' ) }
-			>
-				{ translate( 'All' ) }
-			</SegmentedControl.Item>
-			<SegmentedControl.Item
-				selected={ campaignsFilter === 'active' }
-				onClick={ () => handleChangeFilter( 'active' ) }
-			>
-				{ translate( 'Active', { context: 'comment status' } ) }
-			</SegmentedControl.Item>
-			<SegmentedControl.Item
-				selected={ campaignsFilter === 'created' }
-				onClick={ () => handleChangeFilter( 'created' ) }
-			>
-				{ translate( 'In moderation', { context: 'comment status' } ) }
-			</SegmentedControl.Item>
-			<SegmentedControl.Item
-				selected={ campaignsFilter === 'finished' }
-				onClick={ () => handleChangeFilter( 'finished' ) }
-			>
-				{ translate( 'Completed', { context: 'comment status' } ) }
-			</SegmentedControl.Item>
-			<SegmentedControl.Item
-				selected={ campaignsFilter === 'rejected' }
-				onClick={ () => handleChangeFilter( 'rejected' ) }
-			>
-				{ translate( 'Rejected', { context: 'comment status' } ) }
-			</SegmentedControl.Item>
+			{ options.map( ( option ) => (
+				<SegmentedControl.Item
+					key={ option.value }
+					selected={
+						option.selectedCondition ? option.selectedCondition : campaignsFilter === option.value
+					}
+					onClick={ () => handleChange( option.value as CampaignsFilterType ) }
+				>
+					<span ref={ ( el ) => ( tabsRef.current[ option.value ] = el ) }>{ option.label }</span>
+				</SegmentedControl.Item>
+			) ) }
 		</SegmentedControl>
 	);
 }

--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -440,6 +440,13 @@ body.is-section-promote-post-i2 {
 		.select-dropdown__header {
 			border: none;
 		}
+
+		.segmented-control.is-compact {
+			overflow-x: auto;
+			&::-webkit-scrollbar {
+				display: none;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Related to #

This PR adds scroll functionality in the filter section

## Testing Instructions

- Put your browser in mobile view
- Go to "campaigns" section, you should be able to scroll in the filter list

![scroll_filter](https://github.com/Automattic/wp-calypso/assets/43957544/a8899d0a-2b63-4942-880f-de82af216af1)

Added also smooth scrolling when clicking a section.
![scroll_filter2](https://github.com/Automattic/wp-calypso/assets/43957544/b6cb2cf7-2a85-4867-baf0-33c7d2c1a6ed)


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
