### PR TITLE
Subscription Management: Rename "Follow" labels to "Subscriptions" equivalent

### DIFF
--- a/client/reader/following-manage/search-followed.jsx
+++ b/client/reader/following-manage/search-followed.jsx
@@ -1,9 +1,12 @@
+import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import SearchCard from 'calypso/components/search-card';
 
 const noop = () => {};
+
+const isSubscriptionManagerEnabled = config.isEnabled( 'reader/subscription-management' );
 
 class FollowingManageSearchFollowed extends Component {
 	static propTypes = {
@@ -16,13 +19,18 @@ class FollowingManageSearchFollowed extends Component {
 	};
 
 	render() {
+		const { translate } = this.props;
 		return (
 			<SearchCard
 				compact={ true }
 				pinned={ false }
 				className="following-manage__search-followed"
 				additionalClasses="following-manage__search-followed-input"
-				placeholder={ this.props.translate( 'Search followed sites…' ) }
+				placeholder={
+					isSubscriptionManagerEnabled
+						? translate( 'Search…' )
+						: translate( 'Search followed sites…' )
+				}
 				onSearch={ this.props.onSearch }
 				initialValue={ this.props.initialValue }
 				delaySearch={ true }

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -44,6 +44,8 @@ import ReaderSidebarTags from './reader-sidebar-tags';
 import 'calypso/my-sites/sidebar/style.scss'; // Copy styles from the My Sites sidebar.
 import './style.scss';
 
+const isSubscriptionManagerEnabled = isEnabled( 'reader/subscription-management' );
+
 export class ReaderSidebar extends Component {
 	state = {};
 
@@ -176,7 +178,9 @@ export class ReaderSidebar extends Component {
 					className={ ReaderSidebarHelper.itemLinkClass( '/read', path, {
 						'sidebar-streams__following': true,
 					} ) }
-					label={ translate( 'Following' ) }
+					label={
+						isSubscriptionManagerEnabled ? translate( 'Subscriptions' ) : translate( 'Following' )
+					}
 					onNavigate={ this.handleReaderSidebarFollowedSitesClicked }
 					customIcon={ <ReaderFollowingIcon /> }
 					link="/read"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
![image](https://github.com/Automattic/wp-calypso/assets/2019970/910363a3-da76-45a4-93da-736661d3eb2d)


Resolves https://github.com/Automattic/wp-calypso/issues/78373

## Proposed Changes

* Rename "Follow" reader's sidebar menu item to "Subscriptions"
* Rename "Search followed sites…" input placeholder to "Search…"
* Note that renaming the "Followed P2s" reader's sidebar menu item is not included in the PR because it requires a backend change

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/read

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
