### PR TITLE
Checkout: Show ecommerce features for Woo Express plans

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
 	isMonthly,
+	isWooExpressPlan,
 	isWpComProPlan,
 	isWpComBusinessPlan,
 	isWpComEcommercePlan,
@@ -80,7 +81,7 @@ export default function getPlanFeatures(
 		].filter( isValueTruthy );
 	}
 
-	if ( isWpComEcommercePlan( productSlug ) ) {
+	if ( isWpComEcommercePlan( productSlug ) || isWooExpressPlan( productSlug ) ) {
 		return [
 			! isMonthlyPlan && freeOneYearDomain,
 			isMonthlyPlan && emailSupport,


### PR DESCRIPTION
In #76535, new product types were added for the Woo Express plans. This caused Checkout to only display the default plan features, since previously Woo Express plans passed the `isWpComEcommercePlan()` check.

This PR adds a new check for `isWooExpressPlan()` to the Checkout features, in order to return the same list as other ecommerce plans.

See: pbOQVh-3sY-p2#comment-4146

<img width="330" alt="Screenshot 2023-06-22 at 12 53 06 PM" src="https://github.com/Automattic/wp-calypso/assets/942359/b7016079-afae-4360-8b5a-391fc7bf920a">

**To test:**
- visit Checkout with a Woo Express plan `/checkout/{site_slug}/wooexpress-medium-monthly`
- verify that you see ecommerce features in the "Included with your purchase" list