### PR TITLE
Fix error notice for failed cancellations

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -183,46 +183,45 @@ class RemovePurchase extends Component {
 	};
 
 	handlePurchaseRemoval = async ( purchase ) => {
-		const { userId, isDomainOnlySite, translate, purchasesError } = this.props;
+		const { userId, isDomainOnlySite, translate } = this.props;
 
-		await this.props.removePurchase( purchase.id, userId );
+		try {
+			await this.props.removePurchase( purchase.id, userId );
 
-		const productName = getName( purchase );
-		let successMessage;
+			const productName = getName( purchase );
+			let successMessage;
 
-		if ( purchasesError ) {
-			this.setState( { isRemoving: false } );
-			this.closeDialog();
-			this.props.errorNotice( purchasesError );
-			return;
-		}
-
-		successMessage = translate( '%(productName)s was removed from {{siteName/}}.', {
-			args: { productName },
-			components: { siteName: <em>{ purchase.domain }</em> },
-		} );
-
-		if (
-			isAkismetTemporarySitePurchase( purchase ) ||
-			isJetpackTemporarySitePurchase( purchase )
-		) {
-			successMessage = translate( '%(productName)s was removed from your account.', {
+			successMessage = translate( '%(productName)s was removed from {{siteName/}}.', {
 				args: { productName },
+				components: { siteName: <em>{ purchase.domain }</em> },
 			} );
-		}
 
-		if ( isDomainRegistration( purchase ) ) {
-			if ( isDomainOnlySite ) {
-				this.props.receiveDeletedSite( purchase.siteId );
-				this.props.setAllSitesSelected();
+			if (
+				isAkismetTemporarySitePurchase( purchase ) ||
+				isJetpackTemporarySitePurchase( purchase )
+			) {
+				successMessage = translate( '%(productName)s was removed from your account.', {
+					args: { productName },
+				} );
 			}
 
-			successMessage = translate( 'The domain {{domain/}} was removed from your account.', {
-				components: { domain: <em>{ productName }</em> },
-			} );
-		}
+			if ( isDomainRegistration( purchase ) ) {
+				if ( isDomainOnlySite ) {
+					this.props.receiveDeletedSite( purchase.siteId );
+					this.props.setAllSitesSelected();
+				}
 
-		this.props.successNotice( successMessage, { isPersistent: true } );
+				successMessage = translate( 'The domain {{domain/}} was removed from your account.', {
+					components: { domain: <em>{ productName }</em> },
+				} );
+			}
+
+			this.props.successNotice( successMessage, { isPersistent: true } );
+		} catch ( error ) {
+			this.setState( { isRemoving: false } );
+			this.closeDialog();
+			this.props.errorNotice( error.message );
+		}
 	};
 
 	getChatButton = () => (

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -31,7 +31,6 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { removePurchase } from 'calypso/state/purchases/actions';
-import { getPurchasesError } from 'calypso/state/purchases/selectors';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -483,7 +482,6 @@ export default connect(
 			isAtomicSite: isSiteAutomatedTransfer( state, purchase.siteId ),
 			isJetpack,
 			isAkismet,
-			purchasesError: getPurchasesError( state ),
 			userId: getCurrentUserId( state ),
 			primaryDomain: getPrimaryDomainBySiteId( state, purchase.siteId ),
 		};

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -219,7 +219,7 @@ class RemovePurchase extends Component {
 		} catch ( error ) {
 			this.setState( { isRemoving: false } );
 			this.closeDialog();
-			this.props.errorNotice( error.message );
+			this.props.errorNotice( error.message, { displayOnNextPage: true } );
 		}
 	};
 

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -76,7 +76,7 @@ export const fetchUserPurchases = ( userId ) => ( dispatch ) => {
 export const removePurchase = ( purchaseId, userId ) => ( dispatch, getState ) => {
 	const siteId = getSelectedSiteId( getState() );
 
-	return new Promise( ( resolve ) =>
+	return new Promise( ( resolve, reject ) =>
 		wpcom.req
 			.post( {
 				path: `/purchases/${ purchaseId }/delete`,
@@ -101,7 +101,7 @@ export const removePurchase = ( purchaseId, userId ) => ( dispatch, getState ) =
 					error: error.message || PURCHASE_REMOVE_ERROR_MESSAGE,
 				} );
 
-				resolve( error );
+				reject( error );
 			} )
 	);
 };

--- a/client/state/purchases/test/actions.js
+++ b/client/state/purchases/test/actions.js
@@ -117,12 +117,14 @@ describe( 'actions', () => {
 				} );
 		} );
 
-		test( 'should dispatch fetch/remove actions', () => {
-			return removePurchase( purchaseId, userId )( dispatch, getState ).then( () => {
-				expect( dispatch ).toHaveBeenCalledWith( {
-					type: PURCHASE_REMOVE_FAILED,
-					error: errorMessage,
-				} );
+		test( 'should dispatch fetch/remove actions', async () => {
+			await expect(
+				removePurchase( purchaseId, userId )( dispatch, getState )
+			).rejects.toThrowError();
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: PURCHASE_REMOVE_FAILED,
+				error: errorMessage,
 			} );
 		} );
 	} );


### PR DESCRIPTION
## Proposed Changes
Currently, through `/me/purchases`, if the `/purchases/:purchaseId/delete` request fails, we don't show the error notice correctly. This PR fixes it.

## Testing Instructions
For a site that has any purchased/cancelable upgrades:
- _OPTIONAL: if your upgrade is not cancellable, force the button render by commenting out this line:_

https://github.com/Automattic/wp-calypso/blob/e192ed9e9906b2f01fc7534d9bab416a99a31a7d/client/me/purchases/remove-purchase/index.jsx#L429

- Go to `/me/purchases`;
- Force its cancel to fail by applying this backend patch: 30e70-pb/#diff;
- Select the purchase in the list and click on the "Remove subscription" button;
- Confirm by clicking on the "Submit and remove product" button;
- Ensure you see the error notice with the correct message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?