### PR TITLE
Jetpack Cloud: Allow license card lightbox links to wrap

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/index.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import ModalLinkIcon from 'calypso/assets/images/jetpack/jetpack-icon-modal-link.svg';
+import { preventWidows } from 'calypso/lib/formatting';
 
 import './style.scss';
 
@@ -13,11 +14,17 @@ type Props = {
 const LicenseLightboxLink: FunctionComponent< Props > = ( { productName, onClick } ) => {
 	const translate = useTranslate();
 
+	// In this specific context, not wrapping between words in a product name
+	// gives us a more readable, professional look
+	const noWrapProductName = <>{ preventWidows( productName, Infinity ) }</>;
+
 	return (
 		<Button className="license-lightbox-link" plain onClick={ onClick }>
-			{ translate( 'More about {{productName/}}', {
-				components: { productName: <>{ productName }</> },
-			} ) }
+			<span className="license-lightbox-link__text">
+				{ translate( 'More about {{productName/}}', {
+					components: { productName: noWrapProductName },
+				} ) }
+			</span>
 
 			<img className="license-lightbox-link-icon" src={ ModalLinkIcon } alt="" />
 		</Button>

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/style.scss
@@ -10,6 +10,10 @@
 	white-space: nowrap;
 }
 
+.license-lightbox-link__text {
+	white-space: initial;
+}
+
 .license-lightbox-link-icon {
 	display: inline-block;
 	margin-bottom: -5px;


### PR DESCRIPTION
Resolves `1202619025189113-as-1204839472451653`.
Relates to #78233.

This pull request fixes an issue in which product cards fail to resize properly in several screen widths, especially for products with longer names. Instead of maintaining the correct width, the product card becomes too wide and encroaches on established padding on the left and right sides of the page (see "before" reference video).

## Proposed Changes

In the context of the `LicenseLightboxLink` component:

* Move the product name text into its own `span` element.
* Add a style to the new `span` and set it to `white-space: initial` to allow text wrapping for the product name _only_.
* Specify with `preventWidows` that the words of product names should always be kept on the same line.

## Testing Instructions

1. Visit the "Issue New License" page in Jetpack Cloud.
2. Paying attention to the width of each product card (especially those with longer names, like VaultPress Backup 10GB), resize the browser window from narrow (<350px) to wide (>1280px). Verify the following behaviors:
  **a.** The width of all cards is uniform and never violates established left- or right-side gaps/padding.
  **b.** The product name in the "More about" link is never split across multiple lines.
  **c.** The external link icon in the "More about" link never wraps onto a line by itself (i.e., it's always on the same line as the product name).

### Reference videos

#### Before

https://github.com/Automattic/wp-calypso/assets/670067/66f252d4-5d3e-46da-b5cc-ed6e51657444

#### After

https://github.com/Automattic/wp-calypso/assets/670067/d80930e2-2cde-47ca-9bbd-93510dc343b1

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204839472451653