### PR TITLE
Reader: Update suggested follow retry

### DIFF
--- a/client/data/reader/use-related-sites.ts
+++ b/client/data/reader/use-related-sites.ts
@@ -76,5 +76,9 @@ export const useRelatedSites = (
 		enabled: !! siteId,
 		staleTime: 3600000, // 1 hour
 		select: selectRelatedSites,
+		retry: false,
+		refetchOnMount: false,
+		retryOnMount: false,
+		refetchOnWindowFocus: false,
 	} );
 };


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/78740

This PR fixes an issue where the modal loads with no data.
There are cases where no related sites are found for a particular site/feed and we need to not show the modal in this case. 

### Example

<img width="706" alt="Screenshot 2023-06-28 at 15 14 44" src="https://github.com/Automattic/wp-calypso/assets/5560595/ef169472-f426-421f-ae2f-ca44843fa1fd">

Unfortunately,  https://github.com/Automattic/wp-calypso/pull/78740 didn't fix this issue because the request appear to be retried when it hits the error state.

This PR disables retries to see if that helps.

### Testing

* Go to http://calypso.localhost:3000/read/feeds/18062660 and click Follow - you should see the modal above
* Apply PR and retry and you shouldn't see the modal


Unfortanately, the PR above didn't fix the issue on further testing.