### PR TITLE
Signup: Add new domain-transfer flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -131,8 +131,9 @@ export function generateFlows( {
 			steps: isEnabled( 'signup/professional-email-step' )
 				? [ 'user', 'domains', 'emails', 'plans' ]
 				: [ 'user', 'domains', 'plans' ],
-			destination: getSignupDestination,
-			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pdhack-Hk.',
+			destination: ( dependencies ) => `/domains/manage/${ dependencies.siteSlug }`,
+			description:
+				'Onboarding flow specifically for domain transfers. Read more in https://wp.me/pdhack-Hk.',
 			lastModified: '2023-06-19',
 			showRecaptcha: true,
 		},

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -127,6 +127,16 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
+			name: 'domain-transfer',
+			steps: isEnabled( 'signup/professional-email-step' )
+				? [ 'user', 'domains', 'emails', 'plans' ]
+				: [ 'user', 'domains', 'plans' ],
+			destination: getSignupDestination,
+			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pdhack-Hk.',
+			lastModified: '2023-06-19',
+			showRecaptcha: true,
+		},
+		{
 			name: 'onboarding-pm',
 			steps: [ 'user', 'domains', 'plans-pm' ],
 			destination: getSignupDestination,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -656,7 +656,11 @@ class DomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-			return ! stepSectionName && translate( 'Enter some descriptive keywords to get started' );
+			return (
+				! stepSectionName &&
+				'domain-transfer' !== this.props.flowName &&
+				translate( 'Enter some descriptive keywords to get started' )
+			);
 		}
 
 		return 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName
@@ -667,7 +671,7 @@ class DomainsStep extends Component {
 	getHeaderText() {
 		const { headerText, isAllDomains, isReskinned, stepSectionName, translate } = this.props;
 
-		if ( stepSectionName === 'use-your-domain' ) {
+		if ( stepSectionName === 'use-your-domain' || 'domain-transfer' === this.props.flowName ) {
 			return '';
 		}
 
@@ -712,6 +716,11 @@ class DomainsStep extends Component {
 
 		if ( ! this.props.stepSectionName && this.props.isReskinned && ! this.isTailoredFlow() ) {
 			sideContent = this.getSideContent();
+		}
+
+		if ( 'domain-transfer' === this.props.flowName && ! this.props.stepSectionName ) {
+			content = this.useYourDomainForm();
+			sideContent = null;
 		}
 
 		if ( this.props.step && 'invalid' === this.props.step.status ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -746,7 +746,10 @@ class DomainsStep extends Component {
 	}
 
 	getPreviousStepUrl() {
-		if ( 'use-your-domain' !== this.props.stepSectionName ) {
+		if (
+			'use-your-domain' !== this.props.stepSectionName &&
+			'domain-transfer' !== this.props.flowName
+		) {
 			return null;
 		}
 
@@ -808,6 +811,9 @@ class DomainsStep extends Component {
 		} else if ( isAllDomains ) {
 			backUrl = domainManagementRoot();
 			backLabelText = translate( 'Back to All Domains' );
+		} else if ( ! previousStepBackUrl && 'domain-transfer' === this.props.flowName ) {
+			backUrl = null;
+			backLabelText = null;
 		} else {
 			backUrl = getStepUrl( this.props.flowName, this.props.stepName, null, this.getLocale() );
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -223,7 +223,8 @@
 		"pro",
 		"starter",
 		"domain",
-		"onboarding-2023-pricing-grid"
+		"onboarding-2023-pricing-grid",
+		"domain-transfer"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js"
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See pdhack-Hk-p2

## Proposed Changes

* Adds a new `domain-transfer` flow that starts the user off at the transfer step and then works them through the other steps of onboarding with the user ended up at `/domain/manage/$site_slug` with a prompt to finalize the transfer.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR and build locally. Or, use a calypso.live link.
* Go to `/start/domain-transfer
* Work through the flow with a domain that is unlocked

## Screenshots
<img width="1108" alt="Screenshot 2023-06-20 at 11 51 10 AM" src="https://github.com/Automattic/wp-calypso/assets/1126811/fb2153cc-8887-420e-ab5d-31b8f00060d8">

<img width="1108" alt="Screenshot 2023-06-20 at 11 51 15 AM" src="https://github.com/Automattic/wp-calypso/assets/1126811/5d5d5979-58cf-4ca0-8f76-08c2f4c993bc">

<img width="1108" alt="Screenshot 2023-06-20 at 11 51 20 AM" src="https://github.com/Automattic/wp-calypso/assets/1126811/8e32a5a2-46e1-4033-a408-b98d44a551e5">

<img width="1108" alt="Screenshot 2023-06-20 at 11 51 30 AM" src="https://github.com/Automattic/wp-calypso/assets/1126811/fc52e3ed-df85-4369-a6b8-fd9aab100266">

<img width="1300" alt="Screenshot 2023-06-20 at 12 21 45 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/ac8adc9f-f41a-4b39-bcd4-56f771f14b5a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?