### PR TITLE
Add "Manage All Domains" link to /me sidebar

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -14,7 +14,7 @@ import { getSidebarIsCollapsed } from 'calypso/state/ui/selectors';
 
 export default function SidebarItem( props ) {
 	const isExternalLink = isExternal( props.link );
-	const showAsExternal = isExternalLink && ! props.forceInternalLink;
+	const showAsExternal = ( isExternalLink && ! props.forceInternalLink ) || props.forceExternalLink;
 	const classes = classnames( props.className, props.tipTarget, {
 		selected: props.selected,
 		'has-unseen': props.hasUnseen,
@@ -98,6 +98,7 @@ SidebarItem.propTypes = {
 	selected: PropTypes.bool,
 	expandSection: PropTypes.func,
 	preloadSectionName: PropTypes.string,
+	forceExternalLink: PropTypes.bool,
 	forceInternalLink: PropTypes.bool,
 	testTarget: PropTypes.string,
 	tipTarget: PropTypes.string,

--- a/client/layout/sidebar/test/item.tsx
+++ b/client/layout/sidebar/test/item.tsx
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import SidebarItem from '../item';
+
+const render = ( el ) => renderWithProvider( el );
+
+test( 'external links open in a new tab', () => {
+	// Don't test external links using the traditional "example.com" domain, because that's the domain
+	// Testing Library uses as the default window.location, so they don't appear to be external.
+	render( <SidebarItem label="My Example" link="https://my-example.com" /> );
+
+	expect( screen.getByRole( 'link', { name: 'My Example' } ) ).toHaveAttribute(
+		'target',
+		'_blank'
+	);
+} );
+
+test( 'external links can be forced to open in the same tab', () => {
+	render( <SidebarItem label="My Example" link="https://my-example.com" forceInternalLink /> );
+
+	expect( screen.getByRole( 'link', { name: 'My Example' } ) ).not.toHaveAttribute(
+		'target',
+		'_blank'
+	);
+} );
+
+test( 'internal links open in a the same tab', () => {
+	render( <SidebarItem label="Home" link="/home/example.com" /> );
+
+	expect( screen.getByRole( 'link', { name: 'Home' } ) ).not.toHaveAttribute( 'target', '_blank' );
+} );
+
+test( 'internal links can be forced to open in a new tab', () => {
+	render( <SidebarItem label="Home" link="/home/example.com" forceExternalLink /> );
+
+	expect( screen.getByRole( 'link', { name: 'Home' } ) ).toHaveAttribute( 'target', '_blank' );
+} );

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
-import { localize } from 'i18n-calypso';
+import { englishLocales, localizeUrl } from '@automattic/i18n-utils';
+import i18n, { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Sidebar from 'calypso/layout/sidebar';
@@ -58,7 +58,7 @@ class MeSidebar extends Component {
 	};
 
 	render() {
-		const { context, translate } = this.props;
+		const { context, locale, translate } = this.props;
 		const path = context.path.replace( '/me', '' ); // Remove base path.
 
 		return (
@@ -128,6 +128,16 @@ class MeSidebar extends Component {
 							label={ translate( 'Manage Blogs' ) }
 							materialIcon="apps"
 						/>
+
+						{ ( englishLocales.includes( locale ) ||
+							i18n.hasTranslation( 'Manage All Domains' ) ) && (
+							<SidebarItem
+								link="/domains/manage"
+								label={ translate( 'Manage All Domains' ) }
+								materialIcon="language"
+								forceExternalLink
+							/>
+						) }
 
 						<SidebarItem
 							selected={ itemLinkMatches( '/notifications', path ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2867

## Proposed Changes

* Adds "Manage All Domains" link to `/me` sidebar
* Opens link in new tab
* Link will roll out immediately to `en` users and gradually to everyone else as translations are completed

<img src="https://github.com/Automattic/wp-calypso/assets/1500769/d1428315-9fb8-41c7-be41-6e310b02fb7f" width="279px" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/me`
* See "Manage All Domains" link in the sidebar when using English
* Don't see link when not using English

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
