### PR TITLE
Assembler - Survey - Show the survey in English for all users

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
@@ -1,4 +1,3 @@
-import { useLocale } from '@automattic/i18n-utils';
 import Banner from 'calypso/components/banner';
 import './survey.scss';
 
@@ -7,13 +6,6 @@ interface Props {
 }
 
 const Survey = ( { setSurveyDismissed }: Props ) => {
-	const locale = useLocale();
-
-	// We only target English locale variations
-	if ( ! locale.includes( 'en' ) ) {
-		return null;
-	}
-
 	return (
 		<Banner
 			className="pattern-assembler__survey"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77743

## Proposed Changes

* Show the survey in English for all users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch the UI language to other different than English in Account > Settings
* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3` 
* Verify that you can see the survey 

<img width="343" alt="Screenshot 2566-06-20 at 17 14 18" src="https://github.com/Automattic/wp-calypso/assets/1881481/97039b2c-14f8-489e-a64a-d06d3856b293">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
