### PR TITLE
Fix crash related to useEffect returning a value instead of a function

### DIFF
--- a/client/my-sites/people/team-invite/hooks/use-inviting-notifications.ts
+++ b/client/my-sites/people/team-invite/hooks/use-inviting-notifications.ts
@@ -12,9 +12,15 @@ export function useInvitingNotifications( tokenValues: string[] ) {
 	const noticeConfig = { displayOnNextPage: true };
 
 	useEffect( () => setPrevProgress( progress ), [ progress ] );
-	useEffect( () => prevProgress && error && showInvitingErrorNotice(), [ error ] );
-	useEffect( () => prevProgress && success && showInvitingSuccessNotice(), [ success ] );
-	useEffect( () => prevProgress && failure && showInvitingFailureNotice(), [ failure ] );
+	useEffect( () => {
+		prevProgress && error && showInvitingErrorNotice();
+	}, [ error ] );
+	useEffect( () => {
+		prevProgress && success && showInvitingSuccessNotice();
+	}, [ success ] );
+	useEffect( () => {
+		prevProgress && failure && showInvitingFailureNotice();
+	}, [ failure ] );
 
 	function showInvitingErrorNotice() {
 		let msg;

--- a/client/my-sites/people/team-invite/hooks/use-validation-notifications.ts
+++ b/client/my-sites/people/team-invite/hooks/use-validation-notifications.ts
@@ -10,7 +10,9 @@ export function useValidationNotifications() {
 
 	const { failure } = useSelector( getTokenValidation );
 
-	useEffect( () => failure && showValidationFailureNotice(), [ failure ] );
+	useEffect( () => {
+		failure && showValidationFailureNotice();
+	}, [ failure ] );
 
 	function showValidationFailureNotice() {
 		dispatch(

--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -67,7 +67,9 @@ function InviteForm( props: Props ) {
 	useEffect( toggleShowContractorCb, [ role ] );
 	useEffect( checkSubmitReadiness, [ tokenErrors, validationProgress ] );
 	useEffect( reactOnInvitationSuccess, [ invitingSuccess ] );
-	useEffect( () => ( prevInvitingProgress.current = invitingProgress ), [ invitingProgress ] );
+	useEffect( () => {
+		prevInvitingProgress.current = invitingProgress;
+	}, [ invitingProgress ] );
 	useValidationNotifications();
 	useInvitingNotifications( tokenValues );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: #77046 

## Proposed Changes

Resolves https://a8c.sentry.io/issues/4279026430/?project=6313676

Sentry detected a page crash in this scenario:
1. Go to https://wordpress.com/people/add-subscribers/:site:
2. Navigate back and forth between the two tabs
3. After once or twice going back or forth (or even just waiting a moment), the page will crash.

After testing this locally, I found warnings in the console about useEffect returning a value. This also lead me to a Stackoverflow post: https://stackoverflow.com/questions/74265321/uncaught-typeerror-destroy-is-not-a-function-error-in-react

The issue is that when useEffect's callback returns a value, React will try to call it as a function. (This function can be used to destroy or unsubscribe from things set up in the effect.)

When that value is not a function, the page crashes.

So I went through several useEffect calls on the related pages and updated several inline effect calls to not return values. We had several which were doing like `useEffect( () => ifCheck && doSomething() )`. These can return booleans, which causes the crash. This is probably new behavior in React 18.

I fixed this just be wrapping these callbacks in brackets (e.g. `useEffect( () => { ifCheck && doSomething() } )`), which should be functionally the same.

We will also need to add a linter rule and check this doesn't happen elsewhere.

## Testing Instructions
Follow the above bug-reproduction steps and check that there is no crash.


