### PR TITLE
Blog Onboarding: Add variationName on binary selection signup redirect

### DIFF
--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -34,8 +34,8 @@ const Blog: Flow = {
 
 		const logInUrl =
 			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?redirect_to=/setup/blog`
-				: `/start/account/user?redirect_to=/setup/blog`;
+				? `/start/account/user/${ locale }?redirect_to=/setup/blog&variationName=blogger-intent`
+				: `/start/account/user?redirect_to=/setup/blog&variationName=blogger-intent`;
 
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2797

## Proposed Changes

Add the URL param `&variationName=blogger-intent` when redirecting to the Signup page from the Blog Onboarding binary selection (`/setup/blog`).

## Testing Instructions

* Not logged in, go to `/setup/blog`
* In the signup page URL, you should see `variationName=blogger-intent` on the URL

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
