### PR TITLE
Reader: remove follow button from PostByline component

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -8,9 +8,6 @@ import ReaderPostEllipsisMenu from 'calypso/blocks/reader-post-options-menu/read
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import TimeSince from 'calypso/components/time-since';
 import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
-import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
-import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';
-import FollowButton from 'calypso/reader/follow-button';
 import { getSiteName } from 'calypso/reader/get-helpers';
 import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
 import { getStreamUrl } from 'calypso/reader/route';
@@ -26,8 +23,6 @@ class PostByline extends Component {
 		showAvatar: PropTypes.bool,
 		teams: PropTypes.array,
 		showFollow: PropTypes.bool,
-		showPrimaryFollowButton: PropTypes.bool,
-		followSource: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -44,18 +39,7 @@ class PostByline extends Component {
 	};
 
 	render() {
-		const {
-			post,
-			site,
-			feed,
-			isDiscoverPost,
-			showSiteName,
-			showAvatar,
-			teams,
-			showPrimaryFollowButton,
-			followSource,
-		} = this.props;
-		const followUrl = feed ? feed.feed_URL : post.site_URL;
+		const { post, site, feed, isDiscoverPost, showSiteName, showAvatar, teams } = this.props;
 		const feedId = feed ? feed.feed_ID : get( post, 'feed_ID' );
 		const feedIcon = feed ? feed.site_icon ?? get( feed, 'image' ) : null;
 		const siteId = get( site, 'ID' );
@@ -139,15 +123,6 @@ class PostByline extends Component {
 					</div>
 					<TagsList post={ post } />
 				</div>
-				{ showPrimaryFollowButton && followUrl && (
-					<FollowButton
-						siteUrl={ followUrl }
-						followSource={ followSource }
-						railcar={ post.railcar }
-						followIcon={ ReaderFollowFeedIcon( { iconSize: 20 } ) }
-						followingIcon={ ReaderFollowingFeedIcon( { iconSize: 20 } ) }
-					/>
-				) }
 				<ReaderPostEllipsisMenu site={ site } teams={ teams } post={ post } showFollow={ false } />
 			</div>
 		);

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -41,7 +41,6 @@ class ReaderPostCard extends Component {
 		discoverPost: PropTypes.object,
 		discoverSite: PropTypes.object,
 		showSiteName: PropTypes.bool,
-		followSource: PropTypes.string,
 		isDiscoverStream: PropTypes.bool,
 		postKey: PropTypes.object,
 		compact: PropTypes.bool,
@@ -123,7 +122,6 @@ class ReaderPostCard extends Component {
 			onCommentClick,
 			isSelected,
 			showSiteName,
-			followSource,
 			isDiscoverStream,
 			postKey,
 			isExpanded,
@@ -192,7 +190,6 @@ class ReaderPostCard extends Component {
 					showSiteName={ true }
 					teams={ teams }
 					showFollow={ ! isDiscover }
-					followSource={ followSource }
 				/>
 			);
 		} else {
@@ -205,7 +202,6 @@ class ReaderPostCard extends Component {
 					showAvatar={ ! compact }
 					teams={ teams }
 					showFollow={ ! isDiscover }
-					followSource={ followSource }
 				/>
 			);
 		}

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -38,7 +38,6 @@ class ReaderPostCard extends Component {
 		isSelected: PropTypes.bool,
 		onClick: PropTypes.func,
 		onCommentClick: PropTypes.func,
-		showPrimaryFollowButton: PropTypes.bool,
 		discoverPost: PropTypes.object,
 		discoverSite: PropTypes.object,
 		showSiteName: PropTypes.bool,
@@ -122,7 +121,6 @@ class ReaderPostCard extends Component {
 			site,
 			feed,
 			onCommentClick,
-			showPrimaryFollowButton,
 			isSelected,
 			showSiteName,
 			followSource,
@@ -194,7 +192,6 @@ class ReaderPostCard extends Component {
 					showSiteName={ true }
 					teams={ teams }
 					showFollow={ ! isDiscover }
-					showPrimaryFollowButton={ showPrimaryFollowButton }
 					followSource={ followSource }
 				/>
 			);
@@ -208,7 +205,6 @@ class ReaderPostCard extends Component {
 					showAvatar={ ! compact }
 					teams={ teams }
 					showFollow={ ! isDiscover }
-					showPrimaryFollowButton={ showPrimaryFollowButton }
 					followSource={ followSource }
 				/>
 			);

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -148,7 +148,6 @@ export function following( context, next ) {
 		streamKey: 'following',
 		startDate,
 		recsStreamKey: 'custom_recs_posts_with_images',
-		showPrimaryFollowButtonOnCards: false,
 		trackScrollPage: trackScrollPage.bind(
 			null,
 			basePath,
@@ -209,7 +208,6 @@ export function feedListing( context, next ) {
 				mcKey
 			) }
 			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-			showPrimaryFollowButtonOnCards={ false }
 			suppressSiteNameLink={ true }
 			showBack={ userHasHistory( context ) }
 			placeholder={ null }
@@ -244,7 +242,6 @@ export function blogListing( context, next ) {
 				mcKey
 			) }
 			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-			showPrimaryFollowButtonOnCards={ false }
 			suppressSiteNameLink={ true }
 			showBack={ userHasHistory( context ) }
 			placeholder={ null }
@@ -280,7 +277,6 @@ export function readA8C( context, next ) {
 				analyticsPageTitle,
 				mcKey
 			) }
-			showPrimaryFollowButtonOnCards={ false }
 			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 			placeholder={ null }
 		/>
@@ -315,7 +311,6 @@ export function readFollowingP2( context, next ) {
 				analyticsPageTitle,
 				mcKey
 			) }
-			showPrimaryFollowButtonOnCards={ false }
 			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 			placeholder={ null }
 		/>

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -35,7 +35,6 @@ const exported = {
 				) }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 				suppressSiteNameLink={ true }
-				showPrimaryFollowButtonOnCards={ false }
 				isDiscoverStream={ true }
 				showBack={ false }
 				className="is-discover-stream"

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -43,7 +43,6 @@ export const listListing = ( context, next ) => {
 			streamKey={ streamKey }
 			owner={ encodeURIComponent( context.params.user ) }
 			slug={ encodeURIComponent( context.params.list ) }
-			showPrimaryFollowButtonOnCards={ false }
 			trackScrollPage={ trackScrollPage.bind(
 				null,
 				basePath,

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -75,7 +75,6 @@ const exported = {
 				) }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 				showBack={ false }
-				showPrimaryFollowButtonOnCards={ false }
 				autoFocusInput={ autoFocusInput }
 				onQueryChange={ reportQueryChange }
 				onSortChange={ reportSortChange }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -82,7 +82,6 @@ class ReaderStream extends Component {
 		emptyContent: PropTypes.object,
 		className: PropTypes.string,
 		showDefaultEmptyContentIfMissing: PropTypes.bool,
-		showPrimaryFollowButtonOnCards: PropTypes.bool,
 		placeholderFactory: PropTypes.func,
 		followSource: PropTypes.string,
 		isDiscoverStream: PropTypes.bool,
@@ -100,7 +99,6 @@ class ReaderStream extends Component {
 		onUpdatesShown: noop,
 		className: '',
 		showDefaultEmptyContentIfMissing: true,
-		showPrimaryFollowButtonOnCards: false,
 		isDiscoverStream: false,
 		isMain: true,
 		useCompactCards: false,
@@ -446,7 +444,6 @@ class ReaderStream extends Component {
 					suppressSiteNameLink={ this.props.suppressSiteNameLink }
 					showPostHeader={ this.props.showPostHeader }
 					showFollowInHeader={ this.props.showFollowInHeader }
-					showPrimaryFollowButtonOnCards={ this.props.showPrimaryFollowButtonOnCards }
 					isDiscoverStream={ this.props.isDiscoverStream }
 					showSiteName={ this.props.showSiteNameOnCards }
 					selectedPostKey={ undefined }

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -73,7 +73,6 @@ class ReaderPostCardAdapter extends Component {
 				onClick={ this.onClick }
 				onCommentClick={ this.onCommentClick }
 				isSelected={ this.props.isSelected }
-				showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }
 				followSource={ this.props.followSource }
 				showSiteName={ this.props.showSiteName }
 				isDiscoverStream={ this.props.isDiscoverStream }

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -50,7 +50,6 @@ export const tagListing = ( context, next ) => {
 			startDate={ startDate }
 			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) } // eslint-disable-line
 			showBack={ !! context.lastRoute }
-			showPrimaryFollowButtonOnCards={ false }
 		/>
 	);
 	next();

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -26,7 +26,6 @@ class TagStream extends Component {
 	static propTypes = {
 		encodedTagSlug: PropTypes.string,
 		decodedTagSlug: PropTypes.string,
-		followSource: PropTypes.string.isRequired,
 	};
 
 	state = {


### PR DESCRIPTION
## Proposed Changes

* Removes the FollowButton from PostByline
* Removes the `showPrimaryFollowButton` prop from several places in Reader that was used as a flag to show the follow button in the byline

The follow button is now shown in `ReaderPostActions` or separately in the `RelatedPostCard`. I couldn't find a remaining instance of it showing in the PostByline, so am removing it in this PR.

This cleanup is part of prep work for refreshing the Site feed page, in a similar style to what we've already done for the tag feed.

## Testing Instructions

- Spot check various reader pages (Following, Like, Conversations, Tags, etc) against production for any regressions

