### PR TITLE
Fix traffic breakdown margin for BlazePress' Campaign details

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -168,7 +168,9 @@ export default function CampaignItemDetails( props: Props ) {
 			value: views_organic || 0,
 		},
 	];
-	const databarTotal = databars.reduce( ( total, item ) => total + item.value, 0 );
+	const databarTotal = databars
+		.map( ( item ) => ( item.value > 0 ? item.value : 0 ) ) // Get only positive values.
+		.reduce( ( total, value ) => total + value, 0 );
 
 	const cancelCampaignButtonText =
 		status === 'active' ? __( 'Stop campaign' ) : __( 'Cancel campaign' );

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -168,9 +168,11 @@ export default function CampaignItemDetails( props: Props ) {
 			value: views_organic || 0,
 		},
 	];
-	const databarTotal = databars
-		.map( ( item ) => ( item.value > 0 ? item.value : 0 ) ) // Get only positive values.
-		.reduce( ( total, value ) => total + value, 0 );
+
+	const databarTotal = databars.reduce(
+		( total, { value } ) => ( value > 0 ? total + value : total ), // Sum only positive values.
+		0
+	);
 
 	const cancelCampaignButtonText =
 		status === 'active' ? __( 'Stop campaign' ) : __( 'Cancel campaign' );

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -161,12 +161,16 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 
 			.horizontal-bar-list {
 				margin-bottom: 10px;
+
+				.horizontal-bar-list-item-bar {
+					padding-left: 8px;
+				}
 			}
 
 			.horizontal-bar-list-item {
 				padding: 0;
 				margin-bottom: 8px;
-				padding-right: 4px;
+				padding-right: 8px;
 
 				&:last-child {
 					.horizontal-bar-list-item-bar {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to SELFSERVE-561

## Proposed Changes

* Adjust padding for left and right to `8px`,

![image](https://github.com/Automattic/wp-calypso/assets/115007291/b6ad4a8a-07ac-464e-ba68-c1e29871a3b2)

* Make sure we do not consider negative values while calculating total.

![image](https://github.com/Automattic/wp-calypso/assets/115007291/8573dfc2-9e53-4131-b1c1-91ee4a44f6e8)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch in your local dev. environment
* Build assets (`yarn && yarn start`)
* Make up Ad/Organic data [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx#L161-L170) like:
<img width="361" alt="image" src="https://github.com/Automattic/wp-calypso/assets/115007291/877173dd-07e9-4c20-ac27-b30027a14cbd">

* Open a campaign details page
* Ensure your margins are 8px from each side
<img width="666" alt="Screenshot 2023-06-21 at 13 31 06" src="https://github.com/Automattic/wp-calypso/assets/115007291/4868fb3f-7046-44ff-aab3-e5084bc40e77">

* Also, check that the percentage is calculated correct even if backend provided us with negative values (in particular, if you have `327` clicks for **Ad** and a negative value for **Organic**, the former should have `100%` fill as on the image below):
<img width="999" alt="Screenshot 2023-06-21 at 13 39 28" src="https://github.com/Automattic/wp-calypso/assets/115007291/91bf7e55-f8ee-47e7-ad38-420971af6079">

* For the case Ad/Organic ratio of `327/110`, we should have fill percent as `74.82...%` (`327/(327+110)*100`):
<img width="963" alt="Screenshot 2023-06-21 at 13 44 29" src="https://github.com/Automattic/wp-calypso/assets/115007291/f5f34e8e-1e41-4be2-aa3a-c07e7750299a">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
