### PR TITLE
Sites: tweak domains button appearance

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -190,7 +190,7 @@ export function SitesDashboard( {
 			<PageHeader>
 				<HeaderControls>
 					<DashboardHeading>{ __( 'Sites' ) }</DashboardHeading>
-					<ManageAllDomainsButton transparent href="/domains/manage">
+					<ManageAllDomainsButton href="/domains/manage">
 						{ __( 'Manage all domains' ) }
 					</ManageAllDomainsButton>
 					<SplitButton

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -142,7 +142,7 @@ const ScrollButton = styled( Button, { shouldForwardProp: ( prop ) => prop !== '
 `;
 
 const ManageAllDomainsButton = styled( Button )`
-	margin-right: 10px;
+	margin-inline-end: 1rem;
 `;
 
 const SitesDashboardSitesList = createSitesListComponent();


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/78768#issuecomment-1613248578.

## Proposed Changes

Let's make the "Manage all domains" button secondary instead of transparent.

I also added more right margin separating both buttons. It's different from the designs, but it's more consistent with the rest of the page and margins throughout Calypso. cc @saygunnyc 

| trunk | This PR |
| ----- | -------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/84926cd5-f73b-4ed0-aa89-b5cbfee48b55) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/24920225-7082-4c34-a021-d6c1423d98be) |

## Testing Instructions

Visit  `/sites` and verify that the button is secondary instead of transparent, and that is a little more distant from the main CTA.
