### PR TITLE
reader discover - hide nav if no recommended tags.

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -174,7 +174,7 @@ const DiscoverStream = ( props ) => {
 		...props,
 		isDiscoverTags: ! isDefaultTab,
 		streamKey,
-		streamHeader: <DiscoverNavigation />,
+		streamHeader: recommendedTags.length ? <DiscoverNavigation /> : null,
 		useCompactCards: true,
 	};
 

--- a/client/reader/discover/discover-stream.scss
+++ b/client/reader/discover/discover-stream.scss
@@ -7,6 +7,7 @@
 		z-index: 1;
 		pointer-events: none;
 		height: 100%;
+		margin-top: 5px;
 
 		&.display-none {
 			display: none;
@@ -35,6 +36,7 @@
 		position: relative;
 		overflow-x: scroll;
 		margin-bottom: 20px;
+		padding-top: 5px;
 		padding-bottom: 15px;
 		border-bottom: 1px solid var(--color-neutral-5);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This fixes a small visual bug when recommended tags are loading making the 'recommended' tab large and ugly, by hiding the navigation component if there are no other tabs to render. This also fixes a small visual bug with the a11y focus in the nav.

Before:
![recommended-tab-bad](https://github.com/Automattic/wp-calypso/assets/28742426/88ffd485-af6b-422d-ac05-46050127878f)

After:
![recommended-tab-good](https://github.com/Automattic/wp-calypso/assets/28742426/40757236-92ee-4cf8-a672-11fdfa1df151)

Before: 
<img width="163" alt="Screenshot 2023-06-26 at 11 35 58 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/f29dfcb5-e597-4281-91c1-aabb4eb55fe1">

After:
<img width="151" alt="Screenshot 2023-06-26 at 11 37 05 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/5b360e59-2d5f-4ad9-b2e4-10e7abc184e0">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso build
* for the issue with the recommended tab, this is only reproducible when the result is not cached. Therefore you can clear cache or change the `queryKey` in the useQuery on line 29 of discover-stream.js and reload. Verify you do not see a navigation component with only 1 tab ("recommended") taking up the full width while the page loads.
* for the a11y focus, click on a tab and then press the "tab" button to start a11y navigation/focus mode.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
