### PR TITLE
Domains: add link to top bar

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -152,6 +152,10 @@ class MasterbarLoggedIn extends Component {
 		}
 	};
 
+	clickDomains = () => {
+		this.props.setNextLayoutFocus( 'content' );
+	};
+
 	clickReader = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_reader_clicked' );
 		this.handleLayoutFocus( 'reader' );
@@ -175,6 +179,10 @@ class MasterbarLoggedIn extends Component {
 
 	preloadMySites = () => {
 		preload( this.props.domainOnlySite ? 'domains' : 'stats' );
+	};
+
+	preloadDomains = () => {
+		preload( 'domains' );
 	};
 
 	preloadReader = () => {
@@ -282,6 +290,25 @@ class MasterbarLoggedIn extends Component {
 				isLeavingAllowed={ ! isCheckoutPending }
 				loadHelpCenterIcon={ loadHelpCenterIcon }
 			/>
+		);
+	}
+
+	renderDomains( showLabel = true ) {
+		const { translate } = this.props;
+		return (
+			<Item
+				tipTarget="domains"
+				className="masterbar__domains"
+				url="/domains/manage"
+				icon="domains"
+				onClick={ this.clickDomains }
+				isActive={ this.isActive( 'domains' ) }
+				tooltip={ translate( 'Manage domains' ) }
+				preloadSection={ this.preloadDomains }
+			>
+				{ showLabel &&
+					translate( 'Domains', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
+			</Item>
 		);
 	}
 
@@ -521,6 +548,7 @@ class MasterbarLoggedIn extends Component {
 					<Masterbar>
 						<div className="masterbar__section masterbar__section--left">
 							{ this.renderMySites() }
+							{ this.renderDomains( false ) }
 							{ this.renderReader( false ) }
 							{ this.renderLanguageSwitcher() }
 							{ this.renderSearch() }
@@ -541,6 +569,7 @@ class MasterbarLoggedIn extends Component {
 				<Masterbar>
 					<div className="masterbar__section masterbar__section--left">
 						{ this.renderMySites() }
+						{ this.renderDomains() }
 						{ this.renderReader() }
 						{ this.renderLanguageSwitcher() }
 						{ this.renderSearch() }

--- a/client/sections.js
+++ b/client/sections.js
@@ -236,7 +236,7 @@ const sections = [
 		name: 'domains',
 		paths: [ '/domains' ],
 		module: 'calypso/my-sites/domains',
-		group: 'sites',
+		group: 'domains',
 	},
 	{
 		name: 'incoming-redirect',


### PR DESCRIPTION
Related to p1687387772424839-slack-C029GN3KD

## Proposed Changes

This PR adds the "Domains" link alongside "My Sites" in the top bar.

| Desktop | Mobile |
| ---------| -------|
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/8680906c-fba9-4339-94a4-8152a1a774f9) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/61454faa-0517-4622-afa4-995c579837ab) |

## Testing Instructions

1. Open Calypso and verify that clicking the "Domains" link sends the user to `/domains/manage`;
2. Verify that the icon is showing without the label on mobile;
3. Verify that the section becomes active (different, lighter background color) in the top bar.