### PR TITLE
Global Styles: Fix the block-level styles don't work

### DIFF
--- a/packages/global-styles/package.json
+++ b/packages/global-styles/package.json
@@ -33,6 +33,7 @@
 		"@automattic/design-picker": "workspace:^",
 		"@tanstack/react-query": "^4.29.1",
 		"@wordpress/block-editor": "^11.0.0",
+		"@wordpress/block-library": "^8.0.0",
 		"@wordpress/components": "^23.0.0",
 		"@wordpress/compose": "^6.0.0",
 		"@wordpress/edit-site": "^5.0.0",

--- a/packages/global-styles/src/components/global-styles-provider/index.tsx
+++ b/packages/global-styles/src/components/global-styles-provider/index.tsx
@@ -1,4 +1,3 @@
-import { registerCoreBlocks } from '@wordpress/block-library';
 import { GlobalStylesContext } from '@wordpress/edit-site/build-module/components/global-styles/context';
 import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
 import { isEmpty, mapValues } from 'lodash';
@@ -88,10 +87,12 @@ interface Props {
 const GlobalStylesProvider = ( { siteId, stylesheet, children, placeholder = null }: Props ) => {
 	const context = useGlobalStylesContext( siteId, stylesheet );
 
-	// The block-level styles have effects only when the specific blocks are registered so we have to register core blocks.
-	// See https://github.com/WordPress/gutenberg/blob/16486bd946f918d581e4818b73ceaaed82349f71/packages/block-editor/src/components/global-styles/use-global-styles-output.js#L1190
 	useEffect( () => {
-		registerCoreBlocks();
+		// The block-level styles have effects only when the specific blocks are registered so we have to register core blocks.
+		// See https://github.com/WordPress/gutenberg/blob/16486bd946f918d581e4818b73ceaaed82349f71/packages/block-editor/src/components/global-styles/use-global-styles-output.js#L1190
+		import( '@wordpress/block-library' ).then(
+			( { registerCoreBlocks }: typeof import('@wordpress/block-library') ) => registerCoreBlocks()
+		);
 	}, [] );
 
 	if ( ! context.isReady ) {

--- a/packages/global-styles/src/components/global-styles-provider/index.tsx
+++ b/packages/global-styles/src/components/global-styles-provider/index.tsx
@@ -1,7 +1,8 @@
+import { registerCoreBlocks } from '@wordpress/block-library';
 import { GlobalStylesContext } from '@wordpress/edit-site/build-module/components/global-styles/context';
 import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
 import { isEmpty, mapValues } from 'lodash';
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import { useGetGlobalStylesBaseConfig } from '../../hooks';
 import type { GlobalStylesObject } from '../../types';
 
@@ -86,6 +87,12 @@ interface Props {
 
 const GlobalStylesProvider = ( { siteId, stylesheet, children, placeholder = null }: Props ) => {
 	const context = useGlobalStylesContext( siteId, stylesheet );
+
+	// The block-level styles have effects only when the specific blocks are registered so we have to register core blocks.
+	// See https://github.com/WordPress/gutenberg/blob/16486bd946f918d581e4818b73ceaaed82349f71/packages/block-editor/src/components/global-styles/use-global-styles-output.js#L1190
+	useEffect( () => {
+		registerCoreBlocks();
+	}, [] );
 
 	if ( ! context.isReady ) {
 		return placeholder;

--- a/packages/global-styles/src/global.d.ts
+++ b/packages/global-styles/src/global.d.ts
@@ -8,6 +8,10 @@ declare module '@wordpress/block-editor' {
 	export const transformStyles: ( styles: unknown[], wrapperClassName: string ) => string;
 }
 
+declare module '@wordpress/block-library' {
+	export const registerCoreBlocks: () => void;
+}
+
 declare module '@wordpress/components' {
 	interface Props {
 		[ key: string ]: unknown;

--- a/yarn.lock
+++ b/yarn.lock
@@ -801,6 +801,7 @@ __metadata:
     "@automattic/design-picker": "workspace:^"
     "@tanstack/react-query": ^4.29.1
     "@wordpress/block-editor": ^11.0.0
+    "@wordpress/block-library": ^8.0.0
     "@wordpress/components": ^23.0.0
     "@wordpress/compose": ^6.0.0
     "@wordpress/edit-site": ^5.0.0


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1687922523528669/1687478207.570339-slack-CRWCHQGUB

## Proposed Changes

* The block-level styles configured by Colors & Fonts variations don't work as the [useGlobalStylesOutput](https://github.com/WordPress/gutenberg/blob/16486bd946f918d581e4818b73ceaaed82349f71/packages/block-editor/src/components/global-styles/use-global-styles-output.js#L1190) function push the custom styles only when the specific blocks are registered.
* Hence, this PR is focusing on registering the core blocks so that the block-level styles can have effects on the large preview!
* Furthermore, make the `RegisterCoreBlocks` component and load it lazily to avoid the bundle size increasing a lot

### Bundle size

**Before lazy load**

```
name                             parsed_size             gzip_size
pattern-assembler-step            +1123315 B  (+102.1%)  +294081 B  (+91.5%)
import-flow                       +1122084 B   (+43.9%)  +293378 B  (+41.6%)

name                                                                         parsed_size             gzip_size
async-load-automattic-design-preview                                          +1125630 B  (+110.9%)  +295260 B  (+99.9%)
async-load-automattic-global-styles-src-components-global-styles-variations    +324560 B   (+32.7%)   +86611 B  (+30.0%)
```

**After lazy load**

```
name                             parsed_size            gzip_size
import-flow                        +323758 B  (+12.7%)   +86047 B  (+12.2%)
pattern-assembler-step             +323718 B  (+29.4%)   +86631 B  (+26.9%)

name                                                                         parsed_size            gzip_size
async-load-automattic-design-preview                                           +324710 B  (+32.0%)   +87708 B  (+29.7%)
async-load-automattic-global-styles-src-components-global-styles-variations    +324508 B  (+32.7%)   +86901 B  (+30.1%)
```

### Screenshots

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/1a919815-4aa7-4638-bf46-ebe35ae86373) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/db6b132a-9527-4afa-b665-eff9ec20e25a) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6cc273fd-bfa7-40de-904b-cb0f9dbe7117) |![image](https://github.com/Automattic/wp-calypso/assets/13596067/2e16613e-67b8-4bce-81d4-94ee4477b306) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use [Calypso Live Link ](https://github.com/Automattic/wp-calypso/pull/78613#issuecomment-1606542325) from https://github.com/Automattic/wp-calypso/pull/78613
* Go to the Theme Showcase
* Click `...` on the `Creatio` theme
* Pick `Assemble your site`
* On the Assembler screen
  * Select a header
  * Select a font variation
  * Ensure the font family of the site title will be changed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?