### PR TITLE
Update order of Jetpack products on the pricing page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/utils/get-sorted-displayable-products.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/utils/get-sorted-displayable-products.ts
@@ -15,15 +15,15 @@ const setProductsInPosition = ( slugs: ReadonlyArray< string >, position: number
 	slugs.reduce( ( map, slug ) => ( { ...map, [ slug ]: position } ), {} );
 
 const DISPLAYABLE_PRODUCT_POSITION_MAP: Record< string, number > = {
-	...setProductsInPosition( JETPACK_BACKUP_PRODUCTS, 1 ),
-	...setProductsInPosition( JETPACK_VIDEOPRESS_PRODUCTS, 2 ),
-	...setProductsInPosition( JETPACK_SOCIAL_PRODUCTS, 3 ),
-	...setProductsInPosition( JETPACK_BOOST_PRODUCTS, 4 ),
-	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 5 ),
+	...setProductsInPosition( JETPACK_AI_PRODUCTS, 1 ),
+	...setProductsInPosition( JETPACK_BACKUP_PRODUCTS, 2 ),
+	...setProductsInPosition( JETPACK_BOOST_PRODUCTS, 3 ),
+	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 4 ),
+	...setProductsInPosition( JETPACK_SOCIAL_PRODUCTS, 5 ),
 	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 6 ),
-	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 7 ),
+	...setProductsInPosition( JETPACK_VIDEOPRESS_PRODUCTS, 7 ),
 	...setProductsInPosition( JETPACK_CRM_PRODUCTS, 8 ),
-	...setProductsInPosition( JETPACK_AI_PRODUCTS, 9 ),
+	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 9 ),
 };
 
 const sortByProductPosition = ( productA: SelectorProduct, productB: SelectorProduct ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1198218726984184-as-1204856810750978

## Proposed Changes

* Reorder products on the Jetpack pricing page so they have the following order:

**Left column**
- AI 
- Boost 
- Social 
- VideoPress 
- Search

**Right column**
- Backup
- Scan
- Anti-spam
- CRM

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Jetpack Cloud live link
* Go to the pricing page (`/pricing`)
* Confirm that it matches the order mentioned above and the screenshot below

Before | After
--- | ---
<img width="1212" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5714212/3caa8057-b7c1-4475-8753-e2ec886d996d"> | <img width="1210" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5714212/b6cc1dea-ba44-4227-836e-3003ade072bd">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?