### PR TITLE
Blog onboarding: Allow users with multiple sites to view binary selection page

### DIFF
--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -7,7 +7,7 @@ import {
 	Flow,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSelector } from 'calypso/state';
-import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const Blog: Flow = {
 	name: 'blog',
@@ -30,9 +30,7 @@ const Blog: Flow = {
 	useAssertConditions(): AssertConditionResult {
 		const flowName = this.name;
 		const isLoggedIn = useSelector( isUserLoggedIn );
-		const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
 		const locale = useLocale();
-		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
 
 		const logInUrl =
 			locale && locale !== 'en'
@@ -46,13 +44,6 @@ const Blog: Flow = {
 			result = {
 				state: AssertConditionState.CHECKING,
 				message: `${ flowName } requires a logged in user`,
-			};
-		} else if ( userAlreadyHasSites ) {
-			// This prevents a bunch of sites being created accidentally.
-			redirect( `/` );
-			result = {
-				state: AssertConditionState.CHECKING,
-				message: `${ flowName } requires no preexisting sites`,
 			};
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1686916154698269-slack-C02FMH4G8

## Proposed Changes

* This PR allows users with multiple sites to view binary selection page instead of redirecting them to /home.
* From the binary selection page, we rely on the "Start writing" or "Pick a design" flows to properly redirect the user or start the proper flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* With a logged out user go to /setup/blog you should be asked to create an account or login.
* Once logged in, you should be able to see the binary selection page no matter how many sites your user account has.

![binary-selection](https://github.com/Automattic/wp-calypso/assets/140841/ea514dcd-e5d4-4f6f-90a6-ade8b29abb3d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?