### PR TITLE
BackupBrowser: Display file details

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -50,7 +50,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 			setFetchContentsOnMount( true );
 		}
 
-		if ( ! item.hasChildren ) {
+		if ( ! item.hasChildren && item.type !== 'wordpress' ) {
 			if ( ! isOpen ) {
 				setActiveNodePath( path );
 			} else {
@@ -59,7 +59,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 		}
 
 		setIsOpen( ! isOpen );
-	}, [ isOpen, item.hasChildren, path, setActiveNodePath ] );
+	}, [ isOpen, item, path, setActiveNodePath ] );
 
 	const renderChildren = () => {
 		if ( isInitialLoading ) {

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -124,7 +124,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 					</Button>
 				) }
 			</div>
-			{ isCurrentNodeClicked && <FileInfoCard item={ item } /> }
+			{ isCurrentNodeClicked && <FileInfoCard siteId={ siteId } item={ item } /> }
 			{ isOpen && (
 				<>
 					{ item.hasChildren && (

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -45,7 +45,9 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( { siteId, item } 
 			<div className="file-card__details">
 				{ item.type === 'table' && (
 					<div className="file-card__detail">
-						<span className="file-card__label">{ translate( 'Rows:' ) } </span>
+						<span className="file-card__label">
+							{ translate( 'Rows:', { comment: 'Rows refers to database table rows.' } ) }{ ' ' }
+						</span>
 						<span className="file-card__value">{ item.rowCount }</span>
 					</div>
 				) }
@@ -53,14 +55,20 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( { siteId, item } 
 				<div className="file-card__detail-group">
 					{ modifiedTime && (
 						<div className="file-card__detail">
-							<span className="file-card__label">{ translate( 'Modified:' ) } </span>
+							<span className="file-card__label">
+								{ translate( 'Modified:', { comment: 'Date when the file was modified.' } ) }{ ' ' }
+							</span>
 							<span className="file-card__value">{ modifiedTime }</span>
 						</div>
 					) }
 
 					{ size && (
 						<div className="file-card__detail">
-							<span className="file-card__label">{ translate( 'Size:' ) } </span>
+							<span className="file-card__label">
+								{ translate( 'Size:', {
+									comment: 'This refers to file size (bytes, kilobytes, gigabytes, etc.',
+								} ) }{ ' ' }
+							</span>
 							<span className="file-card__value">
 								{ size.unitAmount } { size.unit }
 							</span>
@@ -70,7 +78,11 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( { siteId, item } 
 
 				{ fileInfo?.hash && (
 					<div className="file-card__detail">
-						<span className="file-card__label">{ translate( 'Hash:' ) } </span>
+						<span className="file-card__label">
+							{ translate( 'Hash:', {
+								comment: 'This refers to a unique identifier or checksum.',
+							} ) }{ ' ' }
+						</span>
 						<span className="file-card__value">{ fileInfo.hash }</span>
 					</div>
 				) }

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -1,31 +1,79 @@
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { FileBrowserItem } from './types';
-
+import { useBackupPathInfoQuery } from './use-backup-path-info-query';
+import { convertBytes } from './util';
 interface FileInfoCardProps {
+	siteId: number;
 	item: FileBrowserItem;
 }
 
-const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( { item } ) => {
+const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( { siteId, item } ) => {
 	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
+	const {
+		isSuccess,
+		isInitialLoading,
+		data: fileInfo,
+	} = useBackupPathInfoQuery(
+		siteId,
+		item.period ?? '',
+		item.manifestPath ?? '',
+		item.extensionType ?? ''
+	);
+
+	const modifiedTime = fileInfo?.mtime ? moment.unix( fileInfo.mtime ).format( 'lll' ) : null;
+	const size = fileInfo?.size ? convertBytes( fileInfo.size ) : null;
 
 	// Do not display file info if the item hasChildren (it could be a directory, plugins, themes, etc.)
 	if ( item.hasChildren ) {
 		return null;
 	}
 
-	// Temporary: display the file info only for database tables
-	if ( item.type !== 'table' ) {
+	if ( isInitialLoading ) {
+		return <div className="file-browser-node__loading placeholder" />;
+	}
+
+	if ( ! isSuccess ) {
 		return null;
 	}
 
 	return (
 		<div className="file-card">
 			<div className="file-card__details">
-				<div className="file-card__row">
-					<span className="file-card__label">{ translate( 'Rows:' ) } </span>
-					<span className="file-card__value">{ item.rowCount }</span>
+				{ item.type === 'table' && (
+					<div className="file-card__detail">
+						<span className="file-card__label">{ translate( 'Rows:' ) } </span>
+						<span className="file-card__value">{ item.rowCount }</span>
+					</div>
+				) }
+
+				<div className="file-card__detail-group">
+					{ modifiedTime && (
+						<div className="file-card__detail">
+							<span className="file-card__label">{ translate( 'Modified:' ) } </span>
+							<span className="file-card__value">{ modifiedTime }</span>
+						</div>
+					) }
+
+					{ size && (
+						<div className="file-card__detail">
+							<span className="file-card__label">{ translate( 'Size:' ) } </span>
+							<span className="file-card__value">
+								{ size.unitAmount } { size.unit }
+							</span>
+						</div>
+					) }
 				</div>
+
+				{ fileInfo?.hash && (
+					<div className="file-card__detail">
+						<span className="file-card__label">{ translate( 'Hash:' ) } </span>
+						<span className="file-card__value">{ fileInfo.hash }</span>
+					</div>
+				) }
 			</div>
 			<div className="file-card__actions"></div>
 		</div>

--- a/client/my-sites/backup/backup-contents-page/file-browser/test/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/test/util.ts
@@ -1,0 +1,85 @@
+import { BackupPathInfoResponse, FileBrowserItemInfo } from '../types';
+import { convertBytes, parseBackupPathInfo } from '../util';
+
+describe( 'convertBytes', () => {
+	it( 'should correctly convert bytes to KB', () => {
+		const result = convertBytes( 1024 );
+		expect( result ).toEqual( { unitAmount: '1.0', unit: 'KB' } );
+	} );
+
+	it( 'should correctly convert bytes to MB', () => {
+		const result = convertBytes( 1048576 );
+		expect( result ).toEqual( { unitAmount: '1.0', unit: 'MB' } );
+	} );
+
+	it( 'should correctly convert bytes to GB', () => {
+		const result = convertBytes( 1073741824 );
+		expect( result ).toEqual( { unitAmount: '1.0', unit: 'GB' } );
+	} );
+
+	it( 'should correctly convert bytes to TB', () => {
+		const result = convertBytes( 1099511627776 );
+		expect( result ).toEqual( { unitAmount: '1.0', unit: 'TB' } );
+	} );
+
+	it( 'should respect the decimals parameter', () => {
+		const result = convertBytes( 1500, 2 );
+		expect( result ).toEqual( { unitAmount: '1.46', unit: 'KB' } );
+	} );
+
+	it( 'should correctly handle the case where bytes are less than 1024', () => {
+		const result = convertBytes( 500 );
+		expect( result ).toEqual( { unitAmount: '500.0', unit: 'B' } );
+	} );
+} );
+
+describe( 'parseBackupPathInfo', () => {
+	it( 'should return an empty object if payload is null', () => {
+		const result = parseBackupPathInfo( {} );
+		expect( result ).toEqual( {} );
+	} );
+
+	it( 'should map properties correctly', () => {
+		const payload: BackupPathInfoResponse = {
+			download_url: 'http://example.com',
+			mtime: 123,
+			size: 456,
+			hash: 'abc',
+			data_type: 789,
+			manifest_filter: 'xyz',
+		};
+		const expected: FileBrowserItemInfo = {
+			downloadUrl: 'http://example.com',
+			mtime: 123,
+			size: 456,
+			hash: 'abc',
+			dataType: 789,
+			manifestFilter: 'xyz',
+		};
+
+		const result = parseBackupPathInfo( payload );
+		expect( result ).toEqual( expected );
+	} );
+
+	it( 'should omit properties that are undefined', () => {
+		const payload: BackupPathInfoResponse = {
+			download_url: 'http://example.com',
+			// mtime is undefined
+			size: 456,
+			hash: 'abc',
+			// data_type is undefined
+			manifest_filter: 'xyz',
+		};
+		const expected: FileBrowserItemInfo = {
+			downloadUrl: 'http://example.com',
+			// mtime is omitted
+			size: 456,
+			hash: 'abc',
+			// dataType is omitted
+			manifestFilter: 'xyz',
+		};
+
+		const result = parseBackupPathInfo( payload );
+		expect( result ).toEqual( expected );
+	} );
+} );

--- a/client/my-sites/backup/backup-contents-page/file-browser/types.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/types.ts
@@ -24,6 +24,8 @@ export interface FileBrowserItem {
 	rowCount?: number;
 	children?: FileBrowserItem[];
 	extensionVersion?: string;
+	manifestPath?: string;
+	extensionType?: string;
 }
 
 export interface BackupLsResponse {
@@ -43,4 +45,24 @@ export interface BackupLsResponseContents {
 		row_count?: number;
 		extension_version?: string;
 	};
+}
+
+// Data type for the response from the backup/path-info endpoint
+export interface BackupPathInfoResponse {
+	download_url?: string;
+	mtime?: number;
+	size?: number;
+	hash?: string;
+	data_type?: number;
+	manifest_filter?: string;
+	error?: string;
+}
+
+export interface FileBrowserItemInfo {
+	downloadUrl?: string;
+	mtime?: number;
+	size?: number;
+	hash?: string;
+	dataType?: number;
+	manifestFilter?: string;
 }

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-path-info-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-path-info-query.ts
@@ -23,7 +23,7 @@ export const useBackupPathInfoQuery = (
 				}
 			);
 		},
-		enabled: !! siteId && !! rewindId,
+		enabled: !! siteId,
 		meta: { persist: false },
 		select: parseBackupPathInfo,
 		staleTime: Infinity,

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-path-info-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-path-info-query.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { parseBackupPathInfo } from './util';
+
+export const useBackupPathInfoQuery = (
+	siteId: number,
+	rewindId: string,
+	manifestPath: string,
+	extensionType = ''
+) => {
+	return useQuery( {
+		queryKey: [ 'jetpack-backup-path-info', siteId, rewindId, manifestPath, extensionType ],
+		queryFn: async () => {
+			return wp.req.post(
+				{
+					path: `/sites/${ siteId }/rewind/backup/path-info`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					backup_id: rewindId,
+					manifest_path: manifestPath,
+					extension_type: extensionType,
+				}
+			);
+		},
+		enabled: !! siteId && !! rewindId,
+		meta: { persist: false },
+		select: parseBackupPathInfo,
+		staleTime: Infinity,
+	} );
+};

--- a/client/my-sites/backup/backup-contents-page/file-browser/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/util.ts
@@ -1,5 +1,12 @@
 import { getFileExtension } from 'calypso/lib/media/utils/get-file-extension';
-import { BackupLsResponse, BackupLsResponseContents, FileBrowserItem, FileType } from './types';
+import {
+	BackupLsResponse,
+	BackupLsResponseContents,
+	BackupPathInfoResponse,
+	FileBrowserItem,
+	FileBrowserItemInfo,
+	FileType,
+} from './types';
 
 const extensionToFileType: Record< string, FileType > = {
 	jpg: 'image',
@@ -78,9 +85,10 @@ export const parseBackupContentsData = ( payload: BackupLsResponse ): FileBrowse
 			hasChildren: item.has_children ?? false,
 			...( item.period && { period: item.period } ),
 			...( item.sort && { sort: item.sort } ),
-			...( item.type === 'archive' && { extension_type: name.replace( '*', '' ) } ),
+			...( item.type === 'archive' && { extensionType: name.replace( '*', '' ) } ),
 			...( item.type === 'table' && { rowCount: item.row_count } ),
 			...( item.extension_version && { extensionVersion: item.extension_version } ),
+			...( item.manifest_path && { manifestPath: item.manifest_path } ),
 		};
 	} );
 
@@ -116,4 +124,76 @@ export const parseBackupContentsData = ( payload: BackupLsResponse ): FileBrowse
 		// If types are the same, sort by name
 		return a.name.localeCompare( b.name );
 	} );
+};
+
+/**
+ * Converts a BackupPathInfoResponse object into a FileBrowserItemInfo object.
+ *
+ * The function maps properties from the payload to the returned object,
+ * converting property names from snake_case to camelCase, and omitting any
+ * properties in the payload that are undefined. If the payload is null or
+ * undefined, it returns an empty object.
+ *
+ * @param {BackupPathInfoResponse} payload - The object to convert.
+ * @returns {FileBrowserItemInfo} The converted object.
+ */
+export const parseBackupPathInfo = ( payload: BackupPathInfoResponse ): FileBrowserItemInfo => {
+	if ( ! payload ) {
+		return {};
+	}
+
+	const result: FileBrowserItemInfo = {};
+
+	if ( payload.download_url !== undefined ) {
+		result.downloadUrl = payload.download_url;
+	}
+
+	if ( payload.mtime !== undefined ) {
+		result.mtime = payload.mtime;
+	}
+
+	if ( payload.size !== undefined ) {
+		result.size = Number( payload.size );
+	}
+
+	if ( payload.hash !== undefined ) {
+		result.hash = payload.hash;
+	}
+
+	if ( payload.data_type !== undefined ) {
+		result.dataType = payload.data_type;
+	}
+
+	if ( payload.manifest_filter !== undefined ) {
+		result.manifestFilter = payload.manifest_filter;
+	}
+
+	return result;
+};
+
+/**
+ * Converts a byte value into a more human-readable format, using the appropriate unit (B, KB, MB, GB, TB).
+ *
+ * The function starts with the byte unit and progressively divides the size by 1024,
+ * shifting to the next unit each time, until the size is below 1024 or the unit is TB.
+ * The size is rounded to the specified number of decimal places.
+ *
+ * @param {number} bytes - The size in bytes to convert.
+ * @param {number} [decimals=1] - The number of decimal places to round the size to. Default is 1.
+ * @returns {Object} An object containing the size in the new unit, and the unit itself.
+ */
+export const convertBytes = (
+	bytes: number,
+	decimals = 1
+): { unitAmount: string; unit: string } => {
+	const units = [ 'B', 'KB', 'MB', 'GB', 'TB' ];
+	let size = bytes;
+
+	let i = 0;
+	while ( size >= 1024 && i < units.length - 1 ) {
+		size /= 1024;
+		i++;
+	}
+
+	return { unitAmount: size.toFixed( decimals ), unit: units[ i ] };
 };

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -75,10 +75,6 @@
 				font-size: $font-body-small;
 			}
 
-			&__details {
-				padding-bottom: 16px;
-			}
-
 			@include break-mobile {
 				&__detail-group {
 					display: flex;

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -79,6 +79,13 @@
 				padding-bottom: 16px;
 			}
 
+			@include break-mobile {
+				&__detail-group {
+					display: flex;
+					justify-content: space-between;
+				}
+			}
+
 			&__label {
 				font-weight: bold;
 			}


### PR DESCRIPTION
## Proposed Changes
* Add modified at, hash and file size details when clicking on files
   * The last modified date is converted based on user current locale.
   * Unlike the original design, we are placing the `size` at the right of the `modified` field. 

### Todo / Known issues
- [x] No details are fetched when clicking on plugin files
- [x] Clicks on extension archives are not working
- [x] Add translation context for new strings

## Screenshots
<img width="619" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/4efbd99a-8e9e-40d8-93be-d8a0c96eb313">

## Testing Instructions
### Acceptance testing
* Start a Jetpack Cloud or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Browse files and clicks on any of them, except the WordPress version. Depending on the item type, you should see something like:
  * Plugin/theme archives
    <img width="571" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/b43b1154-ef72-4ae7-956c-baba10954e5e">
  * Database tables
    <img width="596" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/3cfdbae7-dc6b-4170-a0c1-009228cf2d4d">
  * Other files
    <img width="622" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/3d09e4fa-a72f-4240-82c4-b49338abdc46">

### Unit testing
Ensure unit tests are passing by running:
```yarn run test-client client/my-sites/backup/backup-contents-page/file-browser/test```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
