### PR TITLE
Signup: skip the plans step in the domain transfer flow

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -4,6 +4,7 @@ import {
 	planHasFeature,
 	FEATURE_UPLOAD_THEMES_PLUGINS,
 	isEcommerce,
+	isDomainTransfer,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Site } from '@automattic/data-stores';
@@ -1180,7 +1181,7 @@ export function isAddOnsFulfilled( stepName, defaultDependencies, nextProps ) {
 }
 
 export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
-	const { isPaidPlan, sitePlanSlug, submitSignupStep } = nextProps;
+	const { isPaidPlan, sitePlanSlug, submitSignupStep, flowName, signupDependencies } = nextProps;
 	const fulfilledDependencies = [];
 	const dependenciesFromDefaults = {};
 
@@ -1189,6 +1190,11 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 		fulfilledDependencies.push( 'themeSlugWithRepo' );
 		dependenciesFromDefaults.themeSlugWithRepo = defaultDependencies.themeSlugWithRepo;
 	}
+
+	const isTransferSelectedInDomainTransferFlow =
+		'domain-transfer' === flowName &&
+		signupDependencies?.domainItem &&
+		isDomainTransfer( signupDependencies.domainItem );
 
 	if ( isPaidPlan ) {
 		const cartItem = undefined;
@@ -1205,6 +1211,14 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 			{ cartItem, ...dependenciesFromDefaults }
 		);
 		recordExcludeStepEvent( stepName, defaultDependencies.cartItem );
+		fulfilledDependencies.push( 'cartItem' );
+	} else if ( isTransferSelectedInDomainTransferFlow ) {
+		const cartItem = null;
+		submitSignupStep(
+			{ stepName, cartItem, wasSkipped: true },
+			{ cartItem, ...dependenciesFromDefaults }
+		);
+		recordExcludeStepEvent( stepName, sitePlanSlug );
 		fulfilledDependencies.push( 'cartItem' );
 	}
 

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -213,6 +213,32 @@ describe( 'isPlanFulfilled()', () => {
 		expect( flows.excludeStep ).toHaveBeenCalledWith( stepName );
 	} );
 
+	test( 'should remove a step when a domain transfer is selected in the `domain-transfer` flow', () => {
+		const stepName = 'plans';
+		const nextProps = {
+			isPaidPlan: false,
+			sitePlanSlug: 'sitePlanSlug',
+			flowName: 'domain-transfer',
+			signupDependencies: {
+				domainItem: {
+					product_slug: 'domain_transfer',
+				},
+			},
+			submitSignupStep,
+		};
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+		expect( submitSignupStep ).not.toHaveBeenCalled();
+
+		isPlanFulfilled( stepName, undefined, nextProps );
+
+		expect( submitSignupStep ).toHaveBeenCalledWith(
+			{ stepName, cartItem: null, wasSkipped: true },
+			{ cartItem: null }
+		);
+		expect( flows.excludeStep ).toHaveBeenCalledWith( stepName );
+	} );
+
 	test( 'should not remove unfulfilled step', () => {
 		const stepName = 'plans';
 		const nextProps = {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -380,11 +380,6 @@ class DomainsStep extends Component {
 			Object.assign( { domainItem }, useThemeHeadstartItem )
 		);
 
-		// Skip the plans step if we are in the `domain-transfer` flow.
-		if ( 'domain-transfer' === this.props.flowName ) {
-			this.props.submitSignupStep( { stepName: 'plans', wasSkipped: true }, { cartItem: null } );
-		}
-
 		this.props.goToNextStep();
 	};
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -380,6 +380,11 @@ class DomainsStep extends Component {
 			Object.assign( { domainItem }, useThemeHeadstartItem )
 		);
 
+		// Skip the plans step if we are in the `domain-transfer` flow.
+		if ( 'domain-transfer' === this.props.flowName ) {
+			this.props.submitSignupStep( { stepName: 'plans', wasSkipped: true }, { cartItem: null } );
+		}
+
 		this.props.goToNextStep();
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1687402071427169-slack-C05CT832K2T

## Proposed Changes

* If the user is the `domain-transfer` signup flow, and selects the "Transfer" option, then skip the plans step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**Testing the transfer flow**
1. Go to `/start/domain-transfer`.
2. Enter any existing domain name. For the purposes of testing, you do not need to own that domain.
3. On the next step, select Transfer.
4. Confirm that the Plans step **is not** shown.
5. Confirm that you can reach Checkout and complete the purchase.

**Testing the connect flow**
1. Go to `/start/domain-transfer`.
2. Enter any existing domain name. For the purposes of testing, you do not need to own that domain.
3. On the next step, select Connect.
4. Confirm that the Plans step **is** shown.
5. Confirm that you can reach Checkout and complete the purchase.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?