### PR TITLE
Sites: add domain related CTAs

### DIFF
--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -147,13 +147,13 @@ class AddDomainButton extends Component {
 	}
 }
 
-const trackAddDomainClick = () =>
+export const trackAddDomainClick = () =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Management', 'Clicked "Add Domain" Button in List' ),
 		recordTracksEvent( 'calypso_domain_management_list_add_domain_click' )
 	);
 
-const trackAddDomainMenuClick = ( menuUrl ) =>
+export const trackAddDomainMenuClick = ( menuUrl ) =>
 	recordTracksEvent( 'calypso_domain_management_list_add_domain_menu_click', {
 		menu_slug: menuUrl,
 	} );

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -11,10 +11,16 @@ import { useCallback, useEffect, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Pagination from 'calypso/components/pagination';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import PopoverMenuSeparator from 'calypso/components/popover-menu/separator';
 import SplitButton from 'calypso/components/split-button';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import { withoutHttp } from 'calypso/lib/url';
+import {
+	trackAddDomainClick,
+	trackAddDomainMenuClick,
+} from 'calypso/my-sites/domains/domain-management/list/options-domain-button';
+import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
 import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
@@ -209,6 +215,17 @@ export function SitesDashboard( {
 							icon="arrow-down"
 						>
 							<span>{ __( 'Import an existing site' ) }</span>
+						</PopoverMenuItem>
+						<PopoverMenuSeparator />
+						<PopoverMenuItem icon="search" href={ domainAddNew() } onClick={ trackAddDomainClick }>
+							<span>{ __( 'Search for a domain' ) }</span>
+						</PopoverMenuItem>
+						<PopoverMenuItem
+							icon="domains"
+							onClick={ () => trackAddDomainMenuClick( domainUseMyDomain() ) }
+							href={ domainUseMyDomain() }
+						>
+							<span>{ __( 'Use a domain I own' ) }</span>
 						</PopoverMenuItem>
 					</SplitButton>
 				</HeaderControls>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2845

## Proposed Changes

* Add domain related to CTAs to `/sites` page

<img width="330" alt="Screenshot 2566-06-28 at 15 54 37" src="https://github.com/Automattic/wp-calypso/assets/6851384/5b7ac08b-bd3b-4fa9-b864-cdf2cc62f1e8">

## Testing Instructions


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites` and click "Add new site" and verify the new CTAs are added
* Check the Tracks events are fired correctly (search for other usages)
* Consider the UX - it always feels a bit bad to show the Site Picker. 
* I just exported the existing Tracks functions but this can cause problems later when importing. Maybe they should be moved into a separate file?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
