### PR TITLE
Domains: Add empty state to All Domains page

### DIFF
--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -1,5 +1,4 @@
 import { Card } from '@automattic/components';
-import { plus } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
 import page from 'page';
@@ -290,7 +289,6 @@ class AllDomains extends Component {
 						'Here you will be able to manage all the domains you own on WordPress.com. Start by adding some:'
 					) }
 					action={ translate( 'Add a domain' ) }
-					actionIcon={ plus }
 					actionURL="/start/domain"
 					secondaryAction={ translate( 'Transfer a domain' ) }
 					secondaryActionURL="/domains/add"

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -289,9 +289,9 @@ class AllDomains extends Component {
 						'Here you will be able to manage all the domains you own on WordPress.com. Start by adding some:'
 					) }
 					action={ translate( 'Add a domain' ) }
-					actionURL="/start/domain"
+					actionURL="/domains/add"
 					secondaryAction={ translate( 'Transfer a domain' ) }
-					secondaryActionURL="/domains/add"
+					secondaryActionURL="/start/domain-transfer/domains"
 				/>
 			);
 		}

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { plus } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
 import page from 'page';
@@ -45,6 +46,7 @@ import BulkEditContactInfo from './bulk-edit-contact-info';
 import DomainOnlyUpsellCarousel from './domain-only-upsell-carousel';
 import DomainsTable from './domains-table';
 import DomainsTableFilterButton from './domains-table-filter-button';
+import { EmptyDomainsListCardSkeleton } from './empty-domains-list-card-skeleton';
 import { filterDomainsByOwner, filterDomainOnlyDomains } from './helpers';
 import ListItemPlaceholder from './item-placeholder';
 import {
@@ -263,6 +265,22 @@ class AllDomains extends Component {
 			translate,
 			dispatch,
 		} = this.props;
+
+		if ( this.filteredDomains().length === 0 ) {
+			return (
+				<EmptyDomainsListCardSkeleton
+					title={ translate( 'All Domains' ) }
+					line={ translate(
+						'Here you will be able to manage all the domains you own on WordPress.com. Start by adding some:'
+					) }
+					action={ translate( 'Add a domain' ) }
+					actionIcon={ plus }
+					actionURL="/start/domain"
+					secondaryAction={ translate( 'Transfer a domain' ) }
+					secondaryActionURL="/domains/add"
+				/>
+			);
+		}
 
 		const { isSavingContactInfo } = this.state;
 
@@ -668,17 +686,23 @@ class AllDomains extends Component {
 			),
 		};
 
-		const buttons = [
-			this.maybeRenderSeeAllDomainsLink(),
-			this.renderDomainTableFilterButton(),
-			<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
-			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
-		];
+		const buttons =
+			this.filteredDomains().length === 0
+				? []
+				: [
+						this.maybeRenderSeeAllDomainsLink(),
+						this.renderDomainTableFilterButton(),
+						<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
+						<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
+				  ];
 
-		const mobileButtons = [
-			<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
-			<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
-		];
+		const mobileButtons =
+			this.filteredDomains().length === 0
+				? []
+				: [
+						<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
+						<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
+				  ];
 
 		return <DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ mobileButtons } />;
 	}

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -247,6 +247,19 @@ class AllDomains extends Component {
 		} );
 	};
 
