### PR TITLE
Limited GS on Personal: Update plans grid

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -317,6 +317,7 @@ type PlanComparisonGridProps = {
 	planActionOverrides?: PlanActionOverrides;
 	selectedPlan?: string;
 	selectedFeature?: string;
+	isGlobalStylesOnPersonal?: boolean;
 };
 
 type PlanComparisonGridHeaderProps = {
@@ -767,6 +768,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 	planActionOverrides,
 	selectedPlan,
 	selectedFeature,
+	isGlobalStylesOnPersonal,
 } ) => {
 	const translate = useTranslate();
 	// Check to see if we have at least one Woo Express plan we're comparing.
@@ -890,7 +892,8 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 
 			const wpcomFeatures = planObject.get2023PlanComparisonFeatureOverride
 				? planObject.get2023PlanComparisonFeatureOverride().slice()
-				: planObject.get2023PricingGridSignupWpcomFeatures?.().slice() ?? [];
+				: planObject.get2023PricingGridSignupWpcomFeatures?.( isGlobalStylesOnPersonal ).slice() ??
+				  [];
 
 			const jetpackFeatures = planObject.get2023PlanComparisonJetpackFeatureOverride
 				? planObject.get2023PlanComparisonJetpackFeatureOverride().slice()

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -45,6 +45,7 @@ import QueryActivePromotions from 'calypso/components/data/query-active-promotio
 import FoldableCard from 'calypso/components/foldable-card';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
+import { useExperiment } from 'calypso/lib/explat';
 import { FeatureObject, getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible';
@@ -136,6 +137,7 @@ type PlanFeatures2023GridConnectedProps = {
 	manageHref: string;
 	selectedSiteSlug: string | null;
 	isPlanUpgradeCreditEligible: boolean;
+	isGlobalStylesOnPersonal?: boolean;
 };
 
 type PlanFeatures2023GridType = PlanFeatures2023GridProps &
@@ -903,7 +905,7 @@ const withIsLargeCurrency = ( Component: LocalizedComponent< typeof PlanFeatures
 
 /* eslint-disable wpcalypso/redux-no-bound-selectors */
 const ConnectedPlanFeatures2023Grid = connect(
-	( state: IAppState, ownProps: PlanFeatures2023GridProps ) => {
+	( state: IAppState, ownProps: PlanFeatures2023GridType ) => {
 		const {
 			placeholder,
 			plans,
@@ -913,6 +915,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 			currentSitePlanSlug,
 			selectedFeature,
 			intent,
+			isGlobalStylesOnPersonal,
 		} = ownProps;
 		const canUserPurchasePlan =
 			! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId );
@@ -962,7 +965,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 				tagline = planConstantObj.getBlogOnboardingTagLine?.() ?? '';
 			} else {
 				planFeatures = getPlanFeaturesObject(
-					planConstantObj?.get2023PricingGridSignupWpcomFeatures?.() ?? []
+					planConstantObj?.get2023PricingGridSignupWpcomFeatures?.( isGlobalStylesOnPersonal ) ?? []
 				);
 
 				jetpackFeatures = getPlanFeaturesObject(
@@ -1090,12 +1093,14 @@ const ConnectedPlanFeatures2023Grid = connect(
 
 const WrappedPlanFeatures2023Grid = ( props: PlanFeatures2023GridType ) => {
 	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible( props.siteId, props.plans );
+	const [ , globalStylesOnPersonalExperiment ] = useExperiment( 'wpcom_global_styles_personal' );
 
 	if ( props.isInSignup ) {
 		return (
 			<ConnectedPlanFeatures2023Grid
 				{ ...props }
 				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
+				isGlobalStylesOnPersonal={ globalStylesOnPersonalExperiment?.variationName === 'treatment' }
 			/>
 		);
 	}
@@ -1105,6 +1110,7 @@ const WrappedPlanFeatures2023Grid = ( props: PlanFeatures2023GridType ) => {
 			<ConnectedPlanFeatures2023Grid
 				{ ...props }
 				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
+				isGlobalStylesOnPersonal={ globalStylesOnPersonalExperiment?.variationName === 'treatment' }
 			/>
 		</CalypsoShoppingCartProvider>
 	);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -295,6 +295,7 @@ export class PlanFeatures2023Grid extends Component<
 			selectedPlan,
 			selectedFeature,
 			intent,
+			isGlobalStylesOnPersonal,
 		} = this.props;
 		return (
 			<PlansGridContextProvider intent={ intent }>
@@ -344,6 +345,7 @@ export class PlanFeatures2023Grid extends Component<
 								siteId={ siteId }
 								selectedPlan={ selectedPlan }
 								selectedFeature={ selectedFeature }
+								isGlobalStylesOnPersonal={ isGlobalStylesOnPersonal }
 							/>
 							<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
 								<Button onClick={ this.toggleShowPlansComparisonGrid }>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -58,7 +58,6 @@ import {
 	getPlanSlug,
 } from 'calypso/state/plans/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
-import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
 import { getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
@@ -1095,14 +1094,12 @@ const ConnectedPlanFeatures2023Grid = connect(
 
 const WrappedPlanFeatures2023Grid = ( props: PlanFeatures2023GridType ) => {
 	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible( props.siteId, props.plans );
-	const { globalStylesInPersonalPlan } = useSiteGlobalStylesStatus( props.siteId );
 
 	if ( props.isInSignup ) {
 		return (
 			<ConnectedPlanFeatures2023Grid
 				{ ...props }
 				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
-				isGlobalStylesOnPersonal={ globalStylesInPersonalPlan }
 			/>
 		);
 	}
@@ -1112,7 +1109,6 @@ const WrappedPlanFeatures2023Grid = ( props: PlanFeatures2023GridType ) => {
 			<ConnectedPlanFeatures2023Grid
 				{ ...props }
 				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
-				isGlobalStylesOnPersonal={ globalStylesInPersonalPlan }
 			/>
 		</CalypsoShoppingCartProvider>
 	);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -946,17 +946,17 @@ const ConnectedPlanFeatures2023Grid = connect(
 
 			if ( 'plans-newsletter' === intent ) {
 				planFeatures = getPlanFeaturesObject(
-					planConstantObj?.getNewsletterSignupFeatures?.() ?? []
+					planConstantObj?.getNewsletterSignupFeatures?.( isGlobalStylesOnPersonal ) ?? []
 				);
 				tagline = planConstantObj.getNewsletterTagLine?.() ?? '';
 			} else if ( 'plans-link-in-bio' === intent ) {
 				planFeatures = getPlanFeaturesObject(
-					planConstantObj?.getLinkInBioSignupFeatures?.() ?? []
+					planConstantObj?.getLinkInBioSignupFeatures?.( isGlobalStylesOnPersonal ) ?? []
 				);
 				tagline = planConstantObj.getLinkInBioTagLine?.() ?? '';
 			} else if ( 'plans-blog-onboarding' === intent ) {
 				planFeatures = getPlanFeaturesObject(
-					planConstantObj?.getBlogOnboardingSignupFeatures?.() ?? []
+					planConstantObj?.getBlogOnboardingSignupFeatures?.( isGlobalStylesOnPersonal ) ?? []
 				);
 
 				jetpackFeatures = getPlanFeaturesObject(

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -45,7 +45,6 @@ import QueryActivePromotions from 'calypso/components/data/query-active-promotio
 import FoldableCard from 'calypso/components/foldable-card';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
-import { useExperiment } from 'calypso/lib/explat';
 import { FeatureObject, getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible';
@@ -59,6 +58,7 @@ import {
 	getPlanSlug,
 } from 'calypso/state/plans/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
+import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
 import { getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
@@ -1095,14 +1095,14 @@ const ConnectedPlanFeatures2023Grid = connect(
 
 const WrappedPlanFeatures2023Grid = ( props: PlanFeatures2023GridType ) => {
 	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible( props.siteId, props.plans );
-	const [ , globalStylesOnPersonalExperiment ] = useExperiment( 'calypso_global_styles_personal' );
+	const { globalStylesInPersonalPlan } = useSiteGlobalStylesStatus( props.siteId );
 
 	if ( props.isInSignup ) {
 		return (
 			<ConnectedPlanFeatures2023Grid
 				{ ...props }
 				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
-				isGlobalStylesOnPersonal={ globalStylesOnPersonalExperiment?.variationName === 'treatment' }
+				isGlobalStylesOnPersonal={ globalStylesInPersonalPlan }
 			/>
 		);
 	}
@@ -1112,7 +1112,7 @@ const WrappedPlanFeatures2023Grid = ( props: PlanFeatures2023GridType ) => {
 			<ConnectedPlanFeatures2023Grid
 				{ ...props }
 				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
-				isGlobalStylesOnPersonal={ globalStylesOnPersonalExperiment?.variationName === 'treatment' }
+				isGlobalStylesOnPersonal={ globalStylesInPersonalPlan }
 			/>
 		</CalypsoShoppingCartProvider>
 	);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -950,12 +950,12 @@ const ConnectedPlanFeatures2023Grid = connect(
 				planFeatures = getPlanFeaturesObject(
 					planConstantObj?.getNewsletterSignupFeatures?.( isGlobalStylesOnPersonal ) ?? []
 				);
-				tagline = planConstantObj.getNewsletterTagLine?.() ?? '';
+				tagline = planConstantObj.getNewsletterTagLine?.( isGlobalStylesOnPersonal ) ?? '';
 			} else if ( 'plans-link-in-bio' === intent ) {
 				planFeatures = getPlanFeaturesObject(
 					planConstantObj?.getLinkInBioSignupFeatures?.( isGlobalStylesOnPersonal ) ?? []
 				);
-				tagline = planConstantObj.getLinkInBioTagLine?.() ?? '';
+				tagline = planConstantObj.getLinkInBioTagLine?.( isGlobalStylesOnPersonal ) ?? '';
 			} else if ( 'plans-blog-onboarding' === intent ) {
 				planFeatures = getPlanFeaturesObject(
 					planConstantObj?.getBlogOnboardingSignupFeatures?.( isGlobalStylesOnPersonal ) ?? []
@@ -964,7 +964,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 				jetpackFeatures = getPlanFeaturesObject(
 					planConstantObj.getBlogOnboardingSignupJetpackFeatures?.() ?? []
 				);
-				tagline = planConstantObj.getBlogOnboardingTagLine?.() ?? '';
+				tagline = planConstantObj.getBlogOnboardingTagLine?.( isGlobalStylesOnPersonal ) ?? '';
 			} else {
 				planFeatures = getPlanFeaturesObject(
 					planConstantObj?.get2023PricingGridSignupWpcomFeatures?.( isGlobalStylesOnPersonal ) ?? []
@@ -973,7 +973,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 				jetpackFeatures = getPlanFeaturesObject(
 					planConstantObj.get2023PricingGridSignupJetpackFeatures?.() ?? []
 				);
-				tagline = planConstantObj.getPlanTagline?.() ?? '';
+				tagline = planConstantObj.getPlanTagline?.( isGlobalStylesOnPersonal ) ?? '';
 			}
 
 			const rawPrice = getPlanRawPrice( state, planProductId, showMonthlyPrice );

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -1093,7 +1093,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 
 const WrappedPlanFeatures2023Grid = ( props: PlanFeatures2023GridType ) => {
 	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible( props.siteId, props.plans );
-	const [ , globalStylesOnPersonalExperiment ] = useExperiment( 'wpcom_global_styles_personal' );
+	const [ , globalStylesOnPersonalExperiment ] = useExperiment( 'calypso_global_styles_personal' );
 
 	if ( props.isInSignup ) {
 		return (

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -30,6 +30,7 @@ import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
+import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { FreePlanPaidDomainDialog } from './components/free-plan-paid-domain-dialog';
@@ -138,6 +139,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 	const showDomainUpsellDialog = useCallback( () => {
 		setShowDomainUpsellDialog( true );
 	}, [ setShowDomainUpsellDialog ] );
+	const { globalStylesInPersonalPlan } = useSiteGlobalStylesStatus( siteId );
 
 	let planActionOverrides;
 	if ( sitePlanSlug && isFreePlan( sitePlanSlug ) ) {
@@ -183,6 +185,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		currentSitePlanSlug: sitePlanSlug,
 		planActionOverrides,
 		intent,
+		isGlobalStylesOnPersonal: globalStylesInPersonalPlan,
 	};
 
 	const asyncPlanFeatures2023Grid = (

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -18,6 +18,9 @@ jest.mock( 'calypso/state/purchases/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan', () => jest.fn() );
 jest.mock( 'calypso/state/selectors/can-upgrade-to-plan', () => jest.fn() );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSiteId: jest.fn(),
+} ) );
 
 import {
 	GROUP_WPCOM,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -807,10 +807,10 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		i18n.translate(
 			'Jumpstart your Newsletter with a custom domain, ad-free experience, and the ability to sell subscriptions, take payments, and collect donations from day one. Backed with email support to help get everything just right.'
 		),
-	getNewsletterSignupFeatures: () => [
+	getNewsletterSignupFeatures: ( isGlobalStylesOnPersonal = false ) => [
 		FEATURE_CUSTOM_DOMAIN,
-		FEATURE_STYLE_CUSTOMIZATION,
 		FEATURE_UNLIMITED_SUBSCRIBERS,
+		...( isGlobalStylesOnPersonal ? [ FEATURE_STYLE_CUSTOMIZATION ] : [] ),
 		FEATURE_SUPPORT_EMAIL,
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_PAYMENT_TRANSACTION_FEES_8,
@@ -824,18 +824,18 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		i18n.translate(
 			'Stand out and unlock earnings with an ad-free site, custom domain, and the ability to sell subscriptions, take payments, and collect donations. Backed with email support to help get your site just right.'
 		),
-	getLinkInBioSignupFeatures: () => [
+	getLinkInBioSignupFeatures: ( isGlobalStylesOnPersonal = false ) => [
 		FEATURE_CUSTOM_DOMAIN,
-		FEATURE_STYLE_CUSTOMIZATION,
+		...( isGlobalStylesOnPersonal ? [ FEATURE_STYLE_CUSTOMIZATION ] : [] ),
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_SUPPORT_EMAIL,
 		FEATURE_COLLECT_PAYMENTS_LINK_IN_BIO,
 		FEATURE_PAID_SUBSCRIBERS_JP,
 	],
 	getLinkInBioHighlightedFeatures: () => [ FEATURE_CUSTOM_DOMAIN ],
-	getBlogOnboardingSignupFeatures: () => [
+	getBlogOnboardingSignupFeatures: ( isGlobalStylesOnPersonal = false ) => [
 		FEATURE_CUSTOM_DOMAIN,
-		FEATURE_STYLE_CUSTOMIZATION,
+		...( isGlobalStylesOnPersonal ? [ FEATURE_STYLE_CUSTOMIZATION ] : [] ),
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_FAST_DNS,
 		FEATURE_SUPPORT_EMAIL,
@@ -1281,10 +1281,10 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		i18n.translate(
 			'Take your Newsletter further, faster. Get everything included in Personal, plus premium design themes, baked-in video uploads, ad monetization, deep visitor insights from Google Analytics, and live chat support.'
 		),
-	getNewsletterSignupFeatures: () => [
+	getNewsletterSignupFeatures: ( isGlobalStylesOnPersonal = false ) => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_LIVE_CHAT_SUPPORT,
-		FEATURE_STYLE_CUSTOMIZATION,
+		...( isGlobalStylesOnPersonal ? [] : [ FEATURE_STYLE_CUSTOMIZATION ] ),
 		FEATURE_PREMIUM_THEMES_V2,
 		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
 		FEATURE_VIDEOPRESS_JP,
@@ -1302,20 +1302,20 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		i18n.translate(
 			'Take your site further, faster. Get everything included in Personal, plus premium design themes, baked-in video uploads, ad monetization, deep visitor insights from Google Analytics, and live chat support.'
 		),
-	getLinkInBioSignupFeatures: () => [
+	getLinkInBioSignupFeatures: ( isGlobalStylesOnPersonal = false ) => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_LIVE_CHAT_SUPPORT,
 		FEATURE_PREMIUM_THEMES_V2,
-		FEATURE_STYLE_CUSTOMIZATION,
+		...( isGlobalStylesOnPersonal ? [] : [ FEATURE_STYLE_CUSTOMIZATION ] ),
 		FEATURE_VIDEOPRESS_JP,
 		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
 		FEATURE_WORDADS,
 	],
 	getLinkInBioHighlightedFeatures: () => [ FEATURE_CUSTOM_DOMAIN ],
-	getBlogOnboardingSignupFeatures: () => [
+	getBlogOnboardingSignupFeatures: ( isGlobalStylesOnPersonal = false ) => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_PREMIUM_THEMES_V2,
-		FEATURE_STYLE_CUSTOMIZATION,
+		...( isGlobalStylesOnPersonal ? [] : [ FEATURE_STYLE_CUSTOMIZATION ] ),
 		FEATURE_LIVE_CHAT_SUPPORT,
 		FEATURE_WORDADS,
 		FEATURE_PAYMENT_TRANSACTION_FEES_4,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -733,17 +733,34 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	getBlogAudience: () => i18n.translate( 'Best for personal use' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for personal use' ),
 	getStoreAudience: () => i18n.translate( 'Best for personal use' ),
-	getPlanTagline: () => i18n.translate( 'Create your home on the web with a custom domain name.' ),
-	getNewsletterTagLine: () =>
-		i18n.translate( 'Monetize your writing, go ad-free, and expand your media content.' ),
-	getLinkInBioTagLine: () =>
-		i18n.translate(
-			'Take Link In Bio to the next level with gated content, paid subscribers, and an ad-free site.'
-		),
-	getBlogOnboardingTagLine: () =>
-		i18n.translate(
-			'Take the next step with gated content, paid subscribers, and an ad-free site.'
-		),
+	getPlanTagline: ( isGlobalStylesOnPersonal = false ) =>
+		isGlobalStylesOnPersonal
+			? i18n.translate(
+					'Create your home on the web with a custom domain name and powerful design tools.'
+			  )
+			: i18n.translate( 'Create your home on the web with a custom domain name.' ),
+	getNewsletterTagLine: ( isGlobalStylesOnPersonal = false ) =>
+		isGlobalStylesOnPersonal
+			? i18n.translate(
+					'Monetize your writing, go ad-free, and expand your media content with powerful design tools.'
+			  )
+			: i18n.translate( 'Monetize your writing, go ad-free, and expand your media content.' ),
+	getLinkInBioTagLine: ( isGlobalStylesOnPersonal = false ) =>
+		isGlobalStylesOnPersonal
+			? i18n.translate(
+					'Take Link In Bio to the next level with gated content, paid subscribers, and an ad-free site with powerful design tools.'
+			  )
+			: i18n.translate(
+					'Take Link In Bio to the next level with gated content, paid subscribers, and an ad-free site.'
+			  ),
+	getBlogOnboardingTagLine: ( isGlobalStylesOnPersonal = false ) =>
+		isGlobalStylesOnPersonal
+			? i18n.translate(
+					'Take the next step with gated content, paid subscribers, and an ad-free site with powerful design tools.'
+			  )
+			: i18n.translate(
+					'Take the next step with gated content, paid subscribers, and an ad-free site.'
+			  ),
 	getDescription: () =>
 		i18n.translate(
 			'{{strong}}Best for personal use:{{/strong}} Boost your' +
@@ -1223,15 +1240,28 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 	getBlogAudience: () => i18n.translate( 'Best for freelancers' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for freelancers' ),
 	getStoreAudience: () => i18n.translate( 'Best for freelancers' ),
-	getPlanTagline: () => i18n.translate( 'Build a unique website with powerful design tools.' ),
-	getNewsletterTagLine: () =>
-		i18n.translate( 'Make it even more memorable with premium designs and style customization.' ),
-	getLinkInBioTagLine: () =>
-		i18n.translate( 'Make a great first impression with premium designs and style customization.' ),
-	getBlogOnboardingTagLine: () =>
-		i18n.translate(
-			'Make it even more memorable with premium designs, 4K video, and style customization.'
-		),
+	getPlanTagline: ( isGlobalStylesOnPersonal = false ) =>
+		isGlobalStylesOnPersonal
+			? i18n.translate( 'Build a unique website with premium designs.' )
+			: i18n.translate( 'Build a unique website with powerful design tools.' ),
+	getNewsletterTagLine: ( isGlobalStylesOnPersonal = false ) =>
+		isGlobalStylesOnPersonal
+			? i18n.translate( 'Make it even more memorable with premium designs.' )
+			: i18n.translate(
+					'Make it even more memorable with premium designs and style customization.'
+			  ),
+	getLinkInBioTagLine: ( isGlobalStylesOnPersonal = false ) =>
+		isGlobalStylesOnPersonal
+			? i18n.translate( 'Make a great first impression with premium designs.' )
+			: i18n.translate(
+					'Make a great first impression with premium designs and style customization.'
+			  ),
+	getBlogOnboardingTagLine: ( isGlobalStylesOnPersonal = false ) =>
+		isGlobalStylesOnPersonal
+			? i18n.translate( 'Make it even more memorable with premium designs, and 4K video.' )
+			: i18n.translate(
+					'Make it even more memorable with premium designs, 4K video, and style customization.'
+			  ),
 	getDescription: () =>
 		i18n.translate(
 			'{{strong}}Best for freelancers:{{/strong}} Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -792,11 +792,12 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_COLLECT_PAYMENTS_V2,
 		FEATURE_EMAIL_SUPPORT_SIGNUP,
 	],
-	get2023PricingGridSignupWpcomFeatures: () => [
+	get2023PricingGridSignupWpcomFeatures: ( isGlobalStylesOnPersonal = false ) => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_FAST_DNS,
 		FEATURE_SUPPORT_EMAIL,
+		...( isGlobalStylesOnPersonal ? [ FEATURE_STYLE_CUSTOMIZATION ] : [] ),
 		FEATURE_PAYMENT_TRANSACTION_FEES_8,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [ FEATURE_PREMIUM_CONTENT_JP ],
@@ -808,6 +809,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		),
 	getNewsletterSignupFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_STYLE_CUSTOMIZATION,
 		FEATURE_UNLIMITED_SUBSCRIBERS,
 		FEATURE_SUPPORT_EMAIL,
 		FEATURE_AD_FREE_EXPERIENCE,
@@ -824,6 +826,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		),
 	getLinkInBioSignupFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_STYLE_CUSTOMIZATION,
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_SUPPORT_EMAIL,
 		FEATURE_COLLECT_PAYMENTS_LINK_IN_BIO,
@@ -832,6 +835,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	getLinkInBioHighlightedFeatures: () => [ FEATURE_CUSTOM_DOMAIN ],
 	getBlogOnboardingSignupFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_STYLE_CUSTOMIZATION,
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_FAST_DNS,
 		FEATURE_SUPPORT_EMAIL,
@@ -1346,12 +1350,12 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
 			FEATURE_GOOGLE_ANALYTICS,
 		].filter( isValueTruthy ),
-	get2023PricingGridSignupWpcomFeatures: () => [
+	get2023PricingGridSignupWpcomFeatures: ( isGlobalStylesOnPersonal = false ) => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_LIVE_CHAT_SUPPORT,
 		FEATURE_PREMIUM_THEMES_V2,
 		FEATURE_WORDADS,
-		FEATURE_STYLE_CUSTOMIZATION,
+		...( isGlobalStylesOnPersonal ? [] : [ FEATURE_STYLE_CUSTOMIZATION ] ),
 		FEATURE_PAYMENT_TRANSACTION_FEES_4,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -735,20 +735,16 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	getStoreAudience: () => i18n.translate( 'Best for personal use' ),
 	getPlanTagline: ( isGlobalStylesOnPersonal = false ) =>
 		isGlobalStylesOnPersonal
-			? i18n.translate(
-					'Create your home on the web with a custom domain name and powerful design tools.'
-			  )
+			? i18n.translate( 'Add a custom domain name, go ad-free, and unlock powerful design tools.' )
 			: i18n.translate( 'Create your home on the web with a custom domain name.' ),
 	getNewsletterTagLine: ( isGlobalStylesOnPersonal = false ) =>
 		isGlobalStylesOnPersonal
-			? i18n.translate(
-					'Monetize your writing, go ad-free, and expand your media content with powerful design tools.'
-			  )
+			? i18n.translate( 'Add a custom domain name, go ad-free, and unlock powerful design tools.' )
 			: i18n.translate( 'Monetize your writing, go ad-free, and expand your media content.' ),
 	getLinkInBioTagLine: ( isGlobalStylesOnPersonal = false ) =>
 		isGlobalStylesOnPersonal
 			? i18n.translate(
-					'Take Link In Bio to the next level with gated content, paid subscribers, and an ad-free site with powerful design tools.'
+					'Make a great first impression with a custom domain name and powerful design tools.'
 			  )
 			: i18n.translate(
 					'Take Link In Bio to the next level with gated content, paid subscribers, and an ad-free site.'
@@ -756,7 +752,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	getBlogOnboardingTagLine: ( isGlobalStylesOnPersonal = false ) =>
 		isGlobalStylesOnPersonal
 			? i18n.translate(
-					'Take the next step with gated content, paid subscribers, and an ad-free site with powerful design tools.'
+					'Take the next step with a custom domain name, ad-free site, and powerful design tools.'
 			  )
 			: i18n.translate(
 					'Take the next step with gated content, paid subscribers, and an ad-free site.'
@@ -1242,23 +1238,27 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 	getStoreAudience: () => i18n.translate( 'Best for freelancers' ),
 	getPlanTagline: ( isGlobalStylesOnPersonal = false ) =>
 		isGlobalStylesOnPersonal
-			? i18n.translate( 'Build a unique website with premium designs.' )
+			? i18n.translate( 'Make it even more unique with premium themes and layouts.' )
 			: i18n.translate( 'Build a unique website with powerful design tools.' ),
 	getNewsletterTagLine: ( isGlobalStylesOnPersonal = false ) =>
 		isGlobalStylesOnPersonal
-			? i18n.translate( 'Make it even more memorable with premium designs.' )
+			? i18n.translate( 'Set your Newsletter apart with premium themes and layouts.' )
 			: i18n.translate(
 					'Make it even more memorable with premium designs and style customization.'
 			  ),
 	getLinkInBioTagLine: ( isGlobalStylesOnPersonal = false ) =>
 		isGlobalStylesOnPersonal
-			? i18n.translate( 'Make a great first impression with premium designs.' )
+			? i18n.translate(
+					'Take personalization to the next level with a range of premium themes and layouts.'
+			  )
 			: i18n.translate(
 					'Make a great first impression with premium designs and style customization.'
 			  ),
 	getBlogOnboardingTagLine: ( isGlobalStylesOnPersonal = false ) =>
 		isGlobalStylesOnPersonal
-			? i18n.translate( 'Make it even more memorable with premium designs, and 4K video.' )
+			? i18n.translate(
+					'Get more out of your blog with 4K video, extra storage, and premium designs.'
+			  )
 			: i18n.translate(
 					'Make it even more memorable with premium designs, 4K video, and style customization.'
 			  ),

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -40,10 +40,10 @@ export interface WPComPlan extends Plan {
 	getBlogAudience?: () => TranslateResult;
 	getPortfolioAudience?: () => TranslateResult;
 	getStoreAudience?: () => TranslateResult;
-	getPlanTagline?: () => string;
-	getNewsletterTagLine?: () => string;
-	getLinkInBioTagLine?: () => string;
-	getBlogOnboardingTagLine?: () => string;
+	getPlanTagline?: ( isGlobalStylesOnPersonal?: boolean ) => string;
+	getNewsletterTagLine?: ( isGlobalStylesOnPersonal?: boolean ) => string;
+	getLinkInBioTagLine?: ( isGlobalStylesOnPersonal?: boolean ) => string;
+	getBlogOnboardingTagLine?: ( isGlobalStylesOnPersonal?: boolean ) => string;
 	getSubTitle?: () => TranslateResult;
 	getPlanCompareFeatures?: (
 		experiment?: string,

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -261,9 +261,9 @@ export type Plan = BillingTerm & {
 	 * a feature for 20GB of storage space would be inferior to it.
 	 */
 	getInferiorFeatures?: () => Feature[];
-	getNewsletterSignupFeatures?: () => Feature[];
-	getLinkInBioSignupFeatures?: () => Feature[];
-	getBlogOnboardingSignupFeatures?: () => Feature[];
+	getNewsletterSignupFeatures?: ( isGlobalStylesOnPersonal?: boolean ) => Feature[];
+	getLinkInBioSignupFeatures?: ( isGlobalStylesOnPersonal?: boolean ) => Feature[];
+	getBlogOnboardingSignupFeatures?: ( isGlobalStylesOnPersonal?: boolean ) => Feature[];
 	getBlogOnboardingHighlightedFeatures?: () => Feature[];
 	getBlogOnboardingSignupJetpackFeatures?: () => Feature[];
 };

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -200,7 +200,7 @@ export type Plan = BillingTerm & {
 	 * this feature list will be ignored in the plans comparison table only.
 	 * Context - pdgrnI-26j
 	 */
-	get2023PricingGridSignupWpcomFeatures?: () => Feature[];
+	get2023PricingGridSignupWpcomFeatures?: ( isGlobalStylesOnPersonal?: boolean ) => Feature[];
 
 	/**
 	 * This function returns the features that are to be overridden and shown in the plans comparison table.


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2855

## Proposed Changes

Adds the "Style customization" feature to the Personal plan in the plans grid if the user is assigned to the treatment group of the `calypso_global_styles_personal` experiment.

Grid/Flow | Control | Treatment
--- | --- | ---
Main grid | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/e77699cf-3e88-4c7e-b1d0-7f0855da2b0b) | <img width="1242" alt="Screenshot 2023-07-04 at 15 32 54" src="https://github.com/Automattic/wp-calypso/assets/2070010/39c90c7a-2247-446a-afad-887e47a16d29"> | <img width="1260" alt="Screenshot 2023-06-26 at 17 46 27" src="https://github.com/Automattic/wp-calypso/assets/1233880/72be0d29-30b9-43d1-8e3d-dd17ea8326b6"> | <img width="1280" alt="Screenshot 2023-06-26 at 17 45 13" src="https://github.com/Automattic/wp-calypso/assets/1233880/bdd494ba-cc7c-4769-9dbe-5d364deb3c77">
Newsletter | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/eb341452-fd56-4f3d-ba6a-72c786b5b9a8)| <img width="1052" alt="Screenshot 2023-07-04 at 15 34 44" src="https://github.com/Automattic/wp-calypso/assets/2070010/80a5ab86-eace-41d3-9cb1-77766d51277b">
Link in Bio | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/365ae6c1-5c79-4b71-a421-eae46a1f36ba) | <img width="1052" alt="Screenshot 2023-07-04 at 15 34 24" src="https://github.com/Automattic/wp-calypso/assets/2070010/8f1c399a-06e9-417d-98ec-ec9edd473b4f">
Blog | <img width="1437" src="https://github.com/Automattic/wp-calypso/assets/1233880/c3fb9e9b-d498-4a08-9688-b36a5d6af4e2"> | <img width="1437" alt="Screenshot 2023-07-05 at 12 07 01" src="https://github.com/Automattic/wp-calypso/assets/1233880/574e39b5-6686-4ebc-a601-14de9d2318a8">






## Testing Instructions

- Use the Calypso live link below.
- Assign yourself to the control group of the experiment (see PCYsg-Fq7-p2#abacus-assignment-bookmarklet and pbxNRc-2HR-p2).
- Run the following in your sandbox to removed the previous cached assignment: `wp_cache_delete( 'global-styles-on-personal-<BLOG_ID>', 'a8c_experiments' );`.
- Go to Upgrades > Plans.
- In the plans main grid, make sure the "Style customization" is included in the Premium plan.
- Click on "Compare plans".
- In the plans comparison grid, make sure the "Style customization" is included in the Premium plan.
- Test the Link in Bio (`/setup/link-in-bio`) or Newsletter (`/setup/newsletter`) flows.
- In the plans step, make sure the "Style customization" is included in the Premium plan.
- Assign yourself to the treatment group of the experiment now.
- Run the following in your sandbox to removed the previous cached assignment: `wp_cache_delete( 'global-styles-on-personal-<BLOG_ID>', 'a8c_experiments' );`.
- Go to Upgrades > Plans.
- In the plans main grid, make sure the "Style customization" is included in the Personal plan.
- Click on "Compare plans".
- In the plans comparison grid, make sure the "Style customization" is included in the Personal plan.
- Test the Link in Bio (`/setup/link-in-bio`) or Newsletter (`/setup/newsletter`) flows.
- In the plans step, make sure the "Style customization" is included in the Personal plan.