### PR TITLE
[DO NOT MERGE] Theme Showcase: Add Assemble your site button to options

### DIFF
--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -1,9 +1,10 @@
 import { Onboard } from '@automattic/data-stores';
-import { BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
 import { useFlowProgress, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
+import { getTheme } from 'calypso/state/themes/selectors';
 import { useQuery } from '../hooks/use-query';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
@@ -14,7 +15,6 @@ import ProcessingStep from './internals/steps-repository/processing-step';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import { Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect } from '@automattic/data-stores';
-import type { Design } from '@automattic/design-picker/src/types';
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -27,25 +27,28 @@ const withThemeAssemblerFlow: Flow = {
 		);
 		const { setSelectedDesign, setIntent } = useDispatch( ONBOARD_STORE );
 		const selectedTheme = useQuery().get( 'theme' );
+		const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedTheme ) );
 
-		// We have to query theme for the Jetpack site.
 		useQueryTheme( 'wpcom', selectedTheme );
 
 		useEffect( () => {
-			if ( selectedTheme === BLANK_CANVAS_DESIGN.slug ) {
-				// User has selected blank-canvas-3 theme from theme showcase and enter assembler flow
-				setSelectedDesign( {
-					...selectedDesign,
-					...BLANK_CANVAS_DESIGN,
-					recipe: {
-						...selectedDesign?.recipe,
-						...BLANK_CANVAS_DESIGN.recipe,
-					},
-				} as Design );
+			if ( ! theme ) {
+				return;
 			}
 
+			setSelectedDesign( {
+				...selectedDesign,
+				slug: theme.id,
+				title: theme.name,
+				recipe: {
+					...selectedDesign?.recipe,
+					stylesheet: theme.stylesheet,
+				},
+				design_type: 'assembler',
+			} );
+
 			setIntent( SiteIntent.WithThemeAssembler );
-		}, [] );
+		}, [ theme ] );
 	},
 
 	useSteps() {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
 import { mapValues, pickBy, flowRight as compose } from 'lodash';
@@ -218,6 +219,25 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			! isThemeActive( state, themeId, siteId ),
 	};
 
+	const assembleSite = {
+		label: translate( 'Assemble your site' ),
+		getUrl: ( state, themeId, siteId ) => {
+			const slug = getSiteSlug( state, siteId );
+
+			return addQueryArgs( `/setup/with-theme-assembler`, {
+				siteSlug: slug,
+				theme: themeId,
+			} );
+		},
+		hideForTheme: ( state, themeId, siteId ) =>
+			! isEnabled( 'themes/assemble-site' ) ||
+			! isUserLoggedIn( state ) ||
+			isJetpackSiteMultiSite( state, siteId ) ||
+			( isExternallyManagedTheme( state, themeId ) &&
+				! isMarketplaceThemeSubscribed( state, themeId, siteId ) ) ||
+			( ! isWpcomTheme( state, themeId ) && ! isSiteWpcomAtomic( state, siteId ) ),
+	};
+
 	if ( isFSEActive ) {
 		customize.label = translate( 'Edit', { comment: "label for button to edit a theme's design" } );
 		customize.extendedLabel = translate( 'Edit this design' );
@@ -297,6 +317,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 		tryandcustomize,
 		deleteTheme,
 		signup,
+		assembleSite,
 		separator,
 		info,
 	};

--- a/config/development.json
+++ b/config/development.json
@@ -194,6 +194,7 @@
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
+		"themes/assemble-site": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-poc": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -130,6 +130,7 @@
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
+		"themes/assemble-site": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-poc": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/production.json
+++ b/config/production.json
@@ -157,6 +157,7 @@
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
+		"themes/assemble-site": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-poc": false,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -151,6 +151,7 @@
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
+		"themes/assemble-site": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-poc": false,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -163,6 +163,7 @@
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
+		"themes/assemble-site": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-poc": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/packages/global-styles/src/hooks/use-color-palette-variations.ts
+++ b/packages/global-styles/src/hooks/use-color-palette-variations.ts
@@ -11,6 +11,7 @@ const useColorPaletteVariations = (
 	stylesheet: string,
 	{ enabled = true }: Options = {}
 ) => {
+	const searchParams = new URLSearchParams( window.location.search );
 	const { data } = useQuery< any, unknown, GlobalStylesObject[] >( {
 		queryKey: [ 'global-styles-color-palette', siteId, stylesheet ],
 		queryFn: async () =>
@@ -18,7 +19,9 @@ const useColorPaletteVariations = (
 				path: `/sites/${ encodeURIComponent( siteId ) }/global-styles-variation/color-palettes`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
-				query: new URLSearchParams( { stylesheet } ).toString(),
+				query: new URLSearchParams( {
+					stylesheet: searchParams.get( 'stylesheet' ) ?? stylesheet,
+				} ).toString(),
 			} ),
 		refetchOnMount: 'always',
 		staleTime: Infinity,

--- a/packages/global-styles/src/hooks/use-font-pairing-variations.ts
+++ b/packages/global-styles/src/hooks/use-font-pairing-variations.ts
@@ -11,6 +11,7 @@ const useFontPairingVariations = (
 	stylesheet: string,
 	{ enabled = true }: Options = {}
 ) => {
+	const searchParams = new URLSearchParams( window.location.search );
 	const { data } = useQuery< any, unknown, GlobalStylesObject[] >( {
 		queryKey: [ 'global-styles-font-pairings', siteId, stylesheet ],
 		queryFn: async () =>
@@ -18,7 +19,9 @@ const useFontPairingVariations = (
 				path: `/sites/${ encodeURIComponent( siteId ) }/global-styles-variation/font-pairings`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
-				query: new URLSearchParams( { stylesheet } ).toString(),
+				query: new URLSearchParams( {
+					stylesheet: searchParams.get( 'stylesheet' ) ?? stylesheet,
+				} ).toString(),
 			} ),
 		refetchOnMount: 'always',
 		staleTime: Infinity,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Introduce a new option called `Assemble your site` to the options of the theme, and use the feature flag `themes/assemble-site` to control whether to display the option.
* When you pick the new option, you will land on the Assembler with the selected theme.
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/b1b003c4-6358-4ddf-9f85-a65336504598)

* Besides, you're able to customize the stylesheet of the variations for the design preview!
  * e.g.: `/setup/site-setup/designSetup?siteSlug=<your_site>&flags=signup%2Fdesign-picker-preview-colors&theme=poema&stylesheet=pub%2Fcreatio`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Theme Showcase
* Click `...` on the any theme
* Pick `Assemble your site`
* Ensure you're heading to the Assembler
* Pick any patterns, and the default styles should be the same as the selected theme

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
