### PR TITLE
Sharing: Fix preview pane bugs

### DIFF
--- a/client/components/share/tumblr-share-preview/index.jsx
+++ b/client/components/share/tumblr-share-preview/index.jsx
@@ -15,7 +15,7 @@ export class TumblrSharePreview extends PureComponent {
 			message,
 		} = this.props;
 
-		const username = externalProfileURL?.match( /[^/]+$/ )[ 0 ];
+		const username = externalProfileURL?.match( /[^/]+$/ )?.[ 0 ];
 
 		return (
 			<TumblrPreviews
@@ -25,7 +25,7 @@ export class TumblrSharePreview extends PureComponent {
 				customText={ decodeEntities( message ) }
 				image={ imageUrl }
 				user={ {
-					displayName: externalName === 'Untitled' ? username : externalName,
+					displayName: externalName === 'Untitled' && username ? username : externalName,
 					avatarUrl: externalProfilePicture,
 				} }
 			/>

--- a/client/state/sites/selectors/build-seo-title.js
+++ b/client/state/sites/selectors/build-seo-title.js
@@ -23,9 +23,9 @@ export default (
 				buildTitle( 'posts', {
 					siteName: site.name,
 					tagline: site.description,
-					postTitle: post.title ?? '',
+					postTitle: post?.title ?? '',
 				} ) ||
-				post.title ||
+				post?.title ||
 				''
 			);
 
@@ -33,7 +33,7 @@ export default (
 			return buildTitle( 'pages', {
 				siteName: site.name,
 				tagline: site.description,
-				pageTitle: post.title ?? '',
+				pageTitle: post?.title ?? '',
 			} );
 
 		case 'groups':
@@ -52,6 +52,6 @@ export default (
 			} );
 
 		default:
-			return post.title || site.name;
+			return post?.title || site.name;
 	}
 };


### PR DESCRIPTION
## Proposed Changes

This PR fixes an error with the sharing preview pane that I found while testing #77046.

I couldn't repro in Calypso, but this could indicate weird, difficult to reproduce bugs since those examples worked at some point.

## Testing Instructions

* Go to `/devdocs/blocks/sharing-preview-pane`
* Verify you're no longer seeing errors thrown and the component loads correctly.
* Click through all tabs and verify you don't see errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
