### PR TITLE
Site Transfers: Add message for staging sites transfer

### DIFF
--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -14,6 +14,7 @@ import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { User } from './use-administrators';
 import { useStartSiteOwnerTransfer } from './use-start-site-owner-transfer';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
 type Props = {
@@ -21,6 +22,7 @@ type Props = {
 	selectedSiteSlug: string | null;
 	siteOwner: User;
 	customDomains: ResponseDomain[];
+	isAtomicSite: any;
 	onSiteTransferSuccess: () => void;
 	onSiteTransferError: () => void;
 	translate: ( text: string, args?: Record< string, unknown > ) => string;
@@ -173,9 +175,11 @@ const UpgradesCard = ( {
 const ContentAndOwnershipCard = ( {
 	siteSlug,
 	siteOwner,
+	isAtomicSite,
 }: {
 	siteSlug: string | null;
 	siteOwner: User;
+	isAtomicSite: any;
 } ) => {
 	const translate = useTranslate();
 	return (
@@ -219,6 +223,19 @@ const ContentAndOwnershipCard = ( {
 						{ strong: <Strong /> }
 					) }
 				</ListItem>
+				{ isAtomicSite && (
+					<ListItem>
+						{ createInterpolateElement(
+							sprintf(
+								translate(
+									'If your site <strong>%(siteSlug)s</strong> has a staging site, it will be transferred to <strong>%(username)s</strong>.'
+								),
+								{ siteSlug, username: siteOwner.login }
+							),
+							{ strong: <Strong /> }
+						) }
+					</ListItem>
+				) }
 			</List>
 		</>
 	);
@@ -229,6 +246,7 @@ const StartSiteOwnerTransfer = ( {
 	selectedSiteSlug,
 	siteOwner,
 	customDomains,
+	isAtomicSite,
 	onSiteTransferSuccess,
 	onSiteTransferError,
 	translate,
@@ -330,7 +348,11 @@ const StartSiteOwnerTransfer = ( {
 						'Please read the following actions that will take place when you transfer this site'
 					) }
 				</Notice>
-				<ContentAndOwnershipCard siteSlug={ selectedSiteSlug } siteOwner={ siteOwner } />
+				<ContentAndOwnershipCard
+					siteSlug={ selectedSiteSlug }
+					siteOwner={ siteOwner }
+					isAtomicSite={ isAtomicSite }
+				/>
 				<UpgradesCard
 					purchases={ purchases }
 					siteSlug={ selectedSiteSlug }
@@ -350,4 +372,5 @@ const StartSiteOwnerTransfer = ( {
 export default connect( ( state: IAppState ) => ( {
 	selectedSiteId: getSelectedSiteId( state ),
 	selectedSiteSlug: getSelectedSiteSlug( state ),
+	isAtomicSite: isSiteAutomatedTransfer( state, getSelectedSiteId( state ) ),
 } ) )( localize( StartSiteOwnerTransfer ) );

--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -10,11 +10,11 @@ import ActionPanelBody from 'calypso/components/action-panel/body';
 import Notice from 'calypso/components/notice';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { User } from './use-administrators';
 import { useStartSiteOwnerTransfer } from './use-start-site-owner-transfer';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
 type Props = {

--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -22,7 +22,7 @@ type Props = {
 	selectedSiteSlug: string | null;
 	siteOwner: User;
 	customDomains: ResponseDomain[];
-	isAtomicSite: any;
+	isAtomicSite: boolean | null;
 	onSiteTransferSuccess: () => void;
 	onSiteTransferError: () => void;
 	translate: ( text: string, args?: Record< string, unknown > ) => string;

--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -227,6 +227,7 @@ const ContentAndOwnershipCard = ( {
 					<ListItem>
 						{ createInterpolateElement(
 							sprintf(
+								// translators: siteSlug is the current site slug, username is the user that the site will be transerred to
 								translate(
 									'If your site <strong>%(siteSlug)s</strong> has a staging site, it will be transferred to <strong>%(username)s</strong>.'
 								),


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2171

## Proposed Changes

This PR adds a message that the staging sites will be transferred along the production site in the site transfer process to the new owner. This change is applicable only to Atomic sites. 

## Testing Instructions

* Create an Atomic site and make sure that you have another administrator added to it
* Navigate to **Settings > General > Transfer your site**
* Select an administrator to transfer your site to
* Proceed to the consent screen
* Observe the message `If your site {yourSite} has a staging site, it will be transferred to {newOwner}` added to the consent screen

<img width="830" alt="Screenshot 2023-06-23 at 11 25 53 AM" src="https://github.com/Automattic/wp-calypso/assets/25575134/cff51f11-0bb6-4e3d-a72f-200d8b02d323">

**To test Simple sites**:

* Create a Simple site and make sure that you have another administrator added to it
* Navigate to **Settings > General > Transfer your site**
* Select an administrator to transfer your site to
* Proceed to the consent screen
* Observe that there is no message regarding the staging sites transfer: 

<img width="789" alt="Screenshot 2023-06-23 at 11 27 46 AM" src="https://github.com/Automattic/wp-calypso/assets/25575134/4bff24e2-ffd3-4ced-a79f-848aac248548">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
