### PR TITLE
Site Assembler: ensure only one snackbar notice is shown per unique action

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -213,7 +213,8 @@ const PatternAssembler = ( {
 	};
 
 	const showNotice = ( action: string, pattern: Pattern ) => {
-		noticeOperations.createNotice( { content: getNoticeContent( action, pattern ) } );
+		noticeOperations.removeNotice( action );
+		noticeOperations.createNotice( { id: action, content: getNoticeContent( action, pattern ) } );
 	};
 
 	const getDesign = () =>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -6,7 +6,6 @@ import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
 	__experimentalUseNavigator as useNavigator,
-	withNotices,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -33,7 +32,7 @@ import usePatternCategories from './hooks/use-pattern-categories';
 import usePatternsMapByCategory from './hooks/use-patterns-map-by-category';
 import { usePrefetchImages } from './hooks/use-prefetch-images';
 import useRecipe from './hooks/use-recipe';
-import Notices, { getNoticeContent } from './notices/notices';
+import withNotices, { NoticesProps } from './notices/notices';
 import PatternAssemblerContainer from './pattern-assembler-container';
 import PatternLargePreview from './pattern-large-preview';
 import ScreenActivation from './screen-activation';
@@ -61,9 +60,9 @@ const PatternAssembler = ( {
 	navigation,
 	flow,
 	stepName,
-	noticeList,
 	noticeOperations,
-}: StepProps & withNotices.Props ) => {
+	noticeUI,
+}: StepProps & NoticesProps ) => {
 	const translate = useTranslate();
 	const navigator = useNavigator();
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
@@ -212,11 +211,6 @@ const PatternAssembler = ( {
 		} );
 	};
 
-	const showNotice = ( action: string, pattern: Pattern ) => {
-		noticeOperations.removeNotice( action );
-		noticeOperations.createNotice( { id: action, content: getNoticeContent( action, pattern ) } );
-	};
-
 	const getDesign = () =>
 		( {
 			...selectedDesign,
@@ -238,12 +232,12 @@ const PatternAssembler = ( {
 		updateActivePatternPosition( -1 );
 		if ( pattern ) {
 			if ( header ) {
-				showNotice( 'replace', pattern );
+				noticeOperations.showPatternReplacedNotice( pattern );
 			} else {
-				showNotice( 'add', pattern );
+				noticeOperations.showPatternInsertedNotice( pattern );
 			}
 		} else if ( header ) {
-			showNotice( 'remove', header );
+			noticeOperations.showPatternRemovedNotice( header );
 		}
 	};
 
@@ -257,12 +251,12 @@ const PatternAssembler = ( {
 		activateFooterPosition( !! pattern );
 		if ( pattern ) {
 			if ( footer ) {
-				showNotice( 'replace', pattern );
+				noticeOperations.showPatternReplacedNotice( pattern );
 			} else {
-				showNotice( 'add', pattern );
+				noticeOperations.showPatternInsertedNotice( pattern );
 			}
 		} else if ( footer ) {
-			showNotice( 'remove', footer );
+			noticeOperations.showPatternRemovedNotice( footer );
 		}
 	};
 
@@ -277,7 +271,7 @@ const PatternAssembler = ( {
 				...sections.slice( sectionPosition + 1 ),
 			] );
 			updateActivePatternPosition( sectionPosition );
-			showNotice( 'replace', pattern );
+			noticeOperations.showPatternReplacedNotice( pattern );
 		}
 	};
 
@@ -290,11 +284,11 @@ const PatternAssembler = ( {
 			},
 		] );
 		updateActivePatternPosition( sections.length );
-		showNotice( 'add', pattern );
+		noticeOperations.showPatternInsertedNotice( pattern );
 	};
 
 	const deleteSection = ( position: number ) => {
-		showNotice( 'remove', sections[ position ] );
+		noticeOperations.showPatternRemovedNotice( sections[ position ] );
 		setSections( [ ...sections.slice( 0, position ), ...sections.slice( position + 1 ) ] );
 		updateActivePatternPosition( position );
 	};
