### PR TITLE
Subscription Management: Rework recommended site tracks implementation.

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
@@ -16,6 +16,8 @@ import {
 	useRecordPostEmailsToggle,
 	useRecordCommentEmailsToggle,
 	useRecordPostEmailsSetFrequency,
+	SOURCE_SUBSCRIPTIONS_SITE_LIST,
+	SOURCE_SUBSCRIPTIONS_UNSUBSCRIBED_NOTICE,
 } from '../../tracks';
 import { Link } from '../link';
 import { SiteSettingsPopover } from '../settings';
@@ -74,8 +76,8 @@ type SiteRowProps = Reader.SiteSubscription & {
 };
 
 const SiteRow = ( {
-	blog_ID,
-	feed_ID,
+	blog_ID: blog_id,
+	feed_ID: feed_id,
 	name,
 	site_icon,
 	URL: url,
@@ -123,11 +125,6 @@ const SiteRow = ( {
 	const recordSiteUnsubscribed = useRecordSiteUnsubscribed();
 	const recordSiteResubscribed = useRecordSiteResubscribed();
 
-	// Make object assignment a little easier
-	const SOURCE_SUBSCRIPTIONS_SITE_LIST = 'subscriptions-site-list';
-	const blog_id = blog_ID;
-	const feed_id = feed_ID;
-
 	const unsubscribeSuccessCallback = () => {
 		recordSiteUnsubscribed( { blog_id, url, source: SOURCE_SUBSCRIPTIONS_SITE_LIST } );
 		dispatch(
@@ -141,7 +138,7 @@ const SiteRow = ( {
 						recordSiteResubscribed( {
 							blog_id,
 							url,
-							source: 'subscriptions-unsubscribed-notice',
+							source: SOURCE_SUBSCRIPTIONS_UNSUBSCRIBED_NOTICE,
 						} );
 					},
 				}
@@ -153,13 +150,13 @@ const SiteRow = ( {
 
 	const siteTitleUrl = useMemo( () => {
 		if ( portal === ReaderPortal ) {
-			return `/read/feeds/${ feed_ID }`;
+			return `/read/feeds/${ feed_id }`;
 		}
 
 		if ( portal === SubscriptionsPortal ) {
-			return `/subscriptions/site/${ blog_ID }`;
+			return `/subscriptions/site/${ blog_id }`;
 		}
-	}, [ blog_ID, feed_ID, portal ] );
+	}, [ blog_id, feed_id, portal ] );
 
 	const handleNotifyMeOfNewPostsChange = ( send_posts: boolean ) => {
 		// Update post notification settings
@@ -285,7 +282,7 @@ const SiteRow = ( {
 					updatingEmailMeNewComments={ updatingEmailMeNewComments }
 					onUnsubscribe={ () =>
 						unsubscribe(
-							{ blog_id: blog_ID, url, doNotInvalidateSiteSubscriptions: true },
+							{ blog_id, url, doNotInvalidateSiteSubscriptions: true },
 							{ onSuccess: unsubscribeSuccessCallback }
 						)
 					}

--- a/client/landing/subscriptions/tracks/constants.ts
+++ b/client/landing/subscriptions/tracks/constants.ts
@@ -1,0 +1,2 @@
+export const SOURCE_SUBSCRIPTIONS_SITE_LIST = 'subscriptions-site-list';
+export const SOURCE_SUBSCRIPTIONS_UNSUBSCRIBED_NOTICE = 'subscriptions-unsubscribed-notice';

--- a/client/landing/subscriptions/tracks/index.ts
+++ b/client/landing/subscriptions/tracks/index.ts
@@ -9,6 +9,5 @@ export { default as useRecordCommentEmailsToggle } from './use-record-comment-em
 export { default as useRecordNotificationsToggle } from './use-record-notifications-toggle';
 export { default as useRecordPostEmailsSetFrequency } from './use-record-post-emails-set-frequency';
 export { default as useRecordPostEmailsToggle } from './use-record-post-emails-toggle';
-// export { default as useRecordRecommendedSiteSubscribed } from './use-record-recommended-site-subscribed';
-// export { default as useRecordRecommendedSiteUnsubscribed } from './use-record-recommended-site-unsubscribed';
-// export { default as useRecordRecommendedSiteDismissed } from './use-record-recommended-site-dismissed';
+export { default as useRecordRecommendedSiteSubscribed } from './use-record-recommended-site-subscribed';
+export { default as useRecordRecommendedSiteDismissed } from './use-record-recommended-site-dismissed';

--- a/client/landing/subscriptions/tracks/index.ts
+++ b/client/landing/subscriptions/tracks/index.ts
@@ -1,3 +1,5 @@
+export const SOURCE_SUBSCRIPTIONS_SITE_LIST = 'subscriptions-site-list';
+export const SOURCE_SUBSCRIPTIONS_UNSUBSCRIBED_NOTICE = 'subscriptions-unsubscribed-notice';
 export { default as useRecordSubscriptionsTracksEvent } from './use-record-subscriptions-tracks-event';
 export { default as useRecordSiteSubscribed } from './use-record-site-subscribed';
 export { default as useRecordSiteUnsubscribed } from './use-record-site-unsubscribed';

--- a/client/landing/subscriptions/tracks/index.ts
+++ b/client/landing/subscriptions/tracks/index.ts
@@ -1,5 +1,4 @@
-export const SOURCE_SUBSCRIPTIONS_SITE_LIST = 'subscriptions-site-list';
-export const SOURCE_SUBSCRIPTIONS_UNSUBSCRIBED_NOTICE = 'subscriptions-unsubscribed-notice';
+export * from './constants';
 export { default as useRecordSubscriptionsTracksEvent } from './use-record-subscriptions-tracks-event';
 export { default as useRecordSiteSubscribed } from './use-record-site-subscribed';
 export { default as useRecordSiteUnsubscribed } from './use-record-site-unsubscribed';

--- a/client/landing/subscriptions/tracks/use-record-recommended-site-dismissed.tsx
+++ b/client/landing/subscriptions/tracks/use-record-recommended-site-dismissed.tsx
@@ -1,0 +1,20 @@
+import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
+
+const useRecordRecommendedSiteDismissed = () => {
+	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
+
+	const recordRecommendedSiteDismissed = ( tracksProps: {
+		blog_id: string;
+		url: string;
+		source?: string;
+	} ) => {
+		recordSubscriptionsTracksEvent(
+			'calypso_subscriptions_recommended_site_dismissed',
+			tracksProps
+		);
+	};
+
+	return recordRecommendedSiteDismissed;
+};
+
+export default useRecordRecommendedSiteDismissed;

--- a/client/landing/subscriptions/tracks/use-record-recommended-site-subscribed.tsx
+++ b/client/landing/subscriptions/tracks/use-record-recommended-site-subscribed.tsx
@@ -1,0 +1,25 @@
+import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks-event';
+
+const useRecordRecommendedSiteSubscribed = () => {
+	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
+
+	const recordRecommendedSiteSubscribed = ( tracksProps: {
+		blog_id: string;
+		url: string;
+		source?: string;
+	} ) => {
+		recordSubscriptionsTracksEvent(
+			'calypso_subscriptions_recommended_site_subscribed',
+			tracksProps
+		);
+
+		// Also record the calypso_subscriptions_site_subscribed event.
+		// reader: calypso_reader_site_followed (ui_algo: following_manage)
+		// subscriptions: calypso_subscriptions_site_subscribed (ui_algo: (not included))
+		recordSubscriptionsTracksEvent( 'calypso_subscriptions_site_subscribed', tracksProps );
+	};
+
+	return recordRecommendedSiteSubscribed;
+};
+
+export default useRecordRecommendedSiteSubscribed;

--- a/client/reader/recommended-sites/recommended-site.tsx
+++ b/client/reader/recommended-sites/recommended-site.tsx
@@ -166,7 +166,7 @@ const RecommendedSite = ( {
 		} );
 
 		// reader: action: site_followed, railcar, ui_algo, ui_position, fetch_algo, fetch_position, fetch_lang,rec_blog_id, (incorrect: only railcar & action accepted)
-		// subman: action: recommended
+		// subman: action: recommended_site_subscribed, railcar
 		recordTrainTracksInteract( {
 			railcarId,
 			action: 'recommended_site_subscribed',

--- a/client/reader/recommended-sites/recommended-site.tsx
+++ b/client/reader/recommended-sites/recommended-site.tsx
@@ -17,6 +17,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { AnyAction } from 'redux';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import { Railcar } from 'calypso/data/marketplace/types';
+import { useSubscriptionManagerContext } from 'calypso/landing/subscriptions/components/subscription-manager-context';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import connectSite from 'calypso/lib/reader-connect-site';
@@ -32,7 +33,6 @@ import { Site } from 'calypso/state/data-layer/wpcom/read/sites/types';
 import { follow } from 'calypso/state/reader/follows/actions';
 import isReaderFollowFeedLoading from 'calypso/state/reader/follows/selectors/is-reader-follow-feed-loading';
 import { dismissSite } from 'calypso/state/reader/site-dismissals/actions';
-import { useSubscriptionManagerContext } from '../../landing/subscriptions/components/subscription-manager-context';
 import {
 	useRecordSiteIconClicked,
 	useRecordSiteTitleClicked,
@@ -102,7 +102,7 @@ const RecommendedSite = ( {
 	useEffect( () => {
 		if ( railcar ) {
 			// reader: railcar, ui_algo: following_manage_recommended_site, ui_position, fetch_algo, fetch_position, rec_blog_id (incorrect: fetch_lang, action)
-			// submain: railcar, ui_algo: subscriptions_recommended_site, ui_position, fetch_algo, fetch_position, rec_blog_id
+			// subman: railcar, ui_algo: subscriptions_recommended_site, ui_position, fetch_algo, fetch_position, rec_blog_id
 			recordTrainTracksRender( {
 				railcarId,
 				uiAlgo: 'subscriptions_recommended_site',

--- a/client/reader/recommended-sites/recommended-sites.tsx
+++ b/client/reader/recommended-sites/recommended-sites.tsx
@@ -1,10 +1,10 @@
+import { Railcar } from '@automattic/calypso-analytics';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import DotPager from 'calypso/components/dot-pager';
-import { Railcar } from 'calypso/data/marketplace/types';
 import { requestRecommendedSites } from 'calypso/state/reader/recommended-sites/actions';
 import {
 	getReaderRecommendedSites,
@@ -19,10 +19,12 @@ const displayRecommendedSitesTotal = 2;
 
 export const seed = Math.floor( Math.random() * 10001 );
 
-type RecommendedSite = {
+type RecommendedSiteType = {
 	ID: number;
+	URL: string;
 	blogId: number;
 	feedId: number;
+	feedUrl: string;
 	railcar?: Railcar;
 };
 
@@ -53,7 +55,7 @@ const RecommendedSites = () => {
 	const dispatch = useDispatch();
 
 	const recommendedSites = useSelector(
-		( state ) => getReaderRecommendedSites( state, seed ) as RecommendedSite[]
+		( state ) => getReaderRecommendedSites( state, seed ) as RecommendedSiteType[]
 	);
 
 	const offset = useSelector( ( state ) => getReaderRecommendedSitesPagingOffset( state, seed ) );

--- a/client/reader/recommended-sites/recommended-sites.tsx
+++ b/client/reader/recommended-sites/recommended-sites.tsx
@@ -20,12 +20,11 @@ const displayRecommendedSitesTotal = 2;
 export const seed = Math.floor( Math.random() * 10001 );
 
 type RecommendedSiteType = {
-	ID: number;
-	URL: string;
 	blogId: number;
 	feedId: number;
-	feedUrl: string;
-	railcar?: Railcar;
+	railcar: Railcar;
+	title: string;
+	url: string;
 };
 
 const RecommendedSitesResponsiveContainer: React.FC = ( { children } ) => {

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -24,7 +24,7 @@ export const fromApi = ( { algorithm, sites } ) =>
 		feedId: site.feed_id,
 		blogId: site.blog_id,
 		title: decodeEntities( site.blog_title ),
-		url: site.blog_url,
+		url: site.blog_url ?? site.URL,
 		railcar: site.railcar,
 		algorithm,
 	} ) );

--- a/packages/calypso-analytics/src/index.ts
+++ b/packages/calypso-analytics/src/index.ts
@@ -21,3 +21,5 @@ export {
 	recordTrainTracksInteract,
 	getNewRailcarId,
 } from './train-tracks';
+
+export type { Railcar } from './train-tracks';

--- a/packages/calypso-analytics/src/train-tracks.ts
+++ b/packages/calypso-analytics/src/train-tracks.ts
@@ -1,6 +1,14 @@
 import { v4 as uuid } from 'uuid';
 import { recordTracksEvent } from './tracks';
 
+export type Railcar = {
+	railcar: string;
+	fetch_algo: string;
+	fetch_lang: string;
+	fetch_position: number;
+	rec_blog_id: string;
+} & Record< string, string | number >;
+
 interface TrainTracksRenderProps {
 	railcarId: string;
 	uiAlgo: string;

--- a/packages/calypso-analytics/src/train-tracks.ts
+++ b/packages/calypso-analytics/src/train-tracks.ts
@@ -6,8 +6,13 @@ interface TrainTracksRenderProps {
 	uiAlgo: string;
 	uiPosition: number;
 	fetchAlgo: string;
-	result: string;
-	query: string;
+	fetchPosition?: number;
+	result?: string;
+	query?: string;
+	recBlogId?: string;
+	recPostId?: string;
+	recFeedId?: string;
+	recFeedItemId?: string;
 }
 
 interface TrainTracksInteractProps {
@@ -20,17 +25,32 @@ export function recordTrainTracksRender( {
 	uiAlgo,
 	uiPosition,
 	fetchAlgo,
-	result,
+	fetchPosition,
 	query,
+	result,
+	recBlogId,
+	recPostId,
+	recFeedId,
+	recFeedItemId,
 }: TrainTracksRenderProps ) {
-	recordTracksEvent( 'calypso_traintracks_render', {
+	const props: { [ key: string ]: string | number } = {};
+
+	// Remap and filter undefined props
+	Object.entries( {
 		railcar: railcarId,
 		ui_algo: uiAlgo,
 		ui_position: uiPosition,
 		fetch_algo: fetchAlgo,
-		rec_result: result,
 		fetch_query: query,
-	} );
+		fetch_position: fetchPosition,
+		rec_result: result,
+		rec_blog_id: recBlogId,
+		rec_post_id: recPostId,
+		rec_feed_id: recFeedId,
+		rec_feed_item_id: recFeedItemId,
+	} ).forEach( ( [ key, val ] ) => val !== undefined && ( props[ key ] = val ) );
+
+	recordTracksEvent( 'calypso_traintracks_render', props );
 }
 
 export function recordTrainTracksInteract( { railcarId, action }: TrainTracksInteractProps ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/78487 https://github.com/Automattic/wp-calypso/issues/78372

This PR is branched off `add/subscriptions-tracks-base` from the following PR. https://github.com/Automattic/wp-calypso/pull/78580

## Proposed Changes

* No more relying on reader's `stats.js` library as that library is code soup.
* Migrate over to the official functions `recordTrainTracksRender` and `recordTrainTracksInteract` function from `@automattic/calypso-analytics`.
* All TrainTracksRender & TrainTracksInteract track event properties are cleaned-up to ensure they stick to the proper usage guideline set out on the fieldguide.
* Introduced the following tracks events:
  * calypso-subscriptions-recommended-site-subscribed
  * calypso-subscriptions-recommended-site-unsubscribed (unused)
  * calypso-subscriptions-recommended-site-dismissed
* Ensure additional `bumpStats` and `gaRecordEvent` still continues to execute for parity with Reader.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Setup:**
* Set `localStorage.setItem( 'debug', 'calypso:analytics*' );` on your console.
* On your network panel, filter to `.gif`.

**Test:**
* Go to `/read/subscriptions`.
* Try the following actions on the recommended site:
  * Subscribe a recommended site
  * Dismiss a recommended site
  * Click on the site title
  * Click on the site icon
  * Click on the site url
* Monitor the tracks event on the console log or the network panel.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
