### PR TITLE
NewHostedSiteOptions: Pass empty array as query key to avoid console error

### DIFF
--- a/client/landing/stepper/hooks/use-get-site-suggestions-query.ts
+++ b/client/landing/stepper/hooks/use-get-site-suggestions-query.ts
@@ -32,7 +32,7 @@ export const useGetSiteSuggestionsQuery = ( {
 		refetchOnWindowFocus,
 		enabled,
 		onSuccess,
-		queryKey: [],
+		queryKey: [ 'site-suggestions' ],
 		meta: {
 			persist: false,
 		},

--- a/client/landing/stepper/hooks/use-get-site-suggestions-query.ts
+++ b/client/landing/stepper/hooks/use-get-site-suggestions-query.ts
@@ -32,6 +32,7 @@ export const useGetSiteSuggestionsQuery = ( {
 		refetchOnWindowFocus,
 		enabled,
 		onSuccess,
+		queryKey: [],
 		meta: {
 			persist: false,
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to n/a

I found this when testing `/start/hosting`. It happens when you get to the hosting options:

<img width="1003" alt="Screenshot 2566-06-21 at 13 25 50" src="https://github.com/Automattic/wp-calypso/assets/6851384/3855b2d9-6fdd-4032-a5ec-f123bf0a2130">

## Proposed Changes

* Pass an empty array as `queryKey` to make React Query happy

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On trunk, go to `/setup/new-hosted-site/options?source=sites-dashboard&ref=topbar&hosting-flow=true`
* Verify there is an error in the console as shown above
* Switch to this branch and then repeat step one and verify there is no longer an error. 
* Verify that you can keep regenerating suggestions, as before. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
