### PR TITLE
Assembler - Fastrack Next Assembler Tasks Jun 2023

### DIFF
--- a/client/components/themes-list/test/__snapshots__/index.jsx.snap
+++ b/client/components/themes-list/test/__snapshots__/index.jsx.snap
@@ -32,8 +32,8 @@ exports[`ThemesList should render a div with a className of "themes-list" 1`] = 
         class="pattern-assembler-cta__subtitle"
       >
         Can’t find something you like? 
-        <br />
-        Jump right into the editor to design your homepage from scratch. 
+        <br /> 
+        Jump right into the editor to design your homepage from scratch.
       </p>
       <button
         class="button pattern-assembler-cta__button is-primary"

--- a/client/components/themes-list/test/__snapshots__/index.jsx.snap
+++ b/client/components/themes-list/test/__snapshots__/index.jsx.snap
@@ -31,7 +31,9 @@ exports[`ThemesList should render a div with a className of "themes-list" 1`] = 
       <p
         class="pattern-assembler-cta__subtitle"
       >
-        Can't find something you like? Jump right into the editor to design your homepage from scratch.
+        Can’t find something you like? 
+        <br />
+        Jump right into the editor to design your homepage from scratch. 
       </p>
       <button
         class="button pattern-assembler-cta__button is-primary"

--- a/client/components/themes-list/test/__snapshots__/index.jsx.snap
+++ b/client/components/themes-list/test/__snapshots__/index.jsx.snap
@@ -31,8 +31,8 @@ exports[`ThemesList should render a div with a className of "themes-list" 1`] = 
       <p
         class="pattern-assembler-cta__subtitle"
       >
-        Can’t find something you like? 
-        <br /> 
+        Can’t find something you like?
+        <br />
         Jump right into the editor to design your homepage from scratch.
       </p>
       <button

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -141,6 +141,7 @@
 		font-size: $font-body;
 		max-width: 600px;
 		text-align: center;
