### PR TITLE
Fixes some styling issues in Advertising - Campaign details page

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -416,41 +416,55 @@ export default function CampaignItemDetails( props: Props ) {
 										) : null }
 									</div>
 									<div>
-										<div className="campaign-item-details__trafic-container-header">
+										<div className="campaign-item-details__traffic-container-header">
 											<span className="campaign-item-details__label">
 												{ translate( 'Traffic breakdown' ) }
 											</span>
-											<span className="campaign-item-details__label">
-												{ translate( 'Visits' ) }
-											</span>
+											{ databarTotal > 0 && (
+												<span className="campaign-item-details__label">
+													{ translate( 'Visits' ) }
+												</span>
+											) }
 										</div>
 										<div className="campaign-item-details__traffic-container-body">
-											<ul className="horizontal-bar-list">
-												{ ! isLoading ? (
-													<HorizontalBarList>
-														{ databars?.map( ( item, index ) => (
-															<HorizontalBarListItem
-																key={ `bar_${ index }` }
-																data={ item }
-																maxValue={ databarTotal }
-																hasIndicator={ false }
-																leftSideItem={ null }
-																useShortLabel={ false }
-																useShortNumber={ true }
-																isStatic={ true }
-																usePlainCard={ false }
-																isLinkUnderlined={ false }
-																leftGroupToggle={ true }
-															/>
-														) ) }
-													</HorizontalBarList>
-												) : (
-													<FlexibleSkeleton />
-												) }
-											</ul>
-											<div className="campaign-item-details__details no-bottom-margin">
-												{ translate( 'Compares traffic when campaign was active' ) }
-											</div>
+											{ isLoading && <FlexibleSkeleton /> }
+
+											{ ! isLoading && databarTotal === 0 && (
+												<div className="campaign-item-details__traffic-no-data">
+													{ translate( 'No data' ) }
+												</div>
+											) }
+
+											{ ! isLoading && databarTotal > 0 && (
+												<>
+													<ul className="horizontal-bar-list">
+														{ ! isLoading ? (
+															<HorizontalBarList>
+																{ databars?.map( ( item, index ) => (
+																	<HorizontalBarListItem
+																		key={ `bar_${ index }` }
+																		data={ item }
+																		maxValue={ databarTotal }
+																		hasIndicator={ false }
+																		leftSideItem={ null }
+																		useShortLabel={ false }
+																		useShortNumber={ true }
+																		isStatic={ true }
+																		usePlainCard={ false }
+																		isLinkUnderlined={ false }
+																		leftGroupToggle={ true }
+																	/>
+																) ) }
+															</HorizontalBarList>
+														) : (
+															<FlexibleSkeleton />
+														) }
+													</ul>
+													<div className="campaign-item-details__details no-bottom-margin">
+														{ translate( 'Compares traffic when campaign was active' ) }
+													</div>
+												</>
+											) }
 										</div>
 									</div>
 								</div>
