### PR TITLE
Subscribers Page: Hide `SubscribersHeaderPopover` when there are no subscribers

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
 import { SortControls } from 'calypso/landing/subscriptions/components/sort-controls';
-import { useSubscriberListManager } from 'calypso/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context';
+import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { SubscribersSortBy } from '../../constants';
 import './style.scss';
 import { useRecordSort } from '../../tracks';
@@ -15,7 +15,7 @@ const getSortOptions = ( translate: ReturnType< typeof useTranslate > ) => [
 
 const ListActionsBar = () => {
 	const translate = useTranslate();
-	const { handleSearch, sortTerm, setSortTerm } = useSubscriberListManager();
+	const { handleSearch, sortTerm, setSortTerm } = useSubscribersPage();
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
 	const recordSort = useRecordSort();
 

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -3,7 +3,7 @@ import Pagination from 'calypso/components/pagination';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
 import { SubscriberList } from 'calypso/my-sites/subscribers/components/subscriber-list';
 import { SubscriberListActionsBar } from 'calypso/my-sites/subscribers/components/subscriber-list-actions-bar';
-import { useSubscriberListManager } from 'calypso/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context';
+import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { useRecordSearch } from '../../tracks';
 import { GrowYourAudience } from '../grow-your-audience';
@@ -18,7 +18,7 @@ const SubscriberListContainer = ( {
 	onClickView,
 	onClickUnsubscribe,
 }: SubscriberListContainerProps ) => {
-	const { grandTotal, total, perPage, page, pageClickCallback } = useSubscriberListManager();
+	const { grandTotal, total, perPage, page, pageClickCallback } = useSubscribersPage();
 	useRecordSearch();
 
 	return (

--- a/client/my-sites/subscribers/components/subscriber-list/subscriber-list.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/subscriber-list.tsx
@@ -1,6 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
-import { useSubscriberListManager } from 'calypso/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context';
+import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { Subscriber } from '../../types';
 import { SubscriberRow } from './subscriber-row';
 import './style.scss';
@@ -12,7 +12,7 @@ type SubscriberListProps = {
 
 const SubscriberList = ( { onView, onUnsubscribe }: SubscriberListProps ) => {
 	const translate = useTranslate();
-	const { subscribers } = useSubscriberListManager();
+	const { subscribers } = useSubscribersPage();
 
 	return (
 		<ul className="subscriber-list" role="table">

--- a/client/my-sites/subscribers/components/subscriber-list/test/subscriber-list.test.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/test/subscriber-list.test.tsx
@@ -17,7 +17,7 @@ jest.mock( '../subscriber-row', () => ( {
 
 // We mock the useSubscriberListManager hook
 jest.mock( '../../subscribers-page/subscribers-page-context', () => ( {
-	useSubscriberListManager: jest.fn(),
+	useSubscribersPage: jest.fn(),
 } ) );
 
 describe( 'SubscriberList', () => {

--- a/client/my-sites/subscribers/components/subscriber-list/test/subscriber-list.test.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/test/subscriber-list.test.tsx
@@ -4,7 +4,7 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
-import { useSubscriberListManager } from '../../subscriber-list-manager/subscriber-list-manager-context';
+import { useSubscribersPage } from '../../subscribers-page/subscribers-page-context';
 import SubscriberList from '../subscriber-list';
 import { SubscriberRow } from '../subscriber-row';
 
@@ -16,7 +16,7 @@ jest.mock( '../subscriber-row', () => ( {
 } ) );
 
 // We mock the useSubscriberListManager hook
-jest.mock( '../../subscriber-list-manager/subscriber-list-manager-context', () => ( {
+jest.mock( '../../subscribers-page/subscribers-page-context', () => ( {
 	useSubscriberListManager: jest.fn(),
 } ) );
 
@@ -33,7 +33,7 @@ describe( 'SubscriberList', () => {
 		jest.clearAllMocks();
 
 		// We set the return value of useSubscriberListManager
-		( useSubscriberListManager as jest.Mock ).mockReturnValue( {
+		( useSubscribersPage as jest.Mock ).mockReturnValue( {
 			subscribers: mockSubscribers,
 		} );
 	} );

--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from 'react-redux';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { addQueryArgs } from 'calypso/lib/url';
-import { useSubscriberListManager } from 'calypso/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { useRecordExport } from '../../tracks';
 import '../shared/popover-style.scss';
@@ -16,7 +15,6 @@ type SubscribersHeaderPopoverProps = {
 };
 
 const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) => {
-	const { grandTotal } = useSubscriberListManager();
 	const [ isVisible, setIsVisible ] = useState( false );
 	const dispatch = useDispatch();
 	const onToggle = useCallback( () => setIsVisible( ( visible ) => ! visible ), [] );
@@ -37,7 +35,7 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 		recordExport();
 	};
 
-	return grandTotal ? (
+	return (
 		<div className="subscriber-popover__container">
 			<button
 				className={ classNames( 'subscriber-popover__toggle', {
@@ -62,7 +60,7 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 				</PopoverMenuItem>
 			</PopoverMenu>
 		</div>
-	) : null;
+	);
 };
 
 export default SubscribersHeaderPopover;

--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from 'react-redux';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { addQueryArgs } from 'calypso/lib/url';
+import { useSubscriberListManager } from 'calypso/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { useRecordExport } from '../../tracks';
 import '../shared/popover-style.scss';
@@ -15,6 +16,7 @@ type SubscribersHeaderPopoverProps = {
 };
 
 const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) => {
+	const { grandTotal } = useSubscriberListManager();
 	const [ isVisible, setIsVisible ] = useState( false );
 	const dispatch = useDispatch();
 	const onToggle = useCallback( () => setIsVisible( ( visible ) => ! visible ), [] );
@@ -35,7 +37,7 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 		recordExport();
 	};
 
-	return (
+	return grandTotal ? (
 		<div className="subscriber-popover__container">
 			<button
 				className={ classNames( 'subscriber-popover__toggle', {
@@ -60,7 +62,7 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 				</PopoverMenuItem>
 			</PopoverMenu>
 		</div>
-	);
+	) : null;
 };
 
 export default SubscribersHeaderPopover;

--- a/client/my-sites/subscribers/components/subscribers-header/index.ts
+++ b/client/my-sites/subscribers/components/subscribers-header/index.ts
@@ -1,0 +1,1 @@
+export { default as SubscribersHeader } from './subscribers-header';

--- a/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
@@ -2,6 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { Item } from 'calypso/components/breadcrumb';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import { useSubscriberListManager } from 'calypso/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context';
 import { SubscribersHeaderPopover } from '../subscribers-header-popover';
 
 type SubscribersHeaderProps = {
@@ -15,6 +16,8 @@ const SubscribersHeader = ( {
 	selectedSiteId,
 	setShowAddSubscribersModal,
 }: SubscribersHeaderProps ) => {
+	const { grandTotal } = useSubscriberListManager();
+
 	return (
 		<FixedNavigationHeader navigationItems={ navigationItems }>
 			<Button
@@ -25,7 +28,7 @@ const SubscribersHeader = ( {
 				<Gridicon icon="plus" size={ 24 } />
 				{ translate( 'Add subscribers' ) }
 			</Button>
-			<SubscribersHeaderPopover siteId={ selectedSiteId } />
+			{ grandTotal ? <SubscribersHeaderPopover siteId={ selectedSiteId } /> : null }
 		</FixedNavigationHeader>
 	);
 };

--- a/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
@@ -2,7 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { Item } from 'calypso/components/breadcrumb';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
-import { useSubscriberListManager } from 'calypso/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context';
+import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { SubscribersHeaderPopover } from '../subscribers-header-popover';
 
 type SubscribersHeaderProps = {
@@ -16,7 +16,7 @@ const SubscribersHeader = ( {
 	selectedSiteId,
 	setShowAddSubscribersModal,
 }: SubscribersHeaderProps ) => {
-	const { grandTotal } = useSubscriberListManager();
+	const { grandTotal } = useSubscribersPage();
 
 	return (
 		<FixedNavigationHeader navigationItems={ navigationItems }>

--- a/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
@@ -1,0 +1,33 @@
+import { Button, Gridicon } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+import { Item } from 'calypso/components/breadcrumb';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import { SubscribersHeaderPopover } from '../subscribers-header-popover';
+
+type SubscribersHeaderProps = {
+	selectedSiteId: number | null;
+	navigationItems: Item[];
+	setShowAddSubscribersModal: React.Dispatch< React.SetStateAction< boolean > >;
+};
+
+const SubscribersHeader = ( {
+	navigationItems,
+	selectedSiteId,
+	setShowAddSubscribersModal,
+}: SubscribersHeaderProps ) => {
+	return (
+		<FixedNavigationHeader navigationItems={ navigationItems }>
+			<Button
+				className="add-subscribers-button"
+				primary
+				onClick={ () => setShowAddSubscribersModal( true ) }
+			>
+				<Gridicon icon="plus" size={ 24 } />
+				{ translate( 'Add subscribers' ) }
+			</Button>
+			<SubscribersHeaderPopover siteId={ selectedSiteId } />
+		</FixedNavigationHeader>
+	);
+};
+
+export default SubscribersHeader;

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -5,14 +5,14 @@ import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { SubscribersSortBy } from '../../constants';
 import { useSubscribersQuery } from '../../queries';
 
-type SubscriberListManagerProviderProps = {
+type SubscribersPageProviderProps = {
 	siteId: number | null;
 	page: number;
 	pageChanged: ( page: number ) => void;
 	children: React.ReactNode;
 };
 
-type SubscriberListManagerContextProps = {
+type SubscribersPageContextProps = {
 	searchTerm: string;
 	handleSearch: ( term: string ) => void;
 	page: number;
@@ -26,18 +26,18 @@ type SubscriberListManagerContextProps = {
 	setSortTerm: ( term: SubscribersSortBy ) => void;
 };
 
-const SubscriberListManagerContext = createContext< SubscriberListManagerContextProps | undefined >(
+const SubscribersPageContext = createContext< SubscribersPageContextProps | undefined >(
 	undefined
 );
 
 const DEFAULT_PER_PAGE = 10;
 
-export const SubscribersListManagerProvider = ( {
+export const SubscribersPageProvider = ( {
 	children,
 	siteId,
 	page,
 	pageChanged,
-}: SubscriberListManagerProviderProps ) => {
+}: SubscribersPageProviderProps ) => {
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ perPage, setPerPage ] = useState( DEFAULT_PER_PAGE );
 	const [ sortTerm, setSortTerm ] = useState( SubscribersSortBy.DateSubscribed );
@@ -78,7 +78,7 @@ export const SubscribersListManagerProvider = ( {
 	);
 
 	return (
-		<SubscriberListManagerContext.Provider
+		<SubscribersPageContext.Provider
 			value={ {
 				searchTerm,
 				handleSearch,
@@ -94,15 +94,15 @@ export const SubscribersListManagerProvider = ( {
 			} }
 		>
 			{ children }
-		</SubscriberListManagerContext.Provider>
+		</SubscribersPageContext.Provider>
 	);
 };
 
-export const useSubscriberListManager = () => {
-	const context = useContext( SubscriberListManagerContext );
+export const useSubscribersPage = () => {
+	const context = useContext( SubscribersPageContext );
 	if ( ! context ) {
 		throw new Error(
-			'useSubscriberListManager must be used within a SubscribersListManagerProvider'
+			'useSubscribersPage must be used within a SubscribersPageProvider'
 		);
 	}
 	return context;

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -101,9 +101,7 @@ export const SubscribersPageProvider = ( {
 export const useSubscribersPage = () => {
 	const context = useContext( SubscribersPageContext );
 	if ( ! context ) {
-		throw new Error(
-			'useSubscribersPage must be used within a SubscribersPageProvider'
-		);
+		throw new Error( 'useSubscribersPage must be used within a SubscribersPageProvider' );
 	}
 	return context;
 };

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -7,7 +7,7 @@ import { Item } from 'calypso/components/breadcrumb';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import { SubscriberListContainer } from 'calypso/my-sites/subscribers/components/subscriber-list-container';
-import { SubscribersListManagerProvider } from 'calypso/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context';
+import { SubscribersPageProvider } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { AddSubscribersModal } from './components/add-subscribers-modal';
@@ -76,7 +76,7 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 	];
 
 	return (
-		<SubscribersListManagerProvider
+		<SubscribersPageProvider
 			siteId={ selectedSiteId }
 			page={ pageNumber }
 			pageChanged={ pageChanged }
@@ -109,7 +109,7 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 					/>
 				) }
 			</Main>
-		</SubscribersListManagerProvider>
+		</SubscribersPageProvider>
 	);
 };
 

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -80,23 +80,24 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 	return (
 		<Main wideLayout className="subscribers">
 			<DocumentHead title={ translate( 'Subscribers' ) } />
-			<FixedNavigationHeader navigationItems={ navigationItems }>
-				<Button
-					className="add-subscribers-button"
-					primary
-					onClick={ () => setShowAddSubscribersModal( true ) }
-				>
-					<Gridicon icon="plus" size={ 24 } />
-					{ translate( 'Add subscribers' ) }
-				</Button>
-				<SubscribersHeaderPopover siteId={ selectedSiteId } />
-			</FixedNavigationHeader>
 
 			<SubscribersListManagerProvider
 				siteId={ selectedSiteId }
 				page={ pageNumber }
 				pageChanged={ pageChanged }
 			>
+				<FixedNavigationHeader navigationItems={ navigationItems }>
+					<Button
+						className="add-subscribers-button"
+						primary
+						onClick={ () => setShowAddSubscribersModal( true ) }
+					>
+						<Gridicon icon="plus" size={ 24 } />
+						{ translate( 'Add subscribers' ) }
+					</Button>
+					<SubscribersHeaderPopover siteId={ selectedSiteId } />
+				</FixedNavigationHeader>
+
 				<SubscriberListContainer
 					onClickView={ onClickView }
 					onClickUnsubscribe={ onClickUnsubscribe }

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,4 +1,3 @@
-import { Button, Gridicon } from '@automattic/components';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import page from 'page';
@@ -6,14 +5,13 @@ import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Item } from 'calypso/components/breadcrumb';
 import DocumentHead from 'calypso/components/data/document-head';
-import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
 import { SubscriberListContainer } from 'calypso/my-sites/subscribers/components/subscriber-list-container';
 import { SubscribersListManagerProvider } from 'calypso/my-sites/subscribers/components/subscriber-list-manager/subscriber-list-manager-context';
 import { successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { AddSubscribersModal } from './components/add-subscribers-modal';
-import { SubscribersHeaderPopover } from './components/subscribers-header-popover';
+import { SubscribersHeader } from './components/subscribers-header';
 import { UnsubscribeModal } from './components/unsubscribe-modal';
 import { getSubscriberDetailsUrl } from './helpers';
 import { useUnsubscribeModal } from './hooks';
@@ -86,17 +84,11 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 				page={ pageNumber }
 				pageChanged={ pageChanged }
 			>
-				<FixedNavigationHeader navigationItems={ navigationItems }>
-					<Button
-						className="add-subscribers-button"
-						primary
-						onClick={ () => setShowAddSubscribersModal( true ) }
-					>
-						<Gridicon icon="plus" size={ 24 } />
-						{ translate( 'Add subscribers' ) }
-					</Button>
-					<SubscribersHeaderPopover siteId={ selectedSiteId } />
-				</FixedNavigationHeader>
+				<SubscribersHeader
+					navigationItems={ navigationItems }
+					selectedSiteId={ selectedSiteId }
+					setShowAddSubscribersModal={ setShowAddSubscribersModal }
+				/>
 
 				<SubscriberListContainer
 					onClickView={ onClickView }

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -76,14 +76,14 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 	];
 
 	return (
-		<Main wideLayout className="subscribers">
-			<DocumentHead title={ translate( 'Subscribers' ) } />
+		<SubscribersListManagerProvider
+			siteId={ selectedSiteId }
+			page={ pageNumber }
+			pageChanged={ pageChanged }
+		>
+			<Main wideLayout className="subscribers">
+				<DocumentHead title={ translate( 'Subscribers' ) } />
 
-			<SubscribersListManagerProvider
-				siteId={ selectedSiteId }
-				page={ pageNumber }
-				pageChanged={ pageChanged }
-			>
 				<SubscribersHeader
 					navigationItems={ navigationItems }
 					selectedSiteId={ selectedSiteId }
@@ -94,22 +94,22 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 					onClickView={ onClickView }
 					onClickUnsubscribe={ onClickUnsubscribe }
 				/>
-			</SubscribersListManagerProvider>
 
-			<UnsubscribeModal
-				subscriber={ currentSubscriber }
-				onCancel={ resetSubscriber }
-				onConfirm={ onConfirmModal }
-			/>
-			{ selectedSiteId && (
-				<AddSubscribersModal
-					siteId={ selectedSiteId }
-					showModal={ showAddSubscribersModal }
-					onClose={ () => setShowAddSubscribersModal( false ) }
-					onAddFinished={ () => addSubscribersCallback() }
+				<UnsubscribeModal
+					subscriber={ currentSubscriber }
+					onCancel={ resetSubscriber }
+					onConfirm={ onConfirmModal }
 				/>
-			) }
-		</Main>
+				{ selectedSiteId && (
+					<AddSubscribersModal
+						siteId={ selectedSiteId }
+						showModal={ showAddSubscribersModal }
+						onClose={ () => setShowAddSubscribersModal( false ) }
+						onAddFinished={ () => addSubscribersCallback() }
+					/>
+				) }
+			</Main>
+		</SubscribersListManagerProvider>
 	);
 };
 

--- a/client/my-sites/subscribers/tracks/use-record-search.ts
+++ b/client/my-sites/subscribers/tracks/use-record-search.ts
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
-import { useSubscriberListManager } from '../components/subscriber-list-manager/subscriber-list-manager-context';
+import { useSubscribersPage } from '../components/subscribers-page/subscribers-page-context';
 import useRecordSubscriberTrackEvent from './use-record-subscriber-tracks-event';
 
 const useRecordSearch = () => {
 	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
-	const { searchTerm } = useSubscriberListManager();
+	const { searchTerm } = useSubscribersPage();
 
 	const [ debouncedRecord ] = useDebouncedCallback( () => {
 		recordSubscribersTracksEvent( 'calypso_subscribers_searched' );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/78801.

| Before | After |
|--------|--------|
| ![Markup on 2023-06-30 at 16:34:48](https://github.com/Automattic/wp-calypso/assets/25105483/8be21e8a-22a0-4e8a-b45d-064a3dabd387) | ![Markup on 2023-06-30 at 16:34:11](https://github.com/Automattic/wp-calypso/assets/25105483/ce8137ed-c5d0-486d-87bc-04789b1d7da9) | 

## Proposed Changes

* Create `SubscribersHeader` component
* Make sure the `SubscribersHeaderPopover` is rendered only if `grandTotal` is present (i.e. there are some subscribers to display) 
* Rename `SubscribersListManagerProvider` to `SubscribersPageProvider`
* Rename `useSubscriberListManager` to `useSubscribersPage `
* Wrap the `Main` component inside `SubscribersPageProvider`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app.
2. Navigate to Users → Subscribers for the site that doesn't have any subscribers. → The ellipsis popover menu **should not** be displayed.
3. Pick a site that has at least one subscriber. → The ellipsis popover menu **should** be displayed.
4. Check for regressions: Try out some actions - like downloading the CSV, removing or adding some subscribers or viewing their details. Everything should be working as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
