### PR TITLE
CI: add retry to Calypso E2E and Gutenberg E2E specs.

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -204,6 +204,9 @@ open class E2EBuildType(
 			// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have been muted previously.
 			nonZeroExitCode = false
 
+			// Support retries using the --onlyFailures flag in Jest.
+			supportTestRetry = true
+
 			// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner crashes and no tests are run.
 			failOnMetricChange {
 				metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT

--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -145,8 +145,14 @@ open class E2EBuildType(
 					cd test/e2e
 					mkdir temp
 
+					# Disable exit on error to support retries.
+					set +o errexit
+
 					# Run suite.
 					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup
+
+					# Restore exit on error.
+					set -o errexit
 
 					# Retry failed tests only.
 					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup --onlyFailures

--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -147,6 +147,9 @@ open class E2EBuildType(
 
 					# Run suite.
 					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup
+
+					# Retry failed tests only.
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup --onlyFailures
 				"""
 				dockerImage = "%docker_image_e2e%"
 				dockerRunParameters = "-u %env.UID% --shm-size=4g"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -825,6 +825,9 @@ object PreReleaseE2ETests : BuildType({
 
 				# Run suite.
 				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=calypso-release
+
+				# Retry failed tests only.
+				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=calypso-release --onlyFailures
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}
@@ -918,6 +921,9 @@ object PreReleaseE2ETests : BuildType({
 		executionTimeoutMin = 20
 		// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have been muted previously.
 		nonZeroExitCode = false
+
+		// Support retries using the --onlyFailures flag in Jest.
+		supportTestRetry = true
 
 		// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner crashes and no tests are run.
 		failOnMetricChange {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -823,8 +823,14 @@ object PreReleaseE2ETests : BuildType({
 				cd test/e2e
 				mkdir temp
 
+				# Disable exit on error to support retries.
+				set +o errexit
+
 				# Run suite.
 				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=calypso-release
+
+				# Restore exit on error.
+				set -o errexit
 
 				# Retry failed tests only.
 				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=calypso-release --onlyFailures

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -152,6 +152,11 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 				let contextIndex = 1;
 
 				const artifactFilename = `${ this.testFilename }__${ sanitizeString( this.failure.name ) }`;
+				const datetime = new Date()
+					.toISOString()
+					.replace( /T/, '_' )
+					.replace( /\..+/, '' )
+					.replace( /:/g, '-' );
 
 				for await ( const context of contexts ) {
 					let pageIndex = 1;
@@ -164,7 +169,7 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 					await context.tracing.stop( { path: traceFilePath } );
 
 					for await ( const page of context.pages() ) {
-						const pageName = `${ artifactFilename }__${ contextIndex }-${ pageIndex }`;
+						const pageName = `${ artifactFilename }__${ datetime }__${ contextIndex }-${ pageIndex }`;
 						// Define artifact filename.
 						const mediaFilePath = path.join( this.testArtifactsPath, pageName );
 

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -110,20 +110,10 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 		this.testArtifactsPath = await fs.mkdtemp(
 			path.join( env.ARTIFACTS_PATH, `${ this.testFilename }__${ date }-` )
 		);
-		const logFilePath = path.join( this.testArtifactsPath, `${ this.testFilename }.log` );
 
 		// Start the browser.
 		const browser = await browserType.launch( {
 			...config.launchOptions,
-			logger: {
-				log: async ( name: string, severity: string, message: string ) => {
-					await fs.appendFile(
-						logFilePath,
-						`${ new Date().toISOString() } ${ process.pid } ${ name } ${ severity }: ${ message }\n`
-					);
-				},
-				isEnabled: ( name ) => name === 'api',
-			},
 		} );
 
 		// Set up the proxy trap.
@@ -151,25 +141,31 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 			if ( this.failure ) {
 				let contextIndex = 1;
 
-				const artifactFilename = `${ this.testFilename }__${ sanitizeString( this.failure.name ) }`;
-				const datetime = new Date()
+				// Timestamp (actually date and time) of the failure.
+				const timestamp = new Date()
 					.toISOString()
 					.replace( /T/, '_' )
 					.replace( /\..+/, '' )
 					.replace( /:/g, '-' );
 
+				// Spec file name and step that filed.
+				const artifactPrefix = `${ this.testFilename }__${ sanitizeString(
+					this.failure.name
+				) }__${ timestamp }`;
+
 				for await ( const context of contexts ) {
 					let pageIndex = 1;
+					// Save trace file per page.
 					const traceFilePath = path.join(
 						this.testArtifactsPath,
-						`${ artifactFilename }__${ contextIndex }.zip`
+						`${ artifactPrefix }__${ contextIndex }.zip`
 					);
 
 					// Traces are saved per context.
 					await context.tracing.stop( { path: traceFilePath } );
 
 					for await ( const page of context.pages() ) {
-						const pageName = `${ artifactFilename }__${ datetime }__${ contextIndex }-${ pageIndex }`;
+						const pageName = `${ artifactPrefix }__${ contextIndex }-${ pageIndex }`;
 						// Define artifact filename.
 						const mediaFilePath = path.join( this.testArtifactsPath, pageName );
 


### PR DESCRIPTION
Related to pciE2j-2cY-p2.

## Proposed Changes

This PR adds a single retry of only failed tests.

## Testing Instructions

Locally, I modified an existing test to fail intentionally on first pass by throwing an exception halfway through.
If the environment variable `RETRY` is defined, then it will not throw an exception, allowing the step to pass.

I ran the first pass and it failed as expected.
Then, on the second pass, I add the `--onlyFailures` flag and defined the env var `RETRY` to allow the step to pass.
The second pass:
- only ran the failing test suite, as expected
- passed all steps

<details>
    <summary>Logs</summary>

```
➜  ~/workspace/wp-calypso-second/test/e2e git:(ci/e2e-add-retry) ✗ yarn jest test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts test/e2e/specs/me/me__smoke.ts
  console.log
    Intentionally failing...

      at Object.<anonymous> (specs/infrastructure/infrastructure__ssr-enabled.ts:23:15)

Artifacts for infrastructure__ssr-enabled: /Users/edwintakahashi/workspace/wp-calypso-second/test/e2e/results/infrastructure__ssr-enabled__2023-06-22_09-08-44-745-GmNF2y
 FAIL  specs/infrastructure/infrastructure__ssr-enabled.ts
  Server-side Rendering
    Check SSR endoint: log-in
      ✓ Check SSR: log-in (2378 ms)
    Check SSR endoint: themes
      ✕ Check SSR: themes (143 ms)
    Check SSR endoint: theme/twentytwentythree
      ○ skipped Check SSR: theme/twentytwentythree

  ● Server-side Rendering › Check SSR endoint: themes › Check SSR: themes



      22 | 					if ( endpoint === 'themes' ) {
      23 | 						console.log( 'Intentionally failing...' );
    > 24 | 						throw new Error();
         | 						      ^
      25 | 					}
      26 | 				}
      27 | 				await page.goto( DataHelper.getCalypsoURL( endpoint ), { timeout: 20 * 1000 } );

      at Object.<anonymous> (specs/infrastructure/infrastructure__ssr-enabled.ts:24:13)

 PASS  specs/me/me__smoke.ts (7.452 s)
  Me: Smoke Test
    ✓ Navigate to /me (809 ms)
    ✓ Navigate to Me > Account Settings (79 ms)
    ✓ Navigate to Me > Purchases (164 ms)
    ✓ Navigate to Me > Security (248 ms)
    ✓ Navigate to Me > Privacy (85 ms)
    ✓ Navigate to Me > Notification Settings (114 ms)
    ✓ Navigate to Me > Blocked Sites (264 ms)
    ✓ Navigate to Me > Apps (129 ms)

Test Suites: 1 failed, 1 passed, 2 total
Tests:       1 failed, 1 skipped, 9 passed, 11 total
Snapshots:   0 total
Time:        8.215 s, estimated 11 s
Ran all test suites matching /test\/e2e\/specs\/infrastructure\/infrastructure__ssr-enabled.ts|test\/e2e\/specs\/me\/me__smoke.ts/i.
➜  ~/workspace/wp-calypso-second/test/e2e git:(ci/e2e-add-retry) ✗ RETRY=1 yarn jest test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts test/e2e/specs/me/me__smoke.ts --onlyFailures
 PASS  specs/infrastructure/infrastructure__ssr-enabled.ts (8.72 s)
  Server-side Rendering
    Check SSR endoint: log-in
      ✓ Check SSR: log-in (1971 ms)
    Check SSR endoint: themes
      ✓ Check SSR: themes (2326 ms)
    Check SSR endoint: theme/twentytwentythree
      ✓ Check SSR: theme/twentytwentythree (3635 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        8.972 s
Ran all test suites matching /test\/e2e\/specs\/infrastructure\/infrastructure__ssr-enabled.ts|test\/e2e\/specs\/me\/me__smoke.ts/i.
```
</details>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?