### PR TITLE
Theme Card: Make theme type badge focusable

### DIFF
--- a/client/components/theme-type-badge/index.tsx
+++ b/client/components/theme-type-badge/index.tsx
@@ -65,6 +65,8 @@ const ThemeTypeBadge = ( {
 			/>
 		),
 		tooltipPosition: 'top',
+		focusOnShow: false,
+		isClickable: true,
 	};
 
 	let badgeContent;

--- a/packages/design-picker/src/components/premium-badge/index.tsx
+++ b/packages/design-picker/src/components/premium-badge/index.tsx
@@ -1,7 +1,7 @@
 import { Gridicon, Popover } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import './style.scss';
 
@@ -16,6 +16,7 @@ interface BadgeProps {
 	shouldHideIcon?: boolean;
 	shouldHideTooltip?: boolean;
 	focusOnShow?: boolean;
+	isClickable?: boolean;
 }
 
 const PremiumBadge = ( {
@@ -29,6 +30,7 @@ const PremiumBadge = ( {
 	shouldHideIcon,
 	shouldHideTooltip,
 	focusOnShow,
+	isClickable,
 }: BadgeProps ) => {
 	const { __ } = useI18n();
 
@@ -45,21 +47,55 @@ const PremiumBadge = ( {
 	const divRef = useRef( null );
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const [ isHovered, setIsHovered ] = useState( false );
+	const [ isPressed, setIsPressed ] = useState( false );
+
+	const isClickableProps = useMemo( () => {
+		if ( ! isClickable ) {
+			return {};
+		}
+
+		return {
+			role: 'button',
+			tabIndex: 0,
+			onBlur: () => {
+				setIsPressed( false );
+				setIsPopoverVisible( false );
+			},
+			onClick: () => {
+				setIsPressed( ! isPopoverVisible );
+				setIsPopoverVisible( ! isPopoverVisible );
+			},
+			onKeyDown: ( event: React.KeyboardEvent ) => {
+				if ( event.key === 'Enter' || event.key === ' ' ) {
+					event.preventDefault();
+					setIsPressed( ! isPopoverVisible );
+					setIsPopoverVisible( ! isPopoverVisible );
+				}
+			},
+		};
+	}, [ isClickable, isPopoverVisible ] );
+
 	return (
 		<div
 			className={ classNames( 'premium-badge', className, {
 				'premium-badge__compact-animation': shouldCompactWithAnimation,
 				'premium-badge--compact': shouldCompactWithAnimation && ! isHovered,
+				'premium-badge--is-clickable': isClickable,
 			} ) }
 			ref={ divRef }
 			onMouseEnter={ () => {
-				setIsPopoverVisible( true );
-				setIsHovered( true );
+				if ( ! isPressed ) {
+					setIsPopoverVisible( true );
+					setIsHovered( true );
+				}
 			} }
 			onMouseLeave={ () => {
-				setIsPopoverVisible( false );
-				setIsHovered( false );
+				if ( ! isPressed ) {
+					setIsPopoverVisible( false );
+					setIsHovered( false );
+				}
 			} }
+			{ ...isClickableProps }
 		>
 			{ ! shouldHideIcon && (
 				<>

--- a/packages/design-picker/src/components/premium-badge/style.scss
+++ b/packages/design-picker/src/components/premium-badge/style.scss
@@ -12,6 +12,14 @@
 	background: var(--studio-black);
 	z-index: 1;
 
+	&--is-clickable {
+		cursor: pointer;
+
+		.accessible-focus &:focus {
+			box-shadow: 0 0 0 2px var(--color-primary-light);
+		}
+	}
+
 	.design-picker .design-picker__option-meta & {
 		min-height: 0;
 	}

--- a/packages/design-picker/src/components/woocommerce-bundled-badge/style.scss
+++ b/packages/design-picker/src/components/woocommerce-bundled-badge/style.scss
@@ -13,6 +13,14 @@
 	background: var(--woocommerce-purple-50);
 	z-index: 1;
 
+	&--is-clickable {
+		cursor: pointer;
+
+		.accessible-focus &:focus {
+			box-shadow: 0 0 0 2px var(--color-primary-light);
+		}
+	}
+
 	svg {
 		height: 20px;
 		margin-right: 5px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75444

## Proposed Changes

This PR updates the theme type badge so that it's keyboard navigable. When the badge is focused, the badge tooltip will be shown. For this PR, I have not made the text "Free" navigable since it has no tooltips, we can explore in a later PR how to improve its accessibility.

![Screenshot 2023-06-21 at 6 28 39 PM](https://github.com/Automattic/wp-calypso/assets/797888/5e642024-7419-4a11-b3bd-8ba5c9007e76)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Using keyboard navigation, ensure that the theme badge is focusable.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
