### PR TITLE
Reader: Fix empty post card comments

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -193,7 +193,7 @@ class ReaderPostCard extends Component {
 					title={ title }
 					isDiscover={ isDiscover }
 					postByline={ postByline }
-					commentIds={ postKey.comments }
+					commentIds={ postKey.comments ?? [] }
 					onClick={ this.handleCardClick }
 				/>
 			);


### PR DESCRIPTION
## Proposed Changes

This PR fixes the [following error](https://a8c.sentry.io/issues/4268913714/?project=6313676) when navigating from any reader page to the Conversations page:

![Screenshot 2023-06-23 at 11 48 46](https://github.com/Automattic/wp-calypso/assets/8436925/d8c12446-541d-4fb4-a36d-d3af913b87f9)




## Testing Instructions

* Load `/activities/likes`
* Click on "Conversations" in the sidebar.
* Verify that error is no longer there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
