### PR TITLE
BackupBrowser: Download and preview actions - Draft

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -1,9 +1,12 @@
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useCallback, useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import wp from 'calypso/lib/wp';
 import { FileBrowserItem } from './types';
 import { useBackupPathInfoQuery } from './use-backup-path-info-query';
 import { convertBytes } from './util';
+
 interface FileInfoCardProps {
 	siteId: number;
 	item: FileBrowserItem;
@@ -26,6 +29,47 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( { siteId, item } 
 
 	const modifiedTime = fileInfo?.mtime ? moment.unix( fileInfo.mtime ).format( 'lll' ) : null;
 	const size = fileInfo?.size ? convertBytes( fileInfo.size ) : null;
+
+	const [ fileContent, setFileContent ] = useState( '' );
+
+	const downloadFile = useCallback( () => {
+		const manifestPath = window.btoa( item.manifestPath ?? '' );
+
+		wp.req
+			.get( {
+				path: `/sites/${ siteId }/rewind/backup/${ item.period }/file/${ manifestPath }/url`,
+				apiNamespace: 'wpcom/v2',
+			} )
+			.then( ( response: { url: string } ) => {
+				const downloadUrl = new URL( response.url );
+				downloadUrl.searchParams.append( 'disposition', 'attachment' );
+				window.open( downloadUrl, '_blank' );
+			} );
+	}, [ siteId, item ] );
+
+	const previewFile = () => {
+		const manifestPath = window.btoa( item.manifestPath ?? '' );
+
+		//Get the download URL
+		wp.req
+			.get( {
+				path: `/sites/${ siteId }/rewind/backup/${ item.period }/file/${ manifestPath }/url`,
+				apiNamespace: 'wpcom/v2',
+			} )
+			.then( ( response: { url: string } ) => {
+				const downloadUrl = response.url.replace( 'https://public-api.wordpress.com/wpcom/v2', '' );
+
+				// Get the file content
+				wp.req
+					.get( {
+						path: downloadUrl,
+						apiNamespace: 'wpcom/v2',
+					} )
+					.then( ( response: any ) => {
+						setFileContent( response );
+					} );
+			} );
+	};
 
 	// Do not display file info if the item hasChildren (it could be a directory, plugins, themes, etc.)
 	if ( item.hasChildren ) {
@@ -87,7 +131,21 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( { siteId, item } 
 					</div>
 				) }
 			</div>
-			<div className="file-card__actions"></div>
+			<div className="file-card__actions">
+				<Button
+					variant="secondary"
+					className="file-card__action"
+					onClick={ downloadFile }
+					text="Download"
+				/>
+				<Button
+					variant="secondary"
+					className="file-card__action"
+					onClick={ previewFile }
+					text="Preview file"
+				/>
+			</div>
+			<div className="file-card__preview">{ fileContent }</div>
 		</div>
 	);
 };

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -82,6 +82,17 @@
 			&__label {
 				font-weight: bold;
 			}
+
+			&__preview {
+				max-width: 350px;
+
+				audio,
+				video,
+				pre,
+				img {
+					max-width: 100%;
+				}
+			}
 		}
 	}
 }

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -75,11 +75,8 @@
 				font-size: $font-body-small;
 			}
 
-			@include break-mobile {
-				&__detail-group {
-					display: flex;
-					justify-content: space-between;
-				}
+			&__details {
+				padding-bottom: 16px;
 			}
 
 			&__label {


### PR DESCRIPTION
PR created for testing purposes.

## Proposed Changes
TBD

## Testing Instructions
TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
