### PR TITLE
Site Transfers: Support going back from site ownership transfer 2nd to 1st step

### DIFF
--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useState } from 'react';
 import { useQueryUserPurchases } from 'calypso/components/data/query-user-purchases';
 import { ResponseDomain } from 'calypso/lib/domains/types';
@@ -61,17 +62,24 @@ const SiteOwnerTransfer = () => {
 		return null;
 	}
 
-	const backHref = '/settings/general/' + selectedSite.slug;
+	const onBackClick = () => {
+		if ( ! pendingDomain && ! newSiteOwner ) {
+			page( '/settings/general/' + selectedSite.slug );
+		} else {
+			setNewSiteOwner( '' );
+		}
+	};
+
 	if ( confirmationHash ) {
 		return (
-			<SiteTransferCard backHref={ backHref }>
+			<SiteTransferCard onClick={ onBackClick }>
 				<ConfirmationTransfer siteId={ selectedSite.ID } confirmationHash={ confirmationHash } />
 			</SiteTransferCard>
 		);
 	}
 
 	return (
-		<SiteTransferCard backHref={ backHref }>
+		<SiteTransferCard onClick={ onBackClick }>
 			{ pendingDomain && <PendingDomainTransfer domain={ pendingDomain } /> }
 			{ ! pendingDomain && ! newSiteOwner && (
 				<SiteOwnerTransferEligibility

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
@@ -63,10 +63,10 @@ const SiteOwnerTransfer = () => {
 	}
 
 	const onBackClick = () => {
-		if ( ! pendingDomain && ! newSiteOwner ) {
-			page( '/settings/general/' + selectedSite.slug );
-		} else {
+		if ( ! pendingDomain && newSiteOwner && ! transferSiteSuccess ) {
 			setNewSiteOwner( '' );
+		} else {
+			page( '/settings/general/' + selectedSite.slug );
 		}
 	};
 

--- a/client/my-sites/site-settings/site-owner-transfer/site-transfer-card.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-transfer-card.tsx
@@ -17,10 +17,10 @@ const ActionPanelStyled = styled( ActionPanel )( {
 
 export function SiteTransferCard( {
 	children,
-	backHref,
+	onClick,
 }: {
 	children: React.ReactNode;
-	backHref: string;
+	onClick: () => void;
 } ) {
 	const translate = useTranslate();
 	return (
@@ -42,7 +42,7 @@ export function SiteTransferCard( {
 				path="/settings/start-site-transfer/:site"
 				title="Settings > Start Site Transfer"
 			/>
-			<HeaderCake backHref={ backHref } isCompact={ true }>
+			<HeaderCake onClick={ onClick } isCompact={ true }>
 				<h1>{ translate( 'Site Transfer' ) }</h1>
 			</HeaderCake>
 			<ActionPanelStyled>{ children }</ActionPanelStyled>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2794

## Proposed Changes

In this PR, I propose to change "Back" button behavior to point from the 2nd to 1st step, and not to General Settings

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Click “Transfer your site”
2. Choose administrator on the list, click “Continue”
3. Read the transfer confirmation text and change your mind about the new site owner
4. Click “Back”
5. Confirm that you see the first step of site ownership transfer and you can choose another administrator

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
