### PR TITLE
Launchpad: Top-align skip button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -101,8 +101,8 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 				stepName="launchpad"
 				goNext={ navigation.goNext }
 				isFullLayout={ true }
-				skipLabelText={ translate( 'Skip to dashboard' ) }
-				skipButtonAlign="bottom"
+				skipLabelText={ translate( 'Skip for now' ) }
+				skipButtonAlign="top"
 				hideBack={ true }
 				stepContent={
 					<StepContent

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -29,6 +29,7 @@ type SidebarProps = {
 	goNext: NavigationControls[ 'goNext' ];
 	goToStep?: NavigationControls[ 'goToStep' ];
 	flow: string | null;
+	hideNavigation: boolean | null;
 };
 
 function getUrlInfo( url: string ) {
@@ -42,7 +43,15 @@ function getUrlInfo( url: string ) {
 	return [ siteName, topLevelDomain ];
 }
 
-const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: SidebarProps ) => {
+const Sidebar = ( {
+	sidebarDomain,
+	siteSlug,
+	submit,
+	goNext,
+	goToStep,
+	flow,
+	hideNavigation,
+}: SidebarProps ) => {
 	let siteName = '';
 	let topLevelDomain = '';
 	let showClipboardButton = false;
@@ -218,17 +227,19 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 					makeLastTaskPrimaryAction={ true }
 				/>
 			</div>
-			<div className="launchpad__sidebar-admin-link">
-				<StepNavigationLink
-					direction="forward"
-					handleClick={ () => {
-						recordTracksEvent( 'calypso_launchpad_go_to_admin_clicked', { flow: flow } );
-						goNext?.();
-					} }
-					label={ translate( 'Skip to dashboard' ) }
-					borderless={ true }
-				/>
-			</div>
+			{ ! hideNavigation && (
+				<div className="launchpad__sidebar-admin-link">
+					<StepNavigationLink
+						direction="forward"
+						handleClick={ () => {
+							recordTracksEvent( 'calypso_launchpad_go_to_admin_clicked', { flow: flow } );
+							goNext?.();
+						} }
+						label={ translate( 'Skip to dashboard' ) }
+						borderless={ true }
+					/>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -64,6 +64,7 @@ const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentP
 					goNext={ goNext }
 					goToStep={ goToStep }
 					flow={ flow }
+					hideNavigation={ flow !== 'newsletter' }
 				/>
 				<LaunchpadSitePreview flow={ flow } siteSlug={ iFrameURL } />
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #76965

## Proposed Changes

This moves the launchpad skip button to the top of the screen and changes the copy.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch or use the calypso.live link.
* Go to `/start` and create a new site.
* Once you get to the "Let's get ready to launch" screen, verify that the "Skip for now" link is at the top of the page. The "Skip to dashboard" link should be gone.

<img width="1256" alt="image" src="https://github.com/Automattic/wp-calypso/assets/917632/de7819d0-8d6c-414a-a971-f5647cf02232">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