+	getSelectedFilter = () => {
+		const { context } = this.props;
+		return context?.query?.filter || 'all-domains';
+	};
+
+	getDomainsList = ( selectedFilter = this.getSelectedFilter() ) => {
+		const { sites } = this.props;
+
+		return selectedFilter === 'domain-only'
+			? filterDomainOnlyDomains( this.mergeFilteredDomainsWithDomainsDetails(), sites )
+			: filterDomainsByOwner( this.mergeFilteredDomainsWithDomainsDetails(), selectedFilter );
+	};
+
 	renderDomainsList() {
 		if ( this.isLoading() ) {
 			return Array.from( { length: 3 } ).map( ( _, n ) => (
@@ -258,7 +271,6 @@ class AllDomains extends Component {
 			purchases,
 			sites,
 			currentRoute,
-			context,
 			requestingSiteDomains,
 			hasLoadedUserPurchases,
 			isContactEmailEditContext,
@@ -266,7 +278,11 @@ class AllDomains extends Component {
 			dispatch,
 		} = this.props;
 
-		if ( this.filteredDomains().length === 0 ) {
+		const { isSavingContactInfo } = this.state;
+
+		const domains = this.getDomainsList();
+
+		if ( domains.length === 0 && this.getSelectedFilter() === 'all-domains' ) {
 			return (
 				<EmptyDomainsListCardSkeleton
 					title={ translate( 'All Domains' ) }
@@ -281,15 +297,6 @@ class AllDomains extends Component {
 				/>
 			);
 		}
-
-		const { isSavingContactInfo } = this.state;
-
-		const selectedFilter = context?.query?.filter || 'all-domains';
-
-		const domains =
-			selectedFilter === 'domain-only'
-				? filterDomainOnlyDomains( this.mergeFilteredDomainsWithDomainsDetails(), sites )
-				: filterDomainsByOwner( this.mergeFilteredDomainsWithDomainsDetails(), selectedFilter );
 
 		const domainsTableColumns = [
 			{
@@ -686,23 +693,23 @@ class AllDomains extends Component {
 			),
 		};
 
-		const buttons =
-			this.filteredDomains().length === 0
-				? []
-				: [
-						this.maybeRenderSeeAllDomainsLink(),
-						this.renderDomainTableFilterButton(),
-						<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
-						<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
-				  ];
+		const hasNoDomains = this.getDomainsList( 'all-domains' ).length === 0;
 
-		const mobileButtons =
-			this.filteredDomains().length === 0
-				? []
-				: [
-						<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
-						<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
-				  ];
+		const buttons = hasNoDomains
+			? []
+			: [
+					this.maybeRenderSeeAllDomainsLink(),
+					this.renderDomainTableFilterButton(),
+					<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
+					<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
+			  ];
+
+		const mobileButtons = hasNoDomains
+			? []
+			: [
+					<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
+					<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
+			  ];
 
 		return <DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ mobileButtons } />;
 	}

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card-skeleton.tsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card-skeleton.tsx
@@ -1,0 +1,97 @@
+import { Card, Button } from '@automattic/components';
+import { Icon } from '@wordpress/icons';
+import classNames from 'classnames';
+import { ReactElement } from 'react';
+import customerHomeIllustrationTaskFindDomain from 'calypso/assets/images/domains/free-domain.svg';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+interface EmptyDomainsListCardSkeletonProps {
+	className?: string;
+	isCompact?: boolean;
+	title?: string;
+	line?: string;
+	actionURL: string;
+	contentType: string;
+	actionIcon?: ReactElement;
+	action: string;
+	secondaryActionURL: string;
+	secondaryAction: string;
+}
+
+export const EmptyDomainsListCardSkeleton = ( {
+	className,
+	isCompact,
+	title,
+	line,
+	actionURL,
+	contentType,
+	action,
+	actionIcon,
+	secondaryActionURL,
+	secondaryAction,
+}: EmptyDomainsListCardSkeletonProps ) => {
+	const dispatch = useDispatch();
+
+	const getActionClickHandler =
+		( type: string, buttonURL: string, sourceCardType: string ) => () => {
+			dispatch(
+				recordTracksEvent( 'calypso_empty_domain_list_card_action', {
+					button_type: type,
+					button_url: buttonURL,
+					source_card_type: sourceCardType,
+				} )
+			);
+		};
+
+	const illustration = customerHomeIllustrationTaskFindDomain && (
+		<img src={ customerHomeIllustrationTaskFindDomain } alt="" width={ 150 } />
+	);
+
+	return (
+		<Card className={ classNames( 'empty-domains-list-card', className ) }>
+			<div
+				className={ classNames( 'empty-domains-list-card__wrapper', {
+					'is-compact': isCompact,
+					'has-title-only': title && ! line,
+				} ) }
+			>
+				<div className="empty-domains-list-card__illustration">{ illustration }</div>
+				<div className="empty-domains-list-card__content">
+					<div className="empty-domains-list-card__text">
+						{ title ? <h2>{ title }</h2> : null }
+						{ line ? <h3>{ line }</h3> : null }
+					</div>
+					<div className="empty-domains-list-card__actions">
+						<Button
+							primary
+							onClick={ getActionClickHandler( 'primary', actionURL, contentType ) }
+							href={ actionURL }
+						>
+							{ actionIcon ? (
+								<Icon
+									icon={ actionIcon }
+									className="gridicon"
+									css={ { marginLeft: '2px', marginRight: '6px' } }
+									viewBox="2 2 20 20"
+								/>
+							) : null }
+							{ action }
+						</Button>
+						<Button
+							onClick={ getActionClickHandler( 'secondary', secondaryActionURL, contentType ) }
+							href={ secondaryActionURL }
+						>
+							{ secondaryAction }
+						</Button>
+					</div>
+				</div>
+			</div>
+			<TrackComponentView
+				eventName="calypso_get_your_domain_empty_impression"
+				eventProperties={ { content_type: contentType } }
+			/>
+		</Card>
+	);
+};

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card-skeleton.tsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card-skeleton.tsx
@@ -1,7 +1,5 @@
 import { Card, Button } from '@automattic/components';
-import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
-import { ReactElement } from 'react';
 import customerHomeIllustrationTaskFindDomain from 'calypso/assets/images/domains/free-domain.svg';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { useDispatch } from 'calypso/state';
@@ -14,7 +12,6 @@ interface EmptyDomainsListCardSkeletonProps {
 	line?: string;
 	actionURL: string;
 	contentType: string;
-	actionIcon?: ReactElement;
 	action: string;
 	secondaryActionURL: string;
 	secondaryAction: string;
@@ -28,7 +25,6 @@ export const EmptyDomainsListCardSkeleton = ( {
 	actionURL,
 	contentType,
 	action,
-	actionIcon,
 	secondaryActionURL,
 	secondaryAction,
 }: EmptyDomainsListCardSkeletonProps ) => {
@@ -69,14 +65,6 @@ export const EmptyDomainsListCardSkeleton = ( {
 							onClick={ getActionClickHandler( 'primary', actionURL, contentType ) }
 							href={ actionURL }
 						>
-							{ actionIcon ? (
-								<Icon
-									icon={ actionIcon }
-									className="gridicon"
-									css={ { marginLeft: '2px', marginRight: '6px' } }
-									viewBox="2 2 20 20"
-								/>
-							) : null }
 							{ action }
 						</Button>
 						<Button

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -1,32 +1,14 @@
 import { isFreePlan } from '@automattic/calypso-products';
-import { Card, Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import customerHomeIllustrationTaskFindDomain from 'calypso/assets/images/domains/free-domain.svg';
-import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { EmptyDomainsListCardSkeleton } from './empty-domains-list-card-skeleton';
 
 import './style.scss';
 
-function EmptyDomainsListCard( {
-	selectedSite,
-	hasDomainCredit,
-	isCompact,
-	dispatchRecordTracksEvent,
-	hasNonWpcomDomains,
-} ) {
+function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNonWpcomDomains } ) {
 	const translate = useTranslate();
-
-	const getActionClickHandler = ( type, buttonURL, sourceCardType ) => () => {
-		dispatchRecordTracksEvent( 'calypso_empty_domain_list_card_action', {
-			button_type: type,
-			button_url: buttonURL,
-			source_card_type: sourceCardType,
-		} );
-	};
 
 	const siteHasPaidPlan =
 		selectedSite?.plan?.product_slug && ! isFreePlan( selectedSite.plan.product_slug );
@@ -66,50 +48,22 @@ function EmptyDomainsListCard( {
 		contentType = 'free_domain_credit';
 	}
 
-	const illustration = customerHomeIllustrationTaskFindDomain && (
-		<img src={ customerHomeIllustrationTaskFindDomain } alt="" width={ 150 } />
-	);
+	const className = classNames( {
+		'has-non-wpcom-domains': hasNonWpcomDomains,
+	} );
 
 	return (
-		<Card
-			className={ classNames( 'empty-domains-list-card', {
-				'has-non-wpcom-domains': hasNonWpcomDomains,
-			} ) }
-		>
-			<div
-				className={ classNames( 'empty-domains-list-card__wrapper', {
-					'is-compact': isCompact,
-					'has-title-only': title && ! line,
-				} ) }
-			>
-				<div className="empty-domains-list-card__illustration">{ illustration }</div>
-				<div className="empty-domains-list-card__content">
-					<div className="empty-domains-list-card__text">
-						{ title ? <h2>{ title }</h2> : null }
-						{ line ? <h3>{ line }</h3> : null }
-					</div>
-					<div className="empty-domains-list-card__actions">
-						<Button
-							primary
-							onClick={ getActionClickHandler( 'primary', actionURL, contentType ) }
-							href={ actionURL }
-						>
-							{ action }
-						</Button>
-						<Button
-							onClick={ getActionClickHandler( 'secondary', secondaryActionURL, contentType ) }
-							href={ secondaryActionURL }
-						>
-							{ secondaryAction }
-						</Button>
-					</div>
-				</div>
-			</div>
-			<TrackComponentView
-				eventName="calypso_get_your_domain_empty_impression"
-				eventProperties={ { content_type: contentType } }
-			/>
-		</Card>
+		<EmptyDomainsListCardSkeleton
+			className={ className }
+			isCompact={ isCompact }
+			title={ title }
+			line={ line }
+			contentType={ contentType }
+			action={ action }
+			actionURL={ actionURL }
+			secondaryAction={ secondaryAction }
+			secondaryActionURL={ secondaryActionURL }
+		/>
 	);
 }
 
@@ -122,6 +76,4 @@ EmptyDomainsListCard.propTypes = {
 	hasNonWpcomDomains: PropTypes.bool,
 };
 
-export default connect( null, { dispatchRecordTracksEvent: recordTracksEvent } )(
-	EmptyDomainsListCard
-);
+export default EmptyDomainsListCard;


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/2869.

## Proposed Changes

Let's add an empty state component to `/domains/manage` when 'All domains' is selected and the user still has no domains.

![image](https://github.com/Automattic/wp-calypso/assets/26530524/b584ccd0-e6bf-434a-a628-4e8dde19ba66)


## Testing Instructions

1. Create an account and two free sites;
2. Browse `/domains/manage`.

You should see the empty state and the CTAs pointing to:
- `/domains/add`;
- `/start/domain-transfer/domains`.