### PR TITLE
Add-Ons: Add Loading State for Add On Cards

### DIFF
--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -1,5 +1,5 @@
 import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, Spinner } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
@@ -105,16 +105,19 @@ const AddOnCard = ( {
 		actionSecondary?.handler( addOnMeta.productSlug );
 	};
 
+	const shouldRenderLoadingState =
+		addOnMeta.productSlug === PRODUCT_1GB_SPACE && addOnMeta.isLoading;
+
 	// if product is space upgrade choose the action based on the purchased status
 	const shouldRenderPrimaryAction =
 		addOnMeta.productSlug === PRODUCT_1GB_SPACE
-			? ! addOnMeta.purchased
-			: availabilityStatus?.available;
+			? ! addOnMeta.purchased && ! shouldRenderLoadingState
+			: availabilityStatus?.available && ! shouldRenderLoadingState;
 
 	const shouldRenderSecondaryAction =
 		addOnMeta.productSlug === PRODUCT_1GB_SPACE
-			? addOnMeta.purchased
-			: ! availabilityStatus?.available;
+			? addOnMeta.purchased && ! shouldRenderLoadingState
+			: ! availabilityStatus?.available && ! shouldRenderLoadingState;
 
 	return (
 		<Container>
@@ -137,6 +140,9 @@ const AddOnCard = ( {
 				</CardHeader>
 				<CardBody className="add-ons-card__body">{ addOnMeta.description }</CardBody>
 				<CardFooter isBorderless={ true } className="add-ons-card__footer">
+					{ shouldRenderLoadingState && (
+						<Spinner size={ 24 } className="spinner-button__spinner" />
+					) }
 					{ shouldRenderSecondaryAction && (
 						<>
 							{ actionSecondary && (

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -32,6 +32,7 @@ export interface AddOnMeta {
 	description: string | null;
 	displayCost: TranslateResult | null;
 	purchased?: boolean;
+	isLoading?: boolean;
 }
 
 // some memoization. executes far too many times
@@ -84,7 +85,7 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 	// if upgrade is bought - show as manage
 	// if upgrade is not bought - only show it if available storage and if it's larger than previously bought upgrade
 	const { data: mediaStorage } = useMediaStorageQuery( siteId );
-	const { billingTransactions } = usePastBillingTransactions();
+	const { billingTransactions, isLoading } = usePastBillingTransactions();
 
 	return useSelector( ( state ): ( AddOnMeta | null )[] => {
 		const filter = getBillingTransactionFilters( state, 'past' );
@@ -126,11 +127,22 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 						return null;
 					}
 
+					// if storage add on hasn't loaded yet
+					if ( isLoading || ! product ) {
+						return {
+							...addOn,
+							name,
+							description,
+							isLoading,
+						};
+					}
+
 					// if storage add on is already purchased
 					if (
 						spaceUpgradesPurchased.findIndex(
 							( spaceUpgrade ) => spaceUpgrade === addOn.quantity
-						) >= 0
+						) >= 0 &&
+						product
 					) {
 						return {
 							...addOn,


### PR DESCRIPTION
### Proposed Changes
Fixes 1856-gh-Automattic/martech
The storage add-on cards will now display a loading spinner component in the card footer while the data is being fetched. After the data is fetched we are displaying the correct action button - **Add** or **Manage**

Fixes 1857-gh-Automattic/martech
Previously we returned `null` for a card that hasn't loaded yet which caused one of the storage add-ons to be displayed for a brief time. Now we are checking if the `product` has loaded before rendering the card

### Testing Instructions
1. Checkout this branch
2. Run `yarn` and `yarn start`
3. Create a new testing site
4. Purchase a space upgrade add on
5. Go to the add-ons screen `http://calypso.localhost:3000/add-ons/YOUR_SITE_SLUG` and start refreshing the page repeatedly. Based on the time it takes for the data to be fetched you should be able to see a loading for the space upgrade cards:

https://github.com/Automattic/wp-calypso/assets/20927667/abce9a93-a1f8-4b3e-b499-2c0c1380670d

