### PR TITLE
Change properties named "visits" to be "views" in Blazepress

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query-new.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query-new.ts
@@ -32,10 +32,10 @@ export type CampaignResponse = {
 		total_budget_left: number;
 		total_budget_used: number;
 		display_delivery_estimate: string;
-		visits_total: number;
-		visits_organic: number;
-		visits_organic_rate: number;
-		visits_ad_rate: number;
+		views_total: number;
+		views_organic: number;
+		views_organic_rate: number;
+		views_ad_rate: number;
 	};
 	billing_data: {
 		payment_method: string;

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -93,8 +93,8 @@ export default function CampaignItemDetails( props: Props ) {
 		total_budget_left,
 		total_budget,
 		total_budget_used,
-		visits_total = 0,
-		visits_organic,
+		views_total = 0,
+		views_organic,
 	} = campaign_stats || {};
 
 	const { card_name, payment_method, subtotal, credits, total } = billing_data || {};
@@ -166,7 +166,7 @@ export default function CampaignItemDetails( props: Props ) {
 		},
 		{
 			label: translate( 'Organic' ),
-			value: visits_organic || 0,
+			value: views_organic || 0,
 		},
 	];
 
@@ -428,7 +428,7 @@ export default function CampaignItemDetails( props: Props ) {
 															<HorizontalBarListItem
 																key={ `bar_${ index }` }
 																data={ item }
-																maxValue={ visits_total }
+																maxValue={ views_total }
 																hasIndicator={ false }
 																leftSideItem={ null }
 																useShortLabel={ false }


### PR DESCRIPTION
Related to #

## Proposed Changes

⚠️ Warning: This PR should be deployed along with a8c-dsp/pull/199


- We're displaying properties named by "visits" when they're "views. The difference is that visits are unique connections and views not. This change is needed in order to make this sync with the DSP 

## Testing Instructions

- Campaign stats data should display correctly in both blazepress i1 and i2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
