### PR TITLE
Add/gated blog domain available for free plan

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -125,9 +125,13 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			</div>
 		);
 	};
-	const replacePaidDomainWithFreeDomain = ( freeDomainSuggestion: DomainSuggestion ) => {
-		setDomain( freeDomainSuggestion );
+
+	const removePaidDomain = () => {
 		setDomainCartItem( null );
+	};
+
+	const setSiteUrlAsFreeDomainSuggestion = ( freeDomainSuggestion: DomainSuggestion ) => {
+		setDomain( freeDomainSuggestion );
 	};
 
 	const plansFeaturesList = () => {
@@ -153,7 +157,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					isReskinned={ isReskinned }
 					hidePlansFeatureComparison={ hidePlansFeatureComparison }
 					intent={ plansIntent }
-					replacePaidDomainWithFreeDomain={ replacePaidDomainWithFreeDomain }
+					removePaidDomain={ removePaidDomain }
+					setSiteUrlAsFreeDomainSuggestion={ setSiteUrlAsFreeDomainSuggestion }
 				/>
 				{ props.shouldIncludeFAQ && <PlanFAQ /> }
 			</div>

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -31,7 +31,7 @@ const FreePlanCustomDomainFeature: React.FC< {
 	return (
 		<SubdomainSuggestion>
 			{ wpcomFreeDomainSuggestion.isLoading && <LoadingPlaceHolder /> }
-			{ wpcomFreeDomainSuggestion.entry && isCustomDomainAllowedOnFreePlan ? (
+			{ isCustomDomainAllowedOnFreePlan ? (
 				<div>
 					{ translate( '%s will be a redirect', {
 						args: [ paidDomainName ],

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -24,13 +24,25 @@ const SubdomainSuggestion = styled.div`
 const FreePlanCustomDomainFeature: React.FC< {
 	paidDomainName: string;
 	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
-} > = ( { paidDomainName, wpcomFreeDomainSuggestion } ) => {
+	isCustomDomainAllowedOnFreePlan?: boolean | null;
+} > = ( { paidDomainName, wpcomFreeDomainSuggestion, isCustomDomainAllowedOnFreePlan } ) => {
+	const translate = useTranslate();
+
 	return (
 		<SubdomainSuggestion>
-			<div className="is-domain-name">{ paidDomainName }</div>
 			{ wpcomFreeDomainSuggestion.isLoading && <LoadingPlaceHolder /> }
-			{ wpcomFreeDomainSuggestion.entry && (
-				<div>{ wpcomFreeDomainSuggestion.entry.domain_name }</div>
+			{ wpcomFreeDomainSuggestion.entry && isCustomDomainAllowedOnFreePlan ? (
+				<div>
+					{ translate( '%s will be a redirect', {
+						args: [ paidDomainName ],
+						comment: '%s is a domain name.',
+					} ) }
+				</div>
+			) : (
+				<>
+					<div className="is-domain-name">{ paidDomainName }</div>
+					<div>{ wpcomFreeDomainSuggestion.entry?.domain_name }</div>
+				</>
 			) }
 		</SubdomainSuggestion>
 	);
@@ -43,6 +55,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
+	isCustomDomainAllowedOnFreePlan?: boolean | null;
 } > = ( {
 	features,
 	planName,
@@ -50,8 +63,10 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	wpcomFreeDomainSuggestion,
 	hideUnavailableFeatures,
 	selectedFeature,
+	isCustomDomainAllowedOnFreePlan,
 } ) => {
 	const translate = useTranslate();
+
 	return (
 		<>
 			{ features.map( ( currentFeature, featureIndex ) => {
@@ -101,6 +116,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 												key={ key }
 												paidDomainName={ paidDomainName as string }
 												wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+												isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 											/>
 										</Plans2023Tooltip>
 									) : (

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -111,7 +111,7 @@ export type PlanFeatures2023GridProps = {
 	// Value of the `?feature=` query param, so we can highlight a given feature and hide plans without it.
 	selectedFeature?: string;
 	intent?: PlansIntent;
-	isCustomDomainAllowedOnFreePlan?: boolean | null;
+	isCustomDomainAllowedOnFreePlan?: boolean | null; // indicate when a custom domain is allowed to be used with the Free plan.
 	isGlobalStylesOnPersonal?: boolean;
 	showLegacyStorageFeature?: boolean;
 };

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -111,6 +111,7 @@ export type PlanFeatures2023GridProps = {
 	// Value of the `?feature=` query param, so we can highlight a given feature and hide plans without it.
 	selectedFeature?: string;
 	intent?: PlansIntent;
+	isCustomDomainAllowedOnFreePlan?: boolean | null;
 	isGlobalStylesOnPersonal?: boolean;
 	showLegacyStorageFeature?: boolean;
 };
@@ -791,6 +792,7 @@ export class PlanFeatures2023Grid extends Component<
 			translate,
 			hideUnavailableFeatures,
 			selectedFeature,
+			isCustomDomainAllowedOnFreePlan,
 		} = this.props;
 		const planProperties = planPropertiesObj.filter(
 			( properties ) =>
@@ -815,6 +817,7 @@ export class PlanFeatures2023Grid extends Component<
 							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
 							selectedFeature={ selectedFeature }
+							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 						/>
 						{ jpFeatures.length !== 0 && (
 							<div className="plan-features-2023-grid__jp-logo" key="jp-logo">

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -1,6 +1,7 @@
 import { PlanSlug, getPlan } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -117,26 +118,63 @@ const StyledButton = styled( Button )`
 	}
 `;
 
-export function FreePlanPaidDomainDialog( {
+function SuggestedPlanSection( {
+	paidDomainName,
+	suggestedPlanSlug,
+	onButtonClick,
+	isBusy,
+}: {
+	paidDomainName: string;
+	suggestedPlanSlug: PlanSlug;
+	onButtonClick: () => void;
+	isBusy: boolean;
+} ) {
+	const translate = useTranslate();
+	const planPrices = usePlanPrices( { planSlug: suggestedPlanSlug, returnMonthly: true } );
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const planTitle = getPlan( suggestedPlanSlug )?.getTitle();
+
+	return (
+		<>
+			<DomainName>
+				<div>{ paidDomainName }</div>
+				<FreeDomainText>{ translate( 'Free for one year' ) }</FreeDomainText>
+			</DomainName>
+			<StyledButton busy={ isBusy } primary onClick={ onButtonClick }>
+				{ currencyCode &&
+					translate( 'Get %(planTitle)s - %(planPrice)s/month', {
+						comment: 'Eg: Get Personal - $4/month',
+						args: {
+							planTitle: planTitle as string,
+							planPrice: formatCurrency(
+								planPrices.discountedRawPrice || planPrices.rawPrice,
+								currencyCode,
+								{ stripZeros: true }
+							),
+						},
+					} ) }
+			</StyledButton>
+		</>
+	);
+}
+
+type DomainPlanDialogProps = {
+	paidDomainName: string;
+	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
+	suggestedPlanSlug: PlanSlug;
+	onFreePlanSelected: () => void;
+	onPlanSelected: () => void;
+};
+
+function DialogPaidPlanIsRequired( {
 	paidDomainName,
 	wpcomFreeDomainSuggestion,
 	suggestedPlanSlug,
 	onFreePlanSelected,
 	onPlanSelected,
-	onClose,
-}: {
-	paidDomainName: string;
-	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
-	suggestedPlanSlug: PlanSlug;
-	onClose: () => void;
-	onFreePlanSelected: () => void;
-	onPlanSelected: () => void;
-} ) {
+}: DomainPlanDialogProps ) {
 	const translate = useTranslate();
 	const [ isBusy, setIsBusy ] = useState( false );
-	const planPrices = usePlanPrices( { planSlug: suggestedPlanSlug, returnMonthly: true } );
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const planTitle = getPlan( suggestedPlanSlug )?.getTitle();
 
 	function handlePaidPlanClick() {
 		setIsBusy( true );
@@ -147,6 +185,135 @@ export function FreePlanPaidDomainDialog( {
 		setIsBusy( true );
 		onFreePlanSelected();
 	}
+
+	return (
+		<DialogContainer>
+			<Heading>{ translate( 'A paid plan is required for your domain.' ) }</Heading>
+			<SubHeading>
+				{ translate(
+					'Custom domains are only available with a paid plan. And they are free for the first year with an annual paid plan.'
+				) }
+			</SubHeading>
+			<ButtonContainer>
+				<RowWithBorder>
+					<SuggestedPlanSection
+						paidDomainName={ paidDomainName }
+						suggestedPlanSlug={ suggestedPlanSlug }
+						isBusy={ isBusy }
+						onButtonClick={ handlePaidPlanClick }
+					/>
+				</RowWithBorder>
+				<Row>
+					<DomainName>
+						{ wpcomFreeDomainSuggestion.isLoading && <LoadingPlaceHolder /> }
+						{ wpcomFreeDomainSuggestion.entry && (
+							<div>{ wpcomFreeDomainSuggestion.entry.domain_name }</div>
+						) }
+					</DomainName>
+					<StyledButton
+						disabled={ wpcomFreeDomainSuggestion.isLoading || ! wpcomFreeDomainSuggestion.entry }
+						busy={ isBusy }
+						onClick={ handleFreeDomainClick }
+					>
+						{ translate( 'Continue with Free plan' ) }
+					</StyledButton>
+				</Row>
+			</ButtonContainer>
+		</DialogContainer>
+	);
+}
+
+function DialogCustomDomainAndFreePlan( {
+	paidDomainName,
+	wpcomFreeDomainSuggestion,
+	suggestedPlanSlug,
+	onFreePlanSelected,
+	onPlanSelected,
+}: DomainPlanDialogProps ) {
+	const translate = useTranslate();
+	const [ isBusy, setIsBusy ] = useState( false );
+
+	function handlePaidPlanClick() {
+		setIsBusy( true );
+		onPlanSelected();
+	}
+
+	function handleFreePlanClick() {
+		setIsBusy( true );
+		onFreePlanSelected();
+	}
+
+	return (
+		<DialogContainer>
+			<Heading>{ translate( 'A paid plan is required for a custom primary domain.' ) }</Heading>
+			<SubHeading>
+				{ translate(
+					'Your custom domain can only be used as the primary domain with a paid plan and is free for the first year with an annual paid plan. For more details, please read {{a}}our support document{{/a}}.',
+					{
+						components: {
+							a: (
+								<a
+									href={ localizeUrl(
+										'https://wordpress.com/support/domains/set-a-primary-address/'
+									) }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+			</SubHeading>
+			<ButtonContainer>
+				<RowWithBorder>
+					<SuggestedPlanSection
+						paidDomainName={ paidDomainName }
+						suggestedPlanSlug={ suggestedPlanSlug }
+						isBusy={ isBusy }
+						onButtonClick={ handlePaidPlanClick }
+					/>
+				</RowWithBorder>
+				<Row>
+					<DomainName>
+						{ wpcomFreeDomainSuggestion.isLoading && <LoadingPlaceHolder /> }
+						{ wpcomFreeDomainSuggestion.entry &&
+							translate( '%(paidDomainName)s redirects to %(wpcomFreeDomain)s', {
+								args: {
+									paidDomainName,
+									wpcomFreeDomain: wpcomFreeDomainSuggestion.entry.domain_name,
+								},
+								comment: '%(wpcomFreeDomain)s is a WordPress.com subdomain, e.g. foo.wordpress.com',
+							} ) }
+					</DomainName>
+					<StyledButton
+						disabled={ wpcomFreeDomainSuggestion.isLoading || ! wpcomFreeDomainSuggestion.entry }
+						busy={ isBusy }
+						onClick={ handleFreePlanClick }
+					>
+						{ translate( 'Continue with Free plan' ) }
+					</StyledButton>
+				</Row>
+			</ButtonContainer>
+		</DialogContainer>
+	);
+}
+
+export function FreePlanPaidDomainDialog( {
+	paidDomainName,
+	wpcomFreeDomainSuggestion,
+	suggestedPlanSlug,
+	isCustomDomainAllowedOnFreePlan,
+	onFreePlanSelected,
+	onPlanSelected,
+	onClose,
+}: DomainPlanDialogProps & { isCustomDomainAllowedOnFreePlan: boolean; onClose: () => void } ) {
+	const dialogCommonProps: DomainPlanDialogProps = {
+		paidDomainName,
+		wpcomFreeDomainSuggestion,
+		suggestedPlanSlug,
+		onFreePlanSelected,
+		onPlanSelected,
+	};
 
 	return (
 		<Dialog
@@ -166,51 +333,11 @@ export function FreePlanPaidDomainDialog( {
 					}
 				` }
 			/>
-			<DialogContainer>
-				<Heading>{ translate( 'A paid plan is required for your domain.' ) }</Heading>
-				<SubHeading>
-					{ translate(
-						'Custom domains are only available with a paid plan. And they are free for the first year with an annual paid plan.'
-					) }
-				</SubHeading>
-				<ButtonContainer>
-					<RowWithBorder>
-						<DomainName>
-							<div>{ paidDomainName }</div>
-							<FreeDomainText>{ translate( 'Free for one year ' ) }</FreeDomainText>
-						</DomainName>
-						<StyledButton busy={ isBusy } primary onClick={ handlePaidPlanClick }>
-							{ currencyCode &&
-								translate( 'Get %(planTitle)s - %(planPrice)s/month', {
-									comment: 'Eg: Get Personal - $4/month',
-									args: {
-										planTitle: planTitle as string,
-										planPrice: formatCurrency(
-											planPrices.discountedRawPrice || planPrices.rawPrice,
-											currencyCode,
-											{ stripZeros: true }
-										),
-									},
-								} ) }
-						</StyledButton>
-					</RowWithBorder>
-					<Row>
-						<DomainName>
-							{ wpcomFreeDomainSuggestion.isLoading && <LoadingPlaceHolder /> }
-							{ wpcomFreeDomainSuggestion.entry && (
-								<div>{ wpcomFreeDomainSuggestion.entry.domain_name }</div>
-							) }
-						</DomainName>
-						<StyledButton
-							disabled={ wpcomFreeDomainSuggestion.isLoading || ! wpcomFreeDomainSuggestion.entry }
-							busy={ isBusy }
-							onClick={ handleFreeDomainClick }
-						>
-							{ translate( 'Continue with Free plan' ) }
-						</StyledButton>
-					</Row>
-				</ButtonContainer>
-			</DialogContainer>
+			{ isCustomDomainAllowedOnFreePlan ? (
+				<DialogCustomDomainAndFreePlan { ...dialogCommonProps } />
+			) : (
+				<DialogPaidPlanIsRequired { ...dialogCommonProps } />
+			) }
 		</Dialog>
 	);
 }

--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -1,0 +1,12 @@
+import config from '@automattic/calypso-config';
+import { getTld } from 'calypso/lib/domains';
+
+const useIsCustomDomainAllowedOnFreePlan = ( domainName?: string ) => {
+	if ( ! domainName ) {
+		return false;
+	}
+
+	return config.isEnabled( 'domains/blog-domain-free-plan' ) && getTld( domainName ) === 'blog';
+};
+
+export default useIsCustomDomainAllowedOnFreePlan;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -414,7 +414,7 @@ const PlansFeaturesMain = ( {
 						}
 						// Since this domain will not be available after it is selected, invalidate the cache.
 						invalidateDomainSuggestionCache();
-						wpcomFreeDomainSuggestion &&
+						wpcomFreeDomainSuggestion.entry &&
 							setSiteUrlAsFreeDomainSuggestion?.( wpcomFreeDomainSuggestion.entry );
 						onUpgradeClick?.( null );
 					} }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -74,22 +74,33 @@ export class PlansStep extends Component {
 		return 'personal';
 	}
 
-	replacePaidDomainWithFreeDomain = ( freeDomainSuggestion ) => {
-		if ( freeDomainSuggestion?.product_slug ) {
-			return;
-		}
+	removePaidDomain = () => {
 		const domainItem = undefined;
-		const siteUrl = freeDomainSuggestion.domain_name.replace( '.wordpress.com', '' );
 
 		this.props.submitSignupStep(
 			{
 				stepName: 'domains',
 				domainItem,
 				isPurchasingItem: false,
-				siteUrl,
 				stepSectionName: undefined,
 			},
 			{ domainItem }
+		);
+	};
+
+	setSiteUrlAsFreeDomainSuggestion = ( freeDomainSuggestion ) => {
+		if ( freeDomainSuggestion?.product_slug ) {
+			return;
+		}
+
+		const siteUrl = freeDomainSuggestion.domain_name.replace( '.wordpress.com', '' );
+
+		this.props.submitSignupStep(
+			{
+				stepName: 'domains',
+				siteUrl,
+			},
+			{}
 		);
 	};
 
@@ -168,7 +179,8 @@ export class PlansStep extends Component {
 					hideEcommercePlan={ this.shouldHideEcommercePlan() }
 					hideEnterprisePlan={ this.props.hideEnterprisePlan }
 					showBiennialToggle={ this.props.showBiennialToggle }
-					replacePaidDomainWithFreeDomain={ this.replacePaidDomainWithFreeDomain }
+					removePaidDomain={ this.removePaidDomain }
+					setSiteUrlAsFreeDomainSuggestion={ this.setSiteUrlAsFreeDomainSuggestion }
 				/>
 			</div>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1794 

## Proposed Changes

This PR implements the foundational control/treatment experience of the experiment proposed in Automattic/martech#1794. Instead of incorporating ExPlat directly, it uses a feature flag instead so it can be iterated further in production if needed, easier to test, and better focus on the UX and the general code structure to begin with.

It is not written in a throwable way like we often did in the past for A/B tests. Instead, it attempts to introduce a basic structure that enables future experiments on paid domains + the Free plan. For example, it should be intuitive to expand into peP6yB-lq-p2. This is also a test to the idea of "Explore What Enables More Efficient Growth Experiments" I outlined in pdgrnI-2vQ-p2: instead of writing throwable code for short-term speed, we should strive more for a flexible strucutre from the real cases so we accumulate the invested effort in each experiment and will move faster and faster, instead of always going back to square 1 after each.

The treatment experience can be found in the feature list:
<img width="828" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/cbf5c358-7aa6-4fad-8a6e-31bb52161e0e">

and the paid domain + free plan modal:
<img width="1271" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/85cd9983-8559-4efc-a248-f90c97769ff5">

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Treatment experience

* Enable the treatment experience by either running `ENABLE_FEATURES=domains/blog-domain-free-plan yarn start` to start your local calypso, or appending `?flags=domains/blog-domain-free-plan`
* Go through the main onboarding flow, and pick a .blog domain in the domain step.
* In the plans page, it should say "xxx.blog is a redirect"
* Clicking the Free plan button, the modal should show the new copy of explaining why a paid plan is required for a custom primary domain.
* Make sure both the CTAs work as expected.
* Pick a non-blog paid domain, and it should act just like what we have in production now.

#### Control experience

By not doing the priliminary feature enabling step, you should be able to access the default experience that we have now. Everything should work as normal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
