### PR TITLE
Jeptack Pro Dashboard: Hide the number of days for Jetpack Search billing

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -58,11 +58,19 @@ export default function BillingDetails() {
 
 							<div className="billing-details__subtotal">
 								{ useDailyPrices &&
+									// Do not show number of days for Jetpack Search since that can be misleading
+									// as Search uses metered pricing on top of daily pricing.
+									product.productSlug !== 'jetpack-search' &&
 									// Translators: * designates a footnote explaining how we calculate the number of days.
 									translate( '%(count)d Day*', '%(count)d Days*', {
 										count: product.productQuantity,
 										args: { count: product.productQuantity },
 									} ) }
+
+								{ /* Empty element to keep vertical alignment equal when we're not displaying days. */ }
+								{ useDailyPrices && product.productSlug === 'jetpack-search' && (
+									<span>&nbsp;</span>
+								) }
 
 								{ ! useDailyPrices &&
 									translate( '%(count)d License', '%(count)d Licenses', {


### PR DESCRIPTION
## Proposed Changes

* Jetpack Pro Dashboard: Hide the number of days for Jetpack Search as that product also uses metered billing which can cause the number of days to look misleading (30 days of usage * 3 times the search metered limits = 90 days being shown for a single month which is obviously not fine).

## Testing Instructions

* Issue a license for Jetpack Search.
* Open up http://jetpack.cloud.localhost:3000/partner-portal/billing and confirm it only shows a subtotal, without a number for days of usage.

![Screen Shot 2023-06-22 at 20 29 01](https://github.com/Automattic/wp-calypso/assets/22746396/3f62b6f0-7b87-44ac-8040-c9b50494b612)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
