### PR TITLE
Always show campaign details link in campaigns table

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -17,7 +17,6 @@ import {
 	getCampaignBudgetData,
 	getCampaignStatus,
 	getCampaignStatusBadgeColor,
-	showDetails,
 } from '../../utils';
 import './style.scss';
 
@@ -71,7 +70,6 @@ export default function CampaignItem( props: Props ) {
 	const budgetString = campaignDays ? `$${ totalBudget } ${ totalBudgetLeftString }` : '-';
 	const budgetStringMobile = campaignDays ? `$${ totalBudget } budget` : null;
 
-	const shouldShowDetailsButton = showDetails( status );
 	const statusBadge = (
 		<Badge type={ getCampaignStatusBadgeColor( status ) }>{ getCampaignStatus( status ) }</Badge>
 	);
@@ -151,9 +149,7 @@ export default function CampaignItem( props: Props ) {
 			<td className="campaign-item__impressions">{ formatNumber( impressions_total ) }</td>
 			<td className="campaign-item__clicks">{ formatNumber( clicks_total ) }</td>
 			<td className="campaign-item__action">
-				{ shouldShowDetailsButton && (
-					<Button href={ openCampaignURL } isLink icon={ chevronRight } />
-				) }
+				<Button href={ openCampaignURL } isLink icon={ chevronRight } />
 			</td>
 		</tr>
 	);

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -62,15 +62,6 @@ export const getCampaignStatusBadgeColor = ( status: string ) => {
 	}
 };
 
-export const showDetails = ( status: string ) => {
-	return [
-		campaignStatus.CANCELED,
-		campaignStatus.ACTIVE,
-		campaignStatus.FINISHED,
-		campaignStatus.REJECTED,
-	].includes( status );
-};
-
 export const getCampaignStatus = ( status: string ) => {
 	switch ( status ) {
 		case campaignStatus.SCHEDULED: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

SELFSERVE-585

## Proposed Changes

it was reported that only the following states of campaigns would show the details link in campaigns table.. 
Canceled, Active, Completed, Rejected

we want to change this and show it everywhere

## Testing Instructions

Create a campaign (so that the status is not on of the above (it would be either in moderation or scheduled) and check that you can see the details link...

review code changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
