### PR TITLE
CI: do not trigger WebApp and WPComTests builds when non-code files are updated.

### DIFF
--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -26,7 +26,6 @@ open class WPComPluginBuild(
 	var buildSteps: BuildSteps.() -> Unit = {},
 	var buildParams: ParametrizedWithType.() -> Unit = {},
 ) : BuildType() {
- the
 	init {
 		// This block allows us to use variable names without having to prefix them with `this.@WPComPluginBuild.`
 		val workingDir = "apps/$pluginSlug"
@@ -63,6 +62,7 @@ open class WPComPluginBuild(
 				triggerRules = """
 					-:test/e2e/**.md
 					-:docs/**.md
+					-:comment=stress test:**
 				""".trimIndent()
 			}
 		}

--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -26,7 +26,7 @@ open class WPComPluginBuild(
 	var buildSteps: BuildSteps.() -> Unit = {},
 	var buildParams: ParametrizedWithType.() -> Unit = {},
 ) : BuildType() {
-
+ the
 	init {
 		// This block allows us to use variable names without having to prefix them with `this.@WPComPluginBuild.`
 		val workingDir = "apps/$pluginSlug"
@@ -57,9 +57,13 @@ open class WPComPluginBuild(
 		triggers {
 			vcs {
 				branchFilter = """
-				+:*
-				-:pull*
-			""".trimIndent()
+					+:*
+					-:pull*
+				""".trimIndent()
+				triggerRules = """
+					-:test/e2e/**.md
+					-:docs/**.md
+				""".trimIndent()
 			}
 		}
 

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -100,7 +100,7 @@ object BuildDockerImage : BuildType({
 
 		// We want calypso.live and Calypso e2e tests to run even if there's a merge conflict,
 		// just to keep things going. However, if we can merge, the webpack cache
-		// can be better utilized, since it's kept up-to-date for trunk commits. 
+		// can be better utilized, since it's kept up-to-date for trunk commits.
 		// Note that this only happens on non-trunk
 		mergeTrunk( skipIfConflict = true )
 
@@ -396,7 +396,7 @@ object RunAllUnitTests : BuildType({
 						return 1
 					fi
 				}
-				
+
 				function prevent_duplicated_packages {
 					if ! DUPLICATED_PACKAGES=${'$'}(
 						set +e
@@ -753,6 +753,9 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 					+:*
 					-:pull*
 					-:trunk
+				""".trimIndent()
+				triggerRules = """
+					-::**.md5
 				""".trimIndent()
 			}
 		},

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -755,7 +755,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 					-:trunk
 				""".trimIndent()
 				triggerRules = """
-					-::**.md5
+					-:**.md
 				""".trimIndent()
 			}
 		},


### PR DESCRIPTION
## Proposed Changes

This PR adds some trigger conditions to builds that we know clogs up the queue.

While the WPComPlugin refactor project is on hold, this is a small change we can make that should be safe and helps reduce the number of builds in the queue somewhat.

Key changes:
- do not trigger Plugin and E2E builds on document (`.md`) changes.
- similar to above, do not trigger Plugin builds on changes that include the term "stress test" (this is something I often do while fixing E2Es).

If there are other clauses that are safe to add, please let me know.

## Testing Instructions

TeamCity config should should work fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
