### PR TITLE
Components: Adjust the Pricing Slider component styling

### DIFF
--- a/packages/components/src/pricing-slider/index.tsx
+++ b/packages/components/src/pricing-slider/index.tsx
@@ -28,7 +28,7 @@ const PricingSlider: React.FC< PricingSliderProps > = ( {
 		'jp-components-pricing-slider--is-holding': isThumbHolding,
 	} );
 
-	const onBeforeChangeCallback = ( beforeValue ) => {
+	const onBeforeChangeCallback = ( beforeValue: number ) => {
 		setIsThumbHolding( true );
 
 		if ( typeof onBeforeChange === 'function' ) {
@@ -36,7 +36,7 @@ const PricingSlider: React.FC< PricingSliderProps > = ( {
 		}
 	};
 
-	const onAfterChangeCallback = ( afterValue ) => {
+	const onAfterChangeCallback = ( afterValue: number ) => {
 		setIsThumbHolding( false );
 
 		if ( typeof onAfterChange === 'function' ) {

--- a/packages/components/src/pricing-slider/index.tsx
+++ b/packages/components/src/pricing-slider/index.tsx
@@ -22,7 +22,27 @@ const PricingSlider: React.FC< PricingSliderProps > = ( {
 	onAfterChange,
 	renderThumb,
 } ) => {
-	const componentClassName = classNames( 'jp-components-pricing-slider', className );
+	const [ isThumbHolding, setIsThumbHolding ] = React.useState( false );
+
+	const componentClassName = classNames( 'jp-components-pricing-slider', className, {
+		'jp-components-pricing-slider--is-holding': isThumbHolding,
+	} );
+
+	const onBeforeChangeCallback = ( beforeValue ) => {
+		setIsThumbHolding( true );
+
+		if ( typeof onBeforeChange === 'function' ) {
+			onBeforeChange( beforeValue );
+		}
+	};
+
+	const onAfterChangeCallback = ( afterValue ) => {
+		setIsThumbHolding( false );
+
+		if ( typeof onAfterChange === 'function' ) {
+			onAfterChange( afterValue );
+		}
+	};
 
 	const renderThumbCallback = renderThumb
 		? renderThumb
@@ -43,8 +63,8 @@ const PricingSlider: React.FC< PricingSliderProps > = ( {
 				step={ step }
 				renderThumb={ renderThumbCallback } // eslint-disable-line react/jsx-no-bind
 				onChange={ onChange } // eslint-disable-line react/jsx-no-bind
-				onBeforeChange={ onBeforeChange } // eslint-disable-line react/jsx-no-bind
-				onAfterChange={ onAfterChange } // eslint-disable-line react/jsx-no-bind
+				onBeforeChange={ onBeforeChangeCallback } // eslint-disable-line react/jsx-no-bind
+				onAfterChange={ onAfterChangeCallback } // eslint-disable-line react/jsx-no-bind
 			/>
 		</div>
 	);

--- a/packages/components/src/pricing-slider/style.scss
+++ b/packages/components/src/pricing-slider/style.scss
@@ -16,6 +16,7 @@ $thumb-horizontal-padding: 16px;
 	--jp-white: #fff;
 	--jp-gray: #dcdcde;
 	--jp-green-40: #069e08;
+	--jp-green-50: #008710;
 }
 
 .jp-components-pricing-slider__control {
@@ -41,7 +42,7 @@ $thumb-horizontal-padding: 16px;
 	align-items: center;
 	background-color: var(--jp-white);
 	border-radius: 4px;
-	border: 1px solid var(--jp-gray);
+	border: 1.5px solid var(--jp-green-50);
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 6px 8px rgba(0, 0, 0, 0.08);
 	color: var(--jp-black);
 	cursor: pointer;
@@ -62,5 +63,9 @@ $thumb-horizontal-padding: 16px;
 	&.jp-components-pricing-slider__thumb--is-active {
 		// On focus styling
 		outline: none;
+	}
+
+	&[aria-valuenow="0"] {
+		border-color: var(--jp-gray);
 	}
 }

--- a/packages/components/src/pricing-slider/style.scss
+++ b/packages/components/src/pricing-slider/style.scss
@@ -19,6 +19,13 @@ $thumb-horizontal-padding: 16px;
 	--jp-green-50: #008710;
 }
 
+// On holding thumb styling
+.jp-components-pricing-slider--is-holding {
+	.jp-components-pricing-slider__thumb {
+		box-shadow: 0 6px 8px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04), 0 0 0 3px rgba(6, 158, 8, 0.25);
+	}
+}
+
 .jp-components-pricing-slider__control {
 	width: 100%;
 	height: $thumb-height + $thumb-vertical-padding * 2;

--- a/packages/components/src/pricing-slider/style.scss
+++ b/packages/components/src/pricing-slider/style.scss
@@ -28,7 +28,7 @@ $thumb-horizontal-padding: 16px;
 
 .jp-components-pricing-slider__control {
 	width: 100%;
-	height: $thumb-height + $thumb-vertical-padding * 2;
+	height: $thumb-height;
 }
 
 .jp-components-pricing-slider__track {
@@ -46,6 +46,7 @@ $thumb-horizontal-padding: 16px;
 }
 
 .jp-components-pricing-slider__thumb {
+	box-sizing: border-box;
 	align-items: center;
 	background-color: var(--jp-white);
 	border-radius: 4px;
@@ -64,7 +65,6 @@ $thumb-horizontal-padding: 16px;
 	letter-spacing: -0.02em;
 	line-height: 24px;
 	padding: $thumb-vertical-padding $thumb-horizontal-padding;
-	transform: translate(0, -20%); // TODO: Check if this -20% translation is correct.
 	white-space: nowrap;
 
 	&.jp-components-pricing-slider__thumb--is-active {

--- a/packages/components/src/pricing-slider/style.scss
+++ b/packages/components/src/pricing-slider/style.scss
@@ -1,3 +1,5 @@
+@import "@automattic/components/src/styles/typography";
+
 $thumb-height: 40px;
 $track-height: 8px;
 $thumb-vertical-padding: 8px;
@@ -55,8 +57,7 @@ $thumb-horizontal-padding: 16px;
 	color: var(--jp-black);
 	cursor: pointer;
 	display: flex;
-	// TODO: Use standardized font here.
-	font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-family: $font-sf-pro-text;
 	font-size: var(--font-body);
 	font-style: normal;
 	font-weight: 600;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/31593 and https://github.com/Automattic/wp-calypso/issues/78741

## Proposed Changes

* Update the thumb's border and focus status styling according to the latest design.
* Fix the relative positions of the control section, track, and thumb.

https://github.com/Automattic/wp-calypso/assets/6869813/4aa9595a-11db-41fd-833e-3b860c62c934

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up Storybook and ensure the Pricing Slider component works in line with the design.
* Ensure the control section exactly covers the thumb and track and the track is at the middle position.

<img width="951" alt="截圖 2023-06-29 下午3 29 20" src="https://github.com/Automattic/wp-calypso/assets/6869813/e429a92b-8209-4485-9db8-35309921c406">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
