### PR TITLE
Subscriber page: Add Tracks events

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { Modal } from '@wordpress/components';
@@ -30,6 +31,7 @@ const AddSubscribersModal = ( {
 						showTitle={ false }
 						showSubtitle={ false }
 						showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
+						recordTracksEvent={ recordTracksEvent }
 					/>
 				</Modal>
 			) }

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -6,6 +6,7 @@ import { SortControls } from 'calypso/landing/subscriptions/components/sort-cont
 import { useSubscriberListManager } from 'calypso/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context';
 import { SubscribersSortBy } from '../../constants';
 import './style.scss';
+import { useRecordSort } from '../../tracks';
 
 const getSortOptions = ( translate: ReturnType< typeof useTranslate > ) => [
 	{ value: SubscribersSortBy.Name, label: translate( 'Name' ) },
@@ -16,6 +17,7 @@ const ListActionsBar = () => {
 	const translate = useTranslate();
 	const { handleSearch, sortTerm, setSortTerm } = useSubscriberListManager();
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
+	const recordSort = useRecordSort();
 
 	return (
 		<div className="list-actions-bar">
@@ -25,7 +27,14 @@ const ListActionsBar = () => {
 				onSearch={ handleSearch }
 			/>
 
-			<SortControls options={ sortOptions } value={ sortTerm } onChange={ setSortTerm } />
+			<SortControls
+				options={ sortOptions }
+				value={ sortTerm }
+				onChange={ ( term ) => {
+					setSortTerm( term );
+					recordSort( { sort_field: term } );
+				} }
+			/>
 		</div>
 	);
 };

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -5,6 +5,7 @@ import { SubscriberList } from 'calypso/my-sites/subscribers/components/subscrib
 import { SubscriberListActionsBar } from 'calypso/my-sites/subscribers/components/subscriber-list-actions-bar';
 import { useSubscriberListManager } from 'calypso/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
+import { useRecordSearch } from '../../tracks';
 import './style.scss';
 
 type SubscriberListContainerProps = {
@@ -17,6 +18,7 @@ const SubscriberListContainer = ( {
 	onClickUnsubscribe,
 }: SubscriberListContainerProps ) => {
 	const { grandTotal, total, perPage, page, pageClickCallback } = useSubscriberListManager();
+	useRecordSearch();
 
 	return (
 		<section className="subscriber-list-container">

--- a/client/my-sites/subscribers/components/subscriber-profile/subscriber-profile.tsx
+++ b/client/my-sites/subscribers/components/subscriber-profile/subscriber-profile.tsx
@@ -13,6 +13,10 @@ const SubscriberProfile = ( {
 	email,
 	compact = true,
 }: SubscriberProfileProps ) => {
+	// When adding a click event for this, make sure to also track it
+	// import { useRecordSubscriberClicked } from '../../tracks';
+	// const recordSubscriberClicked = useRecordSubscriberClicked();
+	// recordSubscriberClicked( 'title', { } ); & recordSubscriberClicked( 'icon', { } );
 	return (
 		<div className={ `subscriber-profile ${ compact ? 'subscriber-profile--compact' : '' }` }>
 			<img src={ avatar } className="subscriber-profile__user-image" alt="Profile pic" />

--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -7,7 +7,7 @@ import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-
+import { useRecordExport } from '../../tracks';
 import '../shared/popover-style.scss';
 
 type SubscribersHeaderPopoverProps = {
@@ -23,6 +23,8 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 		{ page: 'subscribers', blog: siteId, blog_subscribers: 'csv', type: 'email' },
 		'https://dashboard.wordpress.com/wp-admin/index.php'
 	);
+	const recordExport = useRecordExport();
+
 	const onDownloadCsvClick = () => {
 		dispatch(
 			recordGoogleEvent(
@@ -30,6 +32,7 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 				'Clicked Download email subscribers as CSV menu item on Subscribers'
 			)
 		);
+		recordExport();
 	};
 
 	return (

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -1,5 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect } from 'react';
 import ConfirmModal from 'calypso/components/confirm-modal';
+import { useRecordRemoveModal } from '../../tracks';
 import { Subscriber } from '../../types';
 
 export enum UnsubscribeActionType {
@@ -16,6 +18,7 @@ type UnsubscribeModalProps = {
 const UnsubscribeModal = ( { subscriber, onCancel, onConfirm }: UnsubscribeModalProps ) => {
 	const translate = useTranslate();
 	const subscriberHasPlans = !! subscriber?.plans?.length;
+	const recordRemoveModal = useRecordRemoveModal();
 
 	const freeSubscriberProps = {
 		action: UnsubscribeActionType.Unsubscribe,
@@ -47,13 +50,24 @@ const UnsubscribeModal = ( { subscriber, onCancel, onConfirm }: UnsubscribeModal
 		? paidSubscriberProps
 		: freeSubscriberProps;
 
+	useEffect( () => {
+		if ( subscriber ) {
+			recordRemoveModal( subscriberHasPlans, 'modal_showed' );
+		}
+	}, [ recordRemoveModal, subscriberHasPlans, subscriber ] );
+
+	const onCancelClick = useCallback( () => {
+		recordRemoveModal( subscriberHasPlans, 'modal_dismissed' );
+		onCancel();
+	}, [ subscriberHasPlans, onCancel ] );
+
 	return (
 		<ConfirmModal
 			isVisible={ !! subscriber }
 			confirmButtonLabel={ confirmButtonLabel }
 			text={ text }
 			title={ title }
-			onCancel={ onCancel }
+			onCancel={ onCancelClick }
 			onConfirm={ () => onConfirm( action, subscriber ) }
 		/>
 	);

--- a/client/my-sites/subscribers/hooks/use-pagination.ts
+++ b/client/my-sites/subscribers/hooks/use-pagination.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useRecordPaged } from '../tracks';
 
 const usePagination = (
 	page: number,
@@ -6,7 +7,12 @@ const usePagination = (
 	isFetching: boolean
 ) => {
 	const [ currentPage, setCurrentPage ] = useState( page );
-	const pageClickCallback = ( page: number ) => setCurrentPage( page );
+	const recordPaged = useRecordPaged();
+	const pageClickCallback = ( page: number ) => {
+		recordPaged( { page } );
+		setCurrentPage( page );
+	};
+
 	useEffect( () => {
 		if ( ! isFetching && currentPage !== page ) {
 			pageChanged( currentPage );

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -3,11 +3,13 @@ import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { UnsubscribeActionType } from '../components/unsubscribe-modal';
 import { getEarnPaymentsPageUrl } from '../helpers';
+import { useRecordRemoveModal } from '../tracks';
 import { Subscriber } from '../types';
 
 const useUnsubscribeModal = ( unsubscribeMutation: ( subscriber: Subscriber ) => void ) => {
 	const [ currentSubscriber, setCurrentSubscriber ] = useState< Subscriber >();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const recordRemoveModal = useRecordRemoveModal();
 
 	const onClickUnsubscribe = ( subscriber: Subscriber ) => {
 		setCurrentSubscriber( subscriber );
@@ -19,6 +21,7 @@ const useUnsubscribeModal = ( unsubscribeMutation: ( subscriber: Subscriber ) =>
 
 	const onConfirmModal = ( action: UnsubscribeActionType, subscriber?: Subscriber ) => {
 		if ( action === UnsubscribeActionType.Manage ) {
+			recordRemoveModal( true, 'manage_button_clicked' );
 			window.open( getEarnPaymentsPageUrl( selectedSiteSlug ), '_blank' );
 		} else if ( action === UnsubscribeActionType.Unsubscribe && subscriber ) {
 			unsubscribeMutation( subscriber );

--- a/client/my-sites/subscribers/mutations/use-details-page-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-details-page-subscriber-remove-mutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { getSubscriberDetailsCacheKey, getSubscriberDetailsType } from '../helpers';
+import { useRecordSubscriberRemoved } from '../tracks';
 import type { Subscriber } from '../types';
 
 const useDetailsPageSubscriberRemoveMutation = (
@@ -10,6 +11,7 @@ const useDetailsPageSubscriberRemoveMutation = (
 ) => {
 	const queryClient = useQueryClient();
 	const type = getSubscriberDetailsType( userId );
+	const recordSubscriberRemoved = useRecordSubscriberRemoved();
 
 	return useMutation( {
 		mutationFn: async ( subscriber: Subscriber ) => {
@@ -45,6 +47,13 @@ const useDetailsPageSubscriberRemoveMutation = (
 					context.previousData
 				);
 			}
+		},
+		onSuccess: () => {
+			recordSubscriberRemoved( {
+				site_id: siteId,
+				subscription_id: subscriptionId,
+				user_id: userId,
+			} );
 		},
 		onSettled: () => {
 			queryClient.invalidateQueries(

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -1,10 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { getSubscribersCacheKey } from '../helpers';
+import { useRecordSubscriberRemoved } from '../tracks';
 import type { SubscriberEndpointResponse, Subscriber } from '../types';
 
 const useSubscriberRemoveMutation = ( siteId: number | null, currentPage: number ) => {
 	const queryClient = useQueryClient();
+	const recordSubscriberRemoved = useRecordSubscriberRemoved();
 
 	return useMutation( {
 		mutationFn: async ( subscriber: Subscriber ) => {
@@ -100,6 +102,13 @@ const useSubscriberRemoveMutation = ( siteId: number | null, currentPage: number
 					queryClient.setQueryData( getSubscribersCacheKey( siteId, page ), previousSubscribers );
 				} );
 			}
+		},
+		onSuccess: ( data, subscriber ) => {
+			recordSubscriberRemoved( {
+				site_id: siteId,
+				subscription_id: subscriber.subscription_id,
+				user_id: subscriber.user_id,
+			} );
 		},
 		onSettled: () => {
 			queryClient.invalidateQueries( getSubscribersCacheKey( siteId ) );

--- a/client/my-sites/subscribers/tracks/index.ts
+++ b/client/my-sites/subscribers/tracks/index.ts
@@ -1,0 +1,8 @@
+export { default as useRecordSubscribersTracksEvent } from './use-record-subscriber-tracks-event';
+export { default as useRecordSubscriberRemoved } from './use-record-subscriber-removed';
+export { default as useRecordRemoveModal } from './use-record-remove-modal';
+export { default as useRecordSearch } from './use-record-search';
+export { default as useRecordSort } from './use-record-sort';
+export { default as useRecordPaged } from './use-record-paged';
+export { default as useRecordExport } from './use-record-export';
+export { default as useRecordSubscriberClicked } from './use-record-subscriber-clicked';

--- a/client/my-sites/subscribers/tracks/use-record-export.ts
+++ b/client/my-sites/subscribers/tracks/use-record-export.ts
@@ -1,0 +1,11 @@
+import useRecordSubscriberTrackEvent from './use-record-subscriber-tracks-event';
+
+const useRecordExport = () => {
+	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
+
+	return () => {
+		recordSubscribersTracksEvent( 'calypso_subscribers_export_downloaded' );
+	};
+};
+
+export default useRecordExport;

--- a/client/my-sites/subscribers/tracks/use-record-paged.ts
+++ b/client/my-sites/subscribers/tracks/use-record-paged.ts
@@ -1,0 +1,11 @@
+import useRecordSubscriberTrackEvent from './use-record-subscriber-tracks-event';
+
+const useRecordPaged = () => {
+	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
+
+	return ( tracksProps: { page: number } ) => {
+		recordSubscribersTracksEvent( 'calypso_subscribers_list_paged', tracksProps );
+	};
+};
+
+export default useRecordPaged;

--- a/client/my-sites/subscribers/tracks/use-record-remove-modal.ts
+++ b/client/my-sites/subscribers/tracks/use-record-remove-modal.ts
@@ -4,6 +4,12 @@ const useRecordRemoveModal = () => {
 	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
 
 	return ( paid: boolean, action: string ) => {
+		// Allows for:
+		// - calypso_subscribers_remove_paid_subscriber_modal_showed
+		// - calypso_subscribers_remove_paid_subscriber_modal_dismissed
+		// - calypso_subscribers_remove_paid_subscriber_manage_button_clicked
+		// - calypso_subscribers_remove_free_subscriber_modal_showed
+		// - calypso_subscribers_remove_free_subscriber_modal_dismissed
 		const eventName = `calypso_subscribers_remove_${
 			paid ? 'paid' : 'free'
 		}_subscriber_${ action }`;

--- a/client/my-sites/subscribers/tracks/use-record-remove-modal.ts
+++ b/client/my-sites/subscribers/tracks/use-record-remove-modal.ts
@@ -1,0 +1,14 @@
+import useRecordSubscriberTrackEvent from './use-record-subscriber-tracks-event';
+
+const useRecordRemoveModal = () => {
+	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
+
+	return ( paid: boolean, action: string ) => {
+		const eventName = `calypso_subscribers_remove_${
+			paid ? 'paid' : 'free'
+		}_subscriber_${ action }`;
+		recordSubscribersTracksEvent( eventName );
+	};
+};
+
+export default useRecordRemoveModal;

--- a/client/my-sites/subscribers/tracks/use-record-search.ts
+++ b/client/my-sites/subscribers/tracks/use-record-search.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+import { useSubscriberListManager } from '../components/subscriber-list-manager/subscriber-list-manager-context';
+import useRecordSubscriberTrackEvent from './use-record-subscriber-tracks-event';
+
+const useRecordSearch = () => {
+	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
+	const { searchTerm } = useSubscriberListManager();
+
+	const [ debouncedRecord ] = useDebouncedCallback( () => {
+		recordSubscribersTracksEvent( 'calypso_subscribers_searched' );
+	}, 1000 );
+
+	useEffect( () => {
+		if ( searchTerm ) {
+			debouncedRecord();
+		}
+	}, [ debouncedRecord, searchTerm ] );
+};
+
+export default useRecordSearch;

--- a/client/my-sites/subscribers/tracks/use-record-sort.ts
+++ b/client/my-sites/subscribers/tracks/use-record-sort.ts
@@ -1,0 +1,11 @@
+import useRecordSubscriberTrackEvent from './use-record-subscriber-tracks-event';
+
+const useRecordSort = () => {
+	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
+
+	return ( tracksProps: { sort_field: string } ) => {
+		recordSubscribersTracksEvent( 'calypso_subscribers_list_sorted', tracksProps );
+	};
+};
+
+export default useRecordSort;

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-clicked.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-clicked.ts
@@ -1,0 +1,17 @@
+import useRecordSubscriberTrackEvent from './use-record-subscriber-tracks-event';
+
+const useRecordSubscriberClicked = () => {
+	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
+
+	return (
+		where: 'title' | 'icon',
+		tracksProps: { site_id?: number | null; subscription_id?: number; user_id?: number }
+	) => {
+		recordSubscribersTracksEvent(
+			`calypso_subscribers_subscriber_${ where }_clicked`,
+			tracksProps
+		);
+	};
+};
+
+export default useRecordSubscriberClicked;

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-clicked.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-clicked.ts
@@ -7,6 +7,7 @@ const useRecordSubscriberClicked = () => {
 		where: 'title' | 'icon',
 		tracksProps: { site_id?: number | null; subscription_id?: number; user_id?: number }
 	) => {
+		// Allows for calypso_subscribers_subscriber_title_clicked & calypso_subscribers_subscriber_icon_clicked
 		recordSubscribersTracksEvent(
 			`calypso_subscribers_subscriber_${ where }_clicked`,
 			tracksProps

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-removed.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-removed.ts
@@ -1,0 +1,15 @@
+import useRecordSubscriberTrackEvent from './use-record-subscriber-tracks-event';
+
+const useRecordSubscriberRemoved = () => {
+	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
+
+	return ( tracksProps: {
+		site_id?: number | null;
+		subscription_id?: number;
+		user_id?: number;
+	} ) => {
+		recordSubscribersTracksEvent( 'calypso_subscribers_subscriber_removed', tracksProps );
+	};
+};
+
+export default useRecordSubscriberRemoved;

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-tracks-event.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-tracks-event.ts
@@ -1,0 +1,12 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+
+const useRecordSubscriberTracksEvent = () => {
+	const recordSubscribersTracksEvent = ( tracksEventName: string, tracksEventProps?: object ) => {
+		recordTracksEvent( tracksEventName, {
+			...tracksEventProps,
+		} );
+	};
+
+	return recordSubscribersTracksEvent;
+};
+export default useRecordSubscriberTracksEvent;


### PR DESCRIPTION
Closes #78624

## Proposed Changes

This PR adds Tracks events for the subscriber page, as requested [here](https://github.com/Automattic/wp-calypso/issues/78624).

The following events are added:

- calypso_subscribers_subscriber_removed
- calypso_subscribers_remove_(paid/free)_subscriber_modal_showed
- calypso_subscribers_remove_paid_subscriber_manage_button_clicked
- calypso_subscribers_remove_(paid/free)_modal_dismissed
- calypso_subscribers_list_searched
- calypso_subscribers_list_sorted
- calypso_subscribers_list_paged
- calypso_subscribers_export_downloaded

The add/import dialog is already tracked using other events, so I didn't add these events.

I also added the hook for handling subscriber / gravatar clicks, but since these are not clickable currently, I'll leave the implementation of recording those stats to the person who makes these clickable.

## Testing Instructions

1. Apply PR
2. Install the Tracks Vigilante Chrome extension p7H4VZ-4cf-p2, or open the network panel
3. Visit `http://calypso.localhost:3000/subscribers/<siteid>`

Try all these actions and see if they trigger Tracks events:
- Click unsubscribe: `calypso_subscribers_remove_(paid/free)_subscriber_modal_showed`
- Unsubscribe free user (both wpcom & external): `calypso_subscribers_subscriber_removed`
- Click unsubscribe & close the modal (cancel or X): `calypso_subscribers_remove_(paid/free)_modal_dismissed`
- Enter a search string: `calypso_subscribers_list_searched` (after 1s)
- Sort the list: ` calypso_subscribers_list_sorted`
- Go to another page: `calypso_subscribers_list_paged`
- Download subscribers as CSV: `calypso_subscribers_export_downloaded`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?