### PR TITLE
Hosting onboarding: forward `hosting-flow` query parameter to onboarding flow after clicking the CTA

### DIFF
--- a/client/lib/paths/use-add-new-site-url.tsx
+++ b/client/lib/paths/use-add-new-site-url.tsx
@@ -1,25 +1,28 @@
 import config from '@automattic/calypso-config';
 import { useSelector } from 'react-redux';
 import { Primitive } from 'utility-types';
-import { isInHostingFlow } from 'calypso/landing/stepper/utils/is-in-hosting-flow';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { addQueryArgs } from 'calypso/lib/url';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { AppState } from 'calypso/types';
 
 export const useAddNewSiteUrl = ( queryParameters: Record< string, Primitive > ) => {
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
 
-	const hostingFlow = useSelector( isInHostingFlow );
+	const isHostingFlow = useSelector(
+		( state: AppState ) => getCurrentQueryArguments( state )?.[ 'hosting-flow' ] === 'true'
+	);
 
 	return addQueryArgs(
 		{
 			...queryParameters,
-			'hosting-flow': hostingFlow ? true : null,
+			'hosting-flow': isHostingFlow ? true : null,
 		},
 		// eslint-disable-next-line no-nested-ternary
 		isJetpackCloud()
 			? config( 'jetpack_connect_url' )
-			: isDevAccount || hostingFlow
+			: isDevAccount || isHostingFlow
 			? '/setup/new-hosted-site'
 			: config( 'signup_url' )
 	);

--- a/client/lib/paths/use-add-new-site-url.tsx
+++ b/client/lib/paths/use-add-new-site-url.tsx
@@ -1,25 +1,25 @@
 import config from '@automattic/calypso-config';
 import { useSelector } from 'react-redux';
 import { Primitive } from 'utility-types';
+import { isInHostingFlow } from 'calypso/landing/stepper/utils/is-in-hosting-flow';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { addQueryArgs } from 'calypso/lib/url';
-import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
-import type { AppState } from 'calypso/types';
 
 export const useAddNewSiteUrl = ( queryParameters: Record< string, Primitive > ) => {
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
 
-	const isInHostingFlow = useSelector(
-		( state: AppState ) => getInitialQueryArguments( state )?.[ 'hosting-flow' ] === 'true'
-	);
+	const hostingFlow = useSelector( isInHostingFlow );
 
 	return addQueryArgs(
-		queryParameters,
+		{
+			...queryParameters,
+			'hosting-flow': hostingFlow ? true : null,
+		},
 		// eslint-disable-next-line no-nested-ternary
 		isJetpackCloud()
 			? config( 'jetpack_connect_url' )
-			: isDevAccount || isInHostingFlow
+			: isDevAccount || hostingFlow
 			? '/setup/new-hosted-site'
 			: config( 'signup_url' )
 	);

--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -1,8 +1,5 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { useSelector } from 'react-redux';
 import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
-import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import { AppState } from 'calypso/types';
 import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
 import { TRACK_SOURCE_NAME } from '../utils';
 import { EmptyStateCTA } from './empty-state-cta';
@@ -10,14 +7,9 @@ import { EmptyStateCTA } from './empty-state-cta';
 export const CreateSiteCTA = () => {
 	const { __ } = useI18n();
 
-	const isHostingFlow = useSelector(
-		( state: AppState ) => getCurrentQueryArguments( state )?.[ 'hosting-flow' ] === 'true'
-	);
-
 	const createSiteUrl = useAddNewSiteUrl( {
 		source: TRACK_SOURCE_NAME,
 		ref: 'calypso-nosites',
-		'hosting-flow': isHostingFlow ? true : null,
 	} );
 
 	return (

--- a/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
+++ b/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
@@ -1,7 +1,8 @@
-import { isInHostingFlow } from 'calypso/landing/stepper/utils/is-in-hosting-flow';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { AppState } from 'calypso/types';
 import { TRACK_SOURCE_NAME } from '../utils';
 
 export const useSitesDashboardImportSiteUrl = (
@@ -9,13 +10,15 @@ export const useSitesDashboardImportSiteUrl = (
 ) => {
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
 
-	const hostingFlow = useSelector( isInHostingFlow );
+	const isHostingFlow = useSelector(
+		( state: AppState ) => getCurrentQueryArguments( state )?.[ 'hosting-flow' ] === 'true'
+	);
 
 	return addQueryArgs(
 		{
 			source: TRACK_SOURCE_NAME,
 			...additionalParameters,
-			'hosting-flow': hostingFlow ? true : null,
+			'hosting-flow': isHostingFlow ? true : null,
 		},
 		isDevAccount ? '/setup/import-hosted-site' : '/start/import'
 	);

--- a/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
+++ b/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
@@ -1,3 +1,4 @@
+import { isInHostingFlow } from 'calypso/landing/stepper/utils/is-in-hosting-flow';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
@@ -8,10 +9,13 @@ export const useSitesDashboardImportSiteUrl = (
 ) => {
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
 
+	const hostingFlow = useSelector( isInHostingFlow );
+
 	return addQueryArgs(
 		{
 			source: TRACK_SOURCE_NAME,
 			...additionalParameters,
+			'hosting-flow': hostingFlow ? true : null,
 		},
 		isDevAccount ? '/setup/import-hosted-site' : '/start/import'
 	);


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/78230, @p-jackson treated a case where we should let the user try `/setup/(new|import)-hosted-site` even if they are not developers, providing that the `?hosting-flow=true` query parameter is passed to the `/sites` page.

The PR has a bug where the parameter is not passed to the onboarding flow (after the CTA click). This PR fixes it so that every time the parameter exists, it's fed to the flow.

## Testing Instructions

**The user must have a site, this bug does not occur on accounts that have zero sites**

On this PR, browse `/sites?hosting-flow=true` and verify that clicking the "Add new site CTA" correctly sends you to `/setup/new-hosted-site?hosting-flow=true`.

On `trunk`, browse `/sites?hosting-flow=true` and verify that clicking the "Add new site CTA" DOES NOT include `?hosting-flow=true` when redirected to `/setup/new-hosted-site`.

The same thing should happen when browsing the import flow.
