### PR TITLE
Fix missing Jetpack site card for woo core profiler and update heading font-weight

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -206,7 +206,11 @@ export class AuthFormHeader extends Component {
 	getSiteCard() {
 		const { isWpcomMigration, isWooCoreProfiler } = this.props;
 		const { jpVersion } = this.props.authQuery;
-		if ( ! versionCompare( jpVersion, '4.0.3', '>' ) ) {
+		if (
+			// Always show the site card for Woo Core Profiler
+			! isWooCoreProfiler &&
+			! versionCompare( jpVersion, '4.0.3', '>' )
+		) {
 			return null;
 		}
 

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -794,6 +794,7 @@
 			margin-bottom: 12px;
 			font-size: $woo-font-title-large;
 			line-height: 32px;
+			font-weight: 500;
 
 			@media screen and ( max-width: 660px ) {
 				font-size: rem(28px);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78615
![Screenshot 2023-06-29 at 11 46 33](https://github.com/Automattic/wp-calypso/assets/4344253/feac2522-2ba3-4aba-a0e5-05eeb83bce07)

Core Profile doesn't set the value of `jp_version` parameter when using Jetpack Connect Page without JP plugin installed when redirecting the user to Jetpack connection page so we need to ignore the check.

## Proposed Changes

* Skip jp version check for Woo Core Profiler to always show site card

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set up [woocommerce-start-dev-env](https://github.com/woocommerce/woocommerce-start-dev-env)
2. Create a JN site
3. Deactivate the Jetpack plugin
4. Upload, install, and activate the [latest woocommerce nightly build](https://github.com/woocommerce/woocommerce/releases/tag/nightly)
5. Go to Core Profiler flow
6. Install plugins and confirm you're redirected to Jetpack connection page
7. Observe that the site card is shown (If URL contains `jp_version` param value, remove it and reload the page)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
