### PR TITLE
Domains: prioritize all domains view when browsing the page

### DIFF
--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -584,7 +584,7 @@ class AllDomains extends Component {
 		);
 	}
 
-	maybeRenderSeeAllDomainsButton() {
+	maybeRenderSeeAllDomainsLink() {
 		const { context, translate, dispatch } = this.props;
 
 		const selectedFilter = context?.query?.filter || 'all-domains';
@@ -669,7 +669,7 @@ class AllDomains extends Component {
 		};
 
 		const buttons = [
-			this.maybeRenderSeeAllDomainsButton(),
+			this.maybeRenderSeeAllDomainsLink(),
 			this.renderDomainTableFilterButton(),
 			<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
 			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -266,7 +266,7 @@ class AllDomains extends Component {
 
 		const { isSavingContactInfo } = this.state;
 
-		const selectedFilter = context?.query?.filter || 'owned-by-me';
+		const selectedFilter = context?.query?.filter || 'all-domains';
 
 		const domains =
 			selectedFilter === 'domain-only'
@@ -584,23 +584,48 @@ class AllDomains extends Component {
 		);
 	}
 
+	maybeRenderSeeAllDomainsButton() {
+		const { context, translate, dispatch } = this.props;
+
+		const selectedFilter = context?.query?.filter || 'all-domains';
+
+		if ( selectedFilter === 'all-domains' ) {
+			return null;
+		}
+
+		const handleClick = () => {
+			dispatch( recordTracksEvent( 'calypso_domain_management_see_all_domains_link_click' ) );
+		};
+
+		return (
+			<a
+				className="domains-table-see-all-domains-link"
+				href={ domainManagementRoot() }
+				key="breadcrumb_see_all_domains_link"
+				onClick={ handleClick }
+			>
+				{ translate( 'See all domains' ) }
+			</a>
+		);
+	}
+
 	renderDomainTableFilterButton() {
 		const { context, translate, sites } = this.props;
 
-		const selectedFilter = context?.query?.filter || 'owned-by-me';
+		const selectedFilter = context?.query?.filter || 'all-domains';
 		const nonWpcomDomains = this.mergeFilteredDomainsWithDomainsDetails();
 
 		const filterOptions = [
 			{
 				label: translate( 'All domains' ),
 				value: 'all-domains',
-				path: domainManagementRoot() + '?' + stringify( { filter: 'all-domains' } ),
+				path: domainManagementRoot(),
 				count: nonWpcomDomains?.length,
 			},
 			{
 				label: translate( 'Owned by me' ),
 				value: 'owned-by-me',
-				path: domainManagementRoot(),
+				path: domainManagementRoot() + '?' + stringify( { filter: 'owned-by-me' } ),
 				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-me' )?.length,
 			},
 			{
@@ -644,6 +669,7 @@ class AllDomains extends Component {
 		};
 
 		const buttons = [
+			this.maybeRenderSeeAllDomainsButton(),
 			this.renderDomainTableFilterButton(),
 			<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
 			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -2,6 +2,10 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.domains-table-see-all-domains-link {
+	font-size: $font-body-small;
+}
+
 .breadcrumbs {
 	svg.options-domain-button__add.gridicon {
 		margin-left: 2px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2843

## Proposed Changes

* Default to "all domains" and add a shortcut link to "see all domains" when all domains are not selected


| 320px | 768px | 1024x |
| ------------- | ------------- |  ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/6851384/e86f26a1-8f93-4f8c-a168-d1758cc6ac39) | 
![image](https://github.com/Automattic/wp-calypso/assets/6851384/c996e48c-fa90-471d-ab7a-1480e6e2c6b1) |
![image](https://github.com/Automattic/wp-calypso/assets/6851384/92dd4158-42f0-42d0-87f6-cdc15c5fbcb9) |


**Tracks event**
![image](https://github.com/Automattic/wp-calypso/assets/6851384/91c933a4-aa64-46eb-a74e-131db8c0663f)
 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Compare new behaviour at `/domains/manage` on this branch vs. trunk
* Try it out with different themes
* Try it with different viewport sizes
* Try it with RTL languages ([see comment below](https://github.com/Automattic/wp-calypso/pull/78721#issuecomment-1610754620))
* Verify the Tracks event is fired
* Check the a11y is working properly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
