### PR TITLE
Set the created date to be created_at and use the correct status value

### DIFF
--- a/client/data/promote-post/types.ts
+++ b/client/data/promote-post/types.ts
@@ -24,6 +24,7 @@ export type Campaign = {
 		snippet: string;
 	};
 	content_image: string;
+	created_at: string;
 	start_date: string; // "2022-07-18T01:51:12.000Z"
 	end_date: string;
 	status_smart: CampaignStatus;
@@ -39,6 +40,7 @@ export type Campaign = {
 	display_delivery_estimate: string;
 	delivery_percent: number;
 	status: string;
+	ui_status: string;
 	target_url: string;
 	deliver_margin_multiplier: number;
 	audience_list: AudienceList;

--- a/client/data/promote-post/use-promote-post-campaigns-query-new.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query-new.ts
@@ -15,12 +15,14 @@ export type CampaignResponse = {
 	display_delivery_estimate: string;
 	campaign_id: number;
 	start_date: string;
+	created_at: string;
 	end_date: string;
 	display_name: string;
 	creative_html: string;
 	width: number;
 	height: number;
 	status: string;
+	ui_status: string;
 	target_urn: string;
 	delivery_percent: number;
 	campaign_stats: {

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -257,7 +257,7 @@ export default function CampaignItemDetails( props: Props ) {
 
 					<div className="campaign-item__header-status">
 						{ ! isLoading && status ? (
-							<Badge type={ getCampaignStatusBadgeColor( status ) }>
+							<Badge type={ getCampaignStatusBadgeColor( ui_status ) }>
 								{ getCampaignStatus( ui_status ) }
 							</Badge>
 						) : (

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -78,11 +78,13 @@ export default function CampaignItemDetails( props: Props ) {
 		width,
 		height,
 		status,
+		ui_status,
 		campaign_stats,
 		billing_data,
 		display_delivery_estimate = '',
 		target_urn,
 		delivery_percent,
+		created_at,
 	} = campaign || {};
 
 	const {
@@ -118,7 +120,7 @@ export default function CampaignItemDetails( props: Props ) {
 	const overallSpendingFormatted = `$${ formatCents( total_budget_used || 0 ) }`;
 	const deliveryEstimateFormatted = getCampaignEstimatedImpressions( display_delivery_estimate );
 	const campaignTitleFormatted = title || __( 'Untitled' );
-	const campaignCreatedFormatted = moment.utc( start_date ).format( 'MMMM DD, YYYY' );
+	const campaignCreatedFormatted = moment.utc( created_at ).format( 'MMMM DD, YYYY' );
 	const devicesListFormatted = devicesList ? `${ devicesList }` : __( 'All' );
 	const countriesListFormatted = countriesList ? `${ countriesList }` : __( 'Everywhere' );
 	const osListFormatted = OSsList ? `${ OSsList }` : translate( 'All' );
@@ -256,7 +258,7 @@ export default function CampaignItemDetails( props: Props ) {
 					<div className="campaign-item__header-status">
 						{ ! isLoading && status ? (
 							<Badge type={ getCampaignStatusBadgeColor( status ) }>
-								{ getCampaignStatus( status ) }
+								{ getCampaignStatus( ui_status ) }
 							</Badge>
 						) : (
 							<div

--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -44,7 +44,7 @@ export default function CampaignItem( props: Props ) {
 		name,
 		content_config,
 		display_name,
-		status,
+		ui_status,
 		end_date,
 		budget_cents,
 		start_date,
@@ -71,7 +71,9 @@ export default function CampaignItem( props: Props ) {
 	const budgetStringMobile = campaignDays ? `$${ totalBudget } budget` : null;
 
 	const statusBadge = (
-		<Badge type={ getCampaignStatusBadgeColor( status ) }>{ getCampaignStatus( status ) }</Badge>
+		<Badge type={ getCampaignStatusBadgeColor( ui_status ) }>
+			{ getCampaignStatus( ui_status ) }
+		</Badge>
 	);
 	const openCampaignURL = getAdvertisingDashboardPath(
 		`/${ selectedSiteSlug }/campaigns/${ campaign.campaign_id }`

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -34,7 +34,7 @@ export const getPostType = ( type: string ) => {
 	}
 };
 
-export const getCampaignStatusBadgeColor = ( status: string ) => {
+export const getCampaignStatusBadgeColor = ( status?: string ) => {
 	switch ( status ) {
 		case campaignStatus.SCHEDULED: {
 			return 'info-blue';

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -62,7 +62,7 @@ export const getCampaignStatusBadgeColor = ( status: string ) => {
 	}
 };
 
-export const getCampaignStatus = ( status: string ) => {
+export const getCampaignStatus = ( status?: string ) => {
 	switch ( status ) {
 		case campaignStatus.SCHEDULED: {
 			return __( 'Scheduled' );


### PR DESCRIPTION
⚠️ First we need to merge the DSP PR 227

We are not displaying the correct date in "Created" in blazepress campaign individual page. We're using the "start_date". This is incorrect. We're also using the old "status" field when we're displaying it. this PR fixes it

![image](https://github.com/Automattic/wp-calypso/assets/43957544/f347b08f-0605-427d-b95a-e2a59ae65352)


Related to #

## Proposed Changes

* Chanage "start_date" to "created_at"
* Add "ui_status" instead of "status" ONLY when we display it in campaign page

## Testing Instructions

- Bridge your local DSP with the branch `fix/add_created_at_campaign_endpoint` or wait until we merge the DSP patch
* Create a campaign, and moderate it. It should display the "Created: " with the correct value (today) and the. Status should display: "Scheduled"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
