### PR TITLE
Checkout: Increase specificity of checkout padding override

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -53,8 +53,15 @@ body.is-focus-sites {
 
 	// Checkout sets it own padding/margin
 	.is-section-checkout &,
-	.is-section-checkout.has-no-sidebar &,
-	.is-section-checkout.has-no-sidebar .theme-default .focus-content & {
+	.is-section-checkout.has-no-sidebar & {
+		padding: 0;
+		margin: 0;
+	}
+	// Note that we have to use a 0,0,3,1 specificity selector to override the
+	// one in `client/my-sites/sidebar/style.scss` which has 0,0,3,0 in case it
+	// loads second, which happens if checkout is not the first page of calypso
+	// to load.
+	.theme-default.is-section-checkout div.is-section-checkout.focus-content & {
 		padding: 0;
 		margin: 0;
 	}


### PR DESCRIPTION
## Proposed Changes

Part of the recent checkout design changes (https://github.com/Automattic/wp-calypso/pull/77353) was to remove calypso's default layout padding. This was done with [a CSS rule](https://github.com/Automattic/wp-calypso/blob/d4a7f9e9cf320ea36ad7cd8b36dfdce90980fe29/client/layout/style.scss#L58) in the layout file. However, since the Nav Unification project, there's [another rule that adds padding](https://github.com/Automattic/wp-calypso/blob/d4a7f9e9cf320ea36ad7cd8b36dfdce90980fe29/client/my-sites/sidebar/style.scss#L671) to the layout in a sidebar style file. This seems awkward, but it's been there for a while so I figure it's best to work around it.

Both the sidebar rule and the checkout rule end up with [a CSS specificity](https://css-tricks.com/specifics-on-css-specificity/) of 0,0,3,0 (three classnames), so whichever one loads last gets priority. This creates a race condition where the padding will only be overridden if checkout is loaded before the rest of calypso (I don't fully understand why that is but it reliably works that way).

In this PR, we modify the checkout padding override to increase its specificity to 0,0,3,1 (three classnames and an element) so that it will always override the sidebar rule, regardless of load order.

Before:

<img width="727" alt="Screenshot 2023-06-28 at 8 44 28 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/e4163097-888d-4139-977a-4f2fdb7f7303">

After:

<img width="728" alt="Screenshot 2023-06-28 at 8 45 01 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/a3cf0a78-5fbe-443d-a5f3-2a09ac5c10f4">


## Testing Instructions

- Set your browser window to be thin, less than 730px wide.
- Visit a non-checkout page like `/me/purchases`.
- Click on an existing purchase and click "Renew now".
- Verify that when checkout loads, the white background reaches to both sides of the page.