### PR TITLE
Stronger plan getter types

### DIFF
--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -33,7 +33,7 @@ import {
 	WOO_EXPRESS_PLANS,
 } from './constants';
 import { featureGroups, wooExpressFeatureGroups } from './feature-group-plan-map';
-import { PLANS_LIST } from './plans-list';
+import { PLANS_LIST, PlanID } from './plans-list';
 import {
 	isJetpackBusiness,
 	isBusiness,
@@ -72,7 +72,7 @@ export function getPlansSlugs(): string[] {
 	return Object.keys( getPlans() );
 }
 
-export function getPlan( planKey: string | Plan ): Plan | JetpackPlan | WPComPlan | undefined {
+export function getPlan( planKey: PlanID | Plan ): Plan | JetpackPlan | WPComPlan | undefined {
 	if ( typeof planKey !== 'string' ) {
 		if ( Object.values( PLANS_LIST ).includes( planKey ) ) {
 			return planKey;

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -798,7 +798,7 @@ export const chooseDefaultCustomerType = ( {
 	}
 
 	const group = GROUP_WPCOM;
-	const businessPlanSlugs = [
+	const businessPlanSlugs: PlanSlug[] = [
 		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_PREMIUM } )[ 0 ],
 		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_PREMIUM } )[ 0 ],
 		findPlansKeys( { group, term: TERM_TRIENNIALLY, type: TYPE_PREMIUM } )[ 0 ],
@@ -818,8 +818,7 @@ export const chooseDefaultCustomerType = ( {
 	if ( selectedPlan ) {
 		return businessPlanSlugs.includes( selectedPlan ) ? 'business' : 'personal';
 	} else if ( currentPlan ) {
-		const isPlanInBusinessGroup =
-			businessPlanSlugs.indexOf( currentPlan.product_slug as PlanSlug ) !== -1;
+		const isPlanInBusinessGroup = businessPlanSlugs.indexOf( currentPlan.product_slug ) !== -1;
 		return isPlanInBusinessGroup ? 'business' : 'personal';
 	}
 

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -640,6 +640,11 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 			andMore: true,
 		},
 	} ),
+	term: TERM_ANNUALLY,
+	getBillingTimeFrame: () => i18n.translate( 'No expiration date' ),
+	getProductId: () => 1,
+	getStoreSlug: () => PLAN_FREE,
+	getPathSlug: () => 'beginner',
 } );
 
 const getPlanBloggerDetails = (): IncompleteWPcomPlan => ( {
@@ -2293,14 +2298,9 @@ const getPlanJetpackGoldenTokenDetails = (): IncompleteJetpackPlan => ( {
 } );
 
 // DO NOT import. Use `getPlan` instead.
-export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
+const PLANS_LIST_RAW = {
 	[ PLAN_FREE ]: {
 		...getPlanFreeDetails(),
-		term: TERM_ANNUALLY,
-		getBillingTimeFrame: () => i18n.translate( 'No expiration date' ),
-		getProductId: () => 1,
-		getStoreSlug: () => PLAN_FREE,
-		getPathSlug: () => 'beginner',
 	},
 
 	[ PLAN_BLOGGER ]: {
@@ -3180,139 +3180,147 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getPathSlug: () => 'p2-plus',
 		getBillingTimeFrame: () => translate( 'per user per month' ),
 	},
+
+	// Brand new WPCOM plans
+	[ PLAN_WPCOM_PRO ]: {
+		...getPlanProDetails(),
+		term: TERM_ANNUALLY,
+		getProductId: () => 1032,
+		getStoreSlug: () => PLAN_WPCOM_PRO,
+		getPathSlug: () => 'pro',
+		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
+	},
+
+	[ PLAN_WPCOM_PRO_MONTHLY ]: {
+		...getPlanProDetails(),
+		...getMonthlyTimeframe(),
+		availableFor: ( plan ) => [ PLAN_FREE ].includes( plan ),
+		getProductId: () => 1034,
+		getStoreSlug: () => PLAN_WPCOM_PRO_MONTHLY,
+		getPathSlug: () => 'pro-monthly',
+	},
+
+	[ PLAN_WPCOM_PRO_2_YEARS ]: {
+		...getPlanProDetails(),
+		term: TERM_BIENNIALLY,
+		availableFor: ( plan ) =>
+			[ PLAN_FREE, PLAN_WPCOM_STARTER, PLAN_WPCOM_PRO, PLAN_WPCOM_PRO_MONTHLY ].includes( plan ),
+		getProductId: () => 1035,
+		getStoreSlug: () => PLAN_WPCOM_PRO_2_YEARS,
+		getPathSlug: () => 'pro-2-years',
+		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
+	},
+
+	[ PLAN_ECOMMERCE_TRIAL_MONTHLY ]: {
+		...getDotcomPlanDetails(),
+		type: TYPE_ECOMMERCE,
+		group: GROUP_WPCOM,
+		getProductId: () => 1052,
+		getPathSlug: () => PLAN_ECOMMERCE_TRIAL_MONTHLY,
+		term: TERM_MONTHLY,
+		getBillingTimeFrame: () => i18n.translate( 'free trial' ),
+		getStoreSlug: () => PLAN_ECOMMERCE_TRIAL_MONTHLY,
+		getTitle: () => i18n.translate( 'eCommerce free trial' ),
+		getDescription: () => i18n.translate( 'eCommerce free trial' ),
+		getTagline: () =>
+			i18n.translate( 'Get a taste of the world’s most popular eCommerce software.' ),
+	},
+
+	[ PLAN_WPCOM_STARTER ]: {
+		...getDotcomPlanDetails(),
+		group: GROUP_WPCOM,
+		type: TYPE_STARTER,
+		term: TERM_ANNUALLY,
+		getTitle: () => i18n.translate( 'WordPress Starter' ),
+		getProductId: () => 1033,
+		getStoreSlug: () => PLAN_WPCOM_STARTER,
+		getPathSlug: () => 'starter',
+		getDescription: () =>
+			i18n.hasTranslation(
+				'Start with a custom domain name, simple payments, and extra storage.'
+			) || [ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
+				? i18n.translate( 'Start with a custom domain name, simple payments, and extra storage.' )
+				: i18n.translate( 'Start your WordPress.com website. Limited functionality and storage.' ),
+		getSubTitle: () => i18n.translate( 'Essential features. Freedom to grow.' ),
+		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
+		getPlanCompareFeatures: () => [
+			FEATURE_UNLIMITED_TRAFFIC,
+			FEATURE_MANAGED_HOSTING,
+			FEATURE_FREE_THEMES,
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_UNLIMITED_ADMINS,
+			FEATURE_6GB_STORAGE,
+			FEATURE_GOOGLE_ANALYTICS,
+			FEATURE_PAYMENT_BLOCKS,
+			FEATURE_TITAN_EMAIL,
+		],
+		getIncludedFeatures: () => [ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS ],
+		getCancellationFeatureList: (): CancellationFeatureLists => ( {
+			monthly: {
+				featureList: [
+					FEATURE_CANCELLATION_MANAGED_HOSTINGS,
+					FEATURE_CANCELLATION_SEO_AND_SOCIAL,
+					FEATURE_CANCELLATION_EARN_AD_REVENUE,
+					FEATURE_CANCELLATION_SECURITY_AND_SPAM,
+					FEATURE_CANCELLATION_JETPACK_ESSENTIALS,
+				],
+				andMore: true,
+			},
+			yearly: {
+				featureList: [
+					FEATURE_CANCELLATION_MANAGED_HOSTINGS,
+					FEATURE_CANCELLATION_SEO_AND_SOCIAL,
+					FEATURE_CANCELLATION_EARN_AD_REVENUE,
+					FEATURE_CANCELLATION_SECURITY_AND_SPAM,
+					FEATURE_CANCELLATION_JETPACK_ESSENTIALS,
+				],
+				andMore: true,
+			},
+			withDomain: {
+				featureList: [
+					FEATURE_CANCELLATION_MANAGED_HOSTINGS,
+					FEATURE_CANCELLATION_SEO_AND_SOCIAL,
+					FEATURE_CANCELLATION_EARN_AD_REVENUE,
+					FEATURE_CANCELLATION_SECURITY_AND_SPAM,
+				],
+				andMore: true,
+			},
+		} ),
+	},
+
+	[ PLAN_P2_FREE ]: {
+		// Inherits the free plan
+		...getPlanFreeDetails(),
+		getDescription: () =>
+			i18n.translate(
+				'{{strong}}Best for small groups:{{/strong}} All the features needed to share, discuss, review, and collaborate with your team in one spot, without interruptions.',
+				plansDescriptionHeadingComponent
+			),
+		getTitle: () => i18n.translate( 'P2 Free' ),
+		getPlanCompareFeatures: () => [
+			// pay attention to ordering, shared features should align on /plan page
+			FEATURE_P2_3GB_STORAGE,
+			FEATURE_P2_UNLIMITED_USERS,
+			FEATURE_P2_UNLIMITED_POSTS_PAGES,
+			FEATURE_P2_SIMPLE_SEARCH,
+			FEATURE_P2_CUSTOMIZATION_OPTIONS,
+		],
+	},
+
+	[ PLAN_WPCOM_FLEXIBLE ]: {
+		// Inherits the free plan
+		...getPlanFreeDetails(),
+		group: GROUP_WPCOM,
+		type: TYPE_FLEXIBLE,
+		getTitle: () => i18n.translate( 'WordPress Free' ),
+		getBillingTimeFrame: () => i18n.translate( 'upgrade when you need' ),
+		getDescription: () =>
+			i18n.translate( 'Start your free WordPress.com website. Limited functionality and storage.' ),
+		getPlanCompareFeatures: () => [ FEATURE_1GB_STORAGE ],
+	},
 };
 
-PLANS_LIST[ PLAN_P2_FREE ] = {
-	...PLANS_LIST[ PLAN_FREE ],
-	getDescription: () =>
-		i18n.translate(
-			'{{strong}}Best for small groups:{{/strong}} All the features needed to share, discuss, review, and collaborate with your team in one spot, without interruptions.',
-			plansDescriptionHeadingComponent
-		),
-	getTitle: () => i18n.translate( 'P2 Free' ),
-	getPlanCompareFeatures: () => [
-		// pay attention to ordering, shared features should align on /plan page
-		FEATURE_P2_3GB_STORAGE,
-		FEATURE_P2_UNLIMITED_USERS,
-		FEATURE_P2_UNLIMITED_POSTS_PAGES,
-		FEATURE_P2_SIMPLE_SEARCH,
-		FEATURE_P2_CUSTOMIZATION_OPTIONS,
-	],
-};
+export type PlanID = keyof typeof PLANS_LIST_RAW;
 
-// Brand new WPCOM plans
-PLANS_LIST[ PLAN_WPCOM_STARTER ] = {
-	...getDotcomPlanDetails(),
-	group: GROUP_WPCOM,
-	type: TYPE_STARTER,
-	term: TERM_ANNUALLY,
-	getTitle: () => i18n.translate( 'WordPress Starter' ),
-	getProductId: () => 1033,
-	getStoreSlug: () => PLAN_WPCOM_STARTER,
-	getPathSlug: () => 'starter',
-	getDescription: () =>
-		i18n.hasTranslation( 'Start with a custom domain name, simple payments, and extra storage.' ) ||
-		[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
-			? i18n.translate( 'Start with a custom domain name, simple payments, and extra storage.' )
-			: i18n.translate( 'Start your WordPress.com website. Limited functionality and storage.' ),
-	getSubTitle: () => i18n.translate( 'Essential features. Freedom to grow.' ),
-	getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
-	getPlanCompareFeatures: () => [
-		FEATURE_UNLIMITED_TRAFFIC,
-		FEATURE_MANAGED_HOSTING,
-		FEATURE_FREE_THEMES,
-		FEATURE_CUSTOM_DOMAIN,
-		FEATURE_UNLIMITED_ADMINS,
-		FEATURE_6GB_STORAGE,
-		FEATURE_GOOGLE_ANALYTICS,
-		FEATURE_PAYMENT_BLOCKS,
-		FEATURE_TITAN_EMAIL,
-	],
-	getIncludedFeatures: () => [ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS ],
-	getCancellationFeatureList: (): CancellationFeatureLists => ( {
-		monthly: {
-			featureList: [
-				FEATURE_CANCELLATION_MANAGED_HOSTINGS,
-				FEATURE_CANCELLATION_SEO_AND_SOCIAL,
-				FEATURE_CANCELLATION_EARN_AD_REVENUE,
-				FEATURE_CANCELLATION_SECURITY_AND_SPAM,
-				FEATURE_CANCELLATION_JETPACK_ESSENTIALS,
-			],
-			andMore: true,
-		},
-		yearly: {
-			featureList: [
-				FEATURE_CANCELLATION_MANAGED_HOSTINGS,
-				FEATURE_CANCELLATION_SEO_AND_SOCIAL,
-				FEATURE_CANCELLATION_EARN_AD_REVENUE,
-				FEATURE_CANCELLATION_SECURITY_AND_SPAM,
-				FEATURE_CANCELLATION_JETPACK_ESSENTIALS,
-			],
-			andMore: true,
-		},
-		withDomain: {
-			featureList: [
-				FEATURE_CANCELLATION_MANAGED_HOSTINGS,
-				FEATURE_CANCELLATION_SEO_AND_SOCIAL,
-				FEATURE_CANCELLATION_EARN_AD_REVENUE,
-				FEATURE_CANCELLATION_SECURITY_AND_SPAM,
-			],
-			andMore: true,
-		},
-	} ),
-};
-
-PLANS_LIST[ PLAN_WPCOM_FLEXIBLE ] = {
-	// Inherits the free plan
-	...PLANS_LIST[ PLAN_FREE ],
-	group: GROUP_WPCOM,
-	type: TYPE_FLEXIBLE,
-	getTitle: () => i18n.translate( 'WordPress Free' ),
-	getBillingTimeFrame: () => i18n.translate( 'upgrade when you need' ),
-	getDescription: () =>
-		i18n.translate( 'Start your free WordPress.com website. Limited functionality and storage.' ),
-	getPlanCompareFeatures: () => [ FEATURE_1GB_STORAGE ],
-};
-
-PLANS_LIST[ PLAN_WPCOM_PRO ] = {
-	...getPlanProDetails(),
-	term: TERM_ANNUALLY,
-	getProductId: () => 1032,
-	getStoreSlug: () => PLAN_WPCOM_PRO,
-	getPathSlug: () => 'pro',
-	getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
-};
-
-PLANS_LIST[ PLAN_WPCOM_PRO_MONTHLY ] = {
-	...getPlanProDetails(),
-	...getMonthlyTimeframe(),
-	availableFor: ( plan ) => [ PLAN_FREE ].includes( plan ),
-	getProductId: () => 1034,
-	getStoreSlug: () => PLAN_WPCOM_PRO_MONTHLY,
-	getPathSlug: () => 'pro-monthly',
-};
-
-PLANS_LIST[ PLAN_WPCOM_PRO_2_YEARS ] = {
-	...getPlanProDetails(),
-	term: TERM_BIENNIALLY,
-	availableFor: ( plan ) =>
-		[ PLAN_FREE, PLAN_WPCOM_STARTER, PLAN_WPCOM_PRO, PLAN_WPCOM_PRO_MONTHLY ].includes( plan ),
-	getProductId: () => 1035,
-	getStoreSlug: () => PLAN_WPCOM_PRO_2_YEARS,
-	getPathSlug: () => 'pro-2-years',
-	getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
-};
-
-PLANS_LIST[ PLAN_ECOMMERCE_TRIAL_MONTHLY ] = {
-	...getDotcomPlanDetails(),
-	type: TYPE_ECOMMERCE,
-	group: GROUP_WPCOM,
-	getProductId: () => 1052,
-	getPathSlug: () => PLAN_ECOMMERCE_TRIAL_MONTHLY,
-	term: TERM_MONTHLY,
-	getBillingTimeFrame: () => i18n.translate( 'free trial' ),
-	getStoreSlug: () => PLAN_ECOMMERCE_TRIAL_MONTHLY,
-	getTitle: () => i18n.translate( 'eCommerce free trial' ),
-	getDescription: () => i18n.translate( 'eCommerce free trial' ),
-	getTagline: () => i18n.translate( 'Get a taste of the world’s most popular eCommerce software.' ),
-};
+// Note: this does enough type checking that an invalid plan in the list above will cause an error when casting here.
+export const PLANS_LIST = PLANS_LIST_RAW as Record< PlanID, Plan | JetpackPlan | WPComPlan >;

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -3320,7 +3320,7 @@ const PLANS_LIST_RAW = {
 	},
 };
 
-export type PlanID = keyof typeof PLANS_LIST_RAW;
+export type PlanSlug = keyof typeof PLANS_LIST_RAW;
 
 // Note: this does enough type checking that an invalid plan in the list above will cause an error when casting here.
-export const PLANS_LIST = PLANS_LIST_RAW as Record< PlanID, Plan | JetpackPlan | WPComPlan >;
+export const PLANS_LIST = PLANS_LIST_RAW as Record< PlanSlug, Plan | JetpackPlan | WPComPlan >;

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -3181,49 +3181,23 @@ const PLANS_LIST_RAW = {
 		getBillingTimeFrame: () => translate( 'per user per month' ),
 	},
 
-	// Brand new WPCOM plans
-	[ PLAN_WPCOM_PRO ]: {
-		...getPlanProDetails(),
-		term: TERM_ANNUALLY,
-		getProductId: () => 1032,
-		getStoreSlug: () => PLAN_WPCOM_PRO,
-		getPathSlug: () => 'pro',
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
-	},
-
-	[ PLAN_WPCOM_PRO_MONTHLY ]: {
-		...getPlanProDetails(),
-		...getMonthlyTimeframe(),
-		availableFor: ( plan ) => [ PLAN_FREE ].includes( plan ),
-		getProductId: () => 1034,
-		getStoreSlug: () => PLAN_WPCOM_PRO_MONTHLY,
-		getPathSlug: () => 'pro-monthly',
-	},
-
-	[ PLAN_WPCOM_PRO_2_YEARS ]: {
-		...getPlanProDetails(),
-		term: TERM_BIENNIALLY,
-		availableFor: ( plan ) =>
-			[ PLAN_FREE, PLAN_WPCOM_STARTER, PLAN_WPCOM_PRO, PLAN_WPCOM_PRO_MONTHLY ].includes( plan ),
-		getProductId: () => 1035,
-		getStoreSlug: () => PLAN_WPCOM_PRO_2_YEARS,
-		getPathSlug: () => 'pro-2-years',
-		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
-	},
-
-	[ PLAN_ECOMMERCE_TRIAL_MONTHLY ]: {
-		...getDotcomPlanDetails(),
-		type: TYPE_ECOMMERCE,
-		group: GROUP_WPCOM,
-		getProductId: () => 1052,
-		getPathSlug: () => PLAN_ECOMMERCE_TRIAL_MONTHLY,
-		term: TERM_MONTHLY,
-		getBillingTimeFrame: () => i18n.translate( 'free trial' ),
-		getStoreSlug: () => PLAN_ECOMMERCE_TRIAL_MONTHLY,
-		getTitle: () => i18n.translate( 'eCommerce free trial' ),
-		getDescription: () => i18n.translate( 'eCommerce free trial' ),
-		getTagline: () =>
-			i18n.translate( 'Get a taste of the world’s most popular eCommerce software.' ),
+	[ PLAN_P2_FREE ]: {
+		// Inherits the free plan
+		...getPlanFreeDetails(),
+		getDescription: () =>
+			i18n.translate(
+				'{{strong}}Best for small groups:{{/strong}} All the features needed to share, discuss, review, and collaborate with your team in one spot, without interruptions.',
+				plansDescriptionHeadingComponent
+			),
+		getTitle: () => i18n.translate( 'P2 Free' ),
+		getPlanCompareFeatures: () => [
+			// pay attention to ordering, shared features should align on /plan page
+			FEATURE_P2_3GB_STORAGE,
+			FEATURE_P2_UNLIMITED_USERS,
+			FEATURE_P2_UNLIMITED_POSTS_PAGES,
+			FEATURE_P2_SIMPLE_SEARCH,
+			FEATURE_P2_CUSTOMIZATION_OPTIONS,
+		],
 	},
 
 	[ PLAN_WPCOM_STARTER ]: {
@@ -3288,25 +3262,6 @@ const PLANS_LIST_RAW = {
 		} ),
 	},
 
-	[ PLAN_P2_FREE ]: {
-		// Inherits the free plan
-		...getPlanFreeDetails(),
-		getDescription: () =>
-			i18n.translate(
-				'{{strong}}Best for small groups:{{/strong}} All the features needed to share, discuss, review, and collaborate with your team in one spot, without interruptions.',
-				plansDescriptionHeadingComponent
-			),
-		getTitle: () => i18n.translate( 'P2 Free' ),
-		getPlanCompareFeatures: () => [
-			// pay attention to ordering, shared features should align on /plan page
-			FEATURE_P2_3GB_STORAGE,
-			FEATURE_P2_UNLIMITED_USERS,
-			FEATURE_P2_UNLIMITED_POSTS_PAGES,
-			FEATURE_P2_SIMPLE_SEARCH,
-			FEATURE_P2_CUSTOMIZATION_OPTIONS,
-		],
-	},
-
 	[ PLAN_WPCOM_FLEXIBLE ]: {
 		// Inherits the free plan
 		...getPlanFreeDetails(),
@@ -3317,6 +3272,51 @@ const PLANS_LIST_RAW = {
 		getDescription: () =>
 			i18n.translate( 'Start your free WordPress.com website. Limited functionality and storage.' ),
 		getPlanCompareFeatures: () => [ FEATURE_1GB_STORAGE ],
+	},
+
+	// Brand new WPCOM plans
+	[ PLAN_WPCOM_PRO ]: {
+		...getPlanProDetails(),
+		term: TERM_ANNUALLY,
+		getProductId: () => 1032,
+		getStoreSlug: () => PLAN_WPCOM_PRO,
+		getPathSlug: () => 'pro',
+		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
+	},
+
+	[ PLAN_WPCOM_PRO_MONTHLY ]: {
+		...getPlanProDetails(),
+		...getMonthlyTimeframe(),
+		availableFor: ( plan ) => [ PLAN_FREE ].includes( plan ),
+		getProductId: () => 1034,
+		getStoreSlug: () => PLAN_WPCOM_PRO_MONTHLY,
+		getPathSlug: () => 'pro-monthly',
+	},
+
+	[ PLAN_WPCOM_PRO_2_YEARS ]: {
+		...getPlanProDetails(),
+		term: TERM_BIENNIALLY,
+		availableFor: ( plan ) =>
+			[ PLAN_FREE, PLAN_WPCOM_STARTER, PLAN_WPCOM_PRO, PLAN_WPCOM_PRO_MONTHLY ].includes( plan ),
+		getProductId: () => 1035,
+		getStoreSlug: () => PLAN_WPCOM_PRO_2_YEARS,
+		getPathSlug: () => 'pro-2-years',
+		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
+	},
+
+	[ PLAN_ECOMMERCE_TRIAL_MONTHLY ]: {
+		...getDotcomPlanDetails(),
+		type: TYPE_ECOMMERCE,
+		group: GROUP_WPCOM,
+		getProductId: () => 1052,
+		getPathSlug: () => PLAN_ECOMMERCE_TRIAL_MONTHLY,
+		term: TERM_MONTHLY,
+		getBillingTimeFrame: () => i18n.translate( 'free trial' ),
+		getStoreSlug: () => PLAN_ECOMMERCE_TRIAL_MONTHLY,
+		getTitle: () => i18n.translate( 'eCommerce free trial' ),
+		getDescription: () => i18n.translate( 'eCommerce free trial' ),
+		getTagline: () =>
+			i18n.translate( 'Get a taste of the world’s most popular eCommerce software.' ),
 	},
 };
 

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -2298,7 +2298,7 @@ const getPlanJetpackGoldenTokenDetails = (): IncompleteJetpackPlan => ( {
 } );
 
 // DO NOT import. Use `getPlan` instead.
-const PLANS_LIST_RAW = {
+const PLANS_LIST_RAW: Record< string, Partial< Plan > > = {
 	[ PLAN_FREE ]: {
 		...getPlanFreeDetails(),
 	},

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -130,6 +130,8 @@ export type JetpackProductCategory = ( typeof JETPACK_PRODUCT_CATEGORIES )[ numb
 
 // All
 export type ProductSlug = WPComProductSlug | JetpackProductSlug;
+
+// TODO: Remove this in favor of the auto-generated plan slugs in plans-list?
 export type PlanSlug = WPComPlanSlug | JetpackPlanSlug;
 export type PurchasableItemSlug = WPComPurchasableItemSlug | JetpackPurchasableItemSlug;
 

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -233,8 +233,11 @@ export type Plan = BillingTerm & {
 	get2023PricingGridSignupStorageOptions?: () => Feature[];
 	getProductId: () => number;
 	getPathSlug?: () => string;
+	getMonthlySlug?: () => string;
+	getAnnualSlug?: () => string;
 	getStoreSlug: () => PlanSlug;
 	getTitle: () => TranslateResult;
+	getSubTitle?: () => TranslateResult;
 	getDescription: () => TranslateResult;
 	getShortDescription?: () => TranslateResult;
 	getFeaturedDescription?: () => TranslateResult;
@@ -245,6 +248,7 @@ export type Plan = BillingTerm & {
 	getBenefits?: () => Array< TranslateResult >;
 	getRecommendedFor?: () => Array< JetpackTag >;
 	getTagline?: () => TranslateResult;
+	getAudience?: () => TranslateResult;
 	getPlanCardFeatures?: () => Feature[];
 	getCancellationFeatureList?: () => CancellationFeatureLists;
 	/**
@@ -268,6 +272,8 @@ export type Plan = BillingTerm & {
 	getBlogOnboardingSignupFeatures?: () => Feature[];
 	getBlogOnboardingHighlightedFeatures?: () => Feature[];
 	getBlogOnboardingSignupJetpackFeatures?: () => Feature[];
+	getPlanCompareFeatures?: () => Feature[];
+	getSignupFeatures?: () => Feature[];
 };
 
 export type WithSnakeCaseSlug = { product_slug: string };


### PR DESCRIPTION
This was inspired by #78292. Essentially, when you call `getPlan` with a known plan ID, the data is guaranteed to exist, but our types don't enforce that!

This PR adjusts those types to get much more detailed type info:

1. Change `PLANS_LIST` into an internal data structure
2. Move all plans inside of the object instantiation, instead of adding plans later in the file.
3. Add a `PlanSlug` type which is the keys of the `PLANS_LIST`
4. Add `export const PLANS_LIST = PLANS_LIST_RAW as Record<  PlanSlug, Plan | JetpackPlan | WPComPlan >;` so that we know the IDs ahead of time
5. Update `getPlan` to use `PlanSlug` with conditional types so we can guarantee a result in some cases
6. Update all other plan getter functions to use this as well

The big question I have is the difference between this approach vs the existing `PlanSlug` type in `./types` here. 🤔 