### PR TITLE
BackupBrowser: Hide changed details for extensions that don't have extension_version

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -55,14 +55,19 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 		if ( isSuccess ) {
 			let childIsAlternate = isAlternate;
 
-			return backupFiles.map( ( item ) => {
+			return backupFiles.map( ( childItem ) => {
 				childIsAlternate = ! childIsAlternate;
+
+				// Let's hide archives that don't have an extension version
+				if ( childItem.type === 'archive' && ! item.extensionVersion ) {
+					return null;
+				}
 
 				return (
 					<FileBrowserNode
-						key={ item.name }
-						item={ item }
-						path={ `${ path }${ item.name }/` }
+						key={ childItem.name }
+						item={ childItem }
+						path={ `${ path }${ childItem.name }/` }
 						siteId={ siteId }
 						rewindId={ rewindId }
 						isAlternate={ childIsAlternate }

--- a/client/my-sites/backup/backup-contents-page/file-browser/types.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/types.ts
@@ -22,6 +22,7 @@ export interface FileBrowserItem {
 	period?: string;
 	sort?: number;
 	children?: FileBrowserItem[];
+	extensionVersion?: string;
 }
 
 export interface BackupLsResponse {
@@ -38,5 +39,6 @@ export interface BackupLsResponseContents {
 		sort?: number;
 		manifest_path?: string;
 		label?: string;
+		extension_version?: string;
 	};
 }

--- a/client/my-sites/backup/backup-contents-page/file-browser/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/util.ts
@@ -79,6 +79,7 @@ export const parseBackupContentsData = ( payload: BackupLsResponse ): FileBrowse
 			...( item.period && { period: item.period } ),
 			...( item.sort && { sort: item.sort } ),
 			...( item.type === 'archive' && { extension_type: name.replace( '*', '' ) } ),
+			...( item.extension_version && { extensionVersion: item.extension_version } ),
 		};
 	} );
 


### PR DESCRIPTION
## Proposed Changes

* Hide changed/unchanged details for plugins/themes that don't have a `extension_version`

| Before | After |
|---|---|
| <img width="646" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/bcf0dbc2-a9d3-4970-af32-ba388ffb786e"> | <img width="643" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/a7dbadaf-c4ac-430a-9a5e-c0b6a43b2b9d"> |

## Testing Instructions

* Start a Jetpack Cloud or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Browse a premium or custom plugin and ensure it looks similar to the `After` screenshot shared above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
