### PR TITLE
Launchpad: Update domain thank-you post-checkout redirect for Launchpad sites

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Button, Gridicon } from '@automattic/components';
+import { useLaunchpad } from '@automattic/data-stores';
 import { translate } from 'i18n-calypso';
 import { useMemo, useEffect } from 'react';
 import * as React from 'react';
@@ -34,7 +35,11 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 	hideProfessionalEmailStep,
 	type,
 } ) => {
+	const {
+		data: { is_enabled: isLaunchpadKeepBuildingEnabled },
+	} = useLaunchpad( selectedSiteSlug, 'keep-building' );
 	const launchpadScreen = useSiteOption( 'launchpad_screen' );
+	const redirectTo = isLaunchpadKeepBuildingEnabled ? 'home' : 'setup';
 	const siteIntent = useSiteOption( 'site_intent' );
 	const thankYouProps = useMemo< DomainThankYouProps >( () => {
 		const propsGetter = domainThankYouContent[ type ];
@@ -46,6 +51,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 			hideProfessionalEmailStep,
 			siteIntent,
 			launchpadScreen,
+			redirectTo,
 		} );
 	}, [
 		type,
@@ -56,6 +62,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 		hideProfessionalEmailStep,
 		siteIntent,
 		launchpadScreen,
+		redirectTo,
 	] );
 	const dispatch = useDispatch();
 	const isLaunchpadEnabled = launchpadScreen === 'full';
@@ -67,13 +74,20 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 		};
 	}, [ dispatch ] );
 
-	const renderHeader = ( isLaunchpadEnabled: boolean, siteIntent: string ) => {
+	const renderHeader = (
+		isLaunchpadEnabled: boolean,
+		siteIntent: string,
+		redirectTo: 'home' | 'setup'
+	) => {
 		const buttonProps = isLaunchpadEnabled
 			? {
-					onClick: () =>
-						window.location.replace(
-							`/setup/${ siteIntent }/launchpad?siteSlug=${ selectedSiteSlug }`
-						),
+					onClick: () => {
+						const redirectUrl =
+							redirectTo === 'home'
+								? `/home/${ selectedSiteSlug }`
+								: `/setup/${ siteIntent }/launchpad?siteSlug=${ selectedSiteSlug }`;
+						window.location.replace( redirectUrl );
+					},
 			  }
 			: { href: domainManagementRoot() };
 		return (
@@ -91,7 +105,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 
 	return (
 		<>
-			{ renderHeader( isLaunchpadEnabled, siteIntent as string ) }
+			{ renderHeader( isLaunchpadEnabled, siteIntent as string, redirectTo ) }
 			<ThankYou
 				headerBackgroundColor="var( --studio-white )"
 				containerClassName="checkout-thank-you__domains"

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -20,6 +20,7 @@ const domainRegistrationThankYouProps = ( {
 	selectedSiteSlug,
 	siteIntent,
 	launchpadScreen,
+	redirectTo,
 }: DomainThankYouParams ): DomainThankYouProps => {
 	const professionalEmail = buildDomainStepForProfessionalEmail(
 		{
@@ -38,6 +39,7 @@ const domainRegistrationThankYouProps = ( {
 		launchpadScreen as string,
 		selectedSiteSlug,
 		'REGISTRATION',
+		redirectTo,
 		true
 	);
 

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
@@ -117,6 +117,7 @@ export function buildDomainStepForLaunchpadNextSteps(
 	launchpadScreen: string,
 	selectedSiteSlug: string,
 	domainType: DomainThankYouType,
+	redirectTo: string,
 	primary: boolean
 ): ThankYouNextStepProps | null {
 	if ( launchpadScreen !== 'full' || ! siteIntent || ! selectedSiteSlug ) {
@@ -130,11 +131,13 @@ export function buildDomainStepForLaunchpadNextSteps(
 		),
 		stepCta: (
 			<FullWidthButton
-				onClick={ () =>
-					window.location.replace(
-						`/setup/${ siteIntent }/launchpad?siteSlug=${ selectedSiteSlug }`
-					)
-				}
+				onClick={ () => {
+					const redirectUrl =
+						redirectTo === 'home'
+							? `/home/${ selectedSiteSlug }`
+							: `/setup/${ siteIntent }/launchpad?siteSlug=${ selectedSiteSlug }`;
+					window.location.replace( redirectUrl );
+				} }
 				className={ `domain-${ domainType }__thank-you-button domain-thank-you__button` }
 				primary={ primary }
 				busy={ false }

--- a/client/my-sites/checkout/checkout-thank-you/domains/types.ts
+++ b/client/my-sites/checkout/checkout-thank-you/domains/types.ts
@@ -16,6 +16,7 @@ export type DomainThankYouParams = {
 	launchpadScreen: ReturnType< typeof useSiteOption >;
 	selectedSiteSlug: string;
 	siteIntent: ReturnType< typeof useSiteOption >;
+	redirectTo: 'home' | 'setup';
 };
 
 export type DomainThankYouPropsGetter = ( params: DomainThankYouParams ) => DomainThankYouProps;

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -35,6 +35,7 @@ interface LaunchpadResponse {
 	launchpad_screen?: string | boolean | null | undefined;
 	checklist?: Task[] | null;
 	checklist_statuses?: ChecklistStatuses;
+	is_enabled: boolean;
 }
 
 type LaunchpadUpdateSettings = {
@@ -77,6 +78,7 @@ export const useLaunchpad = (
 			launchpad_screen: undefined,
 			checklist_statuses: {},
 			checklist: null,
+			is_enabled: false,
 		},
 	} );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78199

## Proposed Changes

* Add the `is_enabled` API property to the `useLaunchpad` hook so we can check the checklist status on the front end.
* Works with https://github.com/Automattic/jetpack/pull/31623 to determine when the Keep Building task list should be enabled.
* After purchasing a domain, you'll land on a Thank You screen that has two buttons pointing to "Next Steps".
* If the Keep Building task list is active, we should send the user back to `/home/siteSlug` when they click Next Steps.
* If the Keep Building task list is *not* active, we should send them back to `/setup/intent/launchpad?siteSlug=siteSlug` when they click Next Steps

<img width="1663" alt="Screen Shot 2023-06-28 at 2 29 47 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/125e7741-ad01-4350-8b91-86ae992d05b4">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR or view calypso.live
* On your sandbox, apply the patch at https://github.com/Automattic/jetpack/pull/31623 and sandbox the API
* Create a new site from `/start` with the "Promote myself or business" intent
* Launch the site
* You'll land on Customer Home
* Click on "Customize my domain" and purchase a new *.blog domain (don't forget to cancel it within 24 hours!)
* You'll land on a thank-you screen like the one above
* Clicking either of the "Next steps" buttons on that screen should bring you back to `/home/siteSlug`

* Create another new site from `/start` with the "Promote myself or business" intent
* Do *not* launch the site. Click "Skip for now" when you get to the Launchpad in Stepper.
* Go to Upgrades -> Domains and search for a domain
* Purchase the domain (don't forget to cancel it within 24 hours!)
* You should see the same thank-you screen
* Clicking either of the "Next steps" buttons should bring you back to `/setup/site-intent/launchpad?siteSlug=siteSlug`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
