### PR TITLE
Update Congrats page for single/multiple plugins

### DIFF
--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -28,7 +28,7 @@ const ThankYouSectionTitle = styled.h1`
 
 const ThankYouSectionContainer = styled.div`
 	margin-bottom: 35px;
-	&:not( :first-child ) {
+	&:not( :first-of-type ) {
 		border-top: 1px solid var( --studio-gray-5 );
 	}
 	&:last-child {

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -61,7 +61,8 @@ export type ThankYouData = [
 	string,
 	string,
 	string[],
-	boolean
+	boolean,
+	React.ReactElement | null
 ];
 
 export type ThankYouSteps = { steps: string[]; additionalSteps: string[] };

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
@@ -47,6 +47,10 @@ const PluginSectionContent = styled.div`
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
+	flex-basis: 100%;
+	@media ( min-width: 480px ) {
+		flex-basis: initial;
+	}
 `;
 
 const PluginSectionName = styled.div`

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
@@ -21,22 +21,25 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 const PluginSectionContainer = styled.div`
 	display: flex;
 	flex-direction: row;
-	width: 720px;
+	width: 100%;
 	box-sizing: border-box;
 	align-items: center;
-	padding: 24px 0 24px 0;
+	gap: 16px;
+	padding: 24px;
+	border-radius: 2px;
+	border: 1px solid var( --color-border-subtle );
+	flex-wrap: wrap;
 
 	div {
 		min-width: auto;
 	}
 
-	@media ( max-width: 740px ) {
-		width: 500px;
-		gap: 16px;
+	@media ( min-width: 782px ) {
+		width: 720px;
 	}
 
-	@media ( max-width: 520px ) {
-		width: 280px;
+	@media ( min-width: 480px ) {
+		padding: 20px 25px;
 	}
 `;
 
@@ -44,11 +47,6 @@ const PluginSectionContent = styled.div`
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
-	margin: 0 16px;
-
-	@media ( max-width: 740px ) {
-		margin: 0;
-	}
 `;
 
 const PluginSectionName = styled.div`
@@ -56,6 +54,7 @@ const PluginSectionName = styled.div`
 	font-weight: 500;
 	line-height: 24px;
 	color: var( --studio-gray-100 );
+	flex-grow: 1;
 `;
 
 const PluginSectionExpirationDate = styled.div`

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -16,7 +16,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { MarketplaceGoBackSection } from './marketplace-go-back-section';
 import { useAtomicTransfer } from './use-atomic-transfer';
 import { usePageTexts } from './use-page-texts';
-import { usePluginsThankYouData } from './use-plugins-thank-you-data';
+import usePluginsThankYouData from './use-plugins-thank-you-data';
 import { useThankYouFoooter } from './use-thank-you-footer';
 import { useThankYouSteps } from './use-thank-you-steps';
 import { useThemesThankYouData } from './use-themes-thank-you-data';
@@ -46,6 +46,7 @@ const MarketplaceThankYou = ( {
 		pluginSubtitle,
 		pluginsProgressbarSteps,
 		isAtomicNeededForPlugins,
+		thankYouHeaderAction,
 	] = usePluginsThankYouData( pluginSlugs );
 	const [
 		themesSection,
@@ -155,6 +156,7 @@ const MarketplaceThankYou = ( {
 						showSupportSection={ false }
 						thankYouTitle={ title }
 						thankYouSubtitle={ subtitle }
+						thankYouHeaderBody={ thankYouHeaderAction }
 						headerBackgroundColor="#fff"
 						headerTextColor="#000"
 					/>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -7,10 +7,6 @@
 	flex-direction: column;
 	justify-content: center;
 
-	.thank-you__step:not(:first-child) {
-		border-top: 1px solid var(--studio-gray-5);
-	}
-
 	.thank-you__container {
 		padding-top: var(--masterbar-height);
 	}
@@ -32,6 +28,7 @@
 			display: flex;
 			flex-direction: column;
 			width: 100%;
+
 			@include break-mobile {
 				width: auto;
 				align-items: center;
@@ -46,6 +43,7 @@
 	.thank-you__step-section {
 		padding: 0;
 		margin-bottom: 16px;
+		flex-grow: 1;
 	}
 
 	.thank-you__header-title,
@@ -67,7 +65,7 @@
 
 	.thank-you__header-subtitle {
 		margin: 8px auto;
-		max-width: 500px;
+		max-width: 600px;
 		line-height: 24px;
 		font-size: $font-body;
 		color: var(--studio-gray-60);

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -59,8 +59,14 @@
 
 	.thank-you__header-title {
 		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		font-size: 44px; // typography-exception
+		font-size: 48px;
 		line-height: 60px;
+		letter-spacing: -0.32px;
+		@media ( max-width: 480px ) {
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			font-size: 32px; // typography-exception
+			line-height: 40px;
+		}
 	}
 
 	.thank-you__header-subtitle {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -1,6 +1,9 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@automattic/components';
+import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { ThankYouData, ThankYouSectionProps } from 'calypso/components/thank-you/types';
 import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
@@ -19,7 +22,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import { ThankYouPluginSection } from './marketplace-thank-you-plugin-section';
 import MasterbarStyled from './masterbar-styled';
 
-export function usePluginsThankYouData( pluginSlugs: string[] ): ThankYouData {
+export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYouData {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
@@ -173,6 +176,44 @@ export function usePluginsThankYouData( pluginSlugs: string[] ): ThankYouData {
 		[ translate ]
 	);
 
+	const sendTrackEvent = useCallback(
+		( name: string ) => {
+			recordTracksEvent( name, {
+				site_id: siteId,
+				plugins: pluginSlugs.join(),
+			} );
+		},
+		[ siteId, pluginSlugs ]
+	);
+
+	const ThankYouHeaderAction = styled.div`
+		padding: 20px 24px 0 24px;
+		@media ( max-width: 480px ) {
+			text-align: left;
+		}
+	`;
+
+	const ThankYouHeaderActionButton = styled( Button )`
+		border-radius: 4px;
+	`;
+
+	const thankYouHeaderAction =
+		pluginsInformationList.length > 1 ? (
+			<>
+				<ThankYouHeaderAction>
+					<ThankYouHeaderActionButton
+						primary
+						href={ `https://${ siteSlug }/wp-admin/plugins.php` }
+						onClick={ () => {
+							sendTrackEvent( 'calypso_plugin_thank_you_setup_plugins_click' );
+						} }
+					>
+						{ translate( 'Setup the plugins' ) }
+					</ThankYouHeaderActionButton>
+				</ThankYouHeaderAction>
+			</>
+		) : null;
+
 	// Plugins are only installed in atomic sites
 	// so atomic is always needed as long as we have plugins
 	const isAtomicNeeded = pluginSlugs.length > 0;
@@ -185,6 +226,7 @@ export function usePluginsThankYouData( pluginSlugs: string[] ): ThankYouData {
 		subtitle,
 		thankyouSteps,
 		isAtomicNeeded,
+		thankYouHeaderAction,
 	];
 }
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -24,12 +24,15 @@ export function usePluginsThankYouData( pluginSlugs: string[] ): ThankYouData {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
-
 	// texts
-	const title = translate( "Congrats on your site's new superpowers!" );
+	const title = translate( 'Your site, more powerful than ever' );
 	const subtitle = translate(
-		"Now you're really getting the most out of WordPress. Dig in and explore more of our favorite plugins."
-	);
+		'All set! Time to put your new plugin to work and take your site further.',
+		'All set! Time to put your new plugins to work and take your site further.',
+		{
+			count: pluginSlugs.length,
+		}
+	).toString();
 
 	// retrieve WPCom plugin data
 	const wpComPluginsDataResults = useWPCOMPlugins( pluginSlugs );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
@@ -1,5 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { ThankYouSectionProps, ThankYouNextStepProps } from 'calypso/components/thank-you/types';
@@ -47,14 +49,25 @@ export function useThankYouFoooter(
 
 function usePluginSteps(): FooterStep[] {
 	const translate = useTranslate();
+	const { hasTranslation } = useI18n();
+	const locale = useLocale();
+	const newText =
+		'Check out our support documentation for step-by-step instructions and expert guidance on your plugin setup.';
+
+	const descriptionText =
+		locale.startsWith( 'en' ) || hasTranslation?.( newText )
+			? translate(
+					'Check out our support documentation for step-by-step instructions and expert guidance on your plugin setup.'
+			  )
+			: translate(
+					'Check out our support documentation for step-by-step instructions and expert guidance on your plugin set up.'
+			  );
 
 	return [
 		{
 			key: 'thank_you_footer_explore',
 			title: translate( 'Need help setting your plugin up?' ),
-			description: translate(
-				'Check out our support documentation for step-by-step instructions and expert guidance on your plugin setup.'
-			),
+			description: descriptionText,
 			link: `https://wordpress.com/support/plugins/use-your-plugins/`,
 			linkText: translate( 'Plugin setup guide' ),
 			eventKey: 'calypso_plugin_thank_you_explore_plugins_click',

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
@@ -4,7 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { ThankYouSectionProps, ThankYouNextStepProps } from 'calypso/components/thank-you/types';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function useThankYouFoooter(
 	pluginSlugs: Array< string >,
@@ -26,7 +26,7 @@ export function useThankYouFoooter(
 	 * If only plugins are present
 	 */
 	if ( hasPlugins && ! hasThemes ) {
-		footerSteps = [ pluginExploreStep, pluginSupportStep, themeSupportStep ];
+		footerSteps = [ pluginExploreStep, pluginSupportStep ];
 	}
 
 	/**
@@ -47,26 +47,27 @@ export function useThankYouFoooter(
 
 function usePluginSteps(): FooterStep[] {
 	const translate = useTranslate();
-	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	return [
 		{
 			key: 'thank_you_footer_explore',
-			title: translate( 'Keep growing' ),
+			title: translate( 'Need help setting your plugin up?' ),
 			description: translate(
-				'Take your site to the next level. We have all the solutions to help you.'
+				'Check out our support documentation for step-by-step instructions and expert guidance on your plugin set up.'
 			),
-			link: `/plugins/${ siteSlug }`,
-			linkText: translate( 'Explore plugins' ),
+			link: `https://wordpress.com/support/plugins/use-your-plugins/`,
+			linkText: translate( 'Plugin setup guide' ),
 			eventKey: 'calypso_plugin_thank_you_explore_plugins_click',
 			blankTarget: false,
 		},
 		{
 			key: 'thank_you_footer_support_guides',
-			title: translate( 'Learn More' ),
-			description: translate( 'Discover everything you need to know about Plugins.' ),
-			link: 'https://wordpress.com/support/plugins/',
-			linkText: translate( 'Plugin Support' ),
+			title: translate( 'All-in-one plugin documentation' ),
+			description: translate(
+				`Unlock your plugin's potential with our comprehensive support documentation.`
+			),
+			link: 'https://wordpress.com/support/category/plugins-and-integrations/',
+			linkText: translate( 'Plugin documentation' ),
 			eventKey: 'calypso_plugin_thank_you_plugin_support_click',
 		},
 	];

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
@@ -53,7 +53,7 @@ function usePluginSteps(): FooterStep[] {
 			key: 'thank_you_footer_explore',
 			title: translate( 'Need help setting your plugin up?' ),
 			description: translate(
-				'Check out our support documentation for step-by-step instructions and expert guidance on your plugin set up.'
+				'Check out our support documentation for step-by-step instructions and expert guidance on your plugin setup.'
 			),
 			link: `https://wordpress.com/support/plugins/use-your-plugins/`,
 			linkText: translate( 'Plugin setup guide' ),

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -98,5 +98,6 @@ export function useThemesThankYouData( themeSlugs: string[] ): ThankYouData {
 		subtitle,
 		thankyouSteps,
 		isAtomicNeeded,
+		null,
 	];
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2720
## Proposed Changes

* Update design/copy for single plugin congrats page
* Update both for mobile and desktop

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/05f0b857-cd29-46db-83ce-bfca09029d01">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/fdd08da9-186f-4bfe-972b-eea1fc80271e">|


| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/68522332-ad31-4e4d-858c-39d830a210ab">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/ff5f7b9f-9d03-4dd6-b771-c0ee32bcb9c9">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm the design of the single plugin's congrats page matches the Figma design. Note that there're still some discussions with the primary CTA so you can ignore that for now.
Example URL: `http://calypso.localhost:3000/marketplace/thank-you/:slug?plugins=woothemes-sensei`
Design: VLoPHWqcewxNKZYjjkDu3O-fi-1701_2254
* Confirm tracks event are logged when buttons/links are clicked

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you checked for TypeScript, React or other console errors?