### PR TITLE
GF Signup : Fix the domain mapping/transfer related props of the signup completion event.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -37,7 +37,7 @@ import type { DomainSuggestion } from '@automattic/data-stores';
 import './style.scss';
 
 const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
-	const { setHideFreePlan, setDomainCartItem } = useDispatch( ONBOARD_STORE );
+	const { setHideFreePlan, setDomainCartItem, setDomain } = useDispatch( ONBOARD_STORE );
 	const { __ } = useI18n();
 
 	const [ showUseYourDomain, setShowUseYourDomain ] = useState( false );
@@ -88,6 +88,9 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		shouldHideFreePlan = false
 	) => {
 		if ( suggestion ) {
+			setDomain( suggestion );
+
+			/** FIXME: a domain cart item should probably not be set if the domain is free */
 			const domainCartItem = domainRegistration( {
 				domain: suggestion.domain_name,
 				productSlug: suggestion.product_slug || '',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -87,6 +87,10 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		suggestion: DomainSuggestion | undefined,
 		shouldHideFreePlan = false
 	) => {
+		if ( ! suggestion ) {
+			return submit?.();
+		}
+
 		setDomain( suggestion );
 
 		if ( suggestion?.is_free ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -87,10 +87,12 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		suggestion: DomainSuggestion | undefined,
 		shouldHideFreePlan = false
 	) => {
-		if ( suggestion ) {
-			setDomain( suggestion );
+		setDomain( suggestion );
 
-			/** FIXME: a domain cart item should probably not be set if the domain is free */
+		if ( suggestion?.is_free ) {
+			setHideFreePlan( false );
+			setDomainCartItem( undefined );
+		} else {
 			const domainCartItem = domainRegistration( {
 				domain: suggestion.domain_name,
 				productSlug: suggestion.product_slug || '',
@@ -99,11 +101,9 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 
 			setHideFreePlan( Boolean( suggestion.product_slug ) || shouldHideFreePlan );
 			setDomainCartItem( domainCartItem );
-		} else {
-			setDomainCartItem( undefined );
 		}
 
-		submit?.();
+		submit?.( { freeDomain: suggestion?.is_free, domainName: suggestion?.domain_name } );
 	};
 
 	const handleSkip = ( _googleAppsCartItem = undefined, shouldHideFreePlan = false ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -88,6 +88,8 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		shouldHideFreePlan = false
 	) => {
 		if ( ! suggestion ) {
+			setHideFreePlan( false );
+			setDomainCartItem( undefined );
 			return submit?.();
 		}
 

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -1,4 +1,5 @@
 import { isDomainTransfer, isDomainMapping } from '@automattic/calypso-products';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useSelect } from '@wordpress/data';
 import { useCallback } from 'react';
 import { USER_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
@@ -57,8 +58,10 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 			isBlankCanvas: theme?.includes( 'blank-canvas' ),
 			planProductSlug,
 			domainProductSlug,
-			isMapping: hasPaidDomainItem && isDomainMapping( domainCartItem ),
-			isTransfer: hasPaidDomainItem && isDomainTransfer( domainCartItem ),
+			isMapping:
+				hasPaidDomainItem && isDomainMapping( domainCartItem as MinimalRequestCartProduct ),
+			isTransfer:
+				hasPaidDomainItem && isDomainTransfer( domainCartItem as MinimalRequestCartProduct ),
 		} );
 	}, [ domainCartItem, flow, planCartItem, selectedDomain, siteCount, siteId, theme ] );
 };

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -29,20 +29,21 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 		// the length of registration, so I use isNewUser here as an approximation
 		const isNew7DUserSite = isNewUser;
 
-		// Domain cart items can sometimes be included when free. So the selected domain is explicitly checked to see if it's free.
-		// For mappings and transfers this attribute should be empty but it needs to be checked.
-		const isPaidDomainItem = domainCartItem && selectedDomain?.is_free !== true;
-		const hasCartItems = ! isPaidDomainItem || planCartItem; // see the function `dependenciesContainCartItem()
-
 		// Domain product slugs can be a domain purchases like dotcom_domain or dotblog_domain or a mapping like domain_mapping
 		// When purchasing free subdomains the product_slugs is empty (since there is no actual produce being purchased)
 		// so we avoid capturing the product slug in these instances.
-		const domainProductSlug =
-			domainCartItem?.product_slug !== '' ? domainCartItem?.product_slug : undefined;
+		const domainProductSlug = domainCartItem?.product_slug ?? undefined;
+
+		// Domain cart items can sometimes be included when free. So the selected domain is explicitly checked to see if it's free.
+		// For mappings and transfers this attribute should be empty but it needs to be checked.
+		const hasCartItems = !! ( domainProductSlug || planCartItem ); // see the function `dependenciesContainCartItem()
 
 		// When there is no plan put in the cart, `planCartItem` is `null` instead of `undefined` like domainCartItem.
 		// It worths a investigation of whether the both should behave the same.
-		const planProductSlug = planCartItem?.product_slug ? planCartItem.product_slug : undefined;
+		const planProductSlug = planCartItem?.product_slug ?? undefined;
+		// To have a paid domain item it has to either be a paid domain or a different domain product like mapping or transfer.
+		const hasPaidDomainItem =
+			( selectedDomain && ! selectedDomain.is_free ) || !! domainProductSlug;
 
 		recordSignupComplete( {
 			flow,
@@ -56,8 +57,8 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 			isBlankCanvas: theme?.includes( 'blank-canvas' ),
 			planProductSlug,
 			domainProductSlug,
-			isMapping: isPaidDomainItem && isDomainMapping( domainCartItem ),
-			isTransfer: isPaidDomainItem && isDomainTransfer( domainCartItem ),
+			isMapping: hasPaidDomainItem && isDomainMapping( domainCartItem ),
+			isTransfer: hasPaidDomainItem && isDomainTransfer( domainCartItem ),
 		} );
-	}, [ domainCartItem, flow, planCartItem, selectedDomain?.is_free, siteCount, siteId, theme ] );
+	}, [ domainCartItem, flow, planCartItem, selectedDomain, siteCount, siteId, theme ] );
 };

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -58,10 +58,12 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 			isBlankCanvas: theme?.includes( 'blank-canvas' ),
 			planProductSlug,
 			domainProductSlug,
