### PR TITLE
[GB][E2E][AT][FIX][nightlies] Unescape val that should be interpolated in the exec argument strings

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -132,14 +132,14 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 				name = "Post Successful Message to Slack"
 				executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
 				path = "./bin/post-threaded-slack-message.sh"
-				arguments = "%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID_TEST% %GB_E2E_ANNOUNCEMENT_THREAD_TS% \"The \$buildName passed successfully!\" %GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%"
+				arguments = "%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID_TEST% %GB_E2E_ANNOUNCEMENT_THREAD_TS% \"The $buildName passed successfully!\" %GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%"
 			}
 
 			exec {
 				name = "Post Failure Message to Slack"
 				executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 				path = "./bin/post-threaded-slack-message.sh"
-				arguments = "%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID_TEST% %GB_E2E_ANNOUNCEMENT_THREAD_TS% \"The \$buildName failed! Could you have a look? @kitkat-team @calypso-platform-team!\" %GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%"
+				arguments = "%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID_TEST% %GB_E2E_ANNOUNCEMENT_THREAD_TS% \"The $buildName failed! Could you have a look? @kitkat-team @calypso-platform-team!\" %GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%"
 			}
 		},
 		buildFeatures = {


### PR DESCRIPTION
## Proposed Changes

Project: p4TIVU-aAZ-p2

Fix follow-up to: https://github.com/Automattic/wp-calypso/pull/78454.

The build name was not being interpolated because the `$` was being escaped. This changeset unescapes it so that its value is correctly interpolated when Kotlin parses the string.

## Testing Instructions

* Checks should pass.