### PR TITLE
Checkout: Hide masterbar help icon at mobile width

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -887,6 +887,10 @@ a.masterbar__quick-language-switcher {
 
 	.masterbar--is-checkout & {
 		padding: 0 24px;
+
+		@include breakpoint-deprecated( "<480px" ) {
+			display: none;
+		}
 	}
 
 	svg {


### PR DESCRIPTION
## Proposed Changes

This fixes a regression in https://github.com/Automattic/wp-calypso/pull/77353 where at mobile widths the masterbar help button tries to fit itself onto the page at small widths, breaking the layout. In this PR we hide that button at those widths instead.

Props to @JessBoctor for spotting this!

Before:

<img width="282" alt="Screenshot 2023-06-22 at 1 19 57 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/c443d85b-9a40-46c4-8a0b-035cc1fced8e">

After:

<img width="280" alt="Screenshot 2023-06-22 at 1 20 12 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/f2b73a24-7ecb-4c5b-9db5-94871a61fe39">


## Testing Instructions

Use a browser set to emulate a Galaxy Fold and view checkout. Verify that checkout takes up the full page width with no horizontal scrolling.