### PR TITLE
Jetpack Pro Dashboard: fix monitoring notifications settings UI on small screens

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal-form/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal-form/style.scss
@@ -2,13 +2,15 @@
 @import "@wordpress/base-styles/breakpoints";
 
 .dashboard-modal-form__footer {
-	margin-block-end: 32px;
 	width: calc(100% - 64px); // reducing the left and right padding
 	display: flex;
 	justify-content: flex-start;
 	flex-direction: column;
 	position: absolute;
 	bottom: 0;
+	left: 0;
+	padding: 16px 32px;
+	background: var(--studio-white);
 
 	.dashboard-modal-form__footer-buttons {
 		display: flex;
@@ -29,8 +31,8 @@
 		justify-content: right;
 		flex-direction: initial;
 		margin-block-start: 32px;
-		margin-block-end: 0;
 		width: auto;
+		padding: 0;
 
 		.dashboard-modal-form__footer-buttons {
 			justify-content: end;

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
@@ -1,14 +1,38 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
+
 .dashboard-modal {
 	max-height: 100%;
 	width: 480px;
 	animation: components-modal__appear-animation 0.1s ease-out;
 	animation-fill-mode: forwards;
+
+	.components-modal__content {
+		margin-block-start: 50px;
+		padding-block-end: 120px;
+
+		@include break-mobile {
+			margin-block-start: 76px;
+			padding-block-end: 32px;
+		}
+	}
+
+	form {
+		margin-block-start: 32px;
+
+		@include break-mobile {
+			margin-block-start: 16px;
+		}
+	}
 }
 
 .dashboard-modal__sub-title {
 	font-size: 0.75rem;
 	line-height: 14px;
 	color: var(--studio-gray-50);
-	position: absolute;
-	inset-block-start: 50px;
+
+	@include break-mobile {
+		position: absolute;
+		inset-block-start: 50px;
+	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
@@ -17,8 +17,13 @@
 		}
 	}
 
+	.components-modal__header {
+		background: var(--studio-white);
+		padding-block-end: 24px;
+	}
+
 	form {
-		margin-block-start: 32px;
+		margin-block-start: 48px;
 
 		@include break-mobile {
 			margin-block-start: 16px;
@@ -30,9 +35,7 @@
 	font-size: 0.75rem;
 	line-height: 14px;
 	color: var(--studio-gray-50);
-
-	@include break-mobile {
-		position: absolute;
-		inset-block-start: 50px;
-	}
+	position: absolute;
+	inset-block-start: 38px;
+	z-index: 99;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
@@ -38,4 +38,5 @@
 	position: absolute;
 	inset-block-start: 38px;
 	z-index: 99;
+	padding-inline-end: 50px;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
@@ -19,6 +19,11 @@
 
 .notification-settings__content {
 	margin-block-start: -16px;
+	padding-block-end: 120px;
+
+	@include break-mobile {
+		padding-block-end: 0;
+	}
 }
 
 .notification-settings__content-heading-with-beta {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
+
 .configure-downtime-notification__help-text {
 	font-weight: 400;
 	font-size: 0.75rem;
@@ -34,18 +37,26 @@
 }
 
 .configure-contact__phone-input {
-	display: flex;
-
 	fieldset {
 		margin-block-end: 0;
 
 		&:first-child {
-			width: 50%;
-			margin-inline-end: 8px;
+			width: 100%;
+			margin-block-end: 16px;
 
 			select {
 				width: inherit;
 			}
+
+			@include break-mobile {
+				width: 50%;
+				margin-inline-end: 8px;
+				margin-block-end: 0;
+			}
 		}
+	}
+
+	@include break-mobile {
+		display: flex;
 	}
 }


### PR DESCRIPTION
Related to 1204774821045518-as-1204874377449112

## Proposed Changes

This PR fixes the monitor notification settings UI on small screens

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**
1. Run `git checkout fix/monitor-notification-settings-small-screen-ui` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the `/dashboard`.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Verify the UI looks good on small-screen devices(<425px) and large-screen devices

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="319" alt="Screenshot 2023-06-26 at 10 59 58 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/79a67f9b-37d1-490f-b30e-130a077d779f">
</td>
<td>
<img width="315" alt="Screenshot 2023-06-26 at 10 47 45 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/589725a0-3ce0-4f61-a49b-a2809e7d5313">
</td>
</tr>
<tr>
<td>
<img width="312" alt="Screenshot 2023-06-26 at 11 00 20 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0b997a89-7c18-45ff-beeb-563d664b3fc9">
</td>
<td>
<img width="324" alt="Screenshot 2023-06-26 at 10 22 02 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f72d885e-b293-4149-a693-a28e0b7ae88a">
</td>
</tr>
<tr>
<td>
<img width="313" alt="Screenshot 2023-06-26 at 11 01 16 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b22c66f0-4101-4d9b-aacc-48baccbe54c7">
</td>
<td>
<img width="310" alt="Screenshot 2023-06-26 at 11 01 08 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/7705c090-9e33-44c5-90b4-87ea5f93120b">
</td>
</tr>

</table>






## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?