### PR TITLE
importerWordpress: centre loading ellipsis on /setup/import-hosted-site

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
@@ -1,6 +1,7 @@
 /**
  * Common importer integration styles
  */
+.import-hosted-site,
 .site-setup,
 .import-focused {
 	.importer-wrapper:not(.importer-wrapper__wordpress) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to n/a

## Proposed Changes

* Register `.import-hosted-site` with existing CSS styles so the loading spinner is centred like on `import-focused` flow. 

| Trunk |  Branch |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/6851384/4aa2ef61-c523-461e-b8c2-32dd0f31f5a3) | ![image](https://github.com/Automattic/wp-calypso/assets/6851384/2b688691-a065-40a4-a19a-feff1a9a2362) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On trunk, try importing a JN site via `/setup/import-hosted-site/`
* During the `importerWordpress` observe the ellipsis is left aligned
* For comparison, check `setup/import-focused`
* On this branch, repeat steps one and two and observe that the ellipsis is now centred

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
