### PR TITLE
Jetpack Pro Dashboard: Remove the ability to detach licenses

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -4,7 +4,6 @@ import { useCallback, useState } from 'react';
 import useLicenseDownloadUrlMutation from 'calypso/components/data/query-jetpack-partner-portal-licenses/use-license-download-url-mutation';
 import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
 import { LicenseState, LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import UnassignLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/unassign-license-dialog';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -30,7 +29,6 @@ export default function LicenseDetailsActions( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
-	const [ unassignDialog, setUnassignDialog ] = useState( false );
 	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;
 	const downloadUrl = useLicenseDownloadUrlMutation( licenseKey );
 
@@ -43,16 +41,6 @@ export default function LicenseDetailsActions( {
 		setRevokeDialog( false );
 		dispatch( recordTracksEvent( 'calypso_partner_portal_license_details_revoke_dialog_close' ) );
 	}, [ dispatch, setRevokeDialog ] );
-
-	const openUnassignDialog = useCallback( () => {
-		setUnassignDialog( true );
-		dispatch( recordTracksEvent( 'calypso_partner_portal_license_details_unassign_dialog_open' ) );
-	}, [ dispatch, setUnassignDialog ] );
-
-	const closeUnassignDialog = useCallback( () => {
-		setUnassignDialog( false );
-		dispatch( recordTracksEvent( 'calypso_partner_portal_license_details_unassign_dialog_close' ) );
-	}, [ dispatch, setUnassignDialog ] );
 
 	const download = useCallback( () => {
 		downloadUrl.mutate( null, {
@@ -92,13 +80,7 @@ export default function LicenseDetailsActions( {
 				</Button>
 			) }
 
-			{ licenseState === LicenseState.Attached && licenseType === LicenseType.Partner && (
-				<Button compact onClick={ openUnassignDialog }>
-					{ translate( 'Unassign' ) }
-				</Button>
-			) }
-
-			{ licenseState === LicenseState.Detached && licenseType === LicenseType.Partner && (
+			{ licenseState !== LicenseState.Revoked && licenseType === LicenseType.Partner && (
 				<Button compact onClick={ openRevokeDialog } scary>
 					{ translate( 'Revoke' ) }
 				</Button>
@@ -121,15 +103,6 @@ export default function LicenseDetailsActions( {
 					product={ product }
 					siteUrl={ siteUrl }
 					onClose={ closeRevokeDialog }
-				/>
-			) }
-
-			{ unassignDialog && (
-				<UnassignLicenseDialog
-					licenseKey={ licenseKey }
-					product={ product }
-					siteUrl={ siteUrl }
-					onClose={ closeUnassignDialog }
 				/>
 			) }
 		</div>


### PR DESCRIPTION
1201801459945917-as-1204906387906365

## Proposed Changes

* Jetpack Pro Dashboard: Remove the detach button for licenses. License should only be issued, assigned once, and revoked from now on.

## Testing Instructions

* Make sure you have licenses in various states - unassigned, assigned, revoked.
* Expand their details on http://jetpack.cloud.localhost:3000/partner-portal/licenses
* Make sure the Revoke button appears on all except the already revoked ones.
* Make sure the Unassign button no longer appears on any license.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?