### PR TITLE
Update/sites page hides domain only sites

### DIFF
--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -24,6 +24,7 @@ export const SITE_EXCERPT_COMPUTED_FIELDS = [ 'slug' ] as const;
 
 export const SITE_EXCERPT_REQUEST_OPTIONS = [
 	'admin_url',
+	'is_domain_only',
 	'is_redirect',
 	'is_wpforteams_site',
 	'launchpad_screen',

--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -34,7 +34,12 @@ export const useSiteExcerptsQuery = (
 	const store = useStore();
 
 	return useQuery( {
-		queryKey: [ USE_SITE_EXCERPTS_QUERY_KEY ],
+		queryKey: [
+			USE_SITE_EXCERPTS_QUERY_KEY,
+			SITE_EXCERPT_REQUEST_FIELDS,
+			SITE_EXCERPT_REQUEST_OPTIONS,
+			fetchFilter,
+		],
 		queryFn: () => fetchSites( fetchFilter ),
 		select: ( data ) => {
 			const sites = data?.sites.map( computeFields( data?.sites ) ) || [];

--- a/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner.tsx
+++ b/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner.tsx
@@ -19,7 +19,10 @@ const hasLinkInBioSite = ( sites: SiteExcerptData[] ) => {
 export const LinkInBioBanner = ( props: Props ) => {
 	const { displayMode } = props;
 	const isMobile = useMobileBreakpoint();
-	const { data: sites = [], isLoading } = useSiteExcerptsQuery();
+	const { data: sites = [], isLoading } = useSiteExcerptsQuery(
+		[],
+		( site ) => ! site.options.is_domain_only
+	);
 	const siteCount = sites.length;
 	const doesNotAlreadyHaveALinkInBioSite = ! hasLinkInBioSite( sites );
 	const showBanner = ! isLoading && doesNotAlreadyHaveALinkInBioSite && siteCount < 3;

--- a/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner.tsx
+++ b/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner.tsx
@@ -21,7 +21,7 @@ export const LinkInBioBanner = ( props: Props ) => {
 	const isMobile = useMobileBreakpoint();
 	const { data: sites = [], isLoading } = useSiteExcerptsQuery(
 		[],
-		( site ) => ! site.options.is_domain_only
+		( site ) => ! site.options?.is_domain_only
 	);
 	const siteCount = sites.length;
 	const doesNotAlreadyHaveALinkInBioSite = ! hasLinkInBioSite( sites );

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -155,7 +155,7 @@ export function SitesDashboard( {
 	const { __, _n } = useI18n();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
 		[],
-		( site ) => ! site.options.is_domain_only
+		( site ) => ! site.options?.is_domain_only
 	);
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
 	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -153,7 +153,10 @@ export function SitesDashboard( {
 		ref: 'topbar',
 	} );
 	const { __, _n } = useI18n();
-	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
+	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
+		[],
+		( site ) => ! site.options.is_domain_only
+	);
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
 	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();
 	const userPreferencesLoaded = hasSitesSortingPreferenceLoaded && 'none' !== displayMode;

--- a/client/sites-dashboard/components/test/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/test/sites-dashboard.tsx
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import documentHead from 'calypso/state/document-head/reducer';
+import preferences from 'calypso/state/preferences/reducer';
+import purchases from 'calypso/state/purchases/reducer';
+import { reducer as ui } from 'calypso/state/ui/reducer';
+import userSettings from 'calypso/state/user-settings/reducer';
+import { renderWithProvider } from '../../../test-helpers/testing-library';
+import { SitesDashboard } from '../sites-dashboard';
+
+const render = ( el ) =>
+	renderWithProvider( el, {
+		initialState: {
+			preferences: {
+				remoteValues: {
+					'sites-sorting': 'alphabetically-asc',
+					'sites-management-dashboard-display-mode': 'tile',
+				},
+			},
+		},
+		reducers: { documentHead, preferences, purchases, ui, userSettings },
+	} as any );
+
+// react-intersection-observer tries to instantiate an `IntersectionObserver`
+jest.mock( 'react-intersection-observer', () => ( {
+	useInView: () => ( { ref: { current: null }, inView: true } ),
+} ) );
+
+const mockFetchSites = () =>
+	nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.2/me/sites' );
+
+describe( '<SitesDashboard>', () => {
+	test( 'renders dashboard links for each site', async () => {
+		mockFetchSites()
+			.query( true ) // Match any query parameters
+			.reply( 200, {
+				sites: [
+					{ ID: 123, URL: 'http://example1.com', name: 'Example 1' },
+					{ ID: 321, URL: 'http://example2.com', name: 'Example 2' },
+				],
+			} );
+
+		render( <SitesDashboard queryParams={ {} } /> );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Example 1' ) ).toHaveAttribute( 'href', '/home/example1.com' );
+			expect( screen.getByText( 'Example 2' ) ).toHaveAttribute( 'href', '/home/example2.com' );
+		} );
+	} );
+
+	test( 'domain-only sites are not displayed', async () => {
+		mockFetchSites()
+			.query( true ) // Match any query parameters
+			.reply( 200, {
+				sites: [
+					{
+						ID: 123,
+						URL: 'http://example1.com',
+						name: 'Example 1',
+						options: { is_domain_only: false },
+					},
+					{
+						ID: 321,
+						URL: 'http://example2.com',
+						name: 'Example 2',
+						options: { is_domain_only: true },
+					},
+				],
+			} );
+
+		render( <SitesDashboard queryParams={ {} } /> );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Example 1' ) ).toHaveAttribute( 'href', '/home/example1.com' );
+			expect( screen.queryByText( 'Example 2' ) ).not.toBeInTheDocument();
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78652

## Proposed Changes

The way domain-only sites usually work is that each site is associated with one domain. But soon it will be possible for a domain-only site to have multiple domains. This means it's no longer useful to be able to search for your domains in the same interface where you search for your sites. #78652 removes domain-only sites from the site switcher. This PR removes domain-only sites from `/sites`.

* `/sites` now fetches the `is_domain_only` option when it fetches the site list
* Domain-only sites are filtered out before rendering
* Fixed a bug in `useSiteExcerptsQuery` where the cached list would be used even when the requested fields changed

The `/me/sites` API has an `include_domain_only` flag, so you might think we could use this flag to have the filtering done on the server. Alas that is not how `useSiteExcerptsQuery` works. This hook is designed to return the data from Redux store if it's available, in the hopes that the data will already be available. That means that the data returned by `useSiteExcerptsQuery` needs to match what would be in Redux (just with fewer fields).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a domain-only site using the flow at `wordpress.com/domains`
* Confirm domain-only sites no longer appear on `/sites`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors? _lots of errors coming from the React 18 change, but none seem related to my changes_
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
