### PR TITLE
Jetpack Pro Dashboard: disable close on outside modal click for dashboard form modal to support auto-fill

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal-form/index.tsx
@@ -22,6 +22,7 @@ export default function DashboardModalForm( {
 
 	return (
 		<DashboardModal
+			shouldCloseOnClickOutside={ false }
 			title={ title }
 			subtitle={ subtitle }
 			onClose={ onClose }

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/index.tsx
@@ -10,6 +10,7 @@ export type DashboardModalProps = {
 	onClose: () => void;
 	subtitle?: ReactNode;
 	title: string;
+	shouldCloseOnClickOutside?: boolean;
 };
 
 export default function DashboardModal( {
@@ -18,9 +19,11 @@ export default function DashboardModal( {
 	onClose,
 	subtitle,
 	title,
+	shouldCloseOnClickOutside = true,
 }: DashboardModalProps ) {
 	return (
 		<Modal
+			shouldCloseOnClickOutside={ shouldCloseOnClickOutside }
 			open={ true }
 			onRequestClose={ onClose }
 			title={ title }


### PR DESCRIPTION
Related to 1204774821045518-as-1204874377449120

## Proposed Changes

This PR fixes an issue with auto-fill form values that cause the modal to close.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**
1. Run `git checkout /fix/auto-fill-dashboard-form-fields` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the `/dashboard`.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Enable the email notification toggle -> Click the "+ Add email address" button -> Focus the cursor on the Email field -> Select a suggestion from the password manager or auto-fill -> Verify that the modal doesn't close after selecting. You can verify this on any field in the SMS or email fields. 

<img width="470" alt="Screenshot 2023-06-26 at 11 20 33 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ec571a6a-53ad-4ef0-a96f-231ee4b3671e">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?