### PR TITLE
Newsletter: Fix styling bug on setup form

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
@@ -19,7 +19,7 @@ $side-margin: 16;
 	}
 }
 
-.accent-color-control__accent-color-input {
+.select-dropdown.accent-color-control__accent-color-input {
 	background-size: 25px, auto;
 	background-position: left 13px center, 95% !important;
 	background-repeat: no-repeat, no-repeat !important;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fixes styling bug on the setup form during Newsletter onboarding. One of the input bottom borders is hidden/missing. This was a css specificity issue - styling for the core component is overriding some custom styling. It had been fine, so something changed recently. See slack discussion here: p1687946912573919-slack-C052XEUUBL4

**Bug looks like:**
![setup form](https://github.com/Automattic/wp-calypso/assets/21228350/d051ddc0-3a5f-4193-9c5a-8c30dd7f5c2b)

## Testing Instructions

1) Load this branch locally and start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro
2) On setup form, confirm that bottom line now appears on input in screenshot above. 