### PR TITLE
Reader: Suggested Follows - if no related sites found - don't show modal

### DIFF
--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -10,7 +10,7 @@ const ReaderSuggestedFollowsDialog = ( { onClose, siteId, postId, isVisible } ) 
 	const translate = useTranslate();
 	const { data, isLoading } = useRelatedSites( siteId, postId );
 	// If we are no longer loading and no data available, don't show the dialog
-	if ( ! isLoading && ! data ) {
+	if ( ! isLoading && data === undefined ) {
 		return null;
 	}
 	return (


### PR DESCRIPTION
This PR fixes an issue where the modal loads with no data. The logic needs to check if the data is set to `undefined`, not false.

There are cases where no related sites are found for a particular site/feed and we need to not show the modal in this case. 

### Example

<img width="706" alt="Screenshot 2023-06-28 at 15 14 44" src="https://github.com/Automattic/wp-calypso/assets/5560595/ef169472-f426-421f-ae2f-ca44843fa1fd">

### Testing

* Go to http://calypso.localhost:3000/read/feeds/18062660 and click Follow - you should see the modal above
* Apply PR and retry and you shouldn't see the modal
