### PR TITLE
Edge Cache i1: Edge cache feature flag tests

### DIFF
--- a/client/my-sites/hosting/cache-card/test/index.js
+++ b/client/my-sites/hosting/cache-card/test/index.js
@@ -172,7 +172,7 @@ describe( 'CacheCard component', () => {
 		expect( screen.queryByRole( 'checkbox' ) ).toBeFalsy();
 	} );
 
-	it( 'shows the Clear Cache button regradless of the feature status', () => {
+	it( 'shows the Clear Cache button regardless of the feature status', () => {
 		// The loading is true in case the feature is disabled
 		useEdgeCacheQuery.mockReturnValue( { data: true, isLoading: true } );
 		useClearEdgeCacheMutation.mockReturnValue( {

--- a/client/my-sites/hosting/cache-card/test/index.js
+++ b/client/my-sites/hosting/cache-card/test/index.js
@@ -173,7 +173,8 @@ describe( 'CacheCard component', () => {
 	} );
 
 	it( 'shows the Clear Cache button regradless of the feature status', () => {
-		useEdgeCacheQuery.mockReturnValue( { data: true, isLoading: false } );
+		// The loading is true in case the feature is disabled
+		useEdgeCacheQuery.mockReturnValue( { data: true, isLoading: true } );
 		useClearEdgeCacheMutation.mockReturnValue( {
 			clearEdgeCache: jest.fn(),
 			isLoading: false,
@@ -185,10 +186,8 @@ describe( 'CacheCard component', () => {
 			</Provider>
 		);
 		expect( screen.queryByRole( 'button' ) ).toBeTruthy();
-		expect( screen.queryByRole( 'button' ) ).toBeEnabled();
+		expect( screen.queryByRole( 'button' ) ).toBeDisabled();
 		fireEvent.click( screen.getByRole( 'button' ) );
-		expect( useClearEdgeCacheMutation().clearEdgeCache ).toHaveBeenCalledTimes( 1 );
-		useClearEdgeCacheMutation().clearEdgeCache.mockClear();
 		config.disable( EDGE_CACHE_FEATURE );
 		rerender(
 			<Provider store={ store }>

--- a/client/my-sites/hosting/cache-card/test/index.js
+++ b/client/my-sites/hosting/cache-card/test/index.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import config from '@automattic/calypso-config';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -8,6 +9,8 @@ import { useClearEdgeCacheMutation } from 'calypso/my-sites/hosting/cache-card/u
 import { useEdgeCacheQuery } from 'calypso/my-sites/hosting/cache-card/use-edge-cache';
 import { useToggleEdgeCacheMutation } from 'calypso/my-sites/hosting/cache-card/use-toggle-edge-cache';
 import { CacheCard } from '..';
+
+const EDGE_CACHE_FEATURE = 'yolo/edge-cache-i1';
 
 const INITIAL_STATE = {
 	sites: {
@@ -151,5 +154,50 @@ describe( 'CacheCard component', () => {
 		fireEvent.click( screen.getByRole( 'button' ) );
 		expect( useClearEdgeCacheMutation().clearEdgeCache ).toHaveBeenCalledTimes( 1 );
 		expect( defaultProps.clearAtomicWordPressCache ).toHaveBeenCalledTimes( 1 );
+	} );
+	it( 'hides the checkbox button when the feature is disabled', () => {
+		config.enable( EDGE_CACHE_FEATURE );
+		const { rerender } = render(
+			<Provider store={ store }>
+				<CacheCard { ...{ ...defaultProps } } />
+			</Provider>
+		);
+		expect( screen.queryByRole( 'checkbox' ) ).toBeTruthy();
+		config.disable( EDGE_CACHE_FEATURE );
+		rerender(
+			<Provider store={ store }>
+				<CacheCard { ...{ ...defaultProps } } />
+			</Provider>
+		);
+		expect( screen.queryByRole( 'checkbox' ) ).toBeFalsy();
+	} );
+
+	it( 'shows the Clear Cache button regradless of the feature status', () => {
+		useEdgeCacheQuery.mockReturnValue( { data: true, isLoading: false } );
+		useClearEdgeCacheMutation.mockReturnValue( {
+			clearEdgeCache: jest.fn(),
+			isLoading: false,
+		} );
+		config.enable( EDGE_CACHE_FEATURE );
+		const { rerender } = render(
+			<Provider store={ store }>
+				<CacheCard { ...{ ...defaultProps } } />
+			</Provider>
+		);
+		expect( screen.queryByRole( 'button' ) ).toBeTruthy();
+		expect( screen.queryByRole( 'button' ) ).toBeEnabled();
+		fireEvent.click( screen.getByRole( 'button' ) );
+		expect( useClearEdgeCacheMutation().clearEdgeCache ).toHaveBeenCalledTimes( 1 );
+		useClearEdgeCacheMutation().clearEdgeCache.mockClear();
+		config.disable( EDGE_CACHE_FEATURE );
+		rerender(
+			<Provider store={ store }>
+				<CacheCard { ...{ ...defaultProps } } />
+			</Provider>
+		);
+		expect( screen.queryByRole( 'button' ) ).toBeTruthy();
+		expect( screen.queryByRole( 'button' ) ).toBeEnabled();
+		fireEvent.click( screen.getByRole( 'button' ) );
+		expect( useClearEdgeCacheMutation().clearEdgeCache ).toHaveBeenCalledTimes( 0 );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1687766612113259-slack-C04GESRBWKW

## Proposed Changes

As a continuation of [this](https://github.com/Automattic/wp-calypso/pull/78622) fix, this pr adds some tests to test that everything works as expected regardless of the feature status.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?