### PR TITLE
Jetpack Pro Dashboard: add tracking events to the monitor notification SMS configuration changes

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -32,6 +32,7 @@ interface Props {
 	setVerifiedPhoneNumber: ( item: string ) => void;
 	isRemoveAction?: boolean;
 	sites: Array< Site >;
+	recordEvent: ( action: string, params?: object ) => void;
 }
 
 interface FormPhoneInputChangeResult {
@@ -52,6 +53,7 @@ export default function PhoneNumberEditor( {
 	setAllPhoneItems,
 	setVerifiedPhoneNumber,
 	sites,
+	recordEvent,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -112,8 +114,9 @@ export default function PhoneNumberEditor( {
 	const handleResendCodeClick = useCallback( () => {
 		setHelpText( undefined );
 		setPhoneItem( { ...phoneItem, verificationCode: undefined } );
+		recordEvent( 'downtime_monitoring_resend_sms_verification_code' );
 		// TODO: Make API call to resend verification code
-	}, [ phoneItem ] );
+	}, [ phoneItem, recordEvent ] );
 
 	const translationArgs = useMemo(
 		() => ( {
@@ -132,6 +135,7 @@ export default function PhoneNumberEditor( {
 
 	// Function to handle request verification code
 	const handleRequestVerificationCode = () => {
+		recordEvent( 'downtime_monitoring_request_sms_verification_code' );
 		requestVerificationCode.mutate( {
 			type: 'sms',
 			value: `${ phoneItem.countryNumericCode }${ phoneItem.phoneNumber }`,
@@ -142,7 +146,7 @@ export default function PhoneNumberEditor( {
 		} );
 	};
 
-	// Trigger resend code when user chooses to verify email action
+	// Trigger resend code when user chooses to verify phone number action
 	useEffect( () => {
 		if ( isVerifyAction ) {
 			setShowCodeVerification( true );
@@ -168,6 +172,7 @@ export default function PhoneNumberEditor( {
 
 	// Add phone item to the list if the phone number is already verified
 	const handleAddVerifiedPhoneNumber = () => {
+		recordEvent( 'downtime_monitoring_phone_number_already_verified' );
 		handleSetPhoneItems();
 		setVerifiedPhoneNumber( phoneItem.phoneNumberFull );
 	};
@@ -175,6 +180,7 @@ export default function PhoneNumberEditor( {
 	// Verify phone number when user clicks on Verify button
 	const handleVerifyPhoneNumber = () => {
 		setHelpText( undefined );
+		recordEvent( 'downtime_monitoring_verify_phone_number' );
 		if ( phoneItem?.verificationCode ) {
 			verifyPhoneNumber.mutate( {
 				type: 'sms',
@@ -228,12 +234,13 @@ export default function PhoneNumberEditor( {
 
 	// Save unverified phone number to the list when user clicks on Later button
 	function onSaveLater() {
+		recordEvent( 'downtime_monitoring_verify_phone_number_later' );
 		handleSetPhoneItems( false );
 	}
 
 	// Remove phone item when user confirms to remove the phone number
 	const handleRemove = () => {
-		//TODO: add tracks event
+		recordEvent( 'downtime_monitoring_remove_phone_number' );
 		const phoneItems = [ ...allPhoneItems ];
 		const phoneItemIndex = phoneItems.findIndex(
 			( item ) => item.phoneNumberFull === phoneItem.phoneNumberFull

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/utils.ts
@@ -32,10 +32,10 @@ export const getContactActionEventName = (
 			verify: 'downtime_monitoring_email_address_verify_click',
 		},
 		sms: {
-			add: 'downtime_monitoring_sms_number_add_click',
-			edit: 'downtime_monitoring_sms_number_edit_click',
-			remove: 'downtime_monitoring_sms_number_remove_click',
-			verify: 'downtime_monitoring_sms_number_verify_click',
+			add: 'downtime_monitoring_phone_number_add_click',
+			edit: 'downtime_monitoring_phone_number_edit_click',
+			remove: 'downtime_monitoring_phone_number_remove_click',
+			verify: 'downtime_monitoring_phone_number_verify_click',
 		},
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -23,7 +23,7 @@ export default function SMSNotification( {
 	const translate = useTranslate();
 
 	const handleToggleClick = ( isEnabled: boolean ) => {
-		// Record event here
+		recordEvent( isEnabled ? 'sms_notification_enable' : 'sms_notification_disable' );
 		setEnableSMSNotification( isEnabled );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -220,7 +220,7 @@ export default function NotificationSettings( {
 					};
 				} ),
 			};
-			eventParams.email_contacts = params.contacts.sms_numbers?.length;
+			eventParams.sms_contacts = params.contacts.sms_numbers?.length;
 			eventParams.sms_notifications = params.sms_notifications;
 		}
 		recordEvent( 'notification_save_click', eventParams );
@@ -417,6 +417,7 @@ export default function NotificationSettings( {
 				allPhoneItems={ allPhoneItems }
 				selectedAction={ selectedAction }
 				setAllPhoneItems={ handleSetAllPhoneItems }
+				recordEvent={ recordEvent }
 				setVerifiedPhoneNumber={ ( item ) => handleSetVerifiedItem( 'phone', item ) }
 				sites={ sites }
 			/>


### PR DESCRIPTION
Related to 1204774821045518-as-1204783884647374

#### Proposed Changes

This PR adds tracking events to the downtime monitor notification SMS configuration changes.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/monitor-add-phone-number-event-tracking` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Open the dev tool, go to the network tab, and apply the filters - `jetpack-cloud-development` as search and select `Img` filters.

<img width="739" alt="Screenshot 2023-01-19 at 12 43 57 PM" src="https://user-images.githubusercontent.com/10586875/213378720-624de9b6-dc14-489e-a9a2-d7f04cfa478c.png">

5. Perform the below actions and verify that the API call to track the event is made with the right action names on large and small screen devices

`L: Large screen(>1280px)`
`S: Small Screen(<1280px)`

------

<img width="477" alt="Screenshot 2023-06-22 at 12 48 52 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ab0953b5-ef0a-425c-86b0-73dd9dc94211">


#### 1) Enable SMS Notification

Event names

L: calypso_jetpack_agency_dashboard_sms_notification_enable_large_screen
S: calypso_jetpack_agency_dashboard_sms_notification_enable_small_screen

#### 2) Disable SMS Notification

Event names

L: calypso_jetpack_agency_dashboard_sms_notification_disable_large_screen
S: calypso_jetpack_agency_dashboard_sms_notification_disable_small_screen

#### 3) Add phone number

Click on `+ Add phone number`

Event names

L: calypso_jetpack_agency_dashboard_add_phone_number_click_large_screen
S: calypso_jetpack_agency_dashboard_add_phone_number_click_small_screen

------

<img width="477" alt="Screenshot 2023-06-22 at 12 46 45 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/99f53b87-5436-421a-866c-d365624346db">

#### 4) Request SMS verification code

Click on `Verify` to request the verification code. 

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_request_sms_verification_code_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_request_sms_verification_code_small_screen

#### Add a verified phone number

Click on `Verify` to add the already verified phone number.

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_phone_number_already_verified_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_phone_number_already_verified_small_screen

------

<img width="477" alt="Screenshot 2023-06-22 at 12 46 56 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6e0abeaf-734e-457f-bf89-4e40c45fdc22">

#### 5) Resend SMS verification code

Click on `Resend` to request the verification code again. 

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_resend_sms_verification_code_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_resend_sms_verification_code_small_screen

#### 6) Verify SMS verification code

Click on `Verify` to verify the verification code. 

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_verify_phone_number_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_verify_phone_number_small_screen

#### 7) Click verify later

Click on `Later` to verify later.

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_verify_phone_number_later_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_verify_phone_number_later_small_screen

------

<img width="477" alt="Screenshot 2023-06-22 at 1 11 14 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b9862521-0418-4f9a-ac12-1385c8385dbf">


#### 8) Click the `Verify` action

Click `Verify` from the action menu or the `Pending` badge.

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_phone_number_verify_click_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_email_address_verify_click_small_screen

#### 9) Click the `Edit` action

Click on `Edit` from the action menu.

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_phone_number_edit_click_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_phone_number_edit_click_small_screen

#### 10) Click the `Remove` action

Click on `Remove` from the action menu.

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_phone_number_remove_click_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_phone_number_remove_click_small_screen

-----

<img width="477" alt="Screenshot 2023-06-22 at 12 47 52 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/69025673-bf63-44f9-9412-e627323989b1">

#### 11) Remove the phone number

Click on `Remove` on the remove confirmation popup.

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_remove_phone_number_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_remove_phone_number_small_screen

----

<img width="478" alt="Screenshot 2023-06-22 at 2 33 29 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ba0f6cdd-2a94-4e18-875d-e056d64c4e63">

####  12) Save Custom Notification

Event names

L: calypso_jetpack_agency_dashboard_notification_save_click_large_screen
S: calypso_jetpack_agency_dashboard_notification_save_click_small_screen

Extra props – `wp_note_notifications`, `email_notifications`, `jetmon_defer_status_down_minutes`, `email_contacts`, `sms_contacts`, `sms_notifications`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?