### PR TITLE
Reader: wrap slug/timestamp text to prevent overflow

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -289,7 +289,6 @@
 	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 12px;
 	margin-top: 2px;
-	white-space: nowrap;
 	cursor: pointer;
 	&:hover {
 		color: var(--color-text-subtle);


### PR DESCRIPTION
## Proposed Changes

* Removes no wrap rule to prevent slug/site name text overflow

## Testing Instructions

* On both the regular layout (e.g. Following) and compact layout (e.g. tags pages), use browser inspector to make a long slug/site name in  `a.reader-post-card__timestamp-slug` and `a.reader-post-card__timestamp-link`.

| **Before** | **After** |
| - | - |
| <img width="741" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1699996/fa34aa43-ee79-46bd-a6d7-e8e0f0ab4575"> | <img width="665" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1699996/0e750049-a7e1-48ea-a3d9-3a32785c3cb2"> |
