### PR TITLE
Agency Dashboard: Fix a typo in survey copy

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner/index.tsx
@@ -55,7 +55,7 @@ export default function SiteSurveyBanner( { isDashboardView }: Props ) {
 			className="site-survey-banner"
 			title={ translate( 'Help Jetpack build better products for you' ) }
 			description={ translate(
-				'Take this 2 minute survey to help us understand your needs & build products that delivers more value to your clients.'
+				'Take this 2 minute survey to help us understand your needs & build products that deliver more value to your clients.'
 			) }
 			callToAction={ translate( 'Take survey' ) }
 			href="https://automattic.survey.fm/agency-partnership-usage-survey"


### PR DESCRIPTION
## Proposed Changes

Fix a minor grammar error in the survey banner copy that we shipped today.

**Screenshot**:

![image](https://github.com/Automattic/wp-calypso/assets/1749918/657f3331-288b-4303-a5a0-64f05caf7b90)

## Testing Instructions

Follow the instructions on https://github.com/Automattic/wp-calypso/pull/78312

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
