### PR TITLE
Video Stats: add retention rate

### DIFF
--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -130,7 +130,7 @@ $grid-vertical-gutters: 32px;
 
 /* custom video stats style to allow for scrolling */
 .is-section-stats .list-videoplays {
-	overflow-x: scroll;
+	overflow-x: auto;
 
 	.stats-card--header-and-body {
 		width: fit-content;
@@ -335,7 +335,6 @@ $grid-vertical-gutters: 32px;
 	.stats__module-wrapper--videoplays,
 	.list-videoplays {
 		grid-area: videos;
-		overflow-x: scroll;
 
 		// Downloads module is disabled for Jetpack sites.
 		// Expand the Videos module to take up the entire row.

--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -128,6 +128,16 @@ $grid-vertical-gutters: 32px;
 	}
 }
 
+/* custom video stats style to allow for scrolling */
+.is-section-stats .list-videoplays {
+	overflow-x: scroll;
+
+	.stats-card--header-and-body {
+		width: fit-content;
+		min-width: 100%;
+	}
+}
+
 .is-section-stats .stats__module-list--traffic {
 	// @TODO: Avoid using grid-gap by increasing `grid-template-rows` to add the divider for the next section,
 	// which would make different gaps for sites.
@@ -325,6 +335,7 @@ $grid-vertical-gutters: 32px;
 	.stats__module-wrapper--videoplays,
 	.list-videoplays {
 		grid-area: videos;
+		overflow-x: scroll;
 
 		// Downloads module is disabled for Jetpack sites.
 		// Expand the Videos module to take up the entire row.

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -23,7 +23,7 @@
 .card.stats-module {
 	padding: 0;
 	margin-bottom: 10px;
-	overflow-x: scroll;
+	overflow-x: auto;
 }
 // Site sections
 .stats__module-list {

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -23,6 +23,7 @@
 .card.stats-module {
 	padding: 0;
 	margin-bottom: 10px;
+	overflow-x: scroll;
 }
 // Site sections
 .stats__module-list {

--- a/client/my-sites/stats/stats-video-summary/index.jsx
+++ b/client/my-sites/stats/stats-video-summary/index.jsx
@@ -53,6 +53,9 @@ class StatsVideoSummary extends Component {
 		if ( 'watch_time' === query.statType ) {
 			tabLabel = translate( 'Hours Watched' );
 		}
+		if ( 'retention_rate' === query.statType ) {
+			tabLabel = translate( 'Retention Rate' );
+		}
 
 		return (
 			<div>

--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -186,6 +186,7 @@ class VideoPressStatsModule extends Component {
 				impressions: numberFormat( item.impressions ),
 				watch_time:
 					item.watch_time > 1 ? numberFormat( item.watch_time, 1 ) : `< ${ numberFormat( 1, 1 ) }`,
+				retention_rate: item.retention_rate,
 			};
 		} );
 
@@ -215,6 +216,7 @@ class VideoPressStatsModule extends Component {
 									<>
 										<span>{ translate( 'Impressions' ) }</span>
 										<span>{ translate( 'Hours watched' ) }</span>
+										<span>{ translate( 'Retention Rate' ) }</span>
 									</>
 								),
 								body: ( item ) => (
@@ -232,6 +234,13 @@ class VideoPressStatsModule extends Component {
 											onKeyUp={ () => showStat( 'watch_time', item ) }
 										>
 											{ item.watch_time }
+										</span>
+										{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
+										<span
+											onClick={ () => showStat( 'retention_rate', item ) }
+											onKeyUp={ () => showStat( 'retention_rate', item ) }
+										>
+											{ 0 === item.value ? 'n/a' : `${ item.retention_rate }%` }
 										</span>
 									</>
 								),
@@ -269,6 +278,9 @@ class VideoPressStatsModule extends Component {
 									<div className="videopress-stats-module__grid-header videopress-stats-module__grid-metric">
 										Views
 									</div>
+									<div className="videopress-stats-module__grid-header videopress-stats-module__grid-metric">
+										Retention Rate
+									</div>
 								</div>
 								{ completeVideoStats.map( ( row, index ) => (
 									<div
@@ -305,6 +317,16 @@ class VideoPressStatsModule extends Component {
 												{ row.watch_time > 1
 													? numberFormat( row.watch_time, 1 )
 													: `< ${ numberFormat( 1, 1 ) }` }
+											</span>
+										</div>
+										<div className="videopress-stats-module__grid-cell videopress-stats-module__grid-metric">
+											<span
+												onClick={ () => showStat( 'retention_rate', row ) }
+												onKeyUp={ () => showStat( 'retention_rate', row ) }
+												tabIndex="0"
+												role="button"
+											>
+												{ 0 === row.value ? 'n/a' : `${ row.retention_rate }%` }
 											</span>
 										</div>
 										<div className="videopress-stats-module__grid-cell videopress-stats-module__grid-metric">

--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -276,10 +276,10 @@ class VideoPressStatsModule extends Component {
 										Hours Watched
 									</div>
 									<div className="videopress-stats-module__grid-header videopress-stats-module__grid-metric">
-										Views
+										Retention Rate
 									</div>
 									<div className="videopress-stats-module__grid-header videopress-stats-module__grid-metric">
-										Retention Rate
+										Views
 									</div>
 								</div>
 								{ completeVideoStats.map( ( row, index ) => (

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -1,6 +1,6 @@
 .videopress-stats-module__grid {
 	display: grid;
-	grid-template-columns: 50% auto auto auto;
+	grid-template-columns: 50% auto auto auto auto;
 	padding: 0.5em 0;
 	line-height: 40px;
 	font-size: 0.875rem;
@@ -10,7 +10,7 @@
 
 @media screen and ( max-width: 450px ) {
 	.videopress-stats-module__grid {
-		grid-template-columns: 40% auto auto auto;
+		grid-template-columns: 40% auto auto auto auto;
 	}
 }
 

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -6,6 +6,8 @@
 	font-size: 0.875rem;
 
 	color: var(--color-text);
+	min-width: 100%;
+	width: fit-content;
 }
 
 @media screen and ( max-width: 450px ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 1719-gh-automattic/greenhouse

| desktop | mobile (with scrolling) |
| -- | -- |
| <img width="600" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4081020/4654ee6a-a065-43a4-9f00-e109db2d0de4"> | <img width="300" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4081020/b6a92846-1de8-4cdf-a859-a8b458bb583e"> |



## Proposed Changes

* Add a `Retention Rate` stat to video stats. Retention rate calculation discussed here 1719-gh-automattic/greenhouse#issuecomment-1542930989

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply D114247-code to your wpcom sandbox (unless it has already been deployed)
* sandbox `public-api.wordpress.com` (unless D114247-code has been deployed)
* test with `yarn && yarn start` and with a pre-made container from the `Calypso Live` link below. **_For some reason they render different views, its not clear to me why._**
* open a site that has videos uploaded to it
* Click the `Stats` menu
* Scroll down to the `Videos` section. If it is empty, change the stats period to `Weeks`, `Months` or `Years` until you see some Video statistics
* Click the `View details` link
* You should see `Retention Rate` in the list of stats
* Clicking a `Retention Rate` value should open a more detailed view for that video rate
* Clicking `Export csv` should produce a csv with the additional column data included
* switch to a mobile / portrait browser size. You should be able to scroll horizontally to get to the additional info.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?