### PR TITLE
Assembler - Colors and fonts boxes border is missing on Safari 

### DIFF
--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -63,3 +63,8 @@
 		}
 	}
 }
+
+.global-styles-variation__item-preview {
+	padding: 1px;
+}
+

--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -67,4 +67,3 @@
 .global-styles-variation__item-preview {
 	padding: 1px;
 }
-

--- a/packages/global-styles/src/components/font-pairing-variations/style.scss
+++ b/packages/global-styles/src/components/font-pairing-variations/style.scss
@@ -17,17 +17,17 @@
 
 .global-styles-variation__item {
 	position: relative;
-	margin: 3px;
+	margin: 2px;
 	cursor: pointer;
 
 	&::after {
 		content: "";
 		display: block;
 		position: absolute;
-		top: -3px;
-		bottom: -3px;
-		left: -3px;
-		right: -3px;
+		top: -2px;
+		bottom: -2px;
+		left: -2px;
+		right: -2px;
 		border-radius: 3px; /* stylelint-disable-line scales/radii */
 		opacity: 0;
 		pointer-events: none;
@@ -54,3 +54,8 @@
 		}
 	}
 }
+
+.global-styles-variation__item-preview {
+	padding: 1px;
+}
+

--- a/packages/global-styles/src/components/font-pairing-variations/style.scss
+++ b/packages/global-styles/src/components/font-pairing-variations/style.scss
@@ -58,4 +58,3 @@
 .global-styles-variation__item-preview {
 	padding: 1px;
 }
-


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fix the border issue on Safari by changing paddings/margins without affecting the design
* Use the same margin values for Fonts and Colors buttons because we load both and they overwrite each other  

### **Fonts**

The border is fixed in Safari 🥳

|BEFORE|AFTER|
|---|---|
|<img width="312" alt="Screenshot 2566-06-27 at 16 30 17" src="https://github.com/Automattic/wp-calypso/assets/1881481/d37b71c7-c594-4e3b-9731-d96df293c34d">|<img width="310" alt="Screenshot 2566-06-27 at 16 29 49" src="https://github.com/Automattic/wp-calypso/assets/1881481/131f4dc3-8125-4605-a5e3-6f5b3fb266c6">|

No visible changes in Chrome ✌️

|BEFORE|AFTER|
|---|---|
|<img width="310" alt="Screenshot 2566-06-27 at 16 24 08" src="https://github.com/Automattic/wp-calypso/assets/1881481/d2e0bded-6de6-4e07-a9d2-4bab9642e0a0">|<img width="312" alt="Screenshot 2566-06-27 at 16 23 52" src="https://github.com/Automattic/wp-calypso/assets/1881481/baac3b0b-bbbf-424f-a2b6-ce9cb2ca72ca">|

### **Colors**

The border is also fixed in Safari and no visible changes in Chrome.

|BEFORE|AFTER|
|---|---|
|<img width="313" alt="Screenshot 2566-06-27 at 16 20 01" src="https://github.com/Automattic/wp-calypso/assets/1881481/06c1889a-6013-4aea-b1bf-2662ac21b28e">|<img width="311" alt="Screenshot 2566-06-27 at 16 20 23" src="https://github.com/Automattic/wp-calypso/assets/1881481/99fd8496-5cdc-4847-981e-8e8c2a7e64ce">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On Safari and Chrome
* Access the assembler: `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3` 
* Click Color and Fonts to verify that the border appears in Safari and there aren't visible changes in Chrome.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
