### PR TITLE
Domains: Add link to top bar, domains attached to sites are still managed in My Sites

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -211,7 +211,8 @@ class Layout extends Component {
 
 		return (
 			<MasterbarComponent
-				section={ this.props.sectionGroup }
+				sectionGroup={ this.props.sectionGroup }
+				section={ this.props.sectionName }
 				isCheckout={ this.props.sectionName === 'checkout' }
 				isCheckoutPending={ this.props.sectionName === 'checkout-pending' }
 				loadHelpCenterIcon={ loadHelpCenterIcon }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -155,7 +155,16 @@ class MasterbarLoggedIn extends Component {
 
 	clickDomains = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_domains_clicked' );
-		this.handleLayoutFocus( 'sites' );
+
+		if ( 'domains' !== this.props.section ) {
+			// When switching to domains we close the sidebar.
+			this.props.setNextLayoutFocus( 'content' );
+		} else {
+			// When current group is focused then open or close the sidebar depending on current state.
+			'sidebar' === this.props.currentLayoutFocus
+				? this.props.setNextLayoutFocus( 'content' )
+				: this.props.setNextLayoutFocus( 'sidebar' );
+		}
 	};
 
 	clickReader = () => {
@@ -234,6 +243,7 @@ class MasterbarLoggedIn extends Component {
 			translate,
 			isCustomerHomeEnabled,
 			sectionGroup,
+			section,
 		} = this.props;
 		const { isMenuOpen, isResponsiveMenu } = this.state;
 
@@ -246,7 +256,7 @@ class MasterbarLoggedIn extends Component {
 		const icon =
 			this.state.isMobile && this.props.isInEditor ? 'chevron-left' : this.wordpressIcon();
 
-		if ( 'sites' === sectionGroup && isResponsiveMenu ) {
+		if ( 'sites' === sectionGroup && 'domains' !== section && isResponsiveMenu ) {
 			mySitesUrl = '';
 		}
 		if ( ! siteSlug && sectionGroup === 'sites-dashboard' ) {

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -152,6 +152,10 @@ class MasterbarLoggedIn extends Component {
 		}
 	};
 
+	clickDomains = () => {
+		this.props.setNextLayoutFocus( 'content' );
+	};
+
 	clickReader = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_reader_clicked' );
 		this.handleLayoutFocus( 'reader' );
@@ -175,6 +179,10 @@ class MasterbarLoggedIn extends Component {
 
 	preloadMySites = () => {
 		preload( this.props.domainOnlySite ? 'domains' : 'stats' );
+	};
+
+	preloadDomains = () => {
+		preload( 'domains' );
 	};
 
 	preloadReader = () => {
@@ -282,6 +290,25 @@ class MasterbarLoggedIn extends Component {
 				isLeavingAllowed={ ! isCheckoutPending }
 				loadHelpCenterIcon={ loadHelpCenterIcon }
 			/>
+		);
+	}
+
+	renderDomains( showLabel = true ) {
+		const { translate } = this.props;
+		return (
+			<Item
+				tipTarget="domains"
+				className="masterbar__domains"
+				url="/domains/manage"
+				icon="domains"
+				onClick={ this.clickDomains }
+				isActive={ this.isActive( 'domains' ) }
+				tooltip={ translate( 'Manage domains' ) }
+				preloadSection={ this.preloadDomains }
+			>
+				{ showLabel &&
+					translate( 'Domains', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
+			</Item>
 		);
 	}
 
@@ -521,6 +548,7 @@ class MasterbarLoggedIn extends Component {
 					<Masterbar>
 						<div className="masterbar__section masterbar__section--left">
 							{ this.renderMySites() }
+							{ this.renderDomains( false ) }
 							{ this.renderReader( false ) }
 							{ this.renderLanguageSwitcher() }
 							{ this.renderSearch() }
@@ -541,6 +569,7 @@ class MasterbarLoggedIn extends Component {
 				<Masterbar>
 					<div className="masterbar__section masterbar__section--left">
 						{ this.renderMySites() }
+						{ this.renderDomains() }
 						{ this.renderReader() }
 						{ this.renderLanguageSwitcher() }
 						{ this.renderSearch() }

--- a/client/sections.js
+++ b/client/sections.js
@@ -236,7 +236,7 @@ const sections = [
 		name: 'domains',
 		paths: [ '/domains' ],
 		module: 'calypso/my-sites/domains',
-		group: 'domains',
+		group: 'sites',
 	},
 	{
 		name: 'incoming-redirect',

--- a/client/sections.js
+++ b/client/sections.js
@@ -236,7 +236,7 @@ const sections = [
 		name: 'domains',
 		paths: [ '/domains' ],
 		module: 'calypso/my-sites/domains',
-		group: 'sites',
+		group: 'domains',
 	},
 	{
 		name: 'incoming-redirect',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78586

## Proposed Changes

Follows on from the discussion at p1687387772424839-slack-C029GN3KD, this is an alternative to the proposal at #78586.

In this alternative proposal:
- Clicking **Domains** allows you to manage all your domains
- Clicking a domain attached to a site will navigate you back to **My Sites** where you manage the site-specific details of the domain
- Clicking a domain which isn't attached to a site (a "domain only site" in Calypso parlance) doesn't switch back to **My Sites**
- Navigating to **My Sites** and choosing the **Domains** from the sidebar stays within the **My Sites** area.
- Sends a `calypso_masterbar_domains_clicked` event when link is clicked, similar to the other links

In this approach **Domains** isn't really a new section in Calypso, we've just hardcoded a new link to appear in the top toolbar.

I've also done a small refactor to the `<MasterbarLoggedIn>` component; renaming the `section` prop to `sectionGroup` since this is always what it's referred to and it's always been very confusing to me.

See a video of it in action here: p1687745234405809-slack-C04H4NY6STW

| Desktop | Mobile |
| ---------| -------|
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/8680906c-fba9-4339-94a4-8152a1a774f9) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/61454faa-0517-4622-afa4-995c579837ab) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Calypso and verify that clicking the "Domains" link sends the user to `/domains/manage`
- Verify that the icon is showing without the label on mobile
- Verify the link becomes active (different, lighter background colour) in the top bar
- Verify the link is not active when working with a domain which is attached to a site
- Test with a "domain only site". Do this by purchasing a domain through the `/domains` flow and clicking **Just by a domain** when prompted.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?