### PR TITLE
Reader: enforce top border style override for site feed

### DIFF
--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -900,6 +900,6 @@
 	}
 
 	.reader-post-card.card:nth-child(2) {
-		border-top: none;
+		border-top: none !important;
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/78706

## Proposed Changes

* Make sure the temporary border style override for the Reader site feed is present.

## Testing Instructions

* Visit `/read/feeds/{feed-id}` and make sure there's a uniform border separating the header and page content.