### PR TITLE
BackupBrowser: Release backup contents page

### DIFF
--- a/client/components/activity-card/toolbar/buttons/view-files-button.tsx
+++ b/client/components/activity-card/toolbar/buttons/view-files-button.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Icon, file as fileIcon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
@@ -17,10 +16,6 @@ const ViewFilesButton: FunctionComponent< ViewFilesButtonProps > = ( {
 	isPrimary = false,
 } ) => {
 	const translate = useTranslate();
-
-	if ( ! config.isEnabled( 'jetpack/backup-contents-page' ) ) {
-		return null;
-	}
 
 	return (
 		<Button

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import PropTypes from 'prop-types';
@@ -117,9 +116,7 @@ const DailyBackupStatus = ( {
 				deltas={ deltas }
 				selectedDate={ selectedDate }
 				lastBackupAttemptOnDate={ lastBackupAttemptOnDate }
-				{ ...( config.isEnabled( 'jetpack/backup-contents-page' )
-					? { availableActions: [ 'rewind' ] }
-					: {} ) }
+				availableActions={ [ 'rewind' ] }
 			/>
 		) : (
 			<BackupFailed backup={ backup } />

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { default as ActivityCard, useToggleContent } from 'calypso/components/activity-card';
@@ -71,18 +70,16 @@ const BackupSuccessful = ( {
 					{ isToday ? translate( 'Latest backup' ) : translate( 'Latest backup on this day' ) }
 				</div>
 
-				{ config.isEnabled( 'jetpack/backup-contents-page' ) && (
-					<div className="status-card__toolbar">
-						<Toolbar
-							siteId={ siteId }
-							activity={ backup }
-							isContentExpanded={ showContent }
-							onToggleContent={ toggleShowContent }
-							availableActions={ [ 'download', 'rewind', 'view' ] }
-							onClickClone={ onClickClone }
-						/>
-					</div>
-				) }
+				<div className="status-card__toolbar">
+					<Toolbar
+						siteId={ siteId }
+						activity={ backup }
+						isContentExpanded={ showContent }
+						onToggleContent={ toggleShowContent }
+						availableActions={ [ 'download', 'rewind', 'view' ] }
+						onClickClone={ onClickClone }
+					/>
+				</div>
 			</div>
 			<div className="status-card__hide-desktop">
 				<div className="status-card__title">{ displayDate }</div>

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -1,7 +1,5 @@
-import config from '@automattic/calypso-config';
 import { isJetpackBackupSlug } from '@automattic/calypso-products';
 import Debug from 'debug';
-import page from 'page';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import HasVaultPressSwitch from 'calypso/components/jetpack/has-vaultpress-switch';
 import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
@@ -13,14 +11,12 @@ import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { setFilter } from 'calypso/state/activity-log/actions';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import BackupContentsPage from './backup-contents-page';
 import BackupUpsell from './backup-upsell';
 import BackupCloneFlow from './clone-flow';
 import BackupsPage from './main';
 import MultisiteNoBackupPlanSwitch from './multisite-no-backup-plan-switch';
-import { backupMainPath } from './paths';
 import BackupRewindFlow, { RewindFlowPurpose } from './rewind-flow';
 import WPCOMBackupUpsell from './wpcom-backup-upsell';
 import WpcomBackupUpsellPlaceholder from './wpcom-backup-upsell-placeholder';
@@ -169,12 +165,6 @@ export function backupContents( context, next ) {
 	debug( 'controller: backupContents', context.params );
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
-
-	if ( ! config.isEnabled( 'jetpack/backup-contents-page' ) ) {
-		debug( 'controller: backup contents page feature not available', context.params );
-		const siteSlug = getSiteSlug( state, siteId );
-		return page.redirect( backupMainPath( siteSlug ) );
-	}
 
 	context.primary = <BackupContentsPage siteId={ siteId } rewindId={ context.params.rewindId } />;
 	next();

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -41,7 +41,6 @@
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/agency-dashboard": true,
-		"jetpack/backup-contents-page": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/golden-token": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77767

## Proposed Changes

* Remove feature flag checks for `jetpack/backup-contents-page` to enable the Backup Browser to all users.

## Testing Instructions

* Start a Jetpack Cloud and/or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Ensure the daily status card has the `Restore to this point` button **(1)**, a `Actions (+)` **(2)** and when clicking on that, it displays the `View files` **(3)** action as described in the following screenshot:
  * <img width="350" alt="Screen Shot 2023-06-19 at 11 03 56 AM" src="https://github.com/Automattic/wp-calypso/assets/1488641/058ecfb4-236a-4ed2-9617-980dc231c217">
* Click on `View files` and ensure it loads the backup contents page, including the file browsing.
  * <img width="350" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/b33cc9e2-0e90-421c-91c7-bc0dddfefec5">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
