### PR TITLE
Add/reader nav opacity edges

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -3,7 +3,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-import { debounce } from 'lodash';
+import { throttle } from 'lodash';
 import { useState, useRef, useEffect } from 'react';
 import SegmentedControl from 'calypso/components/segmented-control';
 import wpcom from 'calypso/lib/wp';
@@ -49,7 +49,7 @@ const DiscoverStream = ( props ) => {
 
 	// To keep track of the navigation tabs scroll position and keep it from appearing to reset
 	// after child render.
-	const handleScroll = debounce( () => {
+	const handleScroll = throttle( () => {
 		// Save scroll position for later reference.
 		scrollPosition.current = scrollRef.current?.scrollLeft;
 

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -53,7 +53,7 @@ const DiscoverStream = ( props ) => {
 		// Save scroll position for later reference.
 		scrollPosition.current = scrollRef.current?.scrollLeft;
 
-		// Determine and set visibility classes on scroll buttons.
+		// Determine and set visibility classes on scroll button wrappers.
 		const leftScrollButton = document.querySelector( `.${ DEFAULT_CLASS }__left-button-wrapper` );
 		const rightScrollButton = document.querySelector( `.${ DEFAULT_CLASS }__right-button-wrapper` );
 		shouldHideLeftScrollButton()

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -54,12 +54,8 @@ const DiscoverStream = ( props ) => {
 		scrollPosition.current = scrollRef.current?.scrollLeft;
 
 		// Determine and set visibility classes on scroll buttons.
-		const leftScrollButton = document.querySelector(
-			`.${ DEFAULT_CLASS }__tabs-scroll-left-button`
-		);
-		const rightScrollButton = document.querySelector(
-			`.${ DEFAULT_CLASS }__tabs-scroll-right-button`
-		);
+		const leftScrollButton = document.querySelector( `.${ DEFAULT_CLASS }__left-button-wrapper` );
+		const rightScrollButton = document.querySelector( `.${ DEFAULT_CLASS }__right-button-wrapper` );
 		shouldHideLeftScrollButton()
 			? hideElement( leftScrollButton )
 			: showElement( leftScrollButton );
@@ -107,27 +103,35 @@ const DiscoverStream = ( props ) => {
 
 	const DiscoverNavigation = () => (
 		<div className={ DEFAULT_CLASS }>
-			<Button
-				className={ classNames( `${ DEFAULT_CLASS }__tabs-scroll-left-button`, {
+			<div
+				className={ classNames( `${ DEFAULT_CLASS }__left-button-wrapper`, {
 					'display-none': shouldHideLeftScrollButton(),
 				} ) }
-				onClick={ () => bumpScrollX( true ) }
-				tabIndex={ -1 }
 				aria-hidden={ true }
 			>
-				<Gridicon icon="chevron-left" />
-			</Button>
+				<Button
+					className={ `${ DEFAULT_CLASS }__left-button` }
+					onClick={ () => bumpScrollX( true ) }
+					tabIndex={ -1 }
+				>
+					<Gridicon icon="chevron-left" />
+				</Button>
+			</div>
 
-			<Button
-				className={ classNames( `${ DEFAULT_CLASS }__tabs-scroll-right-button`, {
+			<div
+				className={ classNames( `${ DEFAULT_CLASS }__right-button-wrapper`, {
 					'display-none': shouldHideRightScrollButton(),
 				} ) }
-				onClick={ () => bumpScrollX() }
-				tabIndex={ -1 }
 				aria-hidden={ true }
 			>
-				<Gridicon icon="chevron-right" />
-			</Button>
+				<Button
+					className={ `${ DEFAULT_CLASS }__right-button` }
+					onClick={ () => bumpScrollX() }
+					tabIndex={ -1 }
+				>
+					<Gridicon icon="chevron-right" />
+				</Button>
+			</div>
 
 			<div className={ `${ DEFAULT_CLASS }__tabs` } ref={ scrollRef } onScroll={ handleScroll }>
 				<SegmentedControl primary className={ `${ DEFAULT_CLASS }__tab-control` }>

--- a/client/reader/discover/discover-stream.scss
+++ b/client/reader/discover/discover-stream.scss
@@ -1,24 +1,38 @@
 .discover-stream-navigation {
 	position: relative;
 
-	.discover-stream-navigation__tabs-scroll-left-button,
-	.discover-stream-navigation__tabs-scroll-right-button {
-		border-radius: 50%;
-		padding: 6px 10px;
+	.discover-stream-navigation__left-button-wrapper,
+	.discover-stream-navigation__right-button-wrapper {
 		position: absolute;
-		top: 0;
 		z-index: 1;
+		pointer-events: none;
 
 		&.display-none {
 			display: none;
 		}
+
+		.discover-stream-navigation__left-button,
+		.discover-stream-navigation__right-button {
+			border-radius: 50%;
+			padding: 6px 10px;
+			pointer-events: auto;
+		}
+
+		.discover-stream-navigation__left-button {
+			margin-right: 30px;
+		}
+		.discover-stream-navigation__right-button {
+			margin-left: 30px;
+		}
 	}
 
-	.discover-stream-navigation__tabs-scroll-right-button {
+	.discover-stream-navigation__right-button-wrapper {
 		right: 0;
+		background: linear-gradient(270deg, rgba(255, 255, 255, 1) 30%, rgba(255, 255, 255, 0.7) 40%, rgba(255, 255, 255, 0) 100%);
 	}
-	.discover-stream-navigation__tabs-scroll-left-button {
+	.discover-stream-navigation__left-button-wrapper {
 		left: 0;
+		background: linear-gradient(90deg, rgba(255, 255, 255, 1) 30%, rgba(255, 255, 255, 0.7) 40%, rgba(255, 255, 255, 0) 100%);
 	}
 
 	.discover-stream-navigation__tabs {
@@ -37,7 +51,7 @@
 	}
 }
 
-.accessible-focus .discover-stream-navigation .discover-stream-navigation__tabs-scroll-left-button,
-.accessible-focus .discover-stream-navigation .discover-stream-navigation__tabs-scroll-right-button {
+.accessible-focus .discover-stream-navigation .discover-stream-navigation__left-button-wrapper,
+.accessible-focus .discover-stream-navigation .discover-stream-navigation__right-button-wrapper {
 	display: none;
 }

--- a/client/reader/discover/discover-stream.scss
+++ b/client/reader/discover/discover-stream.scss
@@ -46,6 +46,7 @@
 	}
 }
 
+// Hide the buttons and not the wrappers as we still want the opacity/fade effect from wrappers.
 .accessible-focus .discover-stream-navigation .discover-stream-navigation__left-button,
 .accessible-focus .discover-stream-navigation .discover-stream-navigation__right-button {
 	display: none;

--- a/client/reader/discover/discover-stream.scss
+++ b/client/reader/discover/discover-stream.scss
@@ -6,6 +6,7 @@
 		position: absolute;
 		z-index: 1;
 		pointer-events: none;
+		height: 100%;
 
 		&.display-none {
 			display: none;
@@ -17,21 +18,16 @@
 			padding: 6px 10px;
 			pointer-events: auto;
 		}
-
-		.discover-stream-navigation__left-button {
-			margin-right: 30px;
-		}
-		.discover-stream-navigation__right-button {
-			margin-left: 30px;
-		}
 	}
 
 	.discover-stream-navigation__right-button-wrapper {
 		right: 0;
+		padding-left: 30px;
 		background: linear-gradient(270deg, rgba(255, 255, 255, 1) 30%, rgba(255, 255, 255, 0.7) 40%, rgba(255, 255, 255, 0) 100%);
 	}
 	.discover-stream-navigation__left-button-wrapper {
 		left: 0;
+		padding-right: 30px;
 		background: linear-gradient(90deg, rgba(255, 255, 255, 1) 30%, rgba(255, 255, 255, 0.7) 40%, rgba(255, 255, 255, 0) 100%);
 	}
 
@@ -47,11 +43,10 @@
 			border-radius: 4px;
 			margin: 0 5px;
 		}
-
 	}
 }
 
-.accessible-focus .discover-stream-navigation .discover-stream-navigation__left-button-wrapper,
-.accessible-focus .discover-stream-navigation .discover-stream-navigation__right-button-wrapper {
+.accessible-focus .discover-stream-navigation .discover-stream-navigation__left-button,
+.accessible-focus .discover-stream-navigation .discover-stream-navigation__right-button {
 	display: none;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* add opacity edges to reader discover nav. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
