### PR TITLE
Subscription Management: Add calypso_page_view tracking.

### DIFF
--- a/client/landing/subscriptions/index.tsx
+++ b/client/landing/subscriptions/index.tsx
@@ -23,6 +23,7 @@ import { getInitialState, getStateFromCache } from 'calypso/state/initial-state'
 import { createQueryClient } from 'calypso/state/query-client';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
+import RecordPageView from './tracks/record-page-view';
 import './styles/styles.scss';
 
 const setupReduxStore = ( user: CurrentUser ) => {
@@ -60,6 +61,7 @@ window.AppBoot = async () => {
 					<MomentProvider>
 						<WindowLocaleEffectManager />
 						<BrowserRouter>
+							<RecordPageView />
 							<Routes>
 								<Route path="/subscriptions/site/:blogId/*" element={ <SiteSubscriptionPage /> } />
 								<Route path="/subscriptions/*" element={ <SubscriptionManagerPage /> } />

--- a/client/landing/subscriptions/tracks/record-page-view.tsx
+++ b/client/landing/subscriptions/tracks/record-page-view.tsx
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { recordPageView } from 'calypso/lib/analytics/page-view';
+
+const useRoutePath = () => {
+	const { pathname } = useLocation();
+
+	if ( pathname.indexOf( '/subscriptions/settings' ) === 0 ) {
+		return '/subscriptions/settings';
+	}
+
+	if ( pathname.indexOf( '/subscriptions/pending' ) === 0 ) {
+		return '/subscriptions/pending';
+	}
+
+	if ( pathname.indexOf( '/subscriptions/comments' ) === 0 ) {
+		return '/subscriptions/comments';
+	}
+
+	if ( pathname.indexOf( '/subscriptions/sites' ) === 0 ) {
+		return '/subscriptions/sites';
+	}
+
+	if ( pathname.indexOf( '/subscriptions/site/invalid' ) === 0 ) {
+		return '/subscriptions/site/invalid';
+	}
+
+	if ( pathname.indexOf( '/subscriptions/site' ) === 0 ) {
+		return '/subscriptions/site/:blogId';
+	}
+
+	if ( pathname.indexOf( '/subscriptions' ) === 0 ) {
+		return '/subscriptions/sites';
+	}
+
+	return pathname;
+};
+
+export default () => {
+	const routePath = useRoutePath();
+
+	useEffect( () => {
+		recordPageView( routePath, document.title );
+	}, [ routePath ] );
+
+	return <></>;
+};

--- a/client/landing/subscriptions/tracks/record-page-view.tsx
+++ b/client/landing/subscriptions/tracks/record-page-view.tsx
@@ -5,6 +5,14 @@ import { recordPageView } from 'calypso/lib/analytics/page-view';
 const useRoutePath = () => {
 	const { pathname } = useLocation();
 
+	// We are doing manual path matching because we want to
+	// track matched route path, not the full url, e.g.
+	// GOOD: /subscriptions/site/:blogId
+	// BAD: /subscriptions/sites/123456
+	//
+	// The existing functions from react-router couldn't
+	// provide use with a useful matched route path.
+
 	if ( pathname.indexOf( '/subscriptions/settings' ) === 0 ) {
 		return '/subscriptions/settings';
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/78579

## Proposed Changes

* Add `calypso_page_view` tracking in Subscriptions Management.
* This is needed to build funnels, to be used as the starting tracks event.

## Testing Instructions

* Go to `/subscriptions`.
* Filter network panel by `.gif`.
* You should be able to see `calypso_page_view` tracks event being recorded as you navigate through the pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
