### PR TITLE
Disable polling for discover stream

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -575,7 +575,10 @@ class ReaderStream extends Component {
 			showingStream = true;
 			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		}
-		const shouldPoll = streamType !== 'search' && streamType !== 'custom_recs_posts_with_images';
+		// Check array of streamTypes to see if we should poll for updates;
+		const shouldPoll = ! [ 'search', 'custom_recs_posts_with_images', 'discover' ].includes(
+			streamType
+		);
 
 		const TopLevel = this.props.isMain ? ReaderMain : 'div';
 		return (

--- a/client/reader/stream/reader-discover-sidebar/index.jsx
+++ b/client/reader/stream/reader-discover-sidebar/index.jsx
@@ -9,7 +9,7 @@ function unescape( str ) {
 
 // create function to transform item into a site object
 const getSiteFromItem = ( item ) => {
-	if ( item.site_name === undefined ) {
+	if ( item.site_name === undefined || item.site_description === undefined ) {
 		return null;
 	}
 	return {

--- a/client/reader/stream/reader-search-sidebar/index.jsx
+++ b/client/reader/stream/reader-search-sidebar/index.jsx
@@ -9,7 +9,7 @@ function unescape( str ) {
 
 // create function to transform item into a site object
 const getSiteFromItem = ( item ) => {
-	if ( item.site_name === undefined ) {
+	if ( item.site_name === undefined || item.site_description === undefined ) {
 		return null;
 	}
 	return {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -14,6 +14,19 @@
 		.tag-stream__header {
 			max-width: 600px;
 		}
+
+		.reader-tag-sidebar-recommended-sites {
+			max-width: 270px;
+
+			.reader-subscription-list-item .follow-button__label,
+			.reader-subscription-list-item__settings-label {
+				display: none;
+			}
+
+			.reader-site-notification-settings__button-label {
+				display: none;
+			}
+		}
 	}
 }
 
@@ -874,3 +887,4 @@
 		border-radius: 6px; /* stylelint-disable-line scales/radii */
 	}
 }
+

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -15,16 +15,18 @@
 			max-width: 600px;
 		}
 
-		.reader-tag-sidebar-recommended-sites {
-			max-width: 270px;
+		&.is-discover-stream {
+			.reader-tag-sidebar-recommended-sites {
+				max-width: 270px;
 
-			.reader-subscription-list-item .follow-button__label,
-			.reader-subscription-list-item__settings-label {
-				display: none;
-			}
+				.reader-subscription-list-item .follow-button__label,
+				.reader-subscription-list-item__settings-label {
+					display: none;
+				}
 
-			.reader-site-notification-settings__button-label {
-				display: none;
+				.reader-site-notification-settings__button-label {
+					display: none;
+				}
 			}
 		}
 	}

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -167,7 +167,6 @@ export const SITE_LIMITER_FIELDS = [
 	'feed_item_ID',
 	'global_ID',
 	'metadata',
-	'tags',
 	'site_URL',
 	'URL',
 ];


### PR DESCRIPTION
Small PR to fix 2 issues with Discover page

* Sidebar width changes depending on width of sidebar site description - this PR sets a max width
* The discover stream polls, which I don't think it should - it doesn't work and just fails silently - this PR disables it for this streamType.
* Fix issue with undefined site description breaking when using `unescape` - picked up by sentry
* 