### PR TITLE
GS on Personal A/B: Privacy Settings  Implement A/B testing for Global Styles in Personal Plans

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -7,7 +7,10 @@ import {
 	FEATURE_STYLE_CUSTOMIZATION,
 	PLAN_ECOMMERCE_MONTHLY,
 } from '@automattic/calypso-products';
-import { WPCOM_FEATURES_SUBSCRIPTION_GIFTING } from '@automattic/calypso-products/src';
+import {
+	PLAN_PERSONAL,
+	WPCOM_FEATURES_SUBSCRIPTION_GIFTING,
+} from '@automattic/calypso-products/src';
 import { Card, CompactCard, Button, Gridicon } from '@automattic/components';
 import { guessTimezone, localizeUrl } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
@@ -858,19 +861,30 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	advancedCustomizationNotice() {
-		const { translate, selectedSite, siteSlug } = this.props;
-		const upgradeUrl = `/plans/${ siteSlug }?plan=${ PLAN_PREMIUM }&feature=${ FEATURE_STYLE_CUSTOMIZATION }`;
+		const { translate, selectedSite, siteSlug, globalStylesOnPersonalExperiment } = this.props;
+		const upgradeUrl = `/plans/${ siteSlug }?plan=${
+			globalStylesOnPersonalExperiment ? PLAN_PERSONAL : PLAN_PREMIUM
+		}&feature=${ FEATURE_STYLE_CUSTOMIZATION }`;
 
 		return (
 			<>
 				<div className="site-settings__advanced-customization-notice">
 					<div className="site-settings__advanced-customization-notice-cta">
 						<Gridicon icon="info-outline" />
-						<span>
-							{ translate(
-								'Your site contains customized styles that will only be visible once you upgrade to a Premium plan.'
-							) }
-						</span>
+						{ globalStylesOnPersonalExperiment ? (
+							<span>
+								{ translate(
+									'Your site contains customized styles that will only be visible once you upgrade to a Personal plan.'
+								) }
+							</span>
+						) : (
+							<span>
+								{ ' ' }
+								{ translate(
+									'Your site contains customized styles that will only be visible once you upgrade to a Premium plan.'
+								) }{ ' ' }
+							</span>
+						) }
 					</div>
 					<div className="site-settings__advanced-customization-notice-buttons">
 						<Button href={ selectedSite.URL } target="_blank">
@@ -963,14 +977,14 @@ const getFormSettings = ( settings ) => {
 };
 
 const SiteSettingsFormGeneralWithGlobalStylesNotice = ( props ) => {
-	const { globalStylesInUse, shouldLimitGlobalStyles } = useSiteGlobalStylesStatus(
-		props.site?.ID
-	);
+	const { globalStylesInUse, shouldLimitGlobalStyles, globalStylesInPersonalPlan } =
+		useSiteGlobalStylesStatus( props.site?.ID );
 
 	return (
 		<SiteSettingsFormGeneral
 			{ ...props }
 			shouldShowPremiumStylesNotice={ globalStylesInUse && shouldLimitGlobalStyles }
+			globalStylesOnPersonalExperiment={ globalStylesInPersonalPlan }
 		/>
 	);
 };

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -871,20 +871,15 @@ export class SiteSettingsFormGeneral extends Component {
 				<div className="site-settings__advanced-customization-notice">
 					<div className="site-settings__advanced-customization-notice-cta">
 						<Gridicon icon="info-outline" />
-						{ globalStylesOnPersonalExperiment ? (
-							<span>
-								{ translate(
-									'Your site contains customized styles that will only be visible once you upgrade to a Personal plan.'
-								) }
-							</span>
-						) : (
-							<span>
-								{ ' ' }
-								{ translate(
-									'Your site contains customized styles that will only be visible once you upgrade to a Premium plan.'
-								) }{ ' ' }
-							</span>
-						) }
+						<span>
+							{ globalStylesOnPersonalExperiment
+								? translate(
+										'Your site contains customized styles that will only be visible once you upgrade to a Personal plan.'
+								  )
+								: translate(
+										'Your site contains customized styles that will only be visible once you upgrade to a Premium plan.'
+								  ) }
+						</span>
 					</div>
 					<div className="site-settings__advanced-customization-notice-buttons">
 						<Button href={ selectedSite.URL } target="_blank">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2866

## Proposed Changes

This pull request implements an A/B test to evaluate the effects of introducing global styles in Personal plans. Previously, global styles were only available to Premium plans. The notice users see now dynamically changes based on the experiment they are part of, which means users in the treatment group will see a message indicating they have access to Global Styles on their Personal plan.

| Before | After |
--------|-------
![image](https://github.com/Automattic/dotcom-forge/assets/1233880/4cf59bc4-66c5-4327-a7f5-ceb86e9838dc)|![Captura de Pantalla 2023-07-04 a las 10 15 10](https://github.com/Automattic/wp-calypso/assets/1989914/a8c2a134-a7d4-43f2-85c1-58259d3cdfbd)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing Instructions:

* Open the Calypso live link
* Add some global styles to your **free** site, and launch it
* Navigate to Site Settings in the Calypso dashboard `/settings/general/{site}`
* Check the "Advanced Customization Notice" section
* For the users in the control group, the text should still indicate "Your site contains customized styles that will only be visible once you upgrade to a Premium plan."
* For the users in the treatment group, the text should be changed to "Your site contains customized styles that will only be visible once you upgrade to a Personal plan."
* Verify that the message displayed corresponds to the assigned group of the current user (control or treatment) in the `calypso_global_styles_personal` experiment.
* Ensure no other part of the site settings is affected by this change.

You can change your group here (21268-explat-experiment), you also need to clear the cache when switching between groups by executing this command in your sandbox:
`wp_cache_delete( 'global-styles-on-personal-{siteId}', 'a8c_experiments' );` 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?