### PR TITLE
Add-Ons: Show Quantity for Storage Add On in Purchases View

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -20,6 +20,7 @@ import {
 	isDIFMProduct,
 	isJetpackSearchFree,
 	isAkismetProduct,
+	PRODUCT_1GB_SPACE,
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import { encodeProductForUrl } from '@automattic/wpcom-checkout';
@@ -243,6 +244,11 @@ export function getDisplayName( purchase: Purchase ): TranslateResult {
 	if ( jetpackProductsDisplayNames[ purchase.productSlug ] ) {
 		return jetpackProductsDisplayNames[ purchase.productSlug ];
 	}
+
+	if ( purchase.productSlug === PRODUCT_1GB_SPACE && purchase.purchaseRenewalQuantity ) {
+		return `${ getName( purchase ) } ${ purchase.purchaseRenewalQuantity } GB`;
+	}
+
 	return getName( purchase );
 }
 

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -12,6 +12,7 @@ import {
 	isTitanMail,
 	isConciergeSession,
 	getJetpackProductsDisplayNames,
+	getStorageAddOnDisplayName,
 	isWpComPlan,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
@@ -20,7 +21,7 @@ import {
 	isDIFMProduct,
 	isJetpackSearchFree,
 	isAkismetProduct,
-	PRODUCT_1GB_SPACE,
+	isTieredVolumeSpaceAddon,
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import { encodeProductForUrl } from '@automattic/wpcom-checkout';
@@ -240,13 +241,15 @@ export function getName( purchase: Purchase ): string {
 }
 
 export function getDisplayName( purchase: Purchase ): TranslateResult {
+	const { productName, productSlug, purchaseRenewalQuantity } = purchase;
+
 	const jetpackProductsDisplayNames = getJetpackProductsDisplayNames();
-	if ( jetpackProductsDisplayNames[ purchase.productSlug ] ) {
-		return jetpackProductsDisplayNames[ purchase.productSlug ];
+	if ( jetpackProductsDisplayNames[ productSlug ] ) {
+		return jetpackProductsDisplayNames[ productSlug ];
 	}
 
-	if ( purchase.productSlug === PRODUCT_1GB_SPACE && purchase.purchaseRenewalQuantity ) {
-		return `${ getName( purchase ) } ${ purchase.purchaseRenewalQuantity } GB`;
+	if ( isTieredVolumeSpaceAddon( purchase ) ) {
+		return getStorageAddOnDisplayName( productName, purchaseRenewalQuantity );
 	}
 
 	return getName( purchase );

--- a/packages/calypso-products/src/get-storage-addon-display-name.ts
+++ b/packages/calypso-products/src/get-storage-addon-display-name.ts
@@ -1,5 +1,9 @@
 import { translate } from 'i18n-calypso';
 
+/* translators: Information about a recurring yearly payment made by a subscriber to a site owner.
+				%(productName)s - the title of the purchase in the purchase history views,
+				%(quantity)s - the amount of storage purchased in gigabytes
+				GB - gigabytes */
 export function getStorageAddOnDisplayName( productName: string, quantity: number | null ) {
 	if ( quantity ) {
 		return translate( '%(productName)s %(quantity)s GB', {

--- a/packages/calypso-products/src/get-storage-addon-display-name.ts
+++ b/packages/calypso-products/src/get-storage-addon-display-name.ts
@@ -1,0 +1,14 @@
+import { translate } from 'i18n-calypso';
+
+export function getStorageAddOnDisplayName( productName: string, quantity: number | null ) {
+	if ( quantity ) {
+		return translate( '%(productName)s %(quantity)s GB', {
+			args: {
+				productName,
+				quantity,
+			},
+		} );
+	}
+
+	return productName;
+}

--- a/packages/calypso-products/src/index.ts
+++ b/packages/calypso-products/src/index.ts
@@ -7,3 +7,4 @@ export * from './product-values';
 export * from './get-interval-type-for-term';
 export * from './get-price-tier-for-units';
 export * from './is-tiered-volume-space-addon';
+export * from './get-storage-addon-display-name';


### PR DESCRIPTION
Fixes 1724-gh-Automattic/martech

### Proposed Changes
This PR adds the quantity for purchased storage add-on inside the `/me/purchases` and `/purchases/subscriptions`

### Testing Instructions
1. Checkout this branch
2. Run `yarn` and `yarn start`
3. Create a new testing site
4. Go to `http://calypso.localhost:3000/add-ons/YOUR_SITE_SLUG` and purchase one of the available space upgrades:

![image](https://github.com/Automattic/wp-calypso/assets/20927667/e17475f3-e96e-4ee0-b1c7-8f8e0591f295)

5. Go to `http://calypso.localhost:3000/purchases/subscriptions/YOUR_SITE_SLUG` and confirm you see the storage quantity displayed in the product title:

![image](https://github.com/Automattic/wp-calypso/assets/20927667/bb7d1ef4-6f4b-4788-878e-066524953608)

6. Go to `http://calypso.localhost:3000/me/purchases` and confirm you see the storage quantity displayed in the product title:

![image](https://github.com/Automattic/wp-calypso/assets/20927667/301b9345-7377-4f19-996a-6c353d2de5be)
