### PR TITLE
BackupBrowser: Add plugins/themes backed up version

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -83,7 +83,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 	};
 
 	const nodeClassName = classNames( 'file-browser-node', { 'is-alternate': isAlternate } );
-	const [ label, isLabelTruncated ] = useTruncatedFileName( item.name, 30 );
+	const [ label, isLabelTruncated ] = useTruncatedFileName( item.name, 30, item.type );
 
 	return (
 		<div className={ nodeClassName }>

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-type-icon.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-type-icon.tsx
@@ -32,6 +32,7 @@ const fileTypeToIcon: Record< FileType, JSX.Element > = {
 	code: pages,
 	wordpress: wordpress,
 	other: pages,
+	archive: file,
 };
 
 const FileTypeIcon: FunctionComponent< FileTypeIconProps > = ( { type } ) => {

--- a/client/my-sites/backup/backup-contents-page/file-browser/hooks.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/hooks.ts
@@ -1,11 +1,17 @@
 import { getFileExtension } from 'calypso/lib/media/utils/get-file-extension';
+import { FileType } from './types';
 
 type TruncatedFileNameResult = [ string, boolean ];
 
 export const useTruncatedFileName = (
 	name: string,
-	maxLength: number
+	maxLength: number,
+	type: FileType
 ): TruncatedFileNameResult => {
+	if ( type === 'archive' ) {
+		return [ name, false ];
+	}
+
 	const isTruncated = name.length > maxLength;
 	const extension = getFileExtension( name ) || '';
 	const basename = name.replace( `.${ extension }`, '' );

--- a/client/my-sites/backup/backup-contents-page/file-browser/test/hooks.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/test/hooks.ts
@@ -9,7 +9,7 @@ import { useTruncatedFileName } from '../hooks';
 describe( 'useTruncatedFileName', () => {
 	test( 'returns original name when name length is less than max length', () => {
 		const { result } = renderHook( () =>
-			useTruncatedFileName( 'this-is-a-very-long-filename', 30 )
+			useTruncatedFileName( 'this-is-a-very-long-filename', 30, 'text' )
 		);
 
 		expect( result.current[ 0 ] ).toBe( 'this-is-a-very-long-filename' );
@@ -18,7 +18,7 @@ describe( 'useTruncatedFileName', () => {
 
 	test( 'returns truncated name when name length exceeds max length with extension', () => {
 		const { result } = renderHook( () =>
-			useTruncatedFileName( 'this-is-a-very-long-filename.mp3', 30 )
+			useTruncatedFileName( 'this-is-a-very-long-filename.mp3', 30, 'text' )
 		);
 
 		const expectedTruncatedName = 'this-is-a-very-long-file...mp3';
@@ -28,7 +28,7 @@ describe( 'useTruncatedFileName', () => {
 
 	test( 'returns truncated name when name length exceeds max length without extension', () => {
 		const { result } = renderHook( () =>
-			useTruncatedFileName( 'this-is-a-very-very-very-long-filename', 30 )
+			useTruncatedFileName( 'this-is-a-very-very-very-long-filename', 30, 'text' )
 		);
 
 		const expectedTruncatedName = 'this-is-a-very-very-very-lo...';
@@ -38,7 +38,7 @@ describe( 'useTruncatedFileName', () => {
 
 	test( 'truncated name should maintain file extension if exists', () => {
 		const { result } = renderHook( () =>
-			useTruncatedFileName( 'this-is-a-very-long-filename.mp3', 30 )
+			useTruncatedFileName( 'this-is-a-very-long-filename.mp3', 30, 'text' )
 		);
 
 		const extension = getFileExtension( result.current[ 0 ] );
@@ -47,10 +47,19 @@ describe( 'useTruncatedFileName', () => {
 
 	test( 'truncated name should have no extension when original name has no extension', () => {
 		const { result } = renderHook( () =>
-			useTruncatedFileName( 'this-is-a-very-very-very-long-filename', 30 )
+			useTruncatedFileName( 'this-is-a-very-very-very-long-filename', 30, 'text' )
 		);
 
 		const extension = getFileExtension( result.current[ 0 ] );
 		expect( extension ).toBe( '' );
+	} );
+
+	test( 'returns original name when file type is archive', () => {
+		const { result } = renderHook( () =>
+			useTruncatedFileName( 'original version 15.8.1 from WordPress.org', 30, 'archive' )
+		);
+
+		expect( result.current[ 0 ] ).toBe( 'original version 15.8.1 from WordPress.org' );
+		expect( result.current[ 1 ] ).toBe( false );
 	} );
 } );

--- a/client/my-sites/backup/backup-contents-page/file-browser/types.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/types.ts
@@ -1,4 +1,4 @@
-export type ApiFileType = 'file' | 'dir' | 'wordpress' | 'table' | 'theme' | 'plugin';
+export type ApiFileType = 'file' | 'dir' | 'wordpress' | 'table' | 'theme' | 'plugin' | 'archive';
 export type FileType =
 	| 'dir'
 	| 'image'
@@ -12,6 +12,7 @@ export type FileType =
 	| 'translations'
 	| 'code'
 	| 'wordpress'
+	| 'archive'
 	| 'other';
 
 export interface FileBrowserItem {
@@ -36,5 +37,6 @@ export interface BackupLsResponseContents {
 		period?: string;
 		sort?: number;
 		manifest_path?: string;
+		label?: string;
 	};
 }

--- a/client/my-sites/backup/backup-contents-page/file-browser/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/util.ts
@@ -50,6 +50,7 @@ export const transformFileType = (
 		case 'theme':
 		case 'plugin':
 		case 'table':
+		case 'archive':
 			return item.type;
 		case 'file':
 			if ( item.has_children ) {
@@ -69,13 +70,15 @@ export const parseBackupContentsData = ( payload: BackupLsResponse ): FileBrowse
 
 	const transformedData = Object.entries( payload.contents ).map( ( [ name, item ] ) => {
 		const type = transformFileType( name, item );
+		const label = item.label ?? name;
 
 		return {
-			name,
+			name: label,
 			type,
 			hasChildren: item.has_children ?? false,
 			...( item.period && { period: item.period } ),
 			...( item.sort && { sort: item.sort } ),
+			...( item.type === 'archive' && { extension_type: name.replace( '*', '' ) } ),
 		};
 	} );
 


### PR DESCRIPTION
## Proposed Changes

* Map `archive` FileType and assign a folder icon.
* Add new `extension_type` item prop which will receive `changed` or `unchanged` if the item is an `archive`. This will be useful to determine which backup we want to download, the original plugin or the plugin with changes.
* Modify truncate logic to not truncate `archive`'s.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start a Jetpack Cloud or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Click on `Actions (+)` and then on `View files` button to access the backup contents page.
* Navigate through plugins or themes and click on one of these.
* You should see one (or two) items with a folder icon that cannot be expanded similar to one of these:
![image](https://github.com/Automattic/wp-calypso/assets/1488641/aac9f95a-1fe8-4d5e-b2f4-cb29f40dc3dc)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
