### PR TITLE
Subscriber Details: Create useSubscriberDetailsQuery

### DIFF
--- a/client/my-sites/subscribers/controller.js
+++ b/client/my-sites/subscribers/controller.js
@@ -24,6 +24,15 @@ export function subscribers( context, next ) {
 
 export function subscriberDetails( context, next ) {
 	const { path } = context;
+	const userId = path.split( '/' ).pop();
+
+	context.primary = <SubscriberDetailsPage userId={ userId } />;
+
+	next();
+}
+
+export function externalSubscriberDetails( context, next ) {
+	const { path } = context;
 	const subscriberId = path.split( '/' ).pop();
 
 	context.primary = <SubscriberDetailsPage subscriberId={ subscriberId } />;

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -20,9 +20,21 @@ const getSubscribersCacheKey = (
 	return cacheKey;
 };
 
+const getSubscriberDetailsCacheKey = ( siteId: number | null, queryString: string ) => [
+	'subscriber-details',
+	siteId,
+	queryString,
+];
+
 const sanitizeInt = ( intString: string ) => {
 	const parsedInt = parseInt( intString, 10 );
 	return ! Number.isNaN( parsedInt ) && parsedInt > 0 ? parsedInt : undefined;
 };
 
-export { getEarnPageUrl, getEarnPaymentsPageUrl, getSubscribersCacheKey, sanitizeInt };
+export {
+	getEarnPageUrl,
+	getEarnPaymentsPageUrl,
+	getSubscriberDetailsCacheKey,
+	getSubscribersCacheKey,
+	sanitizeInt,
+};

--- a/client/my-sites/subscribers/index.js
+++ b/client/my-sites/subscribers/index.js
@@ -1,16 +1,24 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
-import { subscribers, subscriberDetails } from './controller';
+import { subscribers, subscriberDetails, externalSubscriberDetails } from './controller';
 
 export default function () {
 	page( '/subscribers', siteSelection, sites, navigation, makeLayout, clientRender );
 	page( '/subscribers/:domain', siteSelection, navigation, subscribers, makeLayout, clientRender );
 	page(
-		'/subscribers/:domain/:subscriber',
+		'/subscribers/:domain/:user',
 		siteSelection,
 		navigation,
 		subscriberDetails,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/subscribers/external/:domain/:subscriber',
+		siteSelection,
+		navigation,
+		externalSubscriberDetails,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -41,7 +41,11 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 	const { currentSubscriber, onClickUnsubscribe, onConfirmModal, resetSubscriber } =
 		useUnsubscribeModal( selectedSiteId, pageNumber );
 	const onClickView = ( subscriber: Subscriber ) => {
-		page.show( `/subscribers/${ selectedSiteSlug }/${ subscriber.subscription_id }` );
+		if ( subscriber.user_id ) {
+			page.show( `/subscribers/${ selectedSiteSlug }/${ subscriber.user_id }` );
+		} else {
+			page.show( `/subscribers/external/${ selectedSiteSlug }/${ subscriber.subscription_id }` );
+		}
 	};
 	const [ showAddSubscribersModal, setShowAddSubscribersModal ] = useState( false );
 	const dispatch = useDispatch();

--- a/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { getSubscriberDetailsCacheKey } from '../helpers';
+import type { Subscriber } from '../types';
+
+const useSubscriberDetailsQuery = (
+	siteId: number | null,
+	subscriberId: number | undefined,
+	userId: number | undefined
+) => {
+	let queryString = '';
+
+	if ( subscriberId ) {
+		queryString += `subscriber_id=${ subscriberId }`;
+	} else if ( userId ) {
+		queryString += `user_id=${ userId }`;
+	}
+
+	return useQuery< Subscriber >( {
+		queryKey: getSubscriberDetailsCacheKey( siteId, queryString ),
+		queryFn: () =>
+			wpcom.req.get( {
+				path: `/sites/${ siteId }/subscribers/individual?${ queryString }`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		enabled: !! siteId,
+		keepPreviousData: true,
+	} );
+};
+
+export default useSubscriberDetailsQuery;

--- a/client/my-sites/subscribers/subscriber-details-page.tsx
+++ b/client/my-sites/subscribers/subscriber-details-page.tsx
@@ -8,10 +8,11 @@ import { SubscriberDetails } from './components/subscriber-details';
 import { SubscriberPopover } from './components/subscriber-popover';
 
 type SubscriberDetailsPageProps = {
-	subscriberId: number;
+	subscriberId?: number;
+	userId?: number;
 };
 
-const SubscriberDetailsPage = ( { subscriberId }: SubscriberDetailsPageProps ) => {
+const SubscriberDetailsPage = ( { subscriberId, userId }: SubscriberDetailsPageProps ) => {
 	const translate = useTranslate();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
@@ -25,16 +26,6 @@ const SubscriberDetailsPage = ( { subscriberId }: SubscriberDetailsPageProps ) =
 			href: `/subscribers/${ selectedSiteSlug }/${ subscriberId }`,
 		},
 	];
-
-	const mockSubscriber = {
-		avatar: `https://secure.gravatar.com/avatar/${ subscriberId }`,
-		subscription_id: subscriberId,
-		email_address: 'mock.subscriber@email.com',
-		display_name: 'Mock Subscriber',
-		date_subscribed: '2021-01-01T00:00:00.000Z',
-		open_rate: 0,
-		user_id: 0,
-	};
 
 	return (
 		<Main wideLayout>

--- a/client/my-sites/subscribers/subscriber-details-page.tsx
+++ b/client/my-sites/subscribers/subscriber-details-page.tsx
@@ -3,9 +3,10 @@ import { Item } from 'calypso/components/breadcrumb';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SubscriberDetails } from './components/subscriber-details';
 import { SubscriberPopover } from './components/subscriber-popover';
+import useSubscriberDetailsQuery from './queries/use-subscriber-details-query';
 
 type SubscriberDetailsPageProps = {
 	subscriberId?: number;
@@ -14,7 +15,9 @@ type SubscriberDetailsPageProps = {
 
 const SubscriberDetailsPage = ( { subscriberId, userId }: SubscriberDetailsPageProps ) => {
 	const translate = useTranslate();
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const { data: subscriber } = useSubscriberDetailsQuery( selectedSiteId, subscriberId, userId );
 
 	const navigationItems: Item[] = [
 		{
@@ -32,7 +35,7 @@ const SubscriberDetailsPage = ( { subscriberId, userId }: SubscriberDetailsPageP
 			<FixedNavigationHeader navigationItems={ navigationItems }>
 				<SubscriberPopover onUnsubscribe={ () => undefined } />
 			</FixedNavigationHeader>
-			<SubscriberDetails subscriber={ mockSubscriber } />
+			{ subscriber && <SubscriberDetails subscriber={ subscriber } /> }
 		</Main>
 	);
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78367

## Proposed Changes

* Create useSubscriberDetailsQuery to retrieve individual subscribers
* Create a new route only for external subscribers (`/subscribers/external/:slug/:subscriber_id`)
* Integrate query with details page

## Testing Instructions

* Apply this PR to your local
* Apply this patch D114186-code and sandbox public-api.wordpress.com
* Edit the `SubscriberPopover` on `subscriber-row` to enable the view menu option using isViewButtonVisible
* Go to http://calypso.localhost:3000/subscribers/{site-slug}
* Click on an external subscriber row
* You should be redirected to `/subscribers/external/:slug/:subscriber_id` route and should see the user's name, email and avatar
* Go back and click on a wpcom subscriber row
* You should be redirected to `/subscribers/:slug/:user_id` route and should see the user's name, email and avatar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?