### PR TITLE
BackupBrowser: Add `Go back` button and Tracks events on backup contents page

### DIFF
--- a/client/my-sites/backup/backup-contents-page/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/index.tsx
@@ -1,4 +1,6 @@
 import { Card } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { arrowLeft, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -10,7 +12,9 @@ import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useSelector } from 'calypso/state';
+import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
 import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
+import { backupMainPath } from '../paths';
 import FileBrowser from './file-browser';
 import './style.scss';
 
@@ -26,12 +30,20 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 	const displayDate = getDisplayDate( moment.unix( rewindId ), false );
 
 	const isMultiSite = useSelector( ( state ) => isJetpackSiteMultiSite( state, siteId ) );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	return (
 		<>
 			<Main className="backup-contents-page">
 				<DocumentHead title={ translate( 'Backup contents' ) } />
 				{ isJetpackCloud() && <SidebarNavigation /> }
+				<Button
+					isLink
+					className="backup-contents-page__back-button is-borderless"
+					href={ backupMainPath( siteSlug ) }
+				>
+					<Icon icon={ arrowLeft } size={ 16 } /> { translate( 'Go Back' ) }
+				</Button>
 				<Card>
 					<div className="backup-contents-page__header daily-backup-status status-card">
 						<div className="status-card__message-head">

--- a/client/my-sites/backup/backup-contents-page/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/index.tsx
@@ -2,7 +2,7 @@ import { Card } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { arrowLeft, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import ActionButtons from 'calypso/components/jetpack/daily-backup-status/action-buttons';
 import cloudIcon from 'calypso/components/jetpack/daily-backup-status/status-card/icons/cloud-success.svg';
@@ -11,7 +11,8 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
 import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
 import { backupMainPath } from '../paths';
@@ -24,6 +25,7 @@ interface OwnProps {
 }
 
 const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId } ) => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const getDisplayDate = useGetDisplayDate();
 	const moment = useLocalizedMoment();
@@ -31,6 +33,10 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 
 	const isMultiSite = useSelector( ( state ) => isJetpackSiteMultiSite( state, siteId ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_browser_view' ) );
+	}, [ dispatch ] );
 
 	return (
 		<>

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -1,6 +1,15 @@
 @import "@automattic/onboarding/styles/mixins";
 
 .backup-contents-page {
+	&__back-button.components-button.is-link {
+		color: #000;
+		text-decoration: none;
+
+		svg {
+			margin-right: 2px;
+		}
+	}
+
 	&__header {
 		padding-bottom: 30px;
 


### PR DESCRIPTION
## Proposed Changes
* Add `Go Back` button on backup contents page
* Add `calypso_jetpack_backup_browser_view` Tracks event when the backup contents page renders

## Screenshots
<img width="733" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/6336fadc-13f9-4931-bac0-9f6daf3909ec">

## Testing Instructions
* Start a Jetpack Cloud live branch.
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Add `?flags=jetpack/backup-contents-page` at the end of the URL and refresh the page.
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Open Chrome developer console (in network tab).
* On the daily backup card, click on `Actions (+)` and then click on `View files`.
* You should see a page similar to the one shared above.
  * When it loads, you should see a `t.gif` call with the event `calypso_jetpack_backup_browser_view`.
* Click on the `<- Go Back` button and you should be redirected to the backup page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