@@ -565,7 +559,7 @@ const PatternAssembler = ( {
 			ref={ wrapperRef }
 			tabIndex={ -1 }
 		>
-			<Notices noticeList={ noticeList } noticeOperations={ noticeOperations } />
+			{ noticeUI }
 			<div className="pattern-assembler__sidebar">
 				<NavigatorScreen path={ NAVIGATOR_PATHS.MAIN }>
 					<ScreenMain
@@ -704,7 +698,7 @@ const PatternAssembler = ( {
 	);
 };
 
-const PatternAssemblerStep = ( props: StepProps & withNotices.Props ) => (
+const PatternAssemblerStep = ( props: StepProps & NoticesProps ) => (
 	<NavigatorProvider initialPath={ NAVIGATOR_PATHS.MAIN } tabIndex={ -1 }>
 		<PatternAssembler { ...props } />
 	</NavigatorProvider>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
@@ -1,37 +1,39 @@
-import { SnackbarList, withNotices, NoticeList } from '@wordpress/components';
+import { SnackbarList, withNotices } from '@wordpress/components';
 import i18n from 'i18n-calypso';
-import { useEffect } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import type { Pattern } from '../types';
 import './notices.scss';
 
 const NOTICE_TIMEOUT = 5000;
-
-type Notice = NoticeList.Notice & {
-	timer?: ReturnType< typeof setTimeout >;
-};
 
 const Notices = ( {
 	noticeList,
 	noticeOperations,
 }: Pick< withNotices.Props, 'noticeList' | 'noticeOperations' > ) => {
 	const onRemoveNotice = ( id: string ) => {
-		const notice = noticeList.find( ( notice ) => id === notice.id ) as Notice;
-		if ( notice?.timer ) {
-			clearTimeout( notice.timer );
-			delete notice.timer;
-		}
 		noticeOperations.removeNotice( id );
 	};
 
+	const timersByContentRef = useRef< Map< ReactNode, ReturnType< typeof setTimeout > > >(
+		new Map()
+	);
 	useEffect( () => {
-		const lastNotice = noticeList[ noticeList.length - 1 ] as Notice;
-
-		if ( lastNotice?.id && ! lastNotice?.timer ) {
-			lastNotice.timer = setTimeout(
-				() => noticeOperations.removeNotice( lastNotice.id ),
-				NOTICE_TIMEOUT
-			);
-		}
+		timersByContentRef.current.forEach( ( timer, content ) => {
+			if ( ! noticeList.some( ( notice ) => notice.content === content ) ) {
+				clearTimeout( timer );
+				timersByContentRef.current.delete( content );
+			}
+		} );
+		noticeList.forEach( ( notice ) => {
+			if ( ! timersByContentRef.current.has( notice.content ) ) {
+				timersByContentRef.current.set(
+					notice.content,
+					setTimeout( () => {
+						noticeOperations.removeNotice( notice.id );
+					}, NOTICE_TIMEOUT )
+				);
+			}
+		} );
 	}, [ noticeList, noticeOperations ] );
 
 	return <SnackbarList notices={ noticeList } onRemove={ onRemoveNotice } />;


### PR DESCRIPTION
## Fixes:

- #77645

## Proposed Changes

Currently, each action (add/replace/remove) in the pattern inserter in the Site Assembler flow triggers a snackbar notice in the bottom-right corner of the preview panel on the right. When we do many actions in a short time interval (e.g. trying out headers), this will generate noisy notices and somewhat block the preview.

This PR fixes this problem by only showing one notice per action (add/replace/remove). This is done by assigning the action itself as the ID of the notice, so that we can first remove the previous notice with the same ID before creating a new one.

## Testing Instructions

1. Go to `/setup/with-theme-assembler/patternAssembler?siteSlug=<site slug>`.
2. Try inserting and replacing header/footer many times; make sure that only one `Block pattern ... replaced` notice is shown.
3. Try inserting and removing homepage patterns many times; make sure that only one `Block pattern ... added` / `Block pattern ... `removed` notice is shown (for each add/remove).

Illustrative videos:

|Before|After|
|-|-|
|<video src="https://github.com/Automattic/wp-calypso/assets/1525580/50f9ffac-bbe8-4175-a387-62a3345a3c7a">|<video src="https://github.com/Automattic/wp-calypso/assets/1525580/b8db0eb7-6f91-46f4-b682-c0f173b99207">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
