### PR TITLE
Assembler - Metrics - Use calypso_signup_pattern_assembler_pattern_add_click only for button to Add patterns 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -1,7 +1,7 @@
 export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const SITE_TAGLINE = 'Site Tagline';
-export const PATTERN_TYPES = [ 'header', 'footer', 'section' ];
+
 // Workaround to put the category All in the first position using featured as slug
 export const CATEGORY_ALL_SLUG = 'featured';
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -24,7 +24,7 @@ import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { recordSelectedDesign, getAssemblerSource } from '../../analytics/record-design';
-import { SITE_TAGLINE, PATTERN_TYPES, NAVIGATOR_PATHS, CATEGORY_ALL_SLUG } from './constants';
+import { SITE_TAGLINE, NAVIGATOR_PATHS, CATEGORY_ALL_SLUG } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import useCategoryAll from './hooks/use-category-all';
 import useDotcomPatterns from './hooks/use-dotcom-patterns';
@@ -487,10 +487,6 @@ const PatternAssembler = ( {
 	};
 
 	const onMainItemSelect = ( name: string ) => {
-		if ( PATTERN_TYPES.includes( name ) ) {
-			trackEventPatternAdd( name );
-		}
-
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.MAIN_ITEM_SELECT, { name } );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to PekYwv-WG-p2

## Proposed Changes

- Use the tracks event `calypso_signup_pattern_assembler_pattern_add_click` only for the button to "Add patterns"

This event was meant for the old UI:

![image](https://github.com/Automattic/wp-calypso/assets/1881481/4118334f-52b8-46b5-8f28-45879fd8ddb4)

I propose to not use it for `Header` and `Footer` buttons because on the new UI we use the event `calypso_signup_pattern_assembler_main_item_select` so it seems forced/duplicated to keep using the old event here too. 

I updated the metrics posts to show the `calypso_signup_pattern_assembler_pattern_add_click` duplication and register the event `calypso_signup_pattern_assembler_main_item_select` for the new UI:

<img width="685" alt="Screenshot 2566-06-21 at 15 22 33" src="https://github.com/Automattic/wp-calypso/assets/1881481/5648531a-4469-4ced-a364-a40bd14cb452">

<img width="919" alt="Screenshot 2566-06-21 at 15 29 28" src="https://github.com/Automattic/wp-calypso/assets/1881481/6acf0a23-0f88-4fa7-9e9b-3a781ce616b3">

I'll update the metrics post again after this PR is accepted.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3`
* Click on "Header" and "Footer" to verify that the event `calypso_signup_pattern_assembler_pattern_add_click` is **not** triggered
* Click on "Homepage" > click on a category > click on a pattern > click on "Back" > click on "Homepage" again > click the button `[ + ] Add patterns` to verify that the event `calypso_signup_pattern_assembler_pattern_add_click` is triggered with the prop `pattern_type: section`.

https://github.com/Automattic/wp-calypso/assets/1881481/b91e0478-0427-4758-8b1e-37292f980e39


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?