### PR TITLE
Jetpack Pro Dash: Add ability to attach/use WC licenses

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -135,7 +135,7 @@ export default function AssignLicenseForm( {
 		if ( goToDownloadStep ) {
 			return page.redirect(
 				addQueryArgs(
-					{ products: licenseKeysArray, attachedSiteId: selectedSite?.ID },
+					{ products: licenseKeysArray.join( ' ' ), attachedSiteId: selectedSite?.ID },
 					partnerPortalBasePath( '/download-products' )
 				)
 			);

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -135,7 +135,7 @@ export default function AssignLicenseForm( {
 		if ( goToDownloadStep ) {
 			return page.redirect(
 				addQueryArgs(
-					{ products: licenseKeysArray },
+					{ products: licenseKeysArray, attachedSiteId: selectedSite?.ID },
 					partnerPortalBasePath( '/download-products' )
 				)
 			);

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -14,7 +14,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setPurchasedLicense, resetSite } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
-import { areLicenseKeysAssignableToMultisite } from '../utils';
+import { areLicenseKeysAssignableToMultisite, isWooCommerceProduct } from '../utils';
 import './style.scss';
 
 function setPage( pageNumber: number ): void {
@@ -127,6 +127,19 @@ export default function AssignLicenseForm( {
 
 		dispatch( resetSite() );
 		dispatch( setPurchasedLicense( assignLicensesResult ) );
+
+		const goToDownloadStep = licenseKeysArray.some( ( licenseKey ) =>
+			isWooCommerceProduct( licenseKey )
+		);
+
+		if ( goToDownloadStep ) {
+			return page.redirect(
+				addQueryArgs(
+					{ products: licenseKeysArray },
+					partnerPortalBasePath( '/download-products' )
+				)
+			);
+		}
 
 		const fromDashboard = getQueryArg( window.location.href, 'source' ) === 'dashboard';
 		if ( fromDashboard ) {

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -135,7 +135,7 @@ export default function AssignLicenseForm( {
 		if ( goToDownloadStep ) {
 			return page.redirect(
 				addQueryArgs(
-					{ products: licenseKeysArray.join( ' ' ), attachedSiteId: selectedSite?.ID },
+					{ products: licenseKeysArray.join( ',' ), attachedSiteId: selectedSite?.ID },
 					partnerPortalBasePath( '/download-products' )
 				)
 			);

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -43,14 +43,10 @@ interface Step {
 interface Props {
 	currentStep: StepKey;
 	selectedSite?: SiteDetails | null;
-	showDownloadStep?: boolean | null;
+	showDownloadStep?: boolean;
 }
 
-export default function AssignLicenseStepProgress( {
-	currentStep,
-	selectedSite,
-	showDownloadStep,
-}: Props ) {
+const AssignLicenseStepProgress = ( { currentStep, selectedSite, showDownloadStep }: Props ) => {
 	const translate = useTranslate();
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const sites = useSelector( getSites ).length;
@@ -100,4 +96,10 @@ export default function AssignLicenseStepProgress( {
 			) ) }
 		</div>
 	);
-}
+};
+
+AssignLicenseStepProgress.defaultProps = {
+	showDownloadStep: false,
+};
+
+export default AssignLicenseStepProgress;

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -33,7 +33,7 @@ function CheckMarkOrNumber( { currentStep, step }: { currentStep: number; step: 
 	);
 }
 
-type StepKey = 'issueLicense' | 'addPaymentMethod' | 'assignLicense';
+type StepKey = 'issueLicense' | 'addPaymentMethod' | 'assignLicense' | 'downloadProducts';
 
 interface Step {
 	key: StepKey;
@@ -43,9 +43,14 @@ interface Step {
 interface Props {
 	currentStep: StepKey;
 	selectedSite?: SiteDetails | null;
+	showDownloadStep?: boolean | null;
 }
 
-export default function AssignLicenseStepProgress( { currentStep, selectedSite }: Props ) {
+export default function AssignLicenseStepProgress( {
+	currentStep,
+	selectedSite,
+	showDownloadStep,
+}: Props ) {
 	const translate = useTranslate();
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const sites = useSelector( getSites ).length;
@@ -58,6 +63,10 @@ export default function AssignLicenseStepProgress( { currentStep, selectedSite }
 
 	if ( sites > 0 && ! selectedSite ) {
 		steps.push( { key: 'assignLicense', label: translate( 'Assign license' ) } );
+	}
+
+	if ( showDownloadStep ) {
+		steps.push( { key: 'downloadProducts', label: translate( 'Download product' ) } );
 	}
 
 	// Don't show the breadcrumbs if we have less than 2 as they are not very informative in this case.

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -3,6 +3,7 @@ import LicenseSelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-port
 import AssignLicense from 'calypso/jetpack-cloud/sections/partner-portal/primary/assign-license';
 import BillingDashboard from 'calypso/jetpack-cloud/sections/partner-portal/primary/billing-dashboard';
 import CompanyDetailsDashboard from 'calypso/jetpack-cloud/sections/partner-portal/primary/company-details-dashboard';
+import DownloadProducts from 'calypso/jetpack-cloud/sections/partner-portal/primary/download-products';
 import InvoicesDashboard from 'calypso/jetpack-cloud/sections/partner-portal/primary/invoices-dashboard';
 import IssueLicense from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license';
 import Licenses from 'calypso/jetpack-cloud/sections/partner-portal/primary/licenses';
@@ -94,6 +95,13 @@ export function issueLicenseContext( context: PageJS.Context, next: () => void )
 	context.primary = (
 		<IssueLicense selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
 	);
+	next();
+}
+
+export function downloadProductsContext( context: PageJS.Context, next: () => void ): void {
+	context.header = <Header />;
+	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	context.primary = <DownloadProducts />;
 	next();
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
@@ -1,0 +1,20 @@
+import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+
+export default function DownloadProductsForm() {
+	const translate = useTranslate();
+
+	const attachedSiteId = getQueryArg( window.location.href, 'attachedSiteId' ) as number;
+	const licenseKeys = getQueryArg( window.location.href, 'products' ) as string;
+
+	const wooKeys = licenseKeys.split( ',' ).find( ( key ) => key.startsWith( 'woocommerce-' ) );
+	const jetpackKeys = licenseKeys
+		.split( ',' )
+		.find( ( key ) => ! key.startsWith( 'woocommerce-' ) );
+
+	console.log( 'attachedSiteId', parseInt( attachedSiteId ) );
+	console.log( 'wooKeys', wooKeys );
+	console.log( 'jetpackKeys', jetpackKeys );
+
+	return <div>{ translate( 'Download products' ) }</div>;
+}

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
@@ -18,7 +18,7 @@ export default function DownloadProductsForm() {
 	const sites = useSelector( getSites );
 	const { data: allProducts } = useProductsQuery();
 
-	const attachedSiteId = getQueryArg( window.location.href, 'attachedSiteId' ) as number;
+	const attachedSiteId = getQueryArg( window.location.href, 'attachedSiteId' ) as string;
 	const licenseKeys = getQueryArg( window.location.href, 'products' ) as string;
 	const source = getQueryArg( window.location.href, 'source' ) as string;
 

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
@@ -56,9 +56,17 @@ export default function DownloadProductsForm() {
 			/>
 		) );
 
+	const onNavigate = () => {
+		return page.redirect(
+			'dashboard' === source
+				? page.redirect( '/dashboard' )
+				: page.redirect( partnerPortalBasePath( '/licenses' ) )
+		);
+	};
+
 	// redirect if licenseKeys does not contain a valid product
 	useEffect( () => {
-		if ( ! licenseKeys || ! allProducts ) {
+		if ( ! licenseKeys || ! allProducts || ! site ) {
 			return;
 		}
 
@@ -68,21 +76,9 @@ export default function DownloadProductsForm() {
 		} );
 
 		if ( invalidKeys.length ) {
-			page.redirect(
-				'dashboard' === source
-					? page.redirect( '/dashboard' )
-					: page.redirect( partnerPortalBasePath( '/licenses' ) )
-			);
+			onNavigate();
 		}
-	}, [ licenseKeys, allProducts, source ] );
-
-	const onNavigate = () => {
-		return page.redirect(
-			'dashboard' === source
-				? page.redirect( '/dashboard' )
-				: page.redirect( partnerPortalBasePath( '/licenses' ) )
-		);
-	};
+	}, [ licenseKeys, allProducts, site, onNavigate ] );
 
 	return (
 		<div className="download-products-form">

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
@@ -1,20 +1,99 @@
+import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import {
+	getProductSlugFromKey,
+	isWooCommerceProduct,
+} from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import { partnerPortalBasePath } from 'calypso/lib/jetpack/paths';
+import { useSelector } from 'calypso/state';
+import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
+import getSites from 'calypso/state/selectors/get-sites';
+import './style.scss';
 
 export default function DownloadProductsForm() {
 	const translate = useTranslate();
+	const sites = useSelector( getSites );
+	const { data: allProducts } = useProductsQuery();
 
 	const attachedSiteId = getQueryArg( window.location.href, 'attachedSiteId' ) as number;
 	const licenseKeys = getQueryArg( window.location.href, 'products' ) as string;
+	const source = getQueryArg( window.location.href, 'source' ) as string;
 
-	const wooKeys = licenseKeys.split( ',' ).find( ( key ) => key.startsWith( 'woocommerce-' ) );
-	const jetpackKeys = licenseKeys
-		.split( ',' )
-		.find( ( key ) => ! key.startsWith( 'woocommerce-' ) );
+	const site = sites.find( ( site ) => site.ID === parseInt( attachedSiteId ) );
 
-	console.log( 'attachedSiteId', parseInt( attachedSiteId ) );
-	console.log( 'wooKeys', wooKeys );
-	console.log( 'jetpackKeys', jetpackKeys );
+	const wooKeys =
+		licenseKeys && licenseKeys.split( ',' ).filter( ( key ) => isWooCommerceProduct( key ) );
 
-	return <div>{ translate( 'Download products' ) }</div>;
+	const jetpackKeys =
+		licenseKeys && licenseKeys.split( ',' ).filter( ( key ) => ! isWooCommerceProduct( key ) );
+
+	const jetpackProducts = jetpackKeys.map( ( licenseKey ) => {
+		const productSlug = getProductSlugFromKey( licenseKey );
+		const product = allProducts.find( ( product ) => product.slug === productSlug );
+
+		return (
+			<li key={ licenseKey }>
+				<h4>{ product.name }</h4>
+				<h6>{ licenseKey }</h6>
+			</li>
+		);
+	} );
+
+	const wooProducts = wooKeys.map( ( licenseKey ) => {
+		const productSlug = licenseKey.split( '_' )[ 0 ];
+		const product = allProducts.find( ( product ) => product.slug === productSlug );
+
+		return (
+			<li key={ licenseKey }>
+				<h4>{ product.name }</h4>
+				<h6>{ licenseKey }</h6>
+				<Button compact>{ translate( 'Download' ) }</Button>
+			</li>
+		);
+	} );
+
+	const onNavigate = () => {
+		return page.redirect(
+			'dashboard' === source
+				? page.redirect( '/dashboard' )
+				: page.redirect( partnerPortalBasePath( '/licenses' ) )
+		);
+	};
+
+	return (
+		<div className="download-products-form">
+			<div className="download-products-form__top">
+				<p className="download-products-form__description">
+					{ translate(
+						'Your license has been applied to {{strong}}%(siteUrl)s{{/strong}}, but more action is required.',
+						'Your licenses have been applied to {{strong}}%(siteUrl)s{{/strong}}, but more action is required.',
+						{
+							args: { siteUrl: site && site.domain },
+							components: { strong: <strong /> },
+							count: licenseKeys.split( ',' ).length,
+						}
+					) }
+				</p>
+				<div className="download-products-form__controls">
+					<Button primary className="download-products-form__navigate" onClick={ onNavigate }>
+						{ translate( 'Done' ) }
+					</Button>
+				</div>
+			</div>
+			<div className="download-products-form__bottom">
+				{ !! jetpackProducts.length && (
+					<div className="download-products-form__no-action-items">
+						<div>{ translate( 'No more action is required for these products:' ) }</div>
+						<ul>{ jetpackProducts }</ul>
+					</div>
+				) }
+				<div className="download-products-form__action-items">
+					<div>{ translate( 'These extensions need to be downloaded and installed:' ) }</div>
+					<ul>{ wooProducts }</ul>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
@@ -84,10 +84,11 @@ export default function DownloadProductsForm() {
 			<div className="download-products-form__top">
 				<p className="download-products-form__description">
 					{ translate(
-						'Your license has been applied to %(siteUrl)s, but more action is required.',
-						'Your licenses have been applied to %(siteUrl)s, but more action is required.',
+						'Your license has been applied to {{strong}}%(siteUrl)s{{/strong}}, but more action is required.',
+						'Your licenses have been applied to {{strong}}%(siteUrl)s{{/strong}}, but more action is required.',
 						{
-							args: { siteUrl: <strong>{ siteDomain }</strong> },
+							components: { strong: <strong /> },
+							args: { siteUrl: siteDomain || '' },
 							count: licenseKeys.split( ',' ).length,
 						}
 					) }

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
+import { useEffect } from 'react';
 import WooProductDownload from 'calypso/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download';
 import {
 	getProductSlugFromKey,
@@ -54,6 +55,26 @@ export default function DownloadProductsForm() {
 				allProducts={ allProducts }
 			/>
 		) );
+
+	// redirect if licenseKeys does not contain a valid product
+	useEffect( () => {
+		if ( ! licenseKeys || ! allProducts ) {
+			return;
+		}
+
+		const invalidKeys = licenseKeys.split( ',' ).filter( ( key ) => {
+			const productSlug = getProductSlugFromKey( key );
+			return ! allProducts.find( ( product ) => product.slug === productSlug );
+		} );
+
+		if ( invalidKeys.length ) {
+			page.redirect(
+				'dashboard' === source
+					? page.redirect( '/dashboard' )
+					: page.redirect( partnerPortalBasePath( '/licenses' ) )
+			);
+		}
+	}, [ licenseKeys, allProducts, source ] );
 
 	const onNavigate = () => {
 		return page.redirect(

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import WooProductDownload from 'calypso/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download';
 import {
 	getProductSlugFromKey,
@@ -23,7 +23,8 @@ export default function DownloadProductsForm() {
 	const licenseKeys = getQueryArg( window.location.href, 'products' ) as string;
 	const source = getQueryArg( window.location.href, 'source' ) as string;
 
-	const site = sites.find( ( site ) => site.ID === parseInt( attachedSiteId ) );
+	const site = sites.find( ( site ) => site?.ID === parseInt( attachedSiteId, 10 ) );
+	const siteDomain = site ? site.domain : null;
 
 	const wooKeys =
 		licenseKeys && licenseKeys.split( ',' ).filter( ( key ) => isWooCommerceProduct( key ) );
@@ -33,7 +34,7 @@ export default function DownloadProductsForm() {
 
 	const jetpackProducts =
 		jetpackKeys &&
-		jetpackKeys.map( ( licenseKey ) => {
+		jetpackKeys.map( ( licenseKey: string ) => {
 			const productSlug = getProductSlugFromKey( licenseKey );
 			const product =
 				allProducts && allProducts.find( ( product ) => product.slug === productSlug );
@@ -48,7 +49,7 @@ export default function DownloadProductsForm() {
 
 	const wooProducts =
 		wooKeys &&
-		wooKeys.map( ( licenseKey ) => (
+		wooKeys.map( ( licenseKey: string ) => (
 			<WooProductDownload
 				key={ licenseKey }
 				licenseKey={ licenseKey }
@@ -56,13 +57,11 @@ export default function DownloadProductsForm() {
 			/>
 		) );
 
-	const onNavigate = () => {
+	const onNavigate = useCallback( () => {
 		return page.redirect(
-			'dashboard' === source
-				? page.redirect( '/dashboard' )
-				: page.redirect( partnerPortalBasePath( '/licenses' ) )
+			'dashboard' === source ? '/dashboard' : partnerPortalBasePath( '/licenses' )
 		);
-	};
+	}, [ source ] );
 
 	// redirect if licenseKeys does not contain a valid product
 	useEffect( () => {
@@ -85,11 +84,10 @@ export default function DownloadProductsForm() {
 			<div className="download-products-form__top">
 				<p className="download-products-form__description">
 					{ translate(
-						'Your license has been applied to {{strong}}%(siteUrl)s{{/strong}}, but more action is required.',
-						'Your licenses have been applied to {{strong}}%(siteUrl)s{{/strong}}, but more action is required.',
+						'Your license has been applied to %(siteUrl)s, but more action is required.',
+						'Your licenses have been applied to %(siteUrl)s, but more action is required.',
 						{
-							args: { siteUrl: site && site.domain },
-							components: { strong: <strong /> },
+							args: { siteUrl: <strong>{ siteDomain }</strong> },
 							count: licenseKeys.split( ',' ).length,
 						}
 					) }

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
@@ -30,21 +30,30 @@ export default function DownloadProductsForm() {
 	const jetpackKeys =
 		licenseKeys && licenseKeys.split( ',' ).filter( ( key ) => ! isWooCommerceProduct( key ) );
 
-	const jetpackProducts = jetpackKeys.map( ( licenseKey ) => {
-		const productSlug = getProductSlugFromKey( licenseKey );
-		const product = allProducts && allProducts.find( ( product ) => product.slug === productSlug );
+	const jetpackProducts =
+		jetpackKeys &&
+		jetpackKeys.map( ( licenseKey ) => {
+			const productSlug = getProductSlugFromKey( licenseKey );
+			const product =
+				allProducts && allProducts.find( ( product ) => product.slug === productSlug );
 
-		return (
-			<li key={ licenseKey }>
-				<h5>{ product && product.name }</h5>
-				<pre>{ licenseKey }</pre>
-			</li>
-		);
-	} );
+			return (
+				<li key={ licenseKey }>
+					<h5>{ product && product.name }</h5>
+					<pre>{ licenseKey }</pre>
+				</li>
+			);
+		} );
 
-	const wooProducts = wooKeys.map( ( licenseKey ) => (
-		<WooProductDownload key={ licenseKey } licenseKey={ licenseKey } allProducts={ allProducts } />
-	) );
+	const wooProducts =
+		wooKeys &&
+		wooKeys.map( ( licenseKey ) => (
+			<WooProductDownload
+				key={ licenseKey }
+				licenseKey={ licenseKey }
+				allProducts={ allProducts }
+			/>
+		) );
 
 	const onNavigate = () => {
 		return page.redirect(

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
+import WooProductDownload from 'calypso/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download';
 import {
 	getProductSlugFromKey,
 	isWooCommerceProduct,
@@ -31,28 +32,19 @@ export default function DownloadProductsForm() {
 
 	const jetpackProducts = jetpackKeys.map( ( licenseKey ) => {
 		const productSlug = getProductSlugFromKey( licenseKey );
-		const product = allProducts.find( ( product ) => product.slug === productSlug );
+		const product = allProducts && allProducts.find( ( product ) => product.slug === productSlug );
 
 		return (
 			<li key={ licenseKey }>
-				<h4>{ product.name }</h4>
-				<h6>{ licenseKey }</h6>
+				<h5>{ product && product.name }</h5>
+				<pre>{ licenseKey }</pre>
 			</li>
 		);
 	} );
 
-	const wooProducts = wooKeys.map( ( licenseKey ) => {
-		const productSlug = licenseKey.split( '_' )[ 0 ];
-		const product = allProducts.find( ( product ) => product.slug === productSlug );
-
-		return (
-			<li key={ licenseKey }>
-				<h4>{ product.name }</h4>
-				<h6>{ licenseKey }</h6>
-				<Button compact>{ translate( 'Download' ) }</Button>
-			</li>
-		);
-	} );
+	const wooProducts = wooKeys.map( ( licenseKey ) => (
+		<WooProductDownload key={ licenseKey } licenseKey={ licenseKey } allProducts={ allProducts } />
+	) );
 
 	const onNavigate = () => {
 		return page.redirect(
@@ -84,13 +76,13 @@ export default function DownloadProductsForm() {
 			</div>
 			<div className="download-products-form__bottom">
 				{ !! jetpackProducts.length && (
-					<div className="download-products-form__no-action-items">
-						<div>{ translate( 'No more action is required for these products:' ) }</div>
+					<div className="download-products-form__action-items">
+						<h4>{ translate( 'No more action is required for these products:' ) }</h4>
 						<ul>{ jetpackProducts }</ul>
 					</div>
 				) }
 				<div className="download-products-form__action-items">
-					<div>{ translate( 'These extensions need to be downloaded and installed:' ) }</div>
+					<h4>{ translate( 'These extensions need to be downloaded and installed:' ) }</h4>
 					<ul>{ wooProducts }</ul>
 				</div>
 			</div>

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/index.tsx
@@ -83,15 +83,16 @@ export default function DownloadProductsForm() {
 		<div className="download-products-form">
 			<div className="download-products-form__top">
 				<p className="download-products-form__description">
-					{ translate(
-						'Your license has been applied to {{strong}}%(siteUrl)s{{/strong}}, but more action is required.',
-						'Your licenses have been applied to {{strong}}%(siteUrl)s{{/strong}}, but more action is required.',
-						{
-							components: { strong: <strong /> },
-							args: { siteUrl: siteDomain || '' },
-							count: licenseKeys.split( ',' ).length,
-						}
-					) }
+					{ siteDomain &&
+						translate(
+							'Your license has been applied to {{strong}}%(siteUrl)s{{/strong}}, but more action is required.',
+							'Your licenses have been applied to {{strong}}%(siteUrl)s{{/strong}}, but more action is required.',
+							{
+								components: { strong: <strong /> },
+								args: { siteUrl: siteDomain || '' },
+								count: licenseKeys.split( ',' ).length,
+							}
+						) }
 				</p>
 				<div className="download-products-form__controls">
 					<Button primary className="download-products-form__navigate" onClick={ onNavigate }>

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/style.scss
@@ -32,9 +32,27 @@
 		margin: 64px 0;
 	}
 
-	&__action-items,
-	&__no-action-items {
+	&__action-items {
 		display: block;
+	}
+
+	&__action-items h4 {
+		font-size: 1.25rem;
+	}
+
+	&__action-items h5 {
+		font-size: 1rem;
+	}
+
+	&__action-items pre {
+		font-size: 0.875rem;
+		padding: 0;
+		margin-bottom: 0.6rem;
+	}
+
+	&__action-items ul {
+		list-style-type: none;
+		margin: 1rem 0;
 	}
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/style.scss
@@ -1,0 +1,101 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "../mixins.scss";
+
+.download-products-form {
+
+	p {
+		font-size: 1rem;
+	}
+
+	&__placeholder {
+		@include placeholder( --color-neutral-10 );
+
+		height: 43px;
+	}
+
+	.select-dropdown__container {
+		width: 100%;
+	}
+
+	&__actions {
+		display: flex;
+		justify-content: flex-end;
+		margin: 42px -10px 0;
+
+		> * {
+			margin: 0 10px;
+		}
+	}
+
+	&__pagination {
+		margin: 64px 0;
+	}
+
+	&__action-items,
+	&__no-action-items {
+		display: block;
+	}
+}
+
+.download-products-form__top {
+	display: flex;
+	flex-wrap: nowrap;
+	justify-content: space-between;
+	align-items: center;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		flex-wrap: wrap;
+	}
+}
+
+.download-products-form__controls {
+	@include licensing-portal-bottom-action-bar;
+
+	display: flex;
+	flex-direction: column-reverse;
+	justify-content: stretch;
+	align-items: center;
+	flex-wrap: wrap;
+	flex-grow: 1;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		flex-direction: row;
+		flex-grow: 1;
+		justify-content: flex-end;
+		margin-bottom: 1rem;
+
+		.button {
+			flex-grow: 1;
+		}
+	}
+
+	@include break-medium {
+		.button {
+			flex-grow: 0;
+		}
+	}
+
+	@include break-xlarge {
+		flex-direction: row;
+		flex-grow: 0;
+	}
+}
+
+.download-products-form__bottom {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+p.download-products-form__description {
+	flex: 1 0 100%;
+	align-self: flex-end;
+	margin: 0 0 1rem;
+	font-size: 0.875rem;
+	color: #333;
+
+	@include break-medium {
+		flex: 1 1 auto;
+		margin-right: 1rem;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/style.scss
@@ -32,10 +32,6 @@
 		margin: 64px 0;
 	}
 
-	&__action-items {
-		display: block;
-	}
-
 	&__action-items h4 {
 		font-size: 1.25rem;
 	}
@@ -98,11 +94,6 @@
 		flex-direction: row;
 		flex-grow: 0;
 	}
-}
-
-.download-products-form__bottom {
-	display: flex;
-	flex-wrap: wrap;
 }
 
 p.download-products-form__description {

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download.tsx
@@ -5,8 +5,14 @@ import useLicenseDownloadUrlMutation from 'calypso/components/data/query-jetpack
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
-export default function WooProductDownload( { licenseKey, allProducts } ) {
+interface WooProductDownloadProps {
+	licenseKey: string;
+	allProducts: APIProductFamilyProduct[] | undefined;
+}
+
+export default function WooProductDownload( { licenseKey, allProducts }: WooProductDownloadProps ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const productSlug = licenseKey.split( '_' )[ 0 ];
@@ -24,8 +30,7 @@ export default function WooProductDownload( { licenseKey, allProducts } ) {
 	return (
 		<div className="download-products-list">
 			<ActionCard
-				className="download-products-list__woo-license"
-				headerText={ product.name }
+				headerText={ product?.name ?? '' }
 				mainText={ licenseKey }
 				buttonText={ translate( 'Download' ) }
 				buttonOnClick={ download }

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download.tsx
@@ -34,6 +34,7 @@ export default function WooProductDownload( { licenseKey, allProducts }: WooProd
 				mainText={ licenseKey }
 				buttonText={ translate( 'Download' ) }
 				buttonOnClick={ download }
+				buttonDisabled={ downloadUrl.isLoading }
 			/>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import useLicenseDownloadUrlMutation from 'calypso/components/data/query-jetpack-partner-portal-licenses/use-license-download-url-mutation';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+
+export default function WooProductDownload( { licenseKey, allProducts } ) {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const productSlug = licenseKey.split( '_' )[ 0 ];
+	const product = allProducts && allProducts.find( ( product ) => product.slug === productSlug );
+	const downloadUrl = useLicenseDownloadUrlMutation( licenseKey );
+
+	const download = useCallback( () => {
+		downloadUrl.mutate( null, {
+			onSuccess: ( data ) => window.location.replace( data.download_url ),
+			onError: ( error: Error ) => dispatch( errorNotice( error.message ) ),
+		} );
+		dispatch( recordTracksEvent( 'calypso_partner_portal_download_from_assign' ) );
+	}, [ dispatch, downloadUrl.mutate ] );
+
+	return (
+		<li>
+			<h5>{ product && product.name }</h5>
+			<pre>{ licenseKey }</pre>
+			<Button compact { ...( downloadUrl.isLoading ? { busy: true } : {} ) } onClick={ download }>
+				{ translate( 'Download' ) }
+			</Button>
+		</li>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download.tsx
@@ -1,10 +1,12 @@
+import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import ActionCard from 'calypso/components/action-card';
 import useLicenseDownloadUrlMutation from 'calypso/components/data/query-jetpack-partner-portal-licenses/use-license-download-url-mutation';
+import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 interface WooProductDownloadProps {
@@ -27,11 +29,30 @@ export default function WooProductDownload( { licenseKey, allProducts }: WooProd
 		dispatch( recordTracksEvent( 'calypso_partner_portal_download_from_assign' ) );
 	}, [ dispatch, downloadUrl ] );
 
+	const onCopyLicense = useCallback( () => {
+		dispatch( infoNotice( translate( 'License copied!' ), { duration: 2000 } ) );
+		dispatch( recordTracksEvent( 'calypso_partner_portal_download_copy_license_key' ) );
+	}, [ dispatch, translate ] );
+
 	return (
 		<div className="download-products-list">
 			<ActionCard
 				headerText={ product?.name ?? '' }
-				mainText={ licenseKey }
+				mainText={
+					<div className="license-key">
+						<code className="license-details__license-key">{ licenseKey }</code>
+
+						<ClipboardButton
+							text={ licenseKey }
+							className="license-details__clipboard-button"
+							borderless
+							compact
+							onCopy={ onCopyLicense }
+						>
+							<Gridicon icon="clipboard" />
+						</ClipboardButton>
+					</div>
+				}
 				buttonText={ translate( 'Download' ) }
 				buttonOnClick={ download }
 				buttonDisabled={ downloadUrl.isLoading }

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download.tsx
@@ -1,6 +1,6 @@
-import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import ActionCard from 'calypso/components/action-card';
 import useLicenseDownloadUrlMutation from 'calypso/components/data/query-jetpack-partner-portal-licenses/use-license-download-url-mutation';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -19,15 +19,17 @@ export default function WooProductDownload( { licenseKey, allProducts } ) {
 			onError: ( error: Error ) => dispatch( errorNotice( error.message ) ),
 		} );
 		dispatch( recordTracksEvent( 'calypso_partner_portal_download_from_assign' ) );
-	}, [ dispatch, downloadUrl.mutate ] );
+	}, [ dispatch, downloadUrl ] );
 
 	return (
-		<li>
-			<h5>{ product && product.name }</h5>
-			<pre>{ licenseKey }</pre>
-			<Button compact { ...( downloadUrl.isLoading ? { busy: true } : {} ) } onClick={ download }>
-				{ translate( 'Download' ) }
-			</Button>
-		</li>
+		<div className="download-products-list">
+			<ActionCard
+				className="download-products-list__woo-license"
+				headerText={ product.name }
+				mainText={ licenseKey }
+				buttonText={ translate( 'Download' ) }
+				buttonOnClick={ download }
+			/>
+		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/index.ts
@@ -64,6 +64,18 @@ export default function () {
 		clientRender
 	);
 
+	// Download 3rd party products after assigning
+	page(
+		`/partner-portal/download-products`,
+		controller.requireAccessContext,
+		controller.requireTermsOfServiceConsentContext,
+		controller.requireSelectedPartnerKeyContext,
+		controller.requireValidPaymentMethod,
+		controller.downloadProductsContext,
+		makeLayout,
+		clientRender
+	);
+
 	// Manage payment methods.
 	if ( config.isEnabled( 'jetpack/partner-portal-payment' ) ) {
 		page(

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -53,7 +53,8 @@ export default function IssueMultipleLicensesForm( {
 
 	const bundles =
 		allProducts?.filter(
-			( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-packs'
+			( { family_slug }: { family_slug: string } ) =>
+				family_slug === 'jetpack-packs' && family_slug !== 'woocommerce-extensions'
 		) || [];
 	const backupAddons =
 		allProducts

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -56,8 +56,7 @@ export default function IssueMultipleLicensesForm( {
 
 	const bundles =
 		allProducts?.filter(
-			( { family_slug }: { family_slug: string } ) =>
-				family_slug === 'jetpack-packs' && ! isWooCommerceProduct( family_slug )
+			( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-packs'
 		) || [];
 	const backupAddons =
 		allProducts
@@ -68,7 +67,9 @@ export default function IssueMultipleLicensesForm( {
 	const products =
 		allProducts?.filter(
 			( { family_slug }: { family_slug: string } ) =>
-				family_slug !== 'jetpack-packs' && ! isWooCommerceProduct( family_slug )
+				family_slug !== 'jetpack-packs' &&
+				family_slug !== 'jetpack-backup-storage' &&
+				! isWooCommerceProduct( family_slug )
 		) || [];
 	const wooExtensions =
 		allProducts?.filter( ( { family_slug }: { family_slug: string } ) =>

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -7,7 +7,10 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import LicenseBundleCard from 'calypso/jetpack-cloud/sections/partner-portal/license-bundle-card';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
 import TotalCost from 'calypso/jetpack-cloud/sections/partner-portal/primary/total-cost';
-import { isJetpackBundle } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import {
+	isJetpackBundle,
+	isWooCommerceProduct,
+} from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
@@ -54,7 +57,7 @@ export default function IssueMultipleLicensesForm( {
 	const bundles =
 		allProducts?.filter(
 			( { family_slug }: { family_slug: string } ) =>
-				family_slug === 'jetpack-packs' && family_slug !== 'woocommerce-extensions'
+				family_slug === 'jetpack-packs' && ! isWooCommerceProduct( family_slug )
 		) || [];
 	const backupAddons =
 		allProducts
@@ -62,17 +65,14 @@ export default function IssueMultipleLicensesForm( {
 				( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-backup-storage'
 			)
 			.sort( ( a, b ) => a.product_id - b.product_id ) || [];
-	const wooExtensions =
-		allProducts?.filter(
-			( { family_slug }: { family_slug: string } ) =>
-				family_slug.substring( 0, 'woocommerce-'.length ) === 'woocommerce-'
-		) || [];
 	const products =
 		allProducts?.filter(
 			( { family_slug }: { family_slug: string } ) =>
-				family_slug !== 'jetpack-packs' &&
-				family_slug !== 'jetpack-backup-storage' &&
-				family_slug.substring( 0, 'woocommerce-'.length ) !== 'woocommerce-'
+				family_slug !== 'jetpack-packs' && ! isWooCommerceProduct( family_slug )
+		) || [];
+	const wooExtensions =
+		allProducts?.filter( ( { family_slug }: { family_slug: string } ) =>
+			isWooCommerceProduct( family_slug )
 		) || [];
 
 	const hasPurchasedProductsWithoutBundle = useSelector( ( state ) =>

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -9,7 +9,6 @@ import AssignLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/ass
 import AssignLicenseStepProgress from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-step-progress';
 import { isWooCommerceProduct } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import Layout from '../../layout';
-import LayoutHeader from '../../layout/header';
 
 import './styles.scss';
 
@@ -57,26 +56,17 @@ export default function AssignLicense( {
 			} ) }
 			wide
 		>
-			<AssignLicenseStepProgress currentStep="assignLicense" />
-
-			<LayoutHeader>
-				<CardHeading size={ 36 }>
-					{ translate( 'Assign your license', 'Assign your licenses', {
-						count: licenseKeysArray.length,
-					} ) }
-				</CardHeading>
-			</LayoutHeader>
 			<Main wideLayout className="assign-license">
+				<AssignLicenseStepProgress
+					currentStep="assignLicense"
+					showDownloadStep={ showDownloadStep }
+				/>
 				<DocumentHead
 					title={ translate( 'Assign your license', 'Assign your licenses', {
 						count: licenseKeysArray.length,
 					} ) }
 				/>
 				<SidebarNavigation />
-				<AssignLicenseStepProgress
-					currentStep="assignLicense"
-					showDownloadStep={ showDownloadStep }
-				/>
 				<CardHeading size={ 36 }>
 					{ translate( 'Assign your license', 'Assign your licenses', {
 						count: licenseKeysArray.length,

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -8,7 +8,6 @@ import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import AssignLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form';
 import AssignLicenseStepProgress from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-step-progress';
 import { isWooCommerceProduct } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-import Layout from '../../layout';
 
 import './styles.scss';
 
@@ -49,31 +48,23 @@ export default function AssignLicense( {
 	}, [] );
 
 	return (
-		<Layout
-			className="assign-license"
-			title={ translate( 'Assign your license', 'Assign your licenses', {
-				count: licenseKeysArray.length,
-			} ) }
-			wide
-		>
-			<Main wideLayout className="assign-license">
-				<AssignLicenseStepProgress
-					currentStep="assignLicense"
-					showDownloadStep={ showDownloadStep }
-				/>
-				<DocumentHead
-					title={ translate( 'Assign your license', 'Assign your licenses', {
-						count: licenseKeysArray.length,
-					} ) }
-				/>
-				<SidebarNavigation />
-				<CardHeading size={ 36 }>
-					{ translate( 'Assign your license', 'Assign your licenses', {
-						count: licenseKeysArray.length,
-					} ) }
-				</CardHeading>
-				<AssignLicenseForm sites={ sites } currentPage={ currentPage } search={ search } />
-			</Main>
-		</Layout>
+		<Main wideLayout className="assign-license">
+			<AssignLicenseStepProgress
+				currentStep="assignLicense"
+				showDownloadStep={ showDownloadStep }
+			/>
+			<DocumentHead
+				title={ translate( 'Assign your license', 'Assign your licenses', {
+					count: licenseKeysArray.length,
+				} ) }
+			/>
+			<SidebarNavigation />
+			<CardHeading size={ 36 }>
+				{ translate( 'Assign your license', 'Assign your licenses', {
+					count: licenseKeysArray.length,
+				} ) }
+			</CardHeading>
+			<AssignLicenseForm sites={ sites } currentPage={ currentPage } search={ search } />
+		</Main>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -7,6 +7,7 @@ import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import AssignLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form';
 import AssignLicenseStepProgress from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-step-progress';
+import { isWooCommerceProduct } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import Layout from '../../layout';
 import LayoutHeader from '../../layout/header';
 
@@ -25,7 +26,9 @@ export default function AssignLicense( {
 	const licenseKey = getQueryArg( window.location.href, 'key' ) as string;
 	const products = getQueryArg( window.location.href, 'products' ) as string;
 	const licenseKeysArray = products !== undefined ? products.split( ',' ) : [ licenseKey ];
-	const showDownloadStep = licenseKeysArray.some( ( key ) => key.startsWith( 'woocommerce-' ) );
+	const showDownloadStep = licenseKeysArray.some( ( licenseKey ) =>
+		isWooCommerceProduct( licenseKey )
+	);
 
 	const scrollToTop = () => {
 		window.scrollTo( 0, 0 );

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -2,6 +2,9 @@ import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useLayoutEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import AssignLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form';
 import AssignLicenseStepProgress from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-step-progress';
 import Layout from '../../layout';
@@ -22,6 +25,7 @@ export default function AssignLicense( {
 	const licenseKey = getQueryArg( window.location.href, 'key' ) as string;
 	const products = getQueryArg( window.location.href, 'products' ) as string;
 	const licenseKeysArray = products !== undefined ? products.split( ',' ) : [ licenseKey ];
+	const showDownloadStep = licenseKeysArray.some( ( key ) => key.startsWith( 'woocommerce-' ) );
 
 	const scrollToTop = () => {
 		window.scrollTo( 0, 0 );
@@ -59,8 +63,24 @@ export default function AssignLicense( {
 					} ) }
 				</CardHeading>
 			</LayoutHeader>
-
-			<AssignLicenseForm sites={ sites } currentPage={ currentPage } search={ search } />
+			<Main wideLayout className="assign-license">
+				<DocumentHead
+					title={ translate( 'Assign your license', 'Assign your licenses', {
+						count: licenseKeysArray.length,
+					} ) }
+				/>
+				<SidebarNavigation />
+				<AssignLicenseStepProgress
+					currentStep="assignLicense"
+					showDownloadStep={ showDownloadStep }
+				/>
+				<CardHeading size={ 36 }>
+					{ translate( 'Assign your license', 'Assign your licenses', {
+						count: licenseKeysArray.length,
+					} ) }
+				</CardHeading>
+				<AssignLicenseForm sites={ sites } currentPage={ currentPage } search={ search } />
+			</Main>
 		</Layout>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -1,6 +1,7 @@
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useLayoutEffect } from 'react';
+import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
@@ -58,6 +59,11 @@ export default function AssignLicense( {
 				} ) }
 			/>
 			<SidebarNavigation />
+			<CardHeading size={ 36 }>
+				{ translate( 'Assign your license', 'Assign your licenses', {
+					count: licenseKeysArray.length,
+				} ) }
+			</CardHeading>
 			<AssignLicenseForm sites={ sites } currentPage={ currentPage } search={ search } />
 		</Main>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -24,9 +24,7 @@ export default function AssignLicense( {
 	const licenseKey = getQueryArg( window.location.href, 'key' ) as string;
 	const products = getQueryArg( window.location.href, 'products' ) as string;
 	const licenseKeysArray = products !== undefined ? products.split( ',' ) : [ licenseKey ];
-	const showDownloadStep = licenseKeysArray.some( ( licenseKey ) =>
-		isWooCommerceProduct( licenseKey )
-	);
+	const showDownloadStep = licenseKeysArray.some( isWooCommerceProduct );
 
 	const scrollToTop = () => {
 		window.scrollTo( 0, 0 );

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -1,7 +1,6 @@
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useLayoutEffect } from 'react';
-import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
@@ -59,11 +58,6 @@ export default function AssignLicense( {
 				} ) }
 			/>
 			<SidebarNavigation />
-			<CardHeading size={ 36 }>
-				{ translate( 'Assign your license', 'Assign your licenses', {
-					count: licenseKeysArray.length,
-				} ) }
-			</CardHeading>
 			<AssignLicenseForm sites={ sites } currentPage={ currentPage } search={ search } />
 		</Main>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/primary/download-products/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/download-products/index.tsx
@@ -4,7 +4,6 @@ import { useEffect, useLayoutEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
-import AssignLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form';
 import AssignLicenseStepProgress from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-step-progress';
 import DownloadProductsForm from 'calypso/jetpack-cloud/sections/partner-portal/download-products-form';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
@@ -26,7 +25,7 @@ export default function DownloadProducts() {
 	}, [] );
 
 	useEffect( () => {
-		const layoutClass = 'layout__content--partner-portal-assign-license';
+		const layoutClass = 'layout__content--partner-portal-download-products';
 		const content = document.getElementById( 'content' );
 
 		if ( content ) {
@@ -37,7 +36,7 @@ export default function DownloadProducts() {
 	}, [] );
 
 	return (
-		<Main wideLayout className="assign-license">
+		<Main wideLayout className="download-products">
 			<DocumentHead
 				title={ translate(
 					'Download and Install your product',

--- a/client/jetpack-cloud/sections/partner-portal/primary/download-products/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/download-products/index.tsx
@@ -1,0 +1,61 @@
+import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useLayoutEffect } from 'react';
+import CardHeading from 'calypso/components/card-heading';
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+import AssignLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form';
+import AssignLicenseStepProgress from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-step-progress';
+import DownloadProductsForm from 'calypso/jetpack-cloud/sections/partner-portal/download-products-form';
+import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
+
+import './styles.scss';
+
+export default function DownloadProducts() {
+	const translate = useTranslate();
+	const licenseKey = getQueryArg( window.location.href, 'key' ) as string;
+	const products = getQueryArg( window.location.href, 'products' ) as string;
+	const licenseKeysArray = products !== undefined ? products.split( ',' ) : [ licenseKey ];
+
+	const scrollToTop = () => {
+		window.scrollTo( 0, 0 );
+	};
+
+	useLayoutEffect( () => {
+		scrollToTop();
+	}, [] );
+
+	useEffect( () => {
+		const layoutClass = 'layout__content--partner-portal-assign-license';
+		const content = document.getElementById( 'content' );
+
+		if ( content ) {
+			content.classList.add( layoutClass );
+
+			return () => content.classList.remove( layoutClass );
+		}
+	}, [] );
+
+	return (
+		<Main wideLayout className="assign-license">
+			<DocumentHead
+				title={ translate(
+					'Download and Install your product',
+					'Download and Install your products',
+					{
+						count: licenseKeysArray.length,
+					}
+				) }
+			/>
+			<SidebarNavigation />
+			<AssignLicenseStepProgress currentStep="downloadProducts" showDownloadStep />
+			<CardHeading size={ 36 }>
+				{ translate( 'Download and install your product', 'Download and install your products', {
+					count: licenseKeysArray.length,
+				} ) }
+			</CardHeading>
+
+			<DownloadProductsForm />
+		</Main>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/primary/download-products/styles.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/download-products/styles.scss
@@ -1,0 +1,5 @@
+.assign-license {
+	.assign-license-step-progress {
+		margin-bottom: 40px;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -234,3 +234,13 @@ export const LICENSE_INFO_MODAL_ID = 'show_license_modal';
 export function isWooCommerceProduct( keyOrSlug: string ) {
 	return keyOrSlug.startsWith( 'woocommerce' );
 }
+
+/**
+ * Provided a license key, return the product slug
+ *
+ * @param licenseKey string
+ * @returns string Product slug
+ */
+export function getProductSlugFromKey( licenseKey: string ) {
+	return licenseKey.split( '_' )[ 0 ];
+}


### PR DESCRIPTION
## Proposed Changes

* Creates a new route for a downloads page.
* Injects the new downloads page into the assignment flow whenever a WC license is issued.
* Provides download links and a description of what to do next.
* Modifies the `AssignmentLicenseStepProgress` component to create a new "Download products" step.
* Adds a basic util to determine whether products are WC products based on product slug or product key.
* Adds a basic util to determine a product slug based on a product key.

## To Do

* This PR was a lot more involved than expected because of the complexity of the multi-assign mechanisms. We need to test edge cases and different flows to ensure that nothing breaks.
* Need to ask for design to do a touch up on the downloads page ... I didn't do any design, only added the necessary information.

## Testing Instructions

* Use billing scheme 871 with your partner key (reach out to me if you need this switched).
* Apply this PR and `yarn start-jetpack-cloud`.
* Issue and assign a license for a single WC product. You should see the download screen and be able to download the product.
* Issue and assign licenses for two WC products. You should see the download screen and be able to download both products.
* Issue and assign licenses for any combinations of WC products and Jetpack products. You should see the appropriate download screen.
* Issue licenses for only Jetpack products. You SHOULD NOT see the download screen after assigning.
* Try to break this in any other creative ways you can think of.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
