### PR TITLE
Flaky E2E: minor fixes to the `/me` endpoint smoke test.

### DIFF
--- a/test/e2e/specs/me/me__smoke.ts
+++ b/test/e2e/specs/me/me__smoke.ts
@@ -41,7 +41,6 @@ describe( 'Me: Smoke Test', function () {
 		{ target: 'Privacy', endpoint: 'privacy' },
 		{ target: 'Notification Settings', endpoint: 'notifications' },
 		{ target: 'Blocked Sites', endpoint: 'site-blocks' },
-		{ target: 'Apps', endpoint: 'get-apps' },
 	] )( 'Navigate to Me > $target', async function ( { target, endpoint } ) {
 		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
 			await page

--- a/test/e2e/specs/me/me__smoke.ts
+++ b/test/e2e/specs/me/me__smoke.ts
@@ -44,12 +44,21 @@ describe( 'Me: Smoke Test', function () {
 		{ target: 'Apps', endpoint: 'get-apps' },
 	] )( 'Navigate to Me > $target', async function ( { target, endpoint } ) {
 		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
-			await page.getByRole( 'link', { name: target } ).click();
+			await page
+				.getByRole( 'navigation' )
+				.getByRole( 'link', { name: target, exact: true } )
+				.click();
 		} else {
+			// In mobile, the Me Sidebar requires odd interactions (clicking twice)
+			// to interact and dismiss.
+			// We do not want to codify wrong behavior.
 			// See: https://github.com/Automattic/wp-calypso/issues/78356
 			await page.goto( DataHelper.getCalypsoURL( `me/${ endpoint }` ) );
 		}
+
+		// Ensure the URL changes depending on the endpoint.
 		await page.waitForURL( new RegExp( endpoint ) );
-		await page.getByRole( 'heading', { name: target } );
+		// Ensure the heading title loads.
+		await page.getByRole( 'main' ).getByRole( 'heading', { name: target } ).waitFor();
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76266.

## Proposed Changes

This PR ties up some loose ends of the E2E: Me Smoke Test.

Key changes:
- add missing `waitFor` call for the header.
- use anchors to narrow the locator target.
- match on exact link name in the sidebar.

## Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Calypso E2E (desktop)
  - [ ] Calypso E2E (mobile)
  - [ ] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
