### PR TITLE
Jetpack Pro Dashboard: implement resend SMS verification code for downtime monitoring

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -362,6 +362,6 @@ export interface InitialMonitorSettings {
 	phoneContacts?: StateMonitorSettingsSMS[] | [];
 }
 export interface ResendVerificationCodeParams {
-	type: 'email';
+	type: 'email' | 'sms';
 	value: string;
 }


### PR DESCRIPTION
Related to 1204774821045518-as-1204793234816304

## Proposed Changes

This PR implements resend SMS verification code for downtime monitoring.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-resend-sms-verification-code` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link. 
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Enable SMS notification if not already enabled.
6. Click the `+ Add phone number` button -> Enter all the details-> Click `Verify`.
7. Click on `resend` and verify the button is disabled when the request is being made.

<img width="470" alt="Screenshot 2023-06-28 at 10 28 54 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/44a2f142-9be5-494a-8dff-04f2fdcfdd9f">

<img width="479" alt="Screenshot 2023-06-28 at 10 34 46 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5f3f38a6-2013-4b5f-8bcd-3d823f26d02f">

8. Verify the help text looks like the below once the resend request is successful.

<img width="478" alt="Screenshot 2023-06-28 at 10 32 31 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/26b6f567-c4fc-4849-8d0d-872366d33013">

9. Enter the verification code received on your phone number and click Verify and make sure the phone number is verified.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?