### PR TITLE
Subscriber Details: Enable view details button on subscribers list

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list/subscriber-row.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/subscriber-row.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import TimeSince from 'calypso/components/time-since';
 import useSubscriptionPlans from '../../hooks/use-subscription-plans';
@@ -40,7 +39,7 @@ export const SubscriberRow = ( { subscriber, onView, onUnsubscribe }: Subscriber
 				<SubscriberPopover
 					onView={ () => onView( subscriber ) }
 					onUnsubscribe={ () => onUnsubscribe( subscriber ) }
-					isViewButtonVisible={ isEnabled( 'subscribers/view-subscriber-details' ) }
+					isViewButtonVisible
 				/>
 			</span>
 		</li>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78781

## Proposed Changes

* Enables View details button on subscribers list
* **Merging this PR means to release the Subscriber Details page**

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/subscribers/{site-slug}
* Verify if the View button appears
* Click on View button on a subscriber, you should be redirected to its details page
* Test for regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
