### PR TITLE
New Hosting Options: show visual feedback when generating suggestion

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -1,5 +1,5 @@
 import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
-import { Button, FormInputValidation } from '@automattic/components';
+import { Button, FormInputValidation, Spinner } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useSelect } from '@wordpress/data';
@@ -45,7 +45,7 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 
 	const [ shouldOverrideSiteTitle, setShouldOverrideSiteTitle ] = useState( false );
 
-	const { refetch } = useGetSiteSuggestionsQuery( {
+	const { refetch, isFetching } = useGetSiteSuggestionsQuery( {
 		enabled: shouldOverrideSiteTitle,
 		refetchOnWindowFocus: false,
 		onSuccess: ( response ) => {
@@ -133,8 +133,13 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 						} }
 						aria-label={ translate( 'Generate a random site name' ) }
 					>
-						<Icon icon={ shuffle } fill="currentColor" />
-						{ ! isSmallScreen && translate( 'Generate' ) }
+						{ ! isFetching && (
+							<>
+								<Icon icon={ shuffle } fill="currentColor" />
+								{ ! isSmallScreen && translate( 'Generate' ) }
+							</>
+						) }
+						{ isFetching && <Spinner size={ 16 } /> }
 					</Button>
 				</div>
 				{ siteTitleError ? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to n/a

I found this when testing our hosting flows:

**Trunk**

https://github.com/Automattic/wp-calypso/assets/6851384/f64168db-8256-4150-95c0-6c2d4fb032db

**This branch**

https://github.com/Automattic/wp-calypso/assets/6851384/a8820758-f347-4644-8e5f-a22babf18938 


## Proposed Changes

* Show a Spinner when a new suggestion is being fetched so it's clear your clicked was registered

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On trunk, go to `/setup/new-hosted-site/options?source=sites-dashboard&ref=topbar&hosting-flow=true`
* Click generate and see the name is generated but there is not visual feedback
* On this branch, repeat step one, and you should now see a Spinner control. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors? (yes, and fix one with https://github.com/Automattic/wp-calypso/pull/78459)
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?