### PR TITLE
Subscribers Page: Fix missing translation for navigation item

### DIFF
--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -41,8 +41,8 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 
 	const navigationItems: Item[] = [
 		{
-			label: 'Subscribers',
-			href: `/subscribers`,
+			label: translate( 'Subscribers' ),
+			href: `/subscribers/${ selectedSiteSlug }`,
 			helpBubble: (
 				<span>
 					{ translate(


### PR DESCRIPTION
## Proposed Changes

* Fixes missing translation for Subscribers navigation item on the subscribers page header
* Fixes the item href for consistency 

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/subscribers/testmusicandcoffee.wordpress.com
* Verify if the page is rendered as expected
* Change the locale of your user
* Go back to the page and verify if the header is translated

<img width="408" alt="Screenshot 2023-06-20 at 18 49 45" src="https://github.com/Automattic/wp-calypso/assets/3113712/f9fde2c3-2152-4a86-a8b5-56c6c61e345c">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
