### PR TITLE
Updates the tracks event for the DSP promote post widget

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -131,8 +131,16 @@ export async function showDSP(
  * @param {string} entryPoint - A slug describing the entry point.
  */
 export function recordDSPEntryPoint( entryPoint: string ) {
+	let origin = 'wpcom';
+	if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+		origin = 'jetpack';
+	} else if ( isWpMobileApp() ) {
+		origin = 'wp-mobile-app';
+	}
+
 	const eventProps = {
 		entry_point: entryPoint,
+		origin,
 	};
 
 	return composeAnalytics(


### PR DESCRIPTION

## Proposed Changes

We want more specific tracking events for the DSP widget. This PR adds an additional field to the event details to differentiate the Jetpack native app (Blaze Dashboard app), Jetpack mobile app and regular Wordpress.com users.

## Testing Instructions

* Open the live preview link and navigate to the Tools->Advertising section
* Click on the Promote button in the header
* Close the modal and click on the Promote button in any of the posts
* Go to a device screen, and make the device use a custom user-agent.
In Chrome, you can click on Dimensions->Edit, then on Add custom device. And then change the user agent with the following: `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B91 wp-iphone/12.1`
* Refresh the page and click the promote button of any of the posts

Then verify that the live tracks events have the newly added origin prop. (this could take like 15 minutes to refresh).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