@@ -528,7 +542,7 @@ export default function CampaignItemDetails( props: Props ) {
 												{ subtotal ? (
 													<span className="campaign-item-details__label">
 														<div>{ translate( 'Subtotal' ) }</div>
-														<div>{ subtotalFormatted }</div>
+														<div className="amount">{ subtotalFormatted }</div>
 													</span>
 												) : (
 													[]
@@ -536,16 +550,21 @@ export default function CampaignItemDetails( props: Props ) {
 												{ credits ? (
 													<span className="campaign-item-details__label">
 														<div>{ translate( 'Credits' ) }</div>
-														<div>{ creditsFormatted }</div>
+														<div className="amount">{ creditsFormatted }</div>
 													</span>
 												) : (
 													[]
 												) }
 												{ total ? (
-													<span className="campaign-item-details__label">
-														<div>{ translate( 'Total paid' ) }</div>
-														<div>{ totalFormatted }</div>
-													</span>
+													<>
+														<span className="campaign-item-details__label">
+															<div>{ translate( 'Total paid' ) }</div>
+															<div className="amount">{ totalFormatted }</div>
+														</span>
+														<p className="campaign-item-details__payment-charges-disclosure">
+															{ translate( 'All charges inclusive of VAT, if any.' ) }
+														</p>
+													</>
 												) : (
 													[]
 												) }
@@ -576,6 +595,11 @@ export default function CampaignItemDetails( props: Props ) {
 							<div className="campaign-item-details__preview-content">
 								<AdPreview isLoading={ isLoading } htmlCode={ creative_html || '' } />
 							</div>
+							<p className="campaign-item-details__preview-disclosure">
+								{ translate(
+									'Depending on the platform, the ad may seem differently from the preview.'
+								) }
+							</p>
 						</div>
 
 						<div className="campaign-item-details__support-buttons-container">
@@ -616,8 +640,7 @@ export default function CampaignItemDetails( props: Props ) {
 									<Gridicon icon="external" size={ 16 } />
 								</InlineSupportLink>
 								<div className="campaign-item-details__powered-by">
-									<Gridicon icon="fire" size={ 16 } />
-									<span>{ translate( 'Powered by Blaze' ) }</span>
+									<span>{ translate( 'Blaze - Powered by Jetpack' ) }</span>
 								</div>
 							</div>
 						</div>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -13,9 +13,10 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 	width: 100%;
 
 	.campaign-item-breadcrumb {
+		margin-bottom: 24px;
+
 		@media (max-width: $break-medium) {
 			margin-top: 16px;
-			margin-bottom: 16px;
 		}
 
 		a {
@@ -48,6 +49,8 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 	.campaign-item-details-header-line {
 		margin: 0 -64px 48px;
 		padding: 0;
+		background: #eee;
+
 		@media (max-width: 660px) {
 			margin: 0;
 		}
@@ -63,6 +66,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		font-size: 1.5rem;
 		font-weight: 500;
 		margin-bottom: 10px;
+		line-height: 32px;
 
 		@media (max-width: $break-medium) {
 			font-size: 1.25rem;
@@ -124,7 +128,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 	.campaign-item-details__wrapper {
 		display: flex;
 		flex: 1;
-		gap: 65px;
+		gap: 24px;
 		justify-content: space-between;
 
 		@media (max-width: $break-wide) {
@@ -148,13 +152,13 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 
 		.campaign-item-details__main-stats-container,
 		.campaign-item-details__payment-container {
-			border: 1px solid var(--color-neutral-20);
+			border: 1px solid #ddd;
 			border-radius: 4px;
 			margin-bottom: 65px;
 
 			@media (max-width: 660px) {
 				border: 0;
-				border-bottom: 1px solid var(--color-neutral-20);
+				border: 1px solid #ddd;
 				border-radius: 0;
 				margin-bottom: 0;
 			}
@@ -199,7 +203,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 
 			&:not(:last-child) {
 				@media (min-width: $break-medium) {
-					border-bottom: 1px solid var(--color-neutral-20);
+					border-bottom: 1px solid #ddd;
 				}
 			}
 
@@ -281,6 +285,17 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				margin-bottom: 24px;
 			}
 
+			.campaign-item-details__label .amount {
+				color: $studio-gray-60;
+				font-weight: 400;
+			}
+
+			.campaign-item-details__payment-charges-disclosure {
+				font-size: 0.875rem;
+				line-height: 20px;
+				margin: 12px 0 0;
+				color: $studio-gray-60;
+			}
 		}
 
 		.campaign-item-details__secondary-payment-row {
@@ -314,7 +329,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		}
 
 		.campaign-item-details__ad-destination-url-link {
-			color: var(--color-text);
+			color: var(--studio-gray-50);
 			display: flex;
 			flex-grow: 1;
 			height: unset;
@@ -355,10 +370,21 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 
 	}
 
-	.campaign-item-details__trafic-container-header {
+	.campaign-item-details__traffic-container-header {
 		display: flex;
 		justify-content: space-between;
-		margin-bottom: 12px;
+		margin-bottom: 5px;
+	}
+
+	.campaign-item-details__traffic-container-body {
+		.campaign-item-details__traffic-no-data {
+			border: 1px solid $studio-gray-5;
+			border-radius: 4px;
+			min-height: 40px;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+		}
 	}
 
 
@@ -389,6 +415,11 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 
 	.campaign-item-details__preview-content {
 		margin: 0 auto;
+		max-width: 300px;
+	}
+
+	.campaign-item-details__preview-disclosure {
+		margin: 12px auto 0 auto;
 		max-width: 300px;
 	}
 

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -154,7 +154,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		.campaign-item-details__payment-container {
 			border: 1px solid #ddd;
 			border-radius: 4px;
-			margin-bottom: 65px;
+			margin-bottom: 24px;
 
 			@media (max-width: 660px) {
 				border: 0;

--- a/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
@@ -151,7 +151,10 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 			width: 108px; // TODO: adjust height and width for mobile devices as well.
 		}
 	}
+}
 
+.promote-post-i2__table,
+.campaign-item__header-status {
 	.badge {
 		border-radius: 4px;
 		font-size: 0.75rem;


### PR DESCRIPTION
Related to SELFSERVE-590

## Proposed Changes

This PR fixes some styling issues in the Advertising campaign details page.

![screenshot-1](https://github.com/Automattic/wp-calypso/assets/1258162/e505b952-c38a-493e-a760-70e4eea63e38)

![Screenshot 2023-06-21 at 14 53 16](https://github.com/Automattic/wp-calypso/assets/1258162/2642977d-0a2c-4ddf-93b7-275dcca6a12a)

### Final result:
![Screenshot 2023-06-21 at 14 54 05](https://github.com/Automattic/wp-calypso/assets/1258162/cc2abb62-8643-4b87-b268-0b8a600b29f2)
![Screenshot 2023-06-21 at 14 54 11](https://github.com/Automattic/wp-calypso/assets/1258162/86d63cf2-9471-4b65-8934-0134acc83bd1)
![Screenshot 2023-06-21 at 14 54 22](https://github.com/Automattic/wp-calypso/assets/1258162/8d6eb74f-fb0f-42a0-96cf-6bdb19877893)

## Testing Instructions

* Open the live preview link and then navigate to Tools->Advertising
* Click on the Campaigns tab
* Go to the details of a campaign and verify the changes done in that page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
