### PR TITLE
Site Switcher: Make site icons square again

### DIFF
--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -83,12 +83,9 @@
 			align-items: center;
 			min-width: 0;
 
-			.site-icon {
-				fill: var(--color-text-subtle);
+			.subscriptions__site-icon {
 				width: 40px;
 				height: 40px;
-				flex: none;
-				border-radius: 50%;
 			}
 
 			.title-column {

--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -84,6 +84,7 @@
 			min-width: 0;
 
 			.subscriptions__site-icon {
+				flex: none;
 				width: 40px;
 				height: 40px;
 			}

--- a/client/landing/subscriptions/components/site-icon/site-icon.tsx
+++ b/client/landing/subscriptions/components/site-icon/site-icon.tsx
@@ -9,11 +9,17 @@ type SiteIconProps = {
 
 const SiteIcon = ( { iconUrl, size = 48, siteName }: SiteIconProps ) => {
 	if ( ! iconUrl ) {
-		return <Gridicon className="site-icon" icon="globe" size={ size } />;
+		return <Gridicon className="subscriptions__site-icon" icon="globe" size={ size } />;
 	}
 
 	return (
-		<img className="site-icon" src={ iconUrl } height={ size } width={ size } alt={ siteName } />
+		<img
+			className="subscriptions__site-icon"
+			src={ iconUrl }
+			height={ size }
+			width={ size }
+			alt={ siteName }
+		/>
 	);
 };
 

--- a/client/landing/subscriptions/components/site-icon/styles.scss
+++ b/client/landing/subscriptions/components/site-icon/styles.scss
@@ -1,4 +1,5 @@
-.site-icon {
+// The class name is intentionally prefixed with "site" to avoid conflicts with the "site-icon" class name which is used a lot, in other components, in Calypso
+.subscriptions__site-icon {
 	fill: var(--color-text-subtle);
 	flex: none;
 	border-radius: 50%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

| Before | After |
|:---:|:---:|
| <img src="https://github.com/Automattic/wp-calypso/assets/2019970/2543a179-0be2-4aae-b6e0-bdf29ab156c6" width="400" style="max-height:200px;"> | <img src="https://github.com/Automattic/wp-calypso/assets/2019970/559d4635-2683-49da-8790-c8ea1f9bcc7c" width="400" style="max-height:200px;"> |

Related to p1687769977039419-slack-C9EJ7KSGH

## Proposed Changes

* Redefine the `SiteIcon` component's class name in `landing/subscriptions/` as `subscriptions__site-icon`. This prevents naming conflicts in Calypso with the commonly used `.site-icon` class.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/read
* Click on "My Sites", this should take you to your Calypso's home page
* Click on "< Switch site" 
* Ensure that the site icons displayed beside each site item are not cropped into round shaped component, but instead are displayed as squares

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?