### PR TITLE
Updating checklist_statuses after selecting a theme during onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -1,7 +1,12 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-import { Onboard, useStarterDesignBySlug, useStarterDesignsQuery } from '@automattic/data-stores';
+import {
+	Onboard,
+	updateLaunchpadSettings,
+	useStarterDesignBySlug,
+	useStarterDesignsQuery,
+} from '@automattic/data-stores';
 import {
 	isDefaultGlobalStylesVariationSlug,
 	UnifiedDesignPicker,
@@ -483,8 +488,13 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const { setDesignOnSite, applyThemeWithPatterns } = useDispatch( SITE_STORE );
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
-	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
+	async function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
 		setSelectedDesign( _selectedDesign );
+
+		await updateLaunchpadSettings( siteSlug, {
+			checklist_statuses: { design_completed: true },
+		} );
+
 		if ( siteSlugOrId && _selectedDesign ) {
 			const positionIndex = designs.findIndex(
 				( design ) => design.slug === _selectedDesign?.slug

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -252,6 +252,7 @@ export function getEnhancedTasks(
 					};
 					break;
 				case 'design_selected':
+				case 'design_completed':
 					taskData = {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2637-gh-Automattic/dotcom-forge

## Proposed Changes

* Using `design_completed` instead of `design_selected` for the `design-first` flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply [the sibling Jetpack PR](https://github.com/Automattic/jetpack/pull/31513) to your sandbox with the following command: `bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/using-design-completed-for-design-first-flow`
* Sandbox you API
* Create a new site using the [/setup/design-first](http://calypso.localhost:3000/setup/design-first) flow
* Before selecting a theme, open the Launchad in a new tab and ensure the `Select a design` is not marked as completed
* Go back to the previous tab and select a theme
* Once you're redirect to the Launchpad again, you should see the `Select a design` step completed
* Ensure you can back to design selection by clicking at `Select a design` step in the Launchpad
* Ensure this approach won't affect other flows

https://github.com/Automattic/wp-calypso/assets/1044309/212e4f5c-edac-4969-acca-d7576f990ce9


## Pre-merge Checklist




<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?