### PR TITLE
Reader discover - use refs to manage navigation scroll position

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -1,7 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
 import { translate } from 'i18n-calypso';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import SegmentedControl from 'calypso/components/segmented-control';
 import wpcom from 'calypso/lib/wp';
 import Stream from 'calypso/reader/stream';
@@ -47,14 +47,25 @@ const DiscoverStream = ( props ) => {
 		scrollPosition.current = scrollRef.current?.scrollLeft;
 	};
 
-	// Set the scroll position of the navigation tabs to what we last tracked.
-	if ( scrollRef.current ) {
+	// Set the scroll position and focus of navigation tabs when selected tab changes and this
+	// component is forced to rerender.
+	useEffect( () => {
 		// Set 0 timeout to put this at the end of the callstack so it happens after the children
 		// rerender.
 		setTimeout( () => {
-			scrollRef.current.scrollLeft = scrollPosition.current;
+			// Ignore the recommended tab since this is set on load and is next to the reset point.
+			if ( selectedTab !== 'recommended' ) {
+				const selectedElement = document.querySelector(
+					'.discover-stream__tabs .segmented-control__item.is-selected .segmented-control__link'
+				);
+				selectedElement && selectedElement.focus();
+
+				if ( scrollRef.current ) {
+					scrollRef.current.scrollLeft = scrollPosition.current;
+				}
+			}
 		}, 0 );
-	}
+	}, [ selectedTab ] );
 
 	const DiscoverNavigation = () => (
 		<div className="discover-stream__tabs" ref={ scrollRef } onScroll={ trackScrollPosition }>

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -72,7 +72,7 @@ const DiscoverStream = ( props ) => {
 			<SegmentedControl primary className="discover-stream__tab-control">
 				<SegmentedControl.Item
 					key={ DEFAULT_TAB }
-					selected={ DEFAULT_TAB === selectedTab }
+					selected={ isDefaultTab }
 					onClick={ () => setSelectedTab( DEFAULT_TAB ) }
 				>
 					{ translate( 'Recommended' ) }

--- a/client/reader/discover/discover-stream.scss
+++ b/client/reader/discover/discover-stream.scss
@@ -1,11 +1,11 @@
 .is-discover-stream {
-	.segmented-control.is-primary.discover-stream__tab-control {
+	.discover-stream__tabs {
 		overflow-x: scroll;
 		margin-bottom: 20px;
 		padding-bottom: 15px;
 		border-bottom: 1px solid var(--color-neutral-5);
 
-		.segmented-control__item .segmented-control__link {
+		.segmented-control.is-primary.discover-stream__tab-control .segmented-control__item .segmented-control__link {
 			border: 1px solid var(--color-neutral-10);
 			border-radius: 4px;
 			margin: 0 5px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* uses some refs to track and set scroll position of the navigation tabs.
* ensures scroll position and focus state of the navigation is preserved after it is forced to rerender.

![scroll-not-reset](https://github.com/Automattic/wp-calypso/assets/28742426/c7f94df1-a85b-417c-bfb2-91b65894131c)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run this calypso branch locally (calypso live wont work since discover is not yet enabled there)
* navigate to the reader and discover sections
* mess with the tabs at the top and select other feeds, verify the scroll position and tab focus do not reset on selection.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
