### PR TITLE
Domains: Allow any domain in a domain-only site to be managed

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -240,6 +240,14 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		);
 	}
 
+	// We now allow domain-only sites to have multiple domains, so we need to allow them to be managed
+	// See https://wp.me/pdhack-Hk for more context on the motivation for this decision
+	if ( contextParams.domain ) {
+		domainManagementPaths = domainManagementPaths.concat(
+			allPaths.map( ( pathFactory ) => pathFactory( slug, contextParams.domain ) )
+		);
+	}
+
 	const startsWithPaths = [
 		'/checkout/',
 		`/me/purchases/${ slug }`,
@@ -247,6 +255,8 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		`/purchases/billing-history/${ slug }`,
 		`/purchases/payment-methods/${ slug }`,
 		`/purchases/subscriptions/${ slug }`,
+		// Any page under the `/domsina/manage/all` should be accessible in domain-only sites now that we allow multiple domains in them
+		'/domains/manage/all/',
 	];
 
 	if ( some( startsWithPaths, ( startsWithPath ) => startsWith( path, startsWithPath ) ) ) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -255,7 +255,7 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		`/purchases/billing-history/${ slug }`,
 		`/purchases/payment-methods/${ slug }`,
 		`/purchases/subscriptions/${ slug }`,
-		// Any page under the `/domsina/manage/all` should be accessible in domain-only sites now that we allow multiple domains in them
+		// Any page under `/domsina/manage/all` should be accessible in domain-only sites now that we allow multiple domains in them
 		'/domains/manage/all/',
 	];
 

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -46,15 +46,19 @@ class AddDnsRecord extends Component {
 		const items = [
 			{
 				label: translate( 'Domains' ),
-				href: domainManagementList( selectedSite.slug, selectedDomainName ),
+				href: domainManagementList(
+					selectedSite?.slug,
+					selectedDomainName,
+					selectedSite?.options?.is_domain_only
+				),
 			},
 			{
 				label: selectedDomainName,
-				href: domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute ),
+				href: domainManagementEdit( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{
 				label: translate( 'DNS records' ),
-				href: domainManagementDns( selectedSite.slug, selectedDomainName ),
+				href: domainManagementDns( selectedSite?.slug, selectedDomainName ),
 			},
 			{
 				label: recordBeingEdited
@@ -67,7 +71,7 @@ class AddDnsRecord extends Component {
 			label: translate( 'Back to DNS records', {
 				comment: 'Link to return to the DNs records management page of a domain ',
 			} ),
-			href: domainManagementDns( selectedSite.slug, selectedDomainName ),
+			href: domainManagementDns( selectedSite?.slug, selectedDomainName ),
 			showBackArrow: true,
 		};
 
@@ -76,7 +80,7 @@ class AddDnsRecord extends Component {
 
 	goBack = () => {
 		const { selectedSite, selectedDomainName } = this.props;
-		page( domainManagementDns( selectedSite.slug, selectedDomainName ) );
+		page( domainManagementDns( selectedSite?.slug, selectedDomainName ) );
 	};
 
 	renderMain() {
@@ -121,7 +125,7 @@ class AddDnsRecord extends Component {
 					<DnsAddNew
 						isSubmittingForm={ dns.isSubmittingForm }
 						selectedDomainName={ selectedDomainName }
-						selectedSiteSlug={ selectedSite.slug }
+						selectedSiteSlug={ selectedSite?.slug }
 						goBack={ this.goBack }
 						recordToEdit={ recordBeingEdited }
 					/>

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -41,11 +41,15 @@ class DnsRecords extends Component {
 		const items = [
 			{
 				label: translate( 'Domains' ),
-				href: domainManagementList( selectedSite.slug, selectedDomainName ),
+				href: domainManagementList(
+					selectedSite?.slug,
+					selectedDomainName,
+					selectedSite?.options?.is_domain_only
+				),
 			},
 			{
 				label: selectedDomainName,
-				href: domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute ),
+				href: domainManagementEdit( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{ label: translate( 'DNS records' ) },
 		];
@@ -53,7 +57,7 @@ class DnsRecords extends Component {
 		const mobileItem = {
 			// translators: %(domain)s is the domain name (e.g. example.com) to which settings page the user will return to when pressing the link
 			label: translate( 'Back to %(domain)s', { args: { domain: selectedDomainName } } ),
-			href: domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute ),
+			href: domainManagementEdit( selectedSite?.slug, selectedDomainName, currentRoute ),
 			showBackArrow: true,
 		};
 
@@ -69,7 +73,7 @@ class DnsRecords extends Component {
 		const buttons = [
 			<DnsAddNewRecordButton
 				key="add-new-record-button"
-				site={ selectedSite.slug }
+				site={ selectedSite?.slug }
 				domain={ selectedDomainName }
 			/>,
 			optionsButton,
@@ -78,7 +82,7 @@ class DnsRecords extends Component {
 		const mobileButtons = [
 			<DnsAddNewRecordButton
 				key="mobile-add-new-record-button"
-				site={ selectedSite.slug }
+				site={ selectedSite?.slug }
 				domain={ selectedDomainName }
 				isMobile={ true }
 			/>,
@@ -142,8 +146,8 @@ class DnsRecords extends Component {
 export default connect(
 	( state, { selectedDomainName } ) => {
 		const selectedSite = getSelectedSite( state );
-		const domains = getDomainsBySiteId( state, selectedSite.ID );
-		const isRequestingDomains = isRequestingSiteDomains( state, selectedSite.ID );
+		const domains = getDomainsBySiteId( state, selectedSite?.ID );
+		const isRequestingDomains = isRequestingSiteDomains( state, selectedSite?.ID );
 		const dns = getDomainDns( state, selectedDomainName );
 		const showPlaceholder = ! dns.hasLoadedFromServer || isRequestingDomains;
 

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -51,7 +51,7 @@ const EditContactInfoPage = ( {
 		}
 
 		const previousPath = domainManagementEdit(
-			selectedSite.slug,
+			selectedSite?.slug,
 			selectedDomainName,
 			currentRoute
 		);
@@ -59,7 +59,11 @@ const EditContactInfoPage = ( {
 		const items = [
 			{
 				label: translate( 'Domains' ),
-				href: domainManagementList( selectedSite.slug, currentRoute ),
+				href: domainManagementList(
+					selectedSite?.slug,
+					currentRoute,
+					selectedSite?.options?.is_domain_only
+				),
 			},
 			{
 				label: selectedDomainName,
@@ -96,7 +100,7 @@ const EditContactInfoPage = ( {
 			return (
 				<EditContactInfoPrivacyEnabledCard
 					selectedDomainName={ selectedDomainName }
-					selectedSiteSlug={ selectedSite.slug }
+					selectedSiteSlug={ selectedSite?.slug }
 				/>
 			);
 		}

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -78,7 +78,11 @@ const Settings = ( {
 	}, [ contactInformation, selectedDomainName ] );
 
 	const renderBreadcrumbs = () => {
-		const previousPath = domainManagementList( selectedSite?.slug, currentRoute );
+		const previousPath = domainManagementList(
+			selectedSite?.slug,
+			currentRoute,
+			selectedSite?.options?.is_domain_only
+		);
 
 		const items = [
 			{
@@ -124,7 +128,7 @@ const Settings = ( {
 	};
 
 	const renderStatusSection = () => {
-		if ( ! ( domain && selectedSite.options?.is_domain_only ) ) {
+		if ( ! ( domain && selectedSite?.options?.is_domain_only ) ) {
 			return null;
 		}
 
@@ -149,7 +153,7 @@ const Settings = ( {
 					title={ translate( 'Details', { textOnly: true } ) }
 					subtitle={ translate( 'Registration and auto-renew', { textOnly: true } ) }
 					key="main"
-					expanded={ ! selectedSite.options?.is_domain_only }
+					expanded={ ! selectedSite?.options?.is_domain_only }
 				>
 					<RegisteredDomainDetails
 						domain={ domain }
@@ -381,7 +385,7 @@ const Settings = ( {
 				<Button
 					onClick={ handleTransferDomainClick }
 					href={ domainUseMyDomain(
-						selectedSite.slug,
+						selectedSite?.slug,
 						domain.name,
 						useMyDomainInputMode.transferDomain
 					) }
@@ -404,7 +408,7 @@ const Settings = ( {
 		}
 
 		const contactInformationUpdateLink =
-			selectedSite && domain && domainManagementEditContactInfo( selectedSite.slug, domain.name );
+			selectedSite && domain && domainManagementEditContactInfo( selectedSite?.slug, domain.name );
 
 		return (
 			<Accordion
@@ -461,7 +465,7 @@ const Settings = ( {
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Main wideLayout className="domain-settings-page">
-			{ selectedSite.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite.ID } /> }
+			{ selectedSite?.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderBreadcrumbs() }
 			<SettingsHeader domain={ domain } site={ selectedSite } purchase={ purchase } />

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -81,11 +81,15 @@ const TransferPage = ( props: TransferPageProps ) => {
 			{
 				// translators: Internet domains, e.g. mygroovydomain.com
 				label: __( 'Domains' ),
-				href: domainManagementList( selectedSite.slug, selectedDomainName ),
+				href: domainManagementList(
+					selectedSite?.slug,
+					selectedDomainName,
+					selectedSite?.options?.is_domain_only
+				),
 			},
 			{
 				label: selectedDomainName,
-				href: domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute ),
+				href: domainManagementEdit( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{
 				// translators: Verb - Transfer a domain somewhere else
@@ -99,7 +103,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 				__( 'Back to %s' ),
 				selectedDomainName
 			),
-			href: domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute ),
+			href: domainManagementEdit( selectedSite?.slug, selectedDomainName, currentRoute ),
 			showBackArrow: true,
 		};
 
@@ -118,7 +122,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 				<ActionCard
 					key="transfer-to-another-user"
 					buttonHref={ domainManagementTransferToAnotherUser(
-						selectedSite.slug,
+						selectedSite?.slug,
 						selectedDomainName,
 						currentRoute
 					) }
@@ -152,7 +156,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 			<ActionCard
 				key="transfer-to-another-site"
 				buttonHref={ domainManagementTransferToOtherSite(
-					selectedSite.slug,
+					selectedSite?.slug,
 					selectedDomainName,
 					currentRoute
 				) }

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -58,7 +58,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 			! ( site.jetpack && ! isAtomic ) && // Simple and Atomic sites. Not Jetpack sites.
 			! isWpcomStagingSite &&
 			! ( site?.options?.is_domain_only ?? false ) &&
-			site.ID !== this.props.selectedSite.ID
+			site.ID !== this.props.selectedSite?.ID
 		);
 	};
 
@@ -89,7 +89,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		this.setState( { disableDialogButtons: true } );
 		wpcom.req
 			.post(
-				`/sites/${ selectedSite.ID }/domains/${ selectedDomainName }/transfer-to-site/${ targetSite.ID }`
+				`/sites/${ selectedSite?.ID }/domains/${ selectedDomainName }/transfer-to-site/${ targetSite.ID }`
 			)
 			.then(
 				() => {
@@ -99,7 +99,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 						const transferedTo = this.props.sites.find( ( site ) => site.ID === targetSite.ID );
 						page( domainManagementList( transferedTo?.slug ?? '' ) );
 					} else {
-						page( domainManagementList( this.props.selectedSite.slug ) );
+						page( domainManagementList( this.props.selectedSite?.slug ) );
 					}
 				},
 				( error: Error ) => {
@@ -127,7 +127,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 
 	render() {
 		const { selectedSite, selectedDomainName, currentRoute, translate } = this.props;
-		const { slug } = selectedSite;
+		const slug = selectedSite?.slug;
 		const componentClassName = 'transfer-domain-to-other-site';
 		if ( ! this.isDataReady() ) {
 			return (
@@ -165,22 +165,26 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		const items = [
 			{
 				label: translate( 'Domains' ),
-				href: domainManagementList( selectedSite.slug, selectedDomainName ),
+				href: domainManagementList(
+					selectedSite?.slug,
+					selectedDomainName,
+					selectedSite?.options?.is_domain_only
+				),
 			},
 			{
 				label: selectedDomainName,
-				href: domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute ),
+				href: domainManagementEdit( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{
 				label: translate( 'Transfer' ),
-				href: domainManagementTransfer( selectedSite.slug, selectedDomainName, currentRoute ),
+				href: domainManagementTransfer( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{ label: translate( 'To another WordPress.com site' ) },
 		];
 
 		const mobileItem = {
 			label: translate( 'Back to Transfer' ),
-			href: domainManagementTransfer( selectedSite.slug, selectedDomainName, currentRoute ),
+			href: domainManagementTransfer( selectedSite?.slug, selectedDomainName, currentRoute ),
 			showBackArrow: true,
 		};
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -76,7 +76,7 @@ class TransferDomainToOtherUser extends Component {
 
 	handleTransferCancel = () => {
 		const { selectedSite, selectedDomainName, currentRoute } = this.props;
-		page( domainManagementTransfer( selectedSite.slug, selectedDomainName, currentRoute ) );
+		page( domainManagementTransfer( selectedSite?.slug, selectedDomainName, currentRoute ) );
 	};
 
 	handleConfirmTransferDomain( closeDialog ) {
@@ -95,7 +95,7 @@ class TransferDomainToOtherUser extends Component {
 		this.setState( { disableDialogButtons: true } );
 		wpcom.req
 			.post(
-				`/sites/${ selectedSite.ID }/domains/${ selectedDomainName }/transfer-to-user/${ selectedUserId }`
+				`/sites/${ selectedSite?.ID }/domains/${ selectedDomainName }/transfer-to-user/${ selectedUserId }`
 			)
 			.then(
 				() => {
@@ -104,7 +104,7 @@ class TransferDomainToOtherUser extends Component {
 					closeDialog();
 					page(
 						domainManagementEdit(
-							this.props.selectedSite.slug,
+							this.props.selectedSite?.slug,
 							this.props.selectedDomainName,
 							this.props.currentRoute
 						)
@@ -146,22 +146,26 @@ class TransferDomainToOtherUser extends Component {
 		const items = [
 			{
 				label: translate( 'Domains' ),
-				href: domainManagementList( selectedSite.slug, selectedDomainName ),
+				href: domainManagementList(
+					selectedSite?.slug,
+					selectedDomainName,
+					selectedSite?.options?.is_domain_only
+				),
 			},
 			{
 				label: selectedDomainName,
-				href: domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute ),
+				href: domainManagementEdit( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{
 				label: translate( 'Transfer' ),
-				href: domainManagementTransfer( selectedSite.slug, selectedDomainName, currentRoute ),
+				href: domainManagementTransfer( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{ label: translate( 'Transfer to another user' ) },
 		];
 
 		const mobileItem = {
 			label: translate( 'Back to Transfer' ),
-			href: domainManagementTransfer( selectedSite.slug, selectedDomainName, currentRoute ),
+			href: domainManagementTransfer( selectedSite?.slug, selectedDomainName, currentRoute ),
 			showBackArrow: true,
 		};
 
@@ -362,7 +366,7 @@ class TransferDomainToOtherUser extends Component {
 						{ translate(
 							'You can transfer this domain connection to any administrator on this site. If the user you want to ' +
 								'transfer is not currently an administrator, please {{a}}add them to the site first{{/a}}.',
-							{ components: { a: <a href={ `/people/new/${ selectedSite.slug }` } /> } }
+							{ components: { a: <a href={ `/people/new/${ selectedSite?.slug }` } /> } }
 						) }
 					</p>
 				</>
@@ -382,7 +386,7 @@ class TransferDomainToOtherUser extends Component {
 					{ translate(
 						'You can transfer this domain to any administrator on this site. If the user you want to ' +
 							'transfer is not currently an administrator, please {{a}}add them to the site first{{/a}}.',
-						{ components: { a: <a href={ `/people/new/${ selectedSite.slug }` } /> } }
+						{ components: { a: <a href={ `/people/new/${ selectedSite?.slug }` } /> } }
 					) }
 				</p>
 			</>
@@ -419,7 +423,7 @@ export default connect(
 		return {
 			currentUserId: getCurrentUserId( state ),
 			isMapping: Boolean( domain ) && isMappedDomain( domain ),
-			hasSiteDomainsLoaded: hasLoadedSiteDomains( state, ownProps.selectedSite.ID ),
+			hasSiteDomainsLoaded: hasLoadedSiteDomains( state, ownProps.selectedSite?.ID ),
 			currentRoute: getCurrentRoute( state ),
 		};
 	},

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -76,9 +76,14 @@ export function domainManagementRoot() {
 /**
  * @param {string|undefined} siteName
  * @param {string|undefined} relativeTo
+ * @param {boolean|undefined} isDomainOnlySite
  */
-export function domainManagementList( siteName, relativeTo = null ) {
-	if ( isUnderDomainManagementAll( relativeTo ) || isUnderEmailManagementAll( relativeTo ) ) {
+export function domainManagementList( siteName, relativeTo = null, isDomainOnlySite = false ) {
+	if (
+		isDomainOnlySite ||
+		isUnderDomainManagementAll( relativeTo ) ||
+		isUnderEmailManagementAll( relativeTo )
+	) {
 		return domainManagementRoot();
 	}
 	return domainManagementRoot() + '/' + siteName ?? '';


### PR DESCRIPTION
## Proposed Changes

This PR
- Updates the `isPathAllowedForDomainOnlySite` function to allow any domain in a domain-only site to be managed. Previously, if a domain-only site contained more than one domain, only the primary one could be managed. Trying to access any of the other domains would send you to the "<primary domain> is ready when you are" initial domain-only page.
- Updates the behavior of the "Domains" root breadcrumb link in all domain management subpages - if you're managing a domain-only site, that link should take you back to the "All domains" list page

![Annotation-Annotation on 2023-06-27 at 20-57-35 png](https://github.com/Automattic/wp-calypso/assets/5324818/c8eb4398-3dac-468c-80fe-9e9163108664)

For more context, see pdhack-Hk-p2.

## Testing Instructions

To test this, you need a domain-only site with more than one domain.

- Open the live Calypso link or build this branch locally
- Go to `/domains/manage`, where you can see all the domains you own
- Look for your domain that is in a domain-only site but is not the primary one
- Ensure you can click on its name and completely manage it (change DNS, contact info, etc.)
- Also test the "Domains" root breadcrumb link in different domain management subpages and ensure it takes you to the "All Domains" page

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?