### PR TITLE
Theme Showcase: Fix theme card more button CSS specificity

### DIFF
--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -28,8 +28,8 @@ $theme-card-info-margin-top: 16px;
 			margin-top: 0;
 			padding: 8px 24px;
 
-			.theme__more-button,
-			.theme-card__info-options {
+			.theme-card__info-options,
+			.theme-card__info-options .theme__more-button {
 				position: relative;
 			}
 		}
@@ -217,8 +217,8 @@ $theme-card-info-margin-top: 16px;
 	-webkit-font-smoothing: antialiased;
 
 	&:not(&--has-style-variations) {
-		.theme__more-button,
-		.theme-card__info-options {
+		.theme-card__info-options,
+		.theme-card__info-options .theme__more-button {
 			top: 0;
 		}
 	}
@@ -286,8 +286,8 @@ $theme-card-info-margin-top: 16px;
 	}
 }
 
-.theme__more-button,
-.theme-card__info-options {
+.theme-card__info-options,
+.theme-card__info-options .theme__more-button {
 	border: 0;
 	bottom: 0;
 	display: flex;


### PR DESCRIPTION
## Proposed Changes

As reported in p1687446782198729-slack-C048CUFRGFQ, the theme card more button might have broken CSS in development environments. See screenshot for reference:

| Production | Development |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/797888/d7031302-3d49-4703-af22-c153586dbc6f) | ![image](https://github.com/Automattic/wp-calypso/assets/797888/d44dba63-8b7c-43b0-8adf-a4d3b6ae4f80) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is not 100% reproducible, but we can test that the added CSS specificity doesn't break existing CSS.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?