### PR TITLE
Pro dashboard: Add common dashboard modal form component.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal-form/footer.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal-form/footer.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+type Props = {
+	children: ReactNode;
+	errorMessage?: string | null;
+};
+
+export default function DashboardModalFormFooter( { children, errorMessage }: Props ) {
+	return (
+		<div className="dashboard-modal-form__footer">
+			{ errorMessage && (
+				<div className="dashboard-modal-form__footer-error" role="alert">
+					{ errorMessage }
+				</div>
+			) }
+			<div className="dashboard-modal-form__footer-buttons">{ children }</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal-form/index.tsx
@@ -1,0 +1,33 @@
+import classNames from 'classnames';
+import DashboardModal, { DashboardModalProps } from '../dashboard-modal';
+
+import './style.scss';
+
+type Props = DashboardModalProps & {
+	onSubmit: () => void;
+};
+
+export default function DashboardModalForm( {
+	children,
+	className,
+	onClose,
+	onSubmit,
+	subtitle,
+	title,
+}: Props ) {
+	const handleOnSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		onSubmit();
+	};
+
+	return (
+		<DashboardModal
+			title={ title }
+			subtitle={ subtitle }
+			onClose={ onClose }
+			className={ classNames( 'dashboard-modal-form', className ) }
+		>
+			<form onSubmit={ handleOnSubmit }>{ children }</form>
+		</DashboardModal>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal-form/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal-form/style.scss
@@ -1,0 +1,55 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
+
+.dashboard-modal-form__footer {
+	margin-block-end: 32px;
+	width: calc(100% - 64px); // reducing the left and right padding
+	display: flex;
+	justify-content: flex-start;
+	flex-direction: column;
+	position: absolute;
+	bottom: 0;
+
+	.dashboard-modal-form__footer-buttons {
+		display: flex;
+		flex-direction: column;
+	}
+
+	button {
+		height: 36px;
+		line-height: 18px;
+
+		&:nth-child(2) {
+			margin-block-start: 16px;
+		}
+	}
+
+	@include break-mobile {
+		position: static;
+		justify-content: right;
+		flex-direction: initial;
+		margin-block-start: 32px;
+		margin-block-end: 0;
+		width: auto;
+
+		.dashboard-modal-form__footer-buttons {
+			justify-content: end;
+			width: 100%;
+			flex-direction: initial;
+		}
+
+		button {
+			&:nth-child(2) {
+				margin-inline-start: 12px;
+				margin-block-start: 0;
+			}
+		}
+	}
+}
+
+.dashboard-modal-form__footer-error {
+	font-size: 0.75rem;
+	line-height: 14px;
+	color: var(--color-scary-40);
+	margin-block-end: 16px;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/index.tsx
@@ -1,0 +1,33 @@
+import { Modal } from '@wordpress/components';
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+
+import './style.scss';
+
+export type DashboardModalProps = {
+	children: ReactNode;
+	className?: string;
+	onClose: () => void;
+	subtitle?: ReactNode;
+	title: string;
+};
+
+export default function DashboardModal( {
+	children,
+	className,
+	onClose,
+	subtitle,
+	title,
+}: DashboardModalProps ) {
+	return (
+		<Modal
+			open={ true }
+			onRequestClose={ onClose }
+			title={ title }
+			className={ classNames( 'dashboard-modal', className ) }
+		>
+			<div className="dashboard-modal__sub-title">{ subtitle }</div>
+			{ children }
+		</Modal>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
@@ -1,0 +1,14 @@
+.dashboard-modal {
+	max-height: 100%;
+	width: 480px;
+	animation: components-modal__appear-animation 0.1s ease-out;
+	animation-fill-mode: forwards;
+}
+
+.dashboard-modal__sub-title {
+	font-size: 0.75rem;
+	line-height: 14px;
+	color: var(--studio-gray-50);
+	position: absolute;
+	inset-block-start: 50px;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/email-address-editor.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-import { Modal } from '@wordpress/components';
 import classNames from 'classnames';
 import emailValidator from 'email-validator';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
@@ -7,6 +6,8 @@ import { useCallback, useContext, useEffect, useState, useMemo } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import DashboardModalForm from '../../dashboard-modal-form';
+import DashboardModalFormFooter from '../../dashboard-modal-form/footer';
 import DashboardDataContext from '../../sites-overview/dashboard-data-context';
 import {
 	useRequestVerificationCode,
@@ -272,9 +273,7 @@ export default function EmailAddressEditor( {
 		setVerifiedEmail( emailItem.email );
 	};
 
-	const onSave = ( event: React.FormEvent< HTMLFormElement > ) => {
-		event.preventDefault();
-
+	const onSave = () => {
 		if ( isRemoveAction ) {
 			return handleRemove();
 		}
@@ -318,112 +317,107 @@ export default function EmailAddressEditor( {
 		: translate( 'Verify' );
 
 	return (
-		<Modal
-			open={ true }
-			onRequestClose={ toggleModal }
+		<DashboardModalForm
 			title={ title }
-			className="notification-settings__modal"
+			subtitle={ subtitle }
+			onClose={ toggleModal }
+			onSubmit={ onSave }
 		>
-			<div className="notification-settings__sub-title">{ subtitle }</div>
-
-			<form className="configure-contact__form" onSubmit={ onSave }>
-				{ isRemoveAction ? (
-					selectedEmail && (
-						<div className="margin-top-16">
-							<EmailItemContent isRemoveAction item={ selectedEmail } />
-						</div>
-					)
-				) : (
-					<>
-						<FormFieldset>
-							<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
-							<FormTextInput
-								id="name"
-								name="name"
-								value={ emailItem.name }
-								disabled={ showCodeVerification }
-								onChange={ handleChange( 'name' ) }
-								aria-describedby={ ! isVerifyAction ? 'name-help-text' : undefined }
-							/>
-							{ ! isVerifyAction && (
-								<div className="configure-contact__help-text" id="name-help-text">
-									{ translate( 'Give this email a nickname for your personal reference.' ) }
-								</div>
-							) }
-						</FormFieldset>
-
-						<FormFieldset>
-							<FormLabel htmlFor="email">{ translate( 'Email' ) }</FormLabel>
-							<FormTextInput
-								id="email"
-								name="email"
-								value={ emailItem.email }
-								disabled={ showCodeVerification }
-								onChange={ handleChange( 'email' ) }
-								aria-describedby={ ! isVerifyAction ? 'email-help-text' : undefined }
-							/>
-							{ validationError?.email && (
-								<div className="notification-settings__footer-validation-error" role="alert">
-									{ validationError.email }
-								</div>
-							) }
-							{ ! isVerifyAction && (
-								<div className="configure-contact__help-text" id="email-help-text">
-									{ translate( 'We’ll send a code to verify your email address.' ) }
-								</div>
-							) }
-						</FormFieldset>
-
-						{ showCodeVerification && (
-							<FormFieldset>
-								<FormLabel htmlFor="code">
-									{ translate( 'Please enter the code you received via email' ) }
-								</FormLabel>
-								<FormTextInput
-									id="code"
-									name="code"
-									value={ emailItem.code || '' }
-									onChange={ handleChange( 'code' ) }
-								/>
-								{ validationError?.code && (
-									<div className="notification-settings__footer-validation-error" role="alert">
-										{ validationError.code }
-									</div>
-								) }
-								<div className="configure-contact__help-text" id="code-help-text">
-									{ helpText ??
-										( resendCodeClicked && resendCode.isLoading
-											? translate( 'Sending code' )
-											: translate(
-													'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
-													translationArgs
-											  ) ) }
-								</div>
-							</FormFieldset>
-						) }
-					</>
-				) }
-				<div className="notification-settings__footer">
-					<div className="notification-settings__footer-buttons">
-						<Button onClick={ showCodeVerification ? onSaveLater : toggleModal }>
-							{ showCodeVerification ? translate( 'Later' ) : translate( 'Back' ) }
-						</Button>
-						<Button
-							disabled={
-								! emailItem.name ||
-								! emailItem.email ||
-								( showCodeVerification && ! emailItem.code ) ||
-								verifyEmail.isLoading ||
-								requestVerificationCode.isLoading
-							}
-							type="submit"
-							primary
-						>
-							{ isRemoveAction ? translate( 'Remove' ) : verificationButtonTitle }
-						</Button>
+			{ isRemoveAction ? (
+				selectedEmail && (
+					<div className="margin-top-16">
+						<EmailItemContent isRemoveAction item={ selectedEmail } />
 					</div>
-				</div>
-			</form>
-		</Modal>
+				)
+			) : (
+				<>
+					<FormFieldset>
+						<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
+						<FormTextInput
+							id="name"
+							name="name"
+							value={ emailItem.name }
+							disabled={ showCodeVerification }
+							onChange={ handleChange( 'name' ) }
+							aria-describedby={ ! isVerifyAction ? 'name-help-text' : undefined }
+						/>
+						{ ! isVerifyAction && (
+							<div className="configure-contact__help-text" id="name-help-text">
+								{ translate( 'Give this email a nickname for your personal reference.' ) }
+							</div>
+						) }
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="email">{ translate( 'Email' ) }</FormLabel>
+						<FormTextInput
+							id="email"
+							name="email"
+							value={ emailItem.email }
+							disabled={ showCodeVerification }
+							onChange={ handleChange( 'email' ) }
+							aria-describedby={ ! isVerifyAction ? 'email-help-text' : undefined }
+						/>
+						{ validationError?.email && (
+							<div className="dashboard-modal-form__footer-error" role="alert">
+								{ validationError.email }
+							</div>
+						) }
+						{ ! isVerifyAction && (
+							<div className="configure-contact__help-text" id="email-help-text">
+								{ translate( 'We’ll send a code to verify your email address.' ) }
+							</div>
+						) }
+					</FormFieldset>
+
+					{ showCodeVerification && (
+						<FormFieldset>
+							<FormLabel htmlFor="code">
+								{ translate( 'Please enter the code you received via email' ) }
+							</FormLabel>
+							<FormTextInput
+								id="code"
+								name="code"
+								value={ emailItem.code || '' }
+								onChange={ handleChange( 'code' ) }
+							/>
+							{ validationError?.code && (
+								<div className="dashboard-modal-form__footer-error" role="alert">
+									{ validationError.code }
+								</div>
+							) }
+							<div className="configure-contact__help-text" id="code-help-text">
+								{ helpText ??
+									( resendCodeClicked && resendCode.isLoading
+										? translate( 'Sending code' )
+										: translate(
+												'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
+												translationArgs
+										  ) ) }
+							</div>
+						</FormFieldset>
+					) }
+				</>
+			) }
+
+			<DashboardModalFormFooter>
+				<Button onClick={ showCodeVerification ? onSaveLater : toggleModal }>
+					{ showCodeVerification ? translate( 'Later' ) : translate( 'Back' ) }
+				</Button>
+				<Button
+					disabled={
+						! emailItem.name ||
+						! emailItem.email ||
+						( showCodeVerification && ! emailItem.code ) ||
+						verifyEmail.isLoading ||
+						requestVerificationCode.isLoading
+					}
+					type="submit"
+					primary
+				>
+					{ isRemoveAction ? translate( 'Remove' ) : verificationButtonTitle }
+				</Button>
+			</DashboardModalFormFooter>
+		</DashboardModalForm>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-sms-notification/phone-number-editor.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-import { Modal } from '@wordpress/components';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useContext, useEffect, useMemo } from 'react';
 import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
@@ -9,6 +8,8 @@ import FormPhoneInput from 'calypso/components/forms/form-phone-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { useSelector } from 'calypso/state';
 import getCountries from 'calypso/state/selectors/get-countries';
+import DashboardModalForm from '../../dashboard-modal-form';
+import DashboardModalFormFooter from '../../dashboard-modal-form/footer';
 import DashboardDataContext from '../../sites-overview/dashboard-data-context';
 import {
 	useRequestVerificationCode,
@@ -244,9 +245,7 @@ export default function PhoneNumberEditor( {
 		toggleModal();
 	};
 
-	const onSave = ( event: React.FormEvent< HTMLFormElement > ) => {
-		event.preventDefault();
-
+	const onSave = () => {
 		if ( isRemoveAction ) {
 			return handleRemove();
 		}
@@ -330,101 +329,96 @@ export default function PhoneNumberEditor( {
 		: translate( 'Verify' );
 
 	return (
-		<Modal
-			open={ true }
-			onRequestClose={ toggleModal }
+		<DashboardModalForm
 			title={ title }
-			className="notification-settings__modal"
+			subtitle={ subtitle }
+			onClose={ toggleModal }
+			onSubmit={ onSave }
 		>
-			<div className="notification-settings__sub-title">{ subtitle }</div>
-
-			<form className="configure-contact__form" onSubmit={ onSave }>
-				{ isRemoveAction ? (
-					selectedPhone && (
-						<div className="margin-top-16">
-							<SMSItemContent isRemoveAction item={ selectedPhone } />
-						</div>
-					)
-				) : (
-					<>
-						<FormFieldset>
-							<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
-							<FormTextInput
-								id="name"
-								name="name"
-								value={ phoneItem.name }
-								onChange={ handleChange( 'name' ) }
-								aria-describedby={ ! isVerifyAction ? 'name-help-text' : undefined }
-								disabled={ showCodeVerification }
-							/>
-							{ ! isVerifyAction && (
-								<div className="configure-contact__help-text" id="name-help-text">
-									{ translate( 'Give this number a name for your personal reference.' ) }
-								</div>
-							) }
-						</FormFieldset>
-						<div className="configure-contact__phone-input-container">
-							{
-								// Fetch countries list only if not available
-								noCountryList && <QuerySmsCountries />
-							}
-							<FormPhoneInput
-								isDisabled={ noCountryList || showCodeVerification }
-								countriesList={ countriesList }
-								initialCountryCode={ phoneItem.countryCode }
-								initialPhoneNumber={ phoneItem.phoneNumber }
-								onChange={ onChangePhoneInput }
-								className="configure-contact__phone-input"
-							/>
-							{ validationError?.phone && (
-								<div className="notification-settings__footer-validation-error" role="alert">
-									{ validationError?.phone }
-								</div>
-							) }
-							{ ! isVerifyAction && (
-								<div className="configure-contact__help-text" id="phone-help-text">
-									{ translate( 'We’ll send a code to verify your phone number.' ) }
-								</div>
-							) }
-						</div>
-						{ showCodeVerification && (
-							<FormFieldset>
-								<FormLabel htmlFor="code">
-									{ translate( 'Please enter the code you received via SMS' ) }
-								</FormLabel>
-								<FormTextInput
-									id="code"
-									name="code"
-									value={ phoneItem.verificationCode || '' }
-									onChange={ handleChange( 'verificationCode' ) }
-								/>
-								{ validationError?.verificationCode && (
-									<div className="notification-settings__footer-validation-error" role="alert">
-										{ validationError.verificationCode }
-									</div>
-								) }
-								<div className="configure-contact__help-text" id="code-help-text">
-									{ helpText ??
-										translate(
-											'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
-											translationArgs
-										) }
-								</div>
-							</FormFieldset>
-						) }
-					</>
-				) }
-				<div className="notification-settings__footer">
-					<div className="notification-settings__footer-buttons">
-						<Button onClick={ showCodeVerification ? onSaveLater : toggleModal }>
-							{ showCodeVerification ? translate( 'Later' ) : translate( 'Back' ) }
-						</Button>
-						<Button disabled={ isDisabled } type="submit" primary>
-							{ isRemoveAction ? translate( 'Remove' ) : verificationButtonTitle }
-						</Button>
+			{ isRemoveAction ? (
+				selectedPhone && (
+					<div className="margin-top-16">
+						<SMSItemContent isRemoveAction item={ selectedPhone } />
 					</div>
-				</div>
-			</form>
-		</Modal>
+				)
+			) : (
+				<>
+					<FormFieldset>
+						<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
+						<FormTextInput
+							id="name"
+							name="name"
+							value={ phoneItem.name }
+							onChange={ handleChange( 'name' ) }
+							aria-describedby={ ! isVerifyAction ? 'name-help-text' : undefined }
+							disabled={ showCodeVerification }
+						/>
+						{ ! isVerifyAction && (
+							<div className="configure-contact__help-text" id="name-help-text">
+								{ translate( 'Give this number a name for your personal reference.' ) }
+							</div>
+						) }
+					</FormFieldset>
+					<div className="configure-contact__phone-input-container">
+						{
+							// Fetch countries list only if not available
+							noCountryList && <QuerySmsCountries />
+						}
+						<FormPhoneInput
+							isDisabled={ noCountryList || showCodeVerification }
+							countriesList={ countriesList }
+							initialCountryCode={ phoneItem.countryCode }
+							initialPhoneNumber={ phoneItem.phoneNumber }
+							onChange={ onChangePhoneInput }
+							className="configure-contact__phone-input"
+						/>
+						{ validationError?.phone && (
+							<div className="dashboard-modal-form__footer-error" role="alert">
+								{ validationError?.phone }
+							</div>
+						) }
+						{ ! isVerifyAction && (
+							<div className="configure-contact__help-text" id="phone-help-text">
+								{ translate( 'We’ll send a code to verify your phone number.' ) }
+							</div>
+						) }
+					</div>
+					{ showCodeVerification && (
+						<FormFieldset>
+							<FormLabel htmlFor="code">
+								{ translate( 'Please enter the code you received via SMS' ) }
+							</FormLabel>
+							<FormTextInput
+								id="code"
+								name="code"
+								value={ phoneItem.verificationCode || '' }
+								onChange={ handleChange( 'verificationCode' ) }
+							/>
+							{ validationError?.verificationCode && (
+								<div className="dashboard-modal-form__footer-error" role="alert">
+									{ validationError.verificationCode }
+								</div>
+							) }
+							<div className="configure-contact__help-text" id="code-help-text">
+								{ helpText ??
+									translate(
+										'Please wait for a minute. If you didn’t receive it, we can {{button}}resend{{/button}} it.',
+										translationArgs
+									) }
+							</div>
+						</FormFieldset>
+					) }
+				</>
+			) }
+
+			<DashboardModalFormFooter>
+				<Button onClick={ showCodeVerification ? onSaveLater : toggleModal }>
+					{ showCodeVerification ? translate( 'Later' ) : translate( 'Back' ) }
+				</Button>
+				<Button disabled={ isDisabled } type="submit" primary>
+					{ isRemoveAction ? translate( 'Remove' ) : verificationButtonTitle }
+				</Button>
+			</DashboardModalFormFooter>
+		</DashboardModalForm>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/footer.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/footer.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import DashboardModalFormFooter from '../../../dashboard-modal-form/footer';
 
 interface Props {
 	isLoading: boolean;
@@ -20,34 +21,29 @@ export default function NotificationSettingsFormFooter( {
 }: Props ) {
 	const translate = useTranslate();
 
+	const errorMessage = hasUnsavedChanges
+		? translate( 'You have unsaved changes. Are you sure you want to close?' )
+		: validationError;
+
 	return (
-		<div className="notification-settings__footer">
-			{ ( validationError || hasUnsavedChanges ) && (
-				<div className="notification-settings__footer-validation-error" role="alert">
-					{ hasUnsavedChanges
-						? translate( 'You have unsaved changes. Are you sure you want to close?' )
-						: validationError }
-				</div>
-			) }
-			<div className="notification-settings__footer-buttons">
-				<Button
-					onClick={ handleOnClose }
-					aria-label={ translate( 'Cancel and close notification settings popup' ) }
-				>
-					{ translate( 'Cancel' ) }
-				</Button>
-				<Button
-					disabled={
-						// Disable save button if there is no change and not bulk update
-						!! validationError || isLoading || ( ! isBulkUpdate && ! unsavedChangesExist )
-					}
-					type="submit"
-					primary
-					aria-label={ translate( 'Save notification settings' ) }
-				>
-					{ isLoading ? translate( 'Saving Changes' ) : translate( 'Save' ) }
-				</Button>
-			</div>
-		</div>
+		<DashboardModalFormFooter errorMessage={ errorMessage }>
+			<Button
+				onClick={ handleOnClose }
+				aria-label={ translate( 'Cancel and close notification settings popup' ) }
+			>
+				{ translate( 'Cancel' ) }
+			</Button>
+			<Button
+				disabled={
+					// Disable save button if there is no change and not bulk update
+					!! validationError || isLoading || ( ! isBulkUpdate && ! unsavedChangesExist )
+				}
+				type="submit"
+				primary
+				aria-label={ translate( 'Save notification settings' ) }
+			>
+				{ isLoading ? translate( 'Saving Changes' ) : translate( 'Save' ) }
+			</Button>
+		</DashboardModalFormFooter>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -1,9 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Modal } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState, useContext } from 'react';
 import AlertBanner from 'calypso/components/jetpack/alert-banner';
+import DashboardModalForm from '../../dashboard-modal-form';
 import {
 	useUpdateMonitorSettings,
 	useJetpackAgencyDashboardRecordTrackEvent,
@@ -177,9 +177,7 @@ export default function NotificationSettings( {
 		setHasUnsavedChanges( false );
 	};
 
-	function onSave( event: React.FormEvent< HTMLFormElement > ) {
-		event.preventDefault();
-
+	const onSave = () => {
 		if ( ! enableMobileNotification && ! enableEmailNotification ) {
 			return setValidationError( translate( 'Please select at least one contact method.' ) );
 		}
@@ -227,7 +225,7 @@ export default function NotificationSettings( {
 		}
 		recordEvent( 'notification_save_click', eventParams );
 		updateMonitorSettings( params );
-	}
+	};
 
 	function selectDuration( duration: MonitorDuration ) {
 		recordEvent( 'duration_select', { duration: duration.time } );
@@ -426,59 +424,57 @@ export default function NotificationSettings( {
 	}
 
 	return (
-		<Modal
-			open={ true }
-			onRequestClose={ handleOnClose }
+		<DashboardModalForm
+			className="notification-settings"
 			title={ translate( 'Set custom notification' ) }
-			className="notification-settings__modal"
+			subtitle={ getSiteCountText( sites ) }
+			onClose={ handleOnClose }
+			onSubmit={ onSave }
 		>
-			<div className="notification-settings__sub-title">{ getSiteCountText( sites ) }</div>
-			<form onSubmit={ onSave }>
-				{ isBulkUpdate && (
-					<AlertBanner type="warning">
-						{ translate( 'Settings for selected sites will be overwritten.' ) }
-					</AlertBanner>
-				) }
-				<div className={ classNames( { 'notification-settings__content': ! isBulkUpdate } ) }>
-					<NotificationDuration
-						recordEvent={ recordEvent }
-						selectedDuration={ selectedDuration }
-						selectDuration={ selectDuration }
-					/>
-					{ isSMSNotificationEnabled && (
-						<SMSNotification
-							recordEvent={ recordEvent }
-							enableSMSNotification={ enableSMSNotification }
-							setEnableSMSNotification={ setEnableSMSNotification }
-							toggleModal={ toggleAddSMSModal }
-							allPhoneItems={ allPhoneItems }
-							verifiedItem={ verifiedItem }
-						/>
-					) }
-					<MobilePushNotification
-						recordEvent={ recordEvent }
-						enableMobileNotification={ enableMobileNotification }
-						setEnableMobileNotification={ setEnableMobileNotification }
-					/>
-					<EmailNotification
-						recordEvent={ recordEvent }
-						verifiedItem={ verifiedItem }
-						enableEmailNotification={ enableEmailNotification }
-						setEnableEmailNotification={ setEnableEmailNotification }
-						defaultUserEmailAddresses={ defaultUserEmailAddresses }
-						toggleAddEmailModal={ toggleAddEmailModal }
-						allEmailItems={ allEmailItems }
-					/>
-				</div>
-				<NotificationSettingsFormFooter
-					isLoading={ isLoading }
-					validationError={ validationError }
-					isBulkUpdate={ isBulkUpdate }
-					handleOnClose={ handleOnClose }
-					hasUnsavedChanges={ hasUnsavedChanges }
-					unsavedChangesExist={ unsavedChangesExist }
+			{ isBulkUpdate && (
+				<AlertBanner type="warning">
+					{ translate( 'Settings for selected sites will be overwritten.' ) }
+				</AlertBanner>
+			) }
+			<div className={ classNames( { 'notification-settings__content': ! isBulkUpdate } ) }>
+				<NotificationDuration
+					recordEvent={ recordEvent }
+					selectedDuration={ selectedDuration }
+					selectDuration={ selectDuration }
 				/>
-			</form>
-		</Modal>
+				{ isSMSNotificationEnabled && (
+					<SMSNotification
+						recordEvent={ recordEvent }
+						enableSMSNotification={ enableSMSNotification }
+						setEnableSMSNotification={ setEnableSMSNotification }
+						toggleModal={ toggleAddSMSModal }
+						allPhoneItems={ allPhoneItems }
+						verifiedItem={ verifiedItem }
+					/>
+				) }
+				<MobilePushNotification
+					recordEvent={ recordEvent }
+					enableMobileNotification={ enableMobileNotification }
+					setEnableMobileNotification={ setEnableMobileNotification }
+				/>
+				<EmailNotification
+					recordEvent={ recordEvent }
+					verifiedItem={ verifiedItem }
+					enableEmailNotification={ enableEmailNotification }
+					setEnableEmailNotification={ setEnableEmailNotification }
+					defaultUserEmailAddresses={ defaultUserEmailAddresses }
+					toggleAddEmailModal={ toggleAddEmailModal }
+					allEmailItems={ allEmailItems }
+				/>
+			</div>
+			<NotificationSettingsFormFooter
+				isLoading={ isLoading }
+				validationError={ validationError }
+				isBulkUpdate={ isBulkUpdate }
+				handleOnClose={ handleOnClose }
+				hasUnsavedChanges={ hasUnsavedChanges }
+				unsavedChangesExist={ unsavedChangesExist }
+			/>
+		</DashboardModalForm>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
@@ -17,12 +17,6 @@
 	color: var(--studio-gray-50);
 }
 
-.notification-settings__sub-title {
-	@extend .notification-settings-title-light;
-	position: absolute;
-	inset-block-start: 50px;
-}
-
 .notification-settings__content {
 	margin-block-start: -16px;
 }
@@ -63,52 +57,6 @@
 
 .notification-settings__link {
 	text-decoration: underline;
-}
-
-.notification-settings__footer {
-	margin-block-end: 32px;
-	width: calc(100% - 64px); // reducing the left and right padding
-	display: flex;
-	justify-content: flex-start;
-	flex-direction: column;
-	position: absolute;
-	bottom: 0;
-
-	.notification-settings__footer-buttons {
-		display: flex;
-		flex-direction: column;
-	}
-
-	button {
-		height: 36px;
-		line-height: 18px;
-
-		&:nth-child(2) {
-			margin-block-start: 16px;
-		}
-	}
-
-	@include break-mobile {
-		position: static;
-		justify-content: right;
-		flex-direction: initial;
-		margin-block-start: 32px;
-		margin-block-end: 0;
-		width: auto;
-
-		.notification-settings__footer-buttons {
-			justify-content: end;
-			width: 100%;
-			flex-direction: initial;
-		}
-
-		button {
-			&:nth-child(2) {
-				margin-inline-start: 12px;
-				margin-block-start: 0;
-			}
-		}
-	}
 }
 
 .select-dropdown .select-dropdown__container {
@@ -185,12 +133,6 @@
 
 .notification-settings__small-screen {
 	display: inherit;
-}
-
-.notification-settings__footer-validation-error {
-	@extend .notification-settings-title-light;
-	color: var(--color-scary-40);
-	margin-block-end: 16px;
 }
 
 .notification-settings__warning {


### PR DESCRIPTION
This is part of my ongoing refactoring of the Email and Phone number editor to have shared codes. 


One area that has been duplicated is how we structure our forms in Downtime monitoring. The modal form styling has been used thrice, and we may use this pattern in the future. 



Related to 1204774821045518-as-1204802449809227

## Proposed Changes
This PR makes the modal form structure official by adding a common Dashboard modal form component. This will benefit us in the future as this reduces duplicate codes for structuring our modal forms (e,.g. title, subtitle, and footer). This also gives us a way to update the styling of our modal forms in one place.

<img width="1155" alt="Screen Shot 2023-06-22 at 4 01 43 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/69e1f75a-8a8f-4a2f-ac4d-cec2c64813ba">


## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

* Run `git checkout add/dashboard-common-modal-form` and `yarn start-jetpack-cloud`
* Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
* Enable monitor if not enabled already.
* Click on the clock icon next to the monitor toggle.
* Confirm that the modal is working for notification settings, Email address editor and Phone number editor.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?