### PR TITLE
`/read/subscriptions`: Add success notice, and refresh the subscriptions list, after subscribing to a recommended site

### DIFF
--- a/client/state/reader/follows/actions.js
+++ b/client/state/reader/follows/actions.js
@@ -44,6 +44,7 @@ import 'calypso/state/reader/init';
  * @typedef {Object} RecommendedSiteInfo
  * @property {number} seed - Random number for the recommendation logic
  * @property {number} siteId - Identifier of the recommended site
+ * @property {string} siteTitle - Title of the recommended site
  */
 
 /**

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -1,4 +1,4 @@
-import { useSubscriberEmailAddress, useIsLoggedIn } from './hooks';
+import { useSubscriberEmailAddress, useIsLoggedIn, useCacheKey } from './hooks';
 import {
 	usePostUnsubscribeMutation,
 	useSiteDeliveryFrequencyMutation,
@@ -45,6 +45,7 @@ export const SubscriptionManager = {
 	useSiteEmailMeNewCommentsMutation,
 	useIsLoggedIn,
 	useSiteSubscriptionDetailsQuery,
+	useCacheKey,
 };
 
 export {


### PR DESCRIPTION
![Screen Capture on 2023-06-20 at 16-23-20](https://github.com/Automattic/wp-calypso/assets/2019970/71c86f4e-c9d3-4ab0-93d5-4bbf3010ebb0)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/78431
Closes https://github.com/Automattic/wp-calypso/issues/78432

## Proposed Changes

* Introduce the `useInvalidateSiteSubscriptionsCache` which is a custom hook that clears the `react-query` cache for site subscriptions once a subscribe operation is complete. It uses the loading state (`isSubscribeLoading`) to detect when the operation finishes. If the state transitions from loading to not loading, it invalidates the cache by using `react-query`'s `queryClient.invalidateQueries()`. This is necessary because of the disconnection between the state management systems of the site subscriptions list (using react-query) and the reader (using `redux` with `data-layer` middleware).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/read/subscriptions
* Subscribe to a recommended site
* Ensure that the success notice appears once the subscribe action completes, and that the site subscriptions list now includes the newly subscribed-to site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
