### PR TITLE
Launchpad: Update "Edit site design" task to go to edit mode in site editor

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -2,6 +2,7 @@ import { CircularProgressBar } from '@automattic/components';
 import { useLaunchpad } from '@automattic/data-stores';
 import { Launchpad, Task } from '@automattic/launchpad';
 import { isMobile } from '@automattic/viewport';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -70,7 +71,11 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 				case 'design_edited':
 					actionDispatch = () => {
 						recordTaskClickTracksEvent( task );
-						window.location.assign( `/site-editor/${ siteSlug }` );
+						window.location.assign(
+							addQueryArgs( `/site-editor/${ siteSlug }`, {
+								canvas: 'edit',
+							} )
+						);
 					};
 					break;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76966

## Proposed Changes

* Add a query arg specifying we want the "edit" mode in the site editor, not preview mode.

**Before**
<img width="1677" alt="Screen Shot 2023-06-28 at 10 59 08 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/78820daf-351d-4ccb-bc03-98d780348c5a">

**After**
<img width="1664" alt="Screen Shot 2023-06-28 at 10 59 53 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/e35b533c-f328-49c0-a902-5b2070e64e5f">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site from `/start` and select the "Promote myself or business" intent during onboarding.
* Launch your site without completing the "Edit site design" task.
* Land in Customer Home with the Keep Building task list enabled.
* Click on the "Edit site design" task.
* You should be brought to the site editor in "edit" mode (see above for the visual difference) and you should see the `?canvas=edit` query param in the URL

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
