### PR TITLE
Sites: add domains page CTA

### DIFF
--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -86,6 +86,7 @@ class SplitButton extends PureComponent {
 			className,
 			popoverClassName,
 			whiteSeparator,
+			toggleIcon = 'chevron-down',
 		} = this.props;
 		const { isMenuVisible } = this.state;
 		const toggleClasses = classNames( 'split-button__toggle', {
@@ -103,18 +104,20 @@ class SplitButton extends PureComponent {
 
 		return (
 			<span className={ classes }>
-				<Button
-					compact={ compact }
-					primary={ primary }
-					scary={ scary }
-					disabled={ disabled || disableMain }
-					className="split-button__main"
-					onClick={ onClick }
-					href={ this.props.href }
-				>
-					{ icon && <Gridicon icon={ icon } /> }
-					{ label }
-				</Button>
+				{ ( icon || label ) && (
+					<Button
+						compact={ compact }
+						primary={ primary }
+						scary={ scary }
+						disabled={ disabled || disableMain }
+						className="split-button__main"
+						onClick={ onClick }
+						href={ this.props.href }
+					>
+						{ icon && <Gridicon icon={ icon } /> }
+						{ label }
+					</Button>
+				) }
 				<Button
 					compact={ compact }
 					primary={ primary }
@@ -125,7 +128,7 @@ class SplitButton extends PureComponent {
 					disabled={ disabled || disableMenu }
 					className={ toggleClasses }
 				>
-					<Gridicon icon="chevron-down" className="split-button__toggle-icon" />
+					<Gridicon icon={ toggleIcon } className="split-button__toggle-icon" />
 				</Button>
 				<PopoverMenu
 					isVisible={ isMenuVisible }

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Gridicon, useScrollToTop, JetpackLogo } from '@automattic/components';
 import { createSitesListComponent } from '@automattic/sites';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
@@ -140,6 +141,10 @@ const ScrollButton = styled( Button, { shouldForwardProp: ( prop ) => prop !== '
 	}
 `;
 
+const ManageAllDomainsButton = styled( Button )`
+	margin-right: 10px;
+`;
+
 const SitesDashboardSitesList = createSitesListComponent();
 
 export function SitesDashboard( {
@@ -174,6 +179,8 @@ export function SitesDashboard( {
 		smoothScrolling: true,
 	} );
 
+	const isMobile = useMobileBreakpoint();
+
 	useShowSiteCreationNotice( allSites, newSiteID );
 	useShowSiteTransferredNotice();
 
@@ -183,14 +190,18 @@ export function SitesDashboard( {
 			<PageHeader>
 				<HeaderControls>
 					<DashboardHeading>{ __( 'Sites' ) }</DashboardHeading>
+					<ManageAllDomainsButton transparent href="/domains/manage">
+						{ __( 'Manage all domains' ) }
+					</ManageAllDomainsButton>
 					<SplitButton
 						primary
 						whiteSeparator
-						label={ __( 'Add new site' ) }
+						label={ isMobile ? undefined : __( 'Add new site' ) }
 						onClick={ () => {
 							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
 						} }
 						href={ createSiteUrl }
+						toggleIcon={ isMobile ? 'plus' : undefined }
 					>
 						<PopoverMenuItem
 							onClick={ () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/2846

**Mockup**:

![image](https://github.com/Automattic/wp-calypso/assets/6851384/554959d6-961b-4531-a94f-12abc5e2a121)

## Proposed Changes

* Add a link button `/domains/manage`

https://github.com/Automattic/wp-calypso/assets/6851384/2f08f932-3a05-43bb-808c-22c2ffa6cdf7

**Existing Tracks event**:

![image](https://github.com/Automattic/wp-calypso/assets/6851384/0043bf0c-30de-46d4-8906-cc96fd336bcc)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try it out at `/sites`
* Check mobile and desktop match the Figma design
* Is the existing Tracks event enough?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?