### PR TITLE
(CI for GB on WoA i2) Notify about E2E results for all GB edge/nightly releases

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -116,16 +116,19 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 
 			if (nightly) {
 				param("env.GUTENBERG_NIGHTLY", "true");
+			}
+
+			if (edge) {
+				param("env.GUTENBERG_EDGE", "true")
+			}
+
+			if (edge || nightly) {
 				password("GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN", "credentialsJSON:8196e9b8-cf0a-4ab5-9547-95145134f04a", display = ParameterDisplay.HIDDEN);
 				// Uncomment the following to route it to the test channel, don't forget to change the reference in the exec() calls below, too.
 				// Ask someone from the Team Calypso Platform to know what these channels are. They are also available in the source for `announce.sh` (par of Gutenbot).
 				// password("GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID_TEST", "credentialsJSON:180d1bb6-a28e-4985-bf9a-8acba63bb90c", display = ParameterDisplay.HIDDEN);
 				password("GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID", "credentialsJSON:b8ca97ea-322f-499f-aa21-ecdb8b373527", display = ParameterDisplay.HIDDEN);
 				text("GB_E2E_ANNOUNCEMENT_THREAD_TS", value = "", allowEmpty = true, display = ParameterDisplay.HIDDEN);
-			}
-
-			if (edge) {
-				param("env.GUTENBERG_EDGE", "true")
 			}
 		},
 		buildSteps = {


### PR DESCRIPTION
Project: p4TIVU-aFl-p2

## Proposed Changes

As part of p4TIVU-aAZ-p2, I implemented slack notification for GB E2E tests in Calypso; these notifications are sent to the corresponding version announcement thread; however, at the moment, it's only for nightlies. The reason I did that is because I wanted to use the nightlies announcements as a testing ground for them. Now that I see they are working well, there's no reason we shouldn't have the same notifications for all edge releases.

## Testing Instructions

* Check should pass.

Gutenbot counterpart: D114610-code