### PR TITLE
Reader: adapt compact card image size for small screens

### DIFF
--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -1,3 +1,4 @@
+import { useBreakpoint } from '@automattic/viewport-react';
 import PropTypes from 'prop-types';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import ReaderPostEllipsisMenu from 'calypso/blocks/reader-post-options-menu/reader-post-ellipsis-menu';
@@ -20,6 +21,8 @@ const CompactPost = ( {
 			? () => expandCard( { postKey, post, site } )
 			: null;
 
+	const isSmallScreen = useBreakpoint( '<660px' );
+
 	return (
 		<div className="reader-post-card__post">
 			<div className="reader-post-card__post-content">
@@ -35,7 +38,7 @@ const CompactPost = ( {
 							</AutoDirection>
 							{ postByline }
 						</div>
-						{ ! post.canonical_media && (
+						{ ( ! post.canonical_media || isSmallScreen ) && (
 							<ReaderPostEllipsisMenu
 								site={ site }
 								teams={ teams }
@@ -48,12 +51,14 @@ const CompactPost = ( {
 				</div>
 				{ post.canonical_media && (
 					<div className="reader-post-card__post-media">
-						<ReaderPostEllipsisMenu
-							site={ site }
-							teams={ teams }
-							post={ post }
-							showFollow={ false }
-						/>
+						{ ! isSmallScreen && (
+							<ReaderPostEllipsisMenu
+								site={ site }
+								teams={ teams }
+								post={ post }
+								showFollow={ false }
+							/>
+						) }
 						<FeaturedAsset
 							post={ post }
 							canonicalMedia={ post.canonical_media }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -138,8 +138,15 @@
 	&.is-compact {
 		.reader-featured-image {
 			width: 200px !important;
-			min-height: 140px;
-			max-height: 140px;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				width: auto !important;
+				height: 300px !important;
+			}
+
+			@include breakpoint-deprecated( "<480px" ) {
+				height: 200px !important;
+			}
 		}
 
 		.reader-post-card__post {
@@ -156,6 +163,10 @@
 			flex-direction: row;
 			gap: 24px;
 			margin-bottom: 8px;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				flex-direction: column-reverse;
+			}
 		}
 
 		.reader-post-card__post-details {


### PR DESCRIPTION
## Proposed Changes

Expands compact Reader card image to single column for smaller screens. Alternative to 
https://github.com/Automattic/wp-calypso/pull/78745/files.

## Testing Instructions

* View `/tag/{tag-slug}` or `/read/feeds/{feed-id}` on smaller screens to check layout

| **Before** | **After** |
| - | - |
| <img width="398" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1699996/f64b2f19-8bf2-4201-ae09-f825e527184e"> | <img width="412" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1699996/5bc49413-080a-40b2-97c1-a4cae1dcd200"> |



