### PR TITLE
Site transfer: change user information on StartSiteOwnerTransfer

### DIFF
--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
@@ -14,6 +14,7 @@ import PendingDomainTransfer from './pending-domain-transfer';
 import SiteOwnerTransferEligibility from './site-owner-user-search';
 import { SiteTransferCard } from './site-transfer-card';
 import StartSiteOwnerTransfer from './start-site-owner-transfer';
+import { User } from './use-administrators';
 import { useConfirmationTransferHash } from './use-confirmation-transfer-hash';
 
 const Strong = styled( 'strong' )( {
@@ -44,7 +45,7 @@ const SiteTransferComplete = () => {
 const SiteOwnerTransfer = () => {
 	useQueryUserPurchases();
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
-	const [ newSiteOwner, setNewSiteOwner ] = useState( '' );
+	const [ newSiteOwner, setNewSiteOwner ] = useState< User | null >( null );
 	const [ transferSiteSuccess, setSiteTransferSuccess ] = useState( false );
 
 	const translate = useTranslate();
@@ -64,7 +65,7 @@ const SiteOwnerTransfer = () => {
 
 	const onBackClick = () => {
 		if ( ! pendingDomain && newSiteOwner && ! transferSiteSuccess ) {
-			setNewSiteOwner( '' );
+			setNewSiteOwner( null );
 		} else {
 			page( '/settings/general/' + selectedSite.slug );
 		}
@@ -85,7 +86,6 @@ const SiteOwnerTransfer = () => {
 				<SiteOwnerTransferEligibility
 					siteId={ selectedSite.ID }
 					siteSlug={ selectedSite.slug }
-					siteOwner={ newSiteOwner }
 					onNewUserOwnerSubmit={ ( newOwner ) => setNewSiteOwner( newOwner ) }
 				/>
 			) }

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -1,7 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useState, FormEvent, useEffect } from 'react';
+import { useState, FormEvent } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
@@ -9,7 +9,7 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { ChooseUserLoadingPlaceholder } from './choose-user-loading-placeholder';
-import { useAdministrators } from './use-administrators';
+import { User, useAdministrators } from './use-administrators';
 import { useCheckSiteTransferEligibility } from './use-check-site-transfer-eligibility';
 
 const Strong = styled( 'strong' )( {
@@ -69,16 +69,14 @@ function NoAdministrators( { href, siteSlug }: { href: string; siteSlug: string 
 const SiteOwnerTransferEligibility = ( {
 	siteId,
 	siteSlug,
-	siteOwner,
 	onNewUserOwnerSubmit,
 }: {
 	siteId: number;
 	siteSlug: string;
-	siteOwner: string;
-	onNewUserOwnerSubmit: ( user: string ) => void;
+	onNewUserOwnerSubmit: ( user: User ) => void;
 } ) => {
 	const translate = useTranslate();
-	const [ tempSiteOwner, setTempSiteOwner ] = useState( siteOwner );
+	const [ tempSiteOwner, setTempSiteOwner ] = useState< User >();
 	const [ siteTransferEligibilityError, setSiteTransferEligibilityError ] = useState( '' );
 
 	const { checkSiteTransferEligibility, isLoading: isCheckingSiteTransferEligibility } =
@@ -90,20 +88,19 @@ const SiteOwnerTransferEligibility = ( {
 				setSiteTransferEligibilityError( e.message );
 			},
 			onSuccess: () => {
-				onNewUserOwnerSubmit?.( tempSiteOwner || '' );
+				if ( ! tempSiteOwner ) {
+					return;
+				}
+				onNewUserOwnerSubmit?.( tempSiteOwner );
 			},
 		} );
-
-	useEffect( () => {
-		setTempSiteOwner( siteOwner );
-	}, [ siteOwner ] );
 
 	const handleFormSubmit = ( event: FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
 		if ( ! tempSiteOwner ) {
 			return;
 		}
-		checkSiteTransferEligibility( { newSiteOwner: tempSiteOwner } );
+		checkSiteTransferEligibility( { newSiteOwner: tempSiteOwner.email } );
 	};
 
 	const addUsersHref = '/people/team/' + siteSlug;
@@ -136,10 +133,11 @@ const SiteOwnerTransferEligibility = ( {
 			<FormFieldset>
 				<FormLabel>{ translate( 'Administrator' ) }</FormLabel>
 				<FormSelect
-					onChange={ ( event: React.ChangeEvent< HTMLSelectElement > ) =>
-						setTempSiteOwner( event.target.value )
-					}
-					value={ tempSiteOwner }
+					onChange={ ( event: React.ChangeEvent< HTMLSelectElement > ) => {
+						const user = administrators.find( ( user ) => user.email === event.target.value );
+						setTempSiteOwner( user );
+					} }
+					value={ tempSiteOwner?.email }
 				>
 					<option value="">{ translate( 'Select administrator' ) }</option>
 					{ administrators.map( ( user ) => (

--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -198,8 +198,7 @@ const ContentAndOwnershipCard = ( {
 				<ListItem>
 					{ createInterpolateElement(
 						sprintf(
-							// translators: siteSlug is the current site slug, username is the user that the site is going to
-							// transer to
+							// translators: username is the user that the site is going to transer to
 							translate(
 								'You will keep your admin access unless <strong>%(username)s</strong> removes you.'
 							),

--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -12,13 +12,14 @@ import { ResponseDomain } from 'calypso/lib/domains/types';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { User } from './use-administrators';
 import { useStartSiteOwnerTransfer } from './use-start-site-owner-transfer';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
 type Props = {
 	selectedSiteId: number | null;
 	selectedSiteSlug: string | null;
-	siteOwner?: string;
+	siteOwner: User;
 	customDomains: ResponseDomain[];
 	onSiteTransferSuccess: () => void;
 	onSiteTransferError: () => void;
@@ -87,7 +88,7 @@ const DomainsCard = ( {
 }: {
 	domains: ResponseDomain[];
 	siteSlug: string | null;
-	siteOwner?: string;
+	siteOwner: User;
 } ) => {
 	const translate = useTranslate();
 	return (
@@ -98,12 +99,12 @@ const DomainsCard = ( {
 					<ListItem>
 						{ createInterpolateElement(
 							sprintf(
-								// translators: siteSlug is the current site slug, siteOwner is the user that the site is going to
+								// translators: siteSlug is the current site slug, username is the user that the site is going to
 								// transer to
 								translate(
-									'The domain name <strong>%(siteSlug)s</strong> will be transferred to <strong>%(siteOwner)s</strong> and will remain working on the site.'
+									'The domain name <strong>%(siteSlug)s</strong> will be transferred to <strong>%(username)s</strong> and will remain working on the site.'
 								),
-								{ siteSlug, siteOwner }
+								{ siteSlug, username: siteOwner.login }
 							),
 							{ strong: <Strong /> }
 						) }
@@ -114,11 +115,11 @@ const DomainsCard = ( {
 					<Text>
 						{ createInterpolateElement(
 							sprintf(
-								// translators: siteOwner is the user that the site is going to transfer to
+								// translators: username is the user that the site is going to transfer to
 								translate(
-									'The following domains will be transferred to <strong>%(siteOwner)s</strong> and will remain working on the site:'
+									'The following domains will be transferred to <strong>%(username)s</strong> and will remain working on the site:'
 								),
-								{ siteOwner }
+								{ username: siteOwner.login }
 							),
 							{ strong: <Strong /> }
 						) }
@@ -143,7 +144,7 @@ const UpgradesCard = ( {
 }: {
 	purchases: Purchase[];
 	siteSlug: string | null;
-	siteOwner?: string;
+	siteOwner: User;
 } ) => {
 	const translate = useTranslate();
 	if ( purchases.length === 0 ) {
@@ -155,12 +156,12 @@ const UpgradesCard = ( {
 			<Text>
 				{ createInterpolateElement(
 					sprintf(
-						// translators: siteSlug is the current site slug, siteOwner is the user that the site is going to
+						// translators: siteSlug is the current site slug, username is the user that the site is going to
 						// transer to
 						translate(
-							'Your paid upgrades on <strong>%(siteSlug)s</strong> will be transferred to <strong>%(siteOwner)s</strong> and will remain with the site.'
+							'Your paid upgrades on <strong>%(siteSlug)s</strong> will be transferred to <strong>%(username)s</strong> and will remain with the site.'
 						),
-						{ siteSlug, siteOwner }
+						{ siteSlug, username: siteOwner.login }
 					),
 					{ strong: <Strong /> }
 				) }
@@ -174,7 +175,7 @@ const ContentAndOwnershipCard = ( {
 	siteOwner,
 }: {
 	siteSlug: string | null;
-	siteOwner?: string;
+	siteOwner: User;
 } ) => {
 	const translate = useTranslate();
 	return (
@@ -184,12 +185,12 @@ const ContentAndOwnershipCard = ( {
 				<ListItem>
 					{ createInterpolateElement(
 						sprintf(
-							// translators: siteSlug is the current site slug, siteOwner is the user that the site is going to
+							// translators: siteSlug is the current site slug, userInfo is the user that the site is going to
 							// transer to
 							translate(
-								'You’ll be removed as owner of <strong>%(siteSlug)s</strong> and <strong>%(siteOwner)s</strong> will be the new owner from now on.'
+								'You’ll be removed as owner of <strong>%(siteSlug)s</strong> and <strong>%(userInfo)s</strong> will be the new owner from now on.'
 							),
-							{ siteSlug, siteOwner }
+							{ siteSlug, userInfo: `${ siteOwner.login } (${ siteOwner.email })` }
 						),
 						{ strong: <Strong /> }
 					) }
@@ -197,12 +198,12 @@ const ContentAndOwnershipCard = ( {
 				<ListItem>
 					{ createInterpolateElement(
 						sprintf(
-							// translators: siteSlug is the current site slug, siteOwner is the user that the site is going to
+							// translators: siteSlug is the current site slug, username is the user that the site is going to
 							// transer to
 							translate(
-								'You will keep your admin access unless <strong>%(siteOwner)s</strong> removes you.'
+								'You will keep your admin access unless <strong>%(username)s</strong> removes you.'
 							),
-							{ siteOwner }
+							{ username: siteOwner.login }
 						),
 						{ strong: <Strong /> }
 					) }
@@ -210,8 +211,7 @@ const ContentAndOwnershipCard = ( {
 				<ListItem>
 					{ createInterpolateElement(
 						sprintf(
-							// translators: siteSlug is the current site slug, siteOwner is the user that the site is going to
-							// transer to
+							// translators: siteSlug is the current site slug
 							translate(
 								'Your posts on <strong>%(siteSlug)s</strong> will remain authored your account.'
 							),
@@ -262,10 +262,10 @@ const StartSiteOwnerTransfer = ( {
 
 	const handleFormSubmit = ( event: FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
-		if ( ! siteOwner ) {
+		if ( ! siteOwner?.email ) {
 			return;
 		}
-		startSiteOwnerTransfer( { newSiteOwner: siteOwner } );
+		startSiteOwnerTransfer( { newSiteOwner: siteOwner.email } );
 	};
 
 	const startSiteTransferForm = (

--- a/client/my-sites/site-settings/site-owner-transfer/use-administrators.ts
+++ b/client/my-sites/site-settings/site-owner-transfer/use-administrators.ts
@@ -1,6 +1,6 @@
 import useUsersQuery from 'calypso/data/users/use-users-query';
 
-interface User {
+export interface User {
 	ID: number;
 	login: string;
 	email: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/2809 and https://github.com/Automattic/wp-calypso/pull/78534

## Proposed Changes

* Display the username and email for the new site owner when transferring a site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On any site that you own, make sure to have another administrator on that site or add it now.
* Navigate to `Settings General`  > `Transfer your site`
* Select the administrator
* Click on `Continue`
* Observe the copies display the `username` in all cases except the first occurrence that shows `username (email)`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
