### PR TITLE
Reader: fix RSS feed lookup

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -37,11 +37,11 @@ const updateQueryArg = ( params ) =>
 
 const pickSort = ( sort ) => ( sort === 'date' ? SORT_BY_LAST_UPDATED : SORT_BY_RELEVANCE );
 
-const SpacerDiv = withDimensions( ( { width } ) => (
+const SpacerDiv = withDimensions( ( { width, height } ) => (
 	<div
 		style={ {
 			width: `${ width }px`,
-			height: `130px`,
+			height: `${ height - 73 }px`,
 		} }
 	/>
 ) );
@@ -53,11 +53,15 @@ class SearchStream extends React.Component {
 	};
 
 	state = {
-		feed: null,
+		feeds: [],
 	};
 
-	setSearchFeed = ( feed ) => {
-		this.setState( { feed: feed } );
+	resetSearchFeeds = () => {
+		this.setState( { feeds: [] } );
+	};
+
+	setSearchFeeds = ( feeds ) => {
+		this.setState( { feeds: feeds } );
 	};
 
 	getTitle = ( props = this.props ) => props.query || props.translate( 'Search' );
@@ -114,7 +118,7 @@ class SearchStream extends React.Component {
 		const segmentedControlClass = wideDisplay
 			? 'search-stream__sort-picker is-wide'
 			: 'search-stream__sort-picker';
-		const hidePostsAndSites = this.state.feed && this.state.feed?.feed_ID.length === 0;
+		const hidePostsAndSites = this.state.feeds && this.state.feeds?.length === 1;
 
 		let searchPlaceholderText = this.props.searchPlaceholderText;
 		if ( ! searchPlaceholderText ) {
@@ -165,7 +169,7 @@ class SearchStream extends React.Component {
 						<SearchInput
 							onSearch={ this.updateQuery }
 							onSearchClose={ this.scrollToTop }
-							onSearchChange={ () => this.setState( { feed: null } ) }
+							onSearchOpen={ this.resetSearchFeeds }
 							autoFocus={ this.props.autoFocusInput }
 							delaySearch={ true }
 							delayTimeout={ 500 }
@@ -174,7 +178,7 @@ class SearchStream extends React.Component {
 							value={ query || '' }
 						/>
 					</CompactCard>
-					<SearchFollowButton query={ query } feed={ this.state.feed ?? null } />
+					<SearchFollowButton query={ query } feeds={ this.state.feeds } />
 					{ query && (
 						<SegmentedControl compact className={ segmentedControlClass }>
 							<SegmentedControl.Item
@@ -213,7 +217,7 @@ class SearchStream extends React.Component {
 								<SiteResults
 									query={ query }
 									sort={ pickSort( sortOrder ) }
-									onReceiveSearchResults={ this.setSearchFeed }
+									onReceiveSearchResults={ this.setSearchFeeds }
 								/>
 							</div>
 						) }
@@ -227,7 +231,7 @@ class SearchStream extends React.Component {
 							<SiteResults
 								query={ query }
 								sort={ pickSort( sortOrder ) }
-								onReceiveSearchResults={ this.setSearchFeed }
+								onReceiveSearchResults={ this.setSearchFeeds }
 							/>
 						) }
 					</div>

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -56,6 +56,12 @@ class SearchStream extends React.Component {
 		feeds: [],
 	};
 
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.query !== this.props.query ) {
+			this.resetSearchFeeds();
+		}
+	}
+
 	resetSearchFeeds = () => {
 		this.setState( { feeds: [] } );
 	};

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -41,7 +41,7 @@ const SpacerDiv = withDimensions( ( { width } ) => (
 	<div
 		style={ {
 			width: `${ width }px`,
-			height: `60px`,
+			height: `130px`,
 		} }
 	/>
 ) );
@@ -114,7 +114,7 @@ class SearchStream extends React.Component {
 		const segmentedControlClass = wideDisplay
 			? 'search-stream__sort-picker is-wide'
 			: 'search-stream__sort-picker';
-		const hidePostsAndSites = this.state.feed && this.state.feed.feed_ID?.length === 0;
+		const hidePostsAndSites = this.state.feed && this.state.feed?.feed_ID.length === 0;
 
 		let searchPlaceholderText = this.props.searchPlaceholderText;
 		if ( ! searchPlaceholderText ) {

--- a/client/reader/search-stream/search-follow-button.jsx
+++ b/client/reader/search-stream/search-follow-button.jsx
@@ -3,7 +3,7 @@ import { localize } from 'i18n-calypso';
 import { some } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { resemblesUrl, withoutHttp, addSchemeIfMissing } from 'calypso/lib/url';
+import { resemblesUrl, withoutHttp, addSchemeIfMissing, urlToDomainAndPath } from 'calypso/lib/url';
 import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
 import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';
 import FollowButton from 'calypso/reader/follow-button';
@@ -63,7 +63,7 @@ class SearchFollowButton extends Component {
 		// If we find a feed then set the feed object
 		let feed;
 		if ( resemblesUrl( query ) ) {
-			feed = feeds?.find( ( f ) => f.feed_URL.includes( query ) );
+			feed = feeds?.find( ( f ) => f.feed_URL.includes( urlToDomainAndPath( query ) ) );
 		}
 
 		// If no feed found, then don't show the follow button
@@ -71,10 +71,8 @@ class SearchFollowButton extends Component {
 			return null;
 		}
 
-		// We can use the feed to create a follow button
-
 		// If already following this feed then don't show the follow button
-		if ( feed.is_following !== undefined && feed.is_following === true ) {
+		if ( feed.is_following === true ) {
 			return null;
 		}
 

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -81,17 +81,42 @@ export default connect(
 			sort: ownProps.sort,
 		} );
 
-		// Check if searchResults has one item and if it has a feed_ID
+		// Check if searchResults has any feeds
 		if ( searchResults && searchResults.length > 0 ) {
-			let feed = searchResults[ 0 ];
-			if ( feed?.feed_ID.length > 0 ) {
-				// If it has a feed_ID, get the feed object from the state
-				const existingFeed = getFeed( state, feed.feed_ID );
-				if ( existingFeed ) {
-					feed = existingFeed;
+			const feeds = searchResults;
+			// We want to create a list of unique feeds based on searchResults
+			// We need to do this because the search results may contain duplicate feeds URLs with different http or https schemes
+			// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+			const feedResults = feeds.reduce( ( uniqueFeeds, feed ) => {
+				// Strip out the URL scheme for subscribe_URL
+				const strippedSubscribeURL = feed.subscribe_URL.replace( /^https?:\/\//, '' );
+
+				// Check if the array already has an item with the same strippedSubscribeURL or feed_ID
+				const foundItem = uniqueFeeds.find(
+					// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+					( uniqueFeed ) =>
+						( ! feed.feed_ID &&
+							uniqueFeed.subscribe_URL.replace( /^https?:\/\//, '' ) === strippedSubscribeURL ) ||
+						( feed.feed_ID && uniqueFeed.feed_ID === feed.feed_ID )
+				);
+
+				// If no item is found, add the current item to the array
+				if ( ! foundItem ) {
+					let uniqueFeed = feed;
+					if ( feed?.feed_ID.length > 0 ) {
+						// If it has a feed_ID, get the feed object from the state
+						const existingFeed = getFeed( state, feed.feed_ID );
+						if ( existingFeed ) {
+							uniqueFeed = existingFeed;
+						}
+					}
+					uniqueFeeds.push( uniqueFeed );
 				}
-			}
-			ownProps.onReceiveSearchResults( feed );
+
+				return uniqueFeeds;
+			}, [] );
+
+			ownProps.onReceiveSearchResults( feedResults );
 		}
 		return {
 			searchResults: searchResults,

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -89,21 +89,22 @@ export default connect(
 			// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 			const feedResults = feeds.reduce( ( uniqueFeeds, feed ) => {
 				// Strip out the URL scheme for subscribe_URL
-				const strippedSubscribeURL = feed.subscribe_URL.replace( /^https?:\/\//, '' );
+				const strippedSubscribeURL = feed.subscribe_URL?.replace( /^https?:\/\//, '' );
 
 				// Check if the array already has an item with the same strippedSubscribeURL or feed_ID
 				const foundItem = uniqueFeeds.find(
 					// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 					( uniqueFeed ) =>
 						( ! feed.feed_ID &&
-							uniqueFeed.subscribe_URL.replace( /^https?:\/\//, '' ) === strippedSubscribeURL ) ||
+							uniqueFeed.subscribe_URL &&
+							uniqueFeed.subscribe_URL?.replace( /^https?:\/\//, '' ) === strippedSubscribeURL ) ||
 						( feed.feed_ID && uniqueFeed.feed_ID === feed.feed_ID )
 				);
 
 				// If no item is found, add the current item to the array
 				if ( ! foundItem ) {
 					let uniqueFeed = feed;
-					if ( feed?.feed_ID.length > 0 ) {
+					if ( feed?.feed_ID?.length > 0 ) {
 						// If it has a feed_ID, get the feed object from the state
 						const existingFeed = getFeed( state, feed.feed_ID );
 						if ( existingFeed ) {

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -82,11 +82,14 @@ export default connect(
 		} );
 
 		// Check if searchResults has one item and if it has a feed_ID
-		if ( searchResults && searchResults.length === 1 ) {
+		if ( searchResults && searchResults.length > 0 ) {
 			let feed = searchResults[ 0 ];
-			if ( feed.feed_ID.length > 0 ) {
-				// If it has a feed_id, get the feed object from the state
-				feed = getFeed( state, feed.feed_ID );
+			if ( feed?.feed_ID.length > 0 ) {
+				// If it has a feed_ID, get the feed object from the state
+				const existingFeed = getFeed( state, feed.feed_ID );
+				if ( existingFeed ) {
+					feed = existingFeed;
+				}
 			}
 			ownProps.onReceiveSearchResults( feed );
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/loop/issues/108

This PR tries to handle RSS feed lookups better in the Reader search page.

The issue above looks up the following URLs (that should have feeds);

* nealmueller.com
* daringfireball.net

The endpoint doesn't handle this URLs properly and either no results are found or the results are only related because that URL was found referenced in a post on a site elsewhere.

There are a few things to note here;

* The search query returns a feed if a feed is parsed from the query URL
* The feed may not already exist on our backend (no feed ID found) but the user should still be able to follow this feed
* If the search query finds a feed, we will show the `SearchFollowButton` component 
<img width="483" alt="Screenshot 2023-06-23 at 00 10 32" src="https://github.com/Automattic/wp-calypso/assets/5560595/5747701c-4482-452f-97e1-f8f251f95b3b">
* if the search query doesn't find a feed but it still looks like a feed URL, we'll still show the `SearchFollowButton` component
* If no feed found and the search query doesn't look like a feed URL, then we don't show the `SearchFollowButton` 


### Before

https://github.com/Automattic/wp-calypso/assets/5560595/370752ef-c44a-4ea0-b494-f44729b152f4

### After

https://github.com/Automattic/wp-calypso/assets/5560595/803e6bde-ed8a-4c26-ab56-69fedcd2057d


### Testing
* Apply PR locally
* Apply patch code-D114309 on sandbox
* Sandbox public-api.wordpress.com
* Go to http://calypso.localhost:3000/read/search and lookup the 2 URLs above - confirm the UX works as you might expect.
* Test that the search works with other URLs 
* Test search works with non URL queries
* Anything else you can think of!



