### PR TITLE
Update Congrats page for multi plugins

### DIFF
--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -173,7 +173,6 @@ export const ThankYou = ( props: ThankYouProps ) => {
 		thankYouSubtitle,
 		thankYouImage = null,
 		thankYouNotice,
-		thankYouHeaderAction,
 		thankYouHeaderBody = null,
 	} = props;
 
@@ -233,7 +232,6 @@ export const ThankYou = ( props: ThankYouProps ) => {
 						{ thankYouHeaderBody }
 					</ThankYouTitleContainer>
 				) }
-				{ thankYouHeaderAction }
 			</ThankYouHeader>
 			{ thankYouNotice && <ThankYouNotice { ...thankYouNotice } /> }
 			<ThankYouBody className="thank-you__body">

--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -173,6 +173,7 @@ export const ThankYou = ( props: ThankYouProps ) => {
 		thankYouSubtitle,
 		thankYouImage = null,
 		thankYouNotice,
+		thankYouHeaderAction,
 		thankYouHeaderBody = null,
 	} = props;
 
@@ -232,6 +233,7 @@ export const ThankYou = ( props: ThankYouProps ) => {
 						{ thankYouHeaderBody }
 					</ThankYouTitleContainer>
 				) }
+				{ thankYouHeaderAction }
 			</ThankYouHeader>
 			{ thankYouNotice && <ThankYouNotice { ...thankYouNotice } /> }
 			<ThankYouBody className="thank-you__body">

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -52,6 +52,7 @@ export type ThankYouProps = {
 	thankYouSubtitle?: string | TranslateResult;
 	thankYouHeaderBody?: React.ReactElement | null;
 	thankYouNotice?: ThankYouNoticeProps;
+	thankYouHeaderAction: React.ReactElement | null;
 };
 
 export type ThankYouData = [
@@ -61,7 +62,8 @@ export type ThankYouData = [
 	string,
 	string,
 	string[],
-	boolean
+	boolean,
+	React.ReactElement | null
 ];
 
 export type ThankYouSteps = { steps: string[]; additionalSteps: string[] };

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -52,7 +52,6 @@ export type ThankYouProps = {
 	thankYouSubtitle?: string | TranslateResult;
 	thankYouHeaderBody?: React.ReactElement | null;
 	thankYouNotice?: ThankYouNoticeProps;
-	thankYouHeaderAction: React.ReactElement | null;
 };
 
 export type ThankYouData = [

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -16,7 +16,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { MarketplaceGoBackSection } from './marketplace-go-back-section';
 import { useAtomicTransfer } from './use-atomic-transfer';
 import { usePageTexts } from './use-page-texts';
-import { usePluginsThankYouData } from './use-plugins-thank-you-data';
+import usePluginsThankYouData from './use-plugins-thank-you-data';
 import { useThankYouFoooter } from './use-thank-you-footer';
 import { useThankYouSteps } from './use-thank-you-steps';
 import { useThemesThankYouData } from './use-themes-thank-you-data';
@@ -46,6 +46,7 @@ const MarketplaceThankYou = ( {
 		pluginSubtitle,
 		pluginsProgressbarSteps,
 		isAtomicNeededForPlugins,
+		thankyouHeaderAction,
 	] = usePluginsThankYouData( pluginSlugs );
 	const [
 		themesSection,
@@ -155,6 +156,7 @@ const MarketplaceThankYou = ( {
 						showSupportSection={ false }
 						thankYouTitle={ title }
 						thankYouSubtitle={ subtitle }
+						thankYouHeaderAction={ thankyouHeaderAction }
 						headerBackgroundColor="#fff"
 						headerTextColor="#000"
 					/>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -46,7 +46,7 @@ const MarketplaceThankYou = ( {
 		pluginSubtitle,
 		pluginsProgressbarSteps,
 		isAtomicNeededForPlugins,
-		thankyouHeaderAction,
+		thankYouHeaderAction,
 	] = usePluginsThankYouData( pluginSlugs );
 	const [
 		themesSection,
@@ -156,7 +156,7 @@ const MarketplaceThankYou = ( {
 						showSupportSection={ false }
 						thankYouTitle={ title }
 						thankYouSubtitle={ subtitle }
-						thankYouHeaderAction={ thankyouHeaderAction }
+						thankYouHeaderBody={ thankYouHeaderAction }
 						headerBackgroundColor="#fff"
 						headerTextColor="#000"
 					/>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -185,22 +185,32 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		[ siteId ]
 	);
 
+	const ThankYouHeaderAction = styled.div`
+		padding: 20px 24px 0 24px;
+		@media ( max-width: 480px ) {
+			text-align: left;
+		}
+	`;
+
 	const ThankYouHeaderActionButton = styled( Button )`
 		border-radius: 4px;
-		margin-top: 20px;
 	`;
 
 	const thankYouHeaderAction =
 		pluginsInformationList.length > 1 ? (
-			<ThankYouHeaderActionButton
-				primary
-				href={ `https://${ siteSlug }/wp-admin/plugins.php` }
-				onClick={ () => {
-					sendTrackEvent( 'calypso_plugin_thank_you_setup_plugins_click' );
-				} }
-			>
-				{ translate( 'Setup the plugins' ) }
-			</ThankYouHeaderActionButton>
+			<>
+				<ThankYouHeaderAction>
+					<ThankYouHeaderActionButton
+						primary
+						href={ `https://${ siteSlug }/wp-admin/plugins.php` }
+						onClick={ () => {
+							sendTrackEvent( 'calypso_plugin_thank_you_setup_plugins_click' );
+						} }
+					>
+						{ translate( 'Setup the plugins' ) }
+					</ThankYouHeaderActionButton>
+				</ThankYouHeaderAction>
+			</>
 		) : null;
 
 	// Plugins are only installed in atomic sites

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -180,9 +180,10 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		( name: string ) => {
 			recordTracksEvent( name, {
 				site_id: siteId,
+				plugins: pluginSlugs.join(),
 			} );
 		},
-		[ siteId ]
+		[ siteId, pluginSlugs ]
 	);
 
 	const ThankYouHeaderAction = styled.div`

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -1,6 +1,9 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@automattic/components';
+import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { ThankYouData, ThankYouSectionProps } from 'calypso/components/thank-you/types';
 import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
@@ -19,7 +22,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import { ThankYouPluginSection } from './marketplace-thank-you-plugin-section';
 import MasterbarStyled from './masterbar-styled';
 
-export function usePluginsThankYouData( pluginSlugs: string[] ): ThankYouData {
+export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYouData {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
@@ -173,6 +176,33 @@ export function usePluginsThankYouData( pluginSlugs: string[] ): ThankYouData {
 		[ translate ]
 	);
 
+	const sendTrackEvent = useCallback(
+		( name: string ) => {
+			recordTracksEvent( name, {
+				site_id: siteId,
+			} );
+		},
+		[ siteId ]
+	);
+
+	const ThankyouHeaderActionButton = styled( Button )`
+		border-radius: 4px;
+		margin-top: 20px;
+	`;
+
+	const thankyouHeaderAction =
+		pluginsInformationList.length > 1 ? (
+			<ThankyouHeaderActionButton
+				primary
+				href={ `https://${ siteSlug }/wp-admin/plugins.php` }
+				onClick={ () => {
+					sendTrackEvent( 'calypso_plugin_thank_you_setup_plugins_click' );
+				} }
+			>
+				{ translate( 'Setup the plugins' ) }
+			</ThankyouHeaderActionButton>
+		) : null;
+
 	// Plugins are only installed in atomic sites
 	// so atomic is always needed as long as we have plugins
 	const isAtomicNeeded = pluginSlugs.length > 0;
@@ -185,6 +215,7 @@ export function usePluginsThankYouData( pluginSlugs: string[] ): ThankYouData {
 		subtitle,
 		thankyouSteps,
 		isAtomicNeeded,
+		thankyouHeaderAction,
 	];
 }
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -185,14 +185,14 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		[ siteId ]
 	);
 
-	const ThankyouHeaderActionButton = styled( Button )`
+	const ThankYouHeaderActionButton = styled( Button )`
 		border-radius: 4px;
 		margin-top: 20px;
 	`;
 
-	const thankyouHeaderAction =
+	const thankYouHeaderAction =
 		pluginsInformationList.length > 1 ? (
-			<ThankyouHeaderActionButton
+			<ThankYouHeaderActionButton
 				primary
 				href={ `https://${ siteSlug }/wp-admin/plugins.php` }
 				onClick={ () => {
@@ -200,7 +200,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 				} }
 			>
 				{ translate( 'Setup the plugins' ) }
-			</ThankyouHeaderActionButton>
+			</ThankYouHeaderActionButton>
 		) : null;
 
 	// Plugins are only installed in atomic sites
@@ -215,7 +215,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		subtitle,
 		thankyouSteps,
 		isAtomicNeeded,
-		thankyouHeaderAction,
+		thankYouHeaderAction,
 	];
 }
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -98,5 +98,6 @@ export function useThemesThankYouData( themeSlugs: string[] ): ThankYouData {
 		subtitle,
 		thankyouSteps,
 		isAtomicNeeded,
+		null,
 	];
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2722

## Proposed Changes
* Update design/copy for multiple plugins congrats page
* Update both for mobile and desktop
* Add a button between subtitle and the plugins cards.
* The CTA of the button link to `:slug/wp-admin/plugins.php`
* The new button has a new track event

| Desktop | Mobile |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/eae8c429-5d14-4091-a88e-d26c7c743d62) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/22a8f1b4-29d4-41af-b8bd-de11a23a16f9) |

## Testing Instructions

* Confirm the design of the multiple plugins congrats page matches the Figma design.
Example URL: `http://calypso.localhost:3000/marketplace/thank-you/:slug?plugins=woocommerce-subscriptions%2Cwoocommerce-product-bundles`
Design: VLoPHWqcewxNKZYjjkDu3O-fi-1701%3A2254
Check the button discussion for updates: VLoPHWqcewxNKZYjjkDu3O-fi-2446:3296
* Confirm tracks event are logged when buttons/links are clicked
* Confirm track event for `Setup the plugins` button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?