### PR TITLE
Reader: Update discover tags stream layout

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -20,6 +20,7 @@ import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
 import isReaderCardExpanded from 'calypso/state/selectors/is-reader-card-expanded';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
+import PostByline from './byline';
 import ConversationPost from './conversation-post';
 import GalleryPost from './gallery';
 import PhotoPost from './photo';
@@ -115,12 +116,13 @@ class ReaderPostCard extends Component {
 			currentRoute,
 			post,
 			discoverPost,
-			discoverSite,
 			site,
 			feed,
 			onCommentClick,
+			showPrimaryFollowButton,
 			isSelected,
 			showSiteName,
+			followSource,
 			isDiscoverStream,
 			postKey,
 			isExpanded,
@@ -141,7 +143,6 @@ class ReaderPostCard extends Component {
 		const isDiscover = post.is_discover;
 		const title = truncate( post.title, { length: 140, separator: /,? +/ } );
 		const isReaderTagPage = currentRoute.startsWith( '/tag/' );
-		const isReaderDiscoverPage = currentRoute.startsWith( '/discover' );
 		const isReaderSearchPage = currentRoute.startsWith( '/read/search' );
 		const classes = classnames( 'reader-post-card', {
 			'has-thumbnail': !! post.canonical_media,
@@ -152,7 +153,7 @@ class ReaderPostCard extends Component {
 			'is-seen': isSeen,
 			'is-expanded-video': isVideo && isExpanded,
 			'is-compact': compact,
-			'is-tag-post': isReaderTagPage || isReaderDiscoverPage,
+			'is-tag-post': isReaderTagPage || isDiscoverStream,
 		} );
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -174,37 +175,19 @@ class ReaderPostCard extends Component {
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 		// Set up post byline
-		let postByline;
-
-		if ( isDiscoverStream && discoverPost && discoverSite ) {
-			// create a post like object with some props from the discover post
-			const postForByline = Object.assign( {}, discoverPost || {}, {
-				date: post.date,
-				URL: post.URL,
-				primary_tag: post.primary_tag,
-			} );
-			postByline = (
-				<PostByline
-					post={ postForByline }
-					site={ discoverSite }
-					showSiteName={ true }
-					teams={ teams }
-					showFollow={ ! isDiscover }
-				/>
-			);
-		} else {
-			postByline = (
-				<PostByline
-					post={ post }
-					site={ site }
-					feed={ feed }
-					showSiteName={ showSiteName || isDiscover }
-					showAvatar={ ! compact }
-					teams={ teams }
-					showFollow={ ! isDiscover }
-				/>
-			);
-		}
+		const postByline = (
+			<PostByline
+				post={ post }
+				site={ site }
+				feed={ feed }
+				showSiteName={ showSiteName || isDiscover }
+				showAvatar={ ! compact }
+				teams={ teams }
+				showFollow={ ! isDiscover }
+				showPrimaryFollowButton={ showPrimaryFollowButton }
+				followSource={ followSource }
+			/>
+		);
 
 		// Set up post card
 		let readerPostCard;
@@ -214,11 +197,12 @@ class ReaderPostCard extends Component {
 					post={ post }
 					title={ title }
 					isDiscover={ isDiscover }
+					postByline={ postByline }
 					commentIds={ postKey.comments }
 					onClick={ this.handleCardClick }
 				/>
 			);
-		} else if ( isReaderTagPage || isReaderDiscoverPage ) {
+		} else if ( isReaderTagPage || isDiscoverStream ) {
 			readerPostCard = (
 				<TagPost
 					post={ post }
@@ -278,7 +262,7 @@ class ReaderPostCard extends Component {
 		const onClick = ! isPhotoPost && ! compact ? this.handleCardClick : noop;
 		return (
 			<Card className={ classes } onClick={ onClick } tagName="article">
-				{ ! compact && ! isReaderTagPage && postByline }
+				{ ! compact && ! isReaderTagPage && ! isDiscoverStream && postByline }
 				{ readerPostCard }
 				{ this.props.children }
 			</Card>

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -20,7 +20,6 @@ import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
 import isReaderCardExpanded from 'calypso/state/selectors/is-reader-card-expanded';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
-import PostByline from './byline';
 import ConversationPost from './conversation-post';
 import GalleryPost from './gallery';
 import PhotoPost from './photo';
@@ -142,6 +141,7 @@ class ReaderPostCard extends Component {
 		const isDiscover = post.is_discover;
 		const title = truncate( post.title, { length: 140, separator: /,? +/ } );
 		const isReaderTagPage = currentRoute.startsWith( '/tag/' );
+		const isReaderDiscoverPage = currentRoute.startsWith( '/discover' );
 		const isReaderSearchPage = currentRoute.startsWith( '/read/search' );
 		const classes = classnames( 'reader-post-card', {
 			'has-thumbnail': !! post.canonical_media,
@@ -152,7 +152,7 @@ class ReaderPostCard extends Component {
 			'is-seen': isSeen,
 			'is-expanded-video': isVideo && isExpanded,
 			'is-compact': compact,
-			'is-tag-post': isReaderTagPage,
+			'is-tag-post': isReaderTagPage || isReaderDiscoverPage,
 		} );
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -214,12 +214,11 @@ class ReaderPostCard extends Component {
 					post={ post }
 					title={ title }
 					isDiscover={ isDiscover }
-					postByline={ postByline }
 					commentIds={ postKey.comments }
 					onClick={ this.handleCardClick }
 				/>
 			);
-		} else if ( isReaderTagPage ) {
+		} else if ( isReaderTagPage || isReaderDiscoverPage ) {
 			readerPostCard = (
 				<TagPost
 					post={ post }


### PR DESCRIPTION
This PR fixes the Reader discover tags stream layout to copy what we use on the tag pages.

### Before
<img width="650" alt="Screenshot 2023-06-20 at 14 04 12" src="https://github.com/Automattic/wp-calypso/assets/5560595/933ef6a8-e008-4006-a25b-e5eada1373fd">

### After
<img width="1040" alt="Screenshot 2023-06-20 at 16 41 24" src="https://github.com/Automattic/wp-calypso/assets/5560595/5aceb035-0b5a-4a43-be23-02cc8c0973a0">

### Scope
 
I'm not sure if this PR should update the `Recommended` tab post stream to have the same layout as the tags post stream. 

<img width="667" alt="Screenshot 2023-06-20 at 16 44 19" src="https://github.com/Automattic/wp-calypso/assets/5560595/3def8e83-b5b1-4a83-bb87-5f89dbf2699d">

The post stream use different post components.

* The `Recommended` tab uses the `RelatedPostCard` component
* The tags tabs use the `ReaderPostCard` component



