### PR TITLE
Checkout: Add div inside FormLabel for ThirdPartyDevsAccount to separate styles

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/third-party-plugins-developer-account.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/third-party-plugins-developer-account.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 
-const CheckboxTermsWrapper = styled( FormLabel )`
+const CheckboxTermsWrapper = styled.div`
 	column-gap: 8px;
 	display: grid;
 	grid-template-areas:
@@ -65,17 +65,19 @@ function ThirdPartyDevsAccount( { isAccepted, isSubmitted, onChange, translate }
 	};
 
 	return (
-		<CheckboxTermsWrapper>
-			<StyledFormCheckbox
-				onChange={ handleChange }
-				onBlur={ () => setTouched( true ) }
-				checked={ isAccepted }
-			/>
-			<MessageWrapper displayErrorMessage={ displayErrorMessage }>{ message }</MessageWrapper>
-			{ displayErrorMessage && (
-				<ErrorMessage>{ translate( 'The terms above need to be accepted' ) }</ErrorMessage>
-			) }
-		</CheckboxTermsWrapper>
+		<FormLabel>
+			<CheckboxTermsWrapper>
+				<StyledFormCheckbox
+					onChange={ handleChange }
+					onBlur={ () => setTouched( true ) }
+					checked={ isAccepted }
+				/>
+				<MessageWrapper displayErrorMessage={ displayErrorMessage }>{ message }</MessageWrapper>
+				{ displayErrorMessage && (
+					<ErrorMessage>{ translate( 'The terms above need to be accepted' ) }</ErrorMessage>
+				) }
+			</CheckboxTermsWrapper>
+		</FormLabel>
 	);
 }
 


### PR DESCRIPTION
## Proposed Changes

The third-party plugin checkbox in checkout and its label were styled in the recent redesign (#77353) to use CSS grid for their layout. However, these styles are applied on top of the `FormLabel` component which has its own styles. During development, the styles for checkout were loaded last and so we thought the new layout had worked. However, in production it appears that _sometimes_ the checkout styles load first, causing the `FormLabel` styles to take precedence.

In this PR we modify the checkbox so that its styles always take precedence.

Before:

<img width="653" alt="Screenshot 2023-06-27 at 10 49 16 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/475722e8-c1c4-4fec-98fe-80fe3be45e4a">


After:

<img width="676" alt="Screenshot 2023-06-27 at 10 30 18 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/7d0a23f5-0fe9-487f-9751-dfd44ce501db">


## Testing Instructions

- Use an account with a Business plan.
- Click the "Plugins" section of the calypso sidebar.
- Add a marketplace product to your cart like "Yoast". Click to install. You'll be taken to checkout eventually.
- Scroll to the bottom of the page and verify that the checkbox looks ok.