### PR TITLE
Tax Information: Update the sidebar of the tax information form 

### DIFF
--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -88,7 +88,7 @@ export default function VatInfoPage() {
 							/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST") or a generic fallback string of tax names */
 							'The %(taxName)s details saved on this page will be applied to all receipts in your account. Only supported countries appear in the dropdown. For more information about taxes, {{learnMoreLink}}click here{{/learnMoreLink}}.',
 							{
-								args: { taxName: taxName ?? translate( 'Tax (VAT/GST/CT)', { textOnly: true } ) },
+								args: { taxName: taxName ?? translate( 'tax (VAT/GST/CT)', { textOnly: true } ) },
 								components: {
 									learnMoreLink: (
 										<InlineSupportLink

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -1,4 +1,5 @@
 import { CompactCard, Button, Card } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef, useMemo } from 'react';
 import CardHeading from 'calypso/components/card-heading';
@@ -33,6 +34,7 @@ export default function VatInfoPage() {
 	const taxName = useTaxName(
 		currentVatDetails.country ?? vatDetails.country ?? geoData?.country_short ?? 'GB'
 	);
+	const taxSupportPageURL = localizeUrl( 'https://wordpress.com/support/vat-gst-other-taxes/' );
 
 	useRecordVatEvents( { fetchError } );
 
@@ -92,9 +94,11 @@ export default function VatInfoPage() {
 								components: {
 									learnMoreLink: (
 										<InlineSupportLink
-											supportLink="https://wordpress.com/support/vat-gst-other-taxes/"
+											supportLink={ taxSupportPageURL }
 											showText={ true }
 											showIcon={ false }
+											supportPostId={ 234670 } //This is what makes it a modal dialogue
+											linkTitle="VAT, GST, and other taxes"
 										/>
 									),
 								},

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -109,10 +109,10 @@ export default function VatInfoPage() {
 						<br />
 						<br />
 						{ translate(
-							/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST") or a generic fallback string of tax names */
 							/* translators: This is a list of tax-related reasons a customer might need to contact support */
 							'If you:' +
 								'{{ul}}' +
+								/* translators: %(taxName)s is the name of taxes in the country (eg: "VAT" or "GST") or a generic fallback string of tax names */
 								'{{li}}Need to update existing %(taxName)s details{{/li}}' +
 								'{{li}}Have been charged taxes as a business subject to reverse charges{{/li}}' +
 								'{{li}}Do not see your country listed in this form{{/li}}' +

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -85,7 +85,7 @@ export default function VatInfoPage() {
 					<p className="vat-info__sidebar-paragraph">
 						{ translate(
 							/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-							"We currently only provide %(taxName)s invoices to users who are properly registered. %(taxName)s information saved on this page will be applied to all of your account's receipts.",
+							"%(taxName)s details saved on this page will be applied to all of your account's receipts. Only supported countries appear in the dropdown. For more information about taxes, {click here}.",
 							{
 								textOnly: true,
 								args: { taxName: taxName ?? translate( 'VAT', { textOnly: true } ) },

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -36,6 +36,12 @@ export default function VatInfoPage() {
 	);
 	const taxSupportPageURL = localizeUrl( 'https://wordpress.com/support/vat-gst-other-taxes/' );
 
+	const reduxDispatch = useDispatch();
+
+	const clickSupport = () => {
+		reduxDispatch( recordTracksEvent( 'calypso_vat_details_support_click' ) );
+	};
+
 	useRecordVatEvents( { fetchError } );
 
 	if ( fetchError ) {
@@ -88,7 +94,33 @@ export default function VatInfoPage() {
 					<p className="vat-info__sidebar-paragraph">
 						{ translate(
 							/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST") or a generic fallback string of tax names */
-							'The %(taxName)s details saved on this page will be applied to all receipts in your account. Only supported countries appear in the dropdown. For more information about taxes, {{learnMoreLink}}click here{{/learnMoreLink}}.',
+							'The %(taxName)s details saved on this page will be applied to all receipts in your account.',
+							{
+								args: { taxName: taxName ?? translate( 'tax (VAT/GST/CT)', { textOnly: true } ) },
+							}
+						) }
+						<br />
+						<br />
+						{ translate(
+							'Only certain countries are supported. If your country is not listed, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+							{
+								components: {
+									contactSupportLink: (
+										<a
+											target="_blank"
+											href={ CALYPSO_CONTACT }
+											rel="noreferrer"
+											onClick={ clickSupport }
+											title="Contact support for assistance"
+										/>
+									),
+								},
+							}
+						) }
+						<br />
+						<br />
+						{ translate(
+							'For more information about taxes, {{learnMoreLink}}click here{{/learnMoreLink}}.',
 							{
 								args: { taxName: taxName ?? translate( 'tax (VAT/GST/CT)', { textOnly: true } ) },
 								components: {
@@ -97,7 +129,7 @@ export default function VatInfoPage() {
 											supportLink={ taxSupportPageURL }
 											showText={ true }
 											showIcon={ false }
-											supportPostId={ 234670 } //This is what makes it a modal dialogue
+											supportPostId={ 234670 } //This is what makes the document appear in a dialogue
 											linkTitle="VAT, GST, and other taxes"
 										/>
 									),

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -114,7 +114,7 @@ export default function VatInfoPage() {
 							'If you:' +
 								'{{ul}}' +
 								'{{li}}Need to update existing %(taxName)s details{{/li}}' +
-								'{{li}}Have been charged VAT as a VAT-Registered Business subject to reverse charges{{/li}}' +
+								'{{li}}Have been charged taxes as a business subject to reverse charges{{/li}}' +
 								'{{li}}Do not see your country listed in this form{{/li}}' +
 								'{{/ul}}' +
 								'{{contactSupportLink}}Contact our Happiness Engineers{{/contactSupportLink}}. Include your %(taxName)s number and country code when you contact us.',

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -140,7 +140,6 @@ export default function VatInfoPage() {
 						{ translate(
 							'For more information about taxes, {{learnMoreLink}}click here{{/learnMoreLink}}.',
 							{
-								args: { taxName: taxName ?? translate( 'tax (VAT/GST/CT)', { textOnly: true } ) },
 								components: {
 									learnMoreLink: (
 										<InlineSupportLink

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -102,7 +102,7 @@ export default function VatInfoPage() {
 						<br />
 						<br />
 						{ translate(
-							'Only certain countries are supported. If your country is not listed, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+							'Currently, only certain countries are supported. If your country is not listed, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
 							{
 								components: {
 									contactSupportLink: (

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -103,7 +103,7 @@ export default function VatInfoPage() {
 							/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST") or a generic fallback string of tax names */
 							'The %(taxName)s details saved on this page will be applied to all receipts in your account.',
 							{
-								args: { taxName: taxName ?? translate( 'tax (VAT/GST/CT)', { textOnly: true } ) },
+								args: { taxName: taxName ?? fallbackTaxName },
 							}
 						) }
 						<br />
@@ -113,13 +113,13 @@ export default function VatInfoPage() {
 							/* translators: This is a list of tax-related reasons a customer might need to contact support */
 							'If you:' +
 								'{{ul}}' +
-								'{{li}}Need to update existing Tax ID details{{/li}}' +
+								'{{li}}Need to update existing %(taxName)s details{{/li}}' +
 								'{{li}}Have been charged VAT as a VAT-Registered Business subject to reverse charges{{/li}}' +
 								'{{li}}Do not see your country listed in this form{{/li}}' +
 								'{{/ul}}' +
 								'{{contactSupportLink}}Contact our Happiness Engineers{{/contactSupportLink}}. Include your %(taxName)s number and country code when you contact us.',
 							{
-								args: { taxName: taxName ?? translate( 'tax', { textOnly: true } ) },
+								args: { taxName: taxName ?? fallbackTaxName },
 								components: {
 									ul: <ul />,
 									li: <li />,

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -34,13 +34,20 @@ export default function VatInfoPage() {
 	const taxName = useTaxName(
 		currentVatDetails.country ?? vatDetails.country ?? geoData?.country_short ?? 'GB'
 	);
-	const taxSupportPageURL = localizeUrl( 'https://wordpress.com/support/vat-gst-other-taxes/' );
 
 	const reduxDispatch = useDispatch();
 
 	const clickSupport = () => {
 		reduxDispatch( recordTracksEvent( 'calypso_vat_details_support_click' ) );
 	};
+
+	/* This is a call to action for contacting support */
+	const contactSupportLinkTitle = translate( 'Contact Happiness Engineers' );
+
+	const taxSupportPageURL = localizeUrl( 'https://wordpress.com/support/vat-gst-other-taxes/' );
+
+	/* This is the title of the support page from https://wordpress.com/support/vat-gst-other-taxes/ */
+	const taxSupportPageLinkTitle = translate( 'VAT, GST, and other taxes' );
 
 	useRecordVatEvents( { fetchError } );
 
@@ -102,16 +109,27 @@ export default function VatInfoPage() {
 						<br />
 						<br />
 						{ translate(
-							'Currently, only certain countries are supported. If your country is not listed, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+							/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST") or a generic fallback string of tax names */
+							/* translators: This is a list of tax-related reasons a customer might need to contact support */
+							'If you:' +
+								'{{ul}}' +
+								'{{li}}Need to update existing Tax ID details{{/li}}' +
+								'{{li}}Have been charged VAT as a VAT-Registered Business subject to reverse charges{{/li}}' +
+								'{{li}}Do not see your country listed in this form{{/li}}' +
+								'{{/ul}}' +
+								'{{contactSupportLink}}Contact our Happiness Engineers{{/contactSupportLink}}. Include your %(taxName)s number and country code when you contact us.',
 							{
+								args: { taxName: taxName ?? translate( 'tax', { textOnly: true } ) },
 								components: {
+									ul: <ul />,
+									li: <li />,
 									contactSupportLink: (
 										<a
 											target="_blank"
 											href={ CALYPSO_CONTACT }
 											rel="noreferrer"
 											onClick={ clickSupport }
-											title="Contact support for assistance"
+											title={ contactSupportLinkTitle }
 										/>
 									),
 								},
@@ -130,7 +148,7 @@ export default function VatInfoPage() {
 											showText={ true }
 											showIcon={ false }
 											supportPostId={ 234670 } //This is what makes the document appear in a dialogue
-											linkTitle="VAT, GST, and other taxes"
+											linkTitle={ taxSupportPageLinkTitle }
 										/>
 									),
 								},

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -7,6 +7,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
@@ -84,11 +85,19 @@ export default function VatInfoPage() {
 					</CardHeading>
 					<p className="vat-info__sidebar-paragraph">
 						{ translate(
-							/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-							"%(taxName)s details saved on this page will be applied to all of your account's receipts. Only supported countries appear in the dropdown. For more information about taxes, {click here}.",
+							/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST") or a generic fallback string of tax names */
+							'The %(taxName)s details saved on this page will be applied to all receipts in your account. Only supported countries appear in the dropdown. For more information about taxes, {{learnMoreLink}}click here{{/learnMoreLink}}.',
 							{
-								textOnly: true,
-								args: { taxName: taxName ?? translate( 'VAT', { textOnly: true } ) },
+								args: { taxName: taxName ?? translate( 'Tax (VAT/GST/CT)', { textOnly: true } ) },
+								components: {
+									learnMoreLink: (
+										<InlineSupportLink
+											supportLink="https://wordpress.com/support/vat-gst-other-taxes/"
+											showText={ true }
+											showIcon={ false }
+										/>
+									),
+								},
 							}
 						) }
 					</p>

--- a/client/me/purchases/vat-info/style.scss
+++ b/client/me/purchases/vat-info/style.scss
@@ -20,6 +20,10 @@
 	font-size: 0.875rem;
 }
 
+.vat-info__sidebar-paragraph ul {
+	margin: 0 0 1.5em 1.5em;
+}
+
 .vat-info__country-select {
 	width: 100%;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/payments-shilling/issues/1747

Previously, we only provided `VAT Invoices` to users who were registered as a European Business. Since both the scope of who we charge tax-exclusive pricing and how we display our tax vendor information on receipts have changed, this is no longer accurate.

<img width="714" alt="FG-AddTaxForm" src="https://github.com/Automattic/wp-calypso/assets/12505355/7c2fce1a-6267-4c4a-8c62-eb30b0460229"> 

## Proposed Changes

* Remove the warning that we only provide tax receipts (VAT Invoices) to certain users
* Note that not all countries can be validated through this form and direct customers who are in other countries to contact support
* Add a link to tax documentation

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

If you go to http://calypso.localhost:3000/me/purchases/vat-details, you should see the following screen: 

**BEFORE**

![GH78406-Before-Screenshot 2023-07-11 at 15 44 49](https://github.com/Automattic/wp-calypso/assets/12505355/a778445b-c816-4f97-866c-f89bd66977c0)

Next, apply this patch and go to http://calypso.localhost:3000/me/purchases/vat-details

* You should see the new sidebar information: 

**AFTER**

![GH78406-After-Screenshot 2023-07-11 at 15 54 57](https://github.com/Automattic/wp-calypso/assets/12505355/573cf445-2f80-4577-8dec-2ca277334cf3)

* Click on the `please contact support` link and make sure it directs you to `http://calypso.localhost:3000/help`

![GHPR78406-TaxInformationForm-clickSupportLink](https://github.com/Automattic/wp-calypso/assets/12505355/f04634c9-01da-4b46-9edc-682d3ff4687c)


* Click on the `learn more` link. It should open a dialogue displaying the support documentation from https://wordpress.com/support/vat-gst-other-taxes/
* Click on `Close` and make sure the dialogue closes
* Open the dialogue again and click on `Visit Article`, make sure the support article linked above is opened in a new tab

![GHPR78406-TaxInformationForm-clickLearnMoreLink](https://github.com/Automattic/wp-calypso/assets/12505355/f6bd2bcf-80a1-46d3-b017-5a1a017879e0)



* On http://calypso.localhost:3000/me/purchases/vat-details and select a country from the form fields
* Make sure the tax name (e.g. "tax (VAT/GST/CT)") changes to reflect the tax name for the selected country

![GH78406-ChangeCountry-2023-07-11 15 55 16](https://github.com/Automattic/wp-calypso/assets/12505355/11863f26-7fa1-43dd-b8bd-5dff3685a025)

## To dos:

- [x] Localized the URL in the `<InlineSupportLink>` component 
- [x] Make the support documentation pop-up in a modal (this already exists, just need to apply it)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
