### PR TITLE
Jetpack Pro Dashboard: Update padding on the monitor notifications settings popup

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
@@ -20,6 +20,7 @@
 	.components-modal__header {
 		background: var(--studio-white);
 		padding-block-end: 24px;
+		padding-block-start: 12px;
 	}
 
 	form {
@@ -36,7 +37,7 @@
 	line-height: 14px;
 	color: var(--studio-gray-50);
 	position: absolute;
-	inset-block-start: 38px;
+	inset-block-start: 44px;
 	z-index: 99;
 	padding-inline-end: 50px;
 }


### PR DESCRIPTION
Related to 1204774821045518-as-1204922727055218

## Proposed Changes

This PR updates padding on the monitor notifications settings popup.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/padding-on-monitor-notification-settings-popup` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link. 
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Verify the padding on top of the popup looks fine.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="499" alt="Screenshot 2023-06-28 at 1 55 03 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3ffc73b4-f349-4af2-b61a-63da3786d77d">
</td>
<td>
<img width="499" alt="Screenshot 2023-06-28 at 1 53 34 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ff2cdec1-ad7c-4b67-b347-041451a4e08e">
</td>
</tr>
</table>


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?