### PR TITLE
Fixes the databars in the Advertising campaign details page

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -93,7 +93,6 @@ export default function CampaignItemDetails( props: Props ) {
 		budget_left,
 		total_budget,
 		total_budget_used,
-		views_total = 0,
 		views_organic,
 	} = campaign_stats || {};
 
@@ -169,6 +168,7 @@ export default function CampaignItemDetails( props: Props ) {
 			value: views_organic || 0,
 		},
 	];
+	const databarTotal = databars.reduce( ( total, item ) => total + item.value, 0 );
 
 	const cancelCampaignButtonText =
 		status === 'active' ? __( 'Stop campaign' ) : __( 'Cancel campaign' );
@@ -428,7 +428,7 @@ export default function CampaignItemDetails( props: Props ) {
 															<HorizontalBarListItem
 																key={ `bar_${ index }` }
 																data={ item }
-																maxValue={ views_total }
+																maxValue={ databarTotal }
 																hasIndicator={ false }
 																leftSideItem={ null }
 																useShortLabel={ false }


### PR DESCRIPTION
This PR fixes the max value of the data bars in the Advertising campaign's details page

**Current behavior:**
![Screenshot 2023-06-20 at 09 22 40](https://github.com/Automattic/wp-calypso/assets/1258162/00eb85ed-f08b-41d2-9629-7e54123a48d1)

## Proposed Changes

* Fixes the total we send to the HorizontalBarListItem component

## Testing Instructions

* Open the Live preview link
* Go to Tools->Advertising and then click on Campaigns
* Go to the details page of a completed campaign
* Verify that the Traffic breakdown data bars doesn't go out of chart

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
