### PR TITLE
rework `useHelpSearchQuery` & remove unnecessary code

### DIFF
--- a/client/data/help/use-help-search-query.ts
+++ b/client/data/help/use-help-search-query.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { buildQueryString } from '@wordpress/url';
-import React from 'react';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import type { ReactNode } from 'react';
 
 export interface SearchResult {
 	link: string;
-	title: string | React.ReactNode;
+	title: ReactNode;
 	content?: string;
 	icon?: string;
 	post_id?: number;

--- a/client/data/help/use-help-search-query.ts
+++ b/client/data/help/use-help-search-query.ts
@@ -1,10 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
+import { buildQueryString } from '@wordpress/url';
+import React from 'react';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 
 export interface SearchResult {
 	link: string;
-	title: string | React.ReactChild;
+	title: string | React.ReactNode;
 	content?: string;
 	icon?: string;
 	post_id?: number;
@@ -17,38 +19,24 @@ interface APIFetchOptions {
 	path: string;
 }
 
-interface Article {
-	content: string;
-}
-
 const fetchArticlesAPI = ( search: string, locale: string, sectionName: string ) => {
-	const params = `?query=${ encodeURIComponent( search ) }&locale=${ encodeURIComponent(
-		locale
-	) }&section=${ encodeURIComponent( sectionName ) }`;
-	if ( canAccessWpcomApis() ) {
-		return wpcomRequest( {
-			path: `help/search/wpcom${ params }`,
-			apiNamespace: 'wpcom/v2/',
-			apiVersion: '2',
-		} );
-	}
-	return apiFetch( {
-		global: true,
-		path: `/help-center/search${ params }`,
-	} as APIFetchOptions );
-};
+	const queryString = buildQueryString( {
+		query: search,
+		locale,
+		section: sectionName,
+	} );
 
-const fetchArticleAPI = ( blogId: number, postId: number ): Promise< Article > => {
 	if ( canAccessWpcomApis() ) {
 		return wpcomRequest( {
-			path: `help/article/${ blogId }/${ postId }`,
+			path: `help/search/wpcom?${ queryString }`,
 			apiNamespace: 'wpcom/v2/',
 			apiVersion: '2',
 		} );
 	}
+
 	return apiFetch( {
 		global: true,
-		path: `/help-center/fetch-post?blog_id=${ blogId }&post_id=${ postId }`,
+		path: `/help-center/search?${ queryString }`,
 	} as APIFetchOptions );
 };
 
@@ -59,22 +47,9 @@ export const useHelpSearchQuery = (
 	sectionName = ''
 ) => {
 	return useQuery< any >( {
-		queryKey: [ 'help-center-search', search, sectionName ],
+		queryKey: [ 'help-center-search', search, locale, sectionName ],
 		queryFn: () => fetchArticlesAPI( search, locale, sectionName ),
-		onSuccess: async ( data ) => {
-			await Promise.all(
-				data.map( async ( result: SearchResult ) => {
-					if ( ! result.content && result.blog_id && result.post_id ) {
-						const article: Article = await fetchArticleAPI( result.blog_id, result.post_id );
-						return { ...result, content: article.content };
-					}
-					return result;
-				} )
-			);
-		},
 		refetchOnWindowFocus: false,
-		refetchOnMount: true,
-		enabled: true,
 		...queryOptions,
 	} );
 };


### PR DESCRIPTION
Follow up to  #77955

## Proposed Changes

This PR cleans up some code in `client/data/help/use-help-search-query.ts` and reworks the `queryFn` a bit. Also fixes an eslint violation of `@tanstack/query/exhaustive-deps` (was missing the `locale` param in the `queryKey`).

## Testing Instructions

* Verify testing instructions of #77955 still work as described

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
