### PR TITLE
Reader: Fix post card errors

### DIFF
--- a/client/blocks/reader-combined-card/docs/example.jsx
+++ b/client/blocks/reader-combined-card/docs/example.jsx
@@ -1,4 +1,4 @@
-import { ReaderCombinedCard, combinedCardPostKeyToKeys } from 'calypso/blocks/reader-combined-card';
+import ReaderCombinedCard, { combinedCardPostKeyToKeys } from 'calypso/blocks/reader-combined-card';
 import { posts, feed, site } from 'calypso/blocks/reader-post-card/docs/fixtures';
 
 const postKey = {

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -69,7 +69,7 @@ const getDailyPromptText = ( post ) => {
 
 const chooseExcerpt = ( post ) => {
 	// Need to figure out if custom excerpt is different to better_excerpt
-	if ( post.excerpt.length > 0 ) {
+	if ( post.excerpt?.length > 0 ) {
 		// If the post is a dailyprompt, attempt to replace the prompt text with a pullquote.
 		if ( post.tags && post.tags.hasOwnProperty( 'dailyprompt' ) ) {
 			const promptText = getDailyPromptText( post );

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -275,11 +275,9 @@ export default connect(
 			ownProps.postKey &&
 			( isSiteWPForTeams( state, ownProps.postKey.blogId ) ||
 				isFeedWPForTeams( state, ownProps.postKey.feedId ) ),
-		hasOrganization: hasReaderFollowOrganization(
-			state,
-			ownProps.postKey.feedId,
-			ownProps.postKey.blogId
-		),
+		hasOrganization:
+			ownProps.postKey &&
+			hasReaderFollowOrganization( state, ownProps.postKey.feedId, ownProps.postKey.blogId ),
 		isExpanded: isReaderCardExpanded( state, ownProps.postKey ),
 		teams: getReaderTeams( state ),
 	} ),


### PR DESCRIPTION
## Proposed Changes

This PR fixes an error with the reader post card that I found while testing #77046.

I couldn't repro on the reader itself, but since those examples worked at some point, it might indicate a hard-to-repro bug.

## Testing Instructions

* Go to `/devdocs/blocks/reader-post-card`
* Verify you're no longer seeing errors thrown and the reader card loads correctly.
* Go to `/devdocs/blocks/reader-combined-card`
* Verify you're no longer seeing errors thrown and the reader card loads correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
