### PR TITLE
Fix/edge cache UI

### DIFF
--- a/client/my-sites/hosting/cache-card/index.js
+++ b/client/my-sites/hosting/cache-card/index.js
@@ -104,7 +104,7 @@ export const CacheCard = ( {
 	const isClearingCache = isClearingWordpressCache || clearEdgeCacheLoading;
 
 	const clearCache = () => {
-		if ( isEdgeCacheActive ) {
+		if ( isEdgeCacheActive && showEdgeCache ) {
 			clearEdgeCache();
 		}
 		clearAtomicWordPressCache( siteId, 'Manually clearing again.' );
@@ -121,8 +121,7 @@ export const CacheCard = ( {
 						disabled ||
 						isClearingCache ||
 						shouldRateLimitCacheClear ||
-						getEdgeCacheLoading ||
-						toggleEdgeCacheLoading
+						( showEdgeCache && ( getEdgeCacheLoading || toggleEdgeCacheLoading ) )
 					}
 				>
 					<span>{ translate( 'Clear cache' ) }</span>

--- a/client/my-sites/hosting/cache-card/index.js
+++ b/client/my-sites/hosting/cache-card/index.js
@@ -31,6 +31,8 @@ const EdgeCacheDescription = styled.p( {
 } );
 
 const EdgeCacheNotice = styled.p( {
+	fontSize: '14px',
+	fontStyle: 'italic',
 	color: '#646970',
 	marginTop: '18px',
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1687766612113259-slack-C04GESRBWKW

## Proposed Changes

This pr fixes some issues when the edge cache feature is disabled, and some UI elements to match the other hosting cards.

## Testing Instructions



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Pre test
1. Create a site and make it atomic.
2. Visit `Settings > Hosting` configuration and find the `Cache section`

### Test Edge Cache button

1a. Change `yolo/edge-cache-i1` flag in `development.json`.

When `edge-cache-i1` feature is **enabled**:
1b. Ensure that the `Clear cache`  button is enabled
2. When clicked the endpoint `/hosting/edge-cache/active` is called

When `edge-cache-i1` feature is **disabled**:
1b. Ensure that the `Clear cache`  button is enabled
2. When clicked the endpoint `/hosting/edge-cache/active` is *not* called

### Test edge cache notice section

1. Ensure that the notice section looks the same as other hosting section cards:
![edge_cache_notice_sectionpng](https://github.com/Automattic/wp-calypso/assets/497103/dce1ec91-617b-40d9-9095-4a884cd0a318)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?