### PR TITLE
Fixes the navigation item count in the Advertising page

### DIFF
--- a/client/data/promote-post/use-promote-post-posts-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-posts-query-paged.ts
@@ -7,7 +7,7 @@ type BlazablePostsQueryOptions = {
 	page?: number;
 };
 
-const getSearchOptionsQueryParams = ( searchOptions: SearchOptions ) => {
+export const getSearchOptionsQueryParams = ( searchOptions: SearchOptions ) => {
 	let searchQueryParams = '';
 
 	if ( searchOptions.search ) {

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -12,7 +12,9 @@ import { Campaign } from 'calypso/data/promote-post/types';
 import useCampaignsQueryPaged from 'calypso/data/promote-post/use-promote-post-campaigns-query-paged';
 import useCampaignsStatsQuery from 'calypso/data/promote-post/use-promote-post-campaigns-stats-query';
 import useCreditBalanceQuery from 'calypso/data/promote-post/use-promote-post-credit-balance-query';
-import usePostsQueryPaged from 'calypso/data/promote-post/use-promote-post-posts-query-paged';
+import usePostsQueryPaged, {
+	getSearchOptionsQueryParams,
+} from 'calypso/data/promote-post/use-promote-post-posts-query-paged';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import CampaignsList from 'calypso/my-sites/promote-post-i2/components/campaigns-list';
 import PostsList from 'calypso/my-sites/promote-post-i2/components/posts-list';
@@ -57,6 +59,10 @@ export type PagedBlazeContentData = {
 
 export type PagedBlazeSearchResponse = {
 	pages: PagedBlazeContentData[];
+};
+
+const POST_DEFAULT_SEARCH_OPTIONS: SearchOptions = {
+	order: SORT_OPTIONS_DEFAULT,
 };
 
 export default function PromotedPosts( { tab }: Props ) {
@@ -109,9 +115,9 @@ export default function PromotedPosts( { tab }: Props ) {
 	);
 
 	/* query for posts */
-	const [ postsSearchOptions, setPostsSearchOptions ] = useState< SearchOptions >( {
-		order: SORT_OPTIONS_DEFAULT,
-	} );
+	const [ postsSearchOptions, setPostsSearchOptions ] = useState< SearchOptions >(
+		POST_DEFAULT_SEARCH_OPTIONS
+	);
 	const postsQuery = usePostsQueryPaged( selectedSiteId ?? 0, postsSearchOptions );
 
 	const {
@@ -128,7 +134,7 @@ export default function PromotedPosts( { tab }: Props ) {
 	const initialPostQueryState = queryClient.getQueryState( [
 		'promote-post-posts',
 		selectedSiteId,
-		'',
+		getSearchOptionsQueryParams( POST_DEFAULT_SEARCH_OPTIONS ),
 	] );
 
 	const { has_more_pages: postsHasMorePages, items: posts } = getPagedBlazeSearchData(


### PR DESCRIPTION
Related to SELFSERVE-617

The advertising page shows the number of posts/campagins the user has in the navigation items. There is a bug related to the total post, it shows as 0 even if the site has post on it. 

## Proposed Changes

* Change how we get the total posts to show the correct number in the navigation.

## Testing Instructions

* Open the Live preview and navigate to Tools->Advertising
* In the navigation bar, check that the total number of posts is correct
![Screenshot 2023-06-21 at 17 33 25](https://github.com/Automattic/wp-calypso/assets/1258162/df1db2fa-fd47-4c9b-8178-fe53fe49fa3a)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
