### PR TITLE
Subscriber Details: Make reusable SubscriberProfile and SubscriberPopover components

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-list/styles.scss
@@ -66,22 +66,6 @@
 			}
 		}
 
-		.subscriber-popover__container {
-			height: 24px;
-		}
-
-		.subscriber-popover__toggle {
-			cursor: pointer;
-
-			.gridicons-ellipsis {
-				transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-			}
-
-			&.is-popover-visible .gridicons-ellipsis {
-				transform: rotate(90deg);
-			}
-		}
-
 		&:last-child {
 			border-bottom: none;
 		}

--- a/client/my-sites/subscribers/components/subscriber-list/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-list/styles.scss
@@ -48,47 +48,6 @@
 			align-items: center;
 			flex: 3;
 			min-width: 0;
-
-			.subscriber-profile {
-				display: flex;
-				min-width: 0;
-
-				.subscriber-profile__user-image {
-					height: 40px;
-					width: 40px;
-					border-radius: 50%;
-					margin-right: 12px;
-					flex: 0;
-				}
-
-				.subscriber-profile__user-details {
-					display: flex;
-					flex-direction: column;
-					justify-content: center;
-					max-width: 100%;
-					overflow: hidden;
-					min-width: 0;
-
-					.subscriber-profile__name {
-						overflow: hidden;
-						text-overflow: ellipsis;
-						white-space: nowrap;
-						font-weight: bold;
-						line-height: 17px;
-						min-width: 0;
-						font-size: $font-code;
-					}
-
-					.subscriber-profile__email {
-						overflow: hidden;
-						text-overflow: ellipsis;
-						white-space: nowrap;
-						font-size: $font-body-extra-small;
-						color: $studio-gray-60;
-						min-width: 0;
-					}
-				}
-			}
 		}
 
 		.subscriber-list__checkbox-column {

--- a/client/my-sites/subscribers/components/subscriber-list/subscriber-row.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/subscriber-row.tsx
@@ -3,7 +3,7 @@ import TimeSince from 'calypso/components/time-since';
 import useSubscriptionPlans from '../../hooks/use-subscription-plans';
 import { Subscriber } from '../../types';
 import { SubscriberPopover } from './subscriber-popover';
-import { SubscriberProfile } from './subscriber-profile';
+import { SubscriberProfile } from '../subscriber-profile';
 
 type SubscriberRowProps = {
 	onUnsubscribe: ( subscriber: Subscriber ) => void;

--- a/client/my-sites/subscribers/components/subscriber-list/subscriber-row.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/subscriber-row.tsx
@@ -2,7 +2,7 @@ import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import TimeSince from 'calypso/components/time-since';
 import useSubscriptionPlans from '../../hooks/use-subscription-plans';
 import { Subscriber } from '../../types';
-import { SubscriberPopover } from './subscriber-popover';
+import { SubscriberPopover } from '../subscriber-popover';
 import { SubscriberProfile } from '../subscriber-profile';
 
 type SubscriberRowProps = {

--- a/client/my-sites/subscribers/components/subscriber-popover/index.ts
+++ b/client/my-sites/subscribers/components/subscriber-popover/index.ts
@@ -1,0 +1,1 @@
+export { default as SubscriberPopover } from './subscriber-popover';

--- a/client/my-sites/subscribers/components/subscriber-popover/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-popover/styles.scss
@@ -1,0 +1,15 @@
+.subscriber-popover__container {
+	height: 24px;
+}
+
+.subscriber-popover__toggle {
+	cursor: pointer;
+
+	.gridicons-ellipsis {
+		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	}
+
+	&.is-popover-visible .gridicons-ellipsis {
+		transform: rotate(90deg);
+	}
+}

--- a/client/my-sites/subscribers/components/subscriber-popover/subscriber-popover.tsx
+++ b/client/my-sites/subscribers/components/subscriber-popover/subscriber-popover.tsx
@@ -1,5 +1,5 @@
 import { Gridicon } from '@automattic/components';
-import { Icon, seen, trash } from '@wordpress/icons';
+import { close, Icon, seen, trash } from '@wordpress/icons';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
@@ -9,11 +9,20 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import './styles.scss';
 
 type SubscriberPopoverProps = {
+	isCancelPaidSubscriptionButtonVisible?: boolean;
+	isViewButtonVisible?: boolean;
+	onCancelPaidSubscription?: () => void;
 	onUnsubscribe: () => void;
-	onView: () => void;
+	onView?: () => void;
 };
 
-const SubscriberPopover = ( { onUnsubscribe, onView }: SubscriberPopoverProps ) => {
+const SubscriberPopover = ( {
+	isCancelPaidSubscriptionButtonVisible = false,
+	isViewButtonVisible = false,
+	onCancelPaidSubscription,
+	onUnsubscribe,
+	onView,
+}: SubscriberPopoverProps ) => {
 	const [ isVisible, setIsVisible ] = useState( false );
 	const onToggle = useCallback( () => setIsVisible( ( visible ) => ! visible ), [] );
 	const buttonRef = useRef< HTMLButtonElement >( null );
@@ -38,10 +47,18 @@ const SubscriberPopover = ( { onUnsubscribe, onView }: SubscriberPopoverProps ) 
 				className="subscriber-popover"
 				focusOnShow={ false }
 			>
-				<PopoverMenuItem onClick={ onView } className="hidden">
-					<Icon icon={ seen } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
-					{ translate( 'View' ) }
-				</PopoverMenuItem>
+				{ isViewButtonVisible && (
+					<PopoverMenuItem onClick={ onView }>
+						<Icon icon={ seen } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
+						{ translate( 'View' ) }
+					</PopoverMenuItem>
+				) }
+				{ isCancelPaidSubscriptionButtonVisible && (
+					<PopoverMenuItem onClick={ onCancelPaidSubscription }>
+						<Icon icon={ close } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
+						{ translate( 'Cancel paid subscription' ) }
+					</PopoverMenuItem>
+				) }
 				<PopoverMenuItem onClick={ onUnsubscribe }>
 					<Icon icon={ trash } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
 					{ translate( 'Unsubscribe' ) }
@@ -51,4 +68,4 @@ const SubscriberPopover = ( { onUnsubscribe, onView }: SubscriberPopoverProps ) 
 	);
 };
 
-export { SubscriberPopover };
+export default SubscriberPopover;

--- a/client/my-sites/subscribers/components/subscriber-profile/index.ts
+++ b/client/my-sites/subscribers/components/subscriber-profile/index.ts
@@ -1,0 +1,1 @@
+export { default as SubscriberProfile } from './subscriber-profile';

--- a/client/my-sites/subscribers/components/subscriber-profile/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-profile/styles.scss
@@ -1,0 +1,67 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+
+.subscriber-profile {
+	display: flex;
+	align-items: center;
+	min-width: 0;
+
+	&.subscriber-profile--compact {
+		.subscriber-profile__user-details {
+			.subscriber-profile__name {
+				font-weight: 600;
+				font-size: $font-code;
+				line-height: rem(22px);
+			}
+
+			.subscriber-profile__email {
+				font-size: $font-body-extra-small;
+				line-height: rem(24px);
+			}
+		}
+
+		.subscriber-profile__user-image {
+			height: 40px;
+			width: 40px;
+			margin-right: 12px;
+		}
+	}
+
+	.subscriber-profile__user-image {
+		height: 56px;
+		width: 56px;
+		border-radius: 50%;
+		margin-right: 16px;
+		flex: 0;
+	}
+
+	.subscriber-profile__user-details {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		max-width: 100%;
+		overflow: hidden;
+		min-width: 0;
+
+		.subscriber-profile__name {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			font-weight: 500;
+			font-size: $font-title-small;
+			line-height: rem(26px);
+			min-width: 0;
+		}
+
+		.subscriber-profile__email {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			font-weight: 400;
+			font-size: $font-body;
+			line-height: rem(24px);
+			color: $studio-gray-60;
+			min-width: 0;
+		}
+	}
+}

--- a/client/my-sites/subscribers/components/subscriber-profile/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-profile/styles.scss
@@ -60,7 +60,7 @@
 			font-weight: 400;
 			font-size: $font-body;
 			line-height: rem(24px);
-			color: $studio-gray-60;
+			color: $studio-gray-40;
 			min-width: 0;
 		}
 	}

--- a/client/my-sites/subscribers/components/subscriber-profile/subscriber-profile.tsx
+++ b/client/my-sites/subscribers/components/subscriber-profile/subscriber-profile.tsx
@@ -1,14 +1,20 @@
-export const SubscriberProfile = ( {
-	avatar,
-	displayName,
-	email,
-}: {
+import './styles.scss';
+
+type SubscriberProfileProps = {
 	avatar: string;
 	displayName: string;
 	email: string;
-} ) => {
+	compact?: boolean;
+};
+
+const SubscriberProfile = ( {
+	avatar,
+	displayName,
+	email,
+	compact = true,
+}: SubscriberProfileProps ) => {
 	return (
-		<div className="subscriber-profile">
+		<div className={ `subscriber-profile ${ compact ? 'subscriber-profile--compact' : '' }` }>
 			<img src={ avatar } className="subscriber-profile__user-image" alt="Profile pic" />
 			<div className="subscriber-profile__user-details">
 				<span className="subscriber-profile__name">{ displayName }</span>
@@ -19,3 +25,5 @@ export const SubscriberProfile = ( {
 		</div>
 	);
 };
+
+export default SubscriberProfile;

--- a/client/my-sites/subscribers/subscriber-list/test/subscriber-profile.test.tsx
+++ b/client/my-sites/subscribers/subscriber-list/test/subscriber-profile.test.tsx
@@ -3,7 +3,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { SubscriberProfile } from '../../components/subscriber-list/subscriber-profile';
+import { SubscriberProfile } from '../../components/subscriber-profile';
 
 const testName = 'Test Name';
 const testEmail = 'test@test.com';


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78341

## Proposed Changes

* Extract SubscriberProfile from subscribers list
  * Add possibility to change dimensions, compact or expanded
  * The expanded style matches Subscriber Details design on Figma h8tMpJlCqNFemEerU9owHI-fi-1981_71935
* Extract SubscriberPopover from subscribers list
  * Add Cancel Paid Subscription optional button
  * Make View button optional

## Testing Instructions

* Apply this PR to your local
* Test for regressions on Subscribers page
* Test SubscriberProfile component
  * Add `compact={false}` prop to the component on `SubscriberRow`
  * You should see the expanded version on the list
* Test SubscriberPopover component
  * Add isCancelPaidSubscriptionButtonVisible prop on `SubscriberRow`
  * You should see the Cancel Paid Subscription button on the menu
  * Add isViewButtonVisible prop on `SubscriberRow`
  * You should see the View button on the menu
<img width="400" alt="Screenshot 2023-06-16 at 14 24 24" src="https://github.com/Automattic/wp-calypso/assets/3113712/3e922f40-51c2-43f8-b537-5beee6705e1e">

<img width="302" alt="Screenshot 2023-06-16 at 14 37 46" src="https://github.com/Automattic/wp-calypso/assets/3113712/abd78c07-e809-45bb-95f2-9971b6b3a0b5">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?