### PR TITLE
Marketplace: Display variants for Marketplace products 

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -185,13 +185,15 @@ function LineItemWrapper( {
 	const variants = useGetProductVariants( product, ( variant ) => {
 		// Only show term variants which are equal to or longer than the variant that
 		// was in the cart when checkout finished loading (not necessarily the
-		// current variant). For WordPress.com only, not Jetpack or Akismet. See
-		// https://github.com/Automattic/wp-calypso/issues/69633
+		// current variant). For WordPress.com only, not Jetpack, Akismet or Marketplace.
+		// See https://github.com/Automattic/wp-calypso/issues/69633
 		if ( ! initialVariantTerm ) {
 			return true;
 		}
 		const isAkismet = isAkismetProduct( { product_slug: variant.productSlug } );
-		if ( isJetpack || isAkismet ) {
+		const isMarketplace = product.extra?.is_marketplace_product;
+
+		if ( isJetpack || isAkismet || isMarketplace ) {
 			return true;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Solves to #77964

## Proposed Changes

* Update the condition that prevents yearly products from being changed to monthly to not apply to Marketplace products. With this change, all Marketplace products can be changed to Yearly or Monthly variants in the Checkout screen, regardless of the selected initial variant or regardless of the plan of the site.

|Before | After|
|-------|------|
|![CleanShot 2023-06-21 at 16 20 23@2x](https://github.com/Automattic/wp-calypso/assets/3519124/181441da-7ad6-4a6b-9f72-0841bc4da8ad)|![CleanShot 2023-06-21 at 16 19 59@2x](https://github.com/Automattic/wp-calypso/assets/3519124/091ea67e-af42-4fca-91d3-2913fe2b91bc)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using a site with a yearly plan
* Navigate to `/plugins/:siteId` and select a **paid plugin**. For example, `WooCommerce Bookings`
* Click on the `Purchase and activate` CTA button
* Do not complete the purchase, select the `X` on the top-left and select `Leave items` in the modal that appears to leave the items in the cart.
* Navigate to `/themes/:siteId` or go to Appearance > Themes and selecte a **paid theme**. For example, `Yuna`
* Click on `Subscribe to activate` 
* On the checkout page

### Validate
- Both the theme and the plugin purchased have the variants dropdown 
![CleanShot 2023-06-21 at 16 12 39@2x](https://github.com/Automattic/wp-calypso/assets/3519124/3dacb3c4-64fa-4742-a197-4729fd101113)
- The variant dropdown contains the `One year` and `One month` options and both can be selected

### Regression testing
- Make sure you can purchase Marketplace or other products (for example a domain) with sites with either yearly and monthly and no unexpected behaviour different than production happens apart from the changes implemented in this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
