### PR TITLE
Style adjustments for the campaigns

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -267,11 +267,11 @@ export default function CampaignItemDetails( props: Props ) {
 						{ ! isLoading ? (
 							<>
 								<span>&bull;</span>
-								<div className="campaign-item__header-status-date">
+								<div className="campaign-item__header-status-item">
 									{ translate( 'Created:' ) } { campaignCreatedFormatted }
 								</div>
 								<span>&bull;</span>
-								<div className="campaign-item__header-status-date">
+								<div className="campaign-item__header-status-item">
 									{ translate( 'Author:' ) } { display_name }
 								</div>
 							</>
@@ -472,7 +472,7 @@ export default function CampaignItemDetails( props: Props ) {
 											{ ! isLoading ? osListFormatted : <FlexibleSkeleton /> }
 										</span>
 									</div>
-									<div>
+									<div className="campaign-item-details__interests">
 										<span className="campaign-item-details__label">
 											{ translate( 'Interests' ) }
 										</span>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -46,7 +46,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 	}
 
 	.campaign-item-details-header-line {
-		margin: 0 -64px 64px;
+		margin: 0 -64px 48px;
 		padding: 0;
 		@media (max-width: 660px) {
 			margin: 0;
@@ -71,9 +71,10 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 	}
 
 	.campaign-item__header-status {
+		align-items: center;
+		color: $studio-gray-40;
 		display: flex;
 		flex: 1;
-		color: $studio-gray-40;
 
 		span {
 			margin: 0 11px;
@@ -82,11 +83,33 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		.badge {
 			border-radius: 4px;
 		}
+
+		.badge,
+		.campaign-item__header-status-item {
+			font-size: 0.75rem;
+			height: 20px;
+			line-height: 20px;
+		}
 	}
 
 	.campaign-item-details {
 		display: flex;
 		flex-direction: column;
+
+		.campaign-item-details__notice {
+			margin-bottom: 24px;
+		}
+
+		.campaign-item-details__wrapper {
+			.campaign-item-details__label,
+			.campaign-item-details__text {
+				color: var(--studio-gray-100);
+			}
+			.campaign-item-details__text
+			.campaign-item-details__text {
+				line-height: 1.25;
+			}
+		}
 	}
 
 	.campaign-item-details__notice {
@@ -227,6 +250,14 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				display: flex;
 				flex-direction: column;
 				padding: 16px 16px 0;
+
+				&.campaign-item-details__interests {
+					padding-top: 0;
+
+					@media (min-width: calc($break-medium + 1px)) {
+						padding-top: 24px;
+					}
+				}
 
 				@media (min-width: $break-medium) {
 					padding: 24px 24px 0;
@@ -474,6 +505,41 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				background-color: hsl(200, 20%, 95%);
 			}
 		}
+	}
+}
+
+@mixin blazepress-campaign-details-mobile {
+	.campaign-item__container {
+		.campaign-item-details-header-line {
+			margin-bottom: 32px;
+		}
+
+		.campaign-item-details__wrapper {
+			.campaign-item-details .campaign-item-details__notice {
+				margin-bottom: 32px;
+			}
+		}
+	}
+}
+
+// Show Mobile view for screens if window width <= 782px
+@media screen and (max-width: $break-medium) {
+	@include blazepress-campaign-details-mobile;
+}
+
+// Show Mobile view if sidebar is collapsed and main content width <= 782px
+$break-medium-collapsed-menu: $break-medium + 36px;
+@media screen and (max-width: $break-medium-collapsed-menu) {
+	body.is-section-promote-post-i2.is-sidebar-collapsed {
+		@include blazepress-campaign-details-mobile;
+	}
+}
+
+// Show Mobile view if sidebar is expanded and main content width <= 782px
+$break-medium-expanded-menu: $break-medium + 272px;
+@media screen and (max-width: $break-medium-expanded-menu) {
+	body.is-section-promote-post-i2:not(.is-sidebar-collapsed) {
+		@include blazepress-campaign-details-mobile;
 	}
 }
 

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -514,10 +514,8 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 			margin-bottom: 32px;
 		}
 
-		.campaign-item-details__wrapper {
-			.campaign-item-details .campaign-item-details__notice {
-				margin-bottom: 32px;
-			}
+		.campaign-item-details .campaign-item-details__notice {
+			margin-bottom: 32px;
 		}
 	}
 }

--- a/client/my-sites/promote-post-i2/components/campaign-item-page/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-page/style.scss
@@ -36,6 +36,12 @@ body.is-section-promote-post-i2 {
 					max-width: 1040px;
 					width: calc(100% - 128px);
 				}
+
+				// Align vertical align of a campaign status badge.
+				.campaigns-list__table .campaign-item__status .badge {
+					height: 20px;
+					padding: 0 10px;
+				}
 			}
 
 			.advertising__page-header {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to SELFSERVE-574
Comments I'm going to resolve are written in this [comment](https://wp.me/peeHDf-18o#comment-911)

## Proposed Changes
* Center campaign's status badge's text vertically,
* Set 12px as a font-size for badge and details in the campaign details' header,
* Use the right margins between campaign header states for mobile and desktop including cases:
  - desktop:
    - without a notice: gap is `48px`;
    - with a notice (e.g. rejected campaig):
      - gap between header and a notice is `48px`,
      - gap between a notice and stats is `24px`;
  - mobile:
    - without a notice: gap is `32px`;
    - with a notice (e.g. rejected campaig):
      - gap between header and a notice is `32px`,
      - gap between a notice and stats is `32px`;

* Make sure "Interests" section within Campaign Details does not have a redundant padding top for mobile view

## Testing Instructions

- Check out this branch in your local dev. environment,
- Build assets (`yarn && yarn start`),
- Make sure you have campaigns (if not, you can connect wpcom sandbox/tunnel/local DSP to get campaigns from it; otherwise please use your CC and credits to create a campaign in production)
- Open Campaigns page: Tools > Advertising > Campaigns Tab
- Check that the badge's text is aligned correctly
<img width="1594" alt="Screenshot 2023-06-16 at 19 34 52" src="https://github.com/Automattic/wp-calypso/assets/115007291/c11f2adf-ab8d-45a0-a593-414fa881dfdd">

- Open a campaign details
- Make sure font size for details within a header is `12px`:
<img width="505" alt="Screenshot 2023-06-16 at 19 36 24" src="https://github.com/Automattic/wp-calypso/assets/115007291/65e34437-ab3d-43e1-8fea-9f55a81689f3">

- Check that gaps between header and stats (that might include a notice) are satisfy ones describe in proposed changes:

(desktop)
<img width="709" alt="Screenshot 2023-06-16 at 19 37 19" src="https://github.com/Automattic/wp-calypso/assets/115007291/1dfa38b7-0e1a-4340-8260-8092946cbe07">

(mobile)
<img width="712" alt="Screenshot 2023-06-16 at 19 41 34" src="https://github.com/Automattic/wp-calypso/assets/115007291/074b8e9e-370e-47b1-9539-f78fd7c955ad">

- Try out mobile/desktop screen sizes and make sure "Interests" padding is added only when it's really needed:

https://github.com/Automattic/wp-calypso/assets/115007291/cdc3f0e5-df02-4921-a68b-eebe6fb14cf2

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
