### PR TITLE
Add filters to Subscribers Page

### DIFF
--- a/client/landing/subscriptions/hooks/index.ts
+++ b/client/landing/subscriptions/hooks/index.ts
@@ -2,3 +2,4 @@ export { default as usePopoverToggle } from './use-popover-toggle';
 export { default as useSearch } from './use-search';
 export { default as useSubheaderText } from './use-subheader-text';
 export { default as useSiteSubscriptionsFilterOptions } from './use-site-subscriptions-filter-options';
+export { default as useSubscribersFilterOptions } from './use-subscribers-filter-options';

--- a/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
+++ b/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
@@ -1,0 +1,19 @@
+import { Reader } from '@automattic/data-stores';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+
+const FilterBy = Reader.SubscribersFilterBy;
+
+const useSubscribersFilterOptions = () => {
+	const translate = useTranslate();
+	return useMemo(
+		() => [
+			{ value: FilterBy.All, label: translate( 'All' ) },
+			{ value: FilterBy.Paid, label: translate( 'Paid' ) },
+			{ value: FilterBy.Free, label: translate( 'Free' ) },
+		],
+		[ translate ]
+	);
+};
+
+export default useSubscribersFilterOptions;

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/style.scss
@@ -8,6 +8,19 @@
 	gap: 8px;
 	flex-wrap: wrap;
 
