### PR TITLE
Reader: add sidebar to site feed

### DIFF
--- a/client/blocks/reader-post-card/tag-link.jsx
+++ b/client/blocks/reader-post-card/tag-link.jsx
@@ -25,7 +25,7 @@ class TagLink extends Component {
 				tag: tag.slug,
 			} );
 		}
-		this.props.onClick();
+		this.props.onClick( tag );
 	};
 
 	render() {

--- a/client/data/site-tags/use-site-tags.ts
+++ b/client/data/site-tags/use-site-tags.ts
@@ -1,0 +1,25 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { SiteId, URL } from 'calypso/types';
+
+interface Tag {
+	id: number;
+	count: number;
+	description: string;
+	link: URL;
+	name: string;
+	slug: string;
+	taxonomy: 'post_tag';
+	meta: Array< unknown >;
+}
+
+export const useSiteTags = ( siteId: SiteId ): UseQueryResult< Tag[] | null > =>
+	useQuery( {
+		enabled: !! siteId,
+		queryKey: [ 'site-tags', siteId ],
+		queryFn: () =>
+			wp.req.get( `/sites/${ siteId }/tags?order=desc&orderby=count&per_page=10`, {
+				apiNamespace: 'wp/v2',
+			} ),
+		staleTime: 3600000, // 1 hour
+	} );

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -1,21 +1,37 @@
 import { useTranslate } from 'i18n-calypso';
 import ReaderFeedHeader from 'calypso/blocks/reader-feed-header';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryPostCounts from 'calypso/components/data/query-post-counts';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
 import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import { useSiteTags } from 'calypso/data/site-tags/use-site-tags';
 import FeedError from 'calypso/reader/feed-error';
 import { getSiteName } from 'calypso/reader/get-helpers';
 import SiteBlocked from 'calypso/reader/site-blocked';
 import Stream from 'calypso/reader/stream';
 import { useSelector } from 'calypso/state';
+import { getAllPostCount } from 'calypso/state/posts/counts/selectors';
 import { getFeed } from 'calypso/state/reader/feeds/selectors';
 import { getReaderFollowForFeed } from 'calypso/state/reader/follows/selectors';
 import { isSiteBlocked } from 'calypso/state/reader/site-blocks/selectors';
 import { getSite } from 'calypso/state/reader/sites/selectors';
 import EmptyContent from './empty';
+import FeedStreamSidebar from './sidebar';
 
 // If the blog_ID of a reader feed is 0, that means no site exists for it.
 const getReaderSiteId = ( feed ) => ( feed && feed.blog_ID === 0 ? null : feed && feed.blog_ID );
+
+const getFollowerCount = ( feed, site ) => {
+	if ( site && site.subscribers_count ) {
+		return site.subscribers_count;
+	}
+
+	if ( feed && feed.subscribers_count > 0 ) {
+		return feed.subscribers_count;
+	}
+
+	return null;
+};
 
 export default function FeedStream( props ) {
 	const { feedId, className = 'is-site-stream', showBack = true } = props;
@@ -32,18 +48,21 @@ export default function FeedStream( props ) {
 		return _feed;
 	} );
 
-	const { isBlocked, site, siteId } = useSelector( ( state ) => {
+	const { isBlocked, postCount, site, siteId } = useSelector( ( state ) => {
 		const _siteId = getReaderSiteId( feed );
 
 		return {
 			isBlocked: _siteId && isSiteBlocked( state, _siteId ),
+			postCount: _siteId && getAllPostCount( state, _siteId, 'post', 'publish' ),
 			site: _siteId && getSite( state, _siteId ),
 			siteId: _siteId,
 		};
 	} );
 
+	const siteTags = useSiteTags( siteId );
 	const emptyContent = <EmptyContent />;
 	const title = getSiteName( { feed, site } ) || translate( 'Loading Feed' );
+	const followerCount = getFollowerCount( feed, site );
 
 	if ( isBlocked ) {
 		return <SiteBlocked title={ title } siteId={ siteId } />;
@@ -53,16 +72,25 @@ export default function FeedStream( props ) {
 		return <FeedError sidebarTitle={ title } />;
 	}
 
+	const streamSidebar = (
+		<FeedStreamSidebar
+			followerCount={ followerCount }
+			postCount={ postCount }
+			tags={ siteTags.data }
+		/>
+	);
+
 	return (
 		<Stream
 			{ ...props }
 			className={ className }
 			listName={ title }
 			emptyContent={ emptyContent }
+			showFollowButton={ false }
 			showPostHeader={ false }
 			showSiteNameOnCards={ false }
+			streamSidebar={ streamSidebar }
 			useCompactCards={ true }
-			showFollowButton={ false }
 		>
 			<DocumentHead
 				title={ translate( '%s ‹ Reader', {
@@ -76,6 +104,7 @@ export default function FeedStream( props ) {
 				showBack={ showBack }
 				streamKey={ props.streamKey }
 			/>
+			{ siteId && <QueryPostCounts siteId={ siteId } type="post" /> }
 			{ ! feed && <QueryReaderFeed feedId={ feedId } /> }
 			{ siteId && <QueryReaderSite siteId={ siteId } /> }
 		</Stream>

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -89,6 +89,7 @@ export default function FeedStream( props ) {
 			showFollowButton={ false }
 			showPostHeader={ false }
 			showSiteNameOnCards={ false }
+			sidebarTabTitle={ translate( 'Related' ) }
 			streamSidebar={ streamSidebar }
 			useCompactCards={ true }
 		>

--- a/client/reader/feed-stream/sidebar.jsx
+++ b/client/reader/feed-stream/sidebar.jsx
@@ -1,0 +1,77 @@
+import { useTranslate, getLocaleSlug } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
+import TagLink from 'calypso/blocks/reader-post-card/tag-link';
+import formatNumberCompact from 'calypso/lib/format-number-compact';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import '../style.scss';
+
+const FeedStreamSidebar = ( { followerCount, postCount, tags } ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const handleTagSidebarClick = ( tag ) => {
+		recordAction( 'clicked_reader_sidebar_tag' );
+		recordGaEvent( 'Clicked Reader Sidebar Tag' );
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_sidebar_tag_clicked', {
+				tag: decodeURIComponent( tag.slug ),
+			} )
+		);
+	};
+
+	const trackTagsPageLinkClick = () => {
+		recordAction( 'clicked_reader_sidebar_tags_page_link' );
+		dispatch( recordReaderTracksEvent( 'calypso_reader_sidebar_tags_page_link_clicked' ) );
+	};
+
+	return (
+		<>
+			{ ( postCount || followerCount ) && (
+				<div className="reader-tag-sidebar-stats">
+					{ postCount && (
+						<div className="reader-tag-sidebar-stats__item">
+							<span className="reader-tag-sidebar-stats__count">
+								{ formatNumberCompact( postCount ) }
+							</span>
+							<span className="reader-tag-sidebar-stats__title">
+								{ translate( 'Post', 'Posts', { count: postCount } ) }
+							</span>
+						</div>
+					) }
+					{ followerCount && (
+						<div className="reader-tag-sidebar-stats__item">
+							<span className="reader-tag-sidebar-stats__count">
+								{ followerCount.toLocaleString( getLocaleSlug() ) }
+							</span>
+							<span className="reader-tag-sidebar-stats__title">
+								{ translate( 'Follower', 'Followers', { count: followerCount } ) }
+							</span>
+						</div>
+					) }
+				</div>
+			) }
+			{ tags && tags.length > 0 && (
+				<>
+					<div className="reader-tag-sidebar-related-tags">
+						<h2>{ translate( 'Tags' ) }</h2>
+						<div className="reader-post-card__tags">
+							{ tags.map( ( tag ) => (
+								<TagLink tag={ tag } key={ tag.slug } onClick={ handleTagSidebarClick } />
+							) ) }
+						</div>
+					</div>
+					<a
+						className="reader-tag-sidebar-tags-page"
+						href="/tags"
+						onClick={ trackTagsPageLinkClick }
+					>
+						{ translate( 'See all tags' ) }
+					</a>
+				</>
+			) }
+		</>
+	);
+};
+
+export default FeedStreamSidebar;

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -10,9 +10,9 @@ function FollowingStream( { ...props } ) {
 	return (
 		<>
 			<Stream
+				{ ...props }
 				className="following"
 				streamSidebar={ <ReaderListFollowedSites path={ window.location.pathname } /> }
-				{ ...props }
 			>
 				<FollowingIntro />
 			</Stream>

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -17,8 +17,6 @@
 
 		&.is-discover-stream {
 			.reader-tag-sidebar-recommended-sites {
-				max-width: 270px;
-
 				.reader-subscription-list-item .follow-button__label,
 				.reader-subscription-list-item__settings-label {
 					display: none;
@@ -713,7 +711,7 @@
 	.reader-tag-sidebar-related-tags,
 	.reader-tag-sidebar-related-sites {
 		h2 {
-			font-size: $font-body-small;
+			font-size: $font-body;
 			margin-bottom: 14px;
 		}
 	}
@@ -820,6 +818,11 @@
 	}
 }
 
+// Stop the sidebar from expanding too wide when shown in a 2 column layout.
+.stream__two-column .stream__right-column {
+	max-width: 270px;
+}
+
 .stream__header .section-nav-group {
 	display: flex;
 	flex: 1 0 0%;
@@ -890,3 +893,13 @@
 	}
 }
 
+.is-reader-page .is-site-stream {
+	// Temporary, remove when site stream header is resigned and follow button moved to sidebar.
+	.stream__two-column {
+		border-top: 1px solid var(--color-neutral-10);
+	}
+
+	.reader-post-card.card:nth-child(2) {
+		border-top: none;
+	}
+}

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -73,7 +73,6 @@
 
 	.stream__two-column .stream__right-column {
 		margin-top: 0;
-		max-width: 270px;
 	}
 
 	.reader-sidebar-site_link {


### PR DESCRIPTION
## Proposed Changes

Adds a sidebar to the Reader site feed including

- Number of posts
- Number of followers
- List of most used tags on the site

RSS feeds will only show number of followers, as we don't have the other data to display.

Ideally, the sidebar component would be combined with the tag page sidebar into a modular component that supports both layouts, but I'll save that for a separate PR, since there's already enough going on in this one.

## Testing Instructions

* Visit `/read/feeds/{feed-id}`

Be sure to try different types of sites and feeds

| **Before** | **After** |
| - | - |
| <img width="844" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1699996/772c6e99-b757-43ee-938b-612b09c3f924"> | <img width="977" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1699996/178a1617-21df-407e-842c-37ff3f8fc7e0"> |

