### PR TITLE
Switch default start-writing theme to hey from livro

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -43,7 +43,7 @@ const DEFAULT_WP_SITE_THEME = 'pub/zoologist';
 const DEFAULT_LINK_IN_BIO_THEME = 'pub/lynx';
 const DEFAULT_WOOEXPRESS_FLOW = 'pub/twentytwentytwo';
 const DEFAULT_NEWSLETTER_THEME = 'pub/lettre';
-const DEFAULT_START_WRITING_THEME = 'pub/poema';
+const DEFAULT_START_WRITING_THEME = 'pub/hey';
 
 function hasSourceSlug( data: unknown ): data is { sourceSlug: string } {
 	if ( data && ( data as { sourceSlug: string } ).sourceSlug ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -43,7 +43,7 @@ const DEFAULT_WP_SITE_THEME = 'pub/zoologist';
 const DEFAULT_LINK_IN_BIO_THEME = 'pub/lynx';
 const DEFAULT_WOOEXPRESS_FLOW = 'pub/twentytwentytwo';
 const DEFAULT_NEWSLETTER_THEME = 'pub/lettre';
-const DEFAULT_START_WRITING_THEME = 'pub/livro';
+const DEFAULT_START_WRITING_THEME = 'pub/poema';
 
 function hasSourceSlug( data: unknown ): data is { sourceSlug: string } {
 	if ( data && ( data as { sourceSlug: string } ).sourceSlug ) {


### PR DESCRIPTION
pb5gDS-38f-p2#comment-3889

## Proposed Changes

* Switch default start-writing theme to [hey](https://wordpress.com/theme/hey) from [livro](https://wordpress.com/theme/livro)

## Testing Instructions

* On a new user or a user with all sites deleted
* Visit http://calypso.localhost:3000/setup/start-writing
* Theme rendered in the editor should be hey

Before
![Screenshot 2023-06-30 at 11-50-02 Add New Post ‹ Site Title — WordPress](https://github.com/Automattic/wp-calypso/assets/811776/4f8f09ab-d5a7-41c7-a11a-4797826748ee)


After

![image](https://github.com/Automattic/wp-calypso/assets/1044309/4122edc5-34eb-4ee7-8901-4e91950353f2)

