### PR TITLE
Reader search: show followed site, don't show unmatched site.

### DIFF
--- a/client/reader/search-stream/search-follow-button.jsx
+++ b/client/reader/search-stream/search-follow-button.jsx
@@ -71,11 +71,6 @@ class SearchFollowButton extends Component {
 			return null;
 		}
 
-		// If already following this feed then don't show the follow button
-		if ( feed.is_following === true ) {
-			return null;
-		}
-
 		let followTitle = withoutHttp( query );
 		// Use the feed name if available on the feed object
 		if ( feed?.name?.length > 0 ) {

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -118,7 +118,7 @@ export default connect(
 				return uniqueFeeds;
 			}, [] );
 
-			// Rremove single result if it does not match the query
+			// Remove single result if it does not match the query
 			if ( feedResults.length === 1 ) {
 				const isMatch = feedResults[ 0 ].feed_URL?.includes( urlToDomainAndPath( ownProps.query ) );
 


### PR DESCRIPTION
Fix two minor issues with reader search, follow up on https://github.com/Automattic/wp-calypso/pull/78555/


# Testing instructions
### Show empty results page for not found *.wordpress.com URLs see[ original comment](https://github.com/Automattic/wp-calypso/pull/78555#discussion_r1241632865)
Search for e.g. `sadjofosajgnogmrasognrsagnsfogasgomras-.wordpress.com`, you should see the normal "no results found" state

### Return already followed site.
Search for the url of a site, follow it, refresh the page.
Search again, you should be able to unfollow it.