### PR TITLE
Unify Design Preview: Support the colors selection for the designs without style variations

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -89,8 +89,8 @@ export function getDesignEventProps( {
 		has_style_variations: ( design.style_variations || [] ).length > 0,
 		is_style_variation: is_style_variation,
 		...( colorVariation && {
-			font_variation_title: getVariationTitle( colorVariation ),
-			font_variation_type: getVariationType( colorVariation ),
+			color_variation_title: getVariationTitle( colorVariation ),
+			color_variation_type: getVariationType( colorVariation ),
 		} ),
 		...( fontVariation && {
 			font_variation_title: getVariationTitle( fontVariation ),

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -64,12 +64,14 @@ export function getDesignEventProps( {
 	intent,
 	design,
 	styleVariation,
+	colorVariation,
 	fontVariation,
 }: {
 	flow: string | null;
 	intent: string;
 	design: Design;
 	styleVariation?: StyleVariation;
+	colorVariation?: GlobalStylesObject | null;
 	fontVariation?: GlobalStylesObject | null;
 } ) {
 	const is_style_variation = styleVariation && styleVariation.slug !== 'default';
@@ -86,6 +88,10 @@ export function getDesignEventProps( {
 		is_premium: design.is_premium,
 		has_style_variations: ( design.style_variations || [] ).length > 0,
 		is_style_variation: is_style_variation,
+		...( colorVariation && {
+			font_variation_title: getVariationTitle( colorVariation ),
+			font_variation_type: getVariationType( colorVariation ),
+		} ),
 		...( fontVariation && {
 			font_variation_title: getVariationTitle( fontVariation ),
 			font_variation_type: getVariationType( fontVariation ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -174,12 +174,14 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		isPreviewingDesign,
 		selectedDesign,
 		selectedStyleVariation,
+		selectedColorVariation,
 		selectedFontVariation,
 		hasSelectedGlobalStyles,
 		globalStyles,
 		setSelectedDesign,
 		previewDesign,
 		previewDesignVariation,
+		setSelectedColorVariation,
 		setSelectedFontVariation,
 		setGlobalStyles,
 		resetPreview,
@@ -211,10 +213,18 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	function getEventPropsByDesign(
 		design: Design,
 		styleVariation?: StyleVariation,
+		colorVariation?: GlobalStylesObject | null,
 		fontVariation?: GlobalStylesObject | null
 	) {
 		return {
-			...getDesignEventProps( { flow, intent, design, styleVariation, fontVariation } ),
+			...getDesignEventProps( {
+				flow,
+				intent,
+				design,
+				styleVariation,
+				colorVariation,
+				fontVariation,
+			} ),
 			category: categorization.selection,
 			...( design.recipe?.pattern_ids && { pattern_ids: design.recipe.pattern_ids.join( ',' ) } ),
 			...( design.recipe?.header_pattern_ids && {
@@ -601,6 +611,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					recordDeviceClick={ recordDeviceClick }
 					siteId={ site.ID }
 					stylesheet={ selectedDesign.recipe?.stylesheet }
+					selectedColorVariation={ selectedColorVariation }
+					onSelectColorVariation={ setSelectedColorVariation }
 					selectedFontVariation={ selectedFontVariation }
 					onSelectFontVariation={ setSelectedFontVariation }
 					onGlobalStylesChange={ setGlobalStyles }

--- a/config/development.json
+++ b/config/development.json
@@ -177,6 +177,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
+		"signup/design-picker-preview-colors": false,
 		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -114,6 +114,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,
 		"signup/design-picker-pattern-assembler": true,
+		"signup/design-picker-preview-colors": false,
 		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/production.json
+++ b/config/production.json
@@ -138,6 +138,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
+		"signup/design-picker-preview-colors": false,
 		"signup/design-picker-preview-fonts": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -134,6 +134,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
+		"signup/design-picker-preview-colors": false,
 		"signup/design-picker-preview-fonts": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -146,6 +146,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
+		"signup/design-picker-preview-colors": false,
 		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -28,12 +28,14 @@ interface DesignPreviewProps {
 	recordDeviceClick: ( device: string ) => void;
 	siteId: number;
 	stylesheet: string;
+	selectedColorVariation: GlobalStylesObject | null;
+	onSelectColorVariation: ( variation: GlobalStylesObject | null ) => void;
 	selectedFontVariation: GlobalStylesObject | null;
 	onSelectFontVariation: ( variation: GlobalStylesObject | null ) => void;
 	onGlobalStylesChange: ( globalStyles: GlobalStylesObject | null ) => void;
 }
 
-const INJECTED_CSS = `body{ transition: background-color 0.2s linear, color 0.2s linear; };`;
+const INJECTED_CSS = `body{ transition: background-color 0.2s linear, color 0.2s linear; }`;
 
 const getVariationBySlug = ( variations: StyleVariation[], slug: string ) =>
 	variations.find( ( variation ) => variation.slug === slug );
@@ -56,13 +58,16 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	recordDeviceClick,
 	siteId,
 	stylesheet,
+	selectedColorVariation,
+	onSelectColorVariation,
 	selectedFontVariation,
 	onSelectFontVariation,
 	onGlobalStylesChange,
 } ) => {
 	const selectedVariations = useMemo(
-		() => [ selectedFontVariation ].filter( Boolean ) as GlobalStylesObject[],
-		[ selectedFontVariation ]
+		() =>
+			[ selectedColorVariation, selectedFontVariation ].filter( Boolean ) as GlobalStylesObject[],
+		[ selectedColorVariation, selectedFontVariation ]
 	);
 
 	const syncedGlobalStylesUserConfig = useSyncGlobalStylesUserConfig( selectedVariations );
@@ -106,6 +111,8 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 				actionButtons={ actionButtons }
 				siteId={ siteId }
 				stylesheet={ stylesheet }
+				selectedColorVariation={ selectedColorVariation }
+				onSelectColorVariation={ onSelectColorVariation }
 				selectedFontVariation={ selectedFontVariation }
 				onSelectFontVariation={ onSelectFontVariation }
 			/>

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -75,9 +75,6 @@ const Sidebar: React.FC< SidebarProps > = ( {
 	const [ isShowFullDescription, setIsShowFullDescription ] = useState( false );
 	const isShowDescriptionToggle = shortDescription && description !== shortDescription;
 
-	// The variations is undefined when we're still loading the design details
-	const hasStyleVariations = ! variations || variations.length > 0;
-
 	return (
 		<div className="design-preview__sidebar">
 			<div className="design-preview__sidebar-content">
@@ -120,7 +117,7 @@ const Sidebar: React.FC< SidebarProps > = ( {
 						</p>
 					</div>
 				) }
-				{ hasStyleVariations && (
+				{ variations && variations.length > 0 && (
 					<div className="design-preview__sidebar-variations">
 						<div className="design-preview__sidebar-variations-grid">
 							<GlobalStylesVariations
@@ -136,26 +133,30 @@ const Sidebar: React.FC< SidebarProps > = ( {
 						</div>
 					</div>
 				) }
-				{ ! hasStyleVariations && isEnabled( 'signup/design-picker-preview-colors' ) && (
-					<div className="design-preview__sidebar-variations">
-						<ColorPaletteVariations
-							siteId={ siteId }
-							stylesheet={ stylesheet }
-							selectedColorPaletteVariation={ selectedColorVariation }
-							onSelect={ onSelectColorVariation }
-						/>
-					</div>
-				) }
-				{ ! hasStyleVariations && isEnabled( 'signup/design-picker-preview-fonts' ) && (
-					<div className="design-preview__sidebar-variations">
-						<FontPairingVariations
-							siteId={ siteId }
-							stylesheet={ stylesheet }
-							selectedFontPairingVariation={ selectedFontVariation }
-							onSelect={ onSelectFontVariation }
-						/>
-					</div>
-				) }
+				{ variations &&
+					variations.length === 0 &&
+					isEnabled( 'signup/design-picker-preview-colors' ) && (
+						<div className="design-preview__sidebar-variations">
+							<ColorPaletteVariations
+								siteId={ siteId }
+								stylesheet={ stylesheet }
+								selectedColorPaletteVariation={ selectedColorVariation }
+								onSelect={ onSelectColorVariation }
+							/>
+						</div>
+					) }
+				{ variations &&
+					variations.length === 0 &&
+					isEnabled( 'signup/design-picker-preview-fonts' ) && (
+						<div className="design-preview__sidebar-variations">
+							<FontPairingVariations
+								siteId={ siteId }
+								stylesheet={ stylesheet }
+								selectedFontPairingVariation={ selectedFontVariation }
+								onSelect={ onSelectFontVariation }
+							/>
+						</div>
+					) }
 			</div>
 			{ actionButtons && (
 				<div className="design-preview__sidebar-action-buttons">{ actionButtons }</div>

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -1,6 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
-import { GlobalStylesVariations, FontPairingVariations } from '@automattic/global-styles';
+import {
+	GlobalStylesVariations,
+	ColorPaletteVariations,
+	FontPairingVariations,
+} from '@automattic/global-styles';
 import { useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import type { Category, StyleVariation } from '@automattic/design-picker/src/types';
@@ -41,6 +45,8 @@ interface SidebarProps {
 	actionButtons: React.ReactNode;
 	siteId: number;
 	stylesheet: string;
+	selectedColorVariation: GlobalStylesObject | null;
+	onSelectColorVariation: ( variation: GlobalStylesObject | null ) => void;
 	selectedFontVariation: GlobalStylesObject | null;
 	onSelectFontVariation: ( variation: GlobalStylesObject | null ) => void;
 }
@@ -60,12 +66,17 @@ const Sidebar: React.FC< SidebarProps > = ( {
 	actionButtons,
 	siteId,
 	stylesheet,
+	selectedColorVariation,
+	onSelectColorVariation,
 	selectedFontVariation,
 	onSelectFontVariation,
 } ) => {
 	const translate = useTranslate();
 	const [ isShowFullDescription, setIsShowFullDescription ] = useState( false );
 	const isShowDescriptionToggle = shortDescription && description !== shortDescription;
+
+	// The variations is undefined when we're still loading the design details
+	const hasStyleVariations = ! variations || variations.length > 0;
 
 	return (
 		<div className="design-preview__sidebar">
@@ -109,7 +120,7 @@ const Sidebar: React.FC< SidebarProps > = ( {
 						</p>
 					</div>
 				) }
-				{ variations && variations.length > 0 && (
+				{ hasStyleVariations && (
 					<div className="design-preview__sidebar-variations">
 						<div className="design-preview__sidebar-variations-grid">
 							<GlobalStylesVariations
@@ -125,18 +136,26 @@ const Sidebar: React.FC< SidebarProps > = ( {
 						</div>
 					</div>
 				) }
-				{ variations &&
-					variations.length === 0 &&
-					isEnabled( 'signup/design-picker-preview-fonts' ) && (
-						<div className="design-preview__sidebar-variations">
-							<FontPairingVariations
-								siteId={ siteId }
-								stylesheet={ stylesheet }
-								selectedFontPairingVariation={ selectedFontVariation }
-								onSelect={ onSelectFontVariation }
-							/>
-						</div>
-					) }
+				{ ! hasStyleVariations && isEnabled( 'signup/design-picker-preview-colors' ) && (
+					<div className="design-preview__sidebar-variations">
+						<ColorPaletteVariations
+							siteId={ siteId }
+							stylesheet={ stylesheet }
+							selectedColorPaletteVariation={ selectedColorVariation }
+							onSelect={ onSelectColorVariation }
+						/>
+					</div>
+				) }
+				{ ! hasStyleVariations && isEnabled( 'signup/design-picker-preview-fonts' ) && (
+					<div className="design-preview__sidebar-variations">
+						<FontPairingVariations
+							siteId={ siteId }
+							stylesheet={ stylesheet }
+							selectedFontPairingVariation={ selectedFontVariation }
+							onSelect={ onSelectFontVariation }
+						/>
+					</div>
+				) }
 			</div>
 			{ actionButtons && (
 				<div className="design-preview__sidebar-action-buttons">{ actionButtons }</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78419

## Proposed Changes

* Introduce a feature flag, `signup/design-picker-preview-colors`, to control this feature. The flag is disabled by default as I think the UI doesn't look good in the current stage.
* Display the color selection for the designs without style variations
* Apply the selected color variation to the preview
* Apply the selected color variation when you continue to activate the theme
* Display the upsell modal when you select a color variation on your free site

![image](https://github.com/Automattic/wp-calypso/assets/13596067/5d48fad9-2606-4976-8fd4-464471d93a9b)

https://github.com/Automattic/wp-calypso/assets/13596067/3f0cd5e6-21ba-479e-ae0b-02d6f7a352e6

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>flags=signup/design-picker-preview-colors`
* Continue until you land on the Design Picker
* Preview the design without the style variation
* On the preview screen,
  * You have to see the color selection
  * The displayed colors in the preview will be changed when you select any color
  * If the current site is a free site and you select any color, the upsell modal will show when you click the “Continue” button
  * Continue
* When you land on the launchpad, ensure the displayed colors in the preview are the same as you select

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
