### PR TITLE
Universal Header: Remove sub navigation

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -436,14 +436,6 @@ $happy_blocks_is_english = ( 0 === stripos( get_locale(), 'en' ) );
 </div>
 <div class="happy-blocks-mini-search">
 	<div class="happy-blocks-search-container">
-			<div class="happy-blocks-global-header__top">
-				<div class="happy-blocks-global-header__tabs">
-					<?php foreach ( $happy_blocks_tabs as $key => $happy_blocks_tab ) { ?>
-							<a href="<?php echo esc_attr( $happy_blocks_tab['url'] ); ?>" class="happy-blocks-global-header__tab<?php echo $happy_blocks_current_tab === $key ? ' active' : ''; ?>"><?php echo esc_html( $happy_blocks_tab['title'] ); ?></a>
-					<?php } ?>
-				</div>
-			</div>
-			<hr />
 			<div class="happy-blocks-global-header-site__title">
 				<?php if ( $args['include_site_title'] ) : ?>
 					<div class="happy-blocks-global-header-site__title__wrapper">


### PR DESCRIPTION
In this PR we're removing the sub navigation on support.

### Before
<img width="516" alt="Screenshot 2023-06-22 at 12 53 53" src="https://github.com/Automattic/wp-calypso/assets/52076348/858df907-8ab0-4b79-88b2-e6f71ec3eb1f">


### After 

<img width="501" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/be3020f1-8c13-43b6-ae93-0ed74b7746dc">

## Testing
1. Checkout branch
2. Run `yarn dev --sync` from `apps/happy-blocks`
3. Sandbox support site
4. Check wordpress.com/support