### PR TITLE
i18n-calypso: Fix localize HoC type

### DIFF
--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -144,19 +144,17 @@ export interface LocalizeProps {
 	numberFormat: typeof numberFormat;
 }
 
-// Infers prop type from component C
-export type GetProps< C > = C extends React.ComponentType< infer P > ? P : never;
-
 export type WithoutLocalizedProps< OrigProps > = Pick<
 	OrigProps,
 	Exclude< keyof OrigProps, keyof LocalizeProps >
 >;
 
-export type LocalizedComponent< C > = React.ComponentClass<
-	WithoutLocalizedProps< GetProps< C > >
->;
+export type LocalizedComponent< C extends React.JSXElementConstructor< any > > =
+	React.ComponentClass< WithoutLocalizedProps< React.ComponentPropsWithRef< C > > >;
 
-export function localize< C >( component: C ): LocalizedComponent< C >;
+export function localize< C extends React.JSXElementConstructor< any > >(
+	component: C
+): LocalizedComponent< C >;
 export function useTranslate(): typeof translate & { localeSlug: string | undefined };
 export function useRtl(): boolean;
 


### PR DESCRIPTION
Fix a localization type issue that manifested in https://github.com/Automattic/wp-calypso/pull/78554



## Proposed Changes

Changes the `localize` type to use React's `ComponentPropsWithRef` and constrain the type arguments. This prevents us from potentially reaching a `never` type, as seen in #78554.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
