### PR TITLE
Limited Global Styles: Fix notice in view canvas mode

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
@@ -1,5 +1,15 @@
+.edit-site-save-hub {
+	border-top: none;
+	padding-top: 0;
+}
+
+.wpcom-global-styles-notice-container {
+	padding: 24px 24px 0;
+	border-top: 1px solid #2f2f2f;
+}
+
 .wpcom-global-styles-notice {
-	margin: 0 0 12px;
+	margin: 0 0 24px;
 	color: var(--color-text);
 
 	.components-notice__content {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -59,13 +59,18 @@ function GlobalStylesViewNotice() {
 			return;
 		}
 
-		const footer = document.querySelector( '.edit-site-sidebar__footer' );
-		if ( ! footer ) {
+		const saveHub = document.querySelector( '.edit-site-save-hub' );
+		if ( ! saveHub ) {
 			return;
 		}
 
+		// Insert the notice as a sibling of the save hub instead of as a child,
+		// to prevent our notice from breaking the flex styles of the hub.
+		const container = saveHub.parentNode;
 		const noticeContainer = document.createElement( 'div' );
-		footer.prepend( noticeContainer );
+		noticeContainer.classList.add( 'wpcom-global-styles-notice-container' );
+		container.insertBefore( noticeContainer, saveHub );
+
 		render( <GlobalStylesWarningNotice />, noticeContainer );
 	}, [ canvas ] );
 


### PR DESCRIPTION
## Proposed Changes

Fixes the Limited Global Styles notice displayed in the view canvas mode of the site editor, which was broken as of [Gutenberg 16.0](https://github.com/WordPress/gutenberg/pull/50567/files#diff-0cf5246119f61f0f26cb94918697d2cb3a0f40051045d24dd01c98241e79bde7) due to a change in the DOM.

Before | After
--- | ---
<img width="1728" alt="Screenshot 2023-06-21 at 14 05 24" src="https://github.com/Automattic/wp-calypso/assets/1233880/0e528157-f1c5-4156-b7f5-c2234dda9aa2"> | <img width="1540" alt="Screenshot 2023-06-21 at 15 18 57" src="https://github.com/Automattic/wp-calypso/assets/1233880/0f7f0974-3c18-4f8f-b4d0-283df522d64d">



## Testing Instructions

- Apply these changes to your sandbox.
- Sandbox a free site that uses Global Styles.
- Open the site editor.
- Make sure there is a notice at the bottom of the "view canvas mode" sidebar.
- Make sure the notice goes away when using the default style.

