### PR TITLE
Theme Showcase: Hide the Activate Button for Dotorg Themes on Sites on Lower Plans

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -635,11 +635,16 @@ class ThemeSheet extends Component {
 			showTryAndCustomize,
 			isExternallyManagedTheme,
 			isWporg,
+			isLoggedIn,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
 		const tag = author ? translate( 'by %(author)s', { args: { author: author } } ) : placeholder;
-		const shouldRenderButton = ! retired && ! isWPForTeamsSite && ! this.shouldRenderForStaging();
+		const shouldRenderButton =
+			! retired &&
+			! isWPForTeamsSite &&
+			! this.shouldRenderForStaging() &&
+			( ! this.hasWpOrgThemeUpsellBanner() || ! isLoggedIn );
 
 		return (
 			<div className="theme__sheet-header">


### PR DESCRIPTION
## Proposed Changes

* Hide the Dotorg themes activate button on Free, Personal, Premium sites for logged-in users.
* Logged-out users will still see the Activate button, pointing to the login form.

This is a tentative fix for a regression, possibly introduced in #76837, which extended the primary CTA for Dotorg themes to logged-out users.

It seems that the change leaked to logged-in users, where the button would unsuccessfully attempt to start the theme installation process.

| Before | After |
|--------|--------|
| <img width="702" alt="Screenshot 2023-06-22 at 16 20 25" src="https://github.com/Automattic/wp-calypso/assets/2070010/5d306bfe-0699-4506-afad-03fc3ed003ce"> | <img width="702" alt="Screenshot 2023-06-22 at 16 20 22" src="https://github.com/Automattic/wp-calypso/assets/2070010/2a88a78c-b5d4-43ac-b0e6-5c6e0a960d73"> | 

### Note

I'd love a review from both @Automattic/t-rex and @Automattic/lego to ensure this is actually what we want, and I haven't misinterpreted the situation.

cc @retnonindya who found the bug in the first place.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Logged-in and with a Free site selected...
  * Navigate to the Theme Showcase and search for a Dotorg theme (e.g. Astra).
  * Ensure the Activate button is not displayed.
* Pick a Business site.
  * Search for a Dotorg theme again.
  * Ensure the Activate button is displayed without regressions.
* Logged-out...
  * Navigate to the Theme Showcase and search for a Dotorg theme (e.g. Astra).
  * Ensure the Activate button is displayed without regressions.
