### PR TITLE
Fixes the campaign status filter on the Advertising page

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
@@ -41,7 +41,7 @@ const useCampaignsQueryPaged = (
 		async ( { pageParam = 1 } ) => {
 			const resultQuery = await requestDSP< CampaignQueryResult >(
 				siteId,
-				`/search/campaigns/site/${ siteId }?order=asc&order_by=post_date&page=${ pageParam }&${ searchQueryParams }`
+				`/search/campaigns/site/${ siteId }?order=asc&order_by=post_date&page=${ pageParam }${ searchQueryParams }`
 			);
 
 			const { campaigns, page, total_items, total_pages } = resultQuery;

--- a/client/my-sites/promote-post-i2/components/campaigns-filter/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-filter/index.tsx
@@ -44,7 +44,7 @@ export default function CampaignsFilter( props: Props ) {
 			label: translate( 'In moderation', { context: 'comment status' } ),
 		},
 		{
-			value: 'finiasdasdd',
+			value: 'finished',
 			label: translate( 'Completed', { context: 'comment status' } ),
 		},
 		{


### PR DESCRIPTION
The status filter on the Advertising page - Campaigns list page doesn't work correctly for the 'Completed' status.

## Proposed Changes

* Fixed the typo in the Campaign status filter
* Remove exta & symbol that was being added in the resulting API URL. 
We were always appending a & before the querystring, but the method in charge of generating that query string already appended the first &.

## Testing Instructions

* Open the live preview and then Navigate to Tools->Advertising
* Click on the Campaigns link in the navigation
* Filter by completed campaign and verify that you are getting the correct list
You can check the network tab and verify that the correct `finished` status is sent in the `wpcom/v2/sites/219437556/wordads/dsp/api/v1/search/campaigns/site/[SITE_ID]` call.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
