### PR TITLE
Help Center: Ensure correct support experience for Free users

### DIFF
--- a/client/me/help/help-contact-us-footer.tsx
+++ b/client/me/help/help-contact-us-footer.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
+import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import type { FC } from 'react';
@@ -12,10 +13,11 @@ const HELP_CENTER_STORE = HelpCenter.register();
 const HelpContactUsFooter: FC = () => {
 	const { __ } = useI18n();
 	const { setShowHelpCenter, setInitialRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { url } = useStillNeedHelpURL();
 
 	const onClick = () => {
 		recordTracksEvent( 'calypso_help_footer_button_click' );
-		setInitialRoute( '/contact-options' );
+		setInitialRoute( url );
 		setShowHelpCenter( true );
 	};
 

--- a/client/me/help/help-contact-us-header.tsx
+++ b/client/me/help/help-contact-us-header.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
+import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import type { FC } from 'react';
@@ -12,10 +13,11 @@ const HELP_CENTER_STORE = HelpCenter.register();
 const HelpContactUsHeader: FC = () => {
 	const { __ } = useI18n();
 	const { setShowHelpCenter, setInitialRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { url } = useStillNeedHelpURL();
 
 	const onClick = () => {
 		recordTracksEvent( 'calypso_help_header_button_click' );
-		setInitialRoute( '/contact-options' );
+		setInitialRoute( url );
 		setShowHelpCenter( true );
 	};
 

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -47,7 +47,6 @@ export const HelpCenterContactPage: FC = () => {
 		isEligibleForChat,
 		isLoading: isLoadingChatStatus,
 		supportActivity,
-		supportLevel,
 	} = useChatStatus();
 	useZendeskMessaging(
 		'zendesk_support_chat_key',
@@ -123,8 +122,6 @@ export const HelpCenterContactPage: FC = () => {
 		);
 	}
 
-	const hasAccessToLivechat = ! [ 'free', 'personal', 'starter' ].includes( supportLevel || '' );
-
 	return (
 		<div className="help-center-contact-page">
 			<BackButton />
@@ -136,7 +133,7 @@ export const HelpCenterContactPage: FC = () => {
 					displayAt="2023-04-03 00:00Z"
 					closesAt="2023-04-09 00:00Z"
 					reopensAt="2023-04-10 07:00Z"
-					enabled={ hasAccessToLivechat }
+					enabled={ renderChat.render }
 				/>
 
 				<div className={ classnames( 'help-center-contact-page__boxes' ) }>

--- a/packages/help-center/src/hooks/use-should-render-email-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-email-option.tsx
@@ -5,9 +5,6 @@ export function useShouldRenderEmailOption() {
 
 	return {
 		isLoading: isFetching,
-		render:
-			( supportAvailability?.is_user_eligible_for_tickets ||
-				supportAvailability?.is_user_eligible_for_upwork ) ??
-			false,
+		render: supportAvailability?.is_user_eligible_for_tickets ?? false,
 	};
 }

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -4,10 +4,7 @@ import { useSupportAvailability } from '@automattic/data-stores';
 export function useStillNeedHelpURL() {
 	const { data: supportAvailability, isLoading } = useSupportAvailability( 'OTHER' );
 
-	// email support is available for all non-free users, let's use it as a proxy for free users
-	// TODO: check purchases instead
 	const isFreeUser = ! supportAvailability?.is_user_eligible_for_tickets;
-
 	if ( ! isFreeUser ) {
 		return { url: '/contact-options', isLoading };
 	}


### PR DESCRIPTION
Related conversation: peCdcN-4n-p2.

## Proposed Changes

* Use the `useStillNeedHelpURL` hook to set the correct initial route in Help Center to handle Free users properly.
* Don't use Upwork eligibility for ticket eligibility, they are not the same. The above point should fix the issue already, but this is a safe-guard in case Help Center is navigated manually to `/contact-options`.

## Testing Instructions

Make sure that users on Free support level get only Forum support option. When they click on "Still need help?" button, they should go directly to the Forums form. Same if they go to `/help` and click Contact support.

<img width="443" alt="Screenshot 2023-06-16 at 15 53 22" src="https://github.com/Automattic/wp-calypso/assets/3392497/5c259001-8c0e-4921-876e-fd88cb9f095a">

Verify that paid (non-free) users still see all the options they are eligible for.