### PR TITLE
Checkout: Fix credits label padding

### DIFF
--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -97,13 +97,10 @@ interface LabelProps {
 /**
  * This is the label used by radio buttons. It includes a before/after which
  * are fake radio button dots whereas the actual radio button dots are hidden.
- *
- * The inner `span` is where the contents of the label actually goes.
  */
-// TODO: fix RTL
 const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelElement > >`
 	position: relative;
-	padding: 24px;
+	padding: 16px 14px 16px 56px;
 	border-radius: 3px;
 	box-sizing: border-box;
 	width: 100%;
@@ -116,7 +113,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 	height: 72px;
 
 	.rtl & {
-		padding: 16px 40px 16px 14px;
+		padding: 16px 56px 16px 14px;
 	}
 
 	:hover {
@@ -160,10 +157,6 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 			right: 20px;
 			left: auto;
 		}
-	}
-
-	span {
-		padding-left: 32px;
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

This fixes a padding regression inside the "credits" payment method label caused by https://github.com/Automattic/wp-calypso/pull/77353.

Before:

<img width="710" alt="Screenshot 2023-06-23 at 10 28 33 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/2e837d67-d6c8-4fa5-9374-126f7c3c44c3">

After:

<img width="670" alt="Screenshot 2023-06-23 at 11 33 44 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/852bb8b6-c39b-474f-9802-2768bbf4d41c">

Other payment methods that should not change:

<img width="664" alt="Screenshot 2023-06-23 at 11 36 12 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/129806e4-15a2-44c9-8851-d3828dc6141d">


## Testing Instructions

We need to make sure that this fixes the credits button AND that it does not break other payment methods' labels.