### PR TITLE
BulkDomainTransfer: improve default error message

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
@@ -3,6 +3,7 @@ import { doesStringResembleDomain } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import { useDebounce } from 'use-debounce';
+import { getAvailabilityErrorMessage } from 'calypso/components/domains/use-my-domain/utilities';
 
 export function useValidationMessage( domain: string, auth: string, hasDuplicates: boolean ) {
 	// record passed domains to avoid revalidation
@@ -117,12 +118,21 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 			refetch,
 		};
 	}
+
+	const message = getAvailabilityErrorMessage( {
+		availabilityData: validationResult,
+		domainName: domainDebounced,
+		selectedSite: {},
+	} );
+
 	return {
 		valid: false,
 		loading: false,
-		message: __(
-			'An unknown error occurred while checking the domain transferability. Please try again or contact support'
-		),
+		message:
+			message ||
+			__(
+				'An unknown error occurred while checking the domain transferability. Please try again or contact support'
+			),
 		refetch,
 	};
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
@@ -3,7 +3,7 @@ import { doesStringResembleDomain } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import { useDebounce } from 'use-debounce';
-import { getAvailabilityErrorMessage } from 'calypso/components/domains/use-my-domain/utilities';
+import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
 
 export function useValidationMessage( domain: string, auth: string, hasDuplicates: boolean ) {
 	// record passed domains to avoid revalidation
@@ -119,17 +119,13 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		};
 	}
 
-	const message = getAvailabilityErrorMessage( {
-		availabilityData: validationResult,
-		domainName: domainDebounced,
-		selectedSite: {},
-	} );
+	const availabilityNotice = getAvailabilityNotice( domainDebounced, validationResult?.status );
 
 	return {
 		valid: false,
 		loading: false,
 		message:
-			message ||
+			availabilityNotice?.message ||
 			__(
 				'An unknown error occurred while checking the domain transferability. Please try again or contact support'
 			),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
@@ -41,6 +41,8 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		};
 	}
 
+	const availabilityNotice = getAvailabilityNotice( domainDebounced, validationResult?.status );
+
 	if ( passed ) {
 		setPassed( true );
 
@@ -73,6 +75,15 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 			valid: false,
 			loading: true,
 			message: __( 'Checking domain lock status.' ),
+		};
+	}
+
+	if ( availabilityNotice?.message ) {
+		return {
+			valid: false,
+			loading: false,
+			message: availabilityNotice?.message,
+			refetch,
 		};
 	}
 
@@ -119,16 +130,12 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		};
 	}
 
-	const availabilityNotice = getAvailabilityNotice( domainDebounced, validationResult?.status );
-
 	return {
 		valid: false,
 		loading: false,
-		message:
-			availabilityNotice?.message ||
-			__(
-				'An unknown error occurred while checking the domain transferability. Please try again or contact support'
-			),
+		message: __(
+			'An unknown error occurred while checking the domain transferability. Please try again or contact support'
+		),
 		refetch,
 	};
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
@@ -38,8 +38,6 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		};
 	}
 
