### PR TITLE
Flaky E2E: refactor Domain Upsell from Home dashboard.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/my-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/my-home-page.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Locator, Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 
 const selectors = {
@@ -19,6 +19,7 @@ const selectors = {
  */
 export class MyHomePage {
 	private page: Page;
+	private anchor: Locator;
 
 	/**
 	 * Constructs an instance of the component.
@@ -27,6 +28,7 @@ export class MyHomePage {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
+		this.anchor = page.getByRole( 'main' );
 	}
 
 	/**
@@ -53,27 +55,43 @@ export class MyHomePage {
 	}
 
 	/**
-	 * Validates the domain upsell is showing
+	 * Clicks on the button with matching text.
 	 *
-	 * @returns {Promise<void>} No return value.
+	 * @param {string|RegExp} text Text to match on the button.
 	 */
-	async validateDomainUpsell(): Promise< void > {
-		await this.page.locator( selectors.domainUpsellCard ).waitFor();
+	async clickButton( text: string | RegExp ): Promise< void > {
+		await this.anchor.getByRole( 'button', { name: text } ).click();
 	}
 
 	/**
-	 * Get suggested domain name.
+	 * Returns whether a heading matching the text is present.
 	 *
-	 * @returns {string} No return value.
+	 * Returns true if present. False otherwise.
+	 *
+	 * @param {string|RegExp} text Text to match on for the card title.
 	 */
-	async suggestedDomainName(): Promise< string | null > {
-		await this.page.locator( selectors.domainUpsellSuggestedDomain ).waitFor();
+	async isHeadingPresent( text: string | RegExp ): Promise< boolean > {
+		try {
+			await this.anchor.getByRole( 'heading', { name: new RegExp( text ) } ).waitFor();
+			return true;
+		} catch {
+			return false;
+		}
+	}
 
-		const locator = this.page.locator( selectors.domainUpsellSuggestedDomain );
-
-		await locator.waitFor();
-
-		return await locator.locator( 'text' ).textContent();
+	/**
+	 * Get the suggested domain in the upsell card.
+	 *
+	 * @returns {string} Suggested domain. Empty string if not found.
+	 */
+	async getSuggestedUpsellDomain(): Promise< string > {
+		const locator = this.anchor.locator( '.domain-upsell-illustration' );
+		try {
+			await locator.waitFor();
+			return await locator.innerText();
+		} catch {
+			return '';
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -34,9 +34,6 @@ const selectors = {
 		return `.plan-features__${ viewportSuffix } >> .plan-features__actions-button.is-${ plan.toLowerCase() }-plan:has-text("${ buttonText }")`;
 	},
 	activePlan: ( plan: Plans ) => `a.is-${ plan.toLowerCase() }-plan.is-current-plan:visible`,
-	ContinueWithPlanButton: ( buttonText: string ) =>
-		`.plans__header button:has-text("${ buttonText }")`,
-	SkipPlanConfirmButton: ( message: string ) => `.dialog__button-label:has-text("${ message }")`,
 
 	// My Plans tab
 	myPlanTitle: ( planName: Plans ) => `.my-plan-card__title:has-text("${ planName }")`,
@@ -182,19 +179,5 @@ export class PlansPage {
 		} );
 		// These action buttons trigger real page navigations.
 		await Promise.all( [ this.page.waitForNavigation(), this.page.click( selector ) ] );
-	}
-
-	/**
-	 * Click on skip button on the plan page.
-	 */
-	async clickSkipPlanActionButton( buttonText: string ): Promise< void > {
-		await this.page.click( selectors.ContinueWithPlanButton( buttonText ) );
-	}
-
-	/**
-	 * Click on confirm button to continue without a plan.
-	 */
-	async clickSkipPlanConfirmButton( skipPlanButtonText: string ): Promise< void > {
-		await this.page.click( selectors.SkipPlanConfirmButton( skipPlanButtonText ) );
 	}
 }

--- a/test/e2e/specs/domain-upsell/domain-upsell__my-home.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__my-home.ts
@@ -1,13 +1,21 @@
 /**
- * @group calypso-pr
+ * @group calypso-loop
  */
 
-import { TestAccount, BrowserManager, RestAPIClient } from '@automattic/calypso-e2e';
+import {
+	TestAccount,
+	BrowserManager,
+	RestAPIClient,
+	MyHomePage,
+	PlansPage,
+} from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
 describe( 'Domain: Upsell (Home)', function () {
+	let myHomePage: MyHomePage;
+	let plansPage: PlansPage;
 	let suggestedDomain: string;
 	let page: Page;
 
@@ -40,29 +48,28 @@ describe( 'Domain: Upsell (Home)', function () {
 	} );
 
 	it( 'Domain upsell card is present', async function () {
-		await page
-			.getByRole( 'main' )
-			.getByRole( 'heading', { name: /domain/ } )
-			.waitFor();
+		myHomePage = new MyHomePage( page );
+
+		expect( await myHomePage.isHeadingPresent( /domain/ ) ).toBe( true );
 	} );
 
 	it( 'Domain upsell card has suggested domain', async function () {
-		const locator = page.locator( '.domain-upsell-illustration' );
-		await locator.waitFor();
-		suggestedDomain = await locator.innerText();
+		suggestedDomain = await myHomePage.getSuggestedUpsellDomain();
 
 		expect( suggestedDomain ).not.toBe( '' );
 	} );
 
 	it( 'Click to begin searching for a domain', async function () {
-		await page.getByRole( 'main' ).getByRole( 'button', { name: 'Get this domain' } ).click();
+		await myHomePage.clickButton( 'Get this domain' );
 
 		// The test user does not have a plan so the Plans upsell page will load.
 		await page.waitForURL( /plans\/yearly/ );
 	} );
 
 	it( 'Choose the Free plan', async function () {
-		await page.getByRole( 'button', { name: /free plan/ } ).click();
+		plansPage = new PlansPage( page );
+
+		await plansPage.selectPlan( 'Free' );
 	} );
 
 	it( 'Dismiss paid plan upgrade CTA', async function () {

--- a/test/e2e/specs/domain-upsell/domain-upsell__my-home.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__my-home.ts
@@ -2,19 +2,13 @@
  * @group calypso-pr
  */
 
-import {
-	CartCheckoutPage,
-	TestAccount,
-	BrowserManager,
-	RestAPIClient,
-} from '@automattic/calypso-e2e';
+import { TestAccount, BrowserManager, RestAPIClient } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
 describe( 'Domain: Upsell (Home)', function () {
-	let cartCheckoutPage: CartCheckoutPage;
-	let domain: string;
+	let suggestedDomain: string;
 	let page: Page;
 
 	beforeAll( async function () {
@@ -31,17 +25,40 @@ describe( 'Domain: Upsell (Home)', function () {
 		await testAccount.authenticate( page );
 	} );
 
-	it( 'Domain upsell CTA is present', async function () {
+	it( 'Wait for Home dashboard to fully load', async function () {
+		// There is nothing in the front-end to key off to confirm whether the
+		// Home dashboard has fully loaded.
+		// This is a serious compromise to get the ball moving on this refactor.
+		// See: https://github.com/Automattic/wp-calypso/issues/78414
+		try {
+			// Suppress errors because the intention here is to add some wait
+			// for the Home dashboard to finish loading.
+			await page.waitForLoadState( 'networkidle' );
+		} catch {
+			// noop
+		}
+	} );
+
+	it( 'Domain upsell card is present', async function () {
 		await page
 			.getByRole( 'main' )
 			.getByRole( 'heading', { name: /domain/ } )
 			.waitFor();
-
-		domain = await page.locator( '.domain-upsell-illustration' ).innerText();
 	} );
 
-	it( 'Click on domain upsell CTA button', async function () {
+	it( 'Domain upsell card has suggested domain', async function () {
+		const locator = page.locator( '.domain-upsell-illustration' );
+		await locator.waitFor();
+		suggestedDomain = await locator.innerText();
+
+		expect( suggestedDomain ).not.toBe( '' );
+	} );
+
+	it( 'Click to begin searching for a domain', async function () {
 		await page.getByRole( 'main' ).getByRole( 'button', { name: 'Get this domain' } ).click();
+
+		// The test user does not have a plan so the Plans upsell page will load.
+		await page.waitForURL( /plans\/yearly/ );
 	} );
 
 	it( 'Choose the Free plan', async function () {
@@ -52,8 +69,10 @@ describe( 'Domain: Upsell (Home)', function () {
 		await page.getByRole( 'button', { name: 'That works for me' } ).click();
 	} );
 
-	it( 'Secure checkout loads with the selected domain', async function () {
-		cartCheckoutPage = new CartCheckoutPage( page );
-		await cartCheckoutPage.validateCartItem( domain );
+	it( 'Secure checkout loads', async function () {
+		// Intentionally not checking whether the selected domain loads here,
+		// because this spec can run in parallel in many branches thus leading
+		// to a race condition.
+		await page.waitForURL( /checkout/ );
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/77007.

## Proposed Changes

This PR refactors the `Domain Upsell: My Home` spec to be more stable.

Key changes:
- add wait before interacting with the upsell button, which is likely the source of https://github.com/Automattic/wp-calypso/issues/77007.
- remove single-purpose methods in favor of general purpose methods.

## Testing Instructions

Changes survive a 100 iteration loop:
<img width="1029" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6549265/4e83e270-df29-4640-89d8-1d08934f19dd">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
