### PR TITLE
add: wc core profiler flow styling for 2fa

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -38,7 +38,9 @@ import { isPasswordlessAccount, isPartnerSignupQuery } from 'calypso/state/login
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
@@ -239,8 +241,17 @@ class Login extends Component {
 	};
 
 	getSignupUrl = () => {
-		const { currentRoute, oauth2Client, currentQuery, pathname, locale, signupUrl, isWoo } =
-			this.props;
+		const {
+			currentRoute,
+			oauth2Client,
+			currentQuery,
+			initialQuery,
+			pathname,
+			locale,
+			signupUrl,
+			isWoo,
+			isWooCoreProfilerFlow,
+		} = this.props;
 
 		if ( signupUrl ) {
 			return signupUrl;
@@ -249,6 +260,10 @@ class Login extends Component {
 		if ( isWoo && isEmpty( currentQuery ) ) {
 			// if query is empty, return to the woo start flow
 			return 'https://woocommerce.com/start/';
+		}
+
+		if ( isWooCoreProfilerFlow && isEmpty( currentQuery ) ) {
+			return getSignupUrl( initialQuery, currentRoute, oauth2Client, locale, pathname );
 		}
 
 		return getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname );
@@ -433,21 +448,32 @@ class Login extends Component {
 				);
 			}
 		} else if ( isWooCoreProfilerFlow ) {
-			const subtitle = currentQuery.lostpassword_flow
-				? translate(
+			const isLostPasswordFlow = currentQuery.lostpassword_flow;
+			const isTwoFactorAuthnFlow = this.props.twoFactorEnabled;
+
+			let subtitle = null;
+
+			switch ( true ) {
+				case isLostPasswordFlow:
+					headerText = null;
+					subtitle = translate(
 						"Your password reset confirmation is on its way to your email address – please check your junk folder if it's not in your inbox! Once you've reset your password, head back to this page to log in to your account."
-				  )
-				: translate(
+					);
+					break;
+				case isTwoFactorAuthnFlow:
+					headerText = <h3>{ translate( 'Authenticate your login' ) }</h3>;
+					break;
+				default:
+					headerText = <h3>{ translate( 'One last step' ) }</h3>;
+					subtitle = translate(
 						"In order to take advantage of the benefits offered by Jetpack, please log in to your WordPress.com account below. Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
 						{
 							components: {
 								signupLink: <a href={ this.getSignupUrl() } />,
 							},
 						}
-				  );
-			headerText = currentQuery.lostpassword_flow ? null : (
-				<h3>{ translate( 'One last step' ) }</h3>
-			);
+					);
+			}
 			preHeader = null;
 			postHeader = <p className="login__header-subtitle">{ subtitle }</p>;
 		} else if ( isJetpackWooCommerceFlow ) {
@@ -624,7 +650,7 @@ class Login extends Component {
 						rebootAfterLogin={ this.rebootAfterLogin }
 						switchTwoFactorAuthType={ this.handleTwoFactorRequested }
 					/>
-					{ isWoo && ! isPartnerSignup && (
+					{ ( isWoo || isWooCoreProfilerFlow ) && ! isPartnerSignup && (
 						<div className="login__two-factor-footer">
 							<p className="login__two-factor-no-account">
 								{ translate( 'Don’t have an account? {{signupLink}}Sign up{{/signupLink}}', {
@@ -746,8 +772,7 @@ export default connect(
 		partnerSlug: getPartnerSlugFromQuery( state ),
 		isJetpackWooCommerceFlow:
 			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
-		isWooCoreProfilerFlow:
-			'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ),
+		isWooCoreProfilerFlow: isWooCommerceCoreProfilerFlow( state ),
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 		isAnchorFmSignup: getIsAnchorFmSignup(
 			get( getCurrentQueryArguments( state ), 'redirect_to' )
@@ -757,6 +782,7 @@ export default connect(
 			'wpcom-migration'
 		),
 		currentQuery: getCurrentQueryArguments( state ),
+		initialQuery: getInitialQueryArguments( state ),
 		currentRoute: getCurrentRoute( state ),
 		isPartnerSignup: isPartnerSignupQuery( getCurrentQueryArguments( state ) ),
 		loginEmailAddress: getCurrentQueryArguments( state )?.email_address,

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -449,7 +449,7 @@ class Login extends Component {
 			}
 		} else if ( isWooCoreProfilerFlow ) {
 			const isLostPasswordFlow = currentQuery.lostpassword_flow;
-			const isTwoFactorAuthnFlow = this.props.twoFactorEnabled;
+			const isTwoFactorAuthFlow = this.props.twoFactorEnabled;
 
 			let subtitle = null;
 
@@ -460,7 +460,7 @@ class Login extends Component {
 						"Your password reset confirmation is on its way to your email address – please check your junk folder if it's not in your inbox! Once you've reset your password, head back to this page to log in to your account."
 					);
 					break;
-				case isTwoFactorAuthnFlow:
+				case isTwoFactorAuthFlow:
 					headerText = <h3>{ translate( 'Authenticate your login' ) }</h3>;
 					break;
 				default:

--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -44,10 +44,13 @@ class SecurityKeyForm extends Component {
 		const { translate, isWoo, switchTwoFactorAuthType } = this.props;
 
 		return (
-			<form onSubmit={ this.initiateSecurityKeyAuthentication }>
+			<form
+				className="two-factor-authentication__verification-code-form-wrapper"
+				onSubmit={ this.initiateSecurityKeyAuthentication }
+			>
 				<Card compact className="two-factor-authentication__verification-code-form">
 					{ ! this.state.isAuthenticating && (
-						<div>
+						<div className="security-key-form__help-text">
 							<p>
 								{ translate( '{{strong}}Use your security key to finish logging in.{{/strong}}', {
 									components: {

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -11,6 +11,7 @@ import { isTwoFactorAuthTypeSupported } from 'calypso/state/login/selectors';
 import { isPartnerSignupQuery } from 'calypso/state/login/utils';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import Divider from '../divider';
 import './two-factor-actions.scss';
 
@@ -101,7 +102,9 @@ export default connect(
 		isAuthenticatorSupported: isTwoFactorAuthTypeSupported( state, 'authenticator' ),
 		isSmsSupported: isTwoFactorAuthTypeSupported( state, 'sms' ),
 		isSecurityKeySupported: isTwoFactorAuthTypeSupported( state, 'webauthn' ),
-		isWoo: isWooOAuth2Client( getCurrentOAuth2Client( state ) ),
+		isWoo:
+			isWooOAuth2Client( getCurrentOAuth2Client( state ) ) ||
+			isWooCommerceCoreProfilerFlow( state ),
 		isPartnerSignup: isPartnerSignupQuery( getCurrentQueryArguments( state ) ),
 	} ),
 	{

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -127,9 +127,12 @@ class VerificationCodeForm extends Component {
 		}
 
 		return (
-			<form onSubmit={ this.onSubmitForm }>
+			<form
+				className="two-factor-authentication__verification-code-form-wrapper"
+				onSubmit={ this.onSubmitForm }
+			>
 				<Card compact className="two-factor-authentication__verification-code-form">
-					<p>{ helpText }</p>
+					<p className="verification-code-form__help-text">{ helpText }</p>
 
 					<FormFieldset>
 						<FormLabel htmlFor="twoStepCode">{ labelText }</FormLabel>

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -804,6 +804,13 @@
 			font-weight: 500;
 		}
 
+		form.two-factor-authentication__verification-code-form-wrapper {
+			@media screen and ( max-width: 660px ) {
+				margin: 0;
+				max-width: 660px;
+			}
+		}
+
 		.login__header-subtitle,
 		.formatted-header__subtitle {
 			color: $gray-700;
@@ -828,6 +835,74 @@
 			padding: 10px 16px;
 			font-weight: 500;
 			background-color: var(--wp-admin-theme-color);
+		}
+
+		.two-factor-authentication__actions.card button.button {
+			border-radius: 2px;
+			height: 48px;
+			padding: 10px 16px;
+			font-weight: 500;
+			background-color: transparent;
+			color: var(--wp-admin-theme-color);
+			border: 1px solid var(--wp-admin-theme-color);
+			width: 100%;
+		}
+
+		.two-factor-authentication__verification-code-form.card {
+			padding-top: 0;
+			margin-bottom: 36px;
+
+			.verification-code-form__help-text {
+				color: $gray-700;
+			}
+
+			.security-key-form__help-text {
+				color: $gray-700;
+				margin-bottom: 24px;
+
+				p strong {
+					color: $gray-700;
+					font-weight: 400;
+				}
+
+				p:nth-child(2) {
+					@media screen and ( min-width: 660px ) {
+						// css to allow for this element to exceed parent's width
+						width: 152%; // 152% * 405px gets us to 615px which is the design spec
+						position: relative;
+						left: -26%; // shift position back by half of that so that it remains centered
+					}
+				}
+			}
+
+			fieldset.form-fieldset label.form-label {
+				font-weight: 500;
+				text-transform: uppercase;
+				font-size: rem(11px);
+				color: $gray-900;
+			}
+		}
+
+		.two-factor-authentication__actions.card {
+			padding-top: 36px;
+		}
+
+		div.login__two-factor-footer {
+			margin-top: 16px;
+			p {
+				margin-bottom: 0;
+				color: $woo-label-color;
+				font-size: rem(14px);
+				line-height: 24px;
+				letter-spacing: -0.1px;
+
+				a {
+					color: var(--wp-admin-theme-color);
+					font-size: rem(14px);
+					line-height: 24px;
+					letter-spacing: -0.1px;
+				}
+			}
 		}
 
 		span.social-buttons__service-name {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/wp-calypso/issues/77828

## Proposed Changes

* Implemented custom styling for the 2FA screens as indicated by the figma design in the linked issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. (optional, skip steps 6-8 if you have this) Set up [woocommerce-start-dev-env](https://github.com/woocommerce/woocommerce-start-dev-env)
2. Create a JN site and use the [latest woocommerce nightly build](https://github.com/woocommerce/woocommerce/releases/tag/nightly)
3. Ensure that you are not logged in to a wordpress.com user on wordpress.com/me (but also make sure that you have a user that has 2fa set up, either security key or 2fa app or both)
4. Go to Core Profiler flow 
5. Install plugins and confirm you're redirected to Jetpack connection page
6. Note the full wordpress.com/log-in URL
7. Replace wordpress.com with the calypso.live link
8. Login link should look something like this: https://container-wonderful-black.calypso.live/log-in/jetpack?redirect_to=https%3A%2F%2Fwordpress.com%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D214940602%26redirect_uri%3Dhttps%253A%252F%252Fwccore-dev.nerd.sg%252Fwp-admin%252Fadmin.php%253Fhandler%253Djetpack-connection-webhooks%2526action%253Dauthorize%2526_wpnonce%253D174fe6fea7%2526redirect%253Dhttps%25253A%25252F%25252Fwccore-dev.nerd.sg%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Dwc-admin%26state%3D1%26scope%3Dadministrator%253A8677f63a8bdfe955658f36fb0966d72f%26user_email%3Dwordpress%2540example.com%26user_login%3Dnrzo%26jp_version%26secret%3DbifZYFBcHNyxReiei1Ne2Au08W3zFSyX%26blogname%3Dasdf%26site_url%3Dhttps%253A%252F%252Fwccore-dev.nerd.sg%252F%26home_url%3Dhttps%253A%252F%252Fwccore-dev.nerd.sg%252F%26site_icon%26site_lang%3Den_US%26site_created%3D2023-06-23%2B07%253A58%253A57%26allow_site_connection%3D1%26_as%3Dunknown%26from%3Dwoocommerce-core-profiler%26calypso_env%3Dproduction%26installed_ext_success%3D1%26_ui%3D222372596%26_ut%3Dwpcom%253Auser_id%26purchase_nonce%3DD1nJ0JWy%26_wp_nonce%3Ddd40efb543%26redirect_after_auth%3Dhttps%253A%252F%252Fwccore-dev.nerd.sg%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin%26site%3Dhttps%253A%252F%252Fwccore-dev.nerd.sg%252F&from=woocommerce-core-profiler
9. Test around the 2fa screens

https://github.com/Automattic/wp-calypso/assets/27843274/467416f1-fe99-4176-ab90-d4ac3df4916a



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
