### PR TITLE
Accept invite: Pass `email_verification_secret` query parameter to accept invite endpoint

### DIFF
--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -33,9 +33,10 @@ export function acceptInvite( context, next ) {
 			context.store.dispatch( setUserEmailVerified( true ) );
 		}
 		store.remove( 'invite_accepted' );
+		const emailVerificationSecret = context.query.email_verification_secret;
 
 		context.store
-			.dispatch( acceptInviteAction( acceptedInvite ) )
+			.dispatch( acceptInviteAction( acceptedInvite, emailVerificationSecret ) )
 			.then( () => {
 				const redirect = getRedirectAfterAccept( acceptedInvite );
 				debug( 'Accepted invite and redirecting to:  ' + redirect );

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -11,7 +11,7 @@ import { navigate } from 'calypso/lib/navigate';
 import InviteFormHeader from 'calypso/my-sites/invites/invite-form-header';
 import P2InviteAcceptLoggedIn from 'calypso/my-sites/invites/p2/invite-accept-logged-in';
 import { acceptInvite } from 'calypso/state/invites/actions';
-
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import './style.scss';
 
 class InviteAcceptLoggedIn extends Component {
@@ -20,7 +20,7 @@ class InviteAcceptLoggedIn extends Component {
 	accept = () => {
 		this.setState( { submitting: true } );
 		this.props
-			.acceptInvite( this.props.invite )
+			.acceptInvite( this.props.invite, this.props.emailVerificationSecret )
 			.then( () => {
 				navigate( this.props.redirectTo );
 			} )
@@ -153,4 +153,9 @@ class InviteAcceptLoggedIn extends Component {
 	}
 }
 
-export default connect( null, { acceptInvite } )( localize( InviteAcceptLoggedIn ) );
+export default connect(
+	( state ) => ( {
+		emailVerificationSecret: getCurrentQueryArguments( state ).email_verification_secret,
+	} ),
+	{ acceptInvite }
+)( localize( InviteAcceptLoggedIn ) );

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -155,7 +155,7 @@ class InviteAcceptLoggedIn extends Component {
 
 export default connect(
 	( state ) => ( {
-		emailVerificationSecret: getCurrentQueryArguments( state ).email_verification_secret,
+		emailVerificationSecret: getCurrentQueryArguments( state )?.email_verification_secret,
 	} ),
 	{ acceptInvite }
 )( localize( InviteAcceptLoggedIn ) );

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -16,6 +16,7 @@ import InviteFormHeader from 'calypso/my-sites/invites/invite-form-header';
 import P2InviteAcceptLoggedOut from 'calypso/my-sites/invites/p2/invite-accept-logged-out';
 import WpcomLoginForm from 'calypso/signup/wpcom-login-form';
 import { createAccount, acceptInvite } from 'calypso/state/invites/actions';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 
 /**
  * Module variables
@@ -99,7 +100,7 @@ class InviteAcceptLoggedOut extends Component {
 		const { invite } = this.props;
 		this.setState( { submitting: true } );
 		this.props
-			.acceptInvite( invite )
+			.acceptInvite( invite, this.props.emailVerificationSecret )
 			.then( () => {
 				window.location = addQueryArgs(
 					{ update: 'activate', email: invite.sentTo, key: invite.authKey },
@@ -197,6 +198,9 @@ class InviteAcceptLoggedOut extends Component {
 	}
 }
 
-export default connect( null, { createAccount, acceptInvite } )(
-	localize( InviteAcceptLoggedOut )
-);
+export default connect(
+	( state ) => ( {
+		emailVerificationSecret: getCurrentQueryArguments( state ).email_verification_secret,
+	} ),
+	{ createAccount, acceptInvite }
+)( localize( InviteAcceptLoggedOut ) );

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -200,7 +200,7 @@ class InviteAcceptLoggedOut extends Component {
 
 export default connect(
 	( state ) => ( {
-		emailVerificationSecret: getCurrentQueryArguments( state ).email_verification_secret,
+		emailVerificationSecret: getCurrentQueryArguments( state )?.email_verification_secret,
 	} ),
 	{ createAccount, acceptInvite }
 )( localize( InviteAcceptLoggedOut ) );

--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -223,13 +223,14 @@ export function disableInviteLinks( siteId ) {
 	};
 }
 
-export function acceptInvite( invite ) {
+export function acceptInvite( invite, emailVerificationSecret ) {
 	return async ( dispatch ) => {
 		try {
 			const data = await wpcom.req.get(
 				`/sites/${ invite.site.ID }/invites/${ invite.inviteKey }/accept`,
 				{
 					activate: invite.activationKey,
+					email_verification_secret: emailVerificationSecret,
 					include_domain_only: true,
 					apiVersion: '1.3',
 				}


### PR DESCRIPTION
Related to p1687797751584429-slack-C02FMH4G8.

## Proposed Changes

Forwards the `email_verification_secret` query parameter to the `/invite/%s/accept` call in order to verify the account's e-mail.

**DO NOT MERGE** this PR unless @vortfu's approved it.

## Testing Instructions

Follow the instructions defined in D114630-code.