### PR TITLE
Update responsive styles for new compact feed component

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -140,6 +140,13 @@
 			width: 200px !important;
 			min-height: 140px;
 			max-height: 140px;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				width: unset !important;
+				height: 300px !important;
+				min-height: 300px;
+				max-height: 300px;
+			}
 		}
 
 		.reader-post-card__post {
@@ -156,6 +163,10 @@
 			flex-direction: row;
 			gap: 24px;
 			margin-bottom: 8px;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				flex-direction: column-reverse;
+			}
 		}
 
 		.reader-post-card__post-details {


### PR DESCRIPTION
## Description

Yesterday evening, @roo2 reported that responsive styles looked off in our new compact feed component. I told him I'd take a look today.

### Before

![CleanShot 2023-06-28 at 11 11 09](https://github.com/Automattic/wp-calypso/assets/5634774/b3b4731f-ee84-455b-8d4a-697a4d7dd052)

### After

![CleanShot 2023-06-28 at 11 19 16](https://github.com/Automattic/wp-calypso/assets/5634774/bb600d37-a7ec-49dd-a6c7-530b51d850d5)

## Testing

- Apply this patch
- Head to any tag page
- Reduce the size of your browser