### PR TITLE
Subscribers search bar: fix copy

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -11,7 +11,7 @@ const ListActionsBar = () => {
 	return (
 		<div className="list-actions-bar">
 			<SearchInput
-				placeholder={ translate( 'Search by site name or address…' ) }
+				placeholder={ translate( 'Search by name, username or email…' ) }
 				searchIcon={ <SearchIcon size={ 18 } /> }
 				onSearch={ handleSearch }
 			/>


### PR DESCRIPTION
## Proposed Changes

The copy for the search bar wasn't updated.

| Before | After |
|-|-|
| <img width="684" alt="CleanShot 2023-06-22 at 10 03 59@2x" src="https://github.com/Automattic/wp-calypso/assets/528287/5f45dc02-bb2a-4bf1-a2b0-247fbab6b944"> | <img width="591" alt="CleanShot 2023-06-22 at 10 04 08@2x" src="https://github.com/Automattic/wp-calypso/assets/528287/f3d1e59f-d619-484c-9e22-fa05343cdabe"> |

## Testing Instructions

1. Visit `http://calypso.localhost:3000/subscribers/<siteid>` and confirm the copy change

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
