### PR TITLE
Site Selector: Filter out domain-only sites

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -58,6 +58,7 @@ export class SiteSelector extends Component {
 		navigateToSite: PropTypes.func.isRequired,
 		isReskinned: PropTypes.bool,
 		showManageSitesButton: PropTypes.bool,
+		showManageDomainsButton: PropTypes.bool,
 		showHiddenSites: PropTypes.bool,
 		maxResults: PropTypes.number,
 		hasSiteWithPlugins: PropTypes.bool,
@@ -66,6 +67,7 @@ export class SiteSelector extends Component {
 	static defaultProps = {
 		sites: {},
 		showManageSitesButton: false,
+		showManageDomainsButton: false,
 		showAddNewSite: false,
 		showAllSites: false,
 		showHiddenSites: false,
@@ -238,6 +240,10 @@ export class SiteSelector extends Component {
 
 	onManageSitesClick = () => {
 		this.props.recordTracksEvent( 'calypso_manage_sites_click' );
+	};
+
+	onManageDomainsClick = () => {
+		this.props.recordTracksEvent( 'calypso_manage_domains_click' );
 	};
 
 	onSiteHover = ( event, siteId ) => {
@@ -466,8 +472,15 @@ export class SiteSelector extends Component {
 						</span>
 					) }
 				</div>
-				{ ( this.props.showManageSitesButton || this.props.showAddNewSite ) && (
+				{ ( this.props.showManageSitesButton ||
+					this.props.showAddNewSite ||
+					this.props.showManageDomainsButton ) && (
 					<div className="site-selector__actions">
+						{ this.props.showManageDomainsButton && (
+							<Button transparent onClick={ this.onManageDomainsClick } href="/domains/manage">
+								{ this.props.translate( 'Manage domains' ) }
+							</Button>
+						) }
 						{ this.props.showManageSitesButton && (
 							<Button
 								transparent

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -310,6 +310,14 @@ export class SiteSelector extends Component {
 			sites = sites.filter( ( site ) => site.slug !== this.props.selected );
 		}
 
+		// Previously, each domain-only site would correspond to one site in the list.
+		// Soon, bulk transfers of many domains will be attached to a single domain-only site.
+		// Because of this, it no longer makes sense to show domain-only sites in the
+		// site selector.
+
+		// Eventually, we'll want to filter out domain-only sites at the API boundary instead.
+		sites = sites.filter( ( site ) => ! site?.options?.is_domain_only );
+
 		return sites;
 	}
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -316,10 +316,8 @@ export class SiteSelector extends Component {
 			sites = sites.filter( ( site ) => site.slug !== this.props.selected );
 		}
 
-		// Previously, each domain-only site would correspond to one site in the list.
-		// Soon, bulk transfers of many domains will be attached to a single domain-only site.
-		// Because of this, it no longer makes sense to show domain-only sites in the
-		// site selector.
+		// Bulk transfers of many domains get attached to a single domain-only site.
+		// Because of this, it doesn't make sense to show domain-only sites in the site selector.
 
 		// Eventually, we'll want to filter out domain-only sites at the API boundary instead.
 		sites = sites.filter( ( site ) => ! site?.options?.is_domain_only );

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -33,6 +33,7 @@ class MySitesNavigation extends Component {
 
 			sitePickerProps = {
 				showManageSitesButton: true,
+				showManageDomainsButton: true,
 				showHiddenSites: true,
 				maxResults: 50,
 			};

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -30,6 +30,7 @@ class SitePicker extends Component {
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		setLayoutFocus: PropTypes.func.isRequired,
 		showManageSitesButton: PropTypes.bool,
+		showManageDomainsButton: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -103,6 +104,7 @@ class SitePicker extends Component {
 					maxResults={ this.props.maxResults }
 					showHiddenSites={ this.props.showHiddenSites }
 					showManageSitesButton={ this.props.showManageSitesButton }
+					showManageDomainsButton={ this.props.showManageDomainsButton }
 					isPlaceholder={ ! this.state.isRendered }
 					indicator={ true }
 					showAddNewSite={ true }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1873

## Context

Previously, each domain-only site would correspond to one site in the list. Soon, bulk transfers of many domains will be attached to a single domain-only site. Because of this, it no longer makes sense to show domain-only sites in the site selector. Folks will now want to go to `/manage/domains` to handle domain-only sites

## Proposed Changes

* Filters out domain only sites from _**all**_ instances of the site selector
* Adds a Manage Domains button to Calypso Admin Sidebar

## Screenshots

### Calypso Admin Sidebar
| Before      | After |
| ----- | ----- |
| <img width="271" alt="Screenshot 2023-06-26 at 6 07 00 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/f715756d-c396-40d6-8f49-8340f7538ca5"> | <img width="271" alt="Screenshot 2023-06-26 at 6 06 44 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/375a80be-bc1a-40be-9d4e-c54cbb519f08"> |

### me/account
| Before      | After |
| ----- | ----- |
| <img width="765" alt="Screenshot 2023-06-26 at 6 40 41 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/9680fa34-6474-4262-aff5-07bcab2abb34"> | <img width="745" alt="Screenshot 2023-06-26 at 6 40 01 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/a1044270-47d1-4092-ae7f-bf5875c993bd"> |

### /read
| Before      | After |
| ----- | ----- |
| <img width="1086" alt="Screenshot 2023-06-26 at 7 10 36 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/5d8ec56f-2fe2-4574-874f-eafd1ac1cbce"> | <img width="1085" alt="Screenshot 2023-06-26 at 7 11 03 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/8497ac91-660d-4b3d-af03-7d5a004e34fc"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a domain only site
  * https://wordpress.com/domains/
  * searching for a domain
  * selecting a domain ( .blog preferably )
  * clicking on `Get domain`

**Calypso Admin Sidebar**
* Visit https://WordPress.com as a logged in user and open the site selector
* Scroll through the list of rendered sites and verify that no domain-only sites are displayed ( including the one you just created )
* Verify that, in the Calypso admin sidebar, that the Manage domains button redirects the user to `/domains/manage`

**me/account**
* Visit https://WordPress.com/me/account as a logged in user
* Click on the `Primary Site` dropdown
* Scroll through the list of rendered sites and verify that no domain-only sites are displayed ( including the one you just created )

**/read**
* Visit https://WordPress.com/read as a logged in user
* Click on the reader share icon at the bottom of a reader post
* Scroll through the list of rendered sites and verify that no domain-only sites are displayed ( including the one you just created )

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
