### PR TITLE
Components: Add a new Pricing Slider component

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -63,6 +63,7 @@
 		"@types/canvas-confetti": "^1.6.0",
 		"@types/react-slider": "^1.3.1",
 		"qrcode.react": "^3.1.0",
+		"resize-observer-polyfill": "^1.5.1",
 		"typescript": "^4.7.4"
 	},
 	"scripts": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,6 +42,7 @@
 		"lodash": "^4.17.21",
 		"prop-types": "^15.7.2",
 		"react-modal": "^3.16.1",
+		"react-slider": "^2.0.5",
 		"utility-types": "^3.10.0",
 		"wpcom-proxy-request": "workspace:^"
 	},
@@ -60,6 +61,7 @@
 		"@testing-library/react": "^12.1.3",
 		"@testing-library/react-hooks": "7.0.2",
 		"@types/canvas-confetti": "^1.6.0",
+		"@types/react-slider": "^1.3.1",
 		"qrcode.react": "^3.1.0",
 		"typescript": "^4.7.4"
 	},

--- a/packages/components/src/pricing-slider/index.tsx
+++ b/packages/components/src/pricing-slider/index.tsx
@@ -1,0 +1,53 @@
+import classNames from 'classnames';
+import React from 'react';
+import ReactSlider from 'react-slider';
+import { RenderThumbFunction, PricingSliderProps } from './types';
+import './style.scss';
+
+/**
+ * Generate Pricing Slider
+ * More support from the original ReactSlider component: https://zillow.github.io/react-slider/
+ *
+ * @param {PricingSliderProps} props - Props
+ * @returns {React.ReactElement} - JSX element
+ */
+const PricingSlider: React.FC< PricingSliderProps > = ( {
+	className,
+	maxValue = 100,
+	minValue = 0,
+	step = 1,
+	value,
+	onChange,
+	onBeforeChange,
+	onAfterChange,
+	renderThumb,
+} ) => {
+	const componentClassName = classNames( 'jp-components-pricing-slider', className );
+
+	const renderThumbCallback = renderThumb
+		? renderThumb
+		: ( ( ( props, state ) => {
+				return <div { ...props }>{ state.valueNow }</div>;
+		  } ) as RenderThumbFunction );
+
+	return (
+		<div className={ componentClassName } data-testid="pricing-slider">
+			<ReactSlider
+				className="jp-components-pricing-slider__control"
+				thumbClassName="jp-components-pricing-slider__thumb"
+				thumbActiveClassName="jp-components-pricing-slider__thumb--is-active"
+				trackClassName="jp-components-pricing-slider__track"
+				value={ value }
+				max={ maxValue }
+				min={ minValue }
+				step={ step }
+				renderThumb={ renderThumbCallback } // eslint-disable-line react/jsx-no-bind
+				onChange={ onChange } // eslint-disable-line react/jsx-no-bind
+				onBeforeChange={ onBeforeChange } // eslint-disable-line react/jsx-no-bind
+				onAfterChange={ onAfterChange } // eslint-disable-line react/jsx-no-bind
+			/>
+		</div>
+	);
+};
+
+export default PricingSlider;

--- a/packages/components/src/pricing-slider/stories/index.stories.tsx
+++ b/packages/components/src/pricing-slider/stories/index.stories.tsx
@@ -4,12 +4,20 @@ import type { RenderThumbFunction } from '../types';
 import type { StoryFn, Meta } from '@storybook/react';
 
 export default {
-	title: 'JS Packages/Components/Pricing Slider',
+	title: 'packages/components/Pricing Slider',
 	component: PricingSlider,
 } as Meta< typeof PricingSlider >;
 
+const StoryContainer = ( { children }: { children: React.ReactNode } ) => (
+	<div style={ { padding: '10vh 20vw' } }>{ children }</div>
+);
+
 // Export additional stories using pre-defined values
-const Template: StoryFn< typeof PricingSlider > = ( args ) => <PricingSlider { ...args } />;
+const Template: StoryFn< typeof PricingSlider > = ( args ) => (
+	<StoryContainer>
+		<PricingSlider { ...args } />
+	</StoryContainer>
+);
 
 // Export Default story
 export const _default = Template.bind( {} );
