### PR TITLE
My Home: Add Manage all domains quick link

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links-for-devs/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links-for-devs/index.jsx
@@ -8,6 +8,7 @@ import { getPreference } from 'calypso/state/preferences/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedEditor from 'calypso/state/selectors/get-selected-editor';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -27,6 +28,7 @@ const QuickLinksForDevs = ( props ) => {
 	const isExpanded = useSelector(
 		( state ) => getPreference( state, 'homeQuickLinksToggleStatus' ) !== 'collapsed'
 	);
+	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 
 	const dispatch = useDispatch();
 	const updateToggleStatus = ( status ) => {
@@ -74,24 +76,23 @@ const QuickLinksForDevs = ( props ) => {
 				label={ translate( 'Explore themes' ) }
 				materialIcon="view_quilt"
 			/>
+			{ canManageSite && ! isWpcomStagingSite && (
+				<ActionBox
+					href={ `/domains/add/${ siteSlug }` }
+					hideLinkIndicator
+					onClick={ props.trackAddDomainAction }
+					label={ translate( 'Add a domain' ) }
+					gridicon="add-outline"
+				/>
+			) }
 			{ canManageSite && (
-				<>
-					<ActionBox
-						href={ `/domains/add/${ siteSlug }` }
-						hideLinkIndicator
-						onClick={ props.trackAddDomainAction }
-						label={ translate( 'Add a domain' ) }
-						gridicon="add-outline"
-					/>
-
-					<ActionBox
-						href="/domains/manage"
-						hideLinkIndicator
-						onClick={ props.trackManageAllDomainsAction }
-						label={ translate( 'Manage all domains' ) }
-						gridicon="domains"
-					/>
-				</>
+				<ActionBox
+					href="/domains/manage"
+					hideLinkIndicator
+					onClick={ props.trackManageAllDomainsAction }
+					label={ translate( 'Manage all domains' ) }
+					gridicon="domains"
+				/>
 			) }
 			{ siteAdminUrl && (
 				<ActionBox

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -57,6 +57,7 @@ export const QuickLinks = ( {
 	trackDesignLogoAction,
 	trackAddEmailAction,
 	trackAddDomainAction,
+	trackManageAllDomainsAction,
 	trackExplorePluginsAction,
 	isExpanded,
 	updateHomeQuickLinksToggleStatus,
@@ -184,6 +185,7 @@ export const QuickLinks = ( {
 				<ActionBox
 					href="/domains/manage"
 					hideLinkIndicator
+					onClick={ trackManageAllDomainsAction }
 					label={ translate( 'Manage all domains' ) }
 					gridicon="domains"
 				/>
@@ -375,6 +377,17 @@ const trackAddDomainAction = ( isStaticHomePage ) => ( dispatch ) => {
 	);
 };
 
+const trackManageAllDomainsAction = ( isStaticHomePage ) => ( dispatch ) => {
+	dispatch(
+		composeAnalytics(
+			recordTracksEvent( 'calypso_customer_home_my_site_manage_all_domains_click', {
+				is_static_home_page: isStaticHomePage,
+			} ),
+			bumpStat( 'calypso_customer_home', 'my_site_manage_all_domains' )
+		)
+	);
+};
+
 /**
  * Select a list of domains that are eligible to add email to from a larger list.
  * WPCOM-specific domains like free and staging sub-domains are filtered from this list courtesy of `canCurrentUserAddEmail`
@@ -434,6 +447,7 @@ const mapDispatchToProps = {
 	trackAnchorPodcastAction,
 	trackAddEmailAction,
 	trackAddDomainAction,
+	trackManageAllDomainsAction,
 	trackExplorePluginsAction,
 	updateHomeQuickLinksToggleStatus: ( status ) =>
 		savePreference( 'homeQuickLinksToggleStatus', status ),
@@ -456,6 +470,8 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 		trackAnchorPodcastAction: () => dispatchProps.trackAnchorPodcastAction( isStaticHomePage ),
 		trackAddEmailAction: () => dispatchProps.trackAddEmailAction( isStaticHomePage ),
 		trackAddDomainAction: () => dispatchProps.trackAddDomainAction( isStaticHomePage ),
+		trackManageAllDomainsAction: () =>
+			dispatchProps.trackManageAllDomainsAction( isStaticHomePage ),
 		trackExplorePluginsAction: () => dispatchProps.trackExplorePluginsAction( isStaticHomePage ),
 		...ownProps,
 	};

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -175,10 +175,18 @@ export const QuickLinks = ( {
 							hideLinkIndicator
 							onClick={ trackAddDomainAction }
 							label={ translate( 'Add a domain' ) }
-							gridicon="domains"
+							gridicon="add-outline"
 						/>
 					) }
 				</>
+			) }
+			{ canManageSite && (
+				<ActionBox
+					href="/domains/manage"
+					hideLinkIndicator
+					label={ translate( 'Manage all domains' ) }
+					gridicon="domains"
+				/>
 			) }
 			{ siteAdminUrl && (
 				<ActionBox

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -366,7 +366,7 @@ const trackExplorePluginsAction = ( isStaticHomePage ) => ( dispatch ) => {
 	);
 };
 
-const trackAddDomainAction = ( isStaticHomePage ) => ( dispatch ) => {
+export const trackAddDomainAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_add_domain_click', {
@@ -377,7 +377,7 @@ const trackAddDomainAction = ( isStaticHomePage ) => ( dispatch ) => {
 	);
 };
 
-const trackManageAllDomainsAction = ( isStaticHomePage ) => ( dispatch ) => {
+export const trackManageAllDomainsAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_manage_all_domains_click', {


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/2870.

## Proposed Changes

Adds the "Manage all domains" link to Quick Links.

![image](https://github.com/Automattic/wp-calypso/assets/26530524/58549042-b9c3-4adb-a021-185362b49444)

The "Add domain" and "Manage all domains" were added to the Quick Links for Devs:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/55b7ea50-22f3-4ef7-a269-e66346fc683a)

## Testing Instructions

1. Go to "My Home" on any site that you can manage;
2. Verify that the "Manage all domains" link appears below "Add a domain" in the Quick Links section;
3. Verify that clicking the button dispatches the `calypso_customer_home_my_site_manage_all_domains_click` Tracks event;
4. Open a site that was created through `/setup/new-hosted-site` and check that the links also appear in the Quick Links for Devs (don't forget to toggle the developer mode in /me).