### PR TITLE
eslint-plugin-wpcalypso: Add i18n-unlocalized-url rule

### DIFF
--- a/packages/eslint-plugin-wpcalypso/.eslintrc.js
+++ b/packages/eslint-plugin-wpcalypso/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
 				'wpcalypso/i18n-no-this-translate': 'off',
 				'wpcalypso/i18n-no-variables': 'off',
 				'wpcalypso/i18n-translate-identifier': 'off',
-				'wpcalypso/i18n-unloclaized-url': 'off',
+				'wpcalypso/i18n-unlocalized-url': 'off',
 				'wpcalypso/redux-no-bound-selectors': 'off',
 				'wpcalypso/jsx-gridicon-size': 'off',
 				'no-restricted-imports': 'off',

--- a/packages/eslint-plugin-wpcalypso/.eslintrc.js
+++ b/packages/eslint-plugin-wpcalypso/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
 				'wpcalypso/i18n-no-this-translate': 'off',
 				'wpcalypso/i18n-no-variables': 'off',
 				'wpcalypso/i18n-translate-identifier': 'off',
+				'wpcalypso/i18n-unloclaized-url': 'off',
 				'wpcalypso/redux-no-bound-selectors': 'off',
 				'wpcalypso/jsx-gridicon-size': 'off',
 				'no-restricted-imports': 'off',

--- a/packages/eslint-plugin-wpcalypso/lib/configs/recommended.js
+++ b/packages/eslint-plugin-wpcalypso/lib/configs/recommended.js
@@ -164,7 +164,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '**/test/*', '*.json' ],
+			files: [ '**/test/*', '*.json', '*.md' ],
 			rules: {
 				'wpcalypso/i18n-unlocalized-url': 'off',
 			},

--- a/packages/eslint-plugin-wpcalypso/lib/configs/recommended.js
+++ b/packages/eslint-plugin-wpcalypso/lib/configs/recommended.js
@@ -151,6 +151,7 @@ module.exports = {
 		'wpcalypso/i18n-mismatched-placeholders': 'error',
 		'wpcalypso/i18n-named-placeholders': 'error',
 		'wpcalypso/i18n-translate-identifier': 'error',
+		'wpcalypso/i18n-unlocalized-url': 'error',
 		'wpcalypso/jsx-gridicon-size': 'error',
 		'wpcalypso/jsx-classname-namespace': 'error',
 		'wpcalypso/redux-no-bound-selectors': 'error',

--- a/packages/eslint-plugin-wpcalypso/lib/configs/recommended.js
+++ b/packages/eslint-plugin-wpcalypso/lib/configs/recommended.js
@@ -164,7 +164,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: '**/test/*',
+			files: [ '**/test/*', '*.json' ],
 			rules: {
 				'wpcalypso/i18n-unlocalized-url': 'off',
 			},

--- a/packages/eslint-plugin-wpcalypso/lib/configs/recommended.js
+++ b/packages/eslint-plugin-wpcalypso/lib/configs/recommended.js
@@ -162,4 +162,12 @@ module.exports = {
 		// Ensure our codebases use inclusive language
 		'inclusive-language/use-inclusive-words': 'error',
 	},
+	overrides: [
+		{
+			files: '**/test/*',
+			rules: {
+				'wpcalypso/i18n-unlocalized-url': 'off',
+			},
+		},
+	],
 };

--- a/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
@@ -13,14 +13,10 @@ const LOCALIZABLE_URLS = [
 	'apps.wordpress.com',
 	'automattic.com/cookies(/|$)',
 	'automattic.com/privacy(/|$)',
-	'jetpack.com/?$',
-	'wordpress.com/?$',
 	'wordpress.com/blog(/|$)',
 	'wordpress.com/forums(/|$)',
 	'wordpress.com/go(/|$)',
 	'wordpress.com/support(/|$)',
-	'wordpress.com/theme(/|$)',
-	'wordpress.com/themes(/|$)',
 	'wordpress.com/tos(/|$)',
 ];
 

