### PR TITLE
Settings: Adds BBE upsell

### DIFF
--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -101,7 +101,7 @@
 	}
 
 	.banner__icon-no-circle {
-		display: flex;
+		display: none;
 		padding: 3px 4px 4px 3px;
 		margin-right: 16px;
 		align-items: center;
@@ -115,6 +115,9 @@
 			display: none;
 		}
 		.banner__icon-circle {
+			display: flex;
+		}
+		.banner__icon-no-circle {
 			display: flex;
 		}
 	}

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -794,7 +794,7 @@ export class SiteSettingsFormGeneral extends Component {
 					'Leave the heavy lifting to us and let our professional builders craft your compelling website.'
 				) }
 				callToAction={ translate( 'Get started' ) }
-				href="https://wordpress.com/website-building-service/?ref=unlaunched-settings"
+				href="https://wordpress.com/website-design-service/?ref=unlaunched-settings"
 				iconPath={ builtByLogo }
 				disableCircle={ true }
 				event="settings_bb_upsell"

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -795,6 +795,7 @@ export class SiteSettingsFormGeneral extends Component {
 				) }
 				callToAction={ translate( 'Get started' ) }
 				href="https://wordpress.com/website-design-service/?ref=unlaunched-settings"
+				target="_blank"
 				iconPath={ builtByLogo }
 				disableCircle={ true }
 				event="settings_bb_upsell"

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -17,7 +17,9 @@ import { flowRight, get } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
+import builtByLogo from 'calypso/assets/images/illustrations/built-by-wp-vert-blue.png';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import Banner from 'calypso/components/banner';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
@@ -764,6 +766,44 @@ export class SiteSettingsFormGeneral extends Component {
 		}
 	}
 
+	builtByUpsell() {
+		const { translate, site, isUnlaunchedSite: propsisUnlaunchedSite } = this.props;
+
+		// Do not show for launched sites
+		if ( ! propsisUnlaunchedSite ) {
+			return;
+		}
+
+		// Do not show if we don't know when the site was created
+		if ( ! site?.options?.created_at ) {
+			return;
+		}
+
+		// Do not show if the site is less than 4 days old
+		const siteCreatedAt = Date.parse( site?.options?.created_at );
+		const FOUR_DAYS_IN_MILLISECONDS = 4 * 24 * 60 * 60 * 1000;
+		if ( Date.now() - siteCreatedAt < FOUR_DAYS_IN_MILLISECONDS ) {
+			return;
+		}
+
+		return (
+			<Banner
+				className="site-settings__built-by-upsell"
+				title={ translate( 'We’ll build your site for you' ) }
+				description={ translate(
+					'Leave the heavy lifting to us and let our professional builders craft your compelling website.'
+				) }
+				callToAction={ translate( 'Get started' ) }
+				href="https://wordpress.com/website-building-service/?ref=unlaunched-settings"
+				iconPath={ builtByLogo }
+				disableCircle={ true }
+				event="settings_bb_upsell"
+				tracksImpressionName="calypso_settings_bb_upsell_impression"
+				tracksClickName="calypso_settings_bb_upsell_cta_click"
+			/>
+		);
+	}
+
 	render() {
 		const {
 			customizerUrl,
@@ -811,7 +851,7 @@ export class SiteSettingsFormGeneral extends Component {
 				! isWpcomStagingSite
 					? this.renderLaunchSite()
 					: this.privacySettings() }
-
+				{ this.builtByUpsell() }
 				{ ! isWpcomStagingSite && this.giftOptions() }
 				{ ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
 					<div className="site-settings__footer-credit-container">

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -705,10 +705,16 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 }
 
 .site-settings__built-by-upsell {
+	&.banner.card {
+		padding-right: 24px;
+	}
 	.banner__icon-no-circle {
 		img {
 			max-height: 32px;
 			max-width: 32px;
 		}
+	}
+	.banner__action {
+		margin-right: 0;
 	}
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -706,7 +706,7 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 
 .site-settings__built-by-upsell {
 	&.banner.card {
-		padding-right: 24px;
+		padding-inline-end: 24px;
 	}
 	.banner__icon-no-circle {
 		img {
@@ -715,6 +715,6 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 		}
 	}
 	.banner__action {
-		margin-right: 0;
+		margin-inline-end: 0;
 	}
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -703,3 +703,12 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 		white-space: nowrap;
 	}
 }
+
+.site-settings__built-by-upsell {
+	.banner__icon-no-circle {
+		img {
+			max-height: 32px;
+			max-width: 32px;
+		}
+	}
+}

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -791,4 +791,64 @@ describe( 'SiteSettingsFormGeneral', () => {
 			} );
 		} );
 	} );
+
+	describe( 'Built By Upsell', () => {
+		const testProps = {
+			...props,
+			site: {
+				ID: 1234,
+				domain: 'example.wordpress.com',
+				options: {
+					created_at: '2023-06-14T04:37:53+00:00',
+				},
+			},
+			isUnlaunchedSite: true,
+			siteDomains: [ 'example.wordpress.com' ],
+		};
+
+		it( 'Should not show the upsell for launched sites', () => {
+			const { container } = renderWithRedux(
+				<SiteSettingsFormGeneral { ...testProps } isUnlaunchedSite={ false } />
+			);
+
+			expect( container.querySelectorAll( '.site-settings__built-by-upsell' ) ).toHaveLength( 0 );
+		} );
+
+		it( 'Should not show the upsell for sites without created_at', () => {
+			const testPropsWithoutCreatedAt = {
+				...testProps,
+				site: {
+					...testProps.site,
+					options: {
+						created_at: null,
+					},
+				},
+			};
+
+			const { container } = renderWithRedux(
+				<SiteSettingsFormGeneral { ...testPropsWithoutCreatedAt } />
+			);
+
+			expect( container.querySelectorAll( '.site-settings__built-by-upsell' ) ).toHaveLength( 0 );
+		} );
+
+		it( 'Should not show the upsell for sites newer than 4 days', () => {
+			jest
+				.useFakeTimers()
+				.setSystemTime( Date.parse( '2023-06-14T04:37:53+00:00' ) + 3 * 24 * 60 * 60 * 1000 );
+
+			const { container } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
+
+			jest.setSystemTime( jest.getRealSystemTime() );
+			jest.useRealTimers();
+
+			expect( container.querySelectorAll( '.site-settings__built-by-upsell' ) ).toHaveLength( 0 );
+		} );
+
+		it( 'Should show the upsell for unlaunched sites older than 4 days', () => {
+			const { container } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
+
+			expect( container.querySelectorAll( '.site-settings__built-by-upsell' ) ).toHaveLength( 1 );
+		} );
+	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1826

## Proposed Changes

* Adds a Built By Upsell on the Settings page. The upsell is shown for unlaunched sites older than 4 days.
<img width="1305" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/77de3e33-9353-4df8-b2bb-d535bda9a982">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to Settings -> General to test the following cases:
* For Private or Public sites, the upsell should not be visible.
* The upsell should not be visible for sites created less than 4 days ago.
* The upsell should be visible for unlaunched sites created more than 4 days ago. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
