### PR TITLE
Jetpack Pro Dashboard: Fix license card layout for Woo products expanding beyond its container

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/index.tsx
@@ -16,7 +16,17 @@ const LicenseLightboxLink: FunctionComponent< Props > = ( { productName, onClick
 	return (
 		<Button className="license-lightbox-link" plain onClick={ onClick }>
 			{ translate( 'More about {{productName/}}', {
-				components: { productName: <>{ productName }</> },
+				components: {
+					productName:
+						productName.indexOf( 'WooCommerce' ) !== -1 ? (
+							<>
+								<br />
+								{ productName }
+							</>
+						) : (
+							<>{ productName }</>
+						),
+				},
 			} ) }
 
 			<img className="license-lightbox-link-icon" src={ ModalLinkIcon } alt="" />

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/index.tsx
@@ -16,17 +16,7 @@ const LicenseLightboxLink: FunctionComponent< Props > = ( { productName, onClick
 	return (
 		<Button className="license-lightbox-link" plain onClick={ onClick }>
 			{ translate( 'More about {{productName/}}', {
-				components: {
-					productName:
-						productName.indexOf( 'WooCommerce' ) !== -1 ? (
-							<>
-								<br />
-								{ productName }
-							</>
-						) : (
-							<>{ productName }</>
-						),
-				},
+				components: { productName: <>{ productName }</> },
 			} ) }
 
 			<img className="license-lightbox-link-icon" src={ ModalLinkIcon } alt="" />

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/style.scss
@@ -7,7 +7,6 @@
 	text-decoration: underline;
 	text-align: left;
 	cursor: pointer;
-	white-space: nowrap;
 }
 
 .license-lightbox-link-icon {


### PR DESCRIPTION
## Proposed Changes

* Jetpack Pro Dashboard: Fix the more details lightbox button causing its license card to expand beyond the intended width breaking the license card layout.

![Screen Shot 2023-06-28 at 18 12 12](https://github.com/Automattic/wp-calypso/assets/22746396/f12fe001-44a8-4f68-807d-ca5a1363637a)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout D114869-code
* Open up http://jetpack.cloud.localhost:3000/partner-portal/issue-license and confirm the license cards do not overlap each other.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