+	.subscribers__filter-control {
+		min-width: 115px;
+
+		&.select-dropdown,
+		.select-dropdown__header {
+			height: 48px;
+		}
+
+		.select-dropdown__item.is-selected {
+			background-color: var(--color-primary);
+		}
+	}
+
 	.search-component {
 		min-width: min(400px, 100%);
 		flex: 1;
@@ -27,7 +40,6 @@
 		input.search-component__input[type="search"]::placeholder {
 			color: $studio-gray-50;
 		}
-
 	}
 
 	&-spacer {

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -1,12 +1,18 @@
+import { Reader } from '@automattic/data-stores';
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
+import SelectDropdown from 'calypso/components/select-dropdown';
 import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
+import { Option } from 'calypso/landing/subscriptions/components/sort-controls';
+import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
+import { useSubscribersFilterOptions } from 'calypso/landing/subscriptions/hooks';
 import { useSubscriberListManager } from 'calypso/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context';
 import './style.scss';
 
 const ListActionsBar = () => {
 	const translate = useTranslate();
-	const { handleSearch } = useSubscriberListManager();
+	const { handleSearch, filterOption, setFilterOption } = useSubscriberListManager();
+	const filterOptions = useSubscribersFilterOptions();
 
 	return (
 		<div className="list-actions-bar">
@@ -14,6 +20,17 @@ const ListActionsBar = () => {
 				placeholder={ translate( 'Search by site name or address…' ) }
 				searchIcon={ <SearchIcon size={ 18 } /> }
 				onSearch={ handleSearch }
+			/>
+
+			<SelectDropdown
+				className="subscribers__filter-control"
+				options={ filterOptions }
+				onSelect={ ( selectedOption: Option< Reader.SubscribersFilterBy > ) =>
+					setFilterOption( selectedOption.value )
+				}
+				selectedText={ translate( 'Subscription Type: %s', {
+					args: getOptionLabel( filterOptions, filterOption ) || '',
+				} ) }
 			/>
 		</div>
 	);

--- a/client/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context.tsx
@@ -1,3 +1,4 @@
+import { Reader } from '@automattic/data-stores';
 import React, { createContext, useState, useContext, useEffect, useCallback } from 'react';
 import { useDebounce } from 'use-debounce';
 import { usePagination } from 'calypso/my-sites/subscribers/hooks';
@@ -21,6 +22,8 @@ type SubscriberListManagerContextProps = {
 	total: number;
 	grandTotal: number;
 	pageClickCallback: ( page: number ) => void;
+	filterOption: Reader.SubscribersFilterBy;
+	setFilterOption: ( option: Reader.SubscribersFilterBy ) => void;
 };
 
 const SubscriberListManagerContext = createContext< SubscriberListManagerContextProps | undefined >(
@@ -37,6 +40,7 @@ export const SubscribersListManagerProvider = ( {
 }: SubscriberListManagerProviderProps ) => {
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ perPage, setPerPage ] = useState( DEFAULT_PER_PAGE );
+	const [ filterOption, setFilterOption ] = useState( Reader.SubscribersFilterBy.All );
 
 	const handleSearch = useCallback( ( term: string ) => {
 		setSearchTerm( term );
@@ -52,6 +56,7 @@ export const SubscribersListManagerProvider = ( {
 		perPage,
 		search: debouncedSearchTerm,
 		siteId,
+		filterOption,
 	} );
 
 	const { total, per_page, subscribers } = subscribersQueryResult.data || {
@@ -84,6 +89,8 @@ export const SubscribersListManagerProvider = ( {
 				setPerPage,
 				subscribers,
 				pageClickCallback,
+				filterOption,
+				setFilterOption,
 			} }
 		>
 			{ children }

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -9,7 +9,8 @@ const getSubscribersCacheKey = (
 	siteId: number | null,
 	currentPage?: number,
 	perPage?: number,
-	search?: string
+	search?: string,
+	filterOption?: string
 ) => {
 	const cacheKey = [ 'subscribers', siteId ];
 	if ( currentPage ) {
@@ -20,6 +21,9 @@ const getSubscribersCacheKey = (
 	}
 	if ( search ) {
 		cacheKey.push( 'search', search );
+	}
+	if ( filterOption ) {
+		cacheKey.push( 'filter-option', filterOption );
 	}
 	return cacheKey;
 };

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,13 +1,16 @@
+import { SubscribersFilterBy } from '@automattic/data-stores/src/reader';
 import { useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { getSubscribersCacheKey } from '../helpers';
-import type { SubscriberEndpointResponse } from '../types';
+import type { Subscriber, SubscriberEndpointResponse } from '../types';
 
 type SubscriberQueryParams = {
 	siteId: number | null;
 	page?: number;
 	perPage?: number;
 	search?: string;
+	filterOption?: SubscribersFilterBy;
 };
 
 const useSubscribersQuery = ( {
@@ -15,16 +18,36 @@ const useSubscribersQuery = ( {
 	page = 1,
 	perPage = 10,
 	search,
+	filterOption = SubscribersFilterBy.All,
 }: SubscriberQueryParams ) => {
+	const filterFunction = useCallback(
+		( item: Subscriber ) => {
+			switch ( filterOption ) {
+				case SubscribersFilterBy.Paid:
+					return item.plans && item.plans.length > 0;
+				case SubscribersFilterBy.Free:
+					return typeof item.plans === 'undefined';
+				case SubscribersFilterBy.All:
+				default:
+					return true;
+			}
+		},
+		[ filterOption ]
+	);
 	return useQuery< SubscriberEndpointResponse >( {
-		queryKey: getSubscribersCacheKey( siteId, page, perPage, search ),
+		queryKey: getSubscribersCacheKey( siteId, page, perPage, search, filterOption ),
 		queryFn: () =>
-			wpcom.req.get( {
-				path: `/sites/${ siteId }/subscribers?per_page=${ perPage }&page=${ page }${
-					search ? `&search=${ encodeURIComponent( search ) }` : ''
-				}`,
-				apiNamespace: 'wpcom/v2',
-			} ),
+			wpcom.req
+				.get( {
+					path: `/sites/${ siteId }/subscribers?per_page=${ perPage }&page=${ page }${
+						search ? `&search=${ encodeURIComponent( search ) }` : ''
+					}`,
+					apiNamespace: 'wpcom/v2',
+				} )
+				.then( ( response: SubscriberEndpointResponse ) => {
+					const subscribers = response.subscribers.filter( filterFunction );
+					return { ...response, subscribers };
+				} ),
 		enabled: !! siteId,
 		keepPreviousData: true,
 	} );

--- a/packages/data-stores/src/reader/constants.ts
+++ b/packages/data-stores/src/reader/constants.ts
@@ -21,3 +21,9 @@ export enum SiteSubscriptionsSortBy {
 	LastUpdated = 'last_updated',
 	DateSubscribed = 'date_subscribed',
 }
+
+export enum SubscribersFilterBy {
+	All = 'all',
+	Paid = 'paid',
+	Free = 'free',
+}

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -53,6 +53,7 @@ export {
 	PostSubscriptionsSortBy,
 	SiteSubscriptionsFilterBy,
 	SiteSubscriptionsSortBy,
+	SubscribersFilterBy,
 } from './constants';
 
 export { isErrorResponse } from './helpers';


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78360

## Proposed Changes

This PR adds the filter options (All, Paid, Free) to the Subscribers Page:
<img width="1132" alt="2023-06-21_17-50-01" src="https://github.com/Automattic/wp-calypso/assets/3832570/40b94a7c-3a4c-42a9-a687-71cd9733bec5">

## Testing Instructions

**Note:** You should have a site with subscribers from both types, paid and free, in order to test this properly. 

1. Apply this PR and start the application.
2. Go to `http://calypso.localhost:3000/subscribers/{the domain of your site}`.
3. Click on the `Subscription Type` filter and select all the values. You should see the Subscriber list showing only the subscribers with the selected subscription type.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
