### PR TITLE
Update post-delete redirect to point to home instead of stats

### DIFF
--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -101,7 +101,7 @@ class DeleteSite extends Component {
 			if ( useSitesAsLandingPage ) {
 				page.redirect( '/sites' );
 			} else {
-				page.redirect( '/stats' );
+				page.redirect( '/' );
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2663

## Proposed Changes

It was partially fixed in https://github.com/Automattic/wp-calypso/pull/75654

In this diff, I propose to modify a redirect after a user deletes the site to point them to `/` instead of `/stats`. That way, users who have the `/sites` page enabled as default will go to the `/sites` page, and other users will go to their default site home.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ensure "Admin home" is disabled as shown on the screenshot below
1. Create a free Simple site
2. Delete the site in General Settings
3. Confirm that you are redirected to the default site's home

<img width="1064" alt="Screenshot 2023-06-22 at 09 28 58" src="https://github.com/Automattic/wp-calypso/assets/727413/bd64371d-23b6-4104-bf54-5fdcf485d54b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
