### PR TITLE
reader discover page - add default tags

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -10,7 +10,7 @@ import wpcom from 'calypso/lib/wp';
 import Stream from 'calypso/reader/stream';
 import { useSelector } from 'calypso/state';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
-import { DEFAULT_DISCOVER_TAGS } from './helper';
+import { tagsToLoad } from './helper';
 
 import './discover-stream.scss';
 
@@ -24,7 +24,9 @@ const DiscoverStream = ( props ) => {
 	const scrollRef = useRef();
 	const scrollPosition = useRef( 0 );
 	const locale = useLocale();
-	const followedTags = useSelector( getReaderFollowedTags ) || DEFAULT_DISCOVER_TAGS;
+	const readerFollowedTags = useSelector( getReaderFollowedTags );
+	// Determine if we want to show a default list if the user has no tags follwed.
+	const followedTags = tagsToLoad( readerFollowedTags );
 	const [ selectedTab, setSelectedTab ] = useState( DEFAULT_TAB );
 	const { data: interestTags = [] } = useQuery( {
 		queryKey: [ 'read/interests', locale ],
@@ -162,13 +164,11 @@ const DiscoverStream = ( props ) => {
 	let streamKey = `discover:${ selectedTab }`;
 	// We want a different stream key for recommended depending on the followed tags that are available.
 	if ( isDefaultTab ) {
-		if ( ! followedTags.length ) {
-			streamKey += '-no-tags';
-		} else {
-			// Ensures a different key depending on the users followed tags list. So the stream can
-			// update when the user follows/unfollows other tags.
-			streamKey += followedTagSlugs.reduce( ( acc, val ) => acc + `-${ val }`, '' );
-		}
+		// Ensures a different key depending on the users followed tags list. So the stream can
+		// update when the user follows/unfollows other tags. Sort the list first so the key is the
+		// same per same tags followed. This is necessary since we load a default tag list at first.
+		followedTagSlugs.sort();
+		streamKey += followedTagSlugs.reduce( ( acc, val ) => acc + `-${ val }`, '' );
 	}
 
 	const streamProps = {

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -10,6 +10,7 @@ import wpcom from 'calypso/lib/wp';
 import Stream from 'calypso/reader/stream';
 import { useSelector } from 'calypso/state';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
+import { DEFAULT_DISCOVER_TAGS } from './helper';
 
 import './discover-stream.scss';
 
@@ -23,7 +24,7 @@ const DiscoverStream = ( props ) => {
 	const scrollRef = useRef();
 	const scrollPosition = useRef( 0 );
 	const locale = useLocale();
-	const followedTags = useSelector( getReaderFollowedTags ) || [];
+	const followedTags = useSelector( getReaderFollowedTags ) || DEFAULT_DISCOVER_TAGS;
 	const [ selectedTab, setSelectedTab ] = useState( DEFAULT_TAB );
 	const { data: interestTags = [] } = useQuery( {
 		queryKey: [ 'read/interests', locale ],

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -102,7 +102,7 @@ const DiscoverStream = ( props ) => {
 	const followedTagSlugs = followedTags ? followedTags.map( ( tag ) => tag.slug ) : [];
 	const recommendedTags = interestTags.filter( ( tag ) => ! followedTagSlugs.includes( tag.slug ) );
 
-	// Do not supply a fallback empty array as null is good data for tagsToLoad.
+	// Do not supply a fallback empty array as null is good data for getDiscoverStreamTags.
 	const recommendedStreamTags = getDiscoverStreamTags(
 		followedTags && followedTags.map( ( tag ) => tag.slug )
 	);
@@ -167,9 +167,10 @@ const DiscoverStream = ( props ) => {
 	let streamKey = `discover:${ selectedTab }`;
 	// We want a different stream key for recommended depending on the followed tags that are available.
 	if ( isDefaultTab ) {
-		// Ensures a different key depending on the users stream tags list. So the stream can
-		// update when the user follows/unfollows other tags. Sort the list first so the key is the
-		// same per same tags followed. This is necessary since we load a default tag list at first.
+		// Ensures a different key depending on the users stream tags list. So the stream can update
+		// when the user follows/unfollows other tags. Sort the list first so the key is the same
+		// per same tags followed. This is necessary since we load a default tag list when none are
+		// followed.
 		recommendedStreamTags.sort();
 		streamKey += recommendedStreamTags.reduce( ( acc, val ) => acc + `-${ val }`, '' );
 	}

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -3,10 +3,18 @@ import { getUrlParts } from '@automattic/calypso-url';
 import { find, get } from 'lodash';
 import { getSiteUrl as readerRouteGetSiteUrl } from 'calypso/reader/route';
 
-// Used to populate the recommended discover feed when no tags are followed by the user.
-export const DEFAULT_DISCOVER_TAGS = [ 'dailyprompt', 'wordpress' ];
+const DEFAULT_DISCOVER_TAGS = [ 'dailyprompt', 'wordpress' ];
 
-export function tagsToLoad( tags ) {
+/**
+ * Filters tags data and returns the tags intended to be loaded by the discover pages recommended
+ * section. If tags is null, we return an empty array as we have yet to recieve the users followed
+ * tags list. If the users followed tags list is empty, we return a default array of tags used to
+ * load the feed. Otherwise, load the feed based on the users follwed tags.
+ *
+ * @param {Array | null} tags Array of tag slugs to evaluate
+ * @returns {Array} Array of tag slugs that will be used for the discover stream.
+ */
+export function getDiscoverStreamTags( tags ) {
 	// If tags === [], we load default discover tags. If tags is falsy, we need to wait for the data
 	// before determining whether or not to load defaults or use the followed tags array.
 	if ( ! tags ) {

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -6,6 +6,17 @@ import { getSiteUrl as readerRouteGetSiteUrl } from 'calypso/reader/route';
 // Used to populate the recommended discover feed when no tags are followed by the user.
 export const DEFAULT_DISCOVER_TAGS = [ 'dailyprompt', 'wordpress' ];
 
+export function tagsToLoad( tags ) {
+	// If tags === [], we load default discover tags. If tags is falsy, we need to wait for the data
+	// before determining whether or not to load defaults or use the followed tags array.
+	if ( ! tags ) {
+		return [];
+	} else if ( tags.length === 0 ) {
+		return DEFAULT_DISCOVER_TAGS;
+	}
+	return tags;
+}
+
 function hasDiscoverSlug( post, searchSlug ) {
 	const metaData = get( post, 'discover_metadata.discover_fp_post_formats' );
 	return !! ( metaData && find( metaData, { slug: searchSlug } ) );

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -3,6 +3,9 @@ import { getUrlParts } from '@automattic/calypso-url';
 import { find, get } from 'lodash';
 import { getSiteUrl as readerRouteGetSiteUrl } from 'calypso/reader/route';
 
+// Used to populate the recommended discover feed when no tags are followed by the user.
+export const DEFAULT_DISCOVER_TAGS = [ 'dailyprompt', 'wordpress' ];
+
 function hasDiscoverSlug( post, searchSlug ) {
 	const metaData = get( post, 'discover_metadata.discover_fp_post_formats' );
 	return !! ( metaData && find( metaData, { slug: searchSlug } ) );

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,6 +1,6 @@
 import warn from '@wordpress/warning';
 import { random, map, includes, get } from 'lodash';
-import { DEFAULT_DISCOVER_TAGS } from 'calypso/reader/discover/helper';
+import { tagsToLoad } from 'calypso/reader/discover/helper';
 import { keyForPost } from 'calypso/reader/post-key';
 import XPostHelper from 'calypso/reader/xpost-helper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -206,13 +206,14 @@ const streamApis = {
 			return '/read/tags/cards';
 		},
 		dateProperty: 'date',
-		query: ( extras, { tags } ) =>
-			getQueryString( {
+		query: ( extras, { tags } ) => {
+			return getQueryString( {
 				...extras,
-				tags: tags ? Object.values( tags )?.map( ( tag ) => tag.slug ) : DEFAULT_DISCOVER_TAGS,
+				tags: tagsToLoad( tags ),
 				tag_recs_per_card: 5,
 				site_recs_per_card: 5,
-			} ),
+			} );
+		},
 		apiNamespace: 'wpcom/v2',
 	},
 	site: {

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,5 +1,6 @@
 import warn from '@wordpress/warning';
 import { random, map, includes, get } from 'lodash';
+import { DEFAULT_DISCOVER_TAGS } from 'calypso/reader/discover/helper';
 import { keyForPost } from 'calypso/reader/post-key';
 import XPostHelper from 'calypso/reader/xpost-helper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -208,7 +209,7 @@ const streamApis = {
 		query: ( extras, { tags } ) =>
 			getQueryString( {
 				...extras,
-				tags: tags ? Object.values( tags )?.map( ( tag ) => tag.slug ) : [],
+				tags: tags ? Object.values( tags )?.map( ( tag ) => tag.slug ) : DEFAULT_DISCOVER_TAGS,
 				tag_recs_per_card: 5,
 				site_recs_per_card: 5,
 			} ),

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -209,7 +209,7 @@ const streamApis = {
 		query: ( extras, { tags } ) =>
 			getQueryString( {
 				...extras,
-				// Do not supply an empty fallback as null is good info for tagsToLoad
+				// Do not supply an empty fallback as null is good info for getDiscoverStreamTags
 				tags: getDiscoverStreamTags( tags && Object.values( tags )?.map( ( tag ) => tag.slug ) ),
 				tag_recs_per_card: 5,
 				site_recs_per_card: 5,

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,6 +1,6 @@
 import warn from '@wordpress/warning';
 import { random, map, includes, get } from 'lodash';
-import { tagsToLoad } from 'calypso/reader/discover/helper';
+import { getDiscoverStreamTags } from 'calypso/reader/discover/helper';
 import { keyForPost } from 'calypso/reader/post-key';
 import XPostHelper from 'calypso/reader/xpost-helper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -206,14 +206,14 @@ const streamApis = {
 			return '/read/tags/cards';
 		},
 		dateProperty: 'date',
-		query: ( extras, { tags } ) => {
-			return getQueryString( {
+		query: ( extras, { tags } ) =>
+			getQueryString( {
 				...extras,
-				tags: tagsToLoad( tags ),
+				// Do not supply an empty fallback as null is good info for tagsToLoad
+				tags: getDiscoverStreamTags( tags && Object.values( tags )?.map( ( tag ) => tag.slug ) ),
 				tag_recs_per_card: 5,
 				site_recs_per_card: 5,
-			} );
-		},
+			} ),
 		apiNamespace: 'wpcom/v2',
 	},
 	site: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* adds a list of default tags to use to populate the recommended discover feed for when users are not following any tags.
* If the user has no tags, we populate the discover feed with posts for `dailyprompt` and `wordpress` tags.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run this calypso build
* go to the reader and unfollow all tags
* visit the discover page and verify a default stream loads

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
