### PR TITLE
Subscription Management: Click on site title or icon goes to reader feed on reader portal.

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
@@ -64,6 +64,7 @@ type SiteRowProps = Reader.SiteSubscription & {
 
 const SiteRow = ( {
 	blog_ID,
+	feed_ID,
 	name,
 	site_icon,
 	URL: url,
@@ -118,14 +119,13 @@ const SiteRow = ( {
 
 	const siteTitleUrl = useMemo( () => {
 		if ( portal === ReaderPortal ) {
-			// TODO: This should be feed_ID but we will address it separately
-			return `/read/feeds/${ blog_ID }`;
+			return `/read/feeds/${ feed_ID }`;
 		}
 
 		if ( portal === SubscriptionsPortal ) {
 			return `/subscriptions/site/${ blog_ID }`;
 		}
-	}, [ blog_ID, portal ] );
+	}, [ blog_ID, feed_ID, portal ] );
 
 	const handleNotifyMeOfNewPostsChange = ( send_posts: boolean ) => {
 		// Update post notification settings


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/78381

## Proposed Changes

* On reader portal, clicking on site title or site icon should go to the existing reader feed page.

## Testing Instructions

**Test Reader Portal**
* Go to `/read/subscriptions`.
* Click on any of the site title or site icon.
* It should go to the reader feed page.
* Clicking back should go back to the subscription page.

**Test external users**
* Set up the external user subkey.
* Go to `/subscriptions`.
* It should render just fine (hoping to catch `feed_ID is undefined` error, but I think it won't happen).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
