### PR TITLE
Hide the payment empty box if there's no data

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -99,7 +99,8 @@ export default function CampaignItemDetails( props: Props ) {
 	const { card_name, payment_method, subtotal, credits, total } = billing_data || {};
 	const { title, clickUrl } = content_config || {};
 	const canDisplayPaymentSection =
-		( status === 'finished' || status === 'canceled' ) && payment_method && total;
+		( status === 'finished' || status === 'canceled' ) &&
+		( payment_method || ! isNaN( total || 0 ) );
 
 	const onClickPromote = useOpenPromoteWidget( {
 		keyValue: `post-${ getPostIdFromURN( target_urn || '' ) }`, // + campaignId,
@@ -524,7 +525,7 @@ export default function CampaignItemDetails( props: Props ) {
 								</div>
 							</div>
 						</div>
-						{ canDisplayPaymentSection && (
+						{ canDisplayPaymentSection ? (
 							<div className="campaign-item-details__payment-container">
 								<div className="campaign-item-details__payment">
 									<div className="campaign-item-details__payment-row">
@@ -541,7 +542,7 @@ export default function CampaignItemDetails( props: Props ) {
 												) }
 											</div>
 											<div>
-												{ subtotal ? (
+												{ ! isNaN( subtotal || 0 ) ? (
 													<span className="campaign-item-details__label">
 														<div>{ translate( 'Subtotal' ) }</div>
 														<div className="amount">{ subtotalFormatted }</div>
@@ -557,7 +558,7 @@ export default function CampaignItemDetails( props: Props ) {
 												) : (
 													[]
 												) }
-												{ total ? (
+												{ ! isNaN( total || 0 ) ? (
 													<>
 														<span className="campaign-item-details__label">
 															<div>{ translate( 'Total paid' ) }</div>
@@ -575,6 +576,8 @@ export default function CampaignItemDetails( props: Props ) {
 									</div>
 								</div>
 							</div>
+						) : (
+							[]
 						) }
 					</div>
 					<div className="campaign-item-details__preview">

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -98,6 +98,8 @@ export default function CampaignItemDetails( props: Props ) {
 
 	const { card_name, payment_method, subtotal, credits, total } = billing_data || {};
 	const { title, clickUrl } = content_config || {};
+	const canDisplayPaymentSection =
+		( status === 'finished' || status === 'canceled' ) && payment_method && total;
 
 	const onClickPromote = useOpenPromoteWidget( {
 		keyValue: `post-${ getPostIdFromURN( target_urn || '' ) }`, // + campaignId,
@@ -522,7 +524,7 @@ export default function CampaignItemDetails( props: Props ) {
 								</div>
 							</div>
 						</div>
-						{ ( status === 'finished' || status === 'canceled' ) && (
+						{ canDisplayPaymentSection && (
 							<div className="campaign-item-details__payment-container">
 								<div className="campaign-item-details__payment">
 									<div className="campaign-item-details__payment-row">


### PR DESCRIPTION
Related to #

## Proposed Changes

* Hide the payment box if there's no data (old  campaign)

## Testing Instructions
- You need to find a campaign that was completed before we started adding the payment info in the DB
- Open the campaign and you shoudln't see an empty box:

Before:
![image](https://github.com/Automattic/wp-calypso/assets/43957544/a760dbdc-7515-49dd-ada8-d9e37d2ee098)


After the change:
![image](https://github.com/Automattic/wp-calypso/assets/43957544/be859ee8-e3a2-4ec2-8fc7-c15b28b03770)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
