### PR TITLE
Theme showcase: Consider filters when searching WP.org themes

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -343,7 +343,13 @@ export const ConnectedThemesSelection = connect(
 		const themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [];
 
 		const shouldFetchWpOrgThemes = forceWpOrgSearch && sourceSiteId !== 'wporg' && !! search; // Only fetch WP.org themes when searching a term.
-		const wpOrgQuery = { ...query, page: 1 }; // We limit the WP.org themes to one page only.
+		const wpOrgQuery = {
+			...query,
+			// We limit the WP.org themes to one page only.
+			page: 1,
+			// WP.com theme filters don't match WP.org ones, so we add them to the search term.
+			search: filter ? search + ' ' + filter.replaceAll( '+', ' ' ).replaceAll( '-', ' ' ) : search,
+		};
 		const wpOrgThemes = shouldFetchWpOrgThemes
 			? getThemesForQueryIgnoringPage( state, 'wporg', wpOrgQuery ) || []
 			: [];

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -348,7 +348,7 @@ export const ConnectedThemesSelection = connect(
 			// We limit the WP.org themes to one page only.
 			page: 1,
 			// WP.com theme filters don't match WP.org ones, so we add them to the search term.
-			search: filter ? search + ' ' + filter.replaceAll( '+', ' ' ).replaceAll( '-', ' ' ) : search,
+			search: filter ? `${ search } ${ filter.replace( /[+-]/g, ' ' ) }` : search,
 		};
 		const wpOrgThemes = shouldFetchWpOrgThemes
 			? getThemesForQueryIgnoringPage( state, 'wporg', wpOrgQuery ) || []


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2763

## Proposed Changes

Add the entered filters in the theme showcase to the search term used to query WP.org themes.

<img width="913" alt="Screenshot 2023-06-19 at 13 22 31" src="https://github.com/Automattic/wp-calypso/assets/1233880/9e0c9b3f-ff1c-4894-a6e9-41ecb2e16ac4">

We cannot use the filters as tags in the query because the WP.com theme filters don't match the WP.org ones, so that's why we add them to the search term as a fallback.

## Testing Instructions

- Use the Calypso live link below.
- Go to Appearance > Themes.
- Open the Network tab of your browser devtools and observe the calls to `api.wordpress.org/themes`.
- Enter a search term.
- Select some filters.
- Make sure the filters have been appended to the `request[search]` param of the API call.
