### PR TITLE
Extend the Woo GTM tracking in Calypso to also fire in the woo express stepper flow

### DIFF
--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -1,5 +1,6 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
+import recordGTMDatalayerEvent from 'calypso/lib/analytics/ad-tracking/woo/record-gtm-datalayer-event';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
@@ -110,6 +111,7 @@ const wooexpress: Flow = {
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
 			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
+			recordGTMDatalayerEvent( currentStep );
 			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
 			const siteId = getSiteIdBySlug( siteSlug );
 			const adminUrl = siteId && getSiteOption( siteId, 'admin_url' );

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -111,7 +111,6 @@ const wooexpress: Flow = {
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
 			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
-			recordGTMDatalayerEvent( currentStep );
 			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
 			const siteId = getSiteIdBySlug( siteSlug );
 			const adminUrl = siteId && getSiteOption( siteId, 'admin_url' );
@@ -135,6 +134,7 @@ const wooexpress: Flow = {
 					}
 
 					if ( providedDependencies?.pluginsInstalled ) {
+						recordGTMDatalayerEvent( currentStep );
 						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
 					}
 

--- a/client/lib/analytics/ad-tracking/woo/record-gtm-datalayer-event.ts
+++ b/client/lib/analytics/ad-tracking/woo/record-gtm-datalayer-event.ts
@@ -1,0 +1,38 @@
+import { mayWeTrackByTracker } from '../../tracker-buckets';
+import { debug, TRACKING_IDS } from '../constants';
+import { initGTMContainer, loadGTMContainer } from '../gtm-container';
+
+/**
+ * Sends a step event to Google Tag Manager for the woo express stepper flow.
+ *
+ * @param {string} stepName
+ * @returns {void}
+ */
+export default async function recordGTMDatalayerEvent( stepName = '' ) {
+	if ( stepName ) {
+		loadGTMContainer( TRACKING_IDS.wooGoogleTagManagerId )
+			.then( () => initGTMContainer() )
+			.then( () => {
+				debug(
+					`recordGTMDatalayerEvent: Initialized GTM container ${ TRACKING_IDS.wooGoogleTagManagerId }`
+				);
+
+				// We ensure that we can track with GTM
+				if ( ! mayWeTrackByTracker( 'googleTagManager' ) ) {
+					return;
+				}
+
+				const trackEventMeta = {
+					event: 'visitor interaction',
+					interaction_name: stepName,
+				};
+
+				window.dataLayer.push( trackEventMeta );
+
+				debug( `recordGTMDatalayerEvent: Record Woo Express Stepper Event`, trackEventMeta );
+			} )
+			.catch( ( error ) => {
+				debug( 'recordGTMDatalayerEvent: Error loading GTM container', error );
+			} );
+	}
+}

--- a/client/lib/analytics/ad-tracking/woo/record-gtm-datalayer-event.ts
+++ b/client/lib/analytics/ad-tracking/woo/record-gtm-datalayer-event.ts
@@ -8,31 +8,28 @@ import { initGTMContainer, loadGTMContainer } from '../gtm-container';
  * @param {string} stepName
  * @returns {void}
  */
-export default async function recordGTMDatalayerEvent( stepName = '' ) {
-	if ( stepName ) {
-		loadGTMContainer( TRACKING_IDS.wooGoogleTagManagerId )
-			.then( () => initGTMContainer() )
-			.then( () => {
-				debug(
-					`recordGTMDatalayerEvent: Initialized GTM container ${ TRACKING_IDS.wooGoogleTagManagerId }`
-				);
-
-				// We ensure that we can track with GTM
-				if ( ! mayWeTrackByTracker( 'googleTagManager' ) ) {
-					return;
-				}
-
-				const trackEventMeta = {
-					event: 'visitor interaction',
-					interaction_name: stepName,
-				};
-
-				window.dataLayer.push( trackEventMeta );
-
-				debug( `recordGTMDatalayerEvent: Record Woo Express Stepper Event`, trackEventMeta );
-			} )
-			.catch( ( error ) => {
-				debug( 'recordGTMDatalayerEvent: Error loading GTM container', error );
-			} );
+export default function recordGTMDatalayerEvent( stepName = '' ) {
+	// We ensure that we can track with GTM
+	if ( ! mayWeTrackByTracker( 'googleTagManager' ) ) {
+		return;
 	}
+	loadGTMContainer( TRACKING_IDS.wooGoogleTagManagerId )
+		.then( () => initGTMContainer() )
+		.then( () => {
+			debug(
+				`recordGTMDatalayerEvent: Initialized GTM container ${ TRACKING_IDS.wooGoogleTagManagerId }`
+			);
+
+			const trackEventMeta = {
+				event: 'visitor interaction',
+				interaction_name: stepName,
+			};
+
+			window.dataLayer.push( trackEventMeta );
+
+			debug( `recordGTMDatalayerEvent: Record Woo Express Stepper Event`, trackEventMeta );
+		} )
+		.catch( ( error ) => {
+			debug( 'recordGTMDatalayerEvent: Error loading GTM container', error );
+		} );
 }


### PR DESCRIPTION
As we don't get enough data in the Woo GTM container for trial upgrades (users going from a free woo express trial to a paid plan) yet, we should add the Woo GTM container and track users earlier in the flow. E.g. in the stepper flow here: https://wordpress.com/setup/wooexpress/

Related to # 1749-gh-Automattic/martech
Additional Context # p1684695879052389-slack-C1A7F9WG5

Please note, this PR was created to address a bad merge issue in the [original PR](https://github.com/Automattic/wp-calypso/pull/77841) which was already approved. Approval notes from the original PR:
1. https://github.com/Automattic/wp-calypso/pull/77841#issuecomment-1594577270
2. https://github.com/Automattic/wp-calypso/pull/77841#issuecomment-1594591181
3. https://github.com/Automattic/wp-calypso/pull/77841#pullrequestreview-1483379682

## Proposed Changes

* Introduce a new method `recordGTMDatalayerEvent` and load the Woo GTM container in the same.
* Call the method in the stepper flow step changes routine

## Testing Instructions

* Install the GADebugger Chrome Extension and enable
* Switch to the branch on this PR and start Calypso
* Visit /setup/wooexpress/ and cycle through the various steps
* Open Chrome Console and notice that you can see Tag manager events for the various steps

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