@@ -27,7 +35,7 @@ const TemplateWithChangingValue: StoryFn< typeof PricingSlider > = ( args ) => {
 	} ) as RenderThumbFunction;
 
 	return (
-		<div>
+		<StoryContainer>
 			<PricingSlider
 				{ ...args }
 				value={ value }
@@ -37,7 +45,7 @@ const TemplateWithChangingValue: StoryFn< typeof PricingSlider > = ( args ) => {
 			/>
 			<div>{ `Value on changing: ${ value }` }</div>
 			<div>{ `Value on change ends: ${ endValue }` }</div>
-		</div>
+		</StoryContainer>
 	);
 };
 

--- a/packages/components/src/pricing-slider/stories/index.stories.tsx
+++ b/packages/components/src/pricing-slider/stories/index.stories.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import PricingSlider from '../index';
+import type { RenderThumbFunction } from '../types';
+import type { StoryFn, Meta } from '@storybook/react';
+
+export default {
+	title: 'JS Packages/Components/Pricing Slider',
+	component: PricingSlider,
+} as Meta< typeof PricingSlider >;
+
+// Export additional stories using pre-defined values
+const Template: StoryFn< typeof PricingSlider > = ( args ) => <PricingSlider { ...args } />;
+
+// Export Default story
+export const _default = Template.bind( {} );
+
+// Export additional stories using chaning values
+const TemplateWithChangingValue: StoryFn< typeof PricingSlider > = ( args ) => {
+	const [ value, setValue ] = useState( 10 );
+	const [ endValue, setEndValue ] = useState( 10 );
+	const renderThumb = ( ( props, state ) => {
+		return (
+			<div { ...props }>
+				{ state.valueNow } - { state.valueNow % 2 === 0 ? 'Even' : 'Odd' }
+			</div>
+		);
+	} ) as RenderThumbFunction;
+
+	return (
+		<div>
+			<PricingSlider
+				{ ...args }
+				value={ value }
+				onChange={ setValue }
+				onAfterChange={ setEndValue }
+				renderThumb={ renderThumb } // eslint-disable-line react/jsx-no-bind
+			/>
+			<div>{ `Value on changing: ${ value }` }</div>
+			<div>{ `Value on change ends: ${ endValue }` }</div>
+		</div>
+	);
+};
+
+// Export With Default Value story
+export const WithDefaultValue = TemplateWithChangingValue.bind( {} );

--- a/packages/components/src/pricing-slider/style.scss
+++ b/packages/components/src/pricing-slider/style.scss
@@ -1,17 +1,26 @@
-@import "@automattic/jetpack-base-styles/style";
-
 $thumb-height: 40px;
 $track-height: 8px;
+$thumb-vertical-padding: 8px;
+$thumb-horizontal-padding: 16px;
 
 @mixin adjust-track-rail-styles {
 	height: $track-height;
 	border-radius: 8px; /* stylelint-disable-line scales/radii */
 }
 
