### PR TITLE
[earn] :: Allow empty strings in memberships price field.

### DIFF
--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -187,7 +187,8 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	};
 	const handlePriceChange = ( event ) => {
 		const value = parseFloat( event.currentTarget.value );
-		if ( ! isNaN( value ) ) {
+		// Set the current price if the value is a valid number or an empty string.
+		if ( '' === event.currentTarget.value || ! isNaN( value ) ) {
 			setCurrentPrice( event.currentTarget.value );
 		}
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78215

## Proposed Changes

* Allows an empty string in the `handlePriceChange()` handler.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test can be done with any browser.
* If testing against sandboxed store with Safari I had to:
   * disable proxy
   * on sandbox: `sudo global-http enable` (and answer all the prompts)
* Spin up a development version (i.e. `yarn start`)
* Navigate to http://calypso.localhost:3000/earn/payments-plans/neffffearn.wordpress.com#add-newsletter-payment-plan (your URL might be slightly different depending on the site you test against)
* Try entering different values into the currency field.  After this change invalid values are preserved in the field, but the save is not enabled until the value is valid.
* **Test with an empty field** (You can verify against trunk that trying to remove a value (hitting backspace with one integer)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
