### PR TITLE
Add forgot password customizations for core profiler flow

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -298,9 +298,19 @@ class Login extends Component {
 		} else if ( action === 'lostpassword' ) {
 			headerText = <h3>{ translate( 'Forgot your password?' ) }</h3>;
 			postHeader = (
-				<p className="login__header-subtitle">
+				<p className="login__header-subtitle login__lostpassword-subtitle">
 					{ translate(
 						'It happens to the best of us. Enter the email address associated with your WordPress.com account and we’ll send you a link to reset your password.'
+					) }
+					{ isWooCoreProfilerFlow && (
+						<span>
+							<br />
+							{ translate( 'Don’t have an account? {{signupLink}}Sign up{{/signupLink}}', {
+								components: {
+									signupLink: <a href={ this.getSignupUrl() } />,
+								},
+							} ) }
+						</span>
 					) }
 				</p>
 			);
@@ -423,15 +433,18 @@ class Login extends Component {
 				);
 			}
 		} else if ( isWooCoreProfilerFlow ) {
-			headerText = <h3>{ translate( 'One last step' ) }</h3>;
-			preHeader = null;
-			postHeader = (
-				<p className="login__header-subtitle">
-					{ translate(
+			const subtitle = currentQuery.lostpassword_flow
+				? translate(
+						"Your password reset confirmation is on its way to your email address – please check your junk folder if it's not in your inbox! Once you've reset your password, head back to this page to log in to your account."
+				  )
+				: translate(
 						'In order to take advantage of the benefits offered by Jetpack, please log in to your WordPress.com account below.'
-					) }
-				</p>
+				  );
+			headerText = currentQuery.lostpassword_flow ? null : (
+				<h3>{ translate( 'One last step' ) }</h3>
 			);
+			preHeader = null;
+			postHeader = <p className="login__header-subtitle">{ subtitle }</p>;
 		} else if ( isJetpackWooCommerceFlow ) {
 			headerText = translate( 'Log in to your WordPress.com account' );
 			preHeader = (
@@ -552,6 +565,8 @@ class Login extends Component {
 			translate,
 			isPartnerSignup,
 			action,
+			isWooCoreProfilerFlow,
+			currentQuery,
 		} = this.props;
 
 		if ( socialConnect ) {
@@ -571,16 +586,20 @@ class Login extends Component {
 						redirectToAfterLoginUrl={ this.props.redirectTo }
 						oauth2ClientId={ this.props.oauth2Client && this.props.oauth2Client.id }
 						locale={ locale }
+						isWooCoreProfilerFlow={ isWooCoreProfilerFlow }
+						from={ get( currentQuery, 'from' ) }
 					/>
-					<div className="login__lost-password-footer">
-						<p className="login__lost-password-no-account">
-							{ translate( 'Don’t have an account? {{signupLink}}Sign up{{/signupLink}}', {
-								components: {
-									signupLink: <a href={ this.getSignupUrl() } />,
-								},
-							} ) }
-						</p>
-					</div>
+					{ ! isWooCoreProfilerFlow && (
+						<div className="login__lost-password-footer">
+							<p className="login__lost-password-no-account">
+								{ translate( 'Don’t have an account? {{signupLink}}Sign up{{/signupLink}}', {
+									components: {
+										signupLink: <a href={ this.getSignupUrl() } />,
+									},
+								} ) }
+							</p>
+						</div>
+					) }
 				</Fragment>
 			);
 		}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -495,6 +495,9 @@ export class LoginForm extends Component {
 
 	renderUsernameorEmailLabel() {
 		if ( this.props.isP2Login || ( this.props.isWoo && ! this.props.isPartnerSignup ) ) {
+			if ( this.props.isWooCoreProfilerFlow ) {
+				return this.props.translate( 'Your email address' );
+			}
 			return this.props.translate( 'Your email address or username' );
 		}
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -79,6 +79,7 @@ export class LoginForm extends Component {
 		isPartnerSignup: PropTypes.bool,
 		locale: PropTypes.string,
 		showSocialLoginFormOnly: PropTypes.bool,
+		currentQuery: PropTypes.object,
 	};
 
 	state = {
@@ -338,9 +339,9 @@ export class LoginForm extends Component {
 	};
 
 	getLoginButtonText = () => {
-		const { translate, isWoo, wccomFrom } = this.props;
+		const { translate, isWoo, wccomFrom, isWooCoreProfilerFlow } = this.props;
 		if ( this.isPasswordView() || this.isFullView() ) {
-			if ( isWoo && ! wccomFrom ) {
+			if ( isWoo && ! wccomFrom && ! isWooCoreProfilerFlow ) {
 				return translate( 'Get started' );
 			}
 
@@ -515,8 +516,9 @@ export class LoginForm extends Component {
 							login( {
 								redirectTo: this.props.redirectTo,
 								locale: this.props.locale,
-								action: 'lostpassword',
+								action: this.props.isWooCoreProfilerFlow ? 'jetpack/lostpassword' : 'lostpassword',
 								oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
+								from: get( this.props.currentQuery, 'from' ),
 							} )
 						);
 					} }
@@ -555,6 +557,7 @@ export class LoginForm extends Component {
 			showSocialLoginFormOnly,
 			isWoo,
 			isPartnerSignup,
+			isWooCoreProfilerFlow,
 		} = this.props;
 
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
@@ -563,6 +566,7 @@ export class LoginForm extends Component {
 		const isSubmitButtonDisabled = isWoo && ! isPartnerSignup ? isFormFilled : isFormDisabled;
 		const isOauthLogin = !! oauth2Client;
 		const isPasswordHidden = this.isUsernameOrEmailView();
+		const isCoreProfilerLostPasswordFlow = isWooCoreProfilerFlow && currentQuery.lostpassword_flow;
 
 		const signupUrl = this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
@@ -750,7 +754,7 @@ export class LoginForm extends Component {
 					) }
 				</Card>
 
-				{ config.isEnabled( 'signup/social' ) && (
+				{ config.isEnabled( 'signup/social' ) && ! isCoreProfilerLostPasswordFlow && (
 					<Fragment>
 						<Divider>{ this.props.translate( 'or' ) }</Divider>
 						<SocialLoginForm
@@ -791,6 +795,8 @@ export default connect(
 			oauth2Client: getCurrentOAuth2Client( state ),
 			isJetpackWooCommerceFlow:
 				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
+			isWooCoreProfilerFlow:
+				'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
 			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 			isWoo:
 				isWooOAuth2Client( getCurrentOAuth2Client( state ) ) ||

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -1,4 +1,4 @@
-import { FormInputValidation } from '@automattic/components';
+import { FormInputValidation, Spinner } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useState } from 'react';
@@ -7,10 +7,17 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { login } from 'calypso/lib/paths';
 
-const LostPasswordForm = ( { redirectToAfterLoginUrl, oauth2ClientId, locale } ) => {
+const LostPasswordForm = ( {
+	redirectToAfterLoginUrl,
+	oauth2ClientId,
+	locale,
+	from,
+	isWooCoreProfilerFlow,
+} ) => {
 	const translate = useTranslate();
 	const [ email, setEmail ] = useState( '' );
 	const [ error, setError ] = useState( null );
+	const [ isBusy, setBusy ] = useState( false );
 
 	const validateEmail = () => {
 		if ( email.length === 0 || email.includes( '@' ) ) {
@@ -41,7 +48,9 @@ const LostPasswordForm = ( { redirectToAfterLoginUrl, oauth2ClientId, locale } )
 		event.preventDefault();
 
 		try {
+			setBusy( true );
 			const result = await lostPasswordRequest();
+			setBusy( false );
 			if ( result.includes( 'Unable to reset password' ) ) {
 				return setError(
 					translate( "I'm sorry, but we weren't able to find a user with that login information." )
@@ -55,9 +64,12 @@ const LostPasswordForm = ( { redirectToAfterLoginUrl, oauth2ClientId, locale } )
 					redirectTo: redirectToAfterLoginUrl,
 					emailAddress: email,
 					lostpasswordFlow: true,
+					action: isWooCoreProfilerFlow ? 'jetpack' : null,
+					from,
 				} )
 			);
 		} catch ( _httpError ) {
+			setBusy( false );
 			setError(
 				translate( 'There was an error sending the password reset email. Please try again.' )
 			);
@@ -90,8 +102,8 @@ const LostPasswordForm = ( { redirectToAfterLoginUrl, oauth2ClientId, locale } )
 				{ showError && <FormInputValidation isError text={ error } /> }
 			</div>
 			<div className="login__form-action">
-				<FormsButton primary type="submit" disabled={ email.length === 0 || showError }>
-					{ translate( 'Reset my password' ) }
+				<FormsButton primary type="submit" disabled={ email.length === 0 || showError || isBusy }>
+					{ isBusy ? <Spinner /> : translate( 'Reset my password' ) }
 				</FormsButton>
 			</div>
 		</form>

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -1,4 +1,5 @@
-import { FormInputValidation, Spinner } from '@automattic/components';
+import { FormInputValidation } from '@automattic/components';
+import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useState } from 'react';

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -780,11 +780,20 @@
 				}
 			}
 		}
+		.login__form-userdata label.form-label {
+			line-height: 16px;
+		}
+
+		.login__form .login__form-userdata input.form-text-input,
+		.login__form .login__form-userdata input {
+			margin-bottom: 16px;
+		}
 
 		.login__form-header h3,
 		.formatted-header .formatted-header__title {
 			margin-bottom: 12px;
 			font-size: $woo-font-title-large;
+			line-height: 32px;
 
 			@media screen and ( max-width: 660px ) {
 				font-size: rem(28px);
@@ -856,6 +865,7 @@
 		}
 
 		// Log in link on signup page
+		.login__header-subtitle a,
 		.formatted-header__subtitle a {
 			color: var(--wp-admin-theme-color);
 		}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -874,19 +874,11 @@
 			}
 		}
 
-		.spinner__outer,
-		.spinner__inner {
-			border-top-color: var(--wp-admin-theme-color);
-		}
-		.spinner__inner {
-			border-right-color: var(--wp-admin-theme-color);
-		}
-
 		// Lost password
 		.login__lostpassword-form {
 			display: flex;
 			flex-direction: column;
-			padding: 54px 24px 32px;
+			padding: 48px 24px 32px;
 
 			@media screen and ( max-width: 660px ) {
 				padding: 32px 16px 28px;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -868,6 +868,7 @@
 		.login__header-subtitle a,
 		.formatted-header__subtitle a {
 			color: var(--wp-admin-theme-color);
+			line-height: inherit;
 		}
 
 		.form-input-validation {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -873,5 +873,39 @@
 				display: none;
 			}
 		}
+
+		.spinner__outer,
+		.spinner__inner {
+			border-top-color: var(--wp-admin-theme-color);
+		}
+		.spinner__inner {
+			border-right-color: var(--wp-admin-theme-color);
+		}
+
+		// Lost password
+		.login__lostpassword-form {
+			display: flex;
+			flex-direction: column;
+			padding: 54px 24px 32px;
+
+			@media screen and ( max-width: 660px ) {
+				padding: 32px 16px 28px;
+			}
+
+			.login__form-action {
+				margin-top: 24px;
+			}
+
+			input[type="email"].form-text-input {
+				margin-bottom: 0;
+			}
+			.form-input-validation {
+				padding-bottom: 0;
+			}
+		}
+
+		.login__lostpassword-subtitle a {
+			line-height: inherit;
+		}
 	}
 }

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -97,6 +97,7 @@ export default ( router ) => {
 			`/log-in/:socialService(google|apple)/callback/${ lang }`,
 			`/log-in/:isJetpack(jetpack)/${ lang }`,
 			`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
+			`/log-in/:isJetpack(jetpack)/:action(lostpassword)/${ lang }`,
 			`/log-in/:isGutenboarding(new)/${ lang }`,
 			`/log-in/:isGutenboarding(new)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
 			`/log-in/:action(lostpassword)/${ lang }`,


### PR DESCRIPTION
Related to #77829

## Proposed Changes

* Customize forgot password screens for WooCommerce core profiler flow
* Adds spinner during submitting email in forgot password
* Changes button copy from `Get Started` to `Log in` per design

## Testing Instructions

Adapted from https://github.com/Automattic/wp-calypso/pull/68558

In order to test, we'll need to set up a proxy using nginx the lost password API doesn't allow cross-domain POST.

**Setting up proxy**

1. Install nginx on your machine
2. Create an SSL cert and add it to your trusted store

```bash
# These commands are for OSX and Chrome.
# In a different system you may need to change the path for 
# /System/Library/OpenSSL/openssl.cnf and manually trust
# the generated certificate
 
# Generate the certificate
openssl req \
    -newkey rsa:2048 \
    -x509 \
    -nodes \
    -keyout ./config/server/key.pem \
    -new \
    -out ./config/server/certificate.pem \
    -subj /CN=wordpress.com \
    -reqexts SAN \
    -extensions SAN \
    -config <(cat /System/Library/OpenSSL/openssl.cnf \
     <(printf '[SAN]\nsubjectAltName=DNS:wpcalypso.wordpress.com')) \
    -sha256 \
    -days 365
 
# Add it to the trusted certificates
sudo security add-trusted-cert -d -k $(security list-keychains | grep System | cut -d '"' -f 2 ) ./config/server/certificate.pem
```

3. Add `127.0.0.1 wpcalypso.wordpress.com` to your `/etc/hosts` file
4. Use the following config for nginx (you can create new config in `/usr/local/etc/nginx/servers/default.ssl`) 
5. Start nginx

```nginx
server {
    listen 443 ssl;
    server_name wpcalypso.wordpress.com;

    ssl on;
    ssl_certificate <change_me>/wp-calypso/config/server/certificate.pem;
    ssl_certificate_key <change_me>/wp-calypso/config/server/key.pem;

    location / {
        proxy_pass https://wordpress.com;
        proxy_set_header Host $http_host;
    }

    location /calypso {
        proxy_pass http://127.0.0.1:3000;
    }

    location /cspreport {
       proxy_pass http://127.0.0.1:3000;
    }

    location /version {
        proxy_pass http://127.0.0.1:3000;
    }

    location /start {
        proxy_pass http://127.0.0.1:3000;
    }

    location /log-in {
        proxy_pass http://127.0.0.1:3000;
    }
}
```

6. Run `HOST=wpcalypso.wordpress.com yarn start`
7. Make sure you're logged out WordPress.com account.
8. Go to this [link](https://wpcalypso.wordpress.com/log-in/jetpack?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D190450138%26redirect_uri%3Dhttps%253A%252F%252Filyasfoowcpay.jurassic.tube%252Fwp-admin%252Fadmin.php%253Fhandler%253Djetpack-connection-webhooks%2526action%253Dauthorize%2526_wpnonce%253D3e526f1517%2526redirect%253Dhttps%25253A%25252F%25252Filyasfoowcpay.jurassic.tube%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Dwc-admin%26state%3D1%26scope%3Dadministrator%253A03762e316bb79e73117c81a2670dabfd%26user_email%3Dwordpress%2540example.com%26user_login%3Dnrzo%26jp_version%3D12.3-a.6%26secret%3DK8HGrfxbBt6yMpfnx0h8RO6bdKu3pU3a%26blogname%3DHelloWord%2526%2523039%253Bs%26site_url%3Dhttps%253A%252F%252Filyasfoowcpay.jurassic.tube%26home_url%3Dhttps%253A%252F%252Filyasfoowcpay.jurassic.tube%26site_icon%3D%26site_lang%3Den_US%26site_created%3D2023-06-12%252005%253A44%253A13%26allow_site_connection%3D1%26_as%3Dunknown%26from%3Dwoocommerce-core-profiler%26calypso_env%3Dproduction%26_ui%3D189375772%26_ut%3Dwpcom%253Auser_id%26purchase_nonce%3DZyjFK3lz%26_wp_nonce%3D9fcf83c152%26redirect_after_auth%3Dhttps%253A%252F%252Filyasfoowcpay.jurassic.tube%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin%26site%3Dhttps%253A%252F%252Filyasfoowcpay.jurassic.tube&email_address=aegisrunestone3%40gmail.com&from=woocommerce-core-profiler)
9. Click on `Forgot password`
10. Observe the screen matches the first screenshot below
11. Enter your email address and click on `Reset my password`
12. Observe spinner loading
13. Observe you're redirect to a screen that matches the second screenshot below
14. You should receive an email to reset your password

<img width="1224" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/7751a345-c3d0-4aa9-8bc2-c5c4a0e821d1">

<img width="1224" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/7081ba14-635f-4448-a6ea-82c08f5673e0">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
