### PR TITLE
Start Writing flow: Enable first post if not completed

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -57,6 +57,10 @@ export function getEnhancedTasks(
 
 	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
 
+	const firstPostPublished =
+		Boolean( tasks?.find( ( task ) => task.id === 'first_post_published' )?.completed ) ||
+		! isStartWritingFlow( flow );
+
 	const setupBlogCompleted =
 		Boolean( tasks?.find( ( task ) => task.id === 'setup_blog' )?.completed ) ||
 		! isStartWritingFlow( flow );
@@ -225,12 +229,11 @@ export function getEnhancedTasks(
 					taskData = {
 						disabled:
 							mustVerifyEmailBeforePosting ||
-							isStartWritingFlow( flow || null ) ||
-							( task.completed && isDesignFirstFlow( flow || null ) ) ||
+							( task.completed && isBlogOnboardingFlow( flow || null ) ) ||
 							false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							const newPostUrl = ! isDesignFirstFlow( flow || null )
+							const newPostUrl = ! isBlogOnboardingFlow( flow || null )
 								? `/post/${ siteSlug }`
 								: addQueryArgs( `https://${ siteSlug }/wp-admin/post-new.php`, {
 										origin: window.location.origin,
@@ -332,8 +335,13 @@ export function getEnhancedTasks(
 				case 'blog_launched':
 					taskData = {
 						disabled:
-							isBlogOnboardingFlow( flow ) &&
-							( ! planCompleted || ! domainUpsellCompleted || ! setupBlogCompleted ),
+							( isStartWritingFlow( flow ) &&
+								( ! firstPostPublished ||
+									! planCompleted ||
+									! domainUpsellCompleted ||
+									! setupBlogCompleted ) ) ||
+							( isDesignFirstFlow( flow ) &&
+								( ! planCompleted || ! domainUpsellCompleted || ! setupBlogCompleted ) ),
 						actionDispatch: () => {
 							if ( site?.ID ) {
 								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -57,9 +57,9 @@ export function getEnhancedTasks(
 
 	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
 
-	const firstPostPublished =
-		Boolean( tasks?.find( ( task ) => task.id === 'first_post_published' )?.completed ) ||
-		! isStartWritingFlow( flow );
+	const firstPostPublished = Boolean(
+		tasks?.find( ( task ) => task.id === 'first_post_published' )?.completed
+	);
 
 	const setupBlogCompleted =
 		Boolean( tasks?.find( ( task ) => task.id === 'setup_blog' )?.completed ) ||

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -43,7 +43,7 @@ describe( 'Task Helpers', () => {
 		describe( 'when checking if the first post is published', () => {
 			describe( 'and the flow is start-writing', () => {
 				it( 'disable the click link so the user will not get distracted going back to the post', () => {
-					const fakeTasks = [ buildTask( { id: 'first_post_published', completed: false } ) ];
+					const fakeTasks = [ buildTask( { id: 'first_post_published', completed: true } ) ];
 					const enhancedTasks = getEnhancedTasks(
 						fakeTasks,
 						'fake.wordpress.com',


### PR DESCRIPTION
When you start the flow and without publishing a post go to `/`, the Launchpad shows and the `Write your first post` task is not accessible.
Slack: p1687203431393969-slack-CKZHG0QCR

Related to #

## Proposed Changes

Enable `Write your first post` on Launchpad if the user didn't publish a post, and also disable `Launch your blog` if the user didn't publish a post.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/55bd2345-8e1f-49a9-932b-f140a2f8a4a7) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/33cbc743-5c63-47eb-b7d9-6e9eb2e80063) |

## Testing Instructions

- Using a new user OR a user without any site, start the flow with [/setup/start-writing](http://calypso.localhost:3000/setup/start-writing).
- When the editor shows, go to: [/](http://calypso.localhost:3000/)
- You should see the `Write your first post` enabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~