### PR TITLE
Reader: Update sidebar to use ReaderAvatar component

### DIFF
--- a/client/blocks/reader-avatar/index.tsx
+++ b/client/blocks/reader-avatar/index.tsx
@@ -106,8 +106,6 @@ const ReaderAvatar = ( {
 		'has-gravatar': hasAvatar || showPlaceholder,
 	} );
 
-	//console.log( 'ReaderAvatar', { author, siteIcon, feedIcon, siteUrl, isCompact, preferGravatar, preferBlavatar, showPlaceholder, onClick, iconSize } );
-
 	const defaultIconElement = ! hasSiteIcon && ! hasAvatar && ! showPlaceholder && (
 		<Gridicon key="globe-icon" icon="globe" size={ siteIconSize } />
 	);

--- a/client/blocks/reader-avatar/index.tsx
+++ b/client/blocks/reader-avatar/index.tsx
@@ -106,6 +106,8 @@ const ReaderAvatar = ( {
 		'has-gravatar': hasAvatar || showPlaceholder,
 	} );
 
+	//console.log( 'ReaderAvatar', { author, siteIcon, feedIcon, siteUrl, isCompact, preferGravatar, preferBlavatar, showPlaceholder, onClick, iconSize } );
+
 	const defaultIconElement = ! hasSiteIcon && ! hasAvatar && ! showPlaceholder && (
 		<Gridicon key="globe-icon" icon="globe" size={ siteIconSize } />
 	);

--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -2,6 +2,14 @@
 	margin: 0 auto;
 	max-height: 105px;
 
+	.gridicons-globe {
+		fill: var(--color-neutral-100);
+
+		&:hover {
+			fill: var(--color-text-subtle);
+		}
+	}
+
 	&.has-site-and-author-icon {
 		.site-icon {
 			height: 96px;

--- a/client/reader/stream/reader-list-followed-sites/index.jsx
+++ b/client/reader/stream/reader-list-followed-sites/index.jsx
@@ -59,16 +59,16 @@ export class ReaderListFollowedSites extends Component {
 		} );
 	};
 
