### PR TITLE
add/agency dashboard remove phone number functionality

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -222,7 +222,7 @@ export default function PhoneNumberEditor( {
 		handleSetPhoneItems( false );
 	}
 
-	// Remove email item when user confirms to remove the email address
+	// Remove phone item when user confirms to remove the phone number
 	const handleRemove = () => {
 		//TODO: add tracks event
 		const phoneItems = [ ...allPhoneItems ];

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -15,6 +15,7 @@ import {
 	useValidateVerificationCode,
 	useContactModalTitleAndSubtitle,
 } from '../hooks';
+import SMSItemContent from './sms-item-content';
 import type {
 	StateMonitorSettingsSMS,
 	Site,
@@ -28,6 +29,7 @@ interface Props {
 	allPhoneItems: Array< StateMonitorSettingsSMS >;
 	setAllPhoneItems: ( phoneNumbers: Array< StateMonitorSettingsSMS > ) => void;
 	setVerifiedPhoneNumber: ( item: string ) => void;
+	isRemoveAction?: boolean;
 	sites: Array< Site >;
 }
 
@@ -78,6 +80,7 @@ export default function PhoneNumberEditor( {
 	const { verifiedContacts } = useContext( DashboardDataContext );
 
 	const isVerifyAction = selectedAction === 'verify';
+	const isRemoveAction = selectedAction === 'remove';
 
 	const requestVerificationCode = useRequestVerificationCode();
 	const verifyPhoneNumber = useValidateVerificationCode();
@@ -219,8 +222,27 @@ export default function PhoneNumberEditor( {
 		handleSetPhoneItems( false );
 	}
 
+	// Remove email item when user confirms to remove the email address
+	const handleRemove = () => {
+		//TODO: add tracks event
+		const phoneItems = [ ...allPhoneItems ];
+		const phoneItemIndex = phoneItems.findIndex(
+			( item ) => item.phoneNumberFull === phoneItem.phoneNumberFull
+		);
+		if ( phoneItemIndex > -1 ) {
+			phoneItems.splice( phoneItemIndex, 1 );
+		}
+		setAllPhoneItems( phoneItems );
+		toggleModal();
+	};
+
 	const onSave = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
+
+		if ( isRemoveAction ) {
+			return handleRemove();
+		}
+
 		setValidationError( undefined );
 		if ( validationStatus.isValid ) {
 			if (
@@ -309,80 +331,88 @@ export default function PhoneNumberEditor( {
 			<div className="notification-settings__sub-title">{ subtitle }</div>
 
 			<form className="configure-contact__form" onSubmit={ onSave }>
-				<>
-					<FormFieldset>
-						<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
-						<FormTextInput
-							id="name"
-							name="name"
-							value={ phoneItem.name }
-							onChange={ handleChange( 'name' ) }
-							aria-describedby={ ! isVerifyAction ? 'name-help-text' : undefined }
-							disabled={ showCodeVerification }
-						/>
-						{ ! isVerifyAction && (
-							<div className="configure-contact__help-text" id="name-help-text">
-								{ translate( 'Give this number a name for your personal reference.' ) }
-							</div>
-						) }
-					</FormFieldset>
-					<div className="configure-contact__phone-input-container">
-						{
-							// Fetch countries list only if not available
-							noCountryList && <QuerySmsCountries />
-						}
-						<FormPhoneInput
-							isDisabled={ noCountryList || showCodeVerification }
-							countriesList={ countriesList }
-							initialCountryCode={ phoneItem.countryCode }
-							initialPhoneNumber={ phoneItem.phoneNumber }
-							onChange={ onChangePhoneInput }
-							className="configure-contact__phone-input"
-						/>
-						{ validationError?.phone && (
-							<div className="notification-settings__footer-validation-error" role="alert">
-								{ validationError?.phone }
-							</div>
-						) }
-						{ ! isVerifyAction && (
-							<div className="configure-contact__help-text" id="phone-help-text">
-								{ translate( 'We’ll send a code to verify your phone number.' ) }
-							</div>
-						) }
-					</div>
-					{ showCodeVerification && (
+				{ isRemoveAction ? (
+					selectedPhone && (
+						<div className="margin-top-16">
+							<SMSItemContent isRemoveAction item={ selectedPhone } />
+						</div>
+					)
+				) : (
+					<>
 						<FormFieldset>
-							<FormLabel htmlFor="code">
-								{ translate( 'Please enter the code you received via SMS' ) }
-							</FormLabel>
+							<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
 							<FormTextInput
-								id="code"
-								name="code"
-								value={ phoneItem.verificationCode || '' }
-								onChange={ handleChange( 'verificationCode' ) }
+								id="name"
+								name="name"
+								value={ phoneItem.name }
+								onChange={ handleChange( 'name' ) }
+								aria-describedby={ ! isVerifyAction ? 'name-help-text' : undefined }
+								disabled={ showCodeVerification }
 							/>
-							{ validationError?.verificationCode && (
-								<div className="notification-settings__footer-validation-error" role="alert">
-									{ validationError.verificationCode }
+							{ ! isVerifyAction && (
+								<div className="configure-contact__help-text" id="name-help-text">
+									{ translate( 'Give this number a name for your personal reference.' ) }
 								</div>
 							) }
-							<div className="configure-contact__help-text" id="code-help-text">
-								{ helpText ??
-									translate(
-										'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
-										translationArgs
-									) }
-							</div>
 						</FormFieldset>
-					) }
-				</>
+						<div className="configure-contact__phone-input-container">
+							{
+								// Fetch countries list only if not available
+								noCountryList && <QuerySmsCountries />
+							}
+							<FormPhoneInput
+								isDisabled={ noCountryList || showCodeVerification }
+								countriesList={ countriesList }
+								initialCountryCode={ phoneItem.countryCode }
+								initialPhoneNumber={ phoneItem.phoneNumber }
+								onChange={ onChangePhoneInput }
+								className="configure-contact__phone-input"
+							/>
+							{ validationError?.phone && (
+								<div className="notification-settings__footer-validation-error" role="alert">
+									{ validationError?.phone }
+								</div>
+							) }
+							{ ! isVerifyAction && (
+								<div className="configure-contact__help-text" id="phone-help-text">
+									{ translate( 'We’ll send a code to verify your phone number.' ) }
+								</div>
+							) }
+						</div>
+						{ showCodeVerification && (
+							<FormFieldset>
+								<FormLabel htmlFor="code">
+									{ translate( 'Please enter the code you received via SMS' ) }
+								</FormLabel>
+								<FormTextInput
+									id="code"
+									name="code"
+									value={ phoneItem.verificationCode || '' }
+									onChange={ handleChange( 'verificationCode' ) }
+								/>
+								{ validationError?.verificationCode && (
+									<div className="notification-settings__footer-validation-error" role="alert">
+										{ validationError.verificationCode }
+									</div>
+								) }
+								<div className="configure-contact__help-text" id="code-help-text">
+									{ helpText ??
+										translate(
+											'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
+											translationArgs
+										) }
+								</div>
+							</FormFieldset>
+						) }
+					</>
+				) }
 				<div className="notification-settings__footer">
 					<div className="notification-settings__footer-buttons">
 						<Button onClick={ showCodeVerification ? onSaveLater : toggleModal }>
 							{ showCodeVerification ? translate( 'Later' ) : translate( 'Back' ) }
 						</Button>
 						<Button disabled={ isDisabled } type="submit" primary>
-							{ verificationButtonTitle }
+							{ isRemoveAction ? translate( 'Remove' ) : verificationButtonTitle }
 						</Button>
 					</div>
 				</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/sms-item-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/sms-item-content.tsx
@@ -17,6 +17,7 @@ interface Props {
 	toggleModal?: ( item?: StateMonitorSettingsSMS, action?: AllowedMonitorContactActions ) => void;
 	recordEvent?: ( action: string, params?: object ) => void;
 	showVerifiedBadge?: boolean;
+	isRemoveAction?: boolean;
 }
 
 const EVENT_NAMES = {
@@ -101,12 +102,7 @@ export default function SMSItemContent( {
 					<PopoverMenuItem onClick={ () => handleToggleModal( 'edit' ) }>
 						{ translate( 'Edit' ) }
 					</PopoverMenuItem>
-					<PopoverMenuItem
-						onClick={ () => {
-							//TODO handle actions
-							return null;
-						} }
-					>
+					<PopoverMenuItem onClick={ () => handleToggleModal( 'remove' ) }>
 						{ translate( 'Remove' ) }
 					</PopoverMenuItem>
 				</PopoverMenu>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/sms-item-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/sms-item-content.tsx
@@ -31,6 +31,7 @@ export default function SMSItemContent( {
 	toggleModal,
 	recordEvent,
 	showVerifiedBadge,
+	isRemoveAction = false,
 }: Props ) {
 	const translate = useTranslate();
 	const [ isOpen, setIsOpen ] = useState( false );
@@ -61,51 +62,59 @@ export default function SMSItemContent( {
 					<div className="configure-contact-info__card-heading">{ item.phoneNumberFull }</div>
 					<div className="configure-contact-info__card-sub-heading">{ item.name }</div>
 				</span>
+				{
+					// Show the status and actions only if the action is not remove.
+				 }
+				{ ! isRemoveAction && (
+					<>
+						{ ! isVerified && (
+							<span
+								role="button"
+								tabIndex={ 0 }
+								onKeyPress={ () => handleToggleModal( 'verify' ) }
+								onClick={ () => handleToggleModal( 'verify' ) }
+								className="configure-contact-info__verification-status cursor-pointer"
+							>
+								<Badge type="warning">{ translate( 'Pending' ) }</Badge>
+							</span>
+						) }
+						{ showVerifiedBadge && isVerified && (
+							<span className="configure-contact-info__verification-status">
+								<Badge type="success">{ translate( 'Verified' ) }</Badge>
+							</span>
+						) }
+						<>
+							<Button
+								compact
+								borderless
+								className="configure-contact-info__action-icon"
+								onClick={ showActions }
+								aria-label={ translate( 'More actions' ) }
+								ref={ buttonActionRef }
+							>
+								<Icon size={ 18 } icon={ moreHorizontal } />
+							</Button>
+							<PopoverMenu
+								className="configure-contact-info__popover-menu"
+								context={ buttonActionRef.current }
+								isVisible={ isOpen }
+								onClose={ closeDropdown }
+								position="bottom left"
+							>
+								<PopoverMenuItem onClick={ () => handleToggleModal( 'verify' ) }>
+									{ translate( 'Verify' ) }
+								</PopoverMenuItem>
 
-				{ ! isVerified && (
-					<span
-						role="button"
-						tabIndex={ 0 }
-						onKeyPress={ () => handleToggleModal( 'verify' ) }
-						onClick={ () => handleToggleModal( 'verify' ) }
-						className="configure-contact-info__verification-status cursor-pointer"
-					>
-						<Badge type="warning">{ translate( 'Pending' ) }</Badge>
-					</span>
+								<PopoverMenuItem onClick={ () => handleToggleModal( 'edit' ) }>
+									{ translate( 'Edit' ) }
+								</PopoverMenuItem>
+								<PopoverMenuItem onClick={ () => handleToggleModal( 'remove' ) }>
+									{ translate( 'Remove' ) }
+								</PopoverMenuItem>
+							</PopoverMenu>
+						</>
+					</>
 				) }
-				{ showVerifiedBadge && isVerified && (
-					<span className="configure-contact-info__verification-status">
-						<Badge type="success">{ translate( 'Verified' ) }</Badge>
-					</span>
-				) }
-				<Button
-					compact
-					borderless
-					className="configure-contact-info__action-icon"
-					onClick={ showActions }
-					aria-label={ translate( 'More actions' ) }
-					ref={ buttonActionRef }
-				>
-					<Icon size={ 18 } icon={ moreHorizontal } />
-				</Button>
-				<PopoverMenu
-					className="configure-contact-info__popover-menu"
-					context={ buttonActionRef.current }
-					isVisible={ isOpen }
-					onClose={ closeDropdown }
-					position="bottom left"
-				>
-					<PopoverMenuItem onClick={ () => handleToggleModal( 'verify' ) }>
-						{ translate( 'Verify' ) }
-					</PopoverMenuItem>
-
-					<PopoverMenuItem onClick={ () => handleToggleModal( 'edit' ) }>
-						{ translate( 'Edit' ) }
-					</PopoverMenuItem>
-					<PopoverMenuItem onClick={ () => handleToggleModal( 'remove' ) }>
-						{ translate( 'Remove' ) }
-					</PopoverMenuItem>
-				</PopoverMenu>
 			</div>
 		</Card>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
@@ -170,8 +170,8 @@ export function useContactModalTitleAndSubtitle(
 					subtitle: translate( 'If you update your number, you’ll need to verify it.' ),
 				},
 				remove: {
-					title: '',
-					subtitle: '',
+					title: translate( 'Remove Phone Number' ),
+					subtitle: translate( 'Are you sure you want to remove this phone number?' ),
 				},
 				verify: {
 					title: translate( 'Verify your phone number' ),


### PR DESCRIPTION
Related to # 1204774821045518-as-1204783884585808/f

## Proposed Changes

* This PR enables the remove SMS number functionality to the agency dashboard downtime notification settings

![Screenshot 2023-06-20 at 8 49 00 AM](https://github.com/Automattic/wp-calypso/assets/12895386/e41c7e1f-cfcf-4586-94e8-b7adb0139ee7)


## Testing Instructions

* Use the jetpack cloud live link below to access the dashboard, or apply this PR locally
* You'll need to be an agency partner to test this
* If not enabled, click the slider to enable SMS notifications, add a contact number if one does not exist
* Click the ... menu to the right of the contact once it's added and select remove
* You should see the modal from the screenshot above.  Click the remove button to remove the number. 
* You will then be taken back to the settings modal which should no longer have that number listed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?