### PR TITLE
Subscriptions Management: Styling fixes on reader portal.

### DIFF
--- a/client/landing/subscriptions/hooks/use-subheader-text.tsx
+++ b/client/landing/subscriptions/hooks/use-subheader-text.tsx
@@ -20,7 +20,7 @@ const useSubheaderText = () => {
 				}
 			);
 		}
-		return translate( 'Manage your WordPress.com newsletter and blog subscriptions.' );
+		return translate( 'Manage your WordPress.com blog and newsletter subscriptions.' );
 	}, [ emailAddress, translate ] );
 };
 

--- a/client/reader/recommended-sites/style.scss
+++ b/client/reader/recommended-sites/style.scss
@@ -56,6 +56,7 @@
 			font-size: $font-body;
 			line-height: rem(22px);
 			color: $studio-gray-100;
+			margin-right: 36px; // width of dismiss button
 			@extend %ellipsis;
 		}
 

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -6,7 +6,7 @@
 	&.main {
 		max-width: 1168px;
 		min-height: 100vh;
-		margin: 0;
+		margin: 0 auto;
 		padding: 0 32px;
 
 		@extend %search-component-subscriptions-style;
@@ -35,6 +35,15 @@
 				margin-bottom: 0;
 			}
 		}
+	}
+
+	hr.subscriptions__separator {
+		width: 100%;
+		height: 0;
+		margin: 0;
+		padding: 0;
+		border: none;
+		border-top: 1px solid $studio-gray-5;
 	}
 
 	&__import-export-popover {


### PR DESCRIPTION
## Proposed Changes

* Align center subscriptions container.
* Fix extra whitespace on unsubscribe button.
* Ensure recommended site title doesn't go below dismiss button.
* Reorder blog and newsletter, prioritizing blog (this was an input from Saygun).

## Testing Instructions

* Go to `/read/subscriptions`.
* The above listed issues should be fixed.

**Screenshot (when it was broken):**
<img width="409" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/ca327c06-6851-4860-8210-1d943391beeb">
<img width="467" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/71e7a460-9d64-46ea-a668-41b01487b320">
<img width="1946" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/d44cd423-075f-4907-8810-9e4f495c3356">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
