### PR TITLE
Made the Subscriptions Manager document title better

### DIFF
--- a/client/landing/subscriptions/components/subscription-manager-page/subscription-manager-page.tsx
+++ b/client/landing/subscriptions/components/subscription-manager-page/subscription-manager-page.tsx
@@ -2,7 +2,6 @@ import { SubscriptionManager } from '@automattic/data-stores';
 import { UniversalNavbarHeader } from '@automattic/wpcom-template-parts';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import { TabsSwitcher } from 'calypso/landing/subscriptions/components/tabs-switcher';
@@ -30,7 +29,6 @@ const SubscriptionManagementPage = () => {
 				isLoggedIn={ isLoggedIn }
 			/>
 			<Main className="subscription-manager__container">
-				<DocumentHead title="Subscriptions" />
 				<FormattedHeader
 					brandFont
 					headerText={ translate( 'Subscription management' ) }

--- a/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
@@ -3,6 +3,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import DocumentHead from 'calypso/components/data/document-head';
 import Nav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -68,10 +69,18 @@ const useTabs = (): SubscriptionManagerTab[] => {
 };
 
 const TabsSwitcher = () => {
+	const translate = useTranslate();
 	const tabs = useTabs();
 	const { label: selectedText, count: selectedCount } = tabs.find( ( tab ) => tab.selected ) ?? {};
 	return (
 		<>
+			<DocumentHead
+				title={ translate( 'Subscriptions: %s', {
+					args: selectedText,
+					comment:
+						'%s is the selected tab. Example: "Subscriptions: Sites" or "Subscriptions: Comments"',
+				} ) }
+			/>
 			<Nav
 				className="subscription-manager-tab-switcher"
 				selectedText={ selectedText }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78582

## Proposed Changes

This PR improves the title of the document in the Subscription Manager. Where it said only `Subscriptions — WordPress.com`, now it shows a title depending on the tab selected:

```
Subscriptions: Sites — WordPress.com
Subscriptions: Comments — WordPress.com
Subscriptions: Pending — WordPress.com
Subscriptions: Settings — WordPress.com
```
<img width="1021" alt="Screenshot 2023-06-28 at 18 09 37 (1)" src="https://github.com/Automattic/wp-calypso/assets/3832570/c76d0a66-1010-4258-88f7-4b69085de1ce">

## Testing Instructions

1. Apply this PR and run the application.
2. Go to `http://calypso.localhost:3000/subscriptions/sites`.
3. Check the title should say `Subscriptions: Sites -- WordPress.com`.
4. Change tabs and check the title in the tab should change accordingly.
5. Change language and check the language is changed in the document title too.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
