### PR TITLE
Edge Cache: Update label to account for updated Cache block features

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -297,7 +297,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'web_server_settings',
 			},
 			{
-				label: __( 'Clear cache' ),
+				label: __( 'Cache' ),
 				href: `/hosting-config/${ siteSlug }#cache`,
 				sectionName: 'cache',
 			},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2769

## Proposed Changes

In this PR, I propose to change "Clear cache" label to just "Cache" to account for changed Cache block responsibility - after adding Edge Cache radio button, block will not only allow for clearing cache, but for more general management. 

Also, that way we will align the label with the Hosting Configuration page headings, as now it's the only one that uses a different wording in the menu.

<img width="525" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/40c5a1c8-3d05-4ea1-838c-388592a23051">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the `/sites` page
2. Locate the site with the 'Hosting configuration' menu item
3. Hover the item and confirm that there is a 'Cache' item

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
