### PR TITLE
Cookie Banner: Remove Advertising From Being Selected By Default

### DIFF
--- a/packages/privacy-toolset/src/cookie-banner/consts.ts
+++ b/packages/privacy-toolset/src/cookie-banner/consts.ts
@@ -5,3 +5,9 @@ export const allBucketsTrue: Buckets = {
 	analytics: true,
 	advertising: true,
 };
+
+export const defaultBuckets: Buckets = {
+	essential: true,
+	analytics: true,
+	advertising: false,
+};

--- a/packages/privacy-toolset/src/cookie-banner/customized-consent.tsx
+++ b/packages/privacy-toolset/src/cookie-banner/customized-consent.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { allBucketsTrue } from './consts';
+import { defaultBuckets } from './consts';
 import { GranularConsent } from './granular-consent';
 import type { Buckets, CustomizedConsentContent } from './types';
 
@@ -9,7 +9,7 @@ type Props = {
 };
 
 export const CustomizedConsent = ( { content, onAccept }: Props ) => {
-	const [ buckets, setBuckets ] = useState( allBucketsTrue );
+	const [ buckets, setBuckets ] = useState( defaultBuckets );
 	const handleChangeBucket = ( bucket: keyof Buckets ) => ( checked: boolean ) => {
 		setBuckets( ( prevBuckets ) => ( {
 			...prevBuckets,

--- a/packages/privacy-toolset/src/cookie-banner/test/__snapshots__/cookie-banner.tsx.snap
+++ b/packages/privacy-toolset/src/cookie-banner/test/__snapshots__/cookie-banner.tsx.snap
@@ -78,10 +78,9 @@ exports[`CookieBanner renders in customized consent correctly (after customize b
         class="cookie-banner__bucket-container"
       >
         <span
-          class="components-form-toggle is-checked"
+          class="components-form-toggle"
         >
           <input
-            checked=""
             class="components-form-toggle__input"
             data-testid="advertising-bucket-toggle"
             type="checkbox"

--- a/packages/privacy-toolset/src/cookie-banner/test/cookie-banner.tsx
+++ b/packages/privacy-toolset/src/cookie-banner/test/cookie-banner.tsx
@@ -65,7 +65,7 @@ describe( 'CookieBanner', () => {
 			advertising: true,
 		} );
 	} );
-	test( 'fires onAccept with default selection (all true) (when no change is done in customized consent)', () => {
+	test( 'fires onAccept with default selection (all true except advertising) (when no change is done in customized consent)', () => {
 		const onAccept = jest.fn();
 		const { container } = render(
 			<CookieBanner content={ genericContent } onAccept={ onAccept } />
@@ -76,7 +76,7 @@ describe( 'CookieBanner', () => {
 		expect( onAccept ).toHaveBeenCalledWith( {
 			essential: true,
 			analytics: true,
-			advertising: true,
+			advertising: false,
 		} );
 	} );
 	test( 'fires onAccept with correct selection (when change is done in customized consent)', () => {
@@ -86,12 +86,12 @@ describe( 'CookieBanner', () => {
 		);
 		fireEvent.click( getByText( container, 'customizeButton' ) );
 		fireEvent.click( getByTestId( container, 'essential-bucket-toggle' ) );
-		fireEvent.click( getByTestId( container, 'analytics-bucket-toggle' ) );
+		fireEvent.click( getByTestId( container, 'advertising-bucket-toggle' ) );
 
 		fireEvent.click( getByText( container, 'acceptSelectionButton' ) );
 		expect( onAccept ).toHaveBeenCalledWith( {
 			essential: false,
-			analytics: false,
+			analytics: true,
 			advertising: true,
 		} );
 	} );


### PR DESCRIPTION
[Fixes 1884-gh-Automattic/martech](https://github.com/Automattic/martech/issues/1884)

#### Proposed Changes

Remove the `Advertising` toggle from being pre-selected by default on the Calypso Cookie Banner

![image](https://github.com/Automattic/wp-calypso/assets/20927667/1c010a70-ccd5-4565-b9b5-3a7cbbc14727)


#### Testing Instructions
1. Checkout this branch
2. Since the cookie banner is not enabled by default on the development environment, you have to enable it manually. Go to `config/development.json`and change `"cookie-banner"` and `"ad-tracking"` to `true`
3. Run `yarn` and `yarn start`
4. Go to `http://calypso.localhost:3000/`.
5. If you don't see the cookie banner yet, you will have to clear the cookies. Open `Chrome DevTools`. Go to the `Application` tab and look for `Storage -> Cookies -> http://calypso.localhost:3000/` on the left-hand side. Right-click on `http://calypso.localhost:3000/` and select `Clear`
6. Refresh the page and you should be able to see the Cookie Banner
7. Click on `Customize` and verify the `Advertising` toggle is not selected by default


https://github.com/Automattic/wp-calypso/assets/20927667/140d49d6-6ced-4822-bb55-19dd01c38aa8