### PR TITLE
Reader: remove unused showPostHeader prop

### DIFF
--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -76,7 +76,6 @@ const FeedStream = ( props ) => {
 			emptyContent={ emptyContent }
 			listName={ title }
 			showFollowButton={ false }
-			showPostHeader={ false }
 			showSiteNameOnCards={ false }
 			sidebarTabTitle={ translate( 'Related' ) }
 			streamSidebar={ streamSidebar }

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -72,7 +72,6 @@ const SiteStream = ( props ) => {
 			emptyContent={ emptyContent }
 			listName={ title }
 			showFollowButton={ false }
-			showPostHeader={ false }
 			showSiteNameOnCards={ false }
 			sidebarTabTitle={ translate( 'Related' ) }
 			streamSidebar={ streamSidebar }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -73,7 +73,6 @@ class ReaderStream extends Component {
 		showDefaultEmptyContentIfMissing: PropTypes.bool,
 		showFollowButton: PropTypes.bool,
 		showFollowInHeader: PropTypes.bool,
-		showPostHeader: PropTypes.bool,
 		sidebarTabTitle: PropTypes.string,
 		streamHeader: PropTypes.element,
 		streamSidebar: PropTypes.element,
@@ -93,7 +92,6 @@ class ReaderStream extends Component {
 		showDefaultEmptyContentIfMissing: true,
 		showFollowButton: true,
 		showFollowInHeader: false,
-		showPostHeader: true,
 		suppressSiteNameLink: false,
 		useCompactCards: false,
 	};
@@ -434,7 +432,6 @@ class ReaderStream extends Component {
 					handleClick={ showPost }
 					postKey={ postKey }
 					suppressSiteNameLink={ this.props.suppressSiteNameLink }
-					showPostHeader={ this.props.showPostHeader }
 					showFollowInHeader={ this.props.showFollowInHeader }
 					isDiscoverStream={ this.props.isDiscoverStream }
 					showSiteName={ this.props.showSiteNameOnCards }


### PR DESCRIPTION
## Proposed Changes

* Removes the unused `showPostHeader` prop from the Reader Stream component

## Testing Instructions

- Check for JS errors in Reader
- Ensure `showPostHeader` is not present anywhere else in wp-calypso