### PR TITLE
Pro Dashboard: Refetch verified contacts when opening Phone number editor.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -205,6 +205,13 @@ export default function PhoneNumberEditor( {
 		}
 	}, [ translate, verifyPhoneNumber.errorMessage ] );
 
+	// Refetch verified contacts if failed
+	useEffect( () => {
+		verifiedContacts.refetchIfFailed();
+		// Disable linting because we only want to refetch once
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
 	// Set help text when phone number verification fails
 	useEffect( () => {
 		if ( verifyPhoneNumber.isError ) {


### PR DESCRIPTION
Related to 1204774821045518-as-1204793234816319

## Proposed Changes

This PR implements error scenarios if GET `/jetpack-agency/contacts` fails to fetch; the UI will reattempt to fetch the contacts when opening the Phone number editor.

## Testing Instructions
**Prerequisites**
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type

**Instructions**
1. Run `git checkout add/error-handler-for-contact-api` and `yarn start-jetpack-cloud`.
1. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the `/dashboard`.
1. Enable monitor if not enabled already.
1. Click on the clock icon next to the monitor toggle.
1. Click the **+ Add phone number** button -> Enter a valid phone number details and please note down the phone number -> Click Verify
1. Follow the instruction in D113560-code on how to get the verification code and enter it. Once phone number is verified and added to the list, refresh the page without pressing the **'Save'** button. 
1. Open the network tab, find the contacts API, and click on Block request URL
<img src="https://user-images.githubusercontent.com/10586875/242153684-7d14b2de-88f1-46a8-acc0-edf1d11ff8b3.png" />

8. Go to the **Console** tab and clear the local storage using `localStorage.clear()`, and refresh the page.
9. Verify the GET `/jetpack-agency/contacts` is blocked. Please repeat step 8 until the API call is made, and it is blocked.
10. Now, click the **+ Add Phone number** button and verify the GET `/jetpack-agency/contacts` is made and gets blocked.
11. Once all the 3 retries for GET /jetpack-agency/contacts is complete and blocked, uncheck the Enable network request blocking toggle.
<img src="https://user-images.githubusercontent.com/10586875/242155228-a0c8ef50-b29f-4903-9213-17c2e369d21f.png" />

12. Enter the phone number details which was previously verified and click **Verify**. Confirm it no longer requires submitting a verification code, and the phone number is added directly to the list of phones.
13. Now refresh the page without clicking on the **Save** button. Make sure the GET `/jetpack-agency/contacts` are still blocked.
14. Uncheck the `Enable network request blocking` toggle.
15. Now, click the **+ Add phone number** button and verify the GET `/jetpack-agency/contacts` is made and doesn't get blocked.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?