### PR TITLE
Jetpack: Feature comparison cards

### DIFF
--- a/client/jetpack-cloud/sections/comparison/table/links.ts
+++ b/client/jetpack-cloud/sections/comparison/table/links.ts
@@ -21,6 +21,7 @@ export const links = {
 	mobile_app:
 		'https://apps.wordpress.com/get?utm_source=jetpack-com-comparison-tables&amp;utm_medium=direct&amp;utm_campaign=get-apps-promo',
 	payments_block: 'https://jetpack.com/support/jetpack-blocks/payments-block/',
+	transaction_fees: 'https://jetpack.com/support/jetpack-blocks/payments-block/#related-fees',
 	priority_support: 'https://jetpack.com/features/security/expert-priority-support/',
 	related_posts: 'https://jetpack.com/features/traffic/related-posts/',
 	scan: localizeUrl( 'https://jetpack.com/upgrade/scan/' ),

--- a/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
@@ -303,8 +303,17 @@ export const useComparisonData = () => {
 						id: 'payments_block',
 						name: translate( 'Collect payments' ),
 						url: links.payments_block,
+						info: allChecked,
+					},
+					{
+						id: 'transaction_fees',
+						name: translate( 'Transaction fees' ),
+						url: links.transaction_fees,
 						info: {
-							COMPLETE: { content: <CheckIcon /> },
+							FREE: { content: translate( '10% + Stripe fees' ) },
+							STARTER: { content: translate( '8% + Stripe fees' ) },
+							SECURITY: { content: translate( '4% + Stripe fees' ) },
+							COMPLETE: { content: translate( '2% + Stripe fees' ) },
 						},
 					},
 					{


### PR DESCRIPTION
Adds the transaction fees to the Growth area, updates which plans have Collect Payments as a feature and links to the related fees area of support

<img width="1225" alt="Screenshot 2023-06-28 at 08 52 31" src="https://github.com/Automattic/wp-calypso/assets/4077604/4684f1a8-7e25-405a-9cfd-72f31ac3d3a9">