-			isMapping:
-				hasPaidDomainItem && isDomainMapping( domainCartItem as MinimalRequestCartProduct ),
-			isTransfer:
-				hasPaidDomainItem && isDomainTransfer( domainCartItem as MinimalRequestCartProduct ),
+			isMapping: hasPaidDomainItem
+				? isDomainMapping( domainCartItem as MinimalRequestCartProduct )
+				: undefined,
+			isTransfer: hasPaidDomainItem
+				? isDomainTransfer( domainCartItem as MinimalRequestCartProduct )
+				: undefined,
 		} );
 	}, [ domainCartItem, flow, planCartItem, selectedDomain, siteCount, siteId, theme ] );
 };


### PR DESCRIPTION
Fixes Automattic/martech#1878

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to  https://github.com/Automattic/wp-calypso/pull/78333#issuecomment-1602484960

## Proposed Changes

* Fixes domain related prop issues when selecting free or non paid domains
* The domain submit function will no longer create a cart item if the domain is free.
* A domain suggestion item will be set in the store whenever a domain is selected

## Testing Instructions


* Follow the instruction in [the analytics lib README](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/analytics/README.md#L13) and enable the console debugging message, i.e. calling `localStorage.setItem('debug', 'calypso:analytics*');`. Since there will be redirection, make sure to enable "preserve log" for your browser console.
* Go to the Paid Media flow, `/setup/onboarding-media`
* In the domain step select a free domain
* Complete the flow and reach checkout 
* Make sure the `calypso_signup_complete` is fired and the props is_mapping and is_transfer are undefined.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

@escapemanuele Please note that I have changed the domain step here to not include a domain cart item whenever the domain is free. Can you please let me know if there are any issues that could come up here?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