--- a/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
@@ -1,5 +1,5 @@
 /**
- * @file @todo
+ * @file Disallow using unlocalized URL strings
  * @author Automattic
  * @copyright 2023 Automattic. All rights reserved.
  * See LICENSE.md file in root directory for full license.
@@ -9,7 +9,6 @@
 // Constants
 //------------------------------------------------------------------------------
 
-// @todo: should be replaced by url mapping from @automattic/i18n-calypso.
 const LOCALIZABLE_URLS = [
 	'apps.wordpress.com',
 	'automattic.com/cookies(/|$)',

--- a/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
@@ -10,13 +10,28 @@
 //------------------------------------------------------------------------------
 
 const LOCALIZABLE_URLS = [
+	// apps.wordpress.com/**
 	/^(https?:)?\/\/apps\.wordpress\.com/i,
+
+	// automattic.com/cookies/
 	/^(https?:)?\/\/automattic\.com\/cookies\/?$/i,
+
+	// automattic.com/privacy/
 	/^(https?:)?\/\/automattic\.com\/privacy\/?$/i,
+
+	// wordpress.com/tos/
 	/^(https?:)?\/\/wordpress\.com\/tos\/?$/i,
+
+	// wordpress.com/blog/
 	/^(https?:)?\/\/wordpress\.com\/blog\/?$/i,
+
+	// wordpress.com/forums/
 	/^(https?:)?\/\/wordpress\.com\/forums\/?$/i,
+
+	// wordpress.com/go/**
 	/^(https?:)?\/\/wordpress\.com\/go($|\/.*)/i,
+
+	// wordpress.com/support/**
 	/^(https?:)?\/\/wordpress\.com\/support($|\/.*)/i,
 ];
 
@@ -96,6 +111,6 @@ const rule = ( module.exports = function ( context ) {
 	};
 } );
 
-rule.ERROR_MESSAGE = "Url string should be wrapped in 'localizeUrl' function call";
+rule.ERROR_MESSAGE = "URL string should be wrapped in a 'localizeUrl' function call";
 
 rule.schema = [];

--- a/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
@@ -10,14 +10,14 @@
 //------------------------------------------------------------------------------
 
 const LOCALIZABLE_URLS = [
-	'apps.wordpress.com',
-	'automattic.com/cookies(/|$)',
-	'automattic.com/privacy(/|$)',
-	'wordpress.com/blog(/|$)',
-	'wordpress.com/forums(/|$)',
-	'wordpress.com/go(/|$)',
-	'wordpress.com/support(/|$)',
-	'wordpress.com/tos(/|$)',
+	/^(https?:)?\/\/apps\.wordpress\.com/i,
+	/^(https?:)?\/\/automattic\.com\/cookies\/?$/i,
+	/^(https?:)?\/\/automattic\.com\/privacy\/?$/i,
+	/^(https?:)?\/\/wordpress\.com\/tos\/?$/i,
+	/^(https?:)?\/\/wordpress\.com\/blog\/?$/i,
+	/^(https?:)?\/\/wordpress\.com\/forums\/?$/i,
+	/^(https?:)?\/\/wordpress\.com\/go($|\/.*)/i,
+	/^(https?:)?\/\/wordpress\.com\/support($|\/.*)/i,
 ];
 
 //------------------------------------------------------------------------------
@@ -25,28 +25,6 @@ const LOCALIZABLE_URLS = [
 //------------------------------------------------------------------------------
 
 const getCallee = require( '../util/get-callee' );
-
-/**
- * Check whether the provided string is localizable string.
- *
- * @param   {string}  string String to be tested
- * @returns {boolean}
- */
-function isLocalizableUrlString( string ) {
-	return LOCALIZABLE_URLS.some( ( url ) =>
-		new RegExp( `^(https?:)?//${ url.replace( '.', '\\.' ) }`, 'i' ).test( string )
-	);
-}
-
-/**
- * Check whether the provided node type is variable declarator.
- *
- * @param   {string}  type Node type
- * @returns {boolean}
- */
-function isVariableDeclarationValue( type ) {
-	return type === 'VariableDeclarator';
-}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -57,7 +35,7 @@ const rule = ( module.exports = function ( context ) {
 	const urlVariables = new Set();
 
 	/**
-	 * Check whether the node is unlocalized url.
+	 * Check whether the node is an unlocalized URL.
 	 *
 	 * @param   {Object} node
 	 * @param   {string} nodeValueString
@@ -70,12 +48,12 @@ const rule = ( module.exports = function ( context ) {
 		}
 
 		// Check whether the string value of the node is localizable string.
-		if ( ! isLocalizableUrlString( nodeValueString ) ) {
+		if ( ! LOCALIZABLE_URLS.some( ( url ) => url.test( nodeValueString ) ) ) {
 			return;
 		}
 
-		// Url string is assigned to a variable and variable is possibly later used in a localizeUrl call;
-		if ( isVariableDeclarationValue( node.parent.type ) ) {
+		// URL string is assigned to a variable and variable is possibly later used in a localizeUrl call;
+		if ( node.parent.type === 'VariableDeclarator' ) {
 			variableDeclarationValues.push( node );
 		} else {
 			// Report unlocalized url.

--- a/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
@@ -14,25 +14,25 @@ const LOCALIZABLE_URLS = [
 	/^(https?:)?\/\/apps\.wordpress\.com/i,
 
 	// automattic.com/cookies/
-	/^(https?:)?\/\/automattic\.com\/cookies\/?$/i,
+	/^(https?:)?\/\/automattic\.com\/cookies\/?((#|\?).*)?$/i,
 
 	// automattic.com/privacy/
-	/^(https?:)?\/\/automattic\.com\/privacy\/?$/i,
+	/^(https?:)?\/\/automattic\.com\/privacy\/?((#|\?).*)?$/i,
 
 	// wordpress.com/tos/
-	/^(https?:)?\/\/wordpress\.com\/tos\/?$/i,
+	/^(https?:)?\/\/wordpress\.com\/tos\/?((#|\?).*)?$/i,
 
 	// wordpress.com/blog/
-	/^(https?:)?\/\/wordpress\.com\/blog\/?$/i,
+	/^(https?:)?\/\/wordpress\.com\/blog\/?((#|\?).*)?$/i,
 
 	// wordpress.com/forums/
-	/^(https?:)?\/\/wordpress\.com\/forums\/?$/i,
+	/^(https?:)?\/\/wordpress\.com\/forums\/?((#|\?).*)?$/i,
 
 	// wordpress.com/go/**
-	/^(https?:)?\/\/wordpress\.com\/go($|\/.*)/i,
+	/^(https?:)?\/\/wordpress\.com\/go($|(\/|\?|#).*)/i,
 
 	// wordpress.com/support/**
-	/^(https?:)?\/\/wordpress\.com\/support($|\/.*)/i,
+	/^(https?:)?\/\/wordpress\.com\/support($|(\/|\?|#).*)/i,
 ];
 
 //------------------------------------------------------------------------------

--- a/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
@@ -10,7 +10,20 @@
 //------------------------------------------------------------------------------
 
 // @todo: should be replaced by url mapping from @automattic/i18n-calypso.
-const LOCALIZABLE_URLS = [ 'wordpress.com', 'apps.wordpress.com', 'jetpack.com', 'automattic.com' ];
+const LOCALIZABLE_URLS = [
+	'apps.wordpress.com',
+	'automattic.com/cookies(/|$)',
+	'automattic.com/privacy(/|$)',
+	'jetpack.com/?$',
+	'wordpress.com/?$',
+	'wordpress.com/blog(/|$)',
+	'wordpress.com/forums(/|$)',
+	'wordpress.com/go(/|$)',
+	'wordpress.com/support(/|$)',
+	'wordpress.com/theme(/|$)',
+	'wordpress.com/themes(/|$)',
+	'wordpress.com/tos(/|$)',
+];
 
 //------------------------------------------------------------------------------
 // Helper Functions
@@ -91,7 +104,7 @@ const rule = ( module.exports = function ( context ) {
 
 			if ( isLocalizableUrlString && ! isVariableDeclarationValue ) {
 				context.report( {
-					templateLiteralNode,
+					node: templateLiteralNode,
 					message: rule.ERROR_MESSAGE,
 				} );
 			}
@@ -99,6 +112,6 @@ const rule = ( module.exports = function ( context ) {
 	};
 } );
 
-rule.ERROR_MESSAGE = 'Url string should be wrapped in `localizeUrl` function call';
+rule.ERROR_MESSAGE = "Url string should be wrapped in 'localizeUrl' function call";
 
 rule.schema = [];

--- a/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/i18n-unlocalized-url.js
@@ -1,0 +1,104 @@
+/**
+ * @file @todo
+ * @author Automattic
+ * @copyright 2023 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+// @todo: should be replaced by url mapping from @automattic/i18n-calypso.
+const LOCALIZABLE_URLS = [ 'wordpress.com', 'apps.wordpress.com', 'jetpack.com', 'automattic.com' ];
+
+//------------------------------------------------------------------------------
+// Helper Functions
+//------------------------------------------------------------------------------
+
+const getCallee = require( '../util/get-callee' );
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule = ( module.exports = function ( context ) {
+	const variableDeclarationValues = [];
+	const urlVariables = new Set();
+
+	return {
+		'Program:exit': function () {
+			for ( const node of variableDeclarationValues ) {
+				if ( ! urlVariables.has( node.parent?.id?.name ) ) {
+					context.report( {
+						node,
+						message: rule.ERROR_MESSAGE,
+					} );
+				}
+			}
+		},
+		CallExpression: function ( node ) {
+			const callee = getCallee( node );
+			if (
+				callee !== node &&
+				callee.name === 'localizeUrl' &&
+				node.arguments?.[ 0 ]?.type === 'Identifier'
+			) {
+				urlVariables.add( node.arguments[ 0 ]?.name );
+			}
+		},
+		Literal: function ( node ) {
+			// String is wrapped in localizeUrl, therefore we can assume it's localized and we don't need to do any further checks.
+			if ( getCallee( node.parent ).name === 'localizeUrl' ) {
+				return;
+			}
+
+			const isLocalizableUrlString = LOCALIZABLE_URLS.some( ( url ) =>
+				new RegExp( `^(https?:)?//${ url.replace( '.', '\\.' ) }`, 'i' ).test( node.value )
+			);
+
+			// Url string is assigned to a variable and variable is later used in a localizeUrl call;
+			const isVariableDeclarationValue = node.parent.type === 'VariableDeclarator';
+
+			if ( isLocalizableUrlString && isVariableDeclarationValue ) {
+				variableDeclarationValues.push( node );
+			}
+
+			if ( isLocalizableUrlString && ! isVariableDeclarationValue ) {
+				context.report( {
+					node,
+					message: rule.ERROR_MESSAGE,
+				} );
+			}
+		},
+		TemplateElement: function ( node ) {
+			// Template literal is wrapped in localizeUrl, therefore we can assume it's localized and we don't need to do any further checks.
+			const templateLiteralNode = node.parent;
+			if ( getCallee( templateLiteralNode.parent ).name === 'localizeUrl' ) {
+				return;
+			}
+
+			const isLocalizableUrlString = LOCALIZABLE_URLS.some( ( url ) =>
+				new RegExp( `^(https?:)?//${ url.replace( '.', '\\.' ) }`, 'i' ).test( node.value.raw )
+			);
+
+			// Url template string is assigned to a variable and variable is later used in a localizeUrl call;
+			const isVariableDeclarationValue = templateLiteralNode.parent.type === 'VariableDeclarator';
+
+			if ( isLocalizableUrlString && isVariableDeclarationValue ) {
+				variableDeclarationValues.push( templateLiteralNode );
+			}
+
+			if ( isLocalizableUrlString && ! isVariableDeclarationValue ) {
+				context.report( {
+					templateLiteralNode,
+					message: rule.ERROR_MESSAGE,
+				} );
+			}
+		},
+	};
+} );
+
+rule.ERROR_MESSAGE = 'Url string should be wrapped in `localizeUrl` function call';
+
+rule.schema = [];

--- a/packages/eslint-plugin-wpcalypso/lib/rules/index.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/index.js
@@ -7,6 +7,7 @@ module.exports = {
 	'i18n-no-this-translate': require( './i18n-no-this-translate' ),
 	'i18n-no-variables': require( './i18n-no-variables' ),
 	'i18n-translate-identifier': require( './i18n-translate-identifier' ),
+	'i18n-unlocalized-url': require( './i18n-unlocalized-url' ),
 	'jsx-classname-namespace': require( './jsx-classname-namespace' ),
 	'jsx-gridicon-size': require( './jsx-gridicon-size' ),
 	'post-message-no-wildcard-targets': require( './post-message-no-wildcard-targets' ),

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js
@@ -42,6 +42,10 @@ new RuleTester( {
 				`const link = <a href={ localizeUrl( '${ url }' ) }></a>;`,
 				`const url = '${ url }'; const link = <a href={ localizeUrl( url ) }></a>;`,
 				`const url = localizeUrl( \`${ url }?param=test\` );`,
+				`const url = localizeUrl( true ? '${ url }' : 'https://example.com' );`,
+				`const url = true ? '${ url }' : 'https://example.com'; localizeUrl( url );`,
+				`const url = localizeUrl( false || \`${ url }\` );`,
+				`const url = false || \`${ url }\`; localizeUrl( url );`,
 			] );
 		}, [] ),
 		nonLocalizableUrls.reduce( ( cases, url ) => {
@@ -60,6 +64,10 @@ new RuleTester( {
 			},
 			{
 				code: `const link = <a href={ '${ url }' }></a>;`,
+				errors: [ { message: rule.ERROR_MESSAGE } ],
+			},
+			{
+				code: `isLink ? '${ url }' : ''`,
 				errors: [ { message: rule.ERROR_MESSAGE } ],
 			},
 		] );

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js
@@ -17,29 +17,28 @@ const rule = require( '../i18n-unlocalized-url' );
 //------------------------------------------------------------------------------
 
 const localizableUrls = [
-	'https://apps.wordpress.com/',
 	'https://apps.wordpress.com',
-	'https://apps.wordpress.com/mobile/',
 	'https://apps.wordpress.com/mobile',
-	'https://automattic.com/cookies/',
 	'https://automattic.com/cookies',
-	'https://automattic.com/privacy/',
 	'https://automattic.com/privacy',
-	'https://wordpress.com/tos/',
 	'https://wordpress.com/tos',
-	'https://wordpress.com/blog/',
 	'https://wordpress.com/blog',
-	'https://wordpress.com/forums/',
 	'https://wordpress.com/forums',
-	'https://wordpress.com/go/',
 	'https://wordpress.com/go',
-	'https://wordpress.com/go/some-page/',
 	'https://wordpress.com/go/some-page',
-	'https://wordpress.com/support/',
 	'https://wordpress.com/support',
-	'https://wordpress.com/support/some-article/',
 	'https://wordpress.com/support/some-article',
-];
+].reduce( ( urls, url ) => {
+	// For each individual localizable URL, add the original URL and variants with trailing slash, hash and query string.
+	return urls.concat( [
+		url,
+		`${ url }/`,
+		`${ url }#hash`,
+		`${ url }/#hash`,
+		`${ url }?query-string`,
+		`${ url }/?query-string`,
+	] );
+}, [] );
 
 const nonLocalizableUrls = [
 	'https://example.com',

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js
@@ -17,6 +17,9 @@ const rule = require( '../i18n-unlocalized-url' );
 //------------------------------------------------------------------------------
 
 const localizableUrls = [
+	'https://apps.wordpress.com/',
+	'https://automattic.com/cookies/',
+	'https://automattic.com/privacy/',
 	'https://wordpress.com/support/test-article/',
 	'https://wordpress.com/forums/test-thread/',
 	'https://wordpress.com/tos/',
@@ -39,6 +42,7 @@ new RuleTester( {
 				`const url = '${ url }'; localizeUrl( url );`,
 				`const link = <a href={ localizeUrl( '${ url }' ) }></a>;`,
 				`const url = '${ url }'; const link = <a href={ localizeUrl( url ) }></a>;`,
+				`const url = localizeUrl( \`${ url }?param=test\` );`,
 			] );
 		}, [] ),
 		nonLocalizableUrls.reduce( ( cases, url ) => {

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js
@@ -21,12 +21,11 @@ const localizableUrls = [
 	'https://automattic.com/cookies/',
 	'https://automattic.com/privacy/',
 	'https://wordpress.com/support/test-article/',
-	'https://wordpress.com/forums/test-thread/',
-	'https://wordpress.com/tos/',
+	'https://wordpress.com/forums/',
 	'https://wordpress.com/tos/',
 ];
 
-const nonLocalizableUrls = [ 'https://example.com' ];
+const nonLocalizableUrls = [ 'https://example.com', 'https://wordpress.com/forums/some-thread' ];
 
 new RuleTester( {
 	parserOptions: {

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js
@@ -18,14 +18,37 @@ const rule = require( '../i18n-unlocalized-url' );
 
 const localizableUrls = [
 	'https://apps.wordpress.com/',
+	'https://apps.wordpress.com',
+	'https://apps.wordpress.com/mobile/',
+	'https://apps.wordpress.com/mobile',
 	'https://automattic.com/cookies/',
+	'https://automattic.com/cookies',
 	'https://automattic.com/privacy/',
-	'https://wordpress.com/support/test-article/',
-	'https://wordpress.com/forums/',
+	'https://automattic.com/privacy',
 	'https://wordpress.com/tos/',
+	'https://wordpress.com/tos',
+	'https://wordpress.com/blog/',
+	'https://wordpress.com/blog',
+	'https://wordpress.com/forums/',
+	'https://wordpress.com/forums',
+	'https://wordpress.com/go/',
+	'https://wordpress.com/go',
+	'https://wordpress.com/go/some-page/',
+	'https://wordpress.com/go/some-page',
+	'https://wordpress.com/support/',
+	'https://wordpress.com/support',
+	'https://wordpress.com/support/some-article/',
+	'https://wordpress.com/support/some-article',
 ];
 
-const nonLocalizableUrls = [ 'https://example.com', 'https://wordpress.com/forums/some-thread' ];
+const nonLocalizableUrls = [
+	'https://example.com',
+	'https://automattic.com/cookies/some-page/',
+	'https://automattic.com/privacy/some-page/',
+	'https://wordpress.com/tos/some-page/',
+	'https://wordpress.com/blog/some-post/',
+	'https://wordpress.com/forums/some-thread',
+];
 
 new RuleTester( {
 	parserOptions: {

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js
@@ -1,0 +1,64 @@
+/**
+ * @file Disallow using unlocalized URL strings
+ * @author Automattic
+ * @copyright 2023 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const RuleTester = require( 'eslint' ).RuleTester;
+const rule = require( '../i18n-unlocalized-url' );
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const localizableUrls = [
+	'https://wordpress.com/support/test-article/',
+	'https://wordpress.com/forums/test-thread/',
+	'https://wordpress.com/tos/',
+	'https://wordpress.com/tos/',
+];
+
+const nonLocalizableUrls = [ 'https://example.com' ];
+
+new RuleTester( {
+	parserOptions: {
+		sourceType: 'module',
+		ecmaFeatures: { jsx: true },
+		ecmaVersion: 6,
+	},
+} ).run( 'i18n-unlocalized-url', rule, {
+	valid: [].concat(
+		localizableUrls.reduce( ( cases, url ) => {
+			return cases.concat( [
+				`const url = localizeUrl( '${ url }' )`,
+				`const url = '${ url }'; localizeUrl( url );`,
+				`const link = <a href={ localizeUrl( '${ url }' ) }></a>;`,
+				`const url = '${ url }'; const link = <a href={ localizeUrl( url ) }></a>;`,
+			] );
+		}, [] ),
+		nonLocalizableUrls.reduce( ( cases, url ) => {
+			return cases.concat( [
+				`const url = '${ url }'`,
+				`const link = <a href={ '${ url }' }></a>;`,
+			] );
+		}, [] )
+	),
+
+	invalid: localizableUrls.reduce( ( cases, url ) => {
+		return cases.concat( [
+			{
+				code: `const url = '${ url }'`,
+				errors: [ { message: rule.ERROR_MESSAGE } ],
+			},
+			{
+				code: `const link = <a href={ '${ url }' }></a>;`,
+				errors: [ { message: rule.ERROR_MESSAGE } ],
+			},
+		] );
+	}, [] ),
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Add new rule `i18n-unlocalized-url` in `eslint-plugin-wpcalypso` to test whether the URL string should be wrapped in `localizeUrl` function call if it matches a list of URL patterns that we consider to be localizable.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Run rule unit tests `yarn run test-packages packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-unlocalized-url.js`.
* Run `yarn lint:js` and confirm whether the errors for the new rule `wpcalypso/i18n-unlocalized-url` in the existing code base make sense.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
