### PR TITLE
Theme Showcase: Show Dotorg Themes in the Free Tier if the Site Can Install Them

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -1,4 +1,7 @@
-import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
+import {
+	FEATURE_INSTALL_THEMES,
+	WPCOM_FEATURES_PREMIUM_THEMES,
+} from '@automattic/calypso-products';
 import { compact, property, snakeCase } from 'lodash';
 import { default as pageRouter } from 'page';
 import PropTypes from 'prop-types';
@@ -315,6 +318,7 @@ export const ConnectedThemesSelection = connect(
 			siteId,
 			WPCOM_FEATURES_PREMIUM_THEMES
 		);
+		const canInstallThemes = siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES );
 
 		let sourceSiteId;
 		if ( source === 'wpcom' || source === 'wporg' ) {
@@ -345,8 +349,11 @@ export const ConnectedThemesSelection = connect(
 		const shouldFetchWpOrgThemes =
 			forceWpOrgSearch &&
 			sourceSiteId !== 'wporg' &&
-			!! search && // Only fetch WP.org themes when searching a term.
-			! tier; // WP.org themes are not a good fit for any of the tiers.
+			// Only fetch WP.org themes when searching a term.
+			!! search &&
+			// WP.org themes are not a good fit for any of the tiers,
+			// unless the site can install themes, then they can be searched in the 'free' tier.
+			( ! tier || ( tier === 'free' && canInstallThemes ) );
 		const wpOrgQuery = {
 			...query,
 			// We limit the WP.org themes to one page only.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2793

## Proposed Changes

We currently only show Dotorg themes on search when the pricing tier is set as "All" (in other words: not set).
With this change, we also show them in the "Free" tier, provided the site can actually install them (in other words: it's on a Business plan or higher).

| Premium and Lower | Business and Higher |
|--------|--------|
| <img width="1174" alt="Screenshot 2023-06-21 at 11 40 18" src="https://github.com/Automattic/wp-calypso/assets/2070010/5bf562ee-1fc2-465d-87b2-cee8eef30319"> | <img width="1174" alt="Screenshot 2023-06-21 at 11 39 53" src="https://github.com/Automattic/wp-calypso/assets/2070010/cf46ff4d-421e-40a0-a364-954728539b6d"> | 

## Testing Instructions

- Use the Calypso live link below.
- Go to Appearance > Themes.
- Pick a site with a Business plan or higher.
  - Select the "All" or "Free" tier.
    - Enter a search term that should return Dotorg themes (e.g. `hotel`).
    - Ensure Dotorg themes are displayed in both "All" and "Free" tiers.
  - Select the "Premium" or "Paid" tier.
    - Enter a search term that should return Dotorg themes (e.g. `hotel`).
    - Ensure Dotorg themes are not displayed.
- Pick a site with a Premium plan or lower.
  - Select the "All" tier.
    - Enter a search term that should return Dotorg themes (e.g. `hotel`).
    - Ensure Dotorg themes are displayed.
  - Select the "Free", "Premium", or "Paid" tier.
    - Enter a search term that should return Dotorg themes (e.g. `hotel`).
    - Ensure Dotorg themes are not displayed.