### PR TITLE
Jetpack Cloud: Make Licenses page full width, a la Dashboard

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPartnerPortalLicenseCounts from 'calypso/components/data/query-jetpack-partner-portal-license-counts';
-import Main from 'calypso/components/main';
 import SiteAddLicenseNotification from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification';
 import SiteSurveyBanner from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner';
 import SiteWelcomeBanner from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner';
@@ -65,7 +64,7 @@ export default function Licenses( {
 	const showEmptyStateContent = hasFetched && allLicensesCount === 0;
 
 	return (
-		<Main wideLayout className="licenses">
+		<div className="licenses" role="main">
 			<QueryJetpackPartnerPortalLicenseCounts />
 			<DocumentHead title={ translate( 'Licenses' ) } />
 			<SidebarNavigation />
@@ -100,6 +99,6 @@ export default function Licenses( {
 					<LicenseList />
 				</LicenseListContext.Provider>
 			) }
-		</Main>
+		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -75,30 +75,33 @@ export default function Licenses( {
 				</>
 			) }
 			<SiteAddLicenseNotification />
-			<div className="licenses__header">
-				<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
 
-				<SelectPartnerKeyDropdown />
+			<div className="licenses__container">
+				<div className="licenses__header">
+					<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
 
-				<Button
-					href="/partner-portal/issue-license"
-					onClick={ onIssueNewLicenseClick }
-					primary
-					style={ { marginLeft: 'auto' } }
-				>
-					{ translate( 'Issue New License' ) }
-				</Button>
+					<SelectPartnerKeyDropdown />
+
+					<Button
+						href="/partner-portal/issue-license"
+						onClick={ onIssueNewLicenseClick }
+						primary
+						style={ { marginLeft: 'auto' } }
+					>
+						{ translate( 'Issue New License' ) }
+					</Button>
+				</div>
+
+				{ showEmptyStateContent ? (
+					<OnboardingWidget isLicensesPage />
+				) : (
+					<LicenseListContext.Provider value={ context }>
+						<LicenseStateFilter />
+
+						<LicenseList />
+					</LicenseListContext.Provider>
+				) }
 			</div>
-
-			{ showEmptyStateContent ? (
-				<OnboardingWidget isLicensesPage />
-			) : (
-				<LicenseListContext.Provider value={ context }>
-					<LicenseStateFilter />
-
-					<LicenseList />
-				</LicenseListContext.Provider>
-			) }
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
@@ -1,7 +1,15 @@
 .licenses {
+	header.current-section {
+		padding: 0 16px;
+
+		button {
+			padding: 20px 8px;
+		}
+	}
+
 	&__container {
-	max-width: 1500px;
-	margin: auto;
+		max-width: 1500px;
+		margin: auto;
 
 		padding: 0 16px;
 	}

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
@@ -1,6 +1,10 @@
 .licenses {
+	&__container {
 	max-width: 1500px;
 	margin: auto;
+
+		padding: 0 16px;
+	}
 
 	&__header {
 		display: flex;

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
@@ -1,10 +1,17 @@
 .licenses {
+	max-width: 1500px;
+	margin: auto;
+
 	&__header {
 		display: flex;
 		align-items: center;
 
 		> * + * {
 			margin-left: 24px;
+		}
+
+		.card-heading {
+			margin-block-start: initial;
 		}
 	}
 }


### PR DESCRIPTION
This PR adjusts some padding around the outside of the Licenses page in Jetpack Cloud, to more closely match the page layout on the Dashboard page. 

Resolves `1202619025189113-as-1204839784815643`, `p1686906449261649-slack-C03Q2D22DGV`.

## Proposed Changes

* Wrap Licenses page content in a container element.
* Add styles to said container element to limit maximum width and auto-horizontally center content on the page.
* Adjust padding on the nav element for smaller screens, to match what it looks like on the Dashboard page.

## Testing Instructions

1. In two browser windows, visit the Dashboard (`/dashboard`) and Licenses (`/partner-portal/licenses`) pages in your testing environment.
2. Comparing narrow, medium, wide, and extra-wide screen sizes, verify the page layouts are largely identical in terms of screen-edge padding.
3. On extra-wide screens, verify the width of the content never exceeds 1500px.

### Reference screenshots

#### Narrow (390px)

<img width="250" src="https://github.com/Automattic/wp-calypso/assets/670067/666024d8-4df3-4c93-a29f-4adf73fa1f3f" /> <img width="250" src="https://github.com/Automattic/wp-calypso/assets/670067/87624eee-133e-4c68-908e-7f8af0e55b90" />

#### Tablet (961px)

<img width="300" src="https://github.com/Automattic/wp-calypso/assets/670067/57b6b880-5d48-4fa9-aa49-a17f5b01e333" /> <img width="300" src="https://github.com/Automattic/wp-calypso/assets/670067/540b681e-c046-4971-a91b-ef05168daaf5" />

#### Wide (1281px)

<img width="300" src="https://github.com/Automattic/wp-calypso/assets/670067/5ea039c4-ee5d-4ad8-b42d-8fde3762f0c7" /> <img width="300" src="https://github.com/Automattic/wp-calypso/assets/670067/9ee361f8-cf2f-4ecc-a820-7e67808be36a" />

#### Extra-wide (2000px)

<img width="350" src="https://github.com/Automattic/wp-calypso/assets/670067/9bb94156-fa3c-4d16-bfef-a3a42a2f319a" /> <img width="350" src="https://github.com/Automattic/wp-calypso/assets/670067/a21d5650-d7bd-4bb5-8886-9ddb8d943e8c" />


## Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204839784815643