### PR TITLE
Update page title on tag pages

### DIFF
--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -1,5 +1,8 @@
+import { translate } from 'i18n-calypso';
 import { trim } from 'lodash';
+import titlecase from 'to-title-case';
 import AsyncLoad from 'calypso/components/async-load';
+import DocumentHead from 'calypso/components/data/document-head';
 import {
 	trackPageLoad,
 	trackUpdatesLoaded,
@@ -19,6 +22,8 @@ export const tagListing = ( context, next ) => {
 		.toLowerCase()
 		.replace( /\s+/g, '-' )
 		.replace( /-{2,}/g, '-' );
+	const tagTitle = titlecase( trim( context.params.tag ) ).replace( /[-_]/g, ' ' );
+
 	const encodedTag = encodeURIComponent( tagSlug ).toLowerCase();
 	const streamKey = 'tag:' + tagSlug;
 	const mcKey = 'topic';
@@ -33,24 +38,32 @@ export const tagListing = ( context, next ) => {
 		context.headerSection = renderHeaderSection();
 	}
 	context.primary = (
-		<AsyncLoad
-			require="calypso/reader/tag-stream/main"
-			key={ 'tag-' + encodedTag }
-			streamKey={ streamKey }
-			encodedTagSlug={ encodedTag }
-			decodedTagSlug={ tagSlug }
-			trackScrollPage={ trackScrollPage.bind(
-				// eslint-disable-line
-				null,
-				basePath,
-				fullAnalyticsPageTitle,
-				analyticsPageTitle,
-				mcKey
-			) }
-			startDate={ startDate }
-			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) } // eslint-disable-line
-			showBack={ !! context.lastRoute }
-		/>
+		<>
+			<DocumentHead
+				title={ translate( 'Articles About %s – Reader – WordPress.com', {
+					args: [ tagTitle ],
+					comment: 'page title for reader tag pages. %s is the name of the tag e.g. "art"',
+				} ) }
+			/>
+			<AsyncLoad
+				require="calypso/reader/tag-stream/main"
+				key={ 'tag-' + encodedTag }
+				streamKey={ streamKey }
+				encodedTagSlug={ encodedTag }
+				decodedTagSlug={ tagSlug }
+				trackScrollPage={ trackScrollPage.bind(
+					// eslint-disable-line
+					null,
+					basePath,
+					fullAnalyticsPageTitle,
+					analyticsPageTitle,
+					mcKey
+				) }
+				startDate={ startDate }
+				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) } // eslint-disable-line
+				showBack={ !! context.lastRoute }
+			/>
+		</>
 	);
 	next();
 };

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -40,7 +40,7 @@ export const tagListing = ( context, next ) => {
 	context.primary = (
 		<>
 			<DocumentHead
-				title={ translate( 'Articles About %s – Reader – WordPress.com', {
+				title={ translate( 'Articles About %s ‹ Reader', {
 					args: [ tagTitle ],
 					comment: 'page title for reader tag pages. %s is the name of the tag e.g. "art"',
 				} ) }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -4,7 +4,6 @@ import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import DocumentHead from 'calypso/components/data/document-head';
 import QueryReaderFollowedTags from 'calypso/components/data/query-reader-followed-tags';
 import QueryReaderTag from 'calypso/components/data/query-reader-tag';
 import { navigate } from 'calypso/lib/navigate';
@@ -101,6 +100,7 @@ class TagStream extends Component {
 		const emptyContent = <EmptyContent decodedTagSlug={ this.props.decodedTagSlug } />;
 		const title = this.props.decodedTagSlug;
 		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );
+		const titleText = title.replace( /-/g, ' ' );
 
 		let imageSearchString = this.props.encodedTagSlug;
 
@@ -131,7 +131,7 @@ class TagStream extends Component {
 		// Put the tag stream header at the top of the body, so it can be even with the sidebar in the two column layout.
 		const tagHeader = (
 			<TagStreamHeader
-				title={ title }
+				title={ titleText }
 				description={ this.props.description }
 				imageSearchString={ imageSearchString }
 				showFollow={ !! ( tag && tag.id ) }
@@ -152,12 +152,6 @@ class TagStream extends Component {
 			>
 				<QueryReaderFollowedTags />
 				<QueryReaderTag tag={ this.props.decodedTagSlug } />
-				<DocumentHead
-					title={ this.props.translate( '%s ‹ Reader', {
-						args: title,
-						comment: '%s is the section name. For example: "My Likes"',
-					} ) }
-				/>
 				{ this.props.showBack && <HeaderBack /> }
 			</Stream>
 		);

--- a/client/reader/tags/controller.tsx
+++ b/client/reader/tags/controller.tsx
@@ -33,7 +33,7 @@ export const tagsListing = ( context: PageJSContext, next: () => void ) => {
 	}
 	context.primary = (
 		<>
-			<DocumentHead title={ translate( 'Popular Tags and Posts on WordPress.com' ) } />
+			<DocumentHead title={ translate( 'Popular Tags and Posts ‹ Reader' ) } />
 			<TagsPage
 				trendingTags={ context.params.trendingTags }
 				alphabeticTags={ context.params.alphabeticTags }

--- a/client/reader/tags/controller.tsx
+++ b/client/reader/tags/controller.tsx
@@ -1,5 +1,6 @@
 import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
 import wpcom from 'calypso/lib/wp';
 import performanceMark, { PartialContext } from 'calypso/server/lib/performance-mark';
 import { getCurrentUserLocale, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -31,10 +32,13 @@ export const tagsListing = ( context: PageJSContext, next: () => void ) => {
 		context.headerSection = renderHeaderSection();
 	}
 	context.primary = (
-		<TagsPage
-			trendingTags={ context.params.trendingTags }
-			alphabeticTags={ context.params.alphabeticTags }
-		/>
+		<>
+			<DocumentHead title={ translate( 'Popular Tags and Posts on WordPress.com' ) } />
+			<TagsPage
+				trendingTags={ context.params.trendingTags }
+				alphabeticTags={ context.params.alphabeticTags }
+			/>
+		</>
 	);
 	next();
 };


### PR DESCRIPTION
Simple PR to change the page title on both the `/tags` page and the individual `/tag/$tag` pages.

This gives descriptive page titles to the tags pages for SEO improvement

See first two tasks of pe7F0s-Xe-p2#a2-tasks-for-loop-team

### Testing instructions.
Go to /tags page
Page title should be "Popular Tags and Posts on WordPress.com"

Go to /tag/$tag pages
Page title should be "Articles About {$tag} – Reader – WordPress.com"