### PR TITLE
Credits were being parsed as an Int, which meant we were losing the c…

### DIFF
--- a/client/data/promote-post/use-promote-post-credit-balance-query.ts
+++ b/client/data/promote-post/use-promote-post-credit-balance-query.ts
@@ -14,7 +14,7 @@ const useCreditBalanceQuery = ( queryOptions = {} ) => {
 					selectedSiteId,
 					`/credits/balance`
 				);
-				return balance ? parseInt( balance ) : undefined;
+				return balance ? parseFloat( balance ).toFixed( 2 ) : undefined;
 			}
 			throw new Error( 'wpcomUserId is undefined' );
 		},

--- a/client/my-sites/promote-post-i2/components/credit-balance/index.tsx
+++ b/client/my-sites/promote-post-i2/components/credit-balance/index.tsx
@@ -1,23 +1,21 @@
 import { memo } from '@wordpress/element';
-import { translate, numberFormat } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
 interface Props {
-	balance?: number;
+	balance?: string;
 }
 
-const CreditBalance = ( { balance = 0 }: Props ) => {
+const CreditBalance = ( { balance = '0.00' }: Props ) => {
 	// Hide the section if balance is invalid or is 0
-	if ( ! balance || balance === 0 ) {
+	if ( ! balance || balance === '0.00' ) {
 		return null;
 	}
 
 	return (
 		<div className="promote-post-i2__aux-wrapper">
 			<div className="empty-promotion-list__container">
-				<h3 className="empty-promotion-list__title wp-brand-font">
-					${ numberFormat( balance, 2 ) }
-				</h3>
+				<h3 className="empty-promotion-list__title wp-brand-font">${ balance }</h3>
 				<p className="empty-promotion-list__body">
 					{ translate(
 						'Available credits that will be automatically applied toward your next campaigns. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -69,7 +69,7 @@ export default function PromotedPosts( { tab }: Props ) {
 		entrypoint: 'promoted_posts-header',
 	} );
 
-	const { data: creditBalance = 0 } = useCreditBalanceQuery();
+	const { data: creditBalance = '0.00' } = useCreditBalanceQuery();
 
 	/* query for campaigns */
 	const [ campaignsSearchOptions, setCampaignsSearchOptions ] = useState< SearchOptions >( {} );
@@ -155,9 +155,9 @@ export default function PromotedPosts( { tab }: Props ) {
 			id: 'credits',
 			name: translate( 'Credits' ),
 			className: 'pull-right',
-			itemCount: creditBalance,
+			itemCount: parseFloat( creditBalance ),
 			isCountAmount: true,
-			enabled: creditBalance > 0,
+			enabled: parseFloat( creditBalance ) > 0,
 		},
 	];
 

--- a/client/my-sites/promote-post/components/credit-balance/index.tsx
+++ b/client/my-sites/promote-post/components/credit-balance/index.tsx
@@ -1,7 +1,7 @@
 import './style.scss';
 import { memo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { numberFormat, translate } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import useCreditBalanceQuery from 'calypso/data/promote-post/use-promote-post-credit-balance-query';
@@ -10,7 +10,7 @@ const CreditBalance = () => {
 	const creditBalance = useCreditBalanceQuery();
 	const { data: balance } = creditBalance;
 
-	if ( ! balance || balance === 0 ) {
+	if ( ! balance || balance === '0.00' ) {
 		return null;
 	}
 
@@ -25,7 +25,7 @@ const CreditBalance = () => {
 
 	return (
 		<div className="credit-balance__nav-item">
-			{ __( `Credits: ` ) + `$${ numberFormat( balance, 2 ) }` }
+			{ __( `Credits: ` ) + `$${ balance }` }
 			<InfoPopover
 				className="credit-balance__help-icon"
 				icon="help-outline"

--- a/client/my-sites/promote-post/test/credit-balance.test.tsx
+++ b/client/my-sites/promote-post/test/credit-balance.test.tsx
@@ -26,7 +26,7 @@ describe( 'CreditBalance component', () => {
 	} );
 
 	test( 'displays null when balance is 0.00', () => {
-		const mockBalance = 0.0;
+		const mockBalance = '0.00';
 		useCreditBalanceQuery.mockReturnValue( { data: mockBalance } );
 
 		render( <CreditBalance /> );
@@ -35,7 +35,7 @@ describe( 'CreditBalance component', () => {
 	} );
 
 	test( 'displays "Credits: $10.00" when balance is set to 10', () => {
-		const mockBalance = 10.0;
+		const mockBalance = '10.00';
 		useCreditBalanceQuery.mockReturnValue( { data: mockBalance } );
 
 		render( <CreditBalance /> );


### PR DESCRIPTION
## Proposed Changes

On WP.com the credits balance was being rounded, so here in my example I should have $502.70, but I'm seeing $502.

![Screenshot 2023-06-21 at 12 52 31](https://github.com/Automattic/wp-calypso/assets/6440498/e5ed76e7-da8a-407e-bede-def8e0843b78)


## Testing Instructions

Make sure you have some credits, and that the value is a float.

Visit  the [test site](https://calypso.live/?image=registry.a8c.com/calypso/app:commit-6c81ca3f04c2b24d13507163fc8e56301acd0a0c) and go to `tools -> advertising` or `/advertising/yoursite.com`

Also, note we are working on a redesign of this page, you can toggle this by appending the following flag to the URL.   But both use the same query to grab the balance.

`?flags=promote-post/redesign-i2` True
`?flags=-promote-post/redesign-i2` false (prefixed with a minus -)

Full example here:

https://github.com/Automattic/wp-calypso/assets/6440498/9a77c699-cf32-4386-9c5c-2070430e3b06



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
