### PR TITLE
Sidebar: refresh Manage all domains button

### DIFF
--- a/client/my-sites/sidebar/static-data/all-sites-menu.js
+++ b/client/my-sites/sidebar/static-data/all-sites-menu.js
@@ -18,7 +18,7 @@ export default function allSitesMenu( { showManagePlugins = false } = {} ) {
 		},
 		{
 			icon: 'dashicons-admin-site-alt3',
-			slug: 'upgrades',
+			slug: 'domains',
 			title: translate( 'Domains' ),
 			navigationLabel: translate( 'Manage all domains' ),
 			type: 'menu-item',

--- a/client/my-sites/sidebar/static-data/all-sites-menu.js
+++ b/client/my-sites/sidebar/static-data/all-sites-menu.js
@@ -17,10 +17,10 @@ export default function allSitesMenu( { showManagePlugins = false } = {} ) {
 			url: '/stats/day',
 		},
 		{
-			icon: 'dashicons-cart',
+			icon: 'dashicons-admin-site-alt3',
 			slug: 'upgrades',
 			title: translate( 'Domains' ),
-			navigationLabel: translate( 'View domains for all sites' ),
+			navigationLabel: translate( 'Manage all domains' ),
 			type: 'menu-item',
 			url: '/domains/manage',
 		},

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -372,6 +372,10 @@ $font-size: rem(14px);
 		left: 8px;
 	}
 
+	.all-sites .dashicons-admin-site-alt3 {
+		height: 18px;
+	}
+
 	// client/blocks/site/style.scss
 	.site__content,
 	.all-sites .all-sites__content {


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/2868.

## Proposed Changes

This PR changes the label and icon of the multi-site context CTA for the domains page in the sidebar:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/d3d80160-7ce3-480e-9529-870ffb04cb78)

I also updated the slug from `upgrades` to `domains`. As far as I could tell, this particular slug is only used to identify the click on Tracks: https://github.com/Automattic/wp-calypso/blob/trunk/client/components/site-selector/index.jsx#L367. Let me know if there are bigger implications and the need to revert this change before merging.

## Testing Instructions

1. Open WPCOM and browse site > Upgrades > Domains;
2. Click on "Switch site" and verify that the copy and icon were updated and match the screenshot above.