### PR TITLE
Jetpack Pro Dashboard: Implement save phone numbers & SMS notification toggle status for downtime monitoring

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -225,8 +225,10 @@ export function useUpdateMonitorSettings( sites: Array< { blog_id: number; url: 
 									...site.monitor_settings,
 									monitor_deferment_time: data.settings.jetmon_defer_status_down_minutes,
 									monitor_user_email_notifications: data.settings.email_notifications,
+									monitor_user_sms_notifications: data.settings.sms_notifications,
 									monitor_user_wp_note_notifications: data.settings.wp_note_notifications,
 									monitor_notify_additional_user_emails: data.settings.contacts?.emails ?? [],
+									monitor_notify_additional_user_sms: data.settings.contacts?.sms_numbers ?? [],
 								},
 							};
 						}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -25,8 +25,17 @@ interface MonitorContactEmail {
 	email_address: string;
 	verified: boolean;
 }
+interface MonitorContactSMS {
+	name: string;
+	sms_number: string;
+	number: string;
+	country_code: string;
+	country_numeric_code: string;
+	verified: boolean;
+}
 interface MonitorContacts {
-	emails: Array< MonitorContactEmail >;
+	emails?: Array< MonitorContactEmail >;
+	sms_numbers?: Array< MonitorContactSMS >;
 }
 
 export interface MonitorSettings {
@@ -36,8 +45,10 @@ export interface MonitorSettings {
 	monitor_deferment_time: number;
 	monitor_user_emails: Array< string >;
 	monitor_user_email_notifications: boolean;
+	monitor_user_sms_notifications: boolean;
 	monitor_user_wp_note_notifications: boolean;
 	monitor_notify_additional_user_emails: Array< MonitorContactEmail >;
+	monitor_notify_additional_user_sms: Array< MonitorContactSMS >;
 }
 
 interface StatsObject {
@@ -240,6 +251,7 @@ export interface UpdateMonitorSettingsAPIResponse {
 	success: boolean;
 	settings: {
 		email_notifications: boolean;
+		sms_notifications: boolean;
 		wp_note_notifications: boolean;
 		jetmon_defer_status_down_minutes: number;
 		contacts?: MonitorContacts;
@@ -249,6 +261,7 @@ export interface UpdateMonitorSettingsAPIResponse {
 export interface UpdateMonitorSettingsParams {
 	wp_note_notifications?: boolean;
 	email_notifications?: boolean;
+	sms_notifications?: boolean;
 	jetmon_defer_status_down_minutes?: number;
 	contacts?: MonitorContacts;
 }


### PR DESCRIPTION
Related to 1204774821045518-as-1204793235199845

## Proposed Changes

This PR implements save the phone numbers & SMS notification toggle. 

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/save-monitor-phone-numbers` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Click on the Mobile notification toggle, and click the `+ Add phone number` button -> Enter all the fields -> Click the `Verify` button -> Now click the `Later` button.
6. Click the `Save` button.
7. Click the clock icon next to the monitor toggle on the same site and verify the monitor notification toggle and added email is listed. Refresh the page and verify the same is shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?