### PR TITLE
New hosted site: dispatch Tracks event on suggestion fetch click

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -63,7 +63,7 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 
 	const isSiteTitleEmpty = ! siteTitle || siteTitle.trim().length === 0;
 	const isFormSubmitDisabled = isSiteTitleEmpty;
-	const hasChangedInput = useRef( { geoAffinity: false } );
+	const hasChangedInput = useRef( { title: false, geoAffinity: false } );
 	const isSmallScreen = useMobileBreakpoint();
 
 	const handleSubmit = async ( event: React.FormEvent ) => {
@@ -87,6 +87,7 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 		setFormTouched( true );
 
 		if ( event.currentTarget.name === 'siteTitle' ) {
+			hasChangedInput.current.title = true;
 			return setSiteTitle( event.currentTarget.value );
 		}
 	};
@@ -130,6 +131,11 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 							} else {
 								setShouldOverrideSiteTitle( true );
 							}
+
+							recordTracksEvent( 'calypso_signup_site_options_fetch_suggestion_click', {
+								source: 'site_title',
+								has_changed_title: hasChangedInput.current.title,
+							} );
 						} }
 						aria-label={ translate( 'Generate a random site name' ) }
 					>


### PR DESCRIPTION
## Proposed Changes

Let's see how many users click on the "Generate random name" button. Let's also understand whether the user has tried a custom name before clicking the button. This could be useful to decide if we want to keep the endpoint in the future, and even extend it to other flows that require a site name.

## Testing Instructions

Open `/setup/new-hosted-site` and pick any plan. Enable event logging in the DevTools.

Click the "Generate" button without changing the site name input

You should see the `calypso_signup_site_options_fetch_suggestion_click` event being dispatched with the following props:

```
source: site_title
has_changed_title: false
```

Change the input (e.g. add a character) and click "Generate" again. You should see the same event being dispatched with different prop values:

```
source: site_title
has_changed_title: true
```