### PR TITLE
Help Center: wrap closing callback with a `useCallback`

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import HelpCenter from '@automattic/help-center';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useCallback } from '@wordpress/element';
 import * as ReactDOM from 'react-dom';
 import { whatsNewQueryClient } from '../../common/what-new-query-client';
 import CalypsoStateProvider from './CalypsoStateProvider';
@@ -20,6 +20,8 @@ function AdminHelpCenterContent() {
 		}
 	}, [ show, button ] );
 
+	const closeCallback = useCallback( () => setShowHelpCenter( false ), [ setShowHelpCenter ] );
+
 	const handleToggleHelpCenter = () => {
 		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'show' }`, {
 			force_site_id: true,
@@ -32,7 +34,7 @@ function AdminHelpCenterContent() {
 
 	button.onclick = handleToggleHelpCenter;
 
-	return <HelpCenter handleClose={ () => setShowHelpCenter( false ) } />;
+	return <HelpCenter handleClose={ closeCallback } />;
 }
 
 if ( window?.helpCenterAdminBar?.isLoaded ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -30,7 +30,7 @@ function HelpCenterContent() {
 
 	const show = useSelect( ( select ) => select( 'automattic/help-center' ).isHelpCenterShown() );
 
-	const handleToggleHelpCenter = () => {
+	const handleToggleHelpCenter = useCallback( () => {
 		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'show' }`, {
 			force_site_id: true,
 			location: 'help-center',
@@ -38,7 +38,7 @@ function HelpCenterContent() {
 		} );
 
 		setShowHelpCenter( ! show );
-	};
+	}, [ setShowHelpCenter, show ] );
 
 	useEffect( () => {
 		const timeout = setTimeout( () => setShowHelpIcon( true ), 0 );


### PR DESCRIPTION
This is the same fix as https://github.com/Automattic/wp-calypso/pull/78236 but for `admin-bar.js`

Related to p1687855808480539-slack-C02T4NVL4JJ
