### PR TITLE
Add signup link to WooCoreProfiler Jetpack login screen

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -438,7 +438,12 @@ class Login extends Component {
 						"Your password reset confirmation is on its way to your email address – please check your junk folder if it's not in your inbox! Once you've reset your password, head back to this page to log in to your account."
 				  )
 				: translate(
-						'In order to take advantage of the benefits offered by Jetpack, please log in to your WordPress.com account below.'
+						"In order to take advantage of the benefits offered by Jetpack, please log in to your WordPress.com account below. Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
+						{
+							components: {
+								signupLink: <a href={ this.getSignupUrl() } />,
+							},
+						}
 				  );
 			headerText = currentQuery.lostpassword_flow ? null : (
 				<h3>{ translate( 'One last step' ) }</h3>


### PR DESCRIPTION
Related to #78314

## Proposed Changes

* Adds signup link to Jetpack login screen for WooCommerce core profiler
* This does not address any styling change, as that will be addressed when https://github.com/Automattic/wp-calypso/pull/78391 is merged

## Testing Instructions

* Go to [this url](http://calypso.localhost:3000/log-in/jetpack?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D190450138%26redirect_uri%3Dhttps%253A%252F%252Filyasfoowcpay.jurassic.tube%252Fwp-admin%252Fadmin.php%253Fhandler%253Djetpack-connection-webhooks%2526action%253Dauthorize%2526_wpnonce%253D3e526f1517%2526redirect%253Dhttps%25253A%25252F%25252Filyasfoowcpay.jurassic.tube%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Dwc-admin%26state%3D1%26scope%3Dadministrator%253A03762e316bb79e73117c81a2670dabfd%26user_email%3Dwordpress%2540example.com%26user_login%3Dnrzo%26jp_version%3D12.3-a.6%26secret%3DK8HGrfxbBt6yMpfnx0h8RO6bdKu3pU3a%26blogname%3DHelloWord%2526%2523039%253Bs%26site_url%3Dhttps%253A%252F%252Filyasfoowcpay.jurassic.tube%26home_url%3Dhttps%253A%252F%252Filyasfoowcpay.jurassic.tube%26site_icon%3D%26site_lang%3Den_US%26site_created%3D2023-06-12%252005%253A44%253A13%26allow_site_connection%3D1%26_as%3Dunknown%26from%3Dwoocommerce-core-profiler%26calypso_env%3Dproduction%26_ui%3D189375772%26_ut%3Dwpcom%253Auser_id%26purchase_nonce%3DZyjFK3lz%26_wp_nonce%3D9fcf83c152%26redirect_after_auth%3Dhttps%253A%252F%252Filyasfoowcpay.jurassic.tube%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin%26site%3Dhttps%253A%252F%252Filyasfoowcpay.jurassic.tube&from=woocommerce-core-profiler)
* Click on `Sign up`
* Observe that you're redirected to sign up page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
