### PR TITLE
Allow newsletter setup to use default button text

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -36,7 +36,6 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 		taglinePlaceholder: translate( `Letters from Emily Dickinson's garden` ),
 		iconPlaceholder: translate( 'Add a site icon' ),
 		colorLabel: translate( 'Choose an accent color' ),
-		buttonText: translate( 'Save and continue' ),
 	};
 
 	const {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/76448

## Proposed Changes

In response to feedback, the PR ensures that the Newsletter Setup and Post-Setup screens in onboarding have the same button text, 'Continue'. This is done by removing the custom text in the Setup screen, so the setup form just uses the default [here](https://github.com/Automattic/wp-calypso/blob/66b20f8349d334661601de740609ef5a7ab10b8d/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx#L130).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Load this branch and start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro
2) Confirm that button text on setup screen is `Continue`
3) Continue to Launchpad, click `Personalize your newsletter`, and again confirm the button text on that screen is `Continue`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
