### PR TITLE
Assembler: Fix selected layout and styles are not restored after checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -21,6 +21,10 @@ const SiteIntent = Onboard.SiteIntent;
 const withThemeAssemblerFlow: Flow = {
 	name: WITH_THEME_ASSEMBLER_FLOW,
 	useSideEffect() {
+		const selectedDesign = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
+			[]
+		);
 		const { setSelectedDesign, setIntent } = useDispatch( ONBOARD_STORE );
 		const selectedTheme = useQuery().get( 'theme' );
 
@@ -30,7 +34,14 @@ const withThemeAssemblerFlow: Flow = {
 		useEffect( () => {
 			if ( selectedTheme === BLANK_CANVAS_DESIGN.slug ) {
 				// User has selected blank-canvas-3 theme from theme showcase and enter assembler flow
-				setSelectedDesign( BLANK_CANVAS_DESIGN as Design );
+				setSelectedDesign( {
+					...selectedDesign,
+					...BLANK_CANVAS_DESIGN,
+					recipe: {
+						...selectedDesign?.recipe,
+						...BLANK_CANVAS_DESIGN.recipe,
+					},
+				} as Design );
 			}
 
 			setIntent( SiteIntent.WithThemeAssembler );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78662

## Proposed Changes

* The selected layout and styles are gone after checkout because we will reset the `selectedDesign` whenever people enter the `with-theme-assembler` flow. So, this PR proposed to merge the `selectedDesign` instead of overwriting to keep the selected layout and styles!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start with a free site.
* Go to the Theme Showcase (Appearances => Themes)
* Scroll and click Start designing in Design your own section
* On the Assembler screen
  * Select any layout and styles
  * Continue
  * Upgrade plan
  * Complete the checkout
* When you redirect back to the Assembler, you have to see the selected layout and styles

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
