### PR TITLE
Subscriber Details: Create page route and scaffold component

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-details/index.ts
+++ b/client/my-sites/subscribers/components/subscriber-details/index.ts
@@ -1,0 +1,1 @@
+export { default as SubscriberDetails } from './subscriber-details';

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -1,0 +1,26 @@
+import { Subscriber } from '../../types';
+import { SubscriberProfile } from '../subscriber-profile';
+
+type SubscriberDetailsProps = {
+	subscriber: Subscriber;
+};
+
+const SubscriberDetails = ( { subscriber }: SubscriberDetailsProps ) => {
+	const { avatar, display_name, email_address } = subscriber;
+
+	return (
+		<div className="subscriber-details">
+			<div className="subscriber-details__header">
+				<SubscriberProfile
+					avatar={ avatar }
+					displayName={ display_name }
+					email={ email_address }
+					compact={ false }
+				/>
+			</div>
+			<div className="subscriber-details__content"></div>
+		</div>
+	);
+};
+
+export default SubscriberDetails;

--- a/client/my-sites/subscribers/components/subscriber-list/index.ts
+++ b/client/my-sites/subscribers/components/subscriber-list/index.ts
@@ -1,0 +1,1 @@
+export { default as SubscriberList } from './subscriber-list';

--- a/client/my-sites/subscribers/components/subscriber-list/subscriber-list.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/subscriber-list.tsx
@@ -6,12 +6,11 @@ import './styles.scss';
 
 type SubscriberListProps = {
 	subscribers: Subscriber[];
+	onView: ( subscriber: Subscriber ) => void;
 	onUnsubscribe: ( subscriber: Subscriber ) => void;
 };
 
-const noop = () => undefined;
-
-export const SubscriberList = ( { subscribers, onUnsubscribe }: SubscriberListProps ) => {
+const SubscriberList = ( { subscribers, onView, onUnsubscribe }: SubscriberListProps ) => {
 	const translate = useTranslate();
 
 	return (
@@ -38,10 +37,12 @@ export const SubscriberList = ( { subscribers, onUnsubscribe }: SubscriberListPr
 				<SubscriberRow
 					key={ subscriber.subscription_id }
 					subscriber={ subscriber }
-					onView={ noop }
+					onView={ onView }
 					onUnsubscribe={ onUnsubscribe }
 				/>
 			) ) }
 		</ul>
 	);
 };
+
+export default SubscriberList;

--- a/client/my-sites/subscribers/controller.js
+++ b/client/my-sites/subscribers/controller.js
@@ -1,7 +1,7 @@
 import page from 'page';
 import { addQueryArgs } from 'calypso/lib/route';
 import { sanitizeInt } from './helpers';
