### PR TITLE
Deprecate design preview option viewport_width

### DIFF
--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -139,7 +139,6 @@ export interface DesignPreviewOptions {
 	vertical_id?: string;
 	site_title?: string;
 	site_tagline?: string;
-	viewport_width?: number;
 	viewport_height?: number;
 	use_screenshot_overrides?: boolean;
 	disable_viewport_height?: boolean;

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -52,12 +52,11 @@ describe( 'Design Picker designs utils', () => {
 				language: 'id',
 				vertical_id: '3',
 				site_title: 'Design Title',
-				viewport_width: 1280,
 				viewport_height: 700,
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&vertical_id=3&language=id&viewport_width=1280&viewport_height=700&source_site=patternboilerplates.wordpress.com&site_title=Design%20Title`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&vertical_id=3&language=id&viewport_height=700&source_site=patternboilerplates.wordpress.com&site_title=Design%20Title`
 			);
 		} );
 

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -28,7 +28,6 @@ export const getDesignPreviewUrl = (
 			: undefined,
 		vertical_id: options.vertical_id,
 		language: options.language,
-		...( options.viewport_width && { viewport_width: options.viewport_width } ),
 		viewport_height: ! options.disable_viewport_height
 			? options.viewport_height || DEFAULT_VIEWPORT_HEIGHT
 			: undefined,


### PR DESCRIPTION
## Proposed Changes

This PR removes the design preview option `viewport_width` which was added in https://github.com/Automattic/wp-calypso/pull/64654 to support generated designs. Generated designs have been deprecated, so we don't need this option anymore. D115046-code removes the support for `viewport_width` on the block preview endpoints.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Design Picker/Theme Showcase.
* Ensure that the design/theme previews work as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?