### PR TITLE
Stats: Fixing subscribers data query

### DIFF
--- a/apps/odyssey-stats/src/routes.ts
+++ b/apps/odyssey-stats/src/routes.ts
@@ -57,6 +57,7 @@ export default function ( pageBase = '/' ) {
 
 	// Stat Subscribers Page (do not confuse with people/subscribers/)
 	statsPage( '/stats/subscribers/:site', subscribers );
+	statsPage( `/stats/subscribers/:period(${ validPeriods })/:site`, subscribers );
 
 	// Stat Site Pages
 	statsPage( `/stats/:period(${ validPeriods })/:site`, site );

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -29,14 +29,11 @@ function querySubscribers(
 	const query = {
 		unit: period,
 		quantity,
-		http_envelope: 1,
 		date: formattedDate,
 	};
 
 	return wpcom.req.get(
 		{
-			method: 'GET',
-			apiNamespace: 'rest/v1.1',
 			path: `/sites/${ siteId }/stats/subscribers`,
 		},
 		query


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* removing unnecessary call parameters

Apply the same fix as  #78297

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Calypso**
* Open the live branch for this PR
* Navigate to the traffic stats page at `/stats/day/:siteSlug`
* Navigate to the subscriber stats section and verify that it loads without a line chart
* Add the query string `?flags=stats/subscribers-chart-section` and verify that the page loads with a chart

**Odyssey**
* Build the branch for Odyssey
    * `STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Build Jetpack if necessary
    * `jetpack build plugins/jetpack`
* Open `/wp-admin/admin.php?page=stats`
* Open the Subscribers page
* Add the query string `&flags=stats/subscribers-chart-section` before `#!` and verify that the page loads with a chart

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
