### PR TITLE
Sync translatable strings from the widget

### DIFF
--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -50,12 +50,15 @@ const BlazePressStrings = () => {
 	translate( "Use post's media" );
 	translate( 'Title' );
 	translate( 'Page title' );
-	translate( '%(charactersLeft)s character remaining', '%(charactersLeft)s characters remaining' );
+	translate( '%(charactersLeft)s character remaining', '%(charactersLeft)s characters remaining', {
+		count: 1,
+	} );
 	translate( 'Snippet' );
 	translate( 'Article Snippet' );
 	translate(
 		'%(snippetCharactersLeft)s character remaining',
-		'%(snippetCharactersLeft)s characters remaining'
+		'%(snippetCharactersLeft)s characters remaining',
+		{ count: 1 }
 	);
 	translate( 'Use + / - or simply drag the image to adjust it' );
 	translate( 'Apply' );
@@ -81,7 +84,8 @@ const BlazePressStrings = () => {
 	translate( 'Total' );
 	translate(
 		'Daily spend for %(durationDays)s-day duration',
-		'Daily spend for %(durationDays)s-day duration'
+		'Daily spend for %(durationDays)s-day duration',
+		{ count: 1 }
 	);
 	translate( 'Estimated people reached per day' );
 	translate( 'Start date' );

--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -4,105 +4,19 @@ const BlazePressStrings = () => {
 	const translate = useTranslate();
 	translate( 'Calculating' );
 	translate( 'Cannot calculate' );
-	translate(
-		'By clicking "Submit campaign" you agree to the {{linkTos}}Terms of Service{{/linkTos}} and {{linkAdvertisingPolicy}}Advertising Policy{{/linkAdvertisingPolicy}}, and authorize your payment method to be charged for the budget and duration you chose. {{linkMoreAboutAds}}Learn more{{/linkMoreAboutAds}} about how budgets and payments for Promoted Posts work.'
-	);
-	translate( 'All topics' );
-	translate( 'All languages' );
-	translate( 'Everywhere' );
-	translate( 'Devices' );
-	translate( 'Location' );
-	translate( 'Language' );
-	translate( 'Interests' );
-	translate( 'OS' );
-	translate( 'days' );
-	translate( 'Estimated impressions' );
-	translate( 'Max budget' );
-	translate( 'Duration' );
-	translate( 'Total' );
-	translate( 'Credits will automatically be applied to your order if available.' );
-	translate( 'Ad Preview' );
-	translate( 'Ad destination' );
-	translate( 'Audience' );
-	translate( 'Budget & Duration' );
-	translate( 'Payment' );
-	translate( 'Save' );
-	translate( 'Save selection' );
-	translate( 'Use post image' );
-	translate( 'Upload' );
-	translate( 'Use + / - or simply drag the image to adjust it' );
-	translate( 'You won’t be charged until the ad is approved and starts running.' );
-	translate( 'You can pause spending at any time.' );
-	translate(
-		'You will not be charged and any available credits (if applicable) will not be spent until the ad is approved and starts running. You can pause spending at any time.'
-	);
-	translate( 'Saved cards' );
-	translate( 'Add new card' );
-	translate( '(ending %(lastFour)s)' );
-	translate( 'Expires on %(month)s/%(year)s' );
-	translate( 'What will be the Goal?' );
-	translate( 'Expand your target audience by adjusting audience setting' );
-	translate( 'Budget' );
-	translate( 'Daily budget' );
-	translate( 'Min amount is $%(minBudget)s' );
-	translate( 'Max amount is $%(maxBudget)s' );
-	translate( 'Between' );
-	translate( 'Days' );
-	translate( 'Min %(minDays)d day' );
-	translate( 'Max %(maxDays)d days' );
-	translate( 'Start date' );
-	translate( 'Creating your Ad' );
+	translate( 'Redirecting to my campaigns…' );
 	translate( 'Oops!' );
 	translate( 'The campaign cannot be created. Please {{a}}contact our support team{{/a}}.' );
-	translate( 'Go to campaigns' );
+	translate( 'Go to my campaigns' );
 	translate( 'All set!' );
 	translate(
 		'The ad has been submitted for approval. We’ll send you a confirmation email once it’s approved and running.'
 	);
-	translate( 'Learn more about the' );
-	translate( 'Advertising Policy' );
-	translate(
-		'Cannot create subscription. Please {{supportLink}}contact support{{/supportLink}} or try again later.'
-	);
-	translate(
-		'There was an error with the address. Please verify that all the required data is valid'
-	);
-	translate(
-		'There was an error with the address. The province, state or region should be filled'
-	);
-	translate( 'State field is required' );
-	translate( 'Use saved card' );
-	translate( 'First Name' );
-	translate( 'Last Name' );
-	translate( 'Address 1' );
-	translate( 'Address 2' );
-	translate( 'Country' );
-	translate( 'State' );
-	translate( 'State / Province / Region' );
-	translate( 'City' );
-	translate( 'Zip / Postal code' );
-	translate( 'Save this card for future payments' );
-	translate( 'Checking payment information' );
-	translate( 'Appearance' );
-	translate( 'Image' );
-	translate( 'Title' );
-	translate( '%(charactersLeft)s character remaining' );
-	translate( 'Snippet' );
-	translate( 'Article Snippet' );
-	translate( '%(snippetCharactersLeft)s character remaining' );
-	translate( 'Destination URL' );
-	translate( 'The blog page' );
-	translate( 'The site home' );
-	translate( 'Card Number' );
-	translate( 'Exp. Date' );
-	translate( 'MM / YY' );
-	translate( 'CVV' );
-	translate( 'Pick a few categories, like food or movies, to narrow your audience.' );
-	translate( 'Previous' );
-	translate( 'Continue' );
-	translate( 'Go to my campaigns' );
 	translate( 'Skip and go to my campaigns next time.' );
-	translate( 'Creating Campaign' );
+	translate(
+		'Learn more about the {{linkAdvertisingPolicy}}Advertising Policy{{/linkAdvertisingPolicy}}.'
+	);
+	translate( 'Creating campaign…' );
 	translate( 'Make the most of your Blaze campaign' );
 	translate( 'Choose an eye-catching image for your ad' );
 	translate( 'Adjust your title to make it more engaging' );
@@ -110,11 +24,14 @@ const BlazePressStrings = () => {
 	translate( 'Get started' );
 	translate( 'Learn more' );
 	translate( "Don't show me this step again." );
-	translate( 'Select post to promote' );
+	translate( 'Checking payment information…' );
+	translate( 'Fetching pages…' );
 	translate( 'Fetching posts…' );
-	translate( 'Fetching %(searchPostType)ss…' );
-	translate( 'Fetching more %(searchPostType)ss…' );
-	translate( 'No %(searchPostType)ss found.' );
+	translate( 'Fetching more pages…' );
+	translate( 'Fetching more posts…' );
+	translate( 'No pages found.' );
+	translate( 'No posts found.' );
+	translate( 'Select post to promote' );
 	translate( 'Post' );
 	translate( 'Type' );
 	translate( 'Publish date' );
@@ -123,61 +40,128 @@ const BlazePressStrings = () => {
 	translate( 'Comments' );
 	translate( 'Advanced Settings' );
 	translate( 'Targeted Devices' );
+	translate( 'Destination URL' );
 	translate( 'The page URL' );
 	translate( 'The post URL' );
+	translate( 'The blog page' );
+	translate( 'The site home' );
+	translate( 'Appearance' );
 	translate( 'Ad creative' );
 	translate( "Use post's media" );
+	translate( 'Title' );
 	translate( 'Page title' );
+	translate( '%(charactersLeft)s character remaining', '%(charactersLeft)s characters remaining' );
+	translate( 'Snippet' );
+	translate( 'Article Snippet' );
+	translate(
+		'%(snippetCharactersLeft)s character remaining',
+		'%(snippetCharactersLeft)s characters remaining'
+	);
+	translate( 'Use + / - or simply drag the image to adjust it' );
 	translate( 'Apply' );
 	translate( 'Reset' );
+	translate( 'Upload' );
 	translate( 'Crop' );
-	translate( 'Drop image here' );
-	translate( 'Click or Drag an image here' );
+	translate( 'Drop an image here to upload.' );
+	translate( 'Click or drag an image here to upload.' );
+	translate( 'Audience' );
+	translate( 'Future reach is unavailable' );
+	translate( 'All languages' );
 	translate(
 		'Based on the language of your site we suggest targeting %(lang)s speaking users to ensure the ad is seen by the right audience and to increase its effectiveness.'
 	);
+	translate( 'Language' );
+	translate( 'Everywhere' );
+	translate( 'Location' );
 	translate( 'All Locations' );
+	translate( 'All topics' );
+	translate( 'Interests' );
 	translate( 'Pick a few categories, like food or pets, to narrow your audience.' );
 	translate( 'Budget and duration' );
-	translate( 'Daily spend for %(durationDays)s-day duration' );
+	translate( 'Total' );
+	translate(
+		'Daily spend for %(durationDays)s-day duration',
+		'Daily spend for %(durationDays)s-day duration'
+	);
 	translate( 'Estimated people reached per day' );
+	translate( 'Start date' );
 	translate( 'Duration (days)' );
+	translate( 'days' );
+	translate( 'Credits will be automatically applied to your order when available.' );
+	translate( 'Credits: %(creditsUsed)s (%(remainingCredit)s remain)' );
 	translate( 'Review your campaign' );
 	translate(
 		'We created this campaign to deliver the most valuable traffic, yet you can still make changes before submitting it.'
 	);
+	translate( 'Duration' );
+	translate( 'Budget' );
 	translate( 'day' );
-	translate( 'total' );
+	translate( 'Estimated impressions' );
+	translate( 'Payment' );
+	translate( 'You won’t be charged until the ad is approved and starts running.' );
+	translate( 'You can pause spending at any time.' );
+	translate(
+		'Cannot create subscription. Please {{supportLink}}contact support{{/supportLink}} or try again later.'
+	);
 	translate( 'Could not retrieve countries. Please try again later.' );
 	translate( 'Error submitting payment. Please check payment information.' );
+	translate(
+		'There was an error with the address. Please verify that all the required data is valid'
+	);
+	translate(
+		'There was an error with the address. The province, state or region should be filled'
+	);
+	translate(
+		'There was an error with the address. Please, check that the Zip code exists, is valid for the country, and corresponds for the given address'
+	);
+	translate( 'Use saved card' );
+	translate( 'First Name' );
+	translate( 'Last Name' );
+	translate( 'Country' );
+	translate( 'Zip / Postal code' );
+	translate( 'Save this card for future payments' );
+	translate( 'Saved cards' );
+	translate( 'Add new card' );
+	translate( '(ending %(lastFour)s)' );
+	translate( 'Expires on %(month)s/%(year)s' );
+	translate( 'Card Number' );
+	translate( 'Exp. Date' );
+	translate( 'CVV' );
 	translate( 'Search…' );
 	translate( 'Page' );
 	translate( 'Product' );
-	translate( 'hours ago' );
-	translate( '1 day ago' );
 	translate( 'Untitled' );
 	translate( 'View' );
 	translate( 'Promote' );
+	translate(
+		'By clicking "Submit campaign" you agree to the {{linkTos}}Terms of Service{{/linkTos}} and {{linkAdvertisingPolicy}}Advertising Policy{{/linkAdvertisingPolicy}}, and authorize your payment method to be charged for the budget and duration you chose. {{linkMoreAboutAds}}Learn more{{/linkMoreAboutAds}} about how budgets and payments for Promoted Posts work.'
+	);
 	translate( 'Submit campaign' );
 	translate( 'Make changes' );
 	translate( 'Page Title' );
-	translate( 'Credits will be automatically applied to your order when available.' );
 	translate( 'Summary' );
+	translate( 'Ad Preview' );
 	translate( 'Estimated Impressions' );
 	translate( 'Max Budget' );
 	translate( 'Languages' );
+	translate( 'Devices' );
 	translate( 'Destination' );
-	translate( 'Audience & Budget' );
-	translate( 'Save and Submit' );
-	translate( 'Next' );
-	translate( 'Close' );
+	translate( 'Loading site…' );
+	translate( 'Preparing the wizard…' );
+	translate( 'Fetching subscriptions…' );
+	translate( 'Drop image here' );
+	translate( 'Click or Drag an image here' );
 	translate( '%(field)s is required.' );
 	translate( 'This field is required.' );
 	translate( 'All fields marked as required ({{span}}*{{/span}}) must be completed to continue' );
-	translate( 'All devices' );
-	translate( 'Mobile devices' );
-	translate( 'Desktop devices' );
-	translate( 'Credits' );
+	translate( 'Pick a few categories, like food or movies, to narrow your audience.' );
+	translate( 'All' );
+	translate( 'Mobile' );
+	translate( 'Desktop' );
+	translate( 'hours ago', { context: 'message for recently created post' } );
+	translate( '1 day ago', { context: 'message for post created yesterday' } );
+	translate( '$%(creditUsed)s ($%(remainingCredit)s remain)', { context: 'amount of money' } );
+	translate( 'Credits', { context: 'amount of money' } );
 };
 
 if ( window.BlazePress ) {


### PR DESCRIPTION


## Proposed Changes

- BlazePress: Add new English originals for translation.

## Testing Instructions

- Code review

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
