### PR TITLE
Help Center: Remove a8c button from Help Center

### DIFF
--- a/packages/help-center/src/components/help-center-gpt.tsx
+++ b/packages/help-center/src/components/help-center-gpt.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button, LoadingPlaceholder } from '@automattic/components';
+import { LoadingPlaceholder } from '@automattic/components';
 import { HelpCenterSelect, useJetpackSearchAIQuery } from '@automattic/data-stores';
 import styled from '@emotion/styled';
+import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';


### PR DESCRIPTION
Copy of https://github.com/Automattic/wp-calypso/pull/75896

Pinged you guys to document this issue. `automattic/components`'s button is pretty bad. 

Context: pdDR7T-Jm-p2#comment-769