### PR TITLE
Subscription Management: Resubscribe after unsubscribe succeeded

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-manager/site-row.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import TimeSince from 'calypso/components/time-since';
@@ -91,6 +91,9 @@ const SiteRow = ( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const unsubscribeInProgress = useRef( false );
+	const resubscribePending = useRef( false );
+
 	const hostname = useMemo( () => {
 		try {
 			return new URL( url ).hostname;
@@ -125,7 +128,7 @@ const SiteRow = ( {
 	const recordSiteUnsubscribed = useRecordSiteUnsubscribed();
 	const recordSiteResubscribed = useRecordSiteResubscribed();
 
-	const unsubscribeSuccessCallback = () => {
+	const unsubscribeCallback = () => {
 		recordSiteUnsubscribed( { blog_id, url, source: SOURCE_SUBSCRIPTIONS_SITE_LIST } );
 		dispatch(
 			successNotice(
@@ -134,12 +137,16 @@ const SiteRow = ( {
 					duration: 5000,
 					button: translate( 'Resubscribe' ),
 					onClick: () => {
-						resubscribe( { blog_id, url, doNotInvalidateSiteSubscriptions: true } );
-						recordSiteResubscribed( {
-							blog_id,
-							url,
-							source: SOURCE_SUBSCRIPTIONS_UNSUBSCRIBED_NOTICE,
-						} );
+						if ( unsubscribeInProgress.current ) {
+							resubscribePending.current = true;
+						} else {
+							resubscribe( { blog_id, url, doNotInvalidateSiteSubscriptions: true } );
+							recordSiteResubscribed( {
+								blog_id,
+								url,
+								source: SOURCE_SUBSCRIPTIONS_UNSUBSCRIBED_NOTICE,
+							} );
+						}
 					},
 				}
 			)
@@ -280,12 +287,28 @@ const SiteRow = ( {
 					emailMeNewComments={ !! delivery_methods.email?.send_comments }
 					onEmailMeNewCommentsChange={ handleEmailMeNewCommentsChange }
 					updatingEmailMeNewComments={ updatingEmailMeNewComments }
-					onUnsubscribe={ () =>
+					onUnsubscribe={ () => {
+						unsubscribeInProgress.current = true;
+						unsubscribeCallback();
 						unsubscribe(
 							{ blog_id, url, doNotInvalidateSiteSubscriptions: true },
-							{ onSuccess: unsubscribeSuccessCallback }
-						)
-					}
+							{
+								onSuccess: () => {
+									unsubscribeInProgress.current = false;
+
+									if ( resubscribePending ) {
+										resubscribePending.current = false;
+										resubscribe( { blog_id, url, doNotInvalidateSiteSubscriptions: true } );
+										recordSiteResubscribed( {
+											blog_id,
+											url,
+											source: SOURCE_SUBSCRIPTIONS_UNSUBSCRIBED_NOTICE,
+										} );
+									}
+								},
+							}
+						);
+					} }
 					unsubscribing={ unsubscribing }
 				/>
 			</span>


### PR DESCRIPTION
Closes #78626

## Proposed Changes

This PR changes the behavior of the unsubscribe toast. Clicking Resubscribe will now only fire after the Unsubscribe mutation has succeeded.

`useRef` is used instead of `useState` because the callback function would otherwise capture the state at the moment of invocation.

## Testing Instructions

- Apply this PR
- Go to `http://calypso.localhost:3000/subscriptions/sites`
- Unsubscribe from a site & resubscribe quickly
- Refresh, the site should still be there

To more easily test this, add this before the API call in `packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts` (line 42):

`await new Promise(r => setTimeout(r, 10000));`

This will introduce a 10s timeout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
