### PR TITLE
Domains Thank You: move hooks from `domainRegistrationThankYouProps` to parent

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -34,6 +34,8 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 	hideProfessionalEmailStep,
 	type,
 } ) => {
+	const launchpadScreen = useSiteOption( 'launchpad_screen' );
+	const siteIntent = useSiteOption( 'site_intent' );
 	const thankYouProps = useMemo< DomainThankYouProps >( () => {
 		const propsGetter = domainThankYouContent[ type ];
 		return propsGetter( {
@@ -42,12 +44,21 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 			email,
 			hasProfessionalEmail,
 			hideProfessionalEmailStep,
+			siteIntent,
+			launchpadScreen,
 		} );
-	}, [ type, domain, selectedSiteSlug, email, hasProfessionalEmail, hideProfessionalEmailStep ] );
+	}, [
+		type,
+		domain,
+		selectedSiteSlug,
+		email,
+		hasProfessionalEmail,
+		hideProfessionalEmailStep,
+		siteIntent,
+		launchpadScreen,
+	] );
 	const dispatch = useDispatch();
-	const launchpadScreen = useSiteOption( 'launchpad_screen' );
 	const isLaunchpadEnabled = launchpadScreen === 'full';
-	const siteIntent = useSiteOption( 'site_intent' );
 
 	useEffect( () => {
 		dispatch( hideMasterbar() );

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -7,18 +7,19 @@ import {
 } from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index';
 import { domainManagementList, createSiteFromDomainOnly } from 'calypso/my-sites/domains/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
-import { useSiteOption } from 'calypso/state/sites/hooks';
 import type {
 	DomainThankYouParams,
 	DomainThankYouProps,
 } from 'calypso/my-sites/checkout/checkout-thank-you/domains/types';
 
-const DomainRegistrationThankYouProps = ( {
+const domainRegistrationThankYouProps = ( {
 	domain,
 	email,
 	hasProfessionalEmail,
 	hideProfessionalEmailStep,
 	selectedSiteSlug,
+	siteIntent,
+	launchpadScreen,
 }: DomainThankYouParams ): DomainThankYouProps => {
 	const professionalEmail = buildDomainStepForProfessionalEmail(
 		{
@@ -31,9 +32,6 @@ const DomainRegistrationThankYouProps = ( {
 		'REGISTRATION',
 		true
 	);
-
-	const siteIntent = useSiteOption( 'site_intent' );
-	const launchpadScreen = useSiteOption( 'launchpad_screen' );
 
 	const launchpadNextSteps = buildDomainStepForLaunchpadNextSteps(
 		siteIntent as string,
@@ -117,4 +115,4 @@ const DomainRegistrationThankYouProps = ( {
 	return returnProps;
 };
 
-export default DomainRegistrationThankYouProps;
+export default domainRegistrationThankYouProps;

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
@@ -1,8 +1,8 @@
 import { translate } from 'i18n-calypso';
 import { getTitanEmailUrl, useTitanAppsUrlPrefix } from 'calypso/lib/titan';
-import DomainMappingProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-mapping';
-import DomainRegistrationThankYouProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration';
-import DomainTransferProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer';
+import domainMappingProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-mapping';
+import domainRegistrationThankYouProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration';
+import domainTransferProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import {
 	emailManagementInbox,
@@ -17,9 +17,9 @@ import type {
 } from 'calypso/my-sites/checkout/checkout-thank-you/domains/types';
 
 const thankYouContentGetter: Record< DomainThankYouType, DomainThankYouPropsGetter > = {
-	MAPPING: DomainMappingProps,
-	TRANSFER: DomainTransferProps,
-	REGISTRATION: DomainRegistrationThankYouProps,
+	MAPPING: domainMappingProps,
+	TRANSFER: domainTransferProps,
+	REGISTRATION: domainRegistrationThankYouProps,
 };
 
 export default thankYouContentGetter;
@@ -64,7 +64,10 @@ export function buildDomainStepForProfessionalEmail(
 		hideProfessionalEmailStep,
 		selectedSiteSlug,
 		domain,
-	}: DomainThankYouParams,
+	}: Pick<
+		DomainThankYouParams,
+		'email' | 'hasProfessionalEmail' | 'hideProfessionalEmailStep' | 'selectedSiteSlug' | 'domain'
+	>,
 	domainType: DomainThankYouType,
 	primary: boolean
 ): ThankYouNextStepProps | null {

--- a/client/my-sites/checkout/checkout-thank-you/domains/types.ts
+++ b/client/my-sites/checkout/checkout-thank-you/domains/types.ts
@@ -1,4 +1,5 @@
 import { ThankYouProps } from 'calypso/components/thank-you/types';
+import { useSiteOption } from 'calypso/state/sites/hooks';
 
 export type DomainThankYouType = 'MAPPING' | 'TRANSFER' | 'REGISTRATION';
 
@@ -12,7 +13,9 @@ export type DomainThankYouParams = {
 	email?: string;
 	hasProfessionalEmail: boolean;
 	hideProfessionalEmailStep: boolean;
+	launchpadScreen: ReturnType< typeof useSiteOption >;
 	selectedSiteSlug: string;
+	siteIntent: ReturnType< typeof useSiteOption >;
 };
 
 export type DomainThankYouPropsGetter = ( params: DomainThankYouParams ) => DomainThankYouProps;


### PR DESCRIPTION
At some point, hooks were added to `domainRegistrationThankYouProps()` (and the naming updated) to retrieve the `site_intent` and `launchpadScreen` options, even though the function wasn't a component and is used in hooks elsewhere in the code. 

This PR pulls the hooks out of `domainRegistrationThankYouProps()` and passes the data through its caller in the `DomainThankYou` component.

Fixes: https://github.com/Automattic/wp-calypso/issues/78378

**To test:**
- on an Atomic site, purchase a domain
- verify that the Thank You page renders and doesn't WSOD