+		padding: 0 60px;
 	}
 
 	button {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -69,7 +69,7 @@ const PatternLargePreview = ( {
 
 	const getTitle = () => {
 		if ( ! shouldShowSelectPatternHint ) {
-			return translate( 'Welcome to your blank canvas.' );
+			return translate( 'Welcome to your homepage.' );
 		}
 
 		return translate( 'Ready to start designing?' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -2,7 +2,6 @@ import { PatternRenderer } from '@automattic/block-renderer';
 import { Button, DeviceSwitcher } from '@automattic/components';
 import { useStyle } from '@automattic/global-styles';
 import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
-import { Icon, layout } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useEffect, useState, CSSProperties } from 'react';
@@ -206,7 +205,6 @@ const PatternLargePreview = ( {
 				</ul>
 			) : (
 				<div className="pattern-large-preview__placeholder">
-					<Icon className="pattern-large-preview__placeholder-icon" icon={ layout } size={ 56 } />
 					<h2>{ getTitle() }</h2>
 					<span>{ getDescription() }</span>
 					{ getAction() }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -67,7 +67,7 @@ const PatternLayout = ( {
 			) }
 			<Button className="pattern-layout__add-button" onClick={ () => onAddSection() }>
 				<span className="pattern-layout__add-button-icon">+</span>
-				{ translate( 'Add patterns' ) }
+				{ translate( 'Add sections' ) }
 			</Button>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -68,7 +68,7 @@ const ScreenCategoryList = ( {
 				title={
 					<NavigatorTitle
 						title={
-							replacePatternMode ? translate( 'Replace pattern' ) : translate( 'Add patterns' )
+							replacePatternMode ? translate( 'Replace section' ) : translate( 'Add sections' )
 						}
 					/>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -78,7 +78,7 @@ const ScreenCategoryList = ( {
 								'Replace the selected pattern by choosing from the list of categories below.'
 						  )
 						: translate(
-								'Find the right patterns for you by exploring the list of categories below.'
+								'Find the right patterns for your homepage by exploring the pattern categories below.'
 						  )
 				}
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -31,9 +31,7 @@ const ScreenColorPalettes = ( {
 		<>
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Colors' ) } /> }
-				description={ translate(
-					'Choose from our curated color palettes when you upgrade to the Premium plan or above.'
-				) }
+				description={ translate( 'Discover your ideal color blend, from free to premium styles.' ) }
 				onBack={ onBack }
 			/>
 			<div className="screen-container__body">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
@@ -32,7 +32,7 @@ const ScreenFontPairings = ( {
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Fonts' ) } /> }
 				description={ translate(
-					'Choose from our curated font pairings when you upgrade to the Premium plan or above.'
+					'Elevate your design with expertly curated font pairings, including free and premium.'
 				) }
 				onBack={ onBack }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
@@ -34,7 +34,7 @@ const ScreenFooter = ( {
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Footer' ) } /> }
 				description={ translate(
-					'The footer appears at the bottom of a site and shows useful links and contact information.'
+					'Pick the footer appears at the bottom of every page and shows useful links and your contact information.'
 				) }
 				onBack={ onBack }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
@@ -32,7 +32,7 @@ const ScreenFooter = ( {
 	return (
 		<>
 			<NavigatorHeader
-				title={ <NavigatorTitle title={ translate( 'Footer' ) } /> }
+				title={ <NavigatorTitle title={ translate( 'Add footer' ) } /> }
 				description={ translate(
 					'Pick the footer that appears at the bottom of every page and shows useful links and your contact information.'
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
@@ -34,7 +34,7 @@ const ScreenFooter = ( {
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Add footer' ) } /> }
 				description={ translate(
-					'Pick the footer that appears at the bottom of every page and shows useful links and your contact information.'
+					'Pick the footer that appears at the bottom of every page and shows useful links and contact information.'
 				) }
 				onBack={ onBack }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
@@ -34,7 +34,7 @@ const ScreenFooter = ( {
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Footer' ) } /> }
 				description={ translate(
-					'Pick the footer appears at the bottom of every page and shows useful links and your contact information.'
+					'Pick the footer that appears at the bottom of every page and shows useful links and your contact information.'
 				) }
 				onBack={ onBack }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
@@ -34,7 +34,7 @@ const ScreenHeader = ( {
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Header' ) } /> }
 				description={ translate(
-					'The header appears at the top of every page, with a site name and navigation.'
+					'Pick the header that appears at the top of every page and shows your site logo, title and navigation.'
 				) }
 				onBack={ onBack }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
@@ -32,7 +32,7 @@ const ScreenHeader = ( {
 	return (
 		<>
 			<NavigatorHeader
-				title={ <NavigatorTitle title={ translate( 'Header' ) } /> }
+				title={ <NavigatorTitle title={ translate( 'Add header' ) } /> }
 				description={ translate(
 					'Pick the header that appears at the top of every page and shows your site logo, title and navigation.'
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -49,7 +49,7 @@ const ScreenMain = ( {
 	const { location } = useNavigator();
 	const isInitialLocation = location.isInitial && ! location.isBack;
 	const headerDescription = translate(
-		'Customize everything in your homepage by first adding patterns and then choosing styles.'
+		'Customize everything by first adding patterns and then choosing styles.'
 	);
 
 	// Use the mousedown event to prevent either the button focusing or text selection

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -120,10 +120,10 @@ const ScreenMain = ( {
 							checked={ hasSections }
 							path={ hasSections ? NAVIGATOR_PATHS.SECTION : NAVIGATOR_PATHS.SECTION_PATTERNS }
 							icon={ layout }
-							aria-label={ translate( 'Homepage' ) }
+							aria-label={ translate( 'Sections' ) }
 							onClick={ () => onSelect( 'section' ) }
 						>
-							{ translate( 'Homepage' ) }
+							{ translate( 'Sections' ) }
 						</NavigationButtonAsItem>
 						<NavigationButtonAsItem
 							checked={ hasFooter }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -154,7 +154,7 @@ const ScreenMain = ( {
 			</div>
 			<div className="screen-container__footer">
 				<span className="screen-container__description">
-					{ translate( 'Ready? Go to the Site Editor to continue editing.' ) }
+					{ translate( 'Ready to keep editing?' ) }
 				</span>
 				<Button
 					className="pattern-assembler__button"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -8,17 +8,14 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { focus } from '@wordpress/dom';
 import { header, footer, layout, color, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef } from 'react';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { NAVIGATOR_PATHS } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import NavigatorTitle from './navigator-title';
 import Survey from './survey';
-import type { OnboardSelect } from '@automattic/data-stores';
 import type { MouseEvent } from 'react';
 
 interface Props {
@@ -51,14 +48,9 @@ const ScreenMain = ( {
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const { location } = useNavigator();
 	const isInitialLocation = location.isInitial && ! location.isBack;
-	const selectedDesign = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
-		[]
+	const headerDescription = translate(
+		'Customize everything in your homepage by adding patterns and choosing styles.'
 	);
-
-	const headerDescription = selectedDesign?.is_virtual
-		? translate( 'Customize your homepage with our library of styles and patterns.' )
-		: translate( 'Customize everything in your homepage by adding patterns and choosing styles.' );
 
 	// Use the mousedown event to prevent either the button focusing or text selection
 	const handleMouseDown = ( event: MouseEvent< HTMLButtonElement > ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -58,7 +58,7 @@ const ScreenMain = ( {
 
 	const headerDescription = selectedDesign?.is_virtual
 		? translate( 'Customize your homepage with our library of styles and patterns.' )
-		: translate( 'Use our library of styles and patterns to build a homepage.' );
+		: translate( 'Customize everything in your homepage by adding patterns and choosing styles.' );
 
 	// Use the mousedown event to prevent either the button focusing or text selection
 	const handleMouseDown = ( event: MouseEvent< HTMLButtonElement > ) => {
@@ -100,7 +100,7 @@ const ScreenMain = ( {
 	return (
 		<>
 			<NavigatorHeader
-				title={ <NavigatorTitle title={ translate( 'Design your own' ) } /> }
+				title={ <NavigatorTitle title={ translate( 'Design your own homepage' ) } /> }
 				description={ headerDescription }
 				hideBack
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -171,7 +171,7 @@ const ScreenMain = ( {
 					onMouseDown={ handleMouseDown }
 					onClick={ handleClick }
 				>
-					{ translate( 'Continue' ) }
+					{ translate( 'Save and continue' ) }
 				</Button>
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -127,7 +127,7 @@ const ScreenMain = ( {
 							{ translate( 'Footer' ) }
 						</NavigationButtonAsItem>
 					</NavigatorItemGroup>
-					<NavigatorItemGroup title={ translate( 'Style' ) }>
+					<NavigatorItemGroup title={ translate( 'Styles' ) }>
 						<>
 							<NavigationButtonAsItem
 								checked={ hasColor }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -49,7 +49,7 @@ const ScreenMain = ( {
 	const { location } = useNavigator();
 	const isInitialLocation = location.isInitial && ! location.isBack;
 	const headerDescription = translate(
-		'Customize everything in your homepage by adding patterns and choosing styles.'
+		'Customize everything in your homepage by first adding patterns and then choosing styles.'
 	);
 
 	// Use the mousedown event to prevent either the button focusing or text selection
@@ -153,9 +153,6 @@ const ScreenMain = ( {
 				{ ! surveyDismissed && <Survey setSurveyDismissed={ setSurveyDismissed } /> }
 			</div>
 			<div className="screen-container__footer">
-				<span className="screen-container__description">
-					{ translate( 'Ready to keep editing?' ) }
-				</span>
 				<Button
 					className="pattern-assembler__button"
 					primary

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-section.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-section.tsx
@@ -34,7 +34,7 @@ const ScreenSection = ( {
 	return (
 		<>
 			<NavigatorHeader
-				title={ <NavigatorTitle title={ translate( 'Homepage' ) } /> }
+				title={ <NavigatorTitle title={ translate( 'Sections' ) } /> }
 				description={ translate(
 					'Add and arrange patterns to make your homepage unique and help people understand instantly what the site’s about. '
 				) }
@@ -57,7 +57,7 @@ const ScreenSection = ( {
 			</div>
 			<div className="screen-container__footer">
 				<NavigatorBackButton as={ Button } className="pattern-assembler__button" primary>
-					{ translate( 'Save homepage' ) }
+					{ translate( 'Save sections' ) }
 				</NavigatorBackButton>
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-section.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-section.tsx
@@ -36,7 +36,7 @@ const ScreenSection = ( {
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Sections' ) } /> }
 				description={ translate(
-					'Add and arrange patterns to make your homepage unique and help people understand instantly what the site’s about. '
+					'Add and arrange patterns to make your homepage unique and showcase the content of your site.'
 				) }
 			/>
 			<div className="screen-container__body">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.scss
@@ -1,19 +1,7 @@
 .pattern-assembler__survey {
-	min-height: 76px;
 	border-radius: 4px;
 	background: #f0f7fc;
 	margin: 20px 0;
-
-	&.banner.card.is-dismissible {
-		cursor: default;
-		border: 0;
-		box-shadow: none;
-
-		// Overwrite .banner.card padding without !important
-		@media (min-width: 481px) {
-			padding-right: 52px;
-		}
-	}
 
 	.banner__info .banner__title {
 		font-weight: 400;
@@ -33,8 +21,19 @@
 	.banner__close-icon {
 		fill: var(--studio-gray-60);
 		top: auto;
-		right: 18px;
+		right: 14px;
 		height: 15.4px;
 		width: 15.4px;
+	}
+
+	&.banner.card.is-dismissible {
+		cursor: default;
+		border: 0;
+		box-shadow: none;
+
+		// Overwrite .banner.card
+		@media (min-width: 481px) {
+			padding: 14px 42px 14px 16px;
+		}
 	}
 }

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -35,15 +35,19 @@ const PatternAssemblerCta = ( {
 		return null;
 	}
 
-	let text = customText;
+	let text = customText as string | JSX.Element;
 	if ( ! text ) {
-		text = shouldGoToAssemblerStep
-			? translate(
-					'Can’t find something you like? Use our library of styles and patterns to build a homepage.'
-			  )
-			: translate(
-					"Can't find something you like? Jump right into the editor to design your homepage from scratch."
-			  );
+		text = shouldGoToAssemblerStep ? (
+			<>
+				{ translate( 'Can’t find something you like?' ) }
+				<br />
+				{ translate( 'Use our library of styles and patterns to build a homepage.' ) }
+			</>
+		) : (
+			translate(
+				"Can't find something you like? Jump right into the editor to design your homepage from scratch."
+			)
+		);
 	}
 
 	return (

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -11,7 +11,7 @@ type PatternAssemblerCtaProps = {
 	onButtonClick: ( shouldGoToAssemblerStep: boolean ) => void;
 	showEditorFallback?: boolean;
 	showHeading?: boolean;
-	text?: string;
+	text?: string | JSX.Element;
 };
 
 const PatternAssemblerCta = ( {
@@ -35,18 +35,16 @@ const PatternAssemblerCta = ( {
 		return null;
 	}
 
-	let text = customText as string | JSX.Element;
+	let text = customText;
 	if ( ! text ) {
-		text = shouldGoToAssemblerStep ? (
+		text = (
 			<>
 				{ translate( 'Can’t find something you like?' ) }
 				<br />
-				{ translate( 'Use our library of styles and patterns to build a homepage.' ) }
+				{ shouldGoToAssemblerStep
+					? translate( 'Use our library of styles and patterns to build a homepage.' )
+					: translate( 'Jump right into the editor to design your homepage from scratch.' ) }
 			</>
-		) : (
-			translate(
-				"Can't find something you like? Jump right into the editor to design your homepage from scratch."
-			)
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78513

## Proposed Changes

### Large preview placeholder updates

- Remove icon
- Update copy
- Remove orphan (a single word on the last line of text)
- Remove `Add header` button from the colors and fonts placeholder and update the title copy

**Regular placeholder after removing the icon**

<img width="657" alt="Screenshot 2566-06-26 at 14 22 46" src="https://github.com/Automattic/wp-calypso/assets/1881481/c0da3f85-f109-41b8-b031-8b5d79128e10">

**Colors and fonts placeholder**
 
|Before|After|
|---|---|
|<img width="653" alt="Screenshot 2566-06-27 at 17 05 01" src="https://github.com/Automattic/wp-calypso/assets/1881481/398ef251-856b-409d-986a-5316731f5e71">|<img width="709" alt="Screenshot 2566-06-27 at 17 05 23" src="https://github.com/Automattic/wp-calypso/assets/1881481/425a0c61-fbca-4817-aa9a-a44524ccb4e8">|


**More copy updates**

- Update title and description copy on main screen
- Update title of Header and Footer 
- Update Continue button label and remove the hint
- Update copy to use sections and patterns
- Update description copy on categories screen


**More orphans removed**

- Remove assembler CTA orphan

<img width="966" alt="Screenshot 2566-06-26 at 14 22 29" src="https://github.com/Automattic/wp-calypso/assets/1881481/4df6bd85-20dd-44d2-8122-63f47f1e32f2">

<img width="772" alt="Screenshot 2566-06-26 at 14 39 39" src="https://github.com/Automattic/wp-calypso/assets/1881481/aeed195a-b8d4-4b58-8de5-d3ddd08b72de">


- Remove large preview placeholder orphan
- Remove survey orphan
- Remove screen description orphans

|Main|Add header|Sections|Add sections|Add footer|Colors|Fonts|
|--|--|--|--|--|--|--|
|<img width="358" alt="Screenshot 2566-06-27 at 16 50 49" src="https://github.com/Automattic/wp-calypso/assets/1881481/9ca877b5-1dbc-445b-9da3-76d7d17506b1">|<img width="359" alt="Screenshot 2566-06-27 at 16 51 42" src="https://github.com/Automattic/wp-calypso/assets/1881481/b5c70070-17ea-4d47-a3c8-6919a58893b6">|<img width="357" alt="Screenshot 2566-06-26 at 14 32 35" src="https://github.com/Automattic/wp-calypso/assets/1881481/6a284d07-4922-4fb5-bbc0-6ed92f8c6f21">|<img width="359" alt="Screenshot 2566-06-26 at 14 32 09" src="https://github.com/Automattic/wp-calypso/assets/1881481/6096519d-4260-4b69-a0b3-c97e463b5cb7">|<img width="358" alt="Screenshot 2566-06-27 at 16 51 56" src="https://github.com/Automattic/wp-calypso/assets/1881481/d9223d09-f81c-4945-9c43-67bbe9ebc75a">|<img width="359" alt="Screenshot 2566-06-26 at 14 31 49" src="https://github.com/Automattic/wp-calypso/assets/1881481/25e238c3-a057-4d39-b95b-c4eaba9bfe33">|<img width="358" alt="Screenshot 2566-06-26 at 14 38 44" src="https://github.com/Automattic/wp-calypso/assets/1881481/9a8f8f5c-b31f-4340-a674-1d9f0674ca3c">|


**This PR doesn't fix sidebar alignment issues. There is another [PR](https://github.com/Automattic/wp-calypso/pull/78587) only for that.**

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Using the Calypso Live link below 
* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3`
* Test the whole experience from the CTA until you land on the editor
* Verify the copy makes sense and there aren't typos
* Verify the icon has been removed from the large placeholder 
* Test the copy twice, on a window size larger and smaller than 1280px to verify there aren't orphans in the copy when the sidebar width is reduced

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
