### PR TITLE
Add reader/discover feature flag.

### DIFF
--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -19,7 +19,7 @@ export function isDiscoverFeed( feedId ) {
 }
 
 export function isDiscoverEnabled() {
-	return false;
+	return config.isEnabled( 'reader/discover' );
 }
 
 export function isDiscoverPost( post ) {

--- a/config/development.json
+++ b/config/development.json
@@ -161,6 +161,7 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/comment-polling": false,
+		"reader/discover": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,6 +103,7 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,
+		"reader/discover": false,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,
 		"reader/subscription-management": true,

--- a/config/production.json
+++ b/config/production.json
@@ -124,6 +124,7 @@
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
 		"reader": true,
+		"reader/discover": false,
 		"reader/full-errors": false,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -119,6 +119,7 @@
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
 		"reader": true,
+		"reader/discover": false,
 		"reader/full-errors": false,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,6 +130,7 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,
+		"reader/discover": false,
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds a feature flag to enable the discover page in the development environment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso build - on local developer environment verify the reader discover page is enabled.
* Test the calypso.live link (similarly to horizon and production on deploy), the reader discover page should not be enabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
