### PR TITLE
Jetpack Pro Dashboard: Set contact as verified if /contacts API throws the same error

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -153,11 +153,17 @@ export default function EmailAddressEditor( {
 
 	// Add email item to the list once the email is verified
 	useEffect( () => {
-		if ( verifyEmail.isVerified ) {
+		if ( verifyEmail.isVerified || requestVerificationCode.isVerified ) {
 			handleSetEmailItems();
 			setVerifiedEmail( emailItem.email );
 		}
-	}, [ emailItem.email, handleSetEmailItems, setVerifiedEmail, verifyEmail.isVerified ] );
+	}, [
+		emailItem.email,
+		handleSetEmailItems,
+		requestVerificationCode.isVerified,
+		setVerifiedEmail,
+		verifyEmail.isVerified,
+	] );
 
 	// Show error message when email verification fails
 	useEffect( () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -185,7 +185,7 @@ export default function PhoneNumberEditor( {
 
 	// Add phone item to the list once the phone number is verified
 	useEffect( () => {
-		if ( verifyPhoneNumber.isVerified ) {
+		if ( verifyPhoneNumber.isVerified || requestVerificationCode.isVerified ) {
 			handleSetPhoneItems();
 			setVerifiedPhoneNumber( phoneItem.phoneNumberFull );
 		}
@@ -194,6 +194,7 @@ export default function PhoneNumberEditor( {
 		phoneItem.phoneNumberFull,
 		handleSetPhoneItems,
 		setVerifiedPhoneNumber,
+		requestVerificationCode.isVerified,
 	] );
 
 	// Show error message when phone number verification fails

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks.tsx
@@ -16,10 +16,25 @@ export function useRequestVerificationCode(): {
 	isError: boolean;
 	isLoading: boolean;
 	isSuccess: boolean;
+	isVerified: boolean;
 } {
-	return useRequestContactVerificationCode( {
+	const [ isAlreadyVerifed, setIsAlreadyVerifed ] = useState( false );
+
+	const data = useRequestContactVerificationCode( {
 		retry: false,
+		onError: async ( error ) => {
+			// Add the contact to the list of contacts if already verified
+			if (
+				error?.code &&
+				[ 'existing_verified_email_contact', 'existing_verified_sms_contact' ].includes(
+					error.code
+				)
+			) {
+				setIsAlreadyVerifed( true );
+			}
+		},
 	} );
+	return { ...data, isVerified: isAlreadyVerifed };
 }
 
 const verificationErrorMessages: { [ key: string ]: string } = {
@@ -95,8 +110,8 @@ export function useValidateVerificationCode(): {
 			await handleSetMonitoringContacts( data, params );
 		},
 		onError: async ( error, params ) => {
+			// Add the contact to the list of contacts if already verified
 			if ( error?.code === 'jetpack_agency_contact_is_verified' ) {
-				// Add the contact to the list of contacts if already verified
 				setIsAlreadyVerifed( true );
 				await handleSetMonitoringContacts( { verified: true }, params );
 			}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -162,7 +162,7 @@ export default function NotificationSettings( {
 		}
 		setIsAddSMSModalOpen( ( isAddSMSModalOpen ) => ! isAddSMSModalOpen );
 		if ( isAddSMSModalOpen ) {
-			setSelectedEmail( undefined );
+			setSelectedPhone( undefined );
 			setSelectedAction( undefined );
 		}
 	};


### PR DESCRIPTION
Related to 1204774821045518-as-1204869068963803 & 1204774821045518-as-1204873670870908

## Proposed Changes

This PR

- Handles API error: Set contact as verified when POST /contacts API throws an error that the contact is already verified.
- Fixes a bug: set the selected phone item to undefined when the popup is closed.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**
1. Run `git checkout add/set-monitor-phone-number-as-verified` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the `/dashboard`.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Click the **+ Add phone number** button -> Enter a valid phone number details and please note down the phone number -> Click Verify
6. Follow the instruction in D113560-code on how to get the verification code and enter it. Once the phone number is verified and added to the list, refresh the page without pressing the **'Save'** button. 
7. Set refetchOnWindowFocus: false in the `client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts` after line no 28

```
enabled: isPartnerOAuthTokenLoaded && isMultipleEmailEnabled,
refetchOnWindowFocus: false,
```

8. Open the network tab, find the contacts API, and click on Block request URL

<img src="https://user-images.githubusercontent.com/10586875/242153684-7d14b2de-88f1-46a8-acc0-edf1d11ff8b3.png" />

9. Go to the **Console** tab and clear the local storage using `localStorage.clear()`, and refresh the page.
10. Verify the GET `/jetpack-agency/contacts` is blocked. Please repeat step 8 until the API call is made and it is blocked.
11. Now, click the **+ Add Phone number** button and verify the GET `/jetpack-agency/contacts` is made and gets blocked.
12. Once all the 3 retries for GET /jetpack-agency/contacts is complete and blocked, uncheck the Enable network request blocking toggle.

<img src="https://user-images.githubusercontent.com/10586875/242155228-a0c8ef50-b29f-4903-9213-17c2e369d21f.png" />

13. Enter the phone number details which was previously verified and click **Verify**. Confirm it no longer requires submitting a verification code, and the phone number is added directly to the list of phones.
14. Repeat the same steps for the email and verify it works as expected.
15. We have also fixed a bug that was there with editing. Click on `...` of any SMS contact and selected `Edit` -> Now close the modal and click **+ Add phone number** button -> Verify that the fields are not filled with the old data.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?