### PR TITLE
Launchpad: Add/new variable to click event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -212,7 +212,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 				) }
 				<Launchpad
 					siteSlug={ siteSlug }
-					taskFilter={ () => enhancedTasks }
+					taskFilter={ () => enhancedTasks || [] }
 					makeLastTaskPrimaryAction={ true }
 				/>
 			</div>

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -41,6 +41,13 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 		const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
 
 		return sortedTasks.map( ( task: Task ) => {
+			recordTracksEvent( 'calypso_launchpad_task_view', {
+				checklist_slug: checklistSlug,
+				task_id: task.id,
+				is_completed: task.completed,
+				context: 'customer-home',
+			} );
+
 			let actionDispatch;
 
 			switch ( task.id ) {

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -12,15 +12,6 @@ import './style.scss';
 
 const checklistSlug = 'keep-building';
 
-function recordTaskClickTracksEvent( task: Task ) {
-	recordTracksEvent( 'calypso_launchpad_task_clicked', {
-		checklist_slug: checklistSlug,
-		task_id: task.id,
-		is_completed: task.completed,
-		context: 'customer-home',
-	} );
-}
-
 interface LaunchpadKeepBuildingProps {
 	siteSlug: string | null;
 }
@@ -33,11 +24,22 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
+	const tasklistCompleted = completedSteps === numberOfSteps;
+
+	const recordTaskClickTracksEvent = ( task: Task ) => {
+		recordTracksEvent( 'calypso_launchpad_task_clicked', {
+			checklist_slug: checklistSlug,
+			checklist_completed: tasklistCompleted,
+			task_id: task.id,
+			is_completed: task.completed,
+			context: 'customer-home',
+		} );
+	};
 
 	recordTracksEvent( 'calypso_launchpad_tasklist_viewed', {
 		checklist_slug: checklistSlug,
 		tasks: `,${ checklist?.map( ( task: Task ) => task.id ).join( ',' ) },`,
-		is_completed: completedSteps === numberOfSteps,
+		is_completed: tasklistCompleted,
 		number_of_steps: numberOfSteps,
 		number_of_completed_steps: completedSteps,
 		context: 'customer-home',

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -34,6 +34,15 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 
+	recordTracksEvent( 'calypso_launchpad_tasklist_viewed', {
+		checklist_slug: checklistSlug,
+		tasks: `,${ checklist?.map( ( task: Task ) => task.id ).join( ',' ) },`,
+		is_completed: completedSteps === numberOfSteps,
+		number_of_steps: numberOfSteps,
+		number_of_completed_steps: completedSteps,
+		context: 'customer-home',
+	} );
+
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
 		const completedTasks = tasks.filter( ( task: Task ) => task.completed );
 		const incompleteTasks = tasks.filter( ( task: Task ) => ! task.completed );

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -1,4 +1,5 @@
 import { useLaunchpad } from '@automattic/data-stores';
+import { useEffect, useRef } from 'react';
 import Checklist from './checklist';
 import type { Task } from './types';
 
@@ -6,7 +7,7 @@ export interface LaunchpadProps {
 	siteSlug: string | null;
 	checklistSlug?: string | 0 | null | undefined;
 	makeLastTaskPrimaryAction?: boolean;
-	taskFilter?: ( tasks: Task[] ) => Task[] | null;
+	taskFilter?: ( tasks: Task[] ) => Task[];
 }
 
 const Launchpad = ( {
@@ -17,14 +18,20 @@ const Launchpad = ( {
 }: LaunchpadProps ) => {
 	const launchpadData = useLaunchpad( siteSlug || '', checklistSlug );
 	const { isFetchedAfterMount, data } = launchpadData;
+	const tasks = useRef< Task[] >( [] );
 
-	const originalTasks = data.checklist || [];
-	const tasks = taskFilter ? taskFilter( originalTasks ) : originalTasks;
+	useEffect( () => {
+		const originalTasks = data.checklist || [];
+		tasks.current = taskFilter ? taskFilter( originalTasks ) : originalTasks;
+	}, [ data, taskFilter ] );
 
 	return (
 		<div className="launchpad__checklist-wrapper">
 			{ isFetchedAfterMount ? (
-				<Checklist tasks={ tasks } makeLastTaskPrimaryAction={ makeLastTaskPrimaryAction } />
+				<Checklist
+					tasks={ tasks.current }
+					makeLastTaskPrimaryAction={ makeLastTaskPrimaryAction }
+				/>
 			) : (
 				<Checklist.Placeholder />
 			) }

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -1,5 +1,5 @@
 import { useLaunchpad } from '@automattic/data-stores';
-import { useEffect, useRef } from 'react';
+import { useRef, useMemo } from 'react';
 import Checklist from './checklist';
 import type { Task } from './types';
 
@@ -20,7 +20,7 @@ const Launchpad = ( {
 	const { isFetchedAfterMount, data } = launchpadData;
 	const tasks = useRef< Task[] >( [] );
 
-	useEffect( () => {
+	useMemo( () => {
 		const originalTasks = data.checklist || [];
 		tasks.current = taskFilter ? taskFilter( originalTasks ) : originalTasks;
 	}, [ data, taskFilter ] );

--- a/packages/launchpad/src/test/launchpad.tsx
+++ b/packages/launchpad/src/test/launchpad.tsx
@@ -25,7 +25,9 @@ jest.mock( '@automattic/data-stores', () => {
 describe( 'Launchpad', () => {
 	describe( 'when no taskFilter is provided', () => {
 		it( 'then all tasks from useLaunchpad are rendered', () => {
-			render( <Launchpad siteSlug="any site" /> );
+			const { rerender } = render( <Launchpad siteSlug="any site" /> );
+			rerender( <Launchpad siteSlug="any site" /> );
+
 			const checklistItems = screen.queryAllByRole( 'listitem' );
 			expect( checklistItems.length ).toBe( 3 );
 		} );
@@ -38,7 +40,9 @@ describe( 'Launchpad', () => {
 				return [ tasks[ 0 ] ];
 			};
 
-			render( <Launchpad siteSlug="any site" taskFilter={ filter } /> );
+			const { rerender } = render( <Launchpad siteSlug="any site" taskFilter={ filter } /> );
+			rerender( <Launchpad siteSlug="any site" taskFilter={ filter } /> );
+
 			const checklistItems = screen.queryAllByRole( 'listitem' );
 			expect( checklistItems.length ).toBe( 1 );
 

--- a/packages/launchpad/src/test/launchpad.tsx
+++ b/packages/launchpad/src/test/launchpad.tsx
@@ -26,7 +26,6 @@ describe( 'Launchpad', () => {
 	describe( 'when no taskFilter is provided', () => {
 		it( 'then all tasks from useLaunchpad are rendered', () => {
 			render( <Launchpad siteSlug="any site" /> );
-
 			const checklistItems = screen.queryAllByRole( 'listitem' );
 			expect( checklistItems.length ).toBe( 3 );
 		} );
@@ -43,7 +42,6 @@ describe( 'Launchpad', () => {
 
 			const checklistItems = screen.queryAllByRole( 'listitem' );
 			expect( checklistItems.length ).toBe( 1 );
-
 			const taskId = checklistItems[ 0 ].querySelector( 'button' )?.getAttribute( 'data-task' );
 			expect( taskId ).toBe( 'task1' );
 		} );

--- a/packages/launchpad/src/test/launchpad.tsx
+++ b/packages/launchpad/src/test/launchpad.tsx
@@ -25,8 +25,7 @@ jest.mock( '@automattic/data-stores', () => {
 describe( 'Launchpad', () => {
 	describe( 'when no taskFilter is provided', () => {
 		it( 'then all tasks from useLaunchpad are rendered', () => {
-			const { rerender } = render( <Launchpad siteSlug="any site" /> );
-			rerender( <Launchpad siteSlug="any site" /> );
+			render( <Launchpad siteSlug="any site" /> );
 
 			const checklistItems = screen.queryAllByRole( 'listitem' );
 			expect( checklistItems.length ).toBe( 3 );
@@ -40,8 +39,7 @@ describe( 'Launchpad', () => {
 				return [ tasks[ 0 ] ];
 			};
 
-			const { rerender } = render( <Launchpad siteSlug="any site" taskFilter={ filter } /> );
-			rerender( <Launchpad siteSlug="any site" taskFilter={ filter } /> );
+			render( <Launchpad siteSlug="any site" taskFilter={ filter } /> );
 
 			const checklistItems = screen.queryAllByRole( 'listitem' );
 			expect( checklistItems.length ).toBe( 1 );

--- a/packages/launchpad/src/test/launchpad.tsx
+++ b/packages/launchpad/src/test/launchpad.tsx
@@ -39,9 +39,9 @@ describe( 'Launchpad', () => {
 			};
 
 			render( <Launchpad siteSlug="any site" taskFilter={ filter } /> );
-
 			const checklistItems = screen.queryAllByRole( 'listitem' );
 			expect( checklistItems.length ).toBe( 1 );
+
 			const taskId = checklistItems[ 0 ].querySelector( 'button' )?.getAttribute( 'data-task' );
 			expect( taskId ).toBe( 'task1' );
 		} );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/77616

## Proposed Changes

Added checklist complete status to the task click event. The idea is to be able to check the relevance of keeping the tasks available to users after the checklist is completed.

## Testing Instructions

* Create a new site from /start with the "Promote myself or business" intent.
* Launch your site
* You should see the new Launchpad task list on Customer Home.
* Run on your console: localStorage.debug='calypso:analytics'
* Click on a task
* Check data send on Devtools
* The task-clicked event should have a `checklist_completed` field

![image](https://github.com/Automattic/wp-calypso/assets/3801502/2e33654e-00e7-4b47-889b-8aa343490c10)
