### PR TITLE
Subscription Management: Rename to latest and move it to the first item on the menu.

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -162,6 +162,16 @@ export class ReaderSidebar extends Component {
 
 				<SidebarSeparator />
 
+				<SidebarItem
+					className={ ReaderSidebarHelper.itemLinkClass( '/read', path, {
+						'sidebar-streams__following': true,
+					} ) }
+					label={ isSubscriptionManagerEnabled ? translate( 'Latest' ) : translate( 'Following' ) }
+					onNavigate={ this.handleReaderSidebarFollowedSitesClicked }
+					customIcon={ <ReaderFollowingIcon /> }
+					link="/read"
+				/>
+
 				{ isDiscoverEnabled() && (
 					<SidebarItem
 						className={ ReaderSidebarHelper.itemLinkClass( '/discover', path, {
@@ -173,18 +183,6 @@ export class ReaderSidebar extends Component {
 						link="/discover"
 					/>
 				) }
-
-				<SidebarItem
-					className={ ReaderSidebarHelper.itemLinkClass( '/read', path, {
-						'sidebar-streams__following': true,
-					} ) }
-					label={
-						isSubscriptionManagerEnabled ? translate( 'Subscriptions' ) : translate( 'Following' )
-					}
-					onNavigate={ this.handleReaderSidebarFollowedSitesClicked }
-					customIcon={ <ReaderFollowingIcon /> }
-					link="/read"
-				/>
 
 				<SidebarItem
 					label={ translate( 'Likes' ) }


### PR DESCRIPTION
## Proposed Changes

* Rename "Subscriptions" menu item label to "Latest".
* Move the menu item to the top.

## Testing Instructions

* Go to `/read`
* It should render as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
