### PR TITLE
Refactored out all instances of woocommerce core profiler selector

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -48,6 +48,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import Divider from './divider';
 import SocialLoginForm from './social';
 
@@ -798,12 +799,11 @@ export default connect(
 			oauth2Client: getCurrentOAuth2Client( state ),
 			isJetpackWooCommerceFlow:
 				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
-			isWooCoreProfilerFlow:
-				'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
+			isWooCoreProfilerFlow: isWooCommerceCoreProfilerFlow( state ),
 			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 			isWoo:
 				isWooOAuth2Client( getCurrentOAuth2Client( state ) ) ||
-				'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
+				isWooCommerceCoreProfilerFlow( state ),
 			isPartnerSignup: isPartnerSignupQuery( getCurrentQueryArguments( state ) ),
 			redirectTo: getRedirectToOriginal( state ),
 			requestError: getRequestError( state ),

--- a/client/blocks/login/social-login-tos.jsx
+++ b/client/blocks/login/social-login-tos.jsx
@@ -1,8 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import { connect } from 'react-redux';
-import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 
 function SocialLoginTos( props ) {
 	if ( props.isWooCoreProfilerFlow ) {
@@ -56,6 +55,5 @@ function SocialLoginTos( props ) {
 }
 
 export default connect( ( state ) => ( {
-	isWooCoreProfilerFlow:
-		'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
+	isWooCoreProfilerFlow: isWooCommerceCoreProfilerFlow( state ),
 } ) )( localize( SocialLoginTos ) );

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -59,6 +59,7 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { createSocialUserFailed } from 'calypso/state/login/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import CrowdsignalSignupForm from './crowdsignal';
 import P2SignupForm from './p2';
@@ -1288,8 +1289,7 @@ function TrackRender( { children, eventName } ) {
 export default connect(
 	( state, props ) => {
 		const oauth2Client = getCurrentOAuth2Client( state );
-		const isWooCoreProfilerFlow =
-			'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' );
+		const isWooCoreProfilerFlow = isWooCommerceCoreProfilerFlow( state );
 
 		return {
 			currentUser: getCurrentUser( state ),

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -13,8 +12,8 @@ import { login } from 'calypso/lib/paths';
 import { isWpccFlow } from 'calypso/signup/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
-import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import SocialSignupToS from './social-signup-tos';
 
 class SocialSignupForm extends Component {
@@ -191,7 +190,7 @@ export default connect(
 		oauth2Client: getCurrentOAuth2Client( state ),
 		isWoo:
 			isWooOAuth2Client( getCurrentOAuth2Client( state ) ) ||
-			'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
+			isWooCommerceCoreProfilerFlow( state ),
 	} ),
 	{ recordTracksEvent }
 )( localize( SocialSignupForm ) );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -34,6 +34,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import { getPreference } from 'calypso/state/preferences/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
@@ -344,7 +345,7 @@ export default withCurrentRoute(
 			currentRoute.startsWith( '/checkout/jetpack' );
 		const isWooCoreProfilerFlow =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
-			'woocommerce-core-profiler' === currentQuery?.from;
+			isWooCommerceCoreProfilerFlow( state );
 		const noMasterbarForRoute =
 			isJetpackLogin || currentRoute === '/me/account/closed' || isDomainAndPlanPackageFlow;
 		const noMasterbarForSection =

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -31,9 +31,9 @@ import {
 } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import { masterbarIsVisible } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
-
 import './style.scss';
 
 const LayoutLoggedOut = ( {
@@ -252,7 +252,7 @@ export default withCurrentRoute(
 			! isWooOAuth2Client( oauth2Client ) &&
 			[ 'signup', 'jetpack-connect' ].includes( sectionName );
 		const isJetpackWooCommerceFlow = 'woocommerce-onboarding' === currentQuery?.from;
-		const isWooCoreProfilerFlow = 'woocommerce-core-profiler' === currentQuery?.from;
+		const isWooCoreProfilerFlow = isWooCommerceCoreProfilerFlow( state );
 		const wccomFrom = currentQuery?.[ 'wccom-from' ];
 		const masterbarIsHidden =
 			! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute;

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -26,6 +26,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import { withEnhancers } from 'calypso/state/utils';
 import LoginLinks from './login-links';
 import PrivateSite from './private-site';
@@ -343,8 +344,7 @@ export default connect(
 			get( getCurrentQueryArguments( state ), 'from' ),
 			'wpcom-migration'
 		),
-		isWooCoreProfilerFlow:
-			'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
+		isWooCoreProfilerFlow: isWooCommerceCoreProfilerFlow( state ),
 	} ),
 	{
 		recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),

--- a/client/state/selectors/is-woocommerce-core-profiler-flow.ts
+++ b/client/state/selectors/is-woocommerce-core-profiler-flow.ts
@@ -1,0 +1,20 @@
+import { get } from 'lodash';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns true if the user reached Calypso via the WooCommerce Core Profiler flow.
+ * This is indicated by the `from` query argument being set to `woocommerce-core-profiler`.
+ *
+ * @param  {Object}   state  Global state tree
+ * @returns {?boolean}        Whether the user reached Calypso via the WooCommerce Core Profiler flow
+ */
+export const isWooCommerceCoreProfilerFlow = ( state: AppState ): boolean => {
+	return (
+		'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ) ||
+		'woocommerce-core-profiler' === get( getInitialQueryArguments( state ), 'from' )
+	);
+};
+
+export default isWooCommerceCoreProfilerFlow;

--- a/client/state/selectors/test/is-woocommerce-core-profiler-flow.js
+++ b/client/state/selectors/test/is-woocommerce-core-profiler-flow.js
@@ -1,0 +1,68 @@
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
+
+describe( 'isWooCommerceCoreProfilerFlow', () => {
+	test( 'should return false when no argument', () => {
+		expect( isWooCommerceCoreProfilerFlow() ).toBe( false );
+	} );
+
+	test( 'should return false if no query present', () => {
+		const state = {
+			route: {
+				query: {
+					current: {
+						email_address: 'user@wordpress.com',
+					},
+				},
+			},
+		};
+		expect( isWooCommerceCoreProfilerFlow( state ) ).toBe( false );
+	} );
+	test( 'should return false when from query parameter is present in current query but is not woocommerce-core-profiler', () => {
+		const state = {
+			route: {
+				query: {
+					current: {
+						from: 'meh',
+					},
+				},
+			},
+		};
+		expect( isWooCommerceCoreProfilerFlow( state ) ).toBe( false );
+	} );
+	test( 'should return false when from query parameter is present in initial query but is not woocommerce-core-profiler', () => {
+		const state = {
+			route: {
+				query: {
+					initial: {
+						from: 'meh',
+					},
+				},
+			},
+		};
+		expect( isWooCommerceCoreProfilerFlow( state ) ).toBe( false );
+	} );
+	test( 'should return true when from query parameter is present in current query and is woocommerce-core-profiler', () => {
+		const state = {
+			route: {
+				query: {
+					current: {
+						from: 'woocommerce-core-profiler',
+					},
+				},
+			},
+		};
+		expect( isWooCommerceCoreProfilerFlow( state ) ).toBe( true );
+	} );
+	test( 'should return true when from query parameter is present in initial query and is woocommerce-core-profiler', () => {
+		const state = {
+			route: {
+				query: {
+					initial: {
+						from: 'woocommerce-core-profiler',
+					},
+				},
+			},
+		};
+		expect( isWooCommerceCoreProfilerFlow( state ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

* Consolidated all instances where we were getting the query argument for 'from' === 'woocommerce-core-profiler' from state

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Trivial refactor, should be able to detect issues by reading the code really
* Otherwise, follow testing instructions for these PRs:
    - https://github.com/Automattic/wp-calypso/pull/77826
    - https://github.com/Automattic/wp-calypso/pull/77882
    - https://github.com/Automattic/wp-calypso/pull/77946
    - https://github.com/Automattic/wp-calypso/pull/78391
    - https://github.com/Automattic/wp-calypso/pull/78423

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
