### PR TITLE
Jetpack Pro Dashboard: implement resend verification code timer and limit

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/verify.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/verify.tsx
@@ -59,7 +59,7 @@ export default function VerifyContactForm( {
 	const translate = useTranslate();
 	const countriesList = useSelector( ( state ) => getCountries( state, 'sms' ) ?? [] );
 
-	const { time, showTimer, startTimer } = useCountdownTimer( 30 );
+	const { time, showTimer, startTimer, resendLimitReached } = useCountdownTimer();
 
 	const [ showCodeVerification, setShowCodeVerification ] = useState< boolean >( false );
 
@@ -357,6 +357,11 @@ export default function VerifyContactForm( {
 
 	const getHelpText = () => {
 		if ( resendCodeClicked && isResendingVerificationCodeSuccess ) {
+			if ( resendLimitReached ) {
+				return translate(
+					'You have reached the maximum number of resend attempts. Please contact our support team if you still experience issues.'
+				);
+			}
 			return (
 				<>
 					<div>{ translate( 'We just sent you a new code. Please wait for a minute.' ) }</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/verify.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/verify.tsx
@@ -59,7 +59,7 @@ export default function VerifyContactForm( {
 	const translate = useTranslate();
 	const countriesList = useSelector( ( state ) => getCountries( state, 'sms' ) ?? [] );
 
-	const { time, showTimer, startTimer, resendLimitReached } = useCountdownTimer();
+	const { time, showTimer, startTimer, limitReached } = useCountdownTimer();
 
 	const [ showCodeVerification, setShowCodeVerification ] = useState< boolean >( false );
 
@@ -357,7 +357,7 @@ export default function VerifyContactForm( {
 
 	const getHelpText = () => {
 		if ( resendCodeClicked && isResendingVerificationCodeSuccess ) {
-			if ( resendLimitReached ) {
+			if ( limitReached ) {
 				return translate(
 					'You have reached the maximum number of resend attempts. Please contact our support team if you still experience issues.'
 				);

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -39,7 +39,7 @@ export default function SMSNotification( {
 						<div className="notification-settings__beta-tag">{ translate( 'BETA' ) }</div>
 					</div>
 					<div className="notification-settings__content-sub-heading">
-						{ translate( 'Set up text messages to send to one or more people' ) }
+						{ translate( 'Set up text messages to send to one or more people.' ) }
 					</div>
 				</div>
 			</div>

--- a/client/jetpack-cloud/sections/hooks/use-countdown-timer.ts
+++ b/client/jetpack-cloud/sections/hooks/use-countdown-timer.ts
@@ -4,11 +4,13 @@ interface CountdownTimer {
 	time: string;
 	showTimer: boolean;
 	startTimer: () => void;
+	resendLimitReached: boolean;
 }
 
 const useCountdownTimer = ( initialSeconds = 30 ): CountdownTimer => {
 	const [ seconds, setSeconds ] = useState( initialSeconds );
 	const [ isActive, setIsActive ] = useState( false );
+	const [ timesClicked, setTimeClicked ] = useState( 0 );
 
 	useEffect( () => {
 		let interval: NodeJS.Timeout;
@@ -38,6 +40,7 @@ const useCountdownTimer = ( initialSeconds = 30 ): CountdownTimer => {
 	};
 
 	const startTimer = (): void => {
+		setTimeClicked( timesClicked + 1 );
 		setIsActive( true );
 	};
 
@@ -45,6 +48,7 @@ const useCountdownTimer = ( initialSeconds = 30 ): CountdownTimer => {
 		time: formatTime( seconds ),
 		showTimer: isActive,
 		startTimer,
+		resendLimitReached: timesClicked > 3,
 	};
 };
 

--- a/client/jetpack-cloud/sections/hooks/use-countdown-timer.ts
+++ b/client/jetpack-cloud/sections/hooks/use-countdown-timer.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+
+interface CountdownTimer {
+	time: string;
+	showTimer: boolean;
+	startTimer: () => void;
+}
+
+const useCountdownTimer = ( initialSeconds = 30 ): CountdownTimer => {
+	const [ seconds, setSeconds ] = useState( initialSeconds );
+	const [ isActive, setIsActive ] = useState( false );
+
+	useEffect( () => {
+		let interval: NodeJS.Timeout;
+
+		if ( isActive && seconds > 0 ) {
+			interval = setInterval( () => {
+				setSeconds( ( prevSeconds ) => prevSeconds - 1 );
+			}, 1000 );
+		}
+
+		if ( seconds === 0 ) {
+			setIsActive( false );
+			setSeconds( initialSeconds );
+		}
+
+		return () => clearInterval( interval );
+	}, [ isActive, seconds, initialSeconds ] );
+
+	const formatTime = ( timeInSeconds: number ): string => {
+		const minutes = Math.floor( timeInSeconds / 60 );
+		const seconds = timeInSeconds % 60;
+
+		const formattedMinutes = minutes.toString();
+		const formattedSeconds = seconds < 10 ? `0${ seconds }` : seconds.toString();
+
+		return `${ formattedMinutes }:${ formattedSeconds }`;
+	};
+
+	const startTimer = (): void => {
+		setIsActive( true );
+	};
+
+	return {
+		time: formatTime( seconds ),
+		showTimer: isActive,
+		startTimer,
+	};
+};
+
+export default useCountdownTimer;

--- a/client/jetpack-cloud/sections/hooks/use-countdown-timer.ts
+++ b/client/jetpack-cloud/sections/hooks/use-countdown-timer.ts
@@ -4,10 +4,10 @@ interface CountdownTimer {
 	time: string;
 	showTimer: boolean;
 	startTimer: () => void;
-	resendLimitReached: boolean;
+	limitReached: boolean;
 }
 
-const useCountdownTimer = ( initialSeconds = 30 ): CountdownTimer => {
+const useCountdownTimer = ( initialSeconds = 30, maxLimit = 3 ): CountdownTimer => {
 	const [ seconds, setSeconds ] = useState( initialSeconds );
 	const [ isActive, setIsActive ] = useState( false );
 	const [ timesClicked, setTimeClicked ] = useState( 0 );
@@ -48,7 +48,7 @@ const useCountdownTimer = ( initialSeconds = 30 ): CountdownTimer => {
 		time: formatTime( seconds ),
 		showTimer: isActive,
 		startTimer,
-		resendLimitReached: timesClicked > 3,
+		limitReached: timesClicked > maxLimit,
 	};
 };
 


### PR DESCRIPTION
Related to 1202619025189113-as-1204922360644708

## Proposed Changes

This PR implements a timer(30 sec) and limit(3 times) to send resend verification code.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-resend-sms-verificatio-code-timer-and-limit` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link. 
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Click the `+ Add email address` button -> Enter all the details -> Click the "Verify" button -> Verify that the UI looks like below

<img width="472" alt="Screenshot 2023-06-30 at 6 03 47 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c0ef53bf-8fce-40ce-9564-022935455091">

6. Enter any random code and verify the below error is shown

<img width="475" alt="Screenshot 2023-06-30 at 6 05 32 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e5a666b4-441a-45c7-b4c6-f4b2b2650c02">

7. Click the `resend` button and verify you can see the help text as shown below after the code is sent

<img width="467" alt="Screenshot 2023-06-30 at 2 15 52 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/66cc7b38-62e4-4984-a299-a782c83b121f">

8. Click the `resend` button 3 times and verify that the below help text is shown

<img width="476" alt="Screenshot 2023-06-30 at 5 57 49 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f5de73d4-95a9-4891-a61e-ac54dd9eddb5">

9. We also added a dot at the end of the string `Set up text messages to send to one or more people`

<img width="472" alt="Screenshot 2023-06-30 at 6 08 50 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/92beafd8-2cc0-4b52-9290-7059cebf4884">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?