-	const availabilityNotice = getAvailabilityNotice( domainDebounced, validationResult?.status );
-
 	if ( ! hasGoodDomain ) {
 		return {
 			valid: false,
@@ -57,7 +55,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 	}
 
 	// local validation passed, but we're still loading
-	if ( isValidating || ! validationResult ) {
+	if ( isValidating ) {
 		return {
 			valid: false,
 			loading: true,
@@ -65,55 +63,20 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		};
 	}
 
-	if ( availabilityNotice?.message ) {
-		return {
-			valid: false,
-			loading: false,
-			message: availabilityNotice?.message,
-			refetch,
-		};
-	}
-
-	if ( validationResult?.error ) {
-		return {
-			valid: false,
-			loading: false,
-			message: __(
-				'An unknown error occurred while checking the domain transferability. Please try again or contact support'
-			),
-			refetch,
-		};
-	}
+	const availabilityNotice = getAvailabilityNotice( domain, validationResult?.status );
 
 	// final success
-	if ( validationResult.auth_code_valid ) {
+	if ( validationResult?.auth_code_valid ) {
 		return {
 			valid: true,
 			loading: false,
 			message: __( 'This domain is unlocked and ready to be transferred.' ),
 		};
-	}
-
-	// partial success
-	if ( validationResult?.unlocked ) {
+	} else if ( availabilityNotice?.message ) {
 		return {
 			valid: false,
 			loading: false,
-			message: __( 'This domain is unlocked but the authentication code seems incorrect.' ),
-			refetch,
-		};
-	} else if ( validationResult?.registered === false ) {
-		return {
-			valid: false,
-			loading: false,
-			message: __( 'This domain does not seem to be registered.' ),
-		};
-	} else if ( validationResult?.unlocked === false ) {
-		return {
-			valid: false,
-			loading: false,
-			message: __( 'This domain does not seem to be unlocked.' ),
-			refetch,
+			message: availabilityNotice?.message,
 		};
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
@@ -15,6 +15,8 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 
 	const passedLocalValidation = hasGoodDomain && hasGoodAuthCode && ! hasDuplicates;
 
+	const isDebouncing = domainDebounced !== domain || authDebounced !== auth;
+
 	const {
 		data: validationResult,
 		isFetching: isValidating,
@@ -55,7 +57,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 	}
 
 	// local validation passed, but we're still loading
-	if ( isValidating ) {
+	if ( isValidating || isDebouncing ) {
 		return {
 			valid: false,
 			loading: true,
@@ -63,7 +65,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		};
 	}
 
-	const availabilityNotice = getAvailabilityNotice( domain, validationResult?.status );
+	const availabilityNotice = getAvailabilityNotice( domain, validationResult?.status, null, true );
 
 	// final success
 	if ( validationResult?.auth_code_valid ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
@@ -37,7 +37,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		return {
 			valid: false,
 			loading: false,
-			message: __( 'This domain is a duplicated.' ),
+			message: __( 'This domain has already been entered.' ),
 		};
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/use-validation-message.ts
@@ -1,13 +1,10 @@
 import { useIsDomainCodeValid } from '@automattic/data-stores';
 import { doesStringResembleDomain } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState } from 'react';
 import { useDebounce } from 'use-debounce';
 import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
 
 export function useValidationMessage( domain: string, auth: string, hasDuplicates: boolean ) {
-	// record passed domains to avoid revalidation
-	const [ passed, setPassed ] = useState( false );
 	const { __ } = useI18n();
 
 	const [ domainDebounced ] = useDebounce( domain, 500 );
@@ -28,7 +25,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 			auth: authDebounced,
 		},
 		{
-			enabled: Boolean( ! passed && passedLocalValidation ),
+			enabled: Boolean( passedLocalValidation ),
 			retry: false,
 		}
 	);
@@ -42,16 +39,6 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 	}
 
 	const availabilityNotice = getAvailabilityNotice( domainDebounced, validationResult?.status );
-
-	if ( passed ) {
-		setPassed( true );
-
-		return {
-			valid: true,
-			loading: false,
-			message: __( 'This domain is unlocked and ready to be transferred.' ),
-		};
-	}
 
 	if ( ! hasGoodDomain ) {
 		return {

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -243,10 +243,12 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 		case domainAvailability.TLD_NOT_SUPPORTED:
 		case domainAvailability.TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE:
 		case domainAvailability.TLD_NOT_SUPPORTED_TEMPORARILY:
-			/* translators: %s: TLD (eg .com, .pl) */
-			message = translate( 'Sorry, WordPress.com does not support the %(tld)s TLD.', {
-				args: { tld },
-			} );
+			if ( isForTransferOnly ) {
+				/* translators: %s: TLD (eg .com, .pl) */
+				message = translate( 'Sorry, WordPress.com does not support the %(tld)s TLD.', {
+					args: { tld },
+				} );
+			}
 			break;
 		case domainAvailability.UNKNOWN:
 			// unavailable domains are displayed in the search results, not as a notice OR

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -18,7 +18,7 @@ import {
 	domainTransferIn,
 } from 'calypso/my-sites/domains/paths';
 
-function getAvailabilityNotice( domain, error, errorData ) {
+function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = false ) {
 	const tld = domain ? getTld( domain ) : null;
 	const { site, maintenanceEndTime, availabilityPreCheck } = errorData || {};
 
@@ -235,9 +235,19 @@ function getAvailabilityNotice( domain, error, errorData ) {
 
 		case domainAvailability.MAPPABLE:
 		case domainAvailability.AVAILABLE:
+			if ( isForTransferOnly ) {
+				message = "This domain isn't registered. Please try again.";
+			}
+			break;
+
 		case domainAvailability.TLD_NOT_SUPPORTED:
 		case domainAvailability.TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE:
 		case domainAvailability.TLD_NOT_SUPPORTED_TEMPORARILY:
+			/* translators: %s: TLD (eg .com, .pl) */
+			message = translate( 'Sorry, WordPress.com does not support the %(tld)s TLD.', {
+				args: { tld },
+			} );
+			break;
 		case domainAvailability.UNKNOWN:
 			// unavailable domains are displayed in the search results, not as a notice OR
 			// domain registrations are closed, in which case it is handled in parent

--- a/packages/data-stores/src/queries/use-is-domain-code-valid.ts
+++ b/packages/data-stores/src/queries/use-is-domain-code-valid.ts
@@ -39,17 +39,17 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 		queryKey: [ 'domain-code-valid', VERSION, pair.domain, hashAuthCode( pair.auth ) ],
 		queryFn: async () => {
 			try {
-				const availabity = await wpcomRequest< DomainLockResponse >( {
+				const availability = await wpcomRequest< DomainLockResponse >( {
 					apiVersion: '1.3',
 					path: `/domains/${ encodeURIComponent( pair.domain ) }/is-available`,
 				} );
 
-				const isUnlocked = availabity.status === 'transferrable';
+				const isUnlocked = availability.status === 'transferrable';
 
 				if ( ! isUnlocked ) {
 					return {
 						domain: pair.domain,
-						status: availabity.status,
+						status: availability.status,
 						unlocked: false,
 						auth_code_valid: false,
 					};
@@ -66,7 +66,7 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 					registered: true,
 					unlocked: true,
 					auth_code_valid: response.success,
-					status: availabity.status,
+					status: availability.status,
 				};
 			} catch ( error ) {
 				return {

--- a/packages/data-stores/src/queries/use-is-domain-code-valid.ts
+++ b/packages/data-stores/src/queries/use-is-domain-code-valid.ts
@@ -29,6 +29,7 @@ type DomainLockResponse = {
 	privacy?: boolean;
 	unlocked: boolean | null | undefined;
 	in_redemption?: boolean;
+	status: string;
 };
 
 type DomainCodePair = { domain: string; auth: string };
@@ -38,41 +39,34 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 		queryKey: [ 'domain-code-valid', VERSION, pair.domain, hashAuthCode( pair.auth ) ],
 		queryFn: async () => {
 			try {
-				const { unlocked } = await wpcomRequest< DomainLockResponse >( {
-					apiVersion: '1.1',
-					path: `/domains/${ encodeURIComponent( pair.domain ) }/inbound-transfer-status`,
+				const availabity = await wpcomRequest< DomainLockResponse >( {
+					apiVersion: '1.3',
+					path: `/domains/${ encodeURIComponent( pair.domain ) }/is-available`,
 				} );
 
-				if ( unlocked === null ) {
+				const isUnlocked = availabity.status === 'transferrable';
+
+				if ( ! isUnlocked ) {
 					return {
 						domain: pair.domain,
-						registered: false,
+						status: availabity.status,
 						unlocked: false,
 						auth_code_valid: false,
 					};
 				}
 
-				if ( unlocked ) {
-					const response = await wpcomRequest< DomainCodeResponse >( {
-						apiVersion: '1.1',
-						path: `/domains/${ encodeURIComponent(
-							pair.domain
-						) }/inbound-transfer-check-auth-code`,
-						query: `auth_code=${ encodeURIComponent( pair.auth ) }`,
-					} ).catch( () => ( { success: false } ) );
+				const response = await wpcomRequest< DomainCodeResponse >( {
+					apiVersion: '1.1',
+					path: `/domains/${ encodeURIComponent( pair.domain ) }/inbound-transfer-check-auth-code`,
+					query: `auth_code=${ encodeURIComponent( pair.auth ) }`,
+				} ).catch( () => ( { success: false } ) );
 
-					return {
-						domain: pair.domain,
-						registered: true,
-						unlocked: true,
-						auth_code_valid: response.success,
-					};
-				}
 				return {
 					domain: pair.domain,
 					registered: true,
-					unlocked: false,
-					auth_code_valid: false,
+					unlocked: true,
+					auth_code_valid: response.success,
+					status: availabity.status,
 				};
 			} catch ( error ) {
 				return {


### PR DESCRIPTION
This PR fallbacks on getAvailabilityNotice to check for possible message before displaying the general error

## Proposed Changes

* Improve default error message by using `getAvailabilityNotice `

## Testing Instructions
- Checkout this branch and build or use the PR link
- Test the [new flow](/setup/bulk-domain-transfer/domains) using domain names you have auth codes with and for other possible cases.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
