### PR TITLE
Subscription Manager: add tooltip to new comments column

### DIFF
--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -1,6 +1,7 @@
 $large-tooltip-box-shadow-color: rgba(0, 0, 0, 0.05);
 
 .tooltip.popover {
+	outline: none;
 
 	// always display the popover on top even inside a modal with a high z index
 	z-index: z-index("root", ".tooltip.popover");

--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
@@ -295,10 +295,10 @@ const SiteRow = ( {
 						<div className="new-comments-tooltip__content">
 							{ delivery_methods.email?.send_comments
 								? translate(
-										'You will receive emails when new comments are published on this site.'
+										'You will receive emails notifications for new comments on this site.'
 								  )
 								: translate(
-										"You won't receive emails when new comments are published on this site."
+										"You won't receive email notifications for new comments on this site."
 								  ) }
 						</div>
 					</Tooltip>

--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import { Dispatch, RefObject, SetStateAction, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import TimeSince from 'calypso/components/time-since';
@@ -29,16 +29,22 @@ import {
 	SubscriptionsPortal,
 } from '../subscription-manager-context';
 
-const getIcon = (
-	ref: RefObject< SVGSVGElement >,
-	setTooltipVisible: Dispatch< SetStateAction< boolean > >,
-	color: 'green' | 'red'
-) => (
+interface NotificationStatusProps {
+	tooltipRef: React.RefObject< SVGSVGElement >;
+	setTooltipVisible: React.Dispatch< React.SetStateAction< boolean > >;
+	notificationDisabled: boolean;
+}
+
+const NotificationStatus: React.FC< NotificationStatusProps > = ( {
+	tooltipRef,
+	setTooltipVisible,
+	notificationDisabled,
+} ) => (
 	<Gridicon
-		ref={ ref }
-		icon={ color === 'green' ? 'checkmark' : 'cross' }
+		ref={ tooltipRef }
+		icon={ notificationDisabled ? 'cross' : 'checkmark' }
 		size={ 16 }
-		className={ color }
+		className={ notificationDisabled ? 'red' : 'green' }
 		onMouseEnter={ () => setTooltipVisible( true ) }
 		onMouseLeave={ () => setTooltipVisible( false ) }
 	/>
@@ -211,16 +217,6 @@ const SiteRow = ( {
 		recordPostEmailsSetFrequency( { blog_id, delivery_frequency } );
 	};
 
-	const newColumnIcon = useMemo(
-		() =>
-			getIcon(
-				tooltip,
-				setTooltipVisible,
-				delivery_methods.email?.send_comments ? 'green' : 'red'
-			),
-		[ delivery_methods.email?.send_comments ]
-	);
-
 	return ! isDeleted ? (
 		<li className="row" role="row">
 			<span className="title-cell" role="cell">
@@ -284,7 +280,11 @@ const SiteRow = ( {
 			) }
 			{ isLoggedIn && (
 				<span className="new-comments-cell" role="cell">
-					{ newColumnIcon }
+					<NotificationStatus
+						tooltipRef={ tooltip }
+						setTooltipVisible={ setTooltipVisible }
+						notificationDisabled={ ! delivery_methods.email?.send_comments }
+					/>
 					<Tooltip
 						className="new-comments-tooltip"
 						isVisible={ isTooltipVisible }

--- a/client/landing/subscriptions/components/site-subscriptions-manager/styles.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/styles.scss
@@ -159,3 +159,7 @@
 	}
 
 }
+
+.new-comments-tooltip__content {
+	width: 200px;
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/77488

## Proposed Changes

This PR adds a tooltip to the icons in the new comments columns in Subscription Manager like this:

<img width="1384" alt="Screenshot 2023-06-27 at 18 58 19 (2)" src="https://github.com/Automattic/wp-calypso/assets/3832570/812a85bd-127d-4fc1-9c6a-ab990d51da02">


## Testing Instructions

1. Apply this patch and start the application.
2. Go to `http://calypso.localhost:3000/subscriptions/sites`.
3. Hover over any of the icons in the New Comments column. You should see the tooltips appearing on top of the hovered icon.


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
