### PR TITLE
BulkDomainTransfer: disable retries when checking domain code

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
@@ -28,6 +28,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		},
 		{
 			enabled: Boolean( ! passed && passedLocalValidation ),
+			retry: false,
 		}
 	);
 


### PR DESCRIPTION
React query has a default retry enabled.
In the bulk domain transfer when we have the wrong auth code, this request retries 3 times before if actually fails.
This leads to slow UI since we wait 3 times for the same result.

## Proposed Changes

* Disable retries when using `useIsDomainCodeValid`

## Testing Instructions
- Use the PR build
- To to the step `/setup/bulk-domain-transfer/domains`
- Enter domain in the form and enter some text for auth code
- The error should be reported immediately after the first request errors out.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
