### PR TITLE
Reader: use compact cards for site and feed streams

### DIFF
--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -33,6 +33,7 @@ const ReaderPostActions = ( props ) => {
 		visitUrl,
 		fullPost,
 		translate,
+		showFollow,
 	} = props;
 
 	const [ isSuggestedFollowsModalOpen, setIsSuggestedFollowsModalOpen ] = useState( false );
@@ -97,7 +98,7 @@ const ReaderPostActions = ( props ) => {
 					isVisible={ isSuggestedFollowsModalOpen }
 				/>
 			) }
-			{ shouldShowLikes( post ) && (
+			{ showFollow && shouldShowLikes( post ) && (
 				<li className="reader-post-actions__item">
 					<ReaderFollowButton
 						siteUrl={ post.feed_URL || post.site_URL }
@@ -149,6 +150,7 @@ ReaderPostActions.propTypes = {
 	site: PropTypes.object,
 	onCommentClick: PropTypes.func,
 	showEdit: PropTypes.bool,
+	showFollow: PropTypes.bool,
 	showViews: PropTypes.bool,
 	showSuggestedFollows: PropTypes.bool,
 	iconSize: PropTypes.number,
@@ -158,6 +160,7 @@ ReaderPostActions.propTypes = {
 
 ReaderPostActions.defaultProps = {
 	showEdit: true,
+	showFollow: true,
 	showViews: false,
 	showVisit: false,
 	showSuggestedFollows: false,

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -47,6 +47,7 @@ class ReaderPostCard extends Component {
 		isWPForTeamsItem: PropTypes.bool,
 		teams: PropTypes.array,
 		hasOrganization: PropTypes.bool,
+		showFollowButton: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -54,6 +55,7 @@ class ReaderPostCard extends Component {
 		onCommentClick: noop,
 		isSelected: false,
 		showSiteName: true,
+		showFollowButton: true,
 	};
 
 	propagateCardClick = () => {
@@ -128,6 +130,7 @@ class ReaderPostCard extends Component {
 			hasOrganization,
 			isWPForTeamsItem,
 			teams,
+			showFollowButton,
 		} = this.props;
 
 		let isSeen = false;
@@ -158,6 +161,7 @@ class ReaderPostCard extends Component {
 				post={ discoverPost || post }
 				site={ site }
 				visitUrl={ post.URL }
+				showFollow={ showFollowButton }
 				showVisit={ true }
 				fullPost={ false }
 				onCommentClick={ onCommentClick }

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -55,6 +55,8 @@ class FeedStream extends Component {
 				emptyContent={ emptyContent }
 				showPostHeader={ false }
 				showSiteNameOnCards={ false }
+				useCompactCards={ true }
+				showFollowButton={ false }
 			>
 				<DocumentHead
 					title={ this.props.translate( '%s ‹ Reader', {

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -61,6 +61,8 @@ class SiteStream extends Component {
 				showPostHeader={ false }
 				showSiteNameOnCards={ false }
 				isDiscoverStream={ this.props.isDiscoverStream }
+				useCompactCards={ true }
+				showFollowButton={ false }
 			>
 				<DocumentHead
 					title={ this.props.translate( '%s ‹ Reader', {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -93,6 +93,7 @@ class ReaderStream extends Component {
 		intro: PropTypes.object,
 		forcePlaceholders: PropTypes.bool,
 		recsStreamKey: PropTypes.string,
+		showFollowButton: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -107,6 +108,7 @@ class ReaderStream extends Component {
 		useCompactCards: false,
 		intro: null,
 		forcePlaceholders: false,
+		showFollowButton: true,
 	};
 
 	state = {
@@ -457,6 +459,7 @@ class ReaderStream extends Component {
 					index={ index }
 					compact={ this.props.useCompactCards }
 					siteId={ primarySiteId }
+					showFollowButton={ this.props.showFollowButton }
 				/>
 				{ index === 0 && <PerformanceTrackerStop /> }
 			</Fragment>

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -78,6 +78,7 @@ class ReaderPostCardAdapter extends Component {
 				isDiscoverStream={ this.props.isDiscoverStream }
 				postKey={ this.props.postKey }
 				compact={ this.props.compact }
+				showFollowButton={ this.props.showFollowButton }
 			>
 				{ feedId && <QueryReaderFeed feedId={ feedId } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } /> }


### PR DESCRIPTION
## Proposed Changes

* Updates the site and feed streams in Reader to use the compact card layout introduced in https://github.com/Automattic/wp-calypso/pull/78411/files
* Hides the follow button in the action bar in the site feed, since you can follow/unfollow the site at the top of the page

## Testing Instructions

* Visit the site (e.g. /read/feeds/2283439) and feed(e.g. /read/feeds/68709138) streams, and see the new compact layout, sans follow button.
* Visit other reader pages to check for regressions (tag, following, etc should still show the follow button)

| **Before** | **After** |
| - | - |
| <img width="688" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1699996/7e48136c-24c2-4552-98d4-354f52b53bd7"> | <img width="660" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1699996/0f67a5f2-1a6e-418a-8004-421f9812d144"> |

