### PR TITLE
Hosting: Add is_in_hosting property to calypso_signup_step_start event in stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,6 +1,6 @@
 import { isNewsletterOrLinkInBioFlow, isWooExpressFlow } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useState, useCallback, Suspense, lazy } from 'react';
+import { useEffect, useState, useCallback, Suspense, lazy, useRef } from 'react';
 import Modal from 'react-modal';
 import { Navigate, Route, Routes, generatePath, useNavigate, useLocation } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -55,8 +55,11 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		[]
 	);
 
+	const urlQueryParams = useQuery();
+	const isInHostingFlow = useRef( urlQueryParams.get( 'hosting-flow' ) === 'true' ).current;
+
 	const site = useSite();
-	const ref = useQuery().get( 'ref' ) || '';
+	const ref = urlQueryParams.get( 'ref' ) || '';
 
 	const stepProgress = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
@@ -137,6 +140,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		if ( ! isReEnteringStep ) {
 			recordStepStart( flow.name, kebabCase( currentStepRoute ), {
 				intent,
+				is_in_hosting_flow: isInHostingFlow,
 				...( design && { assembler_source: getAssemblerSource( design ) } ),
 			} );
 		}


### PR DESCRIPTION
## Proposed Changes

For some reason, we have only added the `is_in_hosting_flow` property to `/start/hosting`. On `/setup/(new|import)-hosted-site` flows that property was never passed.

## Testing Instructions

Check that `calypso_signup_step_start` is being dispatched with `is_in_hosting_flow` as a boolean depending whether the `hosting-flow` query parameter is present.