### PR TITLE
Subscriber Details: Display subscriber data on details page

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-details/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-details/styles.scss
@@ -46,6 +46,7 @@
 		}
 
 		.subscriber-details__content-value {
+			display: block;
 			color: $studio-gray-60;
 			font-size: $font-body-small;
 			line-height: rem(20px);

--- a/client/my-sites/subscribers/components/subscriber-details/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-details/styles.scss
@@ -1,0 +1,55 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+
+.subscriber-details {
+	.subscriber-details__header {
+		margin-top: 48px;
+		margin-bottom: 40px;
+	}
+
+	.subscriber-details__content {
+		display: flex;
+		flex-direction: column;
+		padding: 24px;
+		border-radius: 4px;
+		border: 1px solid $studio-gray-5;
+		gap: 16px;
+
+		&:not(:last-child) {
+			margin-bottom: 32px;
+		}
+
+		.subscriber-details__content-column {
+			flex-basis: 33.3%;
+			flex-grow: 1;
+			overflow: hidden;
+			word-wrap: break-word;
+		}
+	}
+
+	.subscriber-details__content-title {
+		color: #000;
+		font-size: $font-body-large;
+		line-height: rem(26px);
+	}
+
+	.subscriber-details__content-body {
+		display: flex;
+		gap: 32px;
+
+		.subscriber-details__content-label {
+			font-size: $font-body-small;
+			font-weight: 500;
+			line-height: rem(20px);
+			letter-spacing: -0.15px;
+			margin-bottom: 4px;
+		}
+
+		.subscriber-details__content-value {
+			color: $studio-gray-60;
+			font-size: $font-body-small;
+			line-height: rem(20px);
+			letter-spacing: -0.15px;
+		}
+	}
+}

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -1,12 +1,21 @@
+import { useTranslate } from 'i18n-calypso';
+import TimeSince from 'calypso/components/time-since';
+import useSubscriptionPlans from '../../hooks/use-subscription-plans';
 import { Subscriber } from '../../types';
 import { SubscriberProfile } from '../subscriber-profile';
+import './styles.scss';
 
 type SubscriberDetailsProps = {
 	subscriber: Subscriber;
 };
 
 const SubscriberDetails = ( { subscriber }: SubscriberDetailsProps ) => {
-	const { avatar, display_name, email_address } = subscriber;
+	const translate = useTranslate();
+	const subscriptionPlans = useSubscriptionPlans( subscriber );
+	const { avatar, date_subscribed, display_name, email_address, country, url } = subscriber;
+	const notApplicableLabel = translate( 'N/A', {
+		context: 'For free subscriptions the plan description is displayed as N/A (not applicable)',
+	} );
 
 	return (
 		<div className="subscriber-details">
@@ -18,7 +27,75 @@ const SubscriberDetails = ( { subscriber }: SubscriberDetailsProps ) => {
 					compact={ false }
 				/>
 			</div>
-			<div className="subscriber-details__content"></div>
+			<div className="subscriber-details__content">
+				<h3 className="subscriber-details__content-title">
+					{ translate( 'Newsletter subscription details' ) }
+				</h3>
+				<div className="subscriber-details__content-body">
+					<div className="subscriber-details__content-column">
+						<div className="subscriber-details__content-label">
+							{ translate( 'Subscription date' ) }
+						</div>
+						<TimeSince
+							className="subscriber-details__content-value"
+							date={ date_subscribed }
+							dateFormat="LL"
+						/>
+					</div>
+					<div className="subscriber-details__content-column">
+						<div className="subscriber-details__content-label">{ translate( 'Plan' ) }</div>
+						{ subscriptionPlans &&
+							subscriptionPlans.map( ( subscriptionPlan, index ) => (
+								<div className="subscriber-details__content-value" key={ index }>
+									{ subscriptionPlan.plan }
+								</div>
+							) ) }
+					</div>
+					<div className="subscriber-details__content-column">
+						<div className="subscriber-details__content-label">{ translate( 'Paid upgrade' ) }</div>
+						{ subscriptionPlans &&
+							subscriptionPlans.map( ( subscriptionPlan, index ) =>
+								subscriptionPlan.startDate ? (
+									<TimeSince
+										className="subscriber-details__content-value"
+										date={ subscriptionPlan.startDate }
+										dateFormat="LL"
+										key={ index }
+									/>
+								) : (
+									<div className="subscriber-details__content-value" key={ index }>
+										{ notApplicableLabel }
+									</div>
+								)
+							) }
+					</div>
+				</div>
+			</div>
+			<div className="subscriber-details__content">
+				<h3 className="subscriber-details__content-title">
+					{ translate( 'Subscriber information' ) }
+				</h3>
+				<div className="subscriber-details__content-body">
+					<div className="subscriber-details__content-column">
+						<div className="subscriber-details__content-label">{ translate( 'Email' ) }</div>
+						<div className="subscriber-details__content-value">{ email_address }</div>
+					</div>
+					{ country && (
+						<div className="subscriber-details__content-column">
+							<div className="subscriber-details__content-label">{ translate( 'Country' ) }</div>
+							<div className="subscriber-details__content-value">{ country.name }</div>
+						</div>
+					) }
+					{ url && (
+						<div className="subscriber-details__content-column">
+							<div className="subscriber-details__content-label">
+								{ translate( 'Acquisition source' ) }
+							</div>
+							<div className="subscriber-details__content-value">{ url }</div>
+						</div>
+					) }
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -47,7 +47,7 @@ const SubscriberDetails = ( { subscriber }: SubscriberDetailsProps ) => {
 						{ subscriptionPlans &&
 							subscriptionPlans.map( ( subscriptionPlan, index ) => (
 								<div className="subscriber-details__content-value" key={ index }>
-									{ subscriptionPlan.plan }
+									{ `${ subscriptionPlan.title }: ${ subscriptionPlan.plan }` }
 								</div>
 							) ) }
 					</div>

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -47,7 +47,8 @@ const SubscriberDetails = ( { subscriber }: SubscriberDetailsProps ) => {
 						{ subscriptionPlans &&
 							subscriptionPlans.map( ( subscriptionPlan, index ) => (
 								<div className="subscriber-details__content-value" key={ index }>
-									{ `${ subscriptionPlan.title }: ${ subscriptionPlan.plan }` }
+									{ subscriptionPlan.title ? `${ subscriptionPlan.title } - ` : '' }
+									{ subscriptionPlan.plan }
 								</div>
 							) ) }
 					</div>

--- a/client/my-sites/subscribers/components/subscriber-list/subscriber-row.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/subscriber-row.tsx
@@ -27,7 +27,7 @@ export const SubscriberRow = ( { subscriber, onView, onUnsubscribe }: Subscriber
 			<span className="subscriber-list__subscription-type-column" role="cell">
 				{ subscriptionPlans &&
 					subscriptionPlans.map( ( subscriptionPlan, index ) => (
-						<div key={ index }>{ subscriptionPlan }</div>
+						<div key={ index }>{ subscriptionPlan.plan }</div>
 					) ) }
 			</span>
 			<span className="subscriber-list__rate-column hidden" role="cell">

--- a/client/my-sites/subscribers/components/subscriber-list/test/subscriber-row.test.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/test/subscriber-row.test.tsx
@@ -35,7 +35,7 @@ describe( 'SubscriberRow', () => {
 	>;
 
 	beforeEach( () => {
-		mockUseSubscriptionPlans.mockReturnValue( [ 'Plan 1', 'Plan 2' ] );
+		mockUseSubscriptionPlans.mockReturnValue( [ { plan: 'Plan 1' }, { plan: 'Plan 2' } ] );
 		( isEnabled as jest.MockedFunction< typeof isEnabled > ).mockReturnValue( true );
 
 		render(

--- a/client/my-sites/subscribers/hooks/use-subscription-plans.ts
+++ b/client/my-sites/subscribers/hooks/use-subscription-plans.ts
@@ -1,11 +1,17 @@
 import { getCurrencyObject } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 import { Subscriber, SubscriptionPlan } from '../types';
 
 const freePlan = 'Free';
 
-const useSubscriptionPlans = ( subscriber: Subscriber ): string[] => {
+type SubscriptionPlanData = {
+	plan: ReactNode;
+	startDate?: string;
+	title?: string;
+};
+
+const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] => {
 	const translate = useTranslate();
 
 	const getPaymentInterval = ( renew_interval: string ) => {
@@ -28,15 +34,22 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): string[] => {
 	}
 
 	const transformSubscriptionPlans = ( subscriptions?: SubscriptionPlan[] ) => {
-		const defaultSubscription = [ { renewalPrice: translate( 'Free' ), when: '' } ];
+		const defaultSubscription = [
+			{
+				renewalPrice: translate( 'Free' ),
+				when: '',
+				title: undefined,
+				start_date: undefined,
+			},
+		];
 
 		if ( subscriptions ) {
 			const result = subscriptions.map( ( subscription: SubscriptionPlan ) => {
-				const { currency, renewal_price, renew_interval } = subscription;
+				const { currency, renewal_price, renew_interval, start_date, title } = subscription;
 				const renewalPrice = formatRenewalPrice( renewal_price, currency );
 				const when = getPaymentInterval( renew_interval );
 
-				return { renewalPrice, when };
+				return { renewalPrice, when, start_date, title };
 			} );
 
 			return result || defaultSubscription;
@@ -48,13 +61,17 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): string[] => {
 	const subscriptionPlans = useMemo( () => {
 		if ( subscriber ) {
 			const plans = transformSubscriptionPlans( subscriber.plans );
-			return plans.map( ( plan ) =>
-				plan.renewalPrice === freePlan
-					? plan.renewalPrice
-					: `${ plan.when } (${ plan.renewalPrice })`
-			);
+			return plans.map( ( plan ) => ( {
+				plan:
+					plan.renewalPrice === freePlan
+						? plan.renewalPrice
+						: `${ plan.when } (${ plan.renewalPrice })`,
+				startDate: plan.start_date,
+				title: plan.title,
+			} ) );
 		}
 		return [];
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ subscriber ] );
 
 	return subscriptionPlans;

--- a/client/my-sites/subscribers/subscriber-details-page.tsx
+++ b/client/my-sites/subscribers/subscriber-details-page.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect } from 'react';
@@ -11,9 +12,11 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import { SubscriberDetails } from './components/subscriber-details';
 import { SubscriberPopover } from './components/subscriber-popover';
 import { UnsubscribeModal } from './components/unsubscribe-modal';
+import { getSubscriberDetailsUrl } from './helpers';
 import { useUnsubscribeModal } from './hooks';
 import useDetailsPageSubscriberRemoveMutation from './mutations/use-details-page-subscriber-remove-mutation';
 import useSubscriberDetailsQuery from './queries/use-subscriber-details-query';
+import './subscriber-details-style.scss';
 
 type SubscriberDetailsPageProps = {
 	subscriptionId?: number;
@@ -25,12 +28,18 @@ const SubscriberDetailsPage = ( { subscriptionId, userId }: SubscriberDetailsPag
 	const dispatch = useDispatch();
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
-	const { data: subscriber } = useSubscriberDetailsQuery( selectedSiteId, subscriptionId, userId );
+
+	const { data: subscriber, isLoading } = useSubscriberDetailsQuery(
+		selectedSiteId,
+		subscriptionId,
+		userId
+	);
 	const { mutate, isSuccess } = useDetailsPageSubscriberRemoveMutation(
 		selectedSiteId,
 		subscriptionId,
 		userId
 	);
+
 	const {
 		currentSubscriber: modalSubscriber,
 		onClickUnsubscribe,
@@ -76,21 +85,22 @@ const SubscriberDetailsPage = ( { subscriptionId, userId }: SubscriberDetailsPag
 		},
 		{
 			label: translate( 'Details' ),
-			href: `/subscribers/${ selectedSiteSlug }/${ subscriptionId }`,
+			href: getSubscriberDetailsUrl( selectedSiteSlug, subscriptionId, userId ),
 		},
 	];
 
 	return (
-		<Main wideLayout>
+		<Main wideLayout className="subscriber-details-page">
 			<FixedNavigationHeader navigationItems={ navigationItems }>
 				<SubscriberPopover onUnsubscribe={ unsubscribeClickHandler } />
 			</FixedNavigationHeader>
-			{ subscriber && <SubscriberDetails subscriber={ subscriber } /> }
+			{ subscriber && ! isLoading && <SubscriberDetails subscriber={ subscriber } /> }
 			<UnsubscribeModal
 				subscriber={ modalSubscriber }
 				onCancel={ resetSubscriber }
 				onConfirm={ onConfirmModal }
 			/>
+			{ isLoading && <Spinner /> }
 		</Main>
 	);
 };

--- a/client/my-sites/subscribers/subscriber-details-style.scss
+++ b/client/my-sites/subscribers/subscriber-details-style.scss
@@ -1,0 +1,11 @@
+@import "@wordpress/base-styles/breakpoints";
+
+.subscriber-details-page.main {
+	padding: 0 32px;
+}
+
+@media ( max-width: $break-medium ) {
+	.is-section-subscribers .subscriber-details {
+		margin-top: 108px;
+	}
+}

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -28,4 +28,9 @@ export type Subscriber = {
 	plans?: SubscriptionPlan[];
 	open_rate?: number;
 	subscriptions?: string[];
+	country?: {
+		code: string;
+		name: string;
+	};
+	url?: string;
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78366

## Proposed Changes

* Add country and url to Subscriber model
* Update useSubscriptionPlans output
* Add loading state
* Display subscriber data on details page

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/subscribers/{site-slug}?flags=subscribers/view-subscriber-details
* Click on View on an external subscriber
* The subscriber information should be displayed
<img width="1075" alt="Screenshot 2023-06-27 at 19 51 33" src="https://github.com/Automattic/wp-calypso/assets/3113712/99e0a549-9724-4c57-b999-5905b470e23b">

* Go back and click on View on an free wpcom subscriber
* The subscriber information should be displayed
<img width="1080" alt="Screenshot 2023-06-27 at 19 43 11" src="https://github.com/Automattic/wp-calypso/assets/3113712/9e8d5838-4c9f-40dc-9c9a-43a9630037a6">

* Go back and click on View on an paid wpcom subscriber
* The subscriber information should be displayed (with the plans stacked)
<img width="1071" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/5d46085a-ee74-4b3b-a771-b6795641bc94">

* Test the Subscriber List for regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
