### PR TITLE
Plans 2023: Typed Async props and other prop cleanup

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -42,6 +42,7 @@ import {
 	TITAN_MAIL_MONTHLY_SLUG,
 	TITAN_MAIL_YEARLY_SLUG,
 	isAkismetProduct,
+	isWpcomEnterpriseGridPlan,
 } from '@automattic/calypso-products';
 import { isWpComProductRenewal as isRenewal } from '@automattic/wpcom-checkout';
 import { getTld } from 'calypso/lib/domains';
@@ -213,8 +214,8 @@ export function hasRenewableSubscription( cart: ObjectWithProducts ): boolean {
  * Creates a new shopping cart item for a plan.
  */
 export function planItem( productSlug: string ): { product_slug: string } | null {
-	// Free plan doesn't have shopping cart.
-	if ( isWpComFreePlan( productSlug ) ) {
+	// Free and Enterprise plans don't have shopping cart.
+	if ( isWpComFreePlan( productSlug ) || isWpcomEnterpriseGridPlan( productSlug ) ) {
 		return null;
 	}
 

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -16,6 +16,7 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PRODUCT_JETPACK_BACKUP_DAILY,
+	PLAN_ENTERPRISE_GRID_WPCOM,
 } from '@automattic/calypso-products';
 const { getPlan, getTermDuration } = require( '@automattic/calypso-products' );
 const cartItems = require( '../cart-items' );
@@ -34,6 +35,10 @@ const {
 describe( 'planItem()', () => {
 	test( 'should return null for free plan', () => {
 		expect( planItem( PLAN_FREE ) ).toBe( null );
+	} );
+
+	test( 'should return null for enterprise grid plan', () => {
+		expect( planItem( PLAN_ENTERPRISE_GRID_WPCOM ) ).toBe( null );
 	} );
 
 	[

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -30,7 +30,7 @@ type PlanFeaturesActionsButtonProps = {
 	manageHref: string;
 	isPlaceholder?: boolean;
 	isPopular?: boolean;
-	isInSignup: boolean;
+	isInSignup?: boolean;
 	isLaunchPage?: boolean;
 	onUpgradeClick: () => void;
 	planName: TranslateResult;

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -31,7 +31,7 @@ type PlanFeaturesActionsButtonProps = {
 	isPlaceholder?: boolean;
 	isPopular?: boolean;
 	isInSignup?: boolean;
-	isLaunchPage?: boolean;
+	isLaunchPage?: boolean | null;
 	onUpgradeClick: () => void;
 	planName: TranslateResult;
 	planType: string;

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -24,7 +24,7 @@ type PlanFeaturesActionsButtonProps = {
 	availableForPurchase: boolean;
 	canUserPurchasePlan?: boolean | null;
 	className: string;
-	currentSitePlanSlug?: string;
+	currentSitePlanSlug?: string | null;
 	current: boolean;
 	freePlan: boolean;
 	manageHref: string;
@@ -151,7 +151,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	current?: boolean;
 	manageHref?: string;
 	canUserPurchasePlan?: boolean | null;
-	currentSitePlanSlug?: string;
+	currentSitePlanSlug?: string | null;
 	buttonText?: string;
 	selectedSiteSlug: string | null;
 	planActionOverrides?: PlanActionOverrides;

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -22,7 +22,7 @@ import type { PlanActionOverrides } from '../types';
 
 type PlanFeaturesActionsButtonProps = {
 	availableForPurchase: boolean;
-	canUserPurchasePlan: boolean;
+	canUserPurchasePlan?: boolean | null;
 	className: string;
 	currentSitePlanSlug?: string;
 	current: boolean;
@@ -35,7 +35,7 @@ type PlanFeaturesActionsButtonProps = {
 	onUpgradeClick: () => void;
 	planName: TranslateResult;
 	planType: string;
-	flowName: string;
+	flowName?: string | null;
 	buttonText?: string;
 	isWpcomEnterpriseGridPlan: boolean;
 	isWooExpressPlusPlan?: boolean;
@@ -150,7 +150,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	planType: string;
 	current?: boolean;
 	manageHref?: string;
-	canUserPurchasePlan?: boolean;
+	canUserPurchasePlan?: boolean | null;
 	currentSitePlanSlug?: string;
 	buttonText?: string;
 	selectedSiteSlug: string | null;

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -22,7 +22,7 @@ interface Props {
 	billingTimeframe: TranslateResult;
 	billingPeriod: number | null | undefined;
 	isMonthlyPlan: boolean;
-	currentSitePlanSlug?: string;
+	currentSitePlanSlug?: string | null;
 	siteId?: number | null;
 }
 

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -40,7 +40,7 @@ const FreePlanCustomDomainFeature: React.FC< { domainName: string } > = ( { doma
 const PlanFeatures2023GridFeatures: React.FC< {
 	features: Array< TransformedFeatureObject >;
 	planName: string;
-	domainName: string;
+	domainName?: string;
 	hideUnavailableFeatures: boolean;
 	selectedFeature?: string;
 } > = ( { features, planName, domainName, hideUnavailableFeatures, selectedFeature } ) => {
@@ -82,7 +82,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 						<PlanFeaturesItem>
 							<span className={ spanClasses } key={ key }>
 								<span className={ itemTitleClasses }>
-									{ isFreePlanAndCustomDomainFeature ? (
+									{ isFreePlanAndCustomDomainFeature && domainName ? (
 										<Plans2023Tooltip
 											text={ translate( '%s is not included', {
 												args: [ domainName ],

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -82,14 +82,17 @@ const PlanFeatures2023GridFeatures: React.FC< {
 						<PlanFeaturesItem>
 							<span className={ spanClasses } key={ key }>
 								<span className={ itemTitleClasses }>
-									{ isFreePlanAndCustomDomainFeature && domainName ? (
+									{ isFreePlanAndCustomDomainFeature ? (
 										<Plans2023Tooltip
 											text={ translate( '%s is not included', {
-												args: [ domainName ],
+												args: [ domainName as string ],
 												comment: '%s is a domain name.',
 											} ) }
 										>
-											<FreePlanCustomDomainFeature key={ key } domainName={ domainName } />
+											<FreePlanCustomDomainFeature
+												key={ key }
+												domainName={ domainName as string }
+											/>
 										</Plans2023Tooltip>
 									) : (
 										<Plans2023Tooltip text={ currentFeature.getDescription?.() }>

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -41,7 +41,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	features: Array< TransformedFeatureObject >;
 	planName: string;
 	domainName?: string;
-	hideUnavailableFeatures: boolean;
+	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
 } > = ( { features, planName, domainName, hideUnavailableFeatures, selectedFeature } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/plan-features-2023-grid/components/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/header-price.tsx
@@ -131,11 +131,11 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	siteId,
 }: PlanFeatures2023GridHeaderPriceProps ) => {
 	const translate = useTranslate();
-	const { planName, showMonthlyPrice } = planProperties;
+	const { planName } = planProperties;
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const planPrices = usePlanPricesDisplay( {
 		planSlug: planName as PlanSlug,
-		returnMonthly: showMonthlyPrice,
+		returnMonthly: true,
 		currentSitePlanSlug,
 		siteId,
 	} );

--- a/client/my-sites/plan-features-2023-grid/components/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/header-price.tsx
@@ -11,7 +11,7 @@ interface PlanFeatures2023GridHeaderPriceProps {
 	planProperties: PlanProperties;
 	isLargeCurrency: boolean;
 	isPlanUpgradeCreditEligible: boolean;
-	currentSitePlanSlug?: string;
+	currentSitePlanSlug?: string | null;
 	siteId?: number | null;
 }
 

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -307,10 +307,10 @@ type PlanComparisonGridProps = {
 	planTypeSelectorProps: PlanTypeSelectorProps;
 	isInSignup?: boolean;
 	isLaunchPage?: boolean | null;
-	flowName: string;
+	flowName?: string | null;
 	currentSitePlanSlug?: string;
 	manageHref: string;
-	canUserPurchasePlan: boolean;
+	canUserPurchasePlan?: boolean | null;
 	selectedSiteSlug: string | null;
 	onUpgradeClick: ( properties: PlanProperties ) => void;
 	siteId?: number | null;
@@ -325,11 +325,11 @@ type PlanComparisonGridHeaderProps = {
 	isInSignup?: boolean;
 	isLaunchPage?: boolean | null;
 	isFooter?: boolean;
-	flowName: string;
+	flowName?: string | null;
 	onPlanChange: ( currentPlan: string, event: ChangeEvent< HTMLSelectElement > ) => void;
 	currentSitePlanSlug?: string;
 	manageHref: string;
-	canUserPurchasePlan: boolean;
+	canUserPurchasePlan?: boolean | null;
 	selectedSiteSlug: string | null;
 	onUpgradeClick: ( properties: PlanProperties ) => void;
 	siteId?: number | null;
@@ -553,7 +553,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	restructuredFeatures: RestructuredFeatures;
 	planName: string;
 	isStorageFeature: boolean;
-	flowName: string;
+	flowName?: string | null;
 	currentSitePlanSlug?: string;
 	selectedPlan?: string;
 } > = ( {
@@ -676,7 +676,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	restructuredFeatures: RestructuredFeatures;
 	restructuredFootnotes: RestructuredFootnotes;
 	isStorageFeature: boolean;
-	flowName: string;
+	flowName?: string | null;
 	currentSitePlanSlug?: string;
 	isHighlighted: boolean;
 	selectedPlan?: string;

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -306,7 +306,7 @@ type PlanComparisonGridProps = {
 	intervalType: string;
 	planTypeSelectorProps: PlanTypeSelectorProps;
 	isInSignup?: boolean;
-	isLaunchPage?: boolean;
+	isLaunchPage?: boolean | null;
 	flowName: string;
 	currentSitePlanSlug?: string;
 	manageHref: string;
@@ -323,7 +323,7 @@ type PlanComparisonGridHeaderProps = {
 	displayedPlansProperties: Array< PlanProperties >;
 	visiblePlansProperties: Array< PlanProperties >;
 	isInSignup?: boolean;
-	isLaunchPage?: boolean;
+	isLaunchPage?: boolean | null;
 	isFooter?: boolean;
 	flowName: string;
 	onPlanChange: ( currentPlan: string, event: ChangeEvent< HTMLSelectElement > ) => void;

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -303,12 +303,12 @@ const FeatureFootnote = styled.span`
 
 type PlanComparisonGridProps = {
 	planProperties?: Array< PlanProperties >;
-	intervalType: string;
+	intervalType?: string;
 	planTypeSelectorProps: PlanTypeSelectorProps;
 	isInSignup?: boolean;
 	isLaunchPage?: boolean | null;
 	flowName?: string | null;
-	currentSitePlanSlug?: string;
+	currentSitePlanSlug?: string | null;
 	manageHref: string;
 	canUserPurchasePlan?: boolean | null;
 	selectedSiteSlug: string | null;
@@ -327,7 +327,7 @@ type PlanComparisonGridHeaderProps = {
 	isFooter?: boolean;
 	flowName?: string | null;
 	onPlanChange: ( currentPlan: string, event: ChangeEvent< HTMLSelectElement > ) => void;
-	currentSitePlanSlug?: string;
+	currentSitePlanSlug?: string | null;
 	manageHref: string;
 	canUserPurchasePlan?: boolean | null;
 	selectedSiteSlug: string | null;
@@ -554,7 +554,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	planName: string;
 	isStorageFeature: boolean;
 	flowName?: string | null;
-	currentSitePlanSlug?: string;
+	currentSitePlanSlug?: string | null;
 	selectedPlan?: string;
 } > = ( {
 	feature,
@@ -677,7 +677,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	restructuredFootnotes: RestructuredFootnotes;
 	isStorageFeature: boolean;
 	flowName?: string | null;
-	currentSitePlanSlug?: string;
+	currentSitePlanSlug?: string | null;
 	isHighlighted: boolean;
 	selectedPlan?: string;
 } > = ( {

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -97,7 +97,7 @@ const Title = styled.div< { isHiddenInMobile?: boolean } >`
 	` ) }
 `;
 
-const Grid = styled.div< { isInSignup: boolean } >`
+const Grid = styled.div< { isInSignup?: boolean } >`
 	display: grid;
 	margin-top: ${ ( props ) => ( props.isInSignup ? '90px' : '64px' ) };
 	background: #fff;
@@ -305,7 +305,7 @@ type PlanComparisonGridProps = {
 	planProperties?: Array< PlanProperties >;
 	intervalType: string;
 	planTypeSelectorProps: PlanTypeSelectorProps;
-	isInSignup: boolean;
+	isInSignup?: boolean;
 	isLaunchPage?: boolean;
 	flowName: string;
 	currentSitePlanSlug?: string;
@@ -322,7 +322,7 @@ type PlanComparisonGridProps = {
 type PlanComparisonGridHeaderProps = {
 	displayedPlansProperties: Array< PlanProperties >;
 	visiblePlansProperties: Array< PlanProperties >;
-	isInSignup: boolean;
+	isInSignup?: boolean;
 	isLaunchPage?: boolean;
 	isFooter?: boolean;
 	flowName: string;

--- a/client/my-sites/plan-features-2023-grid/components/popular-badge.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/popular-badge.tsx
@@ -7,7 +7,7 @@ const PopularBadge: React.FunctionComponent< {
 	isInSignup?: boolean;
 	planName: string;
 	additionalClassName?: string;
-	currentSitePlanSlug?: string;
+	currentSitePlanSlug?: string | null;
 	selectedPlan?: string;
 } > = ( { isInSignup, planName, additionalClassName, currentSitePlanSlug, selectedPlan } ) => {
 	const classes = classNames(

--- a/client/my-sites/plan-features-2023-grid/components/popular-badge.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/popular-badge.tsx
@@ -4,7 +4,7 @@ import PlanPill from 'calypso/components/plans/plan-pill';
 import useHighlightLabel from '../hooks/use-highlight-label';
 
 const PopularBadge: React.FunctionComponent< {
-	isInSignup: boolean;
+	isInSignup?: boolean;
 	planName: string;
 	additionalClassName?: string;
 	currentSitePlanSlug?: string;

--- a/client/my-sites/plan-features-2023-grid/grid-context.tsx
+++ b/client/my-sites/plan-features-2023-grid/grid-context.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext } from '@wordpress/element';
 import type { PlansIntent } from 'calypso/my-sites/plans-features-main/hooks/use-plan-types-with-intent';
 
 interface PlansGridContext {
-	intent: PlansIntent;
+	intent?: PlansIntent;
 }
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );

--- a/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits.tsx
@@ -35,13 +35,7 @@ const mIsPlanAvailableForPurchase = isPlanAvailableForPurchase as jest.MockedFun
 >;
 
 const siteId = 9999999;
-const plansList: PlanSlug[] = [
-	PLAN_FREE,
-	PLAN_PERSONAL,
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-	PLAN_ECOMMERCE,
-];
+const plans: PlanSlug[] = [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE ];
 
 describe( 'useCalculateMaxPlanUpgradeCredit hook', () => {
 	beforeEach( () => {
@@ -84,7 +78,7 @@ describe( 'useCalculateMaxPlanUpgradeCredit hook', () => {
 
 	test( 'Return the correct amount of credits given a plan list', () => {
 		const { result } = renderHookWithProvider( () =>
-			useCalculateMaxPlanUpgradeCredit( siteId, plansList )
+			useCalculateMaxPlanUpgradeCredit( { siteId, plans } )
 		);
 		expect( result.current ).toEqual( 1000 );
 	} );
@@ -95,7 +89,7 @@ describe( 'useCalculateMaxPlanUpgradeCredit hook', () => {
 		);
 
 		const { result } = renderHookWithProvider( () =>
-			useCalculateMaxPlanUpgradeCredit( siteId, plansList )
+			useCalculateMaxPlanUpgradeCredit( { siteId, plans } )
 		);
 		expect( result.current ).toEqual( 800 );
 	} );

--- a/client/my-sites/plan-features-2023-grid/hooks/use-calculate-max-plan-upgrade-credit.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-calculate-max-plan-upgrade-credit.ts
@@ -23,6 +23,7 @@ export function useCalculateMaxPlanUpgradeCredit( { siteId, plans }: Props ): nu
 			sitePlanRawPrice: getSitePlanRawPrice( state, siteId ?? 0, planName ),
 		} ) )
 	);
+
 	if ( ! siteId ) {
 		return 0;
 	}

--- a/client/my-sites/plan-features-2023-grid/hooks/use-calculate-max-plan-upgrade-credit.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-calculate-max-plan-upgrade-credit.ts
@@ -4,18 +4,18 @@ import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors/get-sit
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
 import type { PlanSlug } from '@automattic/calypso-products';
 
+interface Props {
+	siteId?: number | null;
+	plans: PlanSlug[];
+}
+
 /**
  * Calculate available plan credits given a set of displayed plans
  * This is the maximum possible credit value possible when comparing credits per plan
  *
- * @param {*} siteId the selected site id
- * @param {PlanSlug[]}  plans Plans that are considered for the given calculation
  * @returns {number} The maximum amount of credits possible for a given set of plans
  */
-export function useCalculateMaxPlanUpgradeCredit(
-	siteId: number | undefined,
-	plans: PlanSlug[]
-): number {
+export function useCalculateMaxPlanUpgradeCredit( { siteId, plans }: Props ): number {
 	const plansDetails = useSelector( ( state ) =>
 		plans.map( ( planName ) => ( {
 			isPlanAvailableForPurchase: isPlanAvailableForPurchase( state, siteId ?? 0, planName ),

--- a/client/my-sites/plan-features-2023-grid/hooks/use-highlight-adjacency-matrix.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-highlight-adjacency-matrix.ts
@@ -17,7 +17,7 @@ interface HighlightAdjacencyMatrix {
 
 interface Props {
 	visiblePlans: PlanProperties[];
-	currentSitePlanSlug?: string;
+	currentSitePlanSlug?: string | null;
 	selectedPlan?: string;
 }
 

--- a/client/my-sites/plan-features-2023-grid/hooks/use-highlight-label.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-highlight-label.ts
@@ -13,7 +13,7 @@ import { isPopularPlan } from '../lib/is-popular-plan';
 
 interface Props {
 	planName: string;
-	currentSitePlanSlug?: string;
+	currentSitePlanSlug?: string | null;
 	selectedPlan?: string;
 }
 

--- a/client/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible.ts
@@ -19,8 +19,8 @@ export function useIsPlanUpgradeCreditVisible(
 	const isSiteOnPaidPlan = !! useSelector(
 		( state ) => siteId && isCurrentPlanPaid( state, siteId )
 	);
-	const currentSitePlanSlug = useSelector(
-		( state ) => siteId && getSitePlanSlug( state, siteId )
+	const currentSitePlanSlug = useSelector( ( state ) =>
+		siteId ? getSitePlanSlug( state, siteId ) : undefined
 	);
 	const creditsValue = useCalculateMaxPlanUpgradeCredit( { siteId, plans: visiblePlans } );
 	const isJetpackNotAtomic = useSelector(

--- a/client/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible.ts
@@ -19,7 +19,9 @@ export function useIsPlanUpgradeCreditVisible(
 	const isSiteOnPaidPlan = !! useSelector(
 		( state ) => siteId && isCurrentPlanPaid( state, siteId )
 	);
-	const currentSitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, siteId ) );
+	const currentSitePlanSlug = useSelector( ( state ) =>
+		siteId ? getSitePlanSlug( state, siteId ) : undefined
+	);
 	const creditsValue = useCalculateMaxPlanUpgradeCredit( { siteId, plans: visiblePlans } );
 	const isJetpackNotAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )

--- a/client/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible.ts
@@ -13,12 +13,16 @@ import { isCurrentPlanPaid, isJetpackSite } from 'calypso/state/sites/selectors'
  * @returns If the credit should be displayed to the user
  */
 export function useIsPlanUpgradeCreditVisible(
-	siteId: number,
+	siteId?: number | null,
 	visiblePlans: PlanSlug[] = []
 ): boolean {
-	const isSiteOnPaidPlan = !! useSelector( ( state ) => isCurrentPlanPaid( state, siteId ) );
-	const currentSitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, siteId ) );
-	const creditsValue = useCalculateMaxPlanUpgradeCredit( siteId, visiblePlans );
+	const isSiteOnPaidPlan = !! useSelector(
+		( state ) => siteId && isCurrentPlanPaid( state, siteId )
+	);
+	const currentSitePlanSlug = useSelector(
+		( state ) => siteId && getSitePlanSlug( state, siteId )
+	);
+	const creditsValue = useCalculateMaxPlanUpgradeCredit( { siteId, plans: visiblePlans } );
 	const isJetpackNotAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
 	);

--- a/client/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible.ts
@@ -19,9 +19,7 @@ export function useIsPlanUpgradeCreditVisible(
 	const isSiteOnPaidPlan = !! useSelector(
 		( state ) => siteId && isCurrentPlanPaid( state, siteId )
 	);
-	const currentSitePlanSlug = useSelector( ( state ) =>
-		siteId ? getSitePlanSlug( state, siteId ) : undefined
-	);
+	const currentSitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, siteId ) );
 	const creditsValue = useCalculateMaxPlanUpgradeCredit( { siteId, plans: visiblePlans } );
 	const isJetpackNotAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -106,7 +106,7 @@ export type PlanFeatures2023GridProps = {
 	isInSignup?: boolean;
 	siteId?: number | null;
 	isLaunchPage?: boolean | null;
-	isReskinned: boolean;
+	isReskinned?: boolean;
 	onUpgradeClick?: ( cartItem?: MinimalRequestCartProduct | null ) => void;
 	// either you specify the plans prop or isPlaceholder prop
 	plans: PlanSlug[];
@@ -114,9 +114,9 @@ export type PlanFeatures2023GridProps = {
 	flowName?: string | null;
 	domainName?: string;
 	placeholder?: string;
-	intervalType: string;
-	currentSitePlanSlug?: string;
-	hidePlansFeatureComparison: boolean;
+	intervalType?: string;
+	currentSitePlanSlug?: string | null;
+	hidePlansFeatureComparison?: boolean;
 	hideUnavailableFeatures: boolean;
 	planActionOverrides?: PlanActionOverrides;
 	// Value of the `?plan=` query param, so we can highlight a given plan.
@@ -153,7 +153,7 @@ const PlanLogo: React.FunctionComponent< {
 	planProperties: PlanProperties;
 	isMobile?: boolean;
 	isInSignup?: boolean;
-	currentSitePlanSlug?: string;
+	currentSitePlanSlug?: string | null;
 	selectedPlan?: string;
 } > = ( {
 	planPropertiesObj,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -103,7 +103,7 @@ const Container = (
 };
 
 export type PlanFeatures2023GridProps = {
-	isInSignup: boolean;
+	isInSignup?: boolean;
 	siteId: number;
 	isLaunchPage: boolean;
 	isReskinned: boolean;
@@ -112,7 +112,7 @@ export type PlanFeatures2023GridProps = {
 	plans: PlanSlug[];
 	visiblePlans: Array< string >;
 	flowName: string;
-	domainName: string;
+	domainName?: string;
 	placeholder?: string;
 	intervalType: string;
 	currentSitePlanSlug?: string;
@@ -152,7 +152,7 @@ const PlanLogo: React.FunctionComponent< {
 	planIndex: number;
 	planProperties: PlanProperties;
 	isMobile?: boolean;
-	isInSignup: boolean;
+	isInSignup?: boolean;
 	currentSitePlanSlug?: string;
 	selectedPlan?: string;
 } > = ( {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -107,7 +107,7 @@ export type PlanFeatures2023GridProps = {
 	intervalType?: string;
 	currentSitePlanSlug?: string | null;
 	hidePlansFeatureComparison?: boolean;
-	hideUnavailableFeatures?: boolean; // used by Woo to hide features that are not available
+	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
 	planActionOverrides?: PlanActionOverrides;
 	// Value of the `?plan=` query param, so we can highlight a given plan.
 	selectedPlan?: string;

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -1050,7 +1050,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 				isVisible,
 				planConstantObj,
 				planName: plan,
-				planObject: planObject,
 				// TODO: snake_case?
 				product_name_short,
 				rawPrice,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -117,13 +117,13 @@ export type PlanFeatures2023GridProps = {
 	intervalType?: string;
 	currentSitePlanSlug?: string | null;
 	hidePlansFeatureComparison?: boolean;
-	hideUnavailableFeatures: boolean;
+	hideUnavailableFeatures?: boolean; // used by Woo to hide features that are not available
 	planActionOverrides?: PlanActionOverrides;
 	// Value of the `?plan=` query param, so we can highlight a given plan.
 	selectedPlan?: string;
 	// Value of the `?feature=` query param, so we can highlight a given feature and hide plans without it.
 	selectedFeature?: string;
-	intent: PlansIntent;
+	intent?: PlansIntent;
 };
 
 type PlanFeatures2023GridConnectedProps = {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -927,8 +927,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 			const billingPeriod = planObject?.bill_period;
 			const isMonthlyPlan = isMonthly( plan );
 
-			// Show price divided by 12? Only for non JP plans, or if plan is only available yearly.
-			const showMonthlyPrice = true;
 			if ( placeholder || ( ! planObject && plan !== PLAN_ENTERPRISE_GRID_WPCOM ) ) {
 				isPlaceholder = true;
 			}
@@ -967,7 +965,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 				tagline = planConstantObj.getPlanTagline?.() ?? '';
 			}
 
-			const rawPrice = getPlanRawPrice( state, planProductId, showMonthlyPrice );
+			const rawPrice = getPlanRawPrice( state, planProductId, true );
 
 			const monthlyPlanKey = findPlansKeys( {
 				group: planConstantObj.group,
@@ -1061,7 +1059,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 				tagline,
 				storageOptions,
 				billingPeriod,
-				showMonthlyPrice,
 			};
 		} );
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -711,7 +711,7 @@ export class PlanFeatures2023Grid extends Component<
 	maybeRenderRefundNotice( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
 		const { translate, flowName } = this.props;
 
-		if ( ! isAnyHostingFlow( flowName ?? null ) ) {
+		if ( ! isAnyHostingFlow( flowName ) ) {
 			return false;
 		}
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -916,12 +916,15 @@ const ConnectedPlanFeatures2023Grid = connect(
 			selectedFeature,
 			intent,
 		} = ownProps;
+		// TODO: canUserManagePlan should be passed through props instead of being calculated here
 		const canUserPurchasePlan = siteId
 			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
 			: null;
 		const purchaseId = siteId && getCurrentPlanPurchaseId( state, siteId );
+		// TODO selectedSiteSlug has no other use than computing manageRef below. stop propagating it through props
 		const selectedSiteSlug = getSiteSlug( state, siteId );
 
+		// TODO: plan properties should be passed through props instead of being calculated here
 		const planProperties: PlanProperties[] = plans.map( ( plan: PlanSlug ) => {
 			let isPlaceholder = false;
 			const planConstantObj = applyTestFiltersToPlansList( plan, undefined );
@@ -1060,8 +1063,8 @@ const ConnectedPlanFeatures2023Grid = connect(
 				planConstantObj,
 				planName: plan,
 				planObject: planObject,
+				// TODO: snake_case?
 				product_name_short,
-				hideMonthly: false,
 				rawPrice,
 				rawPriceForMonthlyPlan,
 				relatedMonthlyPlan,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -1040,7 +1040,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 				isMonthlyPlan,
 				tagline,
 				storageOptions,
-				cartItemForPlan: isWpcomEnterpriseGridPlan( plan ) ? null : getCartItemForPlan( plan ),
+				cartItemForPlan: getCartItemForPlan( plan ),
 				current: currentSitePlanSlug === plan,
 				isVisible: visiblePlans?.indexOf( plan ) !== -1,
 				billingPeriod: planObject?.bill_period,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -105,7 +105,7 @@ const Container = (
 export type PlanFeatures2023GridProps = {
 	isInSignup?: boolean;
 	siteId: number;
-	isLaunchPage: boolean;
+	isLaunchPage?: boolean | null;
 	isReskinned: boolean;
 	onUpgradeClick: ( cartItem: MinimalRequestCartProduct | null ) => void;
 	// either you specify the plans prop or isPlaceholder prop

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -1,6 +1,5 @@
 import {
 	applyTestFiltersToPlansList,
-	getMonthlyPlanByYearly,
 	findPlansKeys,
 	getPlan as getPlanFromKey,
 	getPlanClass,
@@ -51,12 +50,7 @@ import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plan-features-20
 import { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import {
-	getPlan,
-	getPlanBySlug,
-	getPlanRawPrice,
-	getPlanSlug,
-} from 'calypso/state/plans/selectors';
+import { getPlan, getPlanRawPrice, getPlanSlug } from 'calypso/state/plans/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
@@ -932,10 +926,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 			const planObject = getPlan( state, planProductId );
 			const billingPeriod = planObject?.bill_period;
 			const isMonthlyPlan = isMonthly( plan );
-			const showMonthly = ! isMonthlyPlan;
-			const relatedMonthlyPlan = showMonthly
-				? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) )
-				: null;
 
 			// Show price divided by 12? Only for non JP plans, or if plan is only available yearly.
 			const showMonthlyPrice = true;
@@ -1067,7 +1057,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 				product_name_short,
 				rawPrice,
 				rawPriceForMonthlyPlan,
-				relatedMonthlyPlan,
 				isMonthlyPlan,
 				tagline,
 				storageOptions,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -1,7 +1,5 @@
 import {
 	applyTestFiltersToPlansList,
-	findPlansKeys,
-	getPlan as getPlanFromKey,
 	getPlanClass,
 	isFreePlan,
 	isPersonalPlan,
@@ -9,7 +7,6 @@ import {
 	isWpComFreePlan,
 	isWpcomEnterpriseGridPlan,
 	isMonthly,
-	TERM_MONTHLY,
 	isBusinessPlan,
 	PLAN_ENTERPRISE_GRID_WPCOM,
 	isPremiumPlan,
@@ -104,7 +101,7 @@ export type PlanFeatures2023GridProps = {
 	onUpgradeClick?: ( cartItem?: MinimalRequestCartProduct | null ) => void;
 	// either you specify the plans prop or isPlaceholder prop
 	plans: PlanSlug[];
-	visiblePlans: Array< string >;
+	visiblePlans: PlanSlug[];
 	flowName?: string | null;
 	domainName?: string;
 	placeholder?: string;
@@ -924,7 +921,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 			const planConstantObj = applyTestFiltersToPlansList( plan, undefined );
 			const planProductId = planConstantObj.getProductId();
 			const planObject = getPlan( state, planProductId );
-			const billingPeriod = planObject?.bill_period;
 			const isMonthlyPlan = isMonthly( plan );
 
 			if ( placeholder || ( ! planObject && plan !== PLAN_ENTERPRISE_GRID_WPCOM ) ) {
@@ -967,14 +963,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 
 			const rawPrice = getPlanRawPrice( state, planProductId, true );
 
-			const monthlyPlanKey = findPlansKeys( {
-				group: planConstantObj.group,
-				term: TERM_MONTHLY,
-				type: planConstantObj.type,
-			} )[ 0 ];
-			const monthlyPlanProductId = getPlanFromKey( monthlyPlanKey )?.getProductId();
 			// This is the per month price of a monthly plan. E.g. $14 for Premium monthly.
-			const rawPriceForMonthlyPlan = getPlanRawPrice( state, monthlyPlanProductId ?? 0, true );
 			const annualPlansOnlyFeatures = planConstantObj.getAnnualPlansOnlyFeatures?.() || [];
 			let planFeaturesTransformed: Array< TransformedFeatureObject > = [];
 			let jetpackFeaturesTransformed: Array< TransformedFeatureObject > = [];
@@ -1036,29 +1025,26 @@ const ConnectedPlanFeatures2023Grid = connect(
 				[];
 			const availableForPurchase =
 				isInSignup || ( siteId ? isPlanAvailableForPurchase( state, siteId, plan ) : false );
-			const isCurrentPlan = currentSitePlanSlug === plan;
-			const isVisible = visiblePlans?.indexOf( plan ) !== -1;
 
 			return {
 				availableForPurchase,
 				cartItemForPlan: isWpcomEnterpriseGridPlan( plan ) ? null : getCartItemForPlan( plan ),
 				// TODO: derive currencyCode from planObject
 				currencyCode: getCurrentUserCurrencyCode( state ),
-				current: isCurrentPlan,
+				current: currentSitePlanSlug === plan,
 				features: planFeaturesTransformed,
 				jpFeatures: jetpackFeaturesTransformed,
 				isPlaceholder,
-				isVisible,
+				isVisible: visiblePlans?.indexOf( plan ) !== -1,
 				planConstantObj,
 				planName: plan,
 				// TODO: snake_case?
 				product_name_short,
 				rawPrice,
-				rawPriceForMonthlyPlan,
 				isMonthlyPlan,
 				tagline,
 				storageOptions,
-				billingPeriod,
+				billingPeriod: planObject?.bill_period,
 			};
 		} );
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -50,7 +50,7 @@ import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plan-features-20
 import { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { getPlan, getPlanRawPrice, getPlanSlug } from 'calypso/state/plans/selectors';
+import { getPlan, getPlanRawPrice } from 'calypso/state/plans/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
@@ -1041,7 +1041,8 @@ const ConnectedPlanFeatures2023Grid = connect(
 
 			return {
 				availableForPurchase,
-				cartItemForPlan: getCartItemForPlan( getPlanSlug( state, planProductId ) ?? '' ),
+				cartItemForPlan: isWpcomEnterpriseGridPlan( plan ) ? null : getCartItemForPlan( plan ),
+				// TODO: derive currencyCode from planObject
 				currencyCode: getCurrentUserCurrencyCode( state ),
 				current: isCurrentPlan,
 				features: planFeaturesTransformed,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -51,7 +51,6 @@ import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-p
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
 import { getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
-// TODO clk: remove - use ShoppingCartProvider from shopping-cart package
 import CalypsoShoppingCartProvider from '../checkout/calypso-shopping-cart-provider';
 import { getManagePurchaseUrlFor } from '../purchases/paths';
 import PlanFeatures2023GridActions from './components/actions';

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -93,7 +93,6 @@ const Container = (
 };
 
 export type PlanFeatures2023GridProps = {
-	// either you specify the plans prop or isPlaceholder prop
 	plans: PlanSlug[];
 	visiblePlans: PlanSlug[];
 	isInSignup?: boolean;

--- a/client/my-sites/plan-features-2023-grid/lib/sort-plan-properties.ts
+++ b/client/my-sites/plan-features-2023-grid/lib/sort-plan-properties.ts
@@ -4,7 +4,7 @@ import type { PlanProperties } from '../types';
 
 export function sortPlans(
 	planProperties: PlanProperties[],
-	currentSitePlanProductSlug?: string,
+	currentSitePlanProductSlug?: string | null,
 	isMobile?: boolean
 ): PlanProperties[] {
 	let firstPlanIndex = -1;

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -1,6 +1,5 @@
 import { applyTestFiltersToPlansList, PlanSlug } from '@automattic/calypso-products';
 import { FeatureObject } from 'calypso/lib/plans/features-list';
-import type { PricedAPIPlan } from '@automattic/data-stores';
 
 export type TransformedFeatureObject = FeatureObject & {
 	availableForCurrentPlan: boolean;
@@ -19,7 +18,6 @@ export type PlanProperties = {
 	isVisible: boolean;
 	planConstantObj: ReturnType< typeof applyTestFiltersToPlansList >;
 	planName: PlanSlug;
-	planObject: PricedAPIPlan | undefined;
 	product_name_short: string;
 	rawPrice: number | null;
 	rawPriceForMonthlyPlan: number | null;

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -1,5 +1,6 @@
 import { applyTestFiltersToPlansList, PlanSlug } from '@automattic/calypso-products';
 import { FeatureObject } from 'calypso/lib/plans/features-list';
+import type { TranslateResult } from 'i18n-calypso';
 
 export type TransformedFeatureObject = FeatureObject & {
 	availableForCurrentPlan: boolean;
@@ -31,6 +32,6 @@ export type PlanProperties = {
 export interface PlanActionOverrides {
 	loggedInFreePlan?: {
 		callback: () => void;
-		text: string;
+		text: TranslateResult;
 	};
 }

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -21,7 +21,6 @@ export type PlanProperties = {
 	planName: PlanSlug;
 	planObject: PricedAPIPlan | undefined;
 	product_name_short: string;
-	hideMonthly?: boolean;
 	rawPrice: number | null;
 	rawPriceForMonthlyPlan: number | null;
 	relatedMonthlyPlan: null | PricedAPIPlan | undefined;

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -1,6 +1,5 @@
 import { applyTestFiltersToPlansList, PlanSlug } from '@automattic/calypso-products';
 import { FeatureObject } from 'calypso/lib/plans/features-list';
-import type { TranslateResult } from 'i18n-calypso';
 
 export type TransformedFeatureObject = FeatureObject & {
 	availableForCurrentPlan: boolean;
@@ -32,6 +31,6 @@ export type PlanProperties = {
 export interface PlanActionOverrides {
 	loggedInFreePlan?: {
 		callback: () => void;
-		text: TranslateResult;
+		text: string;
 	};
 }

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -28,7 +28,6 @@ export type PlanProperties = {
 	storageOptions: string[];
 	availableForPurchase: boolean;
 	current?: boolean;
-	showMonthlyPrice: boolean;
 	planActionOverrides?: PlanActionOverrides;
 };
 

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -11,7 +11,7 @@ export type PlanProperties = {
 	cartItemForPlan: {
 		product_slug: string;
 	} | null;
-	currencyCode: string | null;
+	currencyCode?: string | null;
 	features: TransformedFeatureObject[];
 	jpFeatures: TransformedFeatureObject[];
 	isPlaceholder?: boolean;

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -20,7 +20,6 @@ export type PlanProperties = {
 	planName: PlanSlug;
 	product_name_short: string;
 	rawPrice: number | null;
-	rawPriceForMonthlyPlan: number | null;
 	isMonthlyPlan: boolean;
 	tagline: string;
 	storageOptions: string[];

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -23,7 +23,6 @@ export type PlanProperties = {
 	product_name_short: string;
 	rawPrice: number | null;
 	rawPriceForMonthlyPlan: number | null;
-	relatedMonthlyPlan: null | PricedAPIPlan | undefined;
 	isMonthlyPlan: boolean;
 	tagline: string;
 	storageOptions: string[];

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -86,7 +86,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 	let activeDiscount =
 		discountInformation &&
 		getDiscountByName( discountInformation.withDiscount, discountInformation.discountEndDate );
-	const creditsValue = useCalculateMaxPlanUpgradeCredit( siteId, visiblePlans );
+	const creditsValue = useCalculateMaxPlanUpgradeCredit( { siteId, plans: visiblePlans } );
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
 
 	switch ( noticeType ) {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -43,6 +43,7 @@ import type { IntervalType } from './types';
 import type { DomainSuggestion } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { PlanFeatures2023GridProps } from 'calypso/my-sites/plan-features-2023-grid';
+import type { PlanActionOverrides } from 'calypso/my-sites/plan-features-2023-grid/types';
 import type { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import type { IAppState } from 'calypso/state/types';
 import './style.scss';
@@ -86,6 +87,7 @@ type OnboardingPricingGrid2023Props = PlansFeaturesMainProps & {
 	planTypeSelectorProps?: PlanTypeSelectorProps;
 	sitePlanSlug?: string | null;
 	siteSlug?: string | null;
+	intent: PlansIntent;
 };
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
@@ -118,8 +120,6 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		onUpgradeClick,
 		selectedFeature,
 		selectedPlan,
-		withDiscount,
-		discountEndDate,
 		siteId,
 		plansWithScroll,
 		isReskinned,
@@ -137,19 +137,19 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		setShowDomainUpsellDialog( true );
 	}, [ setShowDomainUpsellDialog ] );
 
-	let planActionOverrides;
+	let planActionOverrides: PlanActionOverrides | undefined;
 	if ( sitePlanSlug && isFreePlan( sitePlanSlug ) ) {
 		planActionOverrides = {
 			loggedInFreePlan: domainFromHomeUpsellFlow
 				? {
 						callback: showDomainUpsellDialog,
-						text: translate( 'Keep my plan', { context: 'verb' } ),
+						text: translate( 'Keep my plan', { context: 'verb' } ) as string,
 				  }
 				: {
 						callback: () => {
 							page.redirect( `/add-ons/${ siteSlug }` );
 						},
-						text: translate( 'Manage add-ons', { context: 'verb' } ),
+						text: translate( 'Manage add-ons', { context: 'verb' } ) as string,
 				  },
 		};
 	}
@@ -165,9 +165,6 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		visiblePlans,
 		selectedFeature,
 		selectedPlan,
-		withDiscount,
-		discountEndDate,
-		withScroll: plansWithScroll,
 		siteId,
 		isReskinned,
 		intervalType,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -143,13 +143,13 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 			loggedInFreePlan: domainFromHomeUpsellFlow
 				? {
 						callback: showDomainUpsellDialog,
-						text: translate( 'Keep my plan', { context: 'verb' } ) as string,
+						text: translate( 'Keep my plan', { context: 'verb' } ),
 				  }
 				: {
 						callback: () => {
 							page.redirect( `/add-ons/${ siteSlug }` );
 						},
-						text: translate( 'Manage add-ons', { context: 'verb' } ) as string,
+						text: translate( 'Manage add-ons', { context: 'verb' } ),
 				  },
 		};
 	}

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -87,7 +87,7 @@ type OnboardingPricingGrid2023Props = PlansFeaturesMainProps & {
 	planTypeSelectorProps?: PlanTypeSelectorProps;
 	sitePlanSlug?: string | null;
 	siteSlug?: string | null;
-	intent: PlansIntent;
+	intent?: PlansIntent;
 };
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1,7 +1,6 @@
 import {
 	chooseDefaultCustomerType,
 	getPlan,
-	getPopularPlanSpec,
 	isFreePlan,
 	isPersonalPlan,
 	getPlanPath,
@@ -31,7 +30,7 @@ import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-f
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSitePlanSlug, getSiteSlug } from 'calypso/state/sites/selectors';
 import { FreePlanPaidDomainDialog } from './components/free-plan-paid-domain-dialog';
 import useIntentFromSiteMeta from './hooks/use-intent-from-site-meta';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
@@ -84,7 +83,6 @@ interface PlansFeaturesMainProps {
 type OnboardingPricingGrid2023Props = PlansFeaturesMainProps & {
 	visiblePlans: PlanSlug[];
 	plans: PlanSlug[];
-	customerType: string;
 	planTypeSelectorProps?: PlanTypeSelectorProps;
 	sitePlanSlug?: string | null;
 	siteSlug?: string | null;
@@ -113,7 +111,6 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 	const {
 		plans,
 		visiblePlans,
-		customerType,
 		domainName,
 		isInSignup,
 		isLaunchPage,
@@ -136,7 +133,6 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 	const translate = useTranslate();
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
-	const isJetpack = useSelector( ( state: IAppState ) => isJetpackSite( state, siteId ) ) ?? false;
 	const showDomainUpsellDialog = useCallback( () => {
 		setShowDomainUpsellDialog( true );
 	}, [ setShowDomainUpsellDialog ] );
@@ -172,12 +168,6 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		withDiscount,
 		discountEndDate,
 		withScroll: plansWithScroll,
-		popularPlanSpec: getPopularPlanSpec( {
-			flowName,
-			customerType,
-			isJetpack,
-			availablePlans: visiblePlans,
-		} ),
 		siteId,
 		isReskinned,
 		intervalType,
@@ -197,15 +187,9 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 
 	return (
 		<div
-			className={ classNames(
-				'plans-features-main__group',
-				'is-wpcom',
-				`is-customer-${ customerType }`,
-				'is-2023-pricing-grid',
-				{
-					'is-scrollable': plansWithScroll,
-				}
-			) }
+			className={ classNames( 'plans-features-main__group', 'is-wpcom', 'is-2023-pricing-grid', {
+				'is-scrollable': plansWithScroll,
+			} ) }
 			data-e2e-plans="wpcom"
 		>
 			{ asyncPlanFeatures2023Grid }
@@ -421,7 +405,6 @@ const PlansFeaturesMain = ( {
 					<OnboardingPricingGrid2023
 						plans={ defaultPlans }
 						visiblePlans={ visiblePlans }
-						customerType={ _customerType }
 						domainName={ domainName }
 						isInSignup={ isInSignup }
 						isLaunchPage={ isLaunchPage }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -42,6 +42,7 @@ import useVisiblePlansForPlanFeatures from './hooks/use-visible-plans-for-plan-f
 import type { PlansIntent } from './hooks/use-plan-types-with-intent';
 import type { IntervalType } from './types';
 import type { DomainSuggestion } from '@automattic/data-stores';
+import type { PlanFeatures2023GridProps } from 'calypso/my-sites/plan-features-2023-grid';
 import type { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import type { IAppState } from 'calypso/state/types';
 
@@ -158,7 +159,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 	}
 
 	// TODO clk: Needs typing to PlanFeatures2023GridProps
-	const asyncProps = {
+	const asyncProps: PlanFeatures2023GridProps = {
 		domainName,
 		isInSignup,
 		isLaunchPage,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -42,10 +42,10 @@ import useVisiblePlansForPlanFeatures from './hooks/use-visible-plans-for-plan-f
 import type { PlansIntent } from './hooks/use-plan-types-with-intent';
 import type { IntervalType } from './types';
 import type { DomainSuggestion } from '@automattic/data-stores';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { PlanFeatures2023GridProps } from 'calypso/my-sites/plan-features-2023-grid';
 import type { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import type { IAppState } from 'calypso/state/types';
-
 import './style.scss';
 
 interface PlansFeaturesMainProps {
@@ -57,7 +57,7 @@ interface PlansFeaturesMainProps {
 	basePlansPath?: string;
 	selectedPlan?: string;
 	selectedFeature?: string;
-	onUpgradeClick?: ( cartItemForPlan?: { product_slug: string } | null ) => void;
+	onUpgradeClick?: ( cartItemForPlan?: MinimalRequestCartProduct | null ) => void;
 	redirectToAddDomainFlow?: boolean;
 	hidePlanTypeSelector?: boolean;
 	domainName?: string;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -154,7 +154,6 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		};
 	}
 
-	// TODO clk: Needs typing to PlanFeatures2023GridProps
 	const asyncProps: PlanFeatures2023GridProps = {
 		domainName,
 		isInSignup,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -143,13 +143,13 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 			loggedInFreePlan: domainFromHomeUpsellFlow
 				? {
 						callback: showDomainUpsellDialog,
-						text: translate( 'Keep my plan', { context: 'verb' } ),
+						text: translate( 'Keep my plan', { context: 'verb' } ) as string,
 				  }
 				: {
 						callback: () => {
 							page.redirect( `/add-ons/${ siteSlug }` );
 						},
-						text: translate( 'Manage add-ons', { context: 'verb' } ),
+						text: translate( 'Manage add-ons', { context: 'verb' } ) as string,
 				  },
 		};
 	}

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -3,10 +3,9 @@
  */
 
 jest.mock( 'calypso/components/marketing-message', () => () => null );
-jest.mock( 'calypso/components/async-load', () => ( { visiblePlans, popularPlanSpec } ) => (
+jest.mock( 'calypso/components/async-load', () => ( { visiblePlans } ) => (
 	<div data-testid="plan-features">
 		<div data-testid="visible-plans">{ JSON.stringify( visiblePlans ) }</div>
-		<div data-testid="popular-plan-spec">{ JSON.stringify( popularPlanSpec ) }</div>
 	</div>
 ) );
 jest.mock( 'calypso/my-sites/plans-features-main/components/plan-type-selector', () => () => (
@@ -20,7 +19,6 @@ jest.mock( 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan', () => j
 jest.mock( 'calypso/state/selectors/can-upgrade-to-plan', () => jest.fn() );
 
 import {
-	GROUP_WPCOM,
 	PLAN_FREE,
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
@@ -34,12 +32,9 @@ import {
 	PLAN_PERSONAL_MONTHLY,
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
-	TYPE_BUSINESS,
-	TYPE_PREMIUM,
 	PLAN_ENTERPRISE_GRID_WPCOM,
 } from '@automattic/calypso-products';
 import { screen } from '@testing-library/react';
-import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import useIntentFromSiteMeta from '../hooks/use-intent-from-site-meta';
 import PlansFeaturesMain from '../index';
@@ -267,40 +262,6 @@ describe( 'PlansFeaturesMain', () => {
 					PLAN_ECOMMERCE_2_YEARS,
 					PLAN_ENTERPRISE_GRID_WPCOM,
 				] )
-			);
-		} );
-
-		test( 'Highlights TYPE_PREMIUM as popular plan for personal customer type', () => {
-			renderWithProvider( <PlansFeaturesMain { ...myProps } customerType="personal" /> );
-
-			expect( screen.getByTestId( 'popular-plan-spec' ) ).toHaveTextContent(
-				JSON.stringify( {
-					type: TYPE_PREMIUM,
-					group: GROUP_WPCOM,
-				} )
-			);
-		} );
-
-		test( 'Highlights TYPE_BUSINESS as popular plan for business customer type', () => {
-			renderWithProvider( <PlansFeaturesMain { ...myProps } customerType="business" /> );
-
-			expect( screen.getByTestId( 'popular-plan-spec' ) ).toHaveTextContent(
-				JSON.stringify( {
-					type: TYPE_BUSINESS,
-					group: GROUP_WPCOM,
-				} )
-			);
-		} );
-
-		test( 'Highlights TYPE_BUSINESS as popular plan for empty customer type', () => {
-			canUpgradeToPlan.mockReturnValue( true );
-			renderWithProvider( <PlansFeaturesMain { ...myProps } siteId={ 1 } /> );
-
-			expect( screen.getByTestId( 'popular-plan-spec' ) ).toHaveTextContent(
-				JSON.stringify( {
-					type: TYPE_BUSINESS,
-					group: GROUP_WPCOM,
-				} )
 			);
 		} );
 	} );

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -85,7 +85,7 @@ export const isTransferringHostedSiteCreationFlow = ( flowName: string | null ) 
 	return Boolean( flowName && TRANSFERRING_HOSTED_SITE_FLOW === flowName );
 };
 
-export const isAnyHostingFlow = ( flowName: string | null ) => {
+export const isAnyHostingFlow = ( flowName?: string | null ) => {
 	return Boolean(
 		flowName &&
 			[ HOSTING_LP_FLOW, NEW_HOSTED_SITE_FLOW, TRANSFERRING_HOSTED_SITE_FLOW ].includes( flowName )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/78572

## Proposed Changes

- Types the async props passed to `plan-features-2023-grid` form `plans-features-main` (gotta love these naming conventions)
- Removes several redundant/unused properties
- Several TODOs added to be picked up (by author/me) in other work

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm `/start/plans` and `/plans/[paid and free]` work as before. 
* Try a tailored flow e.g. `/setup/link-in-bio`
* Try `plans/[woo site]` as that imports `plan-features-2023-grid` directly
* Notices, plan prices, features, etc. show as normal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
