### PR TITLE
Subscriber Details: Create unsubscribe mutation

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list/subscriber-row.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/subscriber-row.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import TimeSince from 'calypso/components/time-since';
 import useSubscriptionPlans from '../../hooks/use-subscription-plans';
@@ -39,6 +40,7 @@ export const SubscriberRow = ( { subscriber, onView, onUnsubscribe }: Subscriber
 				<SubscriberPopover
 					onView={ () => onView( subscriber ) }
 					onUnsubscribe={ () => onUnsubscribe( subscriber ) }
+					isViewButtonVisible={ isEnabled( 'subscribers/view-subscriber-details' ) }
 				/>
 			</span>
 		</li>

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -40,22 +40,26 @@ const getSubscriberDetailsUrl = (
 	return `/subscribers/external/${ siteSlug }/${ subscription_id }`;
 };
 
-const getSubscriberDetailsCacheKey = ( siteId: number | null, queryString: string ) => [
-	'subscriber-details',
-	siteId,
-	queryString,
-];
+const getSubscriberDetailsCacheKey = (
+	siteId: number | null,
+	subscriptionId: number | undefined,
+	userId: number | undefined,
+	type: string
+) => [ 'subscriber-details', siteId, subscriptionId, userId, type ];
 
 const sanitizeInt = ( intString: string ) => {
 	const parsedInt = parseInt( intString, 10 );
 	return ! Number.isNaN( parsedInt ) && parsedInt > 0 ? parsedInt : undefined;
 };
 
+const getSubscriberDetailsType = ( userId: number | undefined ) => ( userId ? 'wpcom' : 'email' );
+
 export {
 	getEarnPageUrl,
 	getEarnPaymentsPageUrl,
 	getSubscriberDetailsCacheKey,
 	getSubscriberDetailsUrl,
+	getSubscriberDetailsType,
 	getSubscribersCacheKey,
 	sanitizeInt,
 };

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -3,13 +3,11 @@ import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { UnsubscribeActionType } from '../components/unsubscribe-modal';
 import { getEarnPaymentsPageUrl } from '../helpers';
-import { useSubscriberRemoveMutation } from '../mutations';
 import { Subscriber } from '../types';
 
-const useUnsubscribeModal = ( siteId: number | null, currentPage: number ) => {
+const useUnsubscribeModal = ( unsubscribeMutation: ( subscriber: Subscriber ) => void ) => {
 	const [ currentSubscriber, setCurrentSubscriber ] = useState< Subscriber >();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
-	const { mutate } = useSubscriberRemoveMutation( siteId, currentPage );
 
 	const onClickUnsubscribe = ( subscriber: Subscriber ) => {
 		setCurrentSubscriber( subscriber );
@@ -23,7 +21,7 @@ const useUnsubscribeModal = ( siteId: number | null, currentPage: number ) => {
 		if ( action === UnsubscribeActionType.Manage ) {
 			window.open( getEarnPaymentsPageUrl( selectedSiteSlug ), '_blank' );
 		} else if ( action === UnsubscribeActionType.Unsubscribe && subscriber ) {
-			mutate( subscriber );
+			unsubscribeMutation( subscriber );
 		}
 
 		resetSubscriber();

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -16,6 +16,7 @@ import { SubscribersHeaderPopover } from './components/subscribers-header-popove
 import { UnsubscribeModal } from './components/unsubscribe-modal';
 import { getSubscriberDetailsUrl } from './helpers';
 import { useUnsubscribeModal } from './hooks';
+import { useSubscriberRemoveMutation } from './mutations';
 import { Subscriber } from './types';
 import './style.scss';
 
@@ -27,9 +28,9 @@ type SubscribersProps = {
 const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
-
+	const { mutate } = useSubscriberRemoveMutation( selectedSiteId, pageNumber );
 	const { currentSubscriber, onClickUnsubscribe, onConfirmModal, resetSubscriber } =
-		useUnsubscribeModal( selectedSiteId, pageNumber );
+		useUnsubscribeModal( mutate );
 	const onClickView = ( { subscription_id, user_id }: Subscriber ) => {
 		page.show( getSubscriberDetailsUrl( selectedSiteSlug, subscription_id, user_id ) );
 	};

--- a/client/my-sites/subscribers/mutations/use-details-page-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-details-page-subscriber-remove-mutation.ts
@@ -1,0 +1,57 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { getSubscriberDetailsCacheKey, getSubscriberDetailsType } from '../helpers';
+import type { Subscriber } from '../types';
+
+const useDetailsPageSubscriberRemoveMutation = (
+	siteId: number | null,
+	subscriptionId: number | undefined,
+	userId: number | undefined
+) => {
+	const queryClient = useQueryClient();
+	const type = getSubscriberDetailsType( userId );
+
+	return useMutation( {
+		mutationFn: async ( subscriber: Subscriber ) => {
+			if ( ! siteId || ! subscriber ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while unsubscribing.'
+				);
+			}
+
+			if ( subscriber.user_id ) {
+				await wpcom.req.post( `/sites/${ siteId }/followers/${ subscriber.user_id }/delete` );
+			} else {
+				await wpcom.req.post(
+					`/sites/${ siteId }/email-followers/${ subscriber.subscription_id }/delete`
+				);
+			}
+
+			return true;
+		},
+		onMutate: async () => {
+			const cacheKey = getSubscriberDetailsCacheKey( siteId, subscriptionId, userId, type );
+			await queryClient.cancelQueries( cacheKey );
+
+			return {
+				previousData: queryClient.getQueryData< Subscriber >( cacheKey ),
+			};
+		},
+		onError: ( error, variables, context ) => {
+			if ( context?.previousData ) {
+				queryClient.setQueryData(
+					getSubscriberDetailsCacheKey( siteId, subscriptionId, userId, type ),
+					context.previousData
+				);
+			}
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries(
+				getSubscriberDetailsCacheKey( siteId, subscriptionId, userId, type )
+			);
+		},
+	} );
+};
+
+export default useDetailsPageSubscriberRemoveMutation;

--- a/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import { getSubscriberDetailsCacheKey } from '../helpers';
+import { getSubscriberDetailsCacheKey, getSubscriberDetailsType } from '../helpers';
 import type { Subscriber } from '../types';
 
 const useSubscriberDetailsQuery = (
@@ -8,19 +8,15 @@ const useSubscriberDetailsQuery = (
 	subscriptionId: number | undefined,
 	userId: number | undefined
 ) => {
-	let queryString = '';
-
-	if ( userId ) {
-		queryString = `user_id=${ userId }&type=wpcom`;
-	} else {
-		queryString = `subscription_id=${ subscriptionId }&type=email`;
-	}
+	const type = getSubscriberDetailsType( userId );
 
 	return useQuery< Subscriber >( {
-		queryKey: getSubscriberDetailsCacheKey( siteId, queryString ),
+		queryKey: getSubscriberDetailsCacheKey( siteId, subscriptionId, userId, type ),
 		queryFn: () =>
 			wpcom.req.get( {
-				path: `/sites/${ siteId }/subscribers/individual?${ queryString }`,
+				path: userId
+					? `/sites/${ siteId }/subscribers/individual?user_id=${ userId }&type=${ type }`
+					: `/sites/${ siteId }/subscribers/individual?subscription_id=${ subscriptionId }&type=${ type }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
 		enabled: !! siteId,

--- a/client/my-sites/subscribers/subscriber-details-page.tsx
+++ b/client/my-sites/subscribers/subscriber-details-page.tsx
@@ -25,11 +25,7 @@ const SubscriberDetailsPage = ( { subscriptionId, userId }: SubscriberDetailsPag
 	const dispatch = useDispatch();
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
-	const { data: subscriber, isLoading } = useSubscriberDetailsQuery(
-		selectedSiteId,
-		subscriptionId,
-		userId
-	);
+	const { data: subscriber } = useSubscriberDetailsQuery( selectedSiteId, subscriptionId, userId );
 	const { mutate, isSuccess } = useDetailsPageSubscriberRemoveMutation(
 		selectedSiteId,
 		subscriptionId,

--- a/client/my-sites/subscribers/subscriber-details-page.tsx
+++ b/client/my-sites/subscribers/subscriber-details-page.tsx
@@ -1,11 +1,18 @@
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { Item } from 'calypso/components/breadcrumb';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
 import { useSelector } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SubscriberDetails } from './components/subscriber-details';
 import { SubscriberPopover } from './components/subscriber-popover';
+import { UnsubscribeModal } from './components/unsubscribe-modal';
+import { useUnsubscribeModal } from './hooks';
+import useDetailsPageSubscriberRemoveMutation from './mutations/use-details-page-subscriber-remove-mutation';
 import useSubscriberDetailsQuery from './queries/use-subscriber-details-query';
 
 type SubscriberDetailsPageProps = {
@@ -15,9 +22,56 @@ type SubscriberDetailsPageProps = {
 
 const SubscriberDetailsPage = ( { subscriptionId, userId }: SubscriberDetailsPageProps ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
-	const { data: subscriber } = useSubscriberDetailsQuery( selectedSiteId, subscriptionId, userId );
+	const { data: subscriber, isLoading } = useSubscriberDetailsQuery(
+		selectedSiteId,
+		subscriptionId,
+		userId
+	);
+	const { mutate, isSuccess } = useDetailsPageSubscriberRemoveMutation(
+		selectedSiteId,
+		subscriptionId,
+		userId
+	);
+	const {
+		currentSubscriber: modalSubscriber,
+		onClickUnsubscribe,
+		onConfirmModal,
+		resetSubscriber,
+	} = useUnsubscribeModal( mutate );
+
+	const unsubscribeClickHandler = () => {
+		if ( subscriber ) {
+			onClickUnsubscribe( subscriber );
+		}
+	};
+
+	useEffect( () => {
+		if ( isSuccess ) {
+			resetSubscriber();
+			page.show( `/subscribers/${ selectedSiteSlug }` );
+			dispatch(
+				successNotice(
+					translate( 'You have successfully removed %s from your list.', {
+						args: [ subscriber?.display_name as string ],
+						comment: "%s is the subscriber's public display name",
+					} ),
+					{
+						duration: 5000,
+					}
+				)
+			);
+		}
+	}, [
+		dispatch,
+		isSuccess,
+		resetSubscriber,
+		selectedSiteSlug,
+		subscriber?.display_name,
+		translate,
+	] );
 
 	const navigationItems: Item[] = [
 		{
@@ -33,9 +87,14 @@ const SubscriberDetailsPage = ( { subscriptionId, userId }: SubscriberDetailsPag
 	return (
 		<Main wideLayout>
 			<FixedNavigationHeader navigationItems={ navigationItems }>
-				<SubscriberPopover onUnsubscribe={ () => undefined } />
+				<SubscriberPopover onUnsubscribe={ unsubscribeClickHandler } />
 			</FixedNavigationHeader>
 			{ subscriber && <SubscriberDetails subscriber={ subscriber } /> }
+			<UnsubscribeModal
+				subscriber={ modalSubscriber }
+				onCancel={ resetSubscriber }
+				onConfirm={ onConfirmModal }
+			/>
 		</Main>
 	);
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78405

## Proposed Changes

* Creates unsubscribe mutation for details page
* Makes useUnsubscribeModal reusable
* Applies mutation and modal to the details page
  * Uses the same modal from Subscribers List
  * On success, redirects to the subscribers list and displays a success notice
* Add feature flag to the view button

## Testing Instructions

* Apply this PR to your local env
* Go to http://calypso.localhost:3000/subscribers/{site-slug}?flags=subscribers/view-subscriber-details
* Click on view button on a Free subscriber and you should be redirected to the Details page
* On the header bar > popover menu, click on Unsubscribe
* You should see a confirmation modal, then confirm
* You should be redirected to the list and a success notification should be displayed at the top-right
* Click on view button on a Paid subscriber and you should be redirected to the Details page
* You should see the modal with a "Manage paid subscribers", which redirects you to the Earn/Payments page

<img width="546" alt="Screenshot 2023-06-26 at 18 14 42" src="https://github.com/Automattic/wp-calypso/assets/3113712/23f1881f-97e7-4e97-a130-632b6da4b74a">

<img width="617" alt="Screenshot 2023-06-26 at 18 14 17" src="https://github.com/Automattic/wp-calypso/assets/3113712/8e5b5645-0b77-4441-a83b-5b31bedcd492">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