-import { Subscribers } from './main';
+import SubscriberDetailsPage from './subscriber-details-page';
 
 const pageChanged = ( path ) => ( pageNumber ) => {
 	if ( window ) {
@@ -14,7 +14,12 @@ export function subscribers( context, next ) {
 	const { path, query } = context;
 	const pageNumber = sanitizeInt( query.page ) ?? 1;
 
-	context.primary = <Subscribers page={ pageNumber } pageChanged={ pageChanged( path ) } />;
+
+export function subscriberDetails( context, next ) {
+	const { path } = context;
+	const subscriberId = path.split( '/' ).pop();
+
+	context.primary = <SubscriberDetailsPage subscriberId={ subscriberId } />;
 
 	next();
 }

--- a/client/my-sites/subscribers/controller.js
+++ b/client/my-sites/subscribers/controller.js
@@ -1,6 +1,7 @@
 import page from 'page';
 import { addQueryArgs } from 'calypso/lib/route';
 import { sanitizeInt } from './helpers';
+import SubscribersPage from './main';
 import SubscriberDetailsPage from './subscriber-details-page';
 
 const pageChanged = ( path ) => ( pageNumber ) => {
@@ -14,6 +15,12 @@ export function subscribers( context, next ) {
 	const { path, query } = context;
 	const pageNumber = sanitizeInt( query.page ) ?? 1;
 
+	context.primary = (
+		<SubscribersPage pageNumber={ pageNumber } pageChanged={ pageChanged( path ) } />
+	);
+
+	next();
+}
 
 export function subscriberDetails( context, next ) {
 	const { path } = context;

--- a/client/my-sites/subscribers/index.js
+++ b/client/my-sites/subscribers/index.js
@@ -1,9 +1,17 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
-import { subscribers } from './controller';
+import { subscribers, subscriberDetails } from './controller';
 
 export default function () {
 	page( '/subscribers', siteSelection, sites, navigation, makeLayout, clientRender );
 	page( '/subscribers/:domain', siteSelection, navigation, subscribers, makeLayout, clientRender );
+	page(
+		'/subscribers/:domain/:subscriber',
+		siteSelection,
+		navigation,
+		subscriberDetails,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,37 +1,43 @@
 import { translate } from 'i18n-calypso';
+import page from 'page';
 import { useSelector } from 'react-redux';
 import { Item } from 'calypso/components/breadcrumb';
 import DocumentHead from 'calypso/components/data/document-head';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
 import Pagination from 'calypso/components/pagination';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { EmptyListView } from './components/empty-list-view';
 import { GrowYourAudience } from './components/grow-your-audience';
-import { SubscriberList } from './components/subscriber-list/subscriber-list';
+import { SubscriberList } from './components/subscriber-list';
 import { UnsubscribeModal } from './components/unsubscribe-modal';
 import { usePagination, useUnsubscribeModal } from './hooks';
 import { useSubscribersQuery } from './queries';
+import { Subscriber } from './types';
 import './styles.scss';
 
 type SubscribersProps = {
-	page: number;
+	pageNumber: number;
 	pageChanged: ( page: number ) => void;
 };
 
 const DEFAULT_PER_PAGE = 10;
 
-export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
+const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const initialState = { data: { total: 0, subscribers: [], per_page: DEFAULT_PER_PAGE } };
-	const result = useSubscribersQuery( selectedSiteId, page, DEFAULT_PER_PAGE );
+	const result = useSubscribersQuery( selectedSiteId, pageNumber, DEFAULT_PER_PAGE );
 	const {
 		data: { total, subscribers = [], per_page },
 	} = result && result.data ? result : initialState;
 	const { isFetching } = result;
-	const { pageClickCallback } = usePagination( page, pageChanged, isFetching );
+	const { pageClickCallback } = usePagination( pageNumber, pageChanged, isFetching );
 	const { currentSubscriber, onClickUnsubscribe, onConfirmModal, resetSubscriber } =
-		useUnsubscribeModal( selectedSiteId, page );
+		useUnsubscribeModal( selectedSiteId, pageNumber );
+	const onClickView = ( subscriber: Subscriber ) => {
+		page.show( `/subscribers/${ selectedSiteSlug }/${ subscriber.subscription_id }` );
+	};
 
 	const navigationItems: Item[] = [
 		{
@@ -69,7 +75,11 @@ export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
 							<span className="subscribers__title">{ translate( 'Total' ) }</span>{ ' ' }
 							<span className="subscribers__subscriber-count">{ total }</span>
 						</div>
-						<SubscriberList subscribers={ subscribers } onUnsubscribe={ onClickUnsubscribe } />
+						<SubscriberList
+							subscribers={ subscribers }
+							onView={ onClickView }
+							onUnsubscribe={ onClickUnsubscribe }
+						/>
 					</>
 				) : (
 					<EmptyListView />
@@ -94,3 +104,5 @@ export const Subscribers = ( { page, pageChanged }: SubscribersProps ) => {
 		</Main>
 	);
 };
+
+export default SubscribersPage;

--- a/client/my-sites/subscribers/subscriber-details-page.tsx
+++ b/client/my-sites/subscribers/subscriber-details-page.tsx
@@ -1,0 +1,49 @@
+import { useTranslate } from 'i18n-calypso';
+import { Item } from 'calypso/components/breadcrumb';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import Main from 'calypso/components/main';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { SubscriberDetails } from './components/subscriber-details';
+import { SubscriberPopover } from './components/subscriber-popover';
+
+type SubscriberDetailsPageProps = {
+	subscriberId: number;
+};
+
+const SubscriberDetailsPage = ( { subscriberId }: SubscriberDetailsPageProps ) => {
+	const translate = useTranslate();
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+
+	const navigationItems: Item[] = [
+		{
+			label: translate( 'Subscribers' ),
+			href: `/subscribers/${ selectedSiteSlug }`,
+		},
+		{
+			label: translate( 'Details' ),
+			href: `/subscribers/${ selectedSiteSlug }/${ subscriberId }`,
+		},
+	];
+
+	const mockSubscriber = {
+		avatar: `https://secure.gravatar.com/avatar/${ subscriberId }`,
+		subscription_id: subscriberId,
+		email_address: 'mock.subscriber@email.com',
+		display_name: 'Mock Subscriber',
+		date_subscribed: '2021-01-01T00:00:00.000Z',
+		open_rate: 0,
+		user_id: 0,
+	};
+
+	return (
+		<Main wideLayout>
+			<FixedNavigationHeader navigationItems={ navigationItems }>
+				<SubscriberPopover onUnsubscribe={ () => undefined } />
+			</FixedNavigationHeader>
+			<SubscriberDetails subscriber={ mockSubscriber } />
+		</Main>
+	);
+};
+
+export default SubscriberDetailsPage;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78399

## Proposed Changes

* Create page route `/subscribers/:domain/:subscriber`
* Create scaffold Subscriber Details component
* Add breadcrumb and subscriber profile components

## Testing Instructions

* Apply this PR to your local
* Edit the `SubscriberPopover` on `subscriber-row` to enable the view menu option using `isViewButtonVisible`
* Go to http://calypso.localhost:3000/subscribers/{site-slug}
* Click on View on a subscriber row menu
* You should be redirected to the details page

**View Button**
<img width="370" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/46c073f4-fea3-4c27-b20d-50db790ba4a8">

**Subscriber Details Page**
<img width="1106" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/59bda782-b4fc-4c8e-babe-30ef158ab508">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
