### PR TITLE
Add a button redirects to Block Theme Previews PoC

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -106,15 +106,15 @@ import './style.scss';
 const LivePreviewButton = ( {
 	isActive,
 	isAtomic,
-	isFullSiteEditingTheme,
 	siteSlug,
 	stylesheet,
+	showTryAndCustomize,
 	themeType,
 } ) => {
 	if ( isActive ) {
 		return null;
 	}
-	if ( ! isFullSiteEditingTheme ) {
+	if ( showTryAndCustomize ) {
 		return null;
 	}
 	if ( isAtomic ) {
@@ -631,10 +631,10 @@ class ThemeSheet extends Component {
 			translate,
 			siteSlug,
 			themeType,
-			isFullSiteEditingTheme,
 			stylesheet,
 			isAtomic,
 			isActive,
+			showTryAndCustomize,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -658,9 +658,9 @@ class ThemeSheet extends Component {
 							<LivePreviewButton
 								isActive={ isActive }
 								isAtomic={ isAtomic }
-								isFullSiteEditingTheme={ isFullSiteEditingTheme }
 								siteSlug={ siteSlug }
 								stylesheet={ stylesheet }
+								showTryAndCustomize={ showTryAndCustomize }
 								themeType={ themeType }
 							></LivePreviewButton>
 						) }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -71,6 +71,7 @@ import {
 	themeStartActivationSync as themeStartActivationSyncAction,
 } from 'calypso/state/themes/actions';
 import {
+	getThemeType,
 	doesThemeBundleSoftwareSet,
 	isThemeActive,
 	isThemePremium,
@@ -100,6 +101,31 @@ import ThemeNotFoundError from './theme-not-found-error';
 import ThemeStyleVariations from './theme-style-variations';
 
 import './style.scss';
+
+// WIP
+const LivePreviewButton = ( { siteSlug, themeId, themeType } ) => {
+	let themePath = '';
+	switch ( themeType ) {
+		case 'free':
+			themePath = 'pub/';
+			break;
+		case 'premium':
+			themePath = 'premium/';
+			break;
+	}
+
+	if ( themePath === '' ) {
+		return null;
+	}
+
+	return (
+		<Button
+			href={ `https://${ siteSlug }/wp-admin/site-editor.php?theme_preview=${ themePath }${ themeId }` }
+		>
+			Live Preview (PoC)
+		</Button>
+	);
+};
 
 const noop = () => {};
 
@@ -593,7 +619,17 @@ class ThemeSheet extends Component {
 	};
 
 	renderHeader = () => {
-		const { author, isWPForTeamsSite, name, retired, softLaunched, translate } = this.props;
+		const {
+			author,
+			isWPForTeamsSite,
+			name,
+			retired,
+			softLaunched,
+			translate,
+			themeId,
+			siteSlug,
+			themeType,
+		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
 		const tag = author ? translate( 'by %(author)s', { args: { author: author } } ) : placeholder;
@@ -612,6 +648,13 @@ class ThemeSheet extends Component {
 						<span className="theme__sheet-main-info-tag">{ tag }</span>
 					</div>
 					<div className="theme__sheet-main-actions">
+						{ /* TODO: feature flag */ }
+						{ /* WIP */ }
+						<LivePreviewButton
+							siteSlug={ siteSlug }
+							themeId={ themeId }
+							themeType={ themeType }
+						></LivePreviewButton>
 						{ shouldRenderButton &&
 							( this.shouldRenderUnlockStyleButton()
 								? this.renderUnlockStyleButton()
@@ -1491,8 +1534,13 @@ export default connect(
 		const isMarketplaceThemeSubscribed =
 			isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, theme?.id, siteId );
 
+		// TODO: feature flag
+		// WIP
+		const themeType = getThemeType( state, themeId );
+
 		return {
 			...theme,
+			themeType,
 			themeId,
 			price: getPremiumThemePrice( state, themeId, siteId ),
 			error,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -103,29 +103,17 @@ import ThemeStyleVariations from './theme-style-variations';
 
 import './style.scss';
 
-const LivePreviewButton = ( { siteSlug, themeId, themeType, isFullSiteEditingTheme } ) => {
+const LivePreviewButton = ( { siteSlug, themeType, isFullSiteEditingTheme, stylesheet } ) => {
 	if ( ! isFullSiteEditingTheme ) {
 		return null;
 	}
 
-	let themePath = '';
-	switch ( themeType ) {
-		case 'free':
-			themePath = 'pub/';
-			break;
-		case 'premium':
-			themePath = 'premium/';
-			break;
-	}
-
-	if ( themePath === '' ) {
+	if ( themeType !== 'free' && themeType !== 'premium' ) {
 		return null;
 	}
 
 	return (
-		<Button
-			href={ `https://${ siteSlug }/wp-admin/site-editor.php?theme_preview=${ themePath }${ themeId }` }
-		>
+		<Button href={ `https://${ siteSlug }/wp-admin/site-editor.php?theme_preview=${ stylesheet }` }>
 			Live Preview (PoC)
 		</Button>
 	);
@@ -630,10 +618,10 @@ class ThemeSheet extends Component {
 			retired,
 			softLaunched,
 			translate,
-			themeId,
 			siteSlug,
 			themeType,
 			isFullSiteEditingTheme,
+			stylesheet,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -656,9 +644,9 @@ class ThemeSheet extends Component {
 						{ config.isEnabled( 'themes/block-theme-previews-poc' ) && (
 							<LivePreviewButton
 								siteSlug={ siteSlug }
-								themeId={ themeId }
 								themeType={ themeType }
 								isFullSiteEditingTheme={ isFullSiteEditingTheme }
+								stylesheet={ stylesheet }
 							></LivePreviewButton>
 						) }
 						{ shouldRenderButton &&

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -71,7 +71,6 @@ import {
 	themeStartActivationSync as themeStartActivationSyncAction,
 } from 'calypso/state/themes/actions';
 import {
-	getThemeType,
 	doesThemeBundleSoftwareSet,
 	isThemeActive,
 	isThemePremium,
@@ -631,7 +630,6 @@ class ThemeSheet extends Component {
 			softLaunched,
 			translate,
 			siteSlug,
-			themeType,
 			stylesheet,
 			isAtomic,
 			isActive,
@@ -666,7 +664,6 @@ class ThemeSheet extends Component {
 								showTryAndCustomize={ showTryAndCustomize }
 								siteSlug={ siteSlug }
 								stylesheet={ stylesheet }
-								themeType={ themeType }
 							></LivePreviewButton>
 						) }
 						{ shouldRenderButton &&
@@ -1548,16 +1545,12 @@ export default connect(
 		const isMarketplaceThemeSubscribed =
 			isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, theme?.id, siteId );
 
-		const themeType = config.isEnabled( 'themes/block-theme-previews-poc' )
-			? getThemeType( state, themeId )
-			: undefined;
 		const isFullSiteEditingTheme = config.isEnabled( 'themes/block-theme-previews-poc' )
 			? getIsFullSiteEditingTheme( state, themeId )
 			: undefined;
 
 		return {
 			...theme,
-			themeType,
 			themeId,
 			price: getPremiumThemePrice( state, themeId, siteId ),
 			error,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -104,12 +104,16 @@ import ThemeStyleVariations from './theme-style-variations';
 import './style.scss';
 
 const LivePreviewButton = ( {
-	siteSlug,
-	themeType,
-	isFullSiteEditingTheme,
-	stylesheet,
+	isActive,
 	isAtomic,
+	isFullSiteEditingTheme,
+	siteSlug,
+	stylesheet,
+	themeType,
 } ) => {
+	if ( isActive ) {
+		return null;
+	}
 	if ( ! isFullSiteEditingTheme ) {
 		return null;
 	}
@@ -630,6 +634,7 @@ class ThemeSheet extends Component {
 			isFullSiteEditingTheme,
 			stylesheet,
 			isAtomic,
+			isActive,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -651,11 +656,12 @@ class ThemeSheet extends Component {
 					<div className="theme__sheet-main-actions">
 						{ config.isEnabled( 'themes/block-theme-previews-poc' ) && (
 							<LivePreviewButton
-								siteSlug={ siteSlug }
-								themeType={ themeType }
-								isFullSiteEditingTheme={ isFullSiteEditingTheme }
-								stylesheet={ stylesheet }
+								isActive={ isActive }
 								isAtomic={ isAtomic }
+								isFullSiteEditingTheme={ isFullSiteEditingTheme }
+								siteSlug={ siteSlug }
+								stylesheet={ stylesheet }
+								themeType={ themeType }
 							></LivePreviewButton>
 						) }
 						{ shouldRenderButton &&

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -106,10 +106,11 @@ import './style.scss';
 const LivePreviewButton = ( {
 	isActive,
 	isAtomic,
+	isExternallyManagedTheme,
+	isWporg,
+	showTryAndCustomize,
 	siteSlug,
 	stylesheet,
-	showTryAndCustomize,
-	themeType,
 } ) => {
 	if ( isActive ) {
 		return null;
@@ -120,7 +121,7 @@ const LivePreviewButton = ( {
 	if ( isAtomic ) {
 		return null;
 	}
-	if ( themeType !== 'free' && themeType !== 'premium' ) {
+	if ( isExternallyManagedTheme || isWporg ) {
 		return null;
 	}
 	return (
@@ -635,6 +636,8 @@ class ThemeSheet extends Component {
 			isAtomic,
 			isActive,
 			showTryAndCustomize,
+			isExternallyManagedTheme,
+			isWporg,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -658,9 +661,11 @@ class ThemeSheet extends Component {
 							<LivePreviewButton
 								isActive={ isActive }
 								isAtomic={ isAtomic }
+								isExternallyManagedTheme={ isExternallyManagedTheme }
+								isWporg={ isWporg }
+								showTryAndCustomize={ showTryAndCustomize }
 								siteSlug={ siteSlug }
 								stylesheet={ stylesheet }
-								showTryAndCustomize={ showTryAndCustomize }
 								themeType={ themeType }
 							></LivePreviewButton>
 						) }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -636,8 +636,6 @@ class ThemeSheet extends Component {
 		const tag = author ? translate( 'by %(author)s', { args: { author: author } } ) : placeholder;
 		const shouldRenderButton = ! retired && ! isWPForTeamsSite && ! this.shouldRenderForStaging();
 
-		// console.log( { themeType, 'this.props': this.props } );
-
 		return (
 			<div className="theme__sheet-header">
 				<div className="theme__sheet-main">

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -102,7 +102,6 @@ import ThemeStyleVariations from './theme-style-variations';
 
 import './style.scss';
 
-// WIP
 const LivePreviewButton = ( { siteSlug, themeId, themeType } ) => {
 	let themePath = '';
 	switch ( themeType ) {
@@ -648,13 +647,13 @@ class ThemeSheet extends Component {
 						<span className="theme__sheet-main-info-tag">{ tag }</span>
 					</div>
 					<div className="theme__sheet-main-actions">
-						{ /* TODO: feature flag */ }
-						{ /* WIP */ }
-						<LivePreviewButton
-							siteSlug={ siteSlug }
-							themeId={ themeId }
-							themeType={ themeType }
-						></LivePreviewButton>
+						{ config.isEnabled( 'themes/block-theme-previews-poc' ) && (
+							<LivePreviewButton
+								siteSlug={ siteSlug }
+								themeId={ themeId }
+								themeType={ themeType }
+							></LivePreviewButton>
+						) }
 						{ shouldRenderButton &&
 							( this.shouldRenderUnlockStyleButton()
 								? this.renderUnlockStyleButton()
@@ -1534,9 +1533,9 @@ export default connect(
 		const isMarketplaceThemeSubscribed =
 			isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, theme?.id, siteId );
 
-		// TODO: feature flag
-		// WIP
-		const themeType = getThemeType( state, themeId );
+		const themeType = config.isEnabled( 'themes/block-theme-previews-poc' )
+			? getThemeType( state, themeId )
+			: undefined;
 
 		return {
 			...theme,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -90,6 +90,7 @@ import {
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
 	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
 	isThemeActivationSyncStarted as getIsThemeActivationSyncStarted,
+	isFullSiteEditingTheme as getIsFullSiteEditingTheme,
 } from 'calypso/state/themes/selectors';
 import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-cart';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
@@ -102,7 +103,11 @@ import ThemeStyleVariations from './theme-style-variations';
 
 import './style.scss';
 
-const LivePreviewButton = ( { siteSlug, themeId, themeType } ) => {
+const LivePreviewButton = ( { siteSlug, themeId, themeType, isFullSiteEditingTheme } ) => {
+	if ( ! isFullSiteEditingTheme ) {
+		return null;
+	}
+
 	let themePath = '';
 	switch ( themeType ) {
 		case 'free':
@@ -628,6 +633,7 @@ class ThemeSheet extends Component {
 			themeId,
 			siteSlug,
 			themeType,
+			isFullSiteEditingTheme,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -652,6 +658,7 @@ class ThemeSheet extends Component {
 								siteSlug={ siteSlug }
 								themeId={ themeId }
 								themeType={ themeType }
+								isFullSiteEditingTheme={ isFullSiteEditingTheme }
 							></LivePreviewButton>
 						) }
 						{ shouldRenderButton &&
@@ -1536,6 +1543,9 @@ export default connect(
 		const themeType = config.isEnabled( 'themes/block-theme-previews-poc' )
 			? getThemeType( state, themeId )
 			: undefined;
+		const isFullSiteEditingTheme = config.isEnabled( 'themes/block-theme-previews-poc' )
+			? getIsFullSiteEditingTheme( state, themeId )
+			: undefined;
 
 		return {
 			...theme,
@@ -1553,6 +1563,7 @@ export default connect(
 			productionSiteSlug,
 			isLoggedIn: isUserLoggedIn( state ),
 			isActive: isThemeActive( state, themeId, siteId ),
+			isFullSiteEditingTheme,
 			isJetpack,
 			isAtomic,
 			isStandaloneJetpack,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -103,15 +103,22 @@ import ThemeStyleVariations from './theme-style-variations';
 
 import './style.scss';
 
-const LivePreviewButton = ( { siteSlug, themeType, isFullSiteEditingTheme, stylesheet } ) => {
+const LivePreviewButton = ( {
+	siteSlug,
+	themeType,
+	isFullSiteEditingTheme,
+	stylesheet,
+	isAtomic,
+} ) => {
 	if ( ! isFullSiteEditingTheme ) {
 		return null;
 	}
-
+	if ( isAtomic ) {
+		return null;
+	}
 	if ( themeType !== 'free' && themeType !== 'premium' ) {
 		return null;
 	}
-
 	return (
 		<Button href={ `https://${ siteSlug }/wp-admin/site-editor.php?theme_preview=${ stylesheet }` }>
 			Live Preview (PoC)
@@ -622,11 +629,14 @@ class ThemeSheet extends Component {
 			themeType,
 			isFullSiteEditingTheme,
 			stylesheet,
+			isAtomic,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
 		const tag = author ? translate( 'by %(author)s', { args: { author: author } } ) : placeholder;
 		const shouldRenderButton = ! retired && ! isWPForTeamsSite && ! this.shouldRenderForStaging();
+
+		// console.log( { themeType, 'this.props': this.props } );
 
 		return (
 			<div className="theme__sheet-header">
@@ -647,6 +657,7 @@ class ThemeSheet extends Component {
 								themeType={ themeType }
 								isFullSiteEditingTheme={ isFullSiteEditingTheme }
 								stylesheet={ stylesheet }
+								isAtomic={ isAtomic }
 							></LivePreviewButton>
 						) }
 						{ shouldRenderButton &&

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -89,7 +89,6 @@ import {
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
 	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
 	isThemeActivationSyncStarted as getIsThemeActivationSyncStarted,
-	isFullSiteEditingTheme as getIsFullSiteEditingTheme,
 } from 'calypso/state/themes/selectors';
 import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-cart';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
@@ -1545,10 +1544,6 @@ export default connect(
 		const isMarketplaceThemeSubscribed =
 			isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, theme?.id, siteId );
 
-		const isFullSiteEditingTheme = config.isEnabled( 'themes/block-theme-previews-poc' )
-			? getIsFullSiteEditingTheme( state, themeId )
-			: undefined;
-
 		return {
 			...theme,
 			themeId,
@@ -1564,7 +1559,6 @@ export default connect(
 			productionSiteSlug,
 			isLoggedIn: isUserLoggedIn( state ),
 			isActive: isThemeActive( state, themeId, siteId ),
-			isFullSiteEditingTheme,
 			isJetpack,
 			isAtomic,
 			isStandaloneJetpack,

--- a/config/development.json
+++ b/config/development.json
@@ -194,6 +194,7 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
+		"themes/block-theme-previews-poc": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/interlaced-dotorg-themes": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -132,6 +132,7 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
+		"themes/block-theme-previews-poc": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,

--- a/config/production.json
+++ b/config/production.json
@@ -158,6 +158,7 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
+		"themes/block-theme-previews-poc": false,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -151,6 +151,7 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
+		"themes/block-theme-previews-poc": false,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -163,6 +163,7 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
+		"themes/block-theme-previews-poc": false,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/interlaced-dotorg-themes": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -163,7 +163,7 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews-poc": false,
+		"themes/block-theme-previews-poc": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/interlaced-dotorg-themes": true,
 		"themes/premium": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2594

## Proposed Changes

Add a "Live Preview" button that redirects to Block Theme Previews PoC (Simple sites with free and premium themes only. See https://github.com/Automattic/wp-calypso/pull/78456#discussion_r1236280871).

This makes it easier to test BTP PoC for every stakeholder.
c.f. p1687306954328429/1687248220.835539-slack-CRWCHQGUB

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Theme Showcase page
* Select any theme
* See the "Live Preview (PoC)" button

| before | after |
|--------|--------|
| <img width="1433" alt="Screen Shot 2023-06-21 at 14 12 07" src="https://github.com/Automattic/wp-calypso/assets/5287479/3682f0be-941f-4218-b0fb-98f78042d0cd"> | <img width="1432" alt="Screen Shot 2023-06-21 at 14 15 52" src="https://github.com/Automattic/wp-calypso/assets/5287479/8dc69aa3-36ff-422a-a9e5-c7590ad410e0"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?