### PR TITLE
Colors and Fonts variations - Layout and alignment fixes

### DIFF
--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -2,68 +2,68 @@
 	display: grid;
 	gap: 12px;
 	grid-template-columns: repeat(3, 1fr);
-	width: 100%;
+	min-width: 100%;
 	box-sizing: border-box;
 	margin: 14px -2px 26px;
 
 	.global-styles-variation-container__iframe {
-		max-height: 47px;
+		max-height: 52px;
 	}
 
 	&:last-child {
 		margin-bottom: 0;
 	}
-}
 
-.global-styles-variation__title {
-	display: flex;
-	color: var(--color-neutral-100);
-	font-size: $font-body-small;
-	font-weight: 500;
-	letter-spacing: -0.15px;
-	line-height: 1.7;
-}
-
-.global-styles-variation__item {
-	position: relative;
-	margin: 2px;
-	cursor: pointer;
-
-	&::after {
-		content: "";
-		display: block;
-		position: absolute;
-		top: -2px;
-		bottom: -2px;
-		left: -2px;
-		right: -2px;
-		border-radius: 3px; /* stylelint-disable-line scales/radii */
-		opacity: 0;
-		pointer-events: none;
+	.global-styles-variation__title {
+		display: flex;
+		color: var(--color-neutral-100);
+		font-size: $font-body-small;
+		font-weight: 500;
+		letter-spacing: -0.15px;
+		line-height: 1.7;
 	}
 
-	&:hover,
-	&:focus-visible,
-	&.is-active {
+	.global-styles-variation__item {
+		position: relative;
+		margin: 2px;
+		cursor: pointer;
+
 		&::after {
-			opacity: 1;
+			content: "";
+			display: block;
+			position: absolute;
+			top: -2px;
+			bottom: -2px;
+			left: -2px;
+			right: -2px;
+			border-radius: 3px; /* stylelint-disable-line scales/radii */
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		&:hover,
+		&:focus-visible,
+		&.is-active {
+			&::after {
+				opacity: 1;
+			}
+		}
+
+		&.is-active {
+			&::after {
+				box-shadow: 0 0 0 2px var(--studio-gray);
+			}
+		}
+
+		&:hover,
+		&:focus-visible {
+			&::after {
+				box-shadow: 0 0 0 2px var(--color-primary-light);
+			}
 		}
 	}
 
-	&.is-active {
-		&::after {
-			box-shadow: 0 0 0 2px var(--studio-gray);
-		}
+	.global-styles-variation__item-preview {
+		padding: 1px;
 	}
-
-	&:hover,
-	&:focus-visible {
-		&::after {
-			box-shadow: 0 0 0 2px var(--color-primary-light);
-		}
-	}
-}
-
-.global-styles-variation__item-preview {
-	padding: 1px;
 }

--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -14,15 +14,6 @@
 		margin-bottom: 0;
 	}
 
-	.global-styles-variation__title {
-		display: flex;
-		color: var(--color-neutral-100);
-		font-size: $font-body-small;
-		font-weight: 500;
-		letter-spacing: -0.15px;
-		line-height: 1.7;
-	}
-
 	.global-styles-variation__item {
 		position: relative;
 		margin: 2px;
@@ -66,4 +57,13 @@
 	.global-styles-variation__item-preview {
 		padding: 1px;
 	}
+}
+
+.global-styles-variation__title {
+	display: flex;
+	color: var(--color-neutral-100);
+	font-size: $font-body-small;
+	font-weight: 500;
+	letter-spacing: -0.15px;
+	line-height: 1.7;
 }

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -15,7 +15,7 @@ import type { GlobalStylesObject } from '../../types';
 import './style.scss';
 
 interface FontPairingVariationProps {
-	fontPairingVariation: GlobalStylesObject;
+	fontPairingVariation?: GlobalStylesObject;
 	isActive: boolean;
 	composite?: Record< string, unknown >;
 	onSelect: () => void;
@@ -56,13 +56,14 @@ const FontPairingVariation = ( {
 			aria-label={
 				translate( 'Font: %s', {
 					comment: 'Aria label for font preview buttons',
-					args: fontPairingVariation.title ?? translate( 'Free font' ),
+					// The default font pairing has no title
+					args: fontPairingVariation?.title ?? translate( 'Free font' ),
 				} ) as string
 			}
 		>
 			<div className="global-styles-variation__item-preview">
 				<GlobalStylesContext.Provider value={ context }>
-					<FontPairingVariationPreview title={ fontPairingVariation.title } />
+					<FontPairingVariationPreview />
 				</GlobalStylesContext.Provider>
 			</div>
 		</CompositeItem>
@@ -75,7 +76,7 @@ const FontPairingVariations = ( {
 	selectedFontPairingVariation,
 	onSelect,
 }: FontPairingVariationsProps ) => {
-	const { base } = useContext( GlobalStylesContext );
+	// The theme font pairings don't include the default font pairing
 	const fontPairingVariations = useFontPairingVariations( siteId, stylesheet ) ?? [];
 	const composite = useCompositeState();
 
@@ -89,7 +90,7 @@ const FontPairingVariations = ( {
 			<div className="font-pairing-variations">
 				<FontPairingVariation
 					key="base"
-					fontPairingVariation={ { ...base, title: translate( 'Free font' ) } }
+					// The base is the theme.json, which has the default font pairing
 					isActive={ ! selectedFontPairingVariation }
 					composite={ composite }
 					onSelect={ () => onSelect( null ) }

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -9,15 +9,14 @@ import {
 } from '@wordpress/edit-site/build-module/components/global-styles/hooks';
 import { translate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
-import { STYLE_PREVIEW_WIDTH, STYLE_PREVIEW_HEIGHT, SYSTEM_FONT_SLUG } from '../../constants';
+import { FONT_PREVIEW_WIDTH, FONT_PREVIEW_HEIGHT, SYSTEM_FONT_SLUG } from '../../constants';
 import GlobalStylesVariationContainer from '../global-styles-variation-container';
 import FontFamiliesLoader from './font-families-loader';
 import type { FontFamily } from '../../types';
 
 const DEFAULT_FONT_STYLES: React.CSSProperties = {
-	whiteSpace: 'nowrap',
-	overflow: 'hidden',
-	textOverflow: 'ellipsis',
+	textAlign: 'center',
+	color: '#000000',
 };
 
 interface Props {
@@ -29,6 +28,7 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 
 	const [ textFontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
 	const [ textFontStyle = 'normal' ] = useStyle( 'typography.fontStyle' );
+	const [ textLetterSpacing = '-0.15px' ] = useStyle( 'typography.letterSpacing' );
 	const [ textFontWeight = 400 ] = useStyle( 'typography.fontWeight' );
 
 	const [ headingFontFamily = textFontFamily ] = useStyle(
@@ -38,10 +38,13 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 	const [ headingFontWeight = textFontWeight ] = useStyle(
 		'elements.heading.typography.fontWeight'
 	);
+	const [ headingLetterSpacing = textLetterSpacing ] = useStyle(
+		'elements.heading.typography.letterSpacing'
+	);
 
 	const [ containerResizeListener, { width } ] = useResizeObserver();
-	const ratio = width ? width / STYLE_PREVIEW_WIDTH : 1;
-	const normalizedHeight = Math.ceil( STYLE_PREVIEW_HEIGHT * ratio * 0.5 );
+	const ratio = width ? width / FONT_PREVIEW_WIDTH : 1;
+	const normalizedHeight = Math.ceil( FONT_PREVIEW_HEIGHT * ratio );
 	const externalFontFamilies = fontFamilies.filter( ( { slug } ) => slug !== SYSTEM_FONT_SLUG );
 	const [ isLoaded, setIsLoaded ] = useState( ! externalFontFamilies.length );
 
@@ -94,14 +97,14 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 									overflow: 'hidden',
 								} }
 							>
-								<VStack spacing={ 1 } style={ { margin: '16px' } }>
+								<VStack spacing={ 1 } style={ { margin: '12px', width: '100%' } }>
 									<div
-										title={ headingFontFamilyName }
 										aria-label={ headingFontFamilyName }
 										style={ {
 											...DEFAULT_FONT_STYLES,
-											color: '#000000',
-											fontSize: '16px',
+											fontSize: '18px',
+											lineHeight: '22px',
+											letterSpacing: headingLetterSpacing,
 											fontWeight: headingFontWeight,
 											fontFamily: headingFontFamily,
 											fontStyle: headingFontStyle,
@@ -110,12 +113,12 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 										{ headingFontFamilyName }
 									</div>
 									<div
-										title={ textFontFamilyName }
 										aria-label={ textFontFamilyName }
 										style={ {
 											...DEFAULT_FONT_STYLES,
-											color: '#444444',
-											fontSize: '14px',
+											fontSize: '13px',
+											lineHeight: '23px',
+											letterSpacing: textLetterSpacing,
 											fontWeight: textFontWeight,
 											fontFamily: textFontFamily,
 											fontStyle: textFontStyle,

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -142,7 +142,7 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 								<div
 									style={ {
 										...DEFAULT_FONT_STYLES,
-										lineHeight: '1em',
+										width: '100%',
 										letterSpacing: textLetterSpacing,
 										fontWeight: textFontWeight,
 										fontFamily: textFontFamily,

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -97,12 +97,12 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 									overflow: 'hidden',
 								} }
 							>
-								<VStack spacing={ 1 } style={ { margin: '12px', width: '100%' } }>
+								<VStack spacing={ 1 } style={ { margin: '10px', width: '100%' } }>
 									<div
 										aria-label={ headingFontFamilyName }
 										style={ {
 											...DEFAULT_FONT_STYLES,
-											fontSize: '18px',
+											fontSize: '13.5vw', // 18px for min-width wide breakpoint
 											lineHeight: '22px',
 											letterSpacing: headingLetterSpacing,
 											fontWeight: headingFontWeight,

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -7,7 +7,6 @@ import {
 	useSetting,
 	useStyle,
 } from '@wordpress/edit-site/build-module/components/global-styles/hooks';
-import { translate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import { FONT_PREVIEW_WIDTH, FONT_PREVIEW_HEIGHT, SYSTEM_FONT_SLUG } from '../../constants';
 import GlobalStylesVariationContainer from '../global-styles-variation-container';
@@ -20,11 +19,7 @@ const DEFAULT_FONT_STYLES: React.CSSProperties = {
 	color: '#000000',
 };
 
-interface Props {
-	title?: string;
-}
-
-const FontPairingVariationPreview = ( { title }: Props ) => {
+const FontPairingVariationPreview = () => {
 	const [ fontFamilies ] = useSetting( 'typography.fontFamilies' ) as [ FontFamily[] ];
 
 	const [ textFontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
@@ -89,70 +84,44 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 							overflow: 'hidden',
 						} }
 					>
-						{ title ? (
-							<HStack
-								spacing={ 10 * ratio }
-								justify="flex-start"
-								style={ {
-									height: '100%',
-									overflow: 'hidden',
-								} }
-							>
-								<VStack spacing={ 1 } style={ { margin: '10px', width: '100%' } }>
-									<div
-										aria-label={ headingFontFamilyName }
-										style={ {
-											...DEFAULT_FONT_STYLES,
-											lineHeight: '22px',
-											letterSpacing: headingLetterSpacing,
-											fontWeight: headingFontWeight,
-											fontFamily: headingFontFamily,
-											fontStyle: headingFontStyle,
-										} }
-									>
-										{ headingFontFamilyName }
-									</div>
-									<div
-										aria-label={ textFontFamilyName }
-										style={ {
-											...DEFAULT_FONT_STYLES,
-											fontSize: '13px',
-											lineHeight: '23px',
-											letterSpacing: textLetterSpacing,
-											fontWeight: textFontWeight,
-											fontFamily: textFontFamily,
-											fontStyle: textFontStyle,
-										} }
-									>
-										{ textFontFamilyName }
-									</div>
-								</VStack>
-							</HStack>
-						) : (
-							<HStack
-								align="center"
-								justify="flex-start"
-								style={ {
-									height: '100%',
-									overflow: 'hidden',
-									padding: '16px',
-									boxSizing: 'border-box',
-								} }
-							>
+						<HStack
+							spacing={ 10 * ratio }
+							justify="flex-start"
+							style={ {
+								height: '100%',
+								overflow: 'hidden',
+							} }
+						>
+							<VStack spacing={ 1 } style={ { margin: '10px', width: '100%' } }>
 								<div
+									aria-label={ headingFontFamilyName }
 									style={ {
 										...DEFAULT_FONT_STYLES,
-										width: '100%',
+										lineHeight: '22px',
+										letterSpacing: headingLetterSpacing,
+										fontWeight: headingFontWeight,
+										fontFamily: headingFontFamily,
+										fontStyle: headingFontStyle,
+									} }
+								>
+									{ headingFontFamilyName }
+								</div>
+								<div
+									aria-label={ textFontFamilyName }
+									style={ {
+										...DEFAULT_FONT_STYLES,
+										fontSize: '13px',
+										lineHeight: '23px',
 										letterSpacing: textLetterSpacing,
 										fontWeight: textFontWeight,
 										fontFamily: textFontFamily,
 										fontStyle: textFontStyle,
 									} }
 								>
-									{ translate( 'Default' ) }
+									{ textFontFamilyName }
 								</div>
-							</HStack>
-						) }
+							</VStack>
+						</HStack>
 					</div>
 				</div>
 				<FontFamiliesLoader fontFamilies={ externalFontFamilies } onLoad={ handleOnLoad } />

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -15,6 +15,7 @@ import FontFamiliesLoader from './font-families-loader';
 import type { FontFamily } from '../../types';
 
 const DEFAULT_FONT_STYLES: React.CSSProperties = {
+	fontSize: '13.5vw', // 18px for min-width wide breakpoint and 15px for max-width wide
 	textAlign: 'center',
 	color: '#000000',
 };
@@ -102,7 +103,6 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 										aria-label={ headingFontFamilyName }
 										style={ {
 											...DEFAULT_FONT_STYLES,
-											fontSize: '13.5vw', // 18px for min-width wide breakpoint
 											lineHeight: '22px',
 											letterSpacing: headingLetterSpacing,
 											fontWeight: headingFontWeight,
@@ -141,13 +141,12 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 							>
 								<div
 									style={ {
+										...DEFAULT_FONT_STYLES,
+										lineHeight: '1em',
+										letterSpacing: textLetterSpacing,
+										fontWeight: textFontWeight,
 										fontFamily: textFontFamily,
 										fontStyle: textFontStyle,
-										color: '#000000',
-										fontSize: '16px',
-										fontWeight: textFontWeight,
-										lineHeight: '1em',
-										textAlign: 'center',
 									} }
 								>
 									{ translate( 'Default' ) }

--- a/packages/global-styles/src/components/font-pairing-variations/style.scss
+++ b/packages/global-styles/src/components/font-pairing-variations/style.scss
@@ -14,15 +14,6 @@
 		max-height: 106px;
 	}
 
-	.global-styles-variation__title {
-		display: flex;
-		color: var(--color-neutral-100);
-		font-size: $font-body-small;
-		font-weight: 500;
-		letter-spacing: -0.15px;
-		line-height: 1.4;
-	}
-
 	.global-styles-variation__item {
 		position: relative;
 		margin: 2px;
@@ -66,4 +57,13 @@
 	.global-styles-variation__item-preview {
 		padding: 1px;
 	}
+}
+
+.global-styles-variation__title {
+	display: flex;
+	color: var(--color-neutral-100);
+	font-size: $font-body-small;
+	font-weight: 500;
+	letter-spacing: -0.15px;
+	line-height: 1.4;
 }

--- a/packages/global-styles/src/components/font-pairing-variations/style.scss
+++ b/packages/global-styles/src/components/font-pairing-variations/style.scss
@@ -1,69 +1,69 @@
 .font-pairing-variations {
 	display: grid;
-	gap: 12px;
-	grid-template-columns: repeat(1, 1fr);
-	width: 100%;
+	gap: 10px 6px;
+	grid-template-columns: repeat(2, 1fr);
+	min-width: 100%;
 	box-sizing: border-box;
 	margin: 14px -2px 26px;
-
-	.global-styles-variation-container__iframe {
-		max-height: 80px;
-	}
 
 	&:last-child {
 		margin-bottom: 0;
 	}
-}
 
-.global-styles-variation__title {
-	display: flex;
-	color: var(--color-neutral-100);
-	font-size: $font-body-small;
-	font-weight: 500;
-	letter-spacing: -0.15px;
-	line-height: 1.4;
-}
-
-.global-styles-variation__item {
-	position: relative;
-	margin: 2px;
-	cursor: pointer;
-
-	&::after {
-		content: "";
-		display: block;
-		position: absolute;
-		top: -2px;
-		bottom: -2px;
-		left: -2px;
-		right: -2px;
-		border-radius: 3px; /* stylelint-disable-line scales/radii */
-		opacity: 0;
-		pointer-events: none;
+	.global-styles-variation-container__iframe {
+		max-height: 106px;
 	}
 
-	&:hover,
-	&:focus-visible,
-	&.is-active {
+	.global-styles-variation__title {
+		display: flex;
+		color: var(--color-neutral-100);
+		font-size: $font-body-small;
+		font-weight: 500;
+		letter-spacing: -0.15px;
+		line-height: 1.4;
+	}
+
+	.global-styles-variation__item {
+		position: relative;
+		margin: 2px;
+		cursor: pointer;
+
 		&::after {
-			opacity: 1;
+			content: "";
+			display: block;
+			position: absolute;
+			top: -2px;
+			bottom: -2px;
+			left: -2px;
+			right: -2px;
+			border-radius: 3px; /* stylelint-disable-line scales/radii */
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		&:hover,
+		&:focus-visible,
+		&.is-active {
+			&::after {
+				opacity: 1;
+			}
+		}
+
+		&.is-active {
+			&::after {
+				box-shadow: 0 0 0 2px var(--studio-gray);
+			}
+		}
+
+		&:hover,
+		&:focus-visible {
+			&::after {
+				box-shadow: 0 0 0 2px var(--color-primary-light);
+			}
 		}
 	}
 
-	&.is-active {
-		&::after {
-			box-shadow: 0 0 0 2px var(--studio-gray);
-		}
+	.global-styles-variation__item-preview {
+		padding: 1px;
 	}
-
-	&:hover,
-	&:focus-visible {
-		&::after {
-			box-shadow: 0 0 0 2px var(--color-primary-light);
-		}
-	}
-}
-
-.global-styles-variation__item-preview {
-	padding: 1px;
 }

--- a/packages/global-styles/src/constants.ts
+++ b/packages/global-styles/src/constants.ts
@@ -1,5 +1,7 @@
 export const STYLE_PREVIEW_WIDTH = 248;
 export const STYLE_PREVIEW_HEIGHT = 152;
+export const FONT_PREVIEW_WIDTH = 136;
+export const FONT_PREVIEW_HEIGHT = 106;
 export const STYLE_PREVIEW_COLOR_SWATCH_SIZE = 32;
 
 export const DEFAULT_GLOBAL_STYLES_VARIATION_TITLE = 'default';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78524

Figma Tv3pYqA3EcRfiXC31IxrXE-fi-751_33823

## Proposed Changes

* Font pairing variations in a two-column layout
  * Added support for `typography.letterSpacing` and `elements.heading.typography.letterSpacing` 
  * Removed the tooltip on font names because they are now fully visible
* Color variations boxes alignment fix
* Nesting selectors for fonts and colors to avoid overwriting

Notes:
- The new design for fonts has:
  - `letter-spacing: -0.15px` for all fonts except for "Commissioner" which uses `letter-spacing: -1.15px`
    - I added support for `elements.heading.typography.letterSpacing`
    - The diff D114804-code updates the "letterSpacing" for "Commissioner" in `global-styles-variation/default/font-pairings/commissioner-crimsonpro.json`
  - a border of 1px for the boxes
    - I have **not** changed it for consistency with the hover and focus border we use on the rest of the screens
- The heading font size is `13.5vw` to adjust automatically to the shorter sidebar
  - `18px` for min-width wide (as in the design)
  - `15px` for max-width wide
    - I like this solution because is much simpler than using breakpoints, listening to the window resize event...

### Commissioner letter spacing 

|BEFORE the diff|AFTER the diff (D114804-code)|
|---|---|
|<img width="146" alt="Screenshot 2566-06-28 at 18 11 18" src="https://github.com/Automattic/wp-calypso/assets/1881481/47ed3cb7-ce25-4e51-947f-ab1664e406dd">|<img width="146" alt="Screenshot 2566-06-28 at 17 54 13" src="https://github.com/Automattic/wp-calypso/assets/1881481/f354e6f5-3ccd-4be7-ba58-11e023371ee7">|

### Font pairing variations in a two-column layout

|BEFORE|AFTER Chrome|AFTER max-width wide|AFTER Safari ✌️|
|---|---|---|--|
|<img width="302" alt="Screenshot 2566-06-28 at 17 06 26" src="https://github.com/Automattic/wp-calypso/assets/1881481/8d84b336-3706-46b2-9bae-79b24c26a060">|<img width="352" alt="Screenshot 2566-06-28 at 18 23 23" src="https://github.com/Automattic/wp-calypso/assets/1881481/fc15f7a2-4f17-4f74-ae16-2df9c1ad4ef1">|<img width="302" alt="Screenshot 2566-06-28 at 18 23 58" src="https://github.com/Automattic/wp-calypso/assets/1881481/0525ce3b-a72d-46e0-b01a-69603d7ba17d">|<img width="301" alt="Screenshot 2566-06-28 at 18 27 30" src="https://github.com/Automattic/wp-calypso/assets/1881481/cd7b4a81-17ff-4c9c-8743-62b27e87b7aa">|

### Color variations boxes alignment fix

|BEFORE 🧐|AFTER|
|---|---|
|<img width="296" alt="Screenshot 2566-06-28 at 17 34 46" src="https://github.com/Automattic/wp-calypso/assets/1881481/964f04eb-7b81-4ff8-b54d-b27b7e157e3a">|<img width="296" alt="Screenshot 2566-06-28 at 17 34 00" src="https://github.com/Automattic/wp-calypso/assets/1881481/4fb255b8-06b0-4e22-8ef3-f817d3f5b2a1">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on Safari and Chrome
* Test on a window width smaller and larger than `1280px`
* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3`
* Click on "Fonts" and verify the two-column layout and alignments looks good
* Click on "Colors" and verify the alignment looks better


https://github.com/Automattic/wp-calypso/assets/1881481/6abb7a35-7ae8-407a-93ec-0861c7599b3c



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?