-// Base styles
+// CSS variables
+// Subset of https://github.com/Automattic/jetpack/blob/trunk/projects/js-packages/base-styles/root-variables.scss.
+.jp-components-pricing-slider {
+	--font-body: 16px;
+	--jp-black: #000;
+	--jp-white: #fff;
+	--jp-gray: #dcdcde;
+	--jp-green-40: #069e08;
+}
+
 .jp-components-pricing-slider__control {
 	width: 100%;
-	height: $thumb-height;
+	height: $thumb-height + $thumb-vertical-padding * 2;
 }
 
 .jp-components-pricing-slider__track {
@@ -29,24 +38,26 @@ $track-height: 8px;
 }
 
 .jp-components-pricing-slider__thumb {
-	display: flex;
 	align-items: center;
-	justify-content: center;
-	padding: 8px 16px;
-	height: $thumb-height;
 	background-color: var(--jp-white);
+	border-radius: 4px;
 	border: 1px solid var(--jp-gray);
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 6px 8px rgba(0, 0, 0, 0.08);
-	border-radius: 4px;
 	color: var(--jp-black);
+	cursor: pointer;
+	display: flex;
+	// TODO: Use standardized font here.
 	font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: var(--font-body);
 	font-style: normal;
 	font-weight: 600;
-	font-size: var(--font-body);
-	line-height: 24px;
+	height: $thumb-height;
+	justify-content: center;
 	letter-spacing: -0.02em;
+	line-height: 24px;
+	padding: $thumb-vertical-padding $thumb-horizontal-padding;
+	transform: translate(0, -20%); // TODO: Check if this -20% translation is correct.
 	white-space: nowrap;
-	cursor: pointer;
 
 	&.jp-components-pricing-slider__thumb--is-active {
 		// On focus styling

--- a/packages/components/src/pricing-slider/style.scss
+++ b/packages/components/src/pricing-slider/style.scss
@@ -1,0 +1,55 @@
+@import "@automattic/jetpack-base-styles/style";
+
+$thumb-height: 40px;
+$track-height: 8px;
+
+@mixin adjust-track-rail-styles {
+	height: $track-height;
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+}
+
+// Base styles
+.jp-components-pricing-slider__control {
+	width: 100%;
+	height: $thumb-height;
+}
+
+.jp-components-pricing-slider__track {
+	@include adjust-track-rail-styles;
+	top: calc(($thumb-height / 2) - ($track-height / 2));
+	background: var(--jp-gray);
+
+	&.jp-components-pricing-slider__track-0 {
+		background: var(--jp-green-40);
+	}
+
+	&.jp-components-pricing-slider__track-1 {
+		background: var(--jp-gray);
+	}
+}
+
+.jp-components-pricing-slider__thumb {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 8px 16px;
+	height: $thumb-height;
+	background-color: var(--jp-white);
+	border: 1px solid var(--jp-gray);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 6px 8px rgba(0, 0, 0, 0.08);
+	border-radius: 4px;
+	color: var(--jp-black);
+	font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-style: normal;
+	font-weight: 600;
+	font-size: var(--font-body);
+	line-height: 24px;
+	letter-spacing: -0.02em;
+	white-space: nowrap;
+	cursor: pointer;
+
+	&.jp-components-pricing-slider__thumb--is-active {
+		// On focus styling
+		outline: none;
+	}
+}

--- a/packages/components/src/pricing-slider/test/index.tsx
+++ b/packages/components/src/pricing-slider/test/index.tsx
@@ -1,0 +1,18 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import PricingSlider from '../index';
+
+describe( 'PricingSlider', () => {
+	beforeAll( () => {
+		global.ResizeObserver = require( 'resize-observer-polyfill' );
+	} );
+	it( 'renders the pricing slider', () => {
+		render( <PricingSlider /> );
+		expect( screen.getByTestId( 'pricing-slider' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/components/src/pricing-slider/types.ts
+++ b/packages/components/src/pricing-slider/types.ts
@@ -1,0 +1,60 @@
+import type { HTMLProps, RefCallback } from 'react';
+
+interface HTMLPropsWithRefCallback< T > extends HTMLProps< T > {
+	ref: RefCallback< T >;
+}
+
+export type RenderThumbFunction = (
+	props: HTMLPropsWithRefCallback< HTMLDivElement >,
+	state: { index: number; value: number | ReadonlyArray< number >; valueNow: number }
+) => JSX.Element | null;
+
+export type PricingSliderProps = {
+	/**
+	 * The wrapper class name of this PricingSlider component.
+	 */
+	className?: string;
+
+	/**
+	 * The maximum value of the slider.
+	 */
+	maxValue?: number;
+
+	/**
+	 * The minimum value of the slider.
+	 */
+	minValue?: number;
+
+	/**
+	 * The initial value of the slider.
+	 */
+	value?: number;
+
+	/**
+	 * The step value of the slider.
+	 */
+	step?: number;
+
+	/**
+	 * Callback called on every value change.
+	 * The function will be called with two arguments, the first being the new value(s) the second being thumb index.
+	 */
+	onChange?: ( value: number ) => void;
+
+	/**
+	 * Callback called before starting to move a thumb. The callback will only be called if the action will result in a change.
+	 * The function will be called with two arguments, the first being the initial value(s) the second being thumb index.
+	 */
+	onBeforeChange?: ( value: number ) => void;
+
+	/**
+	 * Callback called only after moving a thumb has ended. The callback will only be called if the action resulted in a change.
+	 * The function will be called with two arguments, the first being the result value(s) the second being thumb index.
+	 */
+	onAfterChange?: ( value: number ) => void;
+
+	/**
+	 * Node to render on the slider.
+	 */
+	renderThumb?: RenderThumbFunction;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -476,6 +476,7 @@ __metadata:
     "@testing-library/react": ^12.1.3
     "@testing-library/react-hooks": 7.0.2
     "@types/canvas-confetti": ^1.6.0
+    "@types/react-slider": ^1.3.1
     "@wordpress/base-styles": ^4.13.0
     "@wordpress/components": ^22.1.0
     "@wordpress/icons": ^9.13.0
@@ -488,6 +489,7 @@ __metadata:
     prop-types: ^15.7.2
     qrcode.react: ^3.1.0
     react-modal: ^3.16.1
+    react-slider: ^2.0.5
     typescript: ^4.7.4
     utility-types: ^3.10.0
     wpcom-proxy-request: "workspace:^"
@@ -6883,6 +6885,15 @@ __metadata:
     "@types/history": "*"
     "@types/react": "*"
   checksum: d75eb06708cf43aea97e91e62b0b7ea8b4393350f00df2443a8527a3a69ef145c2d31ff2d0e30817b13ea13ae5c2e8291f410d63efd7afc466ff981750e3ef19
+  languageName: node
+  linkType: hard
+
+"@types/react-slider@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@types/react-slider@npm:1.3.1"
+  dependencies:
+    "@types/react": "*"
+  checksum: 3b45b86fc1e7ddfa3723aa6a2fb73a34254cd1e1a7ac591874c4bcc400283e9a9b18257a398d103e1cc666c67cffd7394887f4da8db118bc6b7a4e6292b5172a
   languageName: node
   linkType: hard
 
@@ -25375,6 +25386,17 @@ __metadata:
   peerDependencies:
     react: ^16.0.0 || ^17.0.0
   checksum: b95f7ee2d88cf093e5b370663943ceb9199b8dff4217cb8cbffdf5e60966286f898a3ce7257b3c31bab54d698a3c80e70e92b0a8320bc69bdcf4d565678261c9
+  languageName: node
+  linkType: hard
+
+"react-slider@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "react-slider@npm:2.0.5"
+  dependencies:
+    prop-types: ^15.8.1
+  peerDependencies:
+    react: ^16 || ^17 || ^18
+  checksum: 2265b3b407681238a8202989f24f154fff06e142ece1f1fbb69dfdc34f93d3cc722a0ea2beacf7b55bbc542f0256e3bda83e4ec898da05e785351d93f82c293f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -490,6 +490,7 @@ __metadata:
     qrcode.react: ^3.1.0
     react-modal: ^3.16.1
     react-slider: ^2.0.5
+    resize-observer-polyfill: ^1.5.1
     typescript: ^4.7.4
     utility-types: ^3.10.0
     wpcom-proxy-request: "workspace:^"
@@ -26803,7 +26804,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resize-observer-polyfill@npm:1.5.1":
+"resize-observer-polyfill@npm:1.5.1, resize-observer-polyfill@npm:^1.5.1":
   version: 1.5.1
   resolution: "resize-observer-polyfill@npm:1.5.1"
   checksum: 5e882475067f0b97dc07e0f37c3e335ac5bc3520d463f777cec7e894bb273eddbfecb857ae668e6fb6881fd6f6bb7148246967172139302da50fa12ea3a15d95


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/31425 and https://github.com/Automattic/jetpack/issues/31345.

## Proposed Changes

<img width="1042" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/a318f459-4a10-4db1-8a3d-3df3d7de2645">

* Adds a new `Pricing Slider` component which wraps the [react-slider](https://zillow.github.io/react-slider/#reactslider) library.
* Adds a Storybook story along with unit tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up Storybook and ensure the new Pricing Slider component works as expected.
    * I like to go to the following file and comment out lines 7 and 8 for improved compile performance: https://github.com/Automattic/wp-calypso/blob/adaa22b3359358df47f4fb8f28437ad74bbb81b6/.storybook/main.js#L7
    * Execute `yarn storybook:start`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
