### PR TITLE
(WIP) Domains: Show correct initial and renewal prices for high-low premium domains

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -155,8 +155,38 @@ class DomainProductPrice extends Component {
 		);
 	}
 
+	renderHighLowPrice() {
+		const { price, renewPrice, translate } = this.props;
+
+		const className = classnames( 'domain-product-price', 'is-free-domain', 'is-sale-domain', {
+			'domain-product-price__domain-step-signup-flow': this.props.showStrikedOutPrice,
+		} );
+
+		return (
+			<div className={ className }>
+				<div className="domain-product-price__premium-register-price">
+					{ translate( '%(price)s {{small}}for the first year{{/small}}', {
+						args: { price },
+						components: { small: <small /> },
+					} ) }
+				</div>
+				<div className="domain-product-price__premium-renewal-price">
+					{ translate( '%(renewPrice)s {{small}}/year afterwards{{/small}}', {
+						args: { renewPrice },
+						components: { small: <small /> },
+						comment: '%(renewPrice)s is the annual renewal price of a premium domain',
+					} ) }
+				</div>
+			</div>
+		);
+	}
+
 	renderPrice() {
-		const { salePrice, showStrikedOutPrice, price, translate } = this.props;
+		const { salePrice, renewPrice, showStrikedOutPrice, price, translate } = this.props;
+		if ( renewPrice && renewPrice !== price ) {
+			return this.renderHighLowPrice();
+		}
+
 		if ( salePrice ) {
 			return this.renderSalePrice();
 		}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -116,6 +116,13 @@
 		}
 	}
 
+	.domain-product-price__premium-register-price {
+		color: var(--color-neutral-60);
+	}
+	.domain-product-price__premium-renewal-price {
+		text-decoration: none;
+	}
+
 	.is-placeholder & {
 		@include breakpoint-deprecated( ">660px" ) {
 			display: none;

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -393,6 +393,7 @@ class DomainRegistrationSuggestion extends Component {
 			suggestion: { domain_name: domain },
 			productCost,
 			productSaleCost,
+			productRenewCost,
 			premiumDomain,
 			showStrikedOutPrice,
 			isReskinned,
@@ -412,6 +413,7 @@ class DomainRegistrationSuggestion extends Component {
 				priceRule={ this.getPriceRule() }
 				price={ productCost }
 				salePrice={ productSaleCost }
+				renewPrice={ productRenewCost }
 				domain={ domain }
 				domainsWithPlansOnly={ domainsWithPlansOnly }
 				onButtonClick={ this.onButtonClick }
@@ -438,6 +440,7 @@ const mapStateToProps = ( state, props ) => {
 
 	let productCost;
 	let productSaleCost;
+	let productRenewCost;
 
 	if ( isPremium ) {
 		productCost = props.premiumDomain?.cost;
@@ -445,6 +448,15 @@ const mapStateToProps = ( state, props ) => {
 			productSaleCost = formatCurrency( props.premiumDomain?.sale_cost, currentUserCurrencyCode, {
 				stripZeros,
 			} );
+		}
+		if ( props.premiumDomain?.renew_raw_cost ) {
+			productRenewCost = formatCurrency(
+				props.premiumDomain?.renew_raw_cost,
+				currentUserCurrencyCode,
+				{
+					stripZeros,
+				}
+			);
 		}
 	} else {
 		productCost = getDomainPrice( productSlug, productsList, currentUserCurrencyCode, stripZeros );
@@ -461,6 +473,7 @@ const mapStateToProps = ( state, props ) => {
 		showDotGayNotice: isDotGayNoticeRequired( productSlug, productsList ),
 		productCost,
 		productSaleCost,
+		productRenewCost,
 		flowName,
 	};
 };

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -18,6 +18,7 @@ class DomainSuggestion extends Component {
 		domain: PropTypes.string,
 		hidePrice: PropTypes.bool,
 		showChevron: PropTypes.bool,
+		renewPrice: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -34,6 +35,7 @@ class DomainSuggestion extends Component {
 			isSignupStep,
 			showStrikedOutPrice,
 			isReskinned,
+			renewPrice,
 		} = this.props;
 
 		if ( hidePrice ) {
@@ -48,6 +50,7 @@ class DomainSuggestion extends Component {
 			<DomainProductPrice
 				price={ price }
 				salePrice={ salePrice }
+				renewPrice={ renewPrice }
 				rule={ priceRule }
 				isSignupStep={ isSignupStep }
 				showStrikedOutPrice={ showStrikedOutPrice }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -897,6 +897,7 @@ class RegisterDomainStep extends Component {
 				is_premium: data.is_premium,
 				cost: data.cost,
 				sale_cost: data.sale_cost,
+				renew_raw_cost: data.renew_raw_cost,
 				is_price_limit_exceeded: data.is_price_limit_exceeded,
 			} ) )
 			.catch( ( error ) => ( {

--- a/packages/wpcom-checkout/src/introductory-offer.ts
+++ b/packages/wpcom-checkout/src/introductory-offer.ts
@@ -121,6 +121,12 @@ export function getItemIntroductoryOfferDisplay(
 		return null;
 	}
 
+	// This can happen for premium domains which registration price is haigher than the renewal price
+	// In these cases, we don't want to show a "Discount for first year" or related message
+	if ( product.item_subtotal_integer > product.item_original_subtotal_integer ) {
+		return null;
+	}
+
 	const isFreeTrial = product.item_subtotal_integer === 0;
 	const text = getIntroductoryOfferIntervalDisplay(
 		translate,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Note: This depends on D111913-code

This PR updates the domain search page and the checkout pages to show the correct registration and renewal prices when a high-low premium domain is presented.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply D111913-code to your backend and follow its testing instructions
- Open the live Calypso link or build this branch locally

In the `/start` onboarding flow:
- Search for a high-low premium domain (e.g. `wonderful.art`)
- Ensure the registration and renewal prices are shown correctly
- Select that domain and go to the checkout page
- Ensure the registration price is shown correctly

In an existing site:
- Search for a high-low premium domain (e.g. `wonderful.art`)
- Ensure the registration and renewal prices are shown correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?