### PR TITLE
Bulk Domain: Progress bar is back

### DIFF
--- a/client/landing/stepper/declarative-flow/bulk-domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/bulk-domain-transfer.ts
@@ -1,6 +1,6 @@
 import { useLocale } from '@automattic/i18n-utils';
-import { BULK_DOMAIN_TRANSFER } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
+import { useFlowProgress, BULK_DOMAIN_TRANSFER } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import {
 	clearSignupDestinationCookie,
@@ -8,7 +8,7 @@ import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
-import { USER_STORE } from '../stores';
+import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { Flow, ProvidedDependencies } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';
@@ -37,11 +37,14 @@ const bulkDomainTransfer: Flow = {
 
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: _currentStepSlug, flowName } );
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
 		const locale = useLocale();
+		setStepProgress( flowProgress );
 
 		const logInUrl =
 			locale && locale !== 'en'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-domains/styles.scss
@@ -39,10 +39,6 @@
 		}
 	}
 
-	.progress-bar {
-		display: none;
-	}
-
 	.domains__domain-info {
 		display: flex;
 		gap: 20px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bulk-domain-transfer-intro/styles.scss
@@ -30,10 +30,6 @@
 		z-index: 1;
 	}
 
-	.progress-bar {
-		display: none;
-	}
-
 	.intro__content {
 		width: 100%;
 		text-align: center;

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -5,6 +5,7 @@ import {
 	LINK_IN_BIO_TLD_FLOW,
 	FREE_FLOW,
 	COPY_SITE_FLOW,
+	BULK_DOMAIN_TRANSFER,
 } from '../utils/flows';
 
 /* eslint-disable no-restricted-imports */
@@ -88,6 +89,12 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		processing: 2,
 		'automated-copy': 3,
 		'processing-copy': 3,
+	},
+	[ BULK_DOMAIN_TRANSFER ]: {
+		user: 0,
+		intro: 1,
+		domains: 2,
+		processing: 3,
 	},
 };
 


### PR DESCRIPTION
This PR enables the progress bar for the Bulk Domain Flow

![image](https://github.com/Automattic/wp-calypso/assets/52076348/2ab60111-6c19-4b80-be99-ea8505d41226)


## Testing
1. Live link and visit ` /setup/bulk-domain-transfer`
2. Progress bar should be showing in intro and next step