### PR TITLE
Limited GS on Personal: Load styles for treatment group

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -575,7 +575,8 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 	}
 
 	// Limited Global Styles on Personal A/B test.
-	if ( 'treatment' === \ExPlat\assign_current_user( 'calypso_global_styles_personal' ) ) {
+	$owner = get_userdata( wpcom_get_blog_owner( $blog_id ) );
+	if ( 'treatment' === \ExPlat\get_user_assignment( 'calypso_global_styles_personal', $owner ) ) {
 		/*
 		 * Flag site so users of the treatment group can always have access to Global Styles, even
 		 * if the A/B test has finished without expanding Global Styles to the Personal plan.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -580,7 +580,9 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 		 * Flag site so users of the treatment group can always have access to Global Styles, even
 		 * if the A/B test has finished without expanding Global Styles to the Personal plan.
 		 */
-		add_blog_sticker( 'wpcom-global-styles-personal-plan', null, null, $blog_id );
+		if ( ! wpcom_global_styles_has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) ) {
+			add_blog_sticker( 'wpcom-global-styles-personal-plan', null, null, $blog_id );
+		}
 	}
 
 	/*

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -575,7 +575,7 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 	}
 
 	// Limited Global Styles on Personal A/B test.
-	if ( 'treatment' === \ExPlat\assign_current_user( 'wpcom_global_styles_personal' ) ) {
+	if ( 'treatment' === \ExPlat\assign_current_user( 'calypso_global_styles_personal' ) ) {
 		/*
 		 * Flag site so users of the treatment group can always have access to Global Styles, even
 		 * if the A/B test has finished without expanding Global Styles to the Personal plan.


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2781
Fixes https://github.com/Automattic/dotcom-forge/issues/2853

## Proposed Changes

Prevents the Global Styles from being blocked if the user is assigned to the treatment group of the `calypso_global_styles_personal` experiment.

## Testing Instructions

- Apply these changes to your sandbox.
- Create a new WP.com site and upgrade to the Personal plan.
- Go to Appearance > Editor.
- Open the Styles section and select a custom style variation.
- Save the changes.
- Sandbox it.
- Assign yourself to the control group of the experiment (see PCYsg-Fq7-p2#abacus-assignment-bookmarklet).
- Visit the frontend of your site.
- Make sure you see a notice indicating that custom styles won't be public to visitors.
- Assign yourself to the treatment group of the experiment now.
- Visit the frontend of your site.
- Make sure you no longer see the Limited Global Styles notice.
- Assign yourself again to the control group.
- Visit the frontend of your site.
- Make sure that Global Styles remain unlocked (becase you were part of the treatment group at some point).
- Cancel your Personal plan.
- Make sure Global Styles are limited now.
