### PR TITLE
Congrats: Mobile header css bugfix

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
@@ -1,11 +1,13 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenter, HelpCenterSelect } from '@automattic/data-stores';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
 import {
 	useDispatch as useDataStoreDispatch,
 	useSelect as useDataStoreSelect,
 } from '@wordpress/data';
+import { Icon, help } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 
 const HELP_CENTER_STORE = HelpCenter.register();
@@ -29,6 +31,7 @@ const ContactContainer = styled.div`
 
 export function DefaultMasterbarContact() {
 	const translate = useTranslate();
+	const isDesktop = useDesktopBreakpoint();
 
 	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const isShowingHelpCenter = useDataStoreSelect(
@@ -47,12 +50,20 @@ export function DefaultMasterbarContact() {
 		setShowHelpCenter( ! isShowingHelpCenter );
 	};
 
-	return (
-		<ContactContainer>
+	const content = isDesktop ? (
+		<>
 			<label>{ translate( 'Need extra help?' ) }</label>&nbsp;
 			<Button className="marketplace-thank-you-help-center" isLink onClick={ toggleHelpCenter }>
 				{ translate( 'Visit Help Center.' ) }
 			</Button>
-		</ContactContainer>
+		</>
+	) : (
+		<>
+			<Button className="marketplace-thank-you-help-center" isLink onClick={ toggleHelpCenter }>
+				<Icon size={ 24 } icon={ help } />
+			</Button>
+		</>
 	);
+
+	return <ContactContainer>{ content }</ContactContainer>;
 }


### PR DESCRIPTION
Related to [#dotcom-for](https://github.com/Automattic/dotcom-forge/issues/2804)

## Proposed Changes

Following the Figma design (VLoPHWqcewxNKZYjjkDu3O-fi-2414%3A3215), we removed the help text with an icon.

## Testing Instructions

* Purchase a free theme or plugin
* In the congrats screen, you should see an icon instead of the help text.
* Check for no changes on desktop
* Check for click to work as before.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/16af1a6f-077b-40b8-968e-580738a03546) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/ab0e883a-3d8e-4506-96f5-a5c603606533) |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~