### PR TITLE
Subscription Management: Rework tracks foundation, add tracks event for subscribe, unsubscribe, site_url/icon/title clicked.

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
@@ -7,6 +7,8 @@ import ExternalLink from 'calypso/components/external-link';
 import TimeSince from 'calypso/components/time-since';
 import { successNotice } from 'calypso/state/notices/actions';
 import {
+	useRecordSiteUnsubscribed,
+	useRecordSiteResubscribed,
 	useRecordSiteIconClicked,
 	useRecordSiteTitleClicked,
 	useRecordSiteUrlClicked,
@@ -110,15 +112,34 @@ const SiteRow = ( {
 		SubscriptionManager.useSiteUnsubscribeMutation();
 	const { mutate: resubscribe } = SubscriptionManager.useSiteSubscribeMutation();
 
+	// Tracks events recording
+	const recordSiteIconClicked = useRecordSiteIconClicked();
+	const recordSiteTitleClicked = useRecordSiteTitleClicked();
+	const recordSiteUrlClicked = useRecordSiteUrlClicked();
+	const recordNotificationsToggle = useRecordNotificationsToggle();
+	const recordPostEmailsToggle = useRecordPostEmailsToggle();
+	const recordCommentEmailsToggle = useRecordCommentEmailsToggle();
+	const recordPostEmailsSetFrequency = useRecordPostEmailsSetFrequency();
+	const recordSiteUnsubscribed = useRecordSiteUnsubscribed();
+	const recordSiteResubscribed = useRecordSiteResubscribed();
+	const blog_id = blog_ID; // makes object assignment a little easier
+
 	const unsubscribeSuccessCallback = () => {
+		recordSiteUnsubscribed( { blog_id, url, source: 'subscriptions-site-list' } );
 		dispatch(
 			successNotice(
 				translate( 'You have successfully unsubscribed from %(name)s.', { args: { name } } ),
 				{
 					duration: 5000,
 					button: translate( 'Resubscribe' ),
-					onClick: () =>
-						resubscribe( { blog_id: blog_ID, url, doNotInvalidateSiteSubscriptions: true } ),
+					onClick: () => {
+						resubscribe( { blog_id, url, doNotInvalidateSiteSubscriptions: true } );
+						recordSiteResubscribed( {
+							blog_id,
+							url,
+							source: 'unsubscribed-notice-resubscribe-button',
+						} );
+					},
 				}
 			)
 		);
@@ -135,16 +156,6 @@ const SiteRow = ( {
 			return `/subscriptions/site/${ blog_ID }`;
 		}
 	}, [ blog_ID, feed_ID, portal ] );
-
-	// Tracks events recording
-	const recordSiteIconClicked = useRecordSiteIconClicked();
-	const recordSiteTitleClicked = useRecordSiteTitleClicked();
-	const recordSiteUrlClicked = useRecordSiteUrlClicked();
-	const recordNotificationsToggle = useRecordNotificationsToggle();
-	const recordPostEmailsToggle = useRecordPostEmailsToggle();
-	const recordCommentEmailsToggle = useRecordCommentEmailsToggle();
-	const recordPostEmailsSetFrequency = useRecordPostEmailsSetFrequency();
-	const blog_id = blog_ID; // makes object assignment a little easier
 
 	const handleNotifyMeOfNewPostsChange = ( send_posts: boolean ) => {
 		// Update post notification settings

--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
@@ -1,11 +1,20 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { connect, useDispatch } from 'react-redux';
+import ExternalLink from 'calypso/components/external-link';
 import TimeSince from 'calypso/components/time-since';
 import { successNotice } from 'calypso/state/notices/actions';
+import {
+	useRecordSiteIconClicked,
+	useRecordSiteTitleClicked,
+	useRecordSiteUrlClicked,
+	useRecordNotificationsToggle,
+	useRecordPostEmailsToggle,
+	useRecordCommentEmailsToggle,
+	useRecordPostEmailsSetFrequency,
+} from '../../tracks';
 import { Link } from '../link';
 import { SiteSettingsPopover } from '../settings';
 import { SiteIcon } from '../site-icon';
@@ -127,62 +136,68 @@ const SiteRow = ( {
 		}
 	}, [ blog_ID, feed_ID, portal ] );
 
+	// Tracks events recording
+	const recordSiteIconClicked = useRecordSiteIconClicked();
+	const recordSiteTitleClicked = useRecordSiteTitleClicked();
+	const recordSiteUrlClicked = useRecordSiteUrlClicked();
+	const recordNotificationsToggle = useRecordNotificationsToggle();
+	const recordPostEmailsToggle = useRecordPostEmailsToggle();
+	const recordCommentEmailsToggle = useRecordCommentEmailsToggle();
+	const recordPostEmailsSetFrequency = useRecordPostEmailsSetFrequency();
+	const blog_id = blog_ID; // makes object assignment a little easier
+
 	const handleNotifyMeOfNewPostsChange = ( send_posts: boolean ) => {
 		// Update post notification settings
-		updateNotifyMeOfNewPosts( { blog_id: blog_ID, send_posts } );
+		updateNotifyMeOfNewPosts( { blog_id, send_posts } );
 
 		// Record tracks event
-		const tracksProperties = { blog_id: blog_ID, portal };
-		if ( send_posts ) {
-			recordTracksEvent( 'calypso_subscriptions_notifications_toggle_on', tracksProperties );
-		} else {
-			recordTracksEvent( 'calypso_subscriptions_notifications_toggle_off', tracksProperties );
-		}
+		recordNotificationsToggle( send_posts, { blog_id } );
 	};
 
 	const handleEmailMeNewPostsChange = ( send_posts: boolean ) => {
 		// Update post emails settings
-		updateEmailMeNewPosts( { blog_id: blog_ID, send_posts } );
+		updateEmailMeNewPosts( { blog_id, send_posts } );
 
 		// Record tracks event
-		const tracksProperties = { blog_id: blog_ID, portal };
-		if ( send_posts ) {
-			recordTracksEvent( 'calypso_subscriptions_post_emails_toggle_on', tracksProperties );
-		} else {
-			recordTracksEvent( 'calypso_subscriptions_post_emails_toggle_off', tracksProperties );
-		}
+		recordPostEmailsToggle( send_posts, { blog_id } );
 	};
 
 	const handleEmailMeNewCommentsChange = ( send_comments: boolean ) => {
 		// Update comment emails settings
-		updateEmailMeNewComments( { blog_id: blog_ID, send_comments } );
+		updateEmailMeNewComments( { blog_id, send_comments } );
 
 		// Record tracks event
-		const tracksProperties = { blog_id: blog_ID, portal };
-		if ( send_comments ) {
-			recordTracksEvent( 'calypso_subscriptions_comment_emails_toggle_on', tracksProperties );
-		} else {
-			recordTracksEvent( 'calypso_subscriptions_comment_emails_toggle_off', tracksProperties );
-		}
+		recordCommentEmailsToggle( send_comments, { blog_id } );
 	};
 
 	const handleDeliveryFrequencyChange = ( delivery_frequency: Reader.EmailDeliveryFrequency ) => {
 		// Update post emails delivery frequency
-		updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } );
+		updateDeliveryFrequency( { blog_id, delivery_frequency } );
 
 		// Record tracks event
-		const tracksProperties = { blog_id: blog_ID, delivery_frequency, portal };
-		recordTracksEvent( 'calypso_subscriptions_post_emails_set_frequency', tracksProperties );
+		recordPostEmailsSetFrequency( { blog_id, delivery_frequency } );
 	};
 
 	return ! isDeleted ? (
 		<li className="row" role="row">
 			<span className="title-cell" role="cell">
-				<Link className="title-icon" href={ siteTitleUrl }>
+				<Link
+					className="title-icon"
+					href={ siteTitleUrl }
+					onClick={ () => {
+						recordSiteIconClicked( { blog_id } );
+					} }
+				>
 					<SiteIcon iconUrl={ site_icon } size={ 40 } siteName={ name } />
 				</Link>
 				<span className="title-column">
-					<Link className="title-name" href={ siteTitleUrl }>
+					<Link
+						className="title-name"
+						href={ siteTitleUrl }
+						onClick={ () => {
+							recordSiteTitleClicked( { blog_id } );
+						} }
+					>
 						{ name }
 						{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
 						{ !! is_paid_subscription && (
@@ -191,14 +206,17 @@ const SiteRow = ( {
 							</span>
 						) }
 					</Link>
-					<a
+					<ExternalLink
 						className="title-url"
 						{ ...( url && { href: url } ) }
 						rel="noreferrer noopener"
 						target="_blank"
+						onClick={ () => {
+							recordSiteUrlClicked( { blog_id } );
+						} }
 					>
 						{ hostname }
-					</a>
+					</ExternalLink>
 				</span>
 			</span>
 			<span className="date-cell" role="cell">

--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
@@ -122,10 +122,14 @@ const SiteRow = ( {
 	const recordPostEmailsSetFrequency = useRecordPostEmailsSetFrequency();
 	const recordSiteUnsubscribed = useRecordSiteUnsubscribed();
 	const recordSiteResubscribed = useRecordSiteResubscribed();
-	const blog_id = blog_ID; // makes object assignment a little easier
+
+	// Make object assignment a little easier
+	const SOURCE_SUBSCRIPTIONS_SITE_LIST = 'subscriptions-site-list';
+	const blog_id = blog_ID;
+	const feed_id = feed_ID;
 
 	const unsubscribeSuccessCallback = () => {
-		recordSiteUnsubscribed( { blog_id, url, source: 'subscriptions-site-list' } );
+		recordSiteUnsubscribed( { blog_id, url, source: SOURCE_SUBSCRIPTIONS_SITE_LIST } );
 		dispatch(
 			successNotice(
 				translate( 'You have successfully unsubscribed from %(name)s.', { args: { name } } ),
@@ -137,7 +141,7 @@ const SiteRow = ( {
 						recordSiteResubscribed( {
 							blog_id,
 							url,
-							source: 'unsubscribed-notice-resubscribe-button',
+							source: 'subscriptions-unsubscribed-notice',
 						} );
 					},
 				}
@@ -196,7 +200,7 @@ const SiteRow = ( {
 					className="title-icon"
 					href={ siteTitleUrl }
 					onClick={ () => {
-						recordSiteIconClicked( { blog_id } );
+						recordSiteIconClicked( { blog_id, feed_id, source: SOURCE_SUBSCRIPTIONS_SITE_LIST } );
 					} }
 				>
 					<SiteIcon iconUrl={ site_icon } size={ 40 } siteName={ name } />
@@ -206,7 +210,11 @@ const SiteRow = ( {
 						className="title-name"
 						href={ siteTitleUrl }
 						onClick={ () => {
-							recordSiteTitleClicked( { blog_id } );
+							recordSiteTitleClicked( {
+								blog_id,
+								feed_id,
+								source: SOURCE_SUBSCRIPTIONS_SITE_LIST,
+							} );
 						} }
 					>
 						{ name }
@@ -223,7 +231,7 @@ const SiteRow = ( {
 						rel="noreferrer noopener"
 						target="_blank"
 						onClick={ () => {
-							recordSiteUrlClicked( { blog_id } );
+							recordSiteUrlClicked( { blog_id, feed_id, source: SOURCE_SUBSCRIPTIONS_SITE_LIST } );
 						} }
 					>
 						{ hostname }

--- a/client/landing/subscriptions/components/subscription-manager-context/index.tsx
+++ b/client/landing/subscriptions/components/subscription-manager-context/index.tsx
@@ -6,6 +6,8 @@ export type Portal = typeof SubscriptionsPortal | typeof ReaderPortal;
 
 export interface SubscriptionManagerContext {
 	portal: Portal;
+	isSubscriptionsPortal: boolean;
+	isReaderPortal: boolean;
 }
 
 const SubscriptionManagerContext = createContext< SubscriptionManagerContext >(
@@ -15,8 +17,13 @@ const SubscriptionManagerContext = createContext< SubscriptionManagerContext >(
 export const SubscriptionManagerContextProvider: React.FunctionComponent<
 	SubscriptionManagerContext
 > = ( { children, ...context } ) => {
+	const helpers = {
+		isSubscriptionsPortal: context.portal === SubscriptionsPortal,
+		isReaderPortal: context.portal === ReaderPortal,
+	};
+
 	return (
-		<SubscriptionManagerContext.Provider value={ context }>
+		<SubscriptionManagerContext.Provider value={ { ...context, ...helpers } }>
 			{ children }
 		</SubscriptionManagerContext.Provider>
 	);

--- a/client/landing/subscriptions/components/subscription-manager-context/index.tsx
+++ b/client/landing/subscriptions/components/subscription-manager-context/index.tsx
@@ -6,8 +6,8 @@ export type Portal = typeof SubscriptionsPortal | typeof ReaderPortal;
 
 export interface SubscriptionManagerContext {
 	portal: Portal;
-	isSubscriptionsPortal: boolean;
-	isReaderPortal: boolean;
+	isSubscriptionsPortal?: boolean;
+	isReaderPortal?: boolean;
 }
 
 const SubscriptionManagerContext = createContext< SubscriptionManagerContext >(

--- a/client/landing/subscriptions/tracks/index.ts
+++ b/client/landing/subscriptions/tracks/index.ts
@@ -1,6 +1,6 @@
 export { default as useRecordSubscriptionsTracksEvent } from './use-record-subscriptions-tracks-event';
-export { default as useRecordSiteSubscribed } from './use-record-site-subscribed';
-export { default as useRecordSiteUnsubscribed } from './use-record-site-unsubscribed';
+// export { default as useRecordSiteSubscribed } from './use-record-site-subscribed';
+// export { default as useRecordSiteUnsubscribed } from './use-record-site-unsubscribed';
 export { default as useRecordSiteIconClicked } from './use-record-site-icon-clicked';
 export { default as useRecordSiteTitleClicked } from './use-record-site-title-clicked';
 export { default as useRecordSiteUrlClicked } from './use-record-site-url-clicked';
@@ -8,6 +8,6 @@ export { default as useRecordCommentEmailsToggle } from './use-record-comment-em
 export { default as useRecordNotificationsToggle } from './use-record-notifications-toggle';
 export { default as useRecordPostEmailsSetFrequency } from './use-record-post-emails-set-frequency';
 export { default as useRecordPostEmailsToggle } from './use-record-post-emails-toggle';
-export { default as useRecordRecommendedSiteSubscribed } from './use-record-recommended-site-subscribed';
-export { default as useRecordRecommendedSiteUnsubscribed } from './use-record-recommended-site-unsubscribed';
-export { default as useRecordRecommendedSiteDismissed } from './use-record-recommended-site-dismissed';
+// export { default as useRecordRecommendedSiteSubscribed } from './use-record-recommended-site-subscribed';
+// export { default as useRecordRecommendedSiteUnsubscribed } from './use-record-recommended-site-unsubscribed';
+// export { default as useRecordRecommendedSiteDismissed } from './use-record-recommended-site-dismissed';

--- a/client/landing/subscriptions/tracks/index.ts
+++ b/client/landing/subscriptions/tracks/index.ts
@@ -1,0 +1,13 @@
+export { default as useRecordSubscriptionsTracksEvent } from './use-record-subscriptions-tracks-event';
+export { default as useRecordSiteSubscribed } from './use-record-site-subscribed';
+export { default as useRecordSiteUnsubscribed } from './use-record-site-unsubscribed';
+export { default as useRecordSiteIconClicked } from './use-record-site-icon-clicked';
+export { default as useRecordSiteTitleClicked } from './use-record-site-title-clicked';
+export { default as useRecordSiteUrlClicked } from './use-record-site-url-clicked';
+export { default as useRecordCommentEmailsToggle } from './use-record-comment-emails-toggle';
+export { default as useRecordNotificationsToggle } from './use-record-notifications-toggle';
+export { default as useRecordPostEmailsSetFrequency } from './use-record-post-emails-set-frequency';
+export { default as useRecordPostEmailsToggle } from './use-record-post-emails-toggle';
+export { default as useRecordRecommendedSiteSubscribed } from './use-record-recommended-site-subscribed';
+export { default as useRecordRecommendedSiteUnsubscribed } from './use-record-recommended-site-unsubscribed';
+export { default as useRecordRecommendedSiteDismissed } from './use-record-recommended-site-dismissed';

--- a/client/landing/subscriptions/tracks/index.ts
+++ b/client/landing/subscriptions/tracks/index.ts
@@ -1,6 +1,6 @@
 export { default as useRecordSubscriptionsTracksEvent } from './use-record-subscriptions-tracks-event';
-// export { default as useRecordSiteSubscribed } from './use-record-site-subscribed';
-// export { default as useRecordSiteUnsubscribed } from './use-record-site-unsubscribed';
+export { default as useRecordSiteSubscribed } from './use-record-site-subscribed';
+export { default as useRecordSiteUnsubscribed } from './use-record-site-unsubscribed';
 export { default as useRecordSiteIconClicked } from './use-record-site-icon-clicked';
 export { default as useRecordSiteTitleClicked } from './use-record-site-title-clicked';
 export { default as useRecordSiteUrlClicked } from './use-record-site-url-clicked';

--- a/client/landing/subscriptions/tracks/index.ts
+++ b/client/landing/subscriptions/tracks/index.ts
@@ -1,6 +1,7 @@
 export { default as useRecordSubscriptionsTracksEvent } from './use-record-subscriptions-tracks-event';
 export { default as useRecordSiteSubscribed } from './use-record-site-subscribed';
 export { default as useRecordSiteUnsubscribed } from './use-record-site-unsubscribed';
+export { default as useRecordSiteResubscribed } from './use-record-site-resubscribed';
 export { default as useRecordSiteIconClicked } from './use-record-site-icon-clicked';
 export { default as useRecordSiteTitleClicked } from './use-record-site-title-clicked';
 export { default as useRecordSiteUrlClicked } from './use-record-site-url-clicked';

--- a/client/landing/subscriptions/tracks/use-record-comment-emails-toggle.tsx
+++ b/client/landing/subscriptions/tracks/use-record-comment-emails-toggle.tsx
@@ -10,15 +10,16 @@ const useRecordCommentEmailsToggle = () => {
 		}
 	) => {
 		if ( enabled ) {
-			return recordSubscriptionsTracksEvent(
+			recordSubscriptionsTracksEvent(
 				'calypso_subscriptions_comment_emails_toggle_on',
 				tracksProps
 			);
+		} else {
+			recordSubscriptionsTracksEvent(
+				'calypso_subscriptions_comment_emails_toggle_off',
+				tracksProps
+			);
 		}
-		return recordSubscriptionsTracksEvent(
-			'calypso_subscriptions_comment_emails_toggle_off',
-			tracksProps
-		);
 	};
 
 	return recordCommentEmailsToggle;

--- a/client/landing/subscriptions/tracks/use-record-comment-emails-toggle.tsx
+++ b/client/landing/subscriptions/tracks/use-record-comment-emails-toggle.tsx
@@ -1,0 +1,27 @@
+import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
+
+const useRecordCommentEmailsToggle = () => {
+	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
+
+	const recordCommentEmailsToggle = (
+		enabled: boolean,
+		tracksProps: {
+			blog_id: string;
+		}
+	) => {
+		if ( enabled ) {
+			return recordSubscriptionsTracksEvent(
+				'calypso_subscriptions_comment_emails_toggle_on',
+				tracksProps
+			);
+		}
+		return recordSubscriptionsTracksEvent(
+			'calypso_subscriptions_comment_emails_toggle_off',
+			tracksProps
+		);
+	};
+
+	return recordCommentEmailsToggle;
+};
+
+export default useRecordCommentEmailsToggle;

--- a/client/landing/subscriptions/tracks/use-record-notifications-toggle.tsx
+++ b/client/landing/subscriptions/tracks/use-record-notifications-toggle.tsx
@@ -1,0 +1,27 @@
+import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
+
+const useRecordNotificationsToggle = () => {
+	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
+
+	const recordNotificationsToggle = (
+		enabled: boolean,
+		tracksProps: {
+			blog_id: string;
+		}
+	) => {
+		if ( enabled ) {
+			return recordSubscriptionsTracksEvent(
+				'calypso_subscriptions_notifications_toggle_on',
+				tracksProps
+			);
+		}
+		return recordSubscriptionsTracksEvent(
+			'calypso_subscriptions_notifications_toggle_off',
+			tracksProps
+		);
+	};
+
+	return recordNotificationsToggle;
+};
+
+export default useRecordNotificationsToggle;

--- a/client/landing/subscriptions/tracks/use-record-notifications-toggle.tsx
+++ b/client/landing/subscriptions/tracks/use-record-notifications-toggle.tsx
@@ -10,15 +10,16 @@ const useRecordNotificationsToggle = () => {
 		}
 	) => {
 		if ( enabled ) {
-			return recordSubscriptionsTracksEvent(
+			recordSubscriptionsTracksEvent(
 				'calypso_subscriptions_notifications_toggle_on',
 				tracksProps
 			);
+		} else {
+			recordSubscriptionsTracksEvent(
+				'calypso_subscriptions_notifications_toggle_off',
+				tracksProps
+			);
 		}
-		return recordSubscriptionsTracksEvent(
-			'calypso_subscriptions_notifications_toggle_off',
-			tracksProps
-		);
 	};
 
 	return recordNotificationsToggle;

--- a/client/landing/subscriptions/tracks/use-record-post-emails-set-frequency.tsx
+++ b/client/landing/subscriptions/tracks/use-record-post-emails-set-frequency.tsx
@@ -1,0 +1,20 @@
+import { Reader } from '@automattic/data-stores';
+import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
+
+const useRecordPostEmailsSetFrequency = () => {
+	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
+
+	const recordPostEmailsSetFrequency = ( tracksProps: {
+		blog_id: string;
+		delivery_frequency: Reader.EmailDeliveryFrequency;
+	} ) => {
+		return recordSubscriptionsTracksEvent(
+			'calypso_subscriptions_post_emails_set_frequency',
+			tracksProps
+		);
+	};
+
+	return recordPostEmailsSetFrequency;
+};
+
+export default useRecordPostEmailsSetFrequency;

--- a/client/landing/subscriptions/tracks/use-record-post-emails-set-frequency.tsx
+++ b/client/landing/subscriptions/tracks/use-record-post-emails-set-frequency.tsx
@@ -8,7 +8,7 @@ const useRecordPostEmailsSetFrequency = () => {
 		blog_id: string;
 		delivery_frequency: Reader.EmailDeliveryFrequency;
 	} ) => {
-		return recordSubscriptionsTracksEvent(
+		recordSubscriptionsTracksEvent(
 			'calypso_subscriptions_post_emails_set_frequency',
 			tracksProps
 		);

--- a/client/landing/subscriptions/tracks/use-record-post-emails-toggle.tsx
+++ b/client/landing/subscriptions/tracks/use-record-post-emails-toggle.tsx
@@ -1,0 +1,25 @@
+import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
+
+const useRecordPostEmailsToggle = () => {
+	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
+	const recordPostEmailsToggle = (
+		enabled: boolean,
+		tracksProps: {
+			blog_id: string;
+		}
+	) => {
+		if ( enabled ) {
+			return recordSubscriptionsTracksEvent(
+				'calypso_subscriptions_post_emails_toggle_on',
+				tracksProps
+			);
+		}
+		return recordSubscriptionsTracksEvent(
+			'calypso_subscriptions_post_emails_toggle_off',
+			tracksProps
+		);
+	};
+	return recordPostEmailsToggle;
+};
+
+export default useRecordPostEmailsToggle;

--- a/client/landing/subscriptions/tracks/use-record-post-emails-toggle.tsx
+++ b/client/landing/subscriptions/tracks/use-record-post-emails-toggle.tsx
@@ -9,15 +9,10 @@ const useRecordPostEmailsToggle = () => {
 		}
 	) => {
 		if ( enabled ) {
-			return recordSubscriptionsTracksEvent(
-				'calypso_subscriptions_post_emails_toggle_on',
-				tracksProps
-			);
+			recordSubscriptionsTracksEvent( 'calypso_subscriptions_post_emails_toggle_on', tracksProps );
+		} else {
+			recordSubscriptionsTracksEvent( 'calypso_subscriptions_post_emails_toggle_off', tracksProps );
 		}
-		return recordSubscriptionsTracksEvent(
-			'calypso_subscriptions_post_emails_toggle_off',
-			tracksProps
-		);
 	};
 	return recordPostEmailsToggle;
 };

--- a/client/landing/subscriptions/tracks/use-record-site-icon-clicked.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-icon-clicked.tsx
@@ -1,0 +1,13 @@
+import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
+
+const useRecordSiteIconClicked = () => {
+	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
+
+	const recordSiteIconClicked = ( tracksProps: { blog_id: string } ) => {
+		return recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_icon_clicked', tracksProps );
+	};
+
+	return recordSiteIconClicked;
+};
+
+export default useRecordSiteIconClicked;

--- a/client/landing/subscriptions/tracks/use-record-site-icon-clicked.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-icon-clicked.tsx
@@ -3,7 +3,11 @@ import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks
 const useRecordSiteIconClicked = () => {
 	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
 
-	const recordSiteIconClicked = ( tracksProps: { blog_id: string } ) => {
+	const recordSiteIconClicked = ( tracksProps: {
+		blog_id: string;
+		feed_id: string;
+		source?: string;
+	} ) => {
 		recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_icon_clicked', tracksProps );
 	};
 

--- a/client/landing/subscriptions/tracks/use-record-site-icon-clicked.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-icon-clicked.tsx
@@ -4,7 +4,7 @@ const useRecordSiteIconClicked = () => {
 	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
 
 	const recordSiteIconClicked = ( tracksProps: { blog_id: string } ) => {
-		return recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_icon_clicked', tracksProps );
+		recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_icon_clicked', tracksProps );
 	};
 
 	return recordSiteIconClicked;

--- a/client/landing/subscriptions/tracks/use-record-site-resubscribed.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-resubscribed.tsx
@@ -1,0 +1,19 @@
+import useRecordSiteSubscribed from './use-record-site-subscribed';
+import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
+
+const useRecordSiteResubscribed = () => {
+	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
+
+	const recordSiteSubscribed = useRecordSiteSubscribed();
+
+	const recordSiteResubscribed = ( tracksProps: { blog_id: string; url: string } ) => {
+		recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_resubscribed', tracksProps );
+
+		// Also record the calypso_subscriptions_site_subscribed event.
+		recordSiteSubscribed( tracksProps );
+	};
+
+	return recordSiteResubscribed;
+};
+
+export default useRecordSiteResubscribed;

--- a/client/landing/subscriptions/tracks/use-record-site-resubscribed.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-resubscribed.tsx
@@ -6,7 +6,11 @@ const useRecordSiteResubscribed = () => {
 
 	const recordSiteSubscribed = useRecordSiteSubscribed();
 
-	const recordSiteResubscribed = ( tracksProps: { blog_id: string; url: string } ) => {
+	const recordSiteResubscribed = ( tracksProps: {
+		blog_id: string;
+		url: string;
+		source?: string;
+	} ) => {
 		recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_resubscribed', tracksProps );
 
 		// Also record the calypso_subscriptions_site_subscribed event.

--- a/client/landing/subscriptions/tracks/use-record-site-subscribed.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-subscribed.tsx
@@ -1,0 +1,17 @@
+import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
+
+const useRecordSiteSubscribed = () => {
+	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
+
+	const recordSiteSubscribed = ( tracksProps: {
+		blog_id: string;
+		url: string;
+		ui_algo?: string;
+	} ) => {
+		return recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_subscribed', tracksProps );
+	};
+
+	return recordSiteSubscribed;
+};
+
+export default useRecordSiteSubscribed;

--- a/client/landing/subscriptions/tracks/use-record-site-subscribed.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-subscribed.tsx
@@ -1,14 +1,36 @@
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import { bumpStat } from 'calypso/lib/analytics/mc';
+import { useSubscriptionManagerContext } from '../components/subscription-manager-context';
 import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
 
 const useRecordSiteSubscribed = () => {
 	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
 
+	const { isReaderPortal } = useSubscriptionManagerContext();
+
 	const recordSiteSubscribed = ( tracksProps: {
 		blog_id: string;
 		url: string;
-		ui_algo?: string;
+		source?: string;
 	} ) => {
-		return recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_subscribed', tracksProps );
+		// reader: calypso_reader_site_followed, ui_algo: following_manage
+		// subman: calypso_subscriptions_site_subscribed, ui_algo: (removed)
+		recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_subscribed', tracksProps );
+
+		// For reader parity
+		if ( isReaderPortal ) {
+			// reader: following_manage
+			// subman: reader-subscriptions-sites
+			bumpStat( 'reader_follows', 'reader-subscriptions-sites' );
+
+			// reader: followed_blog
+			// subman: subscribed_blog
+			bumpStat( 'reader_actions', 'subscribed_blog' );
+
+			// reader: 'Reader', 'Clicked Follow Blog','reader-following-manage-recommendation'
+			// subman: 'Reader', 'Clicked Subscribe Blog', 'reader-subscriptions-sites'
+			gaRecordEvent( 'Reader', 'Clicked Subscribe Blog', 'reader-subscriptions-sites' );
+		}
 	};
 
 	return recordSiteSubscribed;

--- a/client/landing/subscriptions/tracks/use-record-site-title-clicked.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-title-clicked.tsx
@@ -4,7 +4,7 @@ const useRecordSiteTitleClicked = () => {
 	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
 
 	const recordSiteTitleClicked = ( tracksProps: { blog_id: string } ) => {
-		return recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_title_click', tracksProps );
+		recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_title_click', tracksProps );
 	};
 
 	return recordSiteTitleClicked;

--- a/client/landing/subscriptions/tracks/use-record-site-title-clicked.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-title-clicked.tsx
@@ -3,7 +3,11 @@ import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks
 const useRecordSiteTitleClicked = () => {
 	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
 
-	const recordSiteTitleClicked = ( tracksProps: { blog_id: string } ) => {
+	const recordSiteTitleClicked = ( tracksProps: {
+		blog_id: string;
+		feed_id: string;
+		source?: string;
+	} ) => {
 		recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_title_click', tracksProps );
 	};
 

--- a/client/landing/subscriptions/tracks/use-record-site-title-clicked.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-title-clicked.tsx
@@ -1,0 +1,13 @@
+import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
+
+const useRecordSiteTitleClicked = () => {
+	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
+
+	const recordSiteTitleClicked = ( tracksProps: { blog_id: string } ) => {
+		return recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_title_click', tracksProps );
+	};
+
+	return recordSiteTitleClicked;
+};
+
+export default useRecordSiteTitleClicked;

--- a/client/landing/subscriptions/tracks/use-record-site-unsubscribed.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-unsubscribed.tsx
@@ -1,0 +1,17 @@
+import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
+
+const useRecordSiteUnsubscribed = () => {
+	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
+
+	const recordSiteUnsubscribed = ( tracksProps: {
+		blog_id: string;
+		url: string;
+		ui_algo?: string;
+	} ) => {
+		return recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_unsubscribed', tracksProps );
+	};
+
+	return recordSiteUnsubscribed;
+};
+
+export default useRecordSiteUnsubscribed;

--- a/client/landing/subscriptions/tracks/use-record-site-unsubscribed.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-unsubscribed.tsx
@@ -1,14 +1,37 @@
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import { bumpStat } from 'calypso/lib/analytics/mc';
+import { useSubscriptionManagerContext } from '../components/subscription-manager-context';
 import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
 
 const useRecordSiteUnsubscribed = () => {
 	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
 
+	const { isReaderPortal } = useSubscriptionManagerContext();
+
 	const recordSiteUnsubscribed = ( tracksProps: {
 		blog_id: string;
 		url: string;
 		ui_algo?: string;
+		source?: string;
 	} ) => {
-		return recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_unsubscribed', tracksProps );
+		// reader: calypso_reader_site_unfollowed, ui_algo: following_manage
+		// subman: calypso_subscriptions_site_subscribed, ui_algo: (removed)
+		recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_unsubscribed', tracksProps );
+
+		// For reader parity
+		if ( isReaderPortal ) {
+			// reader: following_manage
+			// subman: reader-subscriptions-sites
+			bumpStat( 'reader_unfollows', 'reader-subscriptions-sites' );
+
+			// reader: unfollowed_blog
+			// subman: unsubscribed_blog
+			bumpStat( 'reader_actions', 'unsubscribed_blog' );
+
+			// reader: 'Reader', 'Clicked Unfollow Blog','reader-following-manage-recommendation'
+			// subman: 'Reader', 'Clicked Unsubscribe Blog', 'reader-subscriptions-sites'
+			gaRecordEvent( 'Reader', 'Clicked Unsubscribe Blog', 'reader-subscriptions-sites' );
+		}
 	};
 
 	return recordSiteUnsubscribed;

--- a/client/landing/subscriptions/tracks/use-record-site-unsubscribed.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-unsubscribed.tsx
@@ -11,7 +11,6 @@ const useRecordSiteUnsubscribed = () => {
 	const recordSiteUnsubscribed = ( tracksProps: {
 		blog_id: string;
 		url: string;
-		ui_algo?: string;
 		source?: string;
 	} ) => {
 		// reader: calypso_reader_site_unfollowed, ui_algo: following_manage

--- a/client/landing/subscriptions/tracks/use-record-site-url-clicked.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-url-clicked.tsx
@@ -1,0 +1,13 @@
+import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
+
+const useRecordSiteUrlClicked = () => {
+	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
+
+	const recordSiteUrlClicked = ( tracksProps: { blog_id: string } ) => {
+		return recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_url_clicked', tracksProps );
+	};
+
+	return recordSiteUrlClicked;
+};
+
+export default useRecordSiteUrlClicked;

--- a/client/landing/subscriptions/tracks/use-record-site-url-clicked.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-url-clicked.tsx
@@ -3,7 +3,11 @@ import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks
 const useRecordSiteUrlClicked = () => {
 	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
 
-	const recordSiteUrlClicked = ( tracksProps: { blog_id: string } ) => {
+	const recordSiteUrlClicked = ( tracksProps: {
+		blog_id: string;
+		feed_id: string;
+		source?: string;
+	} ) => {
 		recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_url_clicked', tracksProps );
 	};
 

--- a/client/landing/subscriptions/tracks/use-record-site-url-clicked.tsx
+++ b/client/landing/subscriptions/tracks/use-record-site-url-clicked.tsx
@@ -4,7 +4,7 @@ const useRecordSiteUrlClicked = () => {
 	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
 
 	const recordSiteUrlClicked = ( tracksProps: { blog_id: string } ) => {
-		return recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_url_clicked', tracksProps );
+		recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_url_clicked', tracksProps );
 	};
 
 	return recordSiteUrlClicked;

--- a/client/landing/subscriptions/tracks/use-record-subscriptions-tracks-event.tsx
+++ b/client/landing/subscriptions/tracks/use-record-subscriptions-tracks-event.tsx
@@ -2,38 +2,14 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { SubscriptionManager } from '@automattic/data-stores';
 import { useSubscriptionManagerContext } from '../components/subscription-manager-context';
 
-const getSource = () => {
-	const path = window.location.pathname;
-
-	if ( path.indexOf( '/subscriptions/settings' ) === 0 ) {
-		return 'subscription-settings';
-	}
-
-	if ( path.indexOf( '/subscriptions/comments' ) === 0 ) {
-		return 'subscription-comments';
-	}
-
-	if ( path.indexOf( '/subscriptions/sites' ) === 0 || path.indexOf( '/subscriptions' ) === 0 ) {
-		return 'subscriptions-sites';
-	}
-
-	if ( path.indexOf( '/read/subscriptions' ) === 0 ) {
-		return 'reader-subscriptions-sites';
-	}
-
-	return 'unknown';
-};
-
 const useRecordSubscriptionsTracksEvent = () => {
 	const { portal } = useSubscriptionManagerContext();
 	const { data: counts } = SubscriptionManager.useSubscriptionsCountQuery();
 
 	const recordSubscriptionsTracksEvent = ( tracksEventName: string, tracksEventProps?: object ) => {
-		const source = getSource();
 		const subscription_count = counts?.blogs;
 
-		return recordTracksEvent( tracksEventName, {
-			source,
+		recordTracksEvent( tracksEventName, {
 			portal,
 			subscription_count,
 			...tracksEventProps,
@@ -42,5 +18,4 @@ const useRecordSubscriptionsTracksEvent = () => {
 
 	return recordSubscriptionsTracksEvent;
 };
-
 export default useRecordSubscriptionsTracksEvent;

--- a/client/landing/subscriptions/tracks/use-record-subscriptions-tracks-event.tsx
+++ b/client/landing/subscriptions/tracks/use-record-subscriptions-tracks-event.tsx
@@ -1,0 +1,46 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { SubscriptionManager } from '@automattic/data-stores';
+import { useSubscriptionManagerContext } from '../components/subscription-manager-context';
+
+const getSource = () => {
+	const path = window.location.pathname;
+
+	if ( path.indexOf( '/subscriptions/settings' ) === 0 ) {
+		return 'subscription-settings';
+	}
+
+	if ( path.indexOf( '/subscriptions/comments' ) === 0 ) {
+		return 'subscription-comments';
+	}
+
+	if ( path.indexOf( '/subscriptions/sites' ) === 0 || path.indexOf( '/subscriptions' ) === 0 ) {
+		return 'subscriptions-sites';
+	}
+
+	if ( path.indexOf( '/read/subscriptions' ) === 0 ) {
+		return 'reader-subscriptions-sites';
+	}
+
+	return 'unknown';
+};
+
+const useRecordSubscriptionsTracksEvent = () => {
+	const { portal } = useSubscriptionManagerContext();
+	const { data: counts } = SubscriptionManager.useSubscriptionsCountQuery();
+
+	const recordSubscriptionsTracksEvent = ( tracksEventName: string, tracksEventProps?: object ) => {
+		const source = getSource();
+		const subscription_count = counts?.blogs;
+
+		return recordTracksEvent( tracksEventName, {
+			source,
+			portal,
+			subscription_count,
+			...tracksEventProps,
+		} );
+	};
+
+	return recordSubscriptionsTracksEvent;
+};
+
+export default useRecordSubscriptionsTracksEvent;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Fixes https://github.com/Automattic/wp-calypso/issues/78487

## Proposed Changes
* Introduce a base tracks event function:
  * recordSubscriptionsTracksEvent( name, props )
* All functions to record tracks event are hooks.
  * The reason for this design is to be able to fetch data returned by hooks.
* All tracks event have the following props (for closer parity with Reader's version):
  * portal = identifies the portal where the event is recorded, e.g. `reader` or `subscriptions`
  * source = (optional) identifies the ui where the event is recorded, e.g. `recommended-site-dismiss-button`, `subscriptions-site-list`
  * subscription_count = user's total subscription count (seems to exist in all reader tracks event, so we're keeping it here too).
* Adds the following tracks event:
  * calypso_subscriptions_site_subscribed
  * calypso_subscriptions_site_unsubscribed
  * calypso_subscriptions_site_resubscribed
  * calypso_subscriptions_site_url_clicked
  * calypso_subscriptions_site_icon_clicked
  * calypso_subscriptions_site_title_clicked
* Reworked previous tracks events:
  * calypso_subscriptions_notifications_toggle_on
  * calypso_subscriptions_notifications_toggle_off
  * calypso_subscriptions_post_emails_toggle_on
  * calypso_subscriptions_post_emails_toggle_off
  * calypso_subscriptions_comment_emails_toggle_on
  * calypso_subscriptions_comment_emails_toggle_off
  * calypso_subscriptions_post_emails_set_frequency
* Some tracks event contains additional reader-related operations (bumpStats, recordGaEvent, etc.)

## Testing Instructions

* Open up `/subscriptions`.
* Open up network panel and filter to `*.gif`.
* Clicking on site title, site icon & site url should log tracks event.
* Changing all site subscription settings should log tracks event.
* Subscribing, unsubscribing and resubscribing should log tracks event.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
