### PR TITLE
Theme checkout thank you redesign updates

### DIFF
--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -19,7 +19,6 @@ const ThankYouContainer = styled.div`
 	-ms-overflow-style: none;
 	/* Negative value to counteract default content padding */
 	margin-top: calc( -79px + var( --masterbar-height ) );
-	margin-bottom: 80px;
 `;
 
 const ThankYouSectionTitle = styled.h1`
@@ -28,10 +27,7 @@ const ThankYouSectionTitle = styled.h1`
 `;
 
 const ThankYouSectionContainer = styled.div`
-	margin-top: 40px;
-	@media ( min-width: 480px ) {
-		margin-top: 50px;
-	}
+	margin-bottom: 35px;
 	&:not( :first-child ) {
 		border-top: 1px solid var( --studio-gray-5 );
 	}
@@ -44,6 +40,7 @@ const ThankYouBody = styled.div`
 	width: 100%;
 	display: flex;
 	justify-content: center;
+	margin-top: 50px;
 	> div {
 		width: 600px;
 		padding: 0 20px;
@@ -60,6 +57,7 @@ const ThankYouNextSteps = styled.div`
 
 	p {
 		color: var( --studio-gray-50 );
+		padding-right: 20px;
 	}
 	> div {
 		display: flex;

--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -28,7 +28,10 @@ const ThankYouSectionTitle = styled.h1`
 `;
 
 const ThankYouSectionContainer = styled.div`
-	margin-top: 50px;
+	margin-top: 40px;
+	@media ( min-width: 480px ) {
+		margin-top: 50px;
+	}
 	&:not( :first-child ) {
 		border-top: 1px solid var( --studio-gray-5 );
 	}

--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -56,7 +56,6 @@ const ThankYouNextSteps = styled.div`
 
 	p {
 		color: var( --studio-gray-50 );
-		padding-right: 20px;
 	}
 	> div {
 		display: flex;

--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -19,6 +19,7 @@ const ThankYouContainer = styled.div`
 	-ms-overflow-style: none;
 	/* Negative value to counteract default content padding */
 	margin-top: calc( -79px + var( --masterbar-height ) );
+	margin-bottom: 80px;
 `;
 
 const ThankYouSectionTitle = styled.h1`

--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -27,7 +27,7 @@ const ThankYouSectionTitle = styled.h1`
 `;
 
 const ThankYouSectionContainer = styled.div`
-	margin-bottom: 35px;
+	margin-top: 50px;
 	&:not( :first-child ) {
 		border-top: 1px solid var( --studio-gray-5 );
 	}
@@ -40,7 +40,6 @@ const ThankYouBody = styled.div`
 	width: 100%;
 	display: flex;
 	justify-content: center;
-	margin-top: 50px;
 	> div {
 		width: 600px;
 		padding: 0 20px;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -46,7 +46,7 @@ const ThemeSectionContent = styled.div`
 	justify-content: space-between;
 	align-items: center;
 	flex-wrap: wrap;
-	gap: 16px;
+	row-gap: 16px;
 
 	padding: 24px;
 	@media ( min-width: 480px ) {
@@ -71,13 +71,10 @@ const ThemeSectionName = styled.div`
 
 const ThemeSectionButtons = styled.div`
 	display: flex;
-	gap: 16px;
+	column-gap: 16px;
+	row-gap: 12px;
+	align-items: flex-start;
 	flex-wrap: wrap;
-
-	& a {
-		flex-grow: 1;
-		justify-content: center;
-	}
 
 	.gridicon.gridicons-external {
 		margin-right: 4px;
@@ -91,6 +88,7 @@ const ThemeButton = styled( Button )`
 const ThemeNameSectionWrapper = styled.div`
 	display: flex;
 	row-gap: 12px;
+	column-gap: 16px;
 	flex-grow: 1;
 	flex-wrap: wrap;
 `;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -21,15 +21,11 @@ import useIsValidThankYouTheme from './use-is-valid-thank-you-theme';
 const ThemeSectionContainer = styled.div`
 	display: flex;
 	flex-direction: column;
-	width: 720px;
+	width: 100%;
 	box-sizing: border-box;
 
-	@media ( max-width: 740px ) {
-		width: 500px;
-	}
-
-	@media ( max-width: 520px ) {
-		width: 280px;
+	@media ( min-width: 782px ) {
+		width: 720px;
 	}
 `;
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -47,7 +47,11 @@ const ThemeSectionContent = styled.div`
 	align-items: center;
 	flex-wrap: wrap;
 	gap: 16px;
-	padding: 20px 25px;
+
+	padding: 24px;
+	@media ( min-width: 480px ) {
+		padding: 20px 25px;
+	}
 	border: 1px solid var( --color-border-subtle );
 `;
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -59,6 +59,7 @@ const ThemeSectionName = styled.div`
 	font-size: 16px;
 	font-weight: 500;
 	line-height: 24px;
+	flex-grow: 1;
 	color: var( --studio-gray-100 );
 	& small {
 		font-size: 14px;
@@ -85,6 +86,13 @@ const ThemeSectionButtons = styled.div`
 
 const ThemeButton = styled( Button )`
 	border-radius: 4px;
+`;
+
+const ThemeNameSectionWrapper = styled.div`
+	display: flex;
+	row-gap: 12px;
+	flex-grow: 1;
+	flex-wrap: wrap;
 `;
 
 export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
@@ -126,34 +134,36 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 			<QueryActiveTheme siteId={ siteId } />
 			<AutoLoadingHomepageModal source="details" />
 			<ThemeSectionContent>
-				<ThemeSectionName>
-					<h5>{ theme.name }</h5>
-					<small>
-						{ theme.author
-							? translate( 'by %(author)s', { args: { author: theme.author } } )
-							: null }
-					</small>
-				</ThemeSectionName>
-				<ThemeSectionButtons>
-					<ThemeButton
-						primary
-						busy={ ( isActivating && ! hasActivated ) || isLoading }
-						onClick={ handleActivateTheme }
-						href={ isActive ? customizeUrl : undefined }
-						disabled={ ! isValidThankyouSectionTheme }
-					>
-						{ isActive
-							? translate( 'Customize this design' )
-							: translate( 'Activate this design' ) }
-					</ThemeButton>
-
-					{ isActive ? (
-						<ThemeButton href={ siteUrl } disabled={ ! isValidThankyouSectionTheme }>
-							<Gridicon size={ 18 } icon="external" />
-							{ translate( 'View site' ) }
+				<ThemeNameSectionWrapper>
+					<ThemeSectionName>
+						<h5>{ theme.name }</h5>
+						<small>
+							{ theme.author
+								? translate( 'by %(author)s', { args: { author: theme.author } } )
+								: null }
+						</small>
+					</ThemeSectionName>
+					<ThemeSectionButtons>
+						<ThemeButton
+							primary
+							busy={ ( isActivating && ! hasActivated ) || isLoading }
+							onClick={ handleActivateTheme }
+							href={ isActive ? customizeUrl : undefined }
+							disabled={ ! isValidThankyouSectionTheme }
+						>
+							{ isActive
+								? translate( 'Customize this design' )
+								: translate( 'Activate this design' ) }
 						</ThemeButton>
-					) : null }
-				</ThemeSectionButtons>
+
+						{ isActive ? (
+							<ThemeButton href={ siteUrl } disabled={ ! isValidThankyouSectionTheme }>
+								<Gridicon size={ 18 } icon="external" />
+								{ translate( 'View site' ) }
+							</ThemeButton>
+						) : null }
+					</ThemeSectionButtons>
+				</ThemeNameSectionWrapper>
 				<ThemeSectionImageContainer>
 					<ThemeSectionImage
 						src={ theme.screenshot }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -51,7 +51,8 @@ const ThemeSectionContent = styled.div`
 	align-items: center;
 	flex-wrap: wrap;
 	gap: 16px;
-	padding-top: 26px;
+	padding: 20px 25px;
+	border: 1px solid var( --color-border-subtle );
 `;
 
 const ThemeSectionName = styled.div`
@@ -124,18 +125,6 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 		<ThemeSectionContainer>
 			<QueryActiveTheme siteId={ siteId } />
 			<AutoLoadingHomepageModal source="details" />
-			<ThemeSectionImageContainer>
-				<ThemeSectionImage
-					src={ theme.screenshot }
-					alt={
-						translate( "%(theme)s's icon", {
-							args: {
-								theme: theme.name,
-							},
-						} ) as string
-					}
-				/>
-			</ThemeSectionImageContainer>
 			<ThemeSectionContent>
 				<ThemeSectionName>
 					<h5>{ theme.name }</h5>
@@ -165,6 +154,18 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 						</ThemeButton>
 					) : null }
 				</ThemeSectionButtons>
+				<ThemeSectionImageContainer>
+					<ThemeSectionImage
+						src={ theme.screenshot }
+						alt={
+							translate( "%(theme)s's icon", {
+								args: {
+									theme: theme.name,
+								},
+							} ) as string
+						}
+					/>
+				</ThemeSectionImageContainer>
 			</ThemeSectionContent>
 		</ThemeSectionContainer>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
@@ -37,7 +37,7 @@ const ContactContainer = styled.div`
 	span {
 		display: none;
 	}
-	@media ( min-width: 480px ) {
+	@media ( min-width: 600px ) {
 		.gridicon {
 			display: none;
 		}

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
@@ -22,7 +22,6 @@ const ContactContainer = styled.div`
 	}
 
 	button.marketplace-thank-you-help-center {
-		color: var( --studio-gray-100 );
 		text-decoration: underline;
 	}
 `;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
@@ -50,7 +50,7 @@ export function DefaultMasterbarContact() {
 		<ContactContainer>
 			<label>{ translate( 'Need extra help?' ) }</label>&nbsp;
 			<Button className="marketplace-thank-you-help-center" isLink onClick={ toggleHelpCenter }>
-				{ translate( 'Visit Help Center.' ) }
+				{ translate( 'Visit Help Center' ) }
 			</Button>
 		</ContactContainer>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
@@ -11,8 +11,11 @@ import { useTranslate } from 'i18n-calypso';
 const HELP_CENTER_STORE = HelpCenter.register();
 
 const ContactContainer = styled.div`
-	margin-top: 24px;
-	margin-right: 24px;
+	display: flex;
+	align-items: center;
+	column-gap: 8px;
+	padding-right: 24px;
+	padding-left: 24px;
 	font-size: 14px;
 	line-height: 20px;
 	font-weight: 500;
@@ -48,7 +51,7 @@ export function DefaultMasterbarContact() {
 
 	return (
 		<ContactContainer>
-			<label>{ translate( 'Need extra help?' ) }</label>&nbsp;
+			<label>{ translate( 'Need extra help?' ) }</label>
 			<Button className="marketplace-thank-you-help-center" isLink onClick={ toggleHelpCenter }>
 				{ translate( 'Visit Help Center' ) }
 			</Button>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Gridicon } from '@automattic/components';
 import { HelpCenter, HelpCenterSelect } from '@automattic/data-stores';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
@@ -27,6 +28,24 @@ const ContactContainer = styled.div`
 	button.marketplace-thank-you-help-center {
 		text-decoration: underline;
 	}
+
+	.gridicon {
+		display: block;
+		fill: var( --studio-gray-60 );
+	}
+	label,
+	span {
+		display: none;
+	}
+	@media ( min-width: 480px ) {
+		.gridicon {
+			display: none;
+		}
+		label,
+		span {
+			display: block;
+		}
+	}
 `;
 
 export function DefaultMasterbarContact() {
@@ -53,7 +72,8 @@ export function DefaultMasterbarContact() {
 		<ContactContainer>
 			<label>{ translate( 'Need extra help?' ) }</label>
 			<Button className="marketplace-thank-you-help-center" isLink onClick={ toggleHelpCenter }>
-				{ translate( 'Visit Help Center' ) }
+				<Gridicon icon="help-outline" />
+				<span>{ translate( 'Visit Help Center' ) }</span>
 			</Button>
 		</ContactContainer>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/index.tsx
@@ -11,9 +11,8 @@ const MasterbarStyledBlock = styled( Masterbar )`
 `;
 
 const WordPressLogoStyled = styled( WordPressLogo )`
-	max-height: calc( 100% - 47px );
-	align-self: center;
 	fill: rgb( 54, 54, 54 );
+	margin: 24px;
 `;
 
 const ItemStyled = styled( Item )`
@@ -58,7 +57,7 @@ const MasterbarStyled = ( {
 	showContact?: boolean;
 } ) => (
 	<MasterbarStyledBlock>
-		<WordPressLogoStyled />
+		<WordPressLogoStyled size={ 24 } />
 		{ canGoBack && (
 			<ItemStyled icon="chevron-left" onClick={ onClick }>
 				{ backText }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/index.tsx
@@ -12,7 +12,11 @@ const MasterbarStyledBlock = styled( Masterbar )`
 
 const WordPressLogoStyled = styled( WordPressLogo )`
 	fill: rgb( 54, 54, 54 );
-	margin: 24px;
+	margin: 24px 12px 24px 24px;
+
+	@media ( min-width: 480px ) {
+		margin: 24px;
+	}
 `;
 
 const ItemStyled = styled( Item )`
@@ -37,8 +41,9 @@ const ItemStyled = styled( Item )`
 	}
 
 	@media ( max-width: 480px ) {
-		.masterbar__item-content {
+		.gridicon + .masterbar__item-content {
 			display: block;
+			padding: 0 0 0 2px;
 		}
 	}
 `;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -19,8 +19,6 @@
 	}
 
 	.thank-you__body {
-		margin: 50px 0;
-
 		> div {
 			width: auto;
 			display: flex;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -84,6 +84,11 @@
 			gap: 40px;
 		}
 		justify-content: center;
+		margin-bottom: 80px;
+
+		@media ( max-width: 480px ) {
+			margin-top: -16px;
+		}
 
 		.thank-you__step {
 			display: flex;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -67,7 +67,7 @@
 			display: flex;
 			flex-direction: column;
 			flex-wrap: wrap;
-			min-width: 260px;
+			min-width: 280px;
 			border-top: none;
 
 			@media ( max-width: 740px ) {
@@ -110,7 +110,7 @@
 		}
 
 		div {
-			max-width: 260px;
+			max-width: 280px;
 
 			@media ( max-width: 740px ) {
 				min-width: auto;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -54,8 +54,6 @@
 
 	.thank-you__footer {
 		max-width: 1072px;
-		padding: 40px;
-		padding-top: 5px;
 		display: flex;
 		flex-wrap: wrap;
 		gap: 40px;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .marketplace-thank-you__container {
 	min-height: 100vh;
 	display: flex;
@@ -15,7 +18,12 @@
 	.thank-you__container-header {
 		min-height: auto;
 		padding: 0;
-		padding-top: 60px;
+
+		margin-top: 30px;
+
+		@include break-mobile {
+			margin-top: 60px;
+		}
 	}
 
 	.thank-you__body {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -15,7 +15,7 @@
 	.thank-you__container-header {
 		min-height: auto;
 		padding: 0;
-		padding-top: 10px;
+		padding-top: 60px;
 	}
 
 	.thank-you__body {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -78,23 +78,25 @@
 		max-width: 1072px;
 		display: flex;
 		flex-wrap: wrap;
-		gap: 40px;
+
+		gap: 30px;
+		@include break-mobile {
+			gap: 40px;
+		}
 		justify-content: center;
 
 		.thank-you__step {
 			display: flex;
 			flex-direction: column;
 			flex-wrap: wrap;
-			min-width: 280px;
 			border-top: none;
 
-			@media ( max-width: 740px ) {
-				min-width: auto;
-				max-width: 420px;
-			}
+			min-width: auto;
+			max-width: 100%;
 
-			@media ( max-width: 520px ) {
-				max-width: 200px;
+			@include break-mobile {
+				min-width: auto;
+				max-width: 280px;
 			}
 
 			h3 {
@@ -121,9 +123,6 @@
 				font-weight: 500;
 				font-size: $font-body-small;
 				line-height: 20px;
-				color: var(--studio-gray-100);
-				text-decoration: none;
-				border-bottom: 1px solid var(--studio-gray-100);
 			}
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -32,7 +32,6 @@
 			display: flex;
 			flex-direction: column;
 			width: 100%;
-			align-items: left;
 			@include break-mobile {
 				width: auto;
 				align-items: center;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -44,16 +44,25 @@
 		margin-bottom: 16px;
 	}
 
+	.thank-you__header-title,
+	.thank-you__header-subtitle {
+		text-align: left;
+		padding: 0 24px;
+
+		@media ( min-width: 480px ) {
+			text-align: center;
+			padding: 0 16px;
+		}
+	}
+
 	.thank-you__header-title {
 		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 44px; // typography-exception
 		line-height: 60px;
-		padding: 0 16px;
 	}
 
 	.thank-you__header-subtitle {
 		margin: 8px auto;
-		padding: 0 16px;
 		max-width: 500px;
 		line-height: 24px;
 		font-size: $font-body;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -28,10 +28,15 @@
 
 	.thank-you__body {
 		> div {
-			width: auto;
+
 			display: flex;
 			flex-direction: column;
-			align-items: center;
+			width: 100%;
+			align-items: left;
+			@include break-mobile {
+				width: auto;
+				align-items: center;
+			}
 		}
 
 		div {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
@@ -33,7 +33,7 @@ export function useThankYouFoooter(
 	 * If only themes are present
 	 */
 	if ( ! hasPlugins && hasThemes ) {
-		footerSteps = [ themeSupportStep, WordPressForumStep, pluginExploreStep ];
+		footerSteps = [ themeSupportStep, WordPressForumStep ];
 	}
 
 	const steps = useNextSteps( footerSteps, pluginSlugs, themeSlugs );
@@ -77,20 +77,22 @@ function useThemeSteps(): FooterStep[] {
 
 	return [
 		{
-			key: 'thank_you_footer_support_guides_themes',
-			title: translate( 'Learn About Themes' ),
-			description: translate( 'Discover everything you need to know about Themes.' ),
-			link: 'https://wordpress.com/support/themes/',
-			linkText: translate( 'Theme Support' ),
-			eventKey: 'calypso_plugin_thank_you_theme_support_click',
+			key: 'thank_you_footer_setup_guides_themes',
+			title: translate( 'Need help setting up your theme?' ),
+			description: translate(
+				'Check out our support documentation for step-by-step instructions and expert guidance on your theme set up.'
+			),
+			link: 'https://wordpress.com/support/themes/set-up-your-theme/',
+			linkText: translate( 'Get set up support' ),
+			eventKey: 'calypso_plugin_thank_you_theme_setup_guide_click',
 		},
 		{
-			key: 'thank_you_footer_forum',
-			title: translate( 'WordPress community' ),
-			description: translate( 'Have a question about this theme? Get help from the community.' ),
-			link: 'https://wordpress.com/forums/',
-			linkText: translate( 'Visit Forum' ),
-			eventKey: 'calypso_plugin_thank_you_forum_click',
+			key: 'thank_you_footer_support_guides_themes',
+			title: translate( 'Your go-to theme resource' ),
+			description: translate( 'Discover everything you need to know about Themes.' ),
+			link: 'https://wordpress.com/support/themes/',
+			linkText: translate( 'Learn more about themes' ),
+			eventKey: 'calypso_plugin_thank_you_theme_support_click',
 		},
 	];
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
@@ -89,7 +89,9 @@ function useThemeSteps(): FooterStep[] {
 		{
 			key: 'thank_you_footer_support_guides_themes',
 			title: translate( 'Your go-to theme resource' ),
-			description: translate( 'Discover everything you need to know about Themes.' ),
+			description: translate(
+				'Take a look at our comprehensive support documentation and learn more about themes.'
+			),
 			link: 'https://wordpress.com/support/themes/',
 			linkText: translate( 'Learn more about themes' ),
 			eventKey: 'calypso_plugin_thank_you_theme_support_click',

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -57,7 +57,7 @@ export function useThemesThankYouData( themeSlugs: string[] ): ThankYouData {
 	const goBackSection = (
 		<MasterbarStyled
 			onClick={ () => page( `/themes/${ siteSlug }` ) }
-			backText={ translate( 'Back to themes' ) }
+			backText={ translate( 'Back to the dashboard' ) }
 			canGoBack={ allThemesFetched }
 			showContact={ allThemesFetched }
 		/>


### PR DESCRIPTION
Split off design work from https://github.com/Automattic/wp-calypso/pull/78420

Fixes https://github.com/Automattic/dotcom-forge/issues/2719

## Proposed Changes

* [x] Desktop design updates from figma
* [x] Mobile design updates from figma

Out of scope:
- Typography changes
- Button padding changes

## Testing Instructions

* Confirm design of theme congrats page matches figma design 
* http://calypso.localhost:3000/marketplace/thank-you/test339798732.wpcomstaging.com?themes=carter
* VLoPHWqcewxNKZYjjkDu3O-fi-2414%3A6862
* Ignore page title and subtitle, those will be resolved by https://github.com/Automattic/wp-calypso/pull/78420

Smoke test some other thank you pages to make sure things aren't too messed up - we might have caused some changes elsewhere (e.g. plugins thank you page, checkout, upsells etc). Some changes here might be unavoidable as we're going to be updating those screens too its not a big deal so long as they're not totally broken.

Before

![Screenshot 2023-06-23 at 17-15-29 Atomic Test Site — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/badda357-9986-4066-bcff-afac2f7102aa)

After

![Screenshot 2023-06-23 at 17-15-12 Atomic Test Site — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/0f7d87a3-1934-4687-948a-9ee1c879e402)
