### PR TITLE
Move Badge component to @automattic/components

### DIFF
--- a/packages/components/src/badge/README.md
+++ b/packages/components/src/badge/README.md
@@ -1,0 +1,20 @@
+# Badge
+
+Badge is a component used to render a short piece of information that
+should stand out from the rest.
+
+## Usage
+
+```jsx
+import { Badge } from '@automattic/components';
+
+function MyComponent() {
+	return <Badge type="warning">Only 6MB left!</Badge>;
+}
+```
+
+## Props
+
+The following props are available to customize the Badge:
+
+- `type`: `'warning'`, `'success'`, `'info'`, `'info-blue'`, `'error'`

--- a/packages/components/src/badge/docs/example.jsx
+++ b/packages/components/src/badge/docs/example.jsx
@@ -1,0 +1,20 @@
+import { Badge } from '..';
+
+const BadgeExample = () => this.props.exampleCode;
+
+Badge.displayName = 'Badge';
+BadgeExample.displayName = 'Badge';
+
+BadgeExample.defaultProps = {
+	exampleCode: (
+		<div>
+			<Badge type="info">Info Badge</Badge>
+			<Badge type="success">Success Badge</Badge>
+			<Badge type="warning">Warning Badge</Badge>
+			<Badge type="info-blue">Info Blue Badge</Badge>
+			<Badge type="error">Error Badge</Badge>
+		</div>
+	),
+};
+
+export default BadgeExample;

--- a/packages/components/src/badge/index.jsx
+++ b/packages/components/src/badge/index.jsx
@@ -1,0 +1,33 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+
+import './style.scss';
+
+export default class Badge extends Component {
+	static propTypes = {
+		type: PropTypes.oneOf( [
+			'warning',
+			'warning-clear',
+			'success',
+			'info',
+			'info-blue',
+			'info-green',
+			'info-purple',
+			'error',
+		] ).isRequired,
+	};
+
+	static defaultProps = {
+		type: 'warning',
+	};
+
+	render() {
+		const { className, type } = this.props;
+		return (
+			<div className={ classNames( `badge badge--${ type }`, className ) }>
+				{ this.props.children }
+			</div>
+		);
+	}
+}

--- a/packages/components/src/badge/style.scss
+++ b/packages/components/src/badge/style.scss
@@ -1,3 +1,5 @@
+@import "@automattic/typography/styles/variables";
+
 $badge-padding-x: 11px;
 $badge-padding-y: 2px;
 

--- a/packages/components/src/badge/style.scss
+++ b/packages/components/src/badge/style.scss
@@ -1,0 +1,50 @@
+.badge {
+	display: inline-block;
+	// A number large enough to exceed height of any badge to make it look like a pill
+	border-radius: 1000px; /* stylelint-disable-line scales/radii */
+	padding: $badge-padding-y $badge-padding-x;
+	font-size: $font-body-small;
+	line-height: 17px;
+	height: 18px;
+}
+
+.badge--warning-clear {
+	color: var(--color-warning);
+	border: 1px solid var(--color-warning);
+	border-radius: 12px; /* stylelint-disable-line scales/radii */
+}
+
+.badge--warning {
+	color: var(--color-warning-80);
+	background-color: var(--color-warning-20);
+}
+
+.badge--success {
+	color: var(--color-text-inverted);
+	background-color: var(--color-success);
+}
+
+.badge--info {
+	color: var(--color-neutral-70);
+	background-color: var(--color-neutral-5);
+}
+
+.badge--info-blue {
+	background-color: var(--studio-blue-50);
+	color: var(--color-text-inverted);
+}
+
+.badge--info-green {
+	color: var(--studio-green-80);
+	background-color: rgba(184, 230, 191, 0.64);
+}
+
+.badge--info-purple {
+	color: var(--studio-woocommerce-purple-80);
+	background-color: var(--studio-woocommerce-purple-5);
+}
+
+.badge--error {
+	background-color: var(--color-error);
+	color: var(--color-text-inverted);
+}

--- a/packages/components/src/badge/style.scss
+++ b/packages/components/src/badge/style.scss
@@ -1,3 +1,6 @@
+$badge-padding-x: 11px;
+$badge-padding-y: 2px;
+
 .badge {
 	display: inline-block;
 	// A number large enough to exceed height of any badge to make it look like a pill

--- a/packages/components/src/badge/test/index.js
+++ b/packages/components/src/badge/test/index.js
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import Badge from '../index';
+
+describe( 'Badge', () => {
+	test( 'should have badge class', () => {
+		const { container } = render( <Badge /> );
+		expect( container.getElementsByClassName( 'badge' ).length ).toBe( 1 );
+	} );
+
+	test( 'should have proper type class (warning)', () => {
+		const { container } = render( <Badge type="warning" /> );
+		expect( container.getElementsByClassName( 'badge badge--warning' ).length ).toBe( 1 );
+	} );
+
+	test( 'should have proper type class (success)', () => {
+		const { container } = render( <Badge type="success" /> );
+		expect( container.getElementsByClassName( 'badge badge--success' ).length ).toBe( 1 );
+	} );
+
+	test( 'should have proper type class (info)', () => {
+		const { container } = render( <Badge type="info" /> );
+		expect( container.getElementsByClassName( 'badge badge--info' ).length ).toBe( 1 );
+	} );
+
+	test( 'should have proper type class (info-blue)', () => {
+		const { container } = render( <Badge type="info-blue" /> );
+		expect( container.getElementsByClassName( 'badge badge--info-blue' ).length ).toBe( 1 );
+	} );
+
+	test( 'should have proper type class (error)', () => {
+		const { container } = render( <Badge type="error" /> );
+		expect( container.getElementsByClassName( 'badge badge--error' ).length ).toBe( 1 );
+	} );
+
+	test( 'should have proper type class (default)', () => {
+		const { container } = render( <Badge /> );
+		expect( container.getElementsByClassName( 'badge badge--warning' ).length ).toBe( 1 );
+	} );
+
+	test( 'should contains the passed children wrapped by a feature-example div', () => {
+		render(
+			<Badge>
+				<div>arbitrary-text-content</div>
+			</Badge>
+		);
+		expect( screen.getByText( 'arbitrary-text-content' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/components/src/badge/test/index.js
+++ b/packages/components/src/badge/test/index.js
@@ -3,6 +3,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import Badge from '../index';
 
 describe( 'Badge', () => {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,4 @@
+export { default as Badge } from './badge';
 export { default as Button } from './button';
 export * as Animation from './animation';
 export { default as Card } from './card';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77564

## Proposed Changes

* Copies the `Badge` component and related tests, examples, etc. to `@automattic/components` so we can use it in other packages (like Launchpad).
* I'll build new PRs on top of this that re-point any references to Badge to the new package.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure all tests pass.
* This alone should not break anything since it's making a copy of the files in question. :) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