-	renderSites = ( sites ) => {
+	renderSites = ( follows ) => {
 		const { path } = this.props;
 		return map(
-			sites,
-			( site ) =>
-				site && (
+			follows,
+			( follow ) =>
+				follow && (
 					<ReaderListFollowingItem
-						key={ site.ID }
+						key={ follow.ID }
 						path={ path }
-						site={ site }
+						follow={ follow }
 						isUnseen={ this.isUnseen() }
 					/>
 				)

--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -17,8 +17,13 @@ const ReaderListFollowingItem = ( props ) => {
 	const { site, path, isUnseen, feed, follow, siteId } = props;
 	const moment = useLocalizedMoment();
 	const dispatch = useDispatch();
-	const feedIcon = feed ? feed.site_icon ?? get( feed, 'image' ) : null;
 	const siteIcon = site ? site.site_icon ?? get( site, 'icon.img' ) : null;
+	let feedIcon = get( follow, 'site_icon' );
+
+	// If feed available, check feed for feed icon
+	if ( feed && feed.image ) {
+		feedIcon = get( feed, 'image' );
+	}
 
 	const handleSidebarClick = ( selectedSite ) => {
 		recordAction( 'clicked_reader_sidebar_following_item' );
@@ -58,8 +63,10 @@ const ReaderListFollowingItem = ( props ) => {
 				onClick={ () => handleSidebarClick( follow ) }
 			>
 				<span className="reader-sidebar-site_siteicon">
-					{ ! site && <QueryReaderSite siteId={ siteId } /> }
-					{ ! feed && follow.feed_ID && <QueryReaderFeed feedId={ follow.feed_ID } /> }
+					{ ! siteIcon && ! feedIcon && ! site && <QueryReaderSite siteId={ siteId } /> }
+					{ ! siteIcon && ! feedIcon && ! feed && follow.feed_ID && (
+						<QueryReaderFeed feedId={ follow.feed_ID } />
+					) }
 					<ReaderAvatar
 						siteIcon={ siteIcon }
 						feedIcon={ feedIcon }

--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -61,7 +61,7 @@ const ReaderListFollowingItem = ( props ) => {
 						feedIcon={ feedIcon }
 						preferGravatar={ true }
 						isCompact={ true }
-						iconSize={ 24 }
+						iconSize={ 32 }
 					/>
 				</span>
 				<span className="reader-sidebar-site_sitename">

--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -2,17 +2,19 @@ import { get } from 'lodash';
 import { connect, useDispatch } from 'react-redux';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import Count from 'calypso/components/count';
+import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { getFeed } from 'calypso/state/reader/feeds/selectors';
-import { getReaderFollowForFeed } from 'calypso/state/reader/follows/selectors';
+import { getSite } from 'calypso/state/reader/sites/selectors';
 import ReaderSidebarHelper from '../../sidebar/helper';
 import '../style.scss';
 
 const ReaderListFollowingItem = ( props ) => {
-	const { site, path, isUnseen, feed } = props;
+	const { site, path, isUnseen, feed, follow, siteId } = props;
 	const moment = useLocalizedMoment();
 	const dispatch = useDispatch();
 	const feedIcon = feed ? feed.site_icon ?? get( feed, 'image' ) : null;
@@ -30,17 +32,17 @@ const ReaderListFollowingItem = ( props ) => {
 
 	let streamLink;
 
-	if ( site.feed_ID ) {
-		streamLink = `/read/feeds/${ site.feed_ID }`;
-	} else if ( site.blog_ID ) {
+	if ( follow.feed_ID ) {
+		streamLink = `/read/feeds/${ follow.feed_ID }`;
+	} else if ( follow.blog_ID ) {
 		// If subscription is missing a feed ID, fallback to blog stream
-		streamLink = `/read/blogs/${ site.blog_ID }`;
+		streamLink = `/read/blogs/${ follow.blog_ID }`;
 	} else {
 		// Skip it
 		return null;
 	}
 
-	const urlForDisplay = formatUrlForDisplay( site.URL );
+	const urlForDisplay = formatUrlForDisplay( follow.URL );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -53,9 +55,11 @@ const ReaderListFollowingItem = ( props ) => {
 			<a
 				className="reader-sidebar-site_link"
 				href={ streamLink }
-				onClick={ () => handleSidebarClick( site ) }
+				onClick={ () => handleSidebarClick( follow ) }
 			>
 				<span className="reader-sidebar-site_siteicon">
+					{ ! site && <QueryReaderSite siteId={ siteId } /> }
+					{ ! feed && follow.feed_ID && <QueryReaderFeed feedId={ follow.feed_ID } /> }
 					<ReaderAvatar
 						siteIcon={ siteIcon }
 						feedIcon={ feedIcon }
@@ -65,20 +69,20 @@ const ReaderListFollowingItem = ( props ) => {
 					/>
 				</span>
 				<span className="reader-sidebar-site_sitename">
-					<span className="reader-sidebar-site_nameurl">{ site.name || urlForDisplay }</span>
-					{ site.last_updated > 0 && (
+					<span className="reader-sidebar-site_nameurl">{ follow.name || urlForDisplay }</span>
+					{ follow.last_updated > 0 && (
 						<span className="reader-sidebar-site_updated">
-							{ moment( new Date( site.last_updated ) ).fromNow() }
+							{ moment( new Date( follow.last_updated ) ).fromNow() }
 						</span>
 					) }
-					{ site.description?.length > 0 && (
-						<span className="reader-sidebar-site_description">{ site.description }</span>
+					{ follow.description?.length > 0 && (
+						<span className="reader-sidebar-site_description">{ follow.description }</span>
 					) }
 					{ urlForDisplay.length > 0 && (
 						<span className="reader-sidebar-site_url">{ urlForDisplay }</span>
 					) }
 				</span>
-				{ isUnseen && site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
+				{ isUnseen && follow.unseen_count > 0 && <Count count={ follow.unseen_count } compact /> }
 			</a>
 		</li>
 	);
@@ -86,17 +90,12 @@ const ReaderListFollowingItem = ( props ) => {
 };
 
 export default connect( ( state, ownProps ) => {
-	const site = ownProps.site;
-	const feedId = get( site, 'feed_ID' );
-	const feed = getFeed( state, feedId );
-
-	// Add site icon to feed object so have icon for external feeds
-	if ( feed ) {
-		const follow = getReaderFollowForFeed( state, parseInt( feedId ) );
-		feed.site_icon = follow?.site_icon;
-	}
+	const feedId = get( ownProps.follow, 'feed_ID' );
+	const siteId = get( ownProps.follow, 'blog_ID' );
 
 	return {
-		feed: feed,
+		feed: getFeed( state, feedId ),
+		site: getSite( state, siteId ),
+		siteId: siteId,
 	};
 } )( ReaderListFollowingItem );


### PR DESCRIPTION
This PR will try to tidy up a couple of issues with the Reader sidebar icons through the `ReaderListFollowingItem` component.

The site doesn't always have a `site_icon`;
* the site owner might not have set a favicon for their blog
* the follow might be a feed, in which case we need to check if the feed has an icon

### Changes of note

* The `site` prop in `ReaderListFollowingItem` is not a site object, it is a `follow` (this PR renames it from `site` to `follow`). The `follow` is populated from a call to `read/follows` endpoint. This endpoint doesn't include a site_icon so we have to rely on a feed or site lookup in state. If not in state then we have no icon to use.
* I added a `QueryReaderSite` and `QueryReaderFeed` to look up a site or feed to get the site icon if not available.

- [x] 1: Use Feed icon when available. This is similar to how handled in the the post stream with the exception that the post stream will fallback to the post author if not site or feed icon found - for the sidebar we don't have a post so we will continue to fallback to the globe gridicon.
- [x] 2: Update the globe gridicon to be black (match site name color), not blue.

### Before

<img width="702" alt="Screenshot 2023-06-29 at 16 39 38" src="https://github.com/Automattic/wp-calypso/assets/5560595/2c06fd25-aae4-4838-bd91-84e45151611e">

### After

<img width="712" alt="Screenshot 2023-06-29 at 16 45 41" src="https://github.com/Automattic/wp-calypso/assets/5560595/22c57d3a-1788-485e-9398-28e19adbf68d">

### Testing

* Apply PR locally
* Confirm site icons in sidebar load as expected
