### PR TITLE
Subscribers Page: Passing the `page` prop as integer to Pagination component in Subscribers Page

### DIFF
--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -87,7 +87,7 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 
 				<Pagination
 					className="subscribers__pagination"
-					page={ page }
+					page={ pageNumber }
 					perPage={ per_page }
 					total={ total }
 					pageClick={ pageClickCallback }


### PR DESCRIPTION
## Proposed Changes

This PR fixes a problem with the Pagination component on the Subscribers Page:

## Testing Instructions

1. Apply this PR and start the application.
2. Go to `http://calypso.localhost:3000/subscribers/{the domain of your site}`.
3. You should not see this error message in the console:
<img width="433" alt="Screenshot 2023-06-20 at 18 35 59" src="https://github.com/Automattic/wp-calypso/assets/3832570/e8a0896b-fb17-4798-9ebf-6ac0da12ce0a">

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
