### PR TITLE
Newsletters: Update title fonts on onboard screens

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -6,6 +6,7 @@
 @import "@automattic/typography/styles/fonts";
 @import "@automattic/onboarding/styles/mixins";
 @import "@automattic/onboarding/styles/variables";
+@import "@automattic/components/src/styles/typography";
 
 /**
  * General onboarding styling
@@ -207,6 +208,30 @@ button {
 			@include break-medium {
 				font-size: $font-headline-medium;
 			}
+		}
+	}
+}
+
+/*
+ * Override font sizes for all newsletter onboarding screens
+ */
+.newsletter,
+.newsletter:not(.domains) {
+	.step-container {
+		.step-container__content h1,
+		.step-container__header h1.formatted-header__title {
+			font-size: rem(32px); //typography-exception
+			line-height: rem(40px); //typography-exception
+
+			@include break-medium {
+				font-size: rem(44px); //typography-exception
+				line-height: rem(52px); //typography-exception
+			}
+		}
+		.step-container__header .formatted-header .formatted-header__subtitle {
+			font-size: rem(16px); //typography-exception
+			line-height: rem(24px); //typography-exception
+			font-family: $font-sf-pro-display;
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -164,3 +164,26 @@
 		display: none;
 	}
 }
+
+// Override styles for newsletter flow
+.newsletter.plans {
+	.step-container {
+		.step-wrapper__header {
+			.formatted-header {
+				h1.formatted-header__title {
+					font-size: rem(32px); //typography-exception
+					line-height: rem(40px); //typography-exception
+
+					@include break-medium {
+						font-size: rem(44px); //typography-exception
+						line-height: rem(52px); //typography-exception
+					}
+				}
+				.formatted-header__subtitle {
+					font-size: rem(16px);
+					line-height: rem(24px);
+				}
+			}
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
@@ -1,3 +1,6 @@
+@import "@automattic/onboarding/styles/mixins";
+@import "@automattic/components/src/styles/typography";
+
 @import "../style";
 .subscribers {
 	.add-subscriber__title-container {
@@ -7,7 +10,7 @@
 			margin: 36px auto 58px auto !important;
 		}
 	}
-	.step-container {
+	.step-container.subscribers {
 		.subscribers {
 			padding-top: 0;
 		}
@@ -24,7 +27,8 @@
 
 			.onboarding-subtitle {
 				margin-bottom: 1.5rem;
-				font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
+				font-size: rem(16px); //typography-exception
+				line-height: rem(24px); //typography-exception
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/75019

## Proposed Changes

This PR updates the title and subtitle font-size and line-height on all Newsletter onboarding screens, except the intro screen (had already been done) and Launchpad (has it's own layout and styling). 

As we don't have a default font size matching the needed size/height, I used rem(XXpx) in each location. Theoretically, we could add new default font sizes/heights and import them, but that seems like overkill. 

Example of what's being changed, in this case on the setup screen: 

![font updates](https://github.com/Automattic/wp-calypso/assets/21228350/5a4c4974-f0f4-4c2d-8a86-959490254d1e)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Check out this branch and start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro
2) Proceed through the steps confirm the correct font sizes and line heights for the title and subtitle at the top of each screen. Specifically: 
   - Screens to check: Setup, Domains, Plans, Subscribers
   - Main title: 44px size / 52px line height on desktop, 32px size / 40px height on mobile
   - Subtitle: 16px size / 24px line height on desktop and mobile