### PR TITLE
Subscriber Details: Update GET individual subscription query to pass subscription type

### DIFF
--- a/client/my-sites/subscribers/controller.js
+++ b/client/my-sites/subscribers/controller.js
@@ -35,7 +35,7 @@ export function externalSubscriberDetails( context, next ) {
 	const { path } = context;
 	const subscriberId = path.split( '/' ).pop();
 
-	context.primary = <SubscriberDetailsPage subscriberId={ subscriberId } />;
+	context.primary = <SubscriberDetailsPage subscriptionId={ subscriberId } />;
 
 	next();
 }

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -28,11 +28,23 @@ const getSubscribersCacheKey = (
 	return cacheKey;
 };
 
-const getSubscriberDetailsCacheKey = ( siteId: number | null, queryString: string ) => [
-	'subscriber-details',
-	siteId,
-	queryString,
-];
+const getSubscriberDetailsUrl = (
+	siteSlug: string | null,
+	subscription_id: number | undefined,
+	user_id: number | undefined
+) => {
+	if ( user_id ) {
+		return `/subscribers/${ siteSlug }/${ user_id }`;
+	}
+
+	return `/subscribers/external/${ siteSlug }/${ subscription_id }`;
+};
+
+const getSubscriberDetailsCacheKey = (
+	siteId: number | null,
+	subscriptionId: number | undefined,
+	type: string
+) => [ 'subscriber-details', siteId, subscriptionId, type ];
 
 const sanitizeInt = ( intString: string ) => {
 	const parsedInt = parseInt( intString, 10 );
@@ -43,6 +55,7 @@ export {
 	getEarnPageUrl,
 	getEarnPaymentsPageUrl,
 	getSubscriberDetailsCacheKey,
+	getSubscriberDetailsUrl,
 	getSubscribersCacheKey,
 	sanitizeInt,
 };

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -40,11 +40,11 @@ const getSubscriberDetailsUrl = (
 	return `/subscribers/external/${ siteSlug }/${ subscription_id }`;
 };
 
-const getSubscriberDetailsCacheKey = (
-	siteId: number | null,
-	subscriptionId: number | undefined,
-	type: string
-) => [ 'subscriber-details', siteId, subscriptionId, type ];
+const getSubscriberDetailsCacheKey = ( siteId: number | null, queryString: string ) => [
+	'subscriber-details',
+	siteId,
+	queryString,
+];
 
 const sanitizeInt = ( intString: string ) => {
 	const parsedInt = parseInt( intString, 10 );

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -14,6 +14,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import { AddSubscribersModal } from './components/add-subscribers-modal';
 import { SubscribersHeaderPopover } from './components/subscribers-header-popover';
 import { UnsubscribeModal } from './components/unsubscribe-modal';
+import { getSubscriberDetailsUrl } from './helpers';
 import { useUnsubscribeModal } from './hooks';
 import { Subscriber } from './types';
 import './style.scss';
@@ -29,12 +30,8 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 
 	const { currentSubscriber, onClickUnsubscribe, onConfirmModal, resetSubscriber } =
 		useUnsubscribeModal( selectedSiteId, pageNumber );
-	const onClickView = ( subscriber: Subscriber ) => {
-		if ( subscriber.user_id ) {
-			page.show( `/subscribers/${ selectedSiteSlug }/${ subscriber.user_id }` );
-		} else {
-			page.show( `/subscribers/external/${ selectedSiteSlug }/${ subscriber.subscription_id }` );
-		}
+	const onClickView = ( { subscription_id, user_id }: Subscriber ) => {
+		page.show( getSubscriberDetailsUrl( selectedSiteSlug, subscription_id, user_id ) );
 	};
 	const [ showAddSubscribersModal, setShowAddSubscribersModal ] = useState( false );
 	const dispatch = useDispatch();

--- a/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
@@ -5,22 +5,17 @@ import type { Subscriber } from '../types';
 
 const useSubscriberDetailsQuery = (
 	siteId: number | null,
-	subscriberId: number | undefined,
+	subscriptionId: number | undefined,
 	userId: number | undefined
 ) => {
-	let queryString = '';
-
-	if ( subscriberId ) {
-		queryString += `subscriber_id=${ subscriberId }`;
-	} else if ( userId ) {
-		queryString += `user_id=${ userId }`;
-	}
+	const type = userId ? 'wpcom' : 'email';
+	const individualSubscriptionId = userId ?? subscriptionId;
 
 	return useQuery< Subscriber >( {
-		queryKey: getSubscriberDetailsCacheKey( siteId, queryString ),
+		queryKey: getSubscriberDetailsCacheKey( siteId, individualSubscriptionId, type ),
 		queryFn: () =>
 			wpcom.req.get( {
-				path: `/sites/${ siteId }/subscribers/individual?${ queryString }`,
+				path: `/sites/${ siteId }/subscribers/individual?subscription_id=${ individualSubscriptionId }&type=${ type }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
 		enabled: !! siteId,

--- a/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
@@ -8,14 +8,19 @@ const useSubscriberDetailsQuery = (
 	subscriptionId: number | undefined,
 	userId: number | undefined
 ) => {
-	const type = userId ? 'wpcom' : 'email';
-	const individualSubscriptionId = userId ?? subscriptionId;
+	let queryString = '';
+
+	if ( userId ) {
+		queryString = `user_id=${ userId }&type=wpcom`;
+	} else {
+		queryString = `subscription_id=${ subscriptionId }&type=email`;
+	}
 
 	return useQuery< Subscriber >( {
-		queryKey: getSubscriberDetailsCacheKey( siteId, individualSubscriptionId, type ),
+		queryKey: getSubscriberDetailsCacheKey( siteId, queryString ),
 		queryFn: () =>
 			wpcom.req.get( {
-				path: `/sites/${ siteId }/subscribers/individual?subscription_id=${ individualSubscriptionId }&type=${ type }`,
+				path: `/sites/${ siteId }/subscribers/individual?${ queryString }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
 		enabled: !! siteId,

--- a/client/my-sites/subscribers/subscriber-details-page.tsx
+++ b/client/my-sites/subscribers/subscriber-details-page.tsx
@@ -9,15 +9,15 @@ import { SubscriberPopover } from './components/subscriber-popover';
 import useSubscriberDetailsQuery from './queries/use-subscriber-details-query';
 
 type SubscriberDetailsPageProps = {
-	subscriberId?: number;
+	subscriptionId?: number;
 	userId?: number;
 };
 
-const SubscriberDetailsPage = ( { subscriberId, userId }: SubscriberDetailsPageProps ) => {
+const SubscriberDetailsPage = ( { subscriptionId, userId }: SubscriberDetailsPageProps ) => {
 	const translate = useTranslate();
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
-	const { data: subscriber } = useSubscriberDetailsQuery( selectedSiteId, subscriberId, userId );
+	const { data: subscriber } = useSubscriberDetailsQuery( selectedSiteId, subscriptionId, userId );
 
 	const navigationItems: Item[] = [
 		{
@@ -26,7 +26,7 @@ const SubscriberDetailsPage = ( { subscriberId, userId }: SubscriberDetailsPageP
 		},
 		{
 			label: translate( 'Details' ),
-			href: `/subscribers/${ selectedSiteSlug }/${ subscriberId }`,
+			href: `/subscribers/${ selectedSiteSlug }/${ subscriptionId }`,
 		},
 	];
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78367

## Proposed Changes

* Extract getSubscriberDetailsUrl
* Rename prop to subscriptionId for consistency
* Update GET individual subscription query to pass subscription type

## Testing Instructions

* Apply this PR to your local
* Apply this patch D114186-code and sandbox public-api.wordpress.com
* Edit the `SubscriberPopover` on `subscriber-row` to enable the view menu option using `isViewButtonVisible`
* Go to http://calypso.localhost:3000/subscribers/{site-slug}
* Click to view an external subscriber
* You should be redirected to `/subscribers/external/:slug/:subscriber_id` route and should see the user's name, email and avatar
* Go back and click to view a subscriber with wpcom account
* You should be redirected to `/subscribers/:slug/:user_id` route and should see the user's name, email and avatar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?