### PR TITLE
SiteSelector: Redirect to `/backup` when switching site while on backup contents page

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -504,7 +504,7 @@ const navigateToSite =
 				}
 
 				// Jetpack Cloud: default to /backups/ when in the details of a particular backup
-				if ( path.match( /^\/backup\/.*\/(download|restore|detail)/ ) ) {
+				if ( path.match( /^\/backup\/.*\/(download|restore|contents)/ ) ) {
 					return '/backup';
 				}
 
@@ -564,7 +564,7 @@ const navigateToSite =
 			}
 
 			// Jetpack Cloud: default to /backups/ when in the details of a particular backup
-			if ( path.match( /^\/backup\/.*\/(download|restore|detail)/ ) ) {
+			if ( path.match( /^\/backup\/.*\/(download|restore|contents)/ ) ) {
 				path = '/backup';
 			}
 


### PR DESCRIPTION
Currently, when the user switches site while on backup contents page, it is throwing a message like `Invalid Date`. This is because it is replacing the `rewindId` parameter with the site slug of the new selected site.

Similar to `/backup/:site/download` and `/backup/:site/restore`, we want the customer to be redirected to the main backup page (`/backup/`) when the user switches site. This fix is to include `/backup/:site/contents` to the redirect rule on `navigateToSite()` in `SiteSelector` component.

We don't have any [`/backup/:site/detail` path configured](https://github.com/Automattic/wp-calypso/blob/55414496b4734adf16b5255b2de3f4d3e7ed54ed/client/my-sites/backup/paths.ts#L1), so we are replacing it with `contents`.

## Proposed Changes

* Add `contents` to the rule to redirect to `/backup/` when the user switches site.

## Testing Instructions

* Start a Jetpack Cloud or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Click on `Actions (+)` and then on `View files` button to access the backup contents page.
* Try switching to another site using the sidebar.
* Ensure it is redirected back to the main backup page `/backup/`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
