### PR TITLE
Plans: highlight the current plan in the plan features grid

### DIFF
--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -106,6 +106,14 @@ $planComparisonMinWidthToGridWidthWithSidebarMap: (
 			display: none;
 		}
 	}
+
+	.plan-features-2023-grid__plan-spotlight {
+		display: none;
+
+		@media ( min-width: $plans-2023-small-breakpoint ) {
+			display: block;
+		}
+	}
 }
 
 /**
@@ -137,6 +145,14 @@ $planComparisonMinWidthToGridWidthWithSidebarMap: (
 
 		@media ( min-width: ( $plans-2023-small-breakpoint + $plan-features-sidebar-width ) ) {
 			display: none;
+		}
+	}
+
+	.plan-features-2023-grid__plan-spotlight {
+		display: none;
+
+		@media ( min-width: $plans-2023-small-breakpoint + $plan-features-sidebar-width ) {
+			display: block;
 		}
 	}
 }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -468,7 +468,6 @@ export class PlanFeatures2023Grid extends Component<
 	 */
 	renderSpotlightPlan( planPropertiesObj: PlanProperties[] ) {
 		const planCardClasses = classNames(
-			'plan-features-2023-grid__mobile-plan-card',
 			'plan-features-2023-grid__plan-spotlight-card',
 			getPlanClass( planPropertiesObj[ 0 ].planName )
 		);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -286,7 +286,7 @@ export class PlanFeatures2023Grid extends Component<
 					<QueryActivePromotions />
 					{ spotlightPlanProperties && (
 						<div className="plan-features-2023-grid__plan-spotlight">
-							{ this.renderSpotlightPlan( [ spotlightPlanProperties ] ) }
+							{ this.renderSpotlightPlan( spotlightPlanProperties ) }
 						</div>
 					) }
 					<div className="plan-features">
@@ -466,20 +466,20 @@ export class PlanFeatures2023Grid extends Component<
 	/**
 	 * Similar to `renderMobileView` above.
 	 */
-	renderSpotlightPlan( planPropertiesObj: PlanProperties[] ) {
+	renderSpotlightPlan( planPropertiesObj: PlanProperties ) {
 		const spotlightPlanClasses = classNames(
 			'plan-features-2023-grid__plan-spotlight-card',
-			getPlanClass( planPropertiesObj[ 0 ].planName )
+			getPlanClass( planPropertiesObj.planName )
 		);
 
 		return (
 			<div className={ spotlightPlanClasses }>
-				{ this.renderPlanLogos( planPropertiesObj, { isMobile: true } ) }
-				{ this.renderPlanHeaders( planPropertiesObj, { isMobile: true } ) }
-				{ this.renderPlanTagline( planPropertiesObj, { isMobile: true } ) }
-				{ this.renderPlanPrice( planPropertiesObj, { isMobile: true } ) }
-				{ this.renderBillingTimeframe( planPropertiesObj, { isMobile: true } ) }
-				{ this.renderTopButtons( planPropertiesObj, { isMobile: true } ) }
+				{ this.renderPlanLogos( [ planPropertiesObj ], { isMobile: true } ) }
+				{ this.renderPlanHeaders( [ planPropertiesObj ], { isMobile: true } ) }
+				{ this.renderPlanTagline( [ planPropertiesObj ], { isMobile: true } ) }
+				{ this.renderPlanPrice( [ planPropertiesObj ], { isMobile: true } ) }
+				{ this.renderBillingTimeframe( [ planPropertiesObj ], { isMobile: true } ) }
+				{ this.renderTopButtons( [ planPropertiesObj ], { isMobile: true } ) }
 			</div>
 		);
 	}

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -284,14 +284,14 @@ export class PlanFeatures2023Grid extends Component<
 			>
 				<div className="plans-wrapper">
 					<QueryActivePromotions />
+					{ spotlightPlanProperties && (
+						<div className="plan-features-2023-grid__plan-spotlight">
+							{ this.renderSpotlightPlan( [ spotlightPlanProperties ] ) }
+						</div>
+					) }
 					<div className="plan-features">
 						<div className="plan-features-2023-grid__content">
 							<div>
-								{ spotlightPlanProperties && (
-									<div className="plan-features-2023-grid__plan-spotlight">
-										{ this.renderSpotlightPlan( [ spotlightPlanProperties ] ) }
-									</div>
-								) }
 								<div className="plan-features-2023-grid__desktop-view">
 									{ this.renderTable( planPropertiesForTable ) }
 								</div>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -467,13 +467,13 @@ export class PlanFeatures2023Grid extends Component<
 	 * Similar to `renderMobileView` above.
 	 */
 	renderSpotlightPlan( planPropertiesObj: PlanProperties[] ) {
-		const planCardClasses = classNames(
+		const spotlightPlanClasses = classNames(
 			'plan-features-2023-grid__plan-spotlight-card',
 			getPlanClass( planPropertiesObj[ 0 ].planName )
 		);
 
 		return (
-			<div className={ planCardClasses }>
+			<div className={ spotlightPlanClasses }>
 				{ this.renderPlanLogos( planPropertiesObj, { isMobile: true } ) }
 				{ this.renderPlanHeaders( planPropertiesObj, { isMobile: true } ) }
 				{ this.renderPlanTagline( planPropertiesObj, { isMobile: true } ) }

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -413,7 +413,7 @@ $mobile-card-max-width: 440px;
 	}
 
 	.plan-features-2023-grid__plan-spotlight {
-		.plan-features-2023-grid__mobile-plan-card.plan-features-2023-grid__plan-spotlight-card {
+		.plan-features-2023-grid__plan-spotlight-card {
 			max-width: 100%;
 			margin-bottom: 64px;
 			border: 1px solid #e0e0e0;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -412,6 +412,46 @@ $mobile-card-max-width: 440px;
 		}
 	}
 
+	.plan-features-2023-grid__plan-spotlight {
+		.plan-features-2023-grid__mobile-plan-card.plan-features-2023-grid__plan-spotlight-card {
+			max-width: 100%;
+			margin-bottom: 64px;
+			border: 1px solid #e0e0e0;
+			/* stylelint-disable-next-line scales/radii */
+			border-radius: 0 0 5px 5px;
+			div.plan-features-2023-grid__table-item {
+				border: none;
+				&.is-top-buttons {
+					position: absolute;
+					top: 46px;
+					right: 0;
+					border-left: 0;
+				}
+
+				&.plan-features-2023-grid__header-billing-info {
+					padding-bottom: 32px;
+				}
+
+				&.popular-plan-parent-class .plan-features-2023-grid__popular-badge {
+					padding-bottom: 23px;
+				}
+
+				.plan-features-2023-grid__header-title {
+					margin-top: 24px;
+				}
+
+				.plan-features-2023-grid__header-tagline {
+					min-height: 0;
+					padding-bottom: 16px;
+				}
+
+				.plan-features-2023-grid__header-logo {
+					margin-top: 18px;
+				}
+			}
+		}
+	}
+
 	.plan-features-2023-grid__header-annual-discount {
 		color: var(--studio-green-60);
 		&-is-loading {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -446,7 +446,7 @@ $mobile-card-max-width: 440px;
 				}
 
 				.plan-features-2023-grid__header-logo {
-					margin-top: 18px;
+					display: none;
 				}
 			}
 		}

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -27,7 +27,6 @@ export type PlanProperties = {
 	availableForPurchase: boolean;
 	current?: boolean;
 	planActionOverrides?: PlanActionOverrides;
-	previousProductName?: string;
 };
 
 // FIXME:

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -19,7 +19,7 @@ export type PlanProperties = {
 	isVisible: boolean;
 	planConstantObj: ReturnType< typeof applyTestFiltersToPlansList >;
 	planName: PlanSlug;
-	product_name_short: string;
+	productNameShort: string;
 	rawPrice: number | null;
 	isMonthlyPlan: boolean;
 	tagline: string;
@@ -27,6 +27,7 @@ export type PlanProperties = {
 	availableForPurchase: boolean;
 	current?: boolean;
 	planActionOverrides?: PlanActionOverrides;
+	previousProductName?: string;
 };
 
 // FIXME:

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -6,6 +6,7 @@ import {
 	getPlanPath,
 	PLAN_PERSONAL,
 	PlanSlug,
+	getPlanClass,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
@@ -87,6 +88,7 @@ export interface PlansFeaturesMainProps {
 	showBiennialToggle?: boolean;
 	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
 	showLegacyStorageFeature?: boolean;
+	isSpotlightOnCurrentPlan?: boolean;
 }
 
 type OnboardingPricingGrid2023Props = PlansFeaturesMainProps & {
@@ -141,6 +143,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		siteSlug,
 		intent,
 		showLegacyStorageFeature,
+		isSpotlightOnCurrentPlan,
 	} = props;
 	const translate = useTranslate();
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
@@ -167,6 +170,13 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		};
 	}
 
+	let spotlightPlanSlug: PlanSlug | undefined;
+	if ( sitePlanSlug && isSpotlightOnCurrentPlan ) {
+		spotlightPlanSlug = Object.keys( planRecords ).find(
+			( planSlug ) => getPlanClass( planSlug ) === getPlanClass( sitePlanSlug )
+		) as PlanSlug | undefined;
+	}
+
 	const asyncProps: PlanFeatures2023GridProps = {
 		paidDomainName,
 		wpcomFreeDomainSuggestion,
@@ -188,6 +198,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		intent,
 		isGlobalStylesOnPersonal: globalStylesInPersonalPlan,
 		showLegacyStorageFeature,
+		spotlightPlanSlug,
 	};
 
 	const asyncPlanFeatures2023Grid = (
@@ -243,6 +254,7 @@ const PlansFeaturesMain = ( {
 	isStepperUpgradeFlow = false,
 	isLaunchPage = false,
 	showLegacyStorageFeature = false,
+	isSpotlightOnCurrentPlan,
 }: PlansFeaturesMainProps ) => {
 	const [ isFreePlanPaidDomainDialogOpen, setIsFreePlanPaidDomainDialogOpen ] = useState( false );
 	const currentPlan = useSelector( ( state: IAppState ) => getCurrentPlan( state, siteId ) );
@@ -455,6 +467,7 @@ const PlansFeaturesMain = ( {
 						siteSlug={ siteSlug }
 						intent={ intent }
 						showLegacyStorageFeature={ showLegacyStorageFeature }
+						isSpotlightOnCurrentPlan={ isSpotlightOnCurrentPlan }
 					/>
 				</>
 			) }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -278,6 +278,7 @@ class Plans extends Component {
 				hidePlansFeatureComparison={ this.props.isDomainAndPlanPackageFlow }
 				showLegacyStorageFeature={ this.props.siteHasLegacyStorage }
 				intent={ plansIntent }
+				isSpotlightOnCurrentPlan={ ! this.props.isDomainAndPlanPackageFlow }
 			/>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1636

## Proposed Changes

* Adds a new card above the pricing grid that highlights the current plan on the /plans page.
* The card is also shown if the current plan is a monthly plan and the user selects "Pay Annually" via the toggle. In this case, the card shows the annual plan details.

Figma: dyXNnR0oHu8H47eUES8ktJ-fi-385%3A39202

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* On a site with a free plan, go to `/plans/<site slug>`. Confirm that the plan card is shown and matches the design.
<img width="1374" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/83800175-0a86-41b1-b6ce-f8235be53aee">

-----

* On a site with a monthly paid plan, go to `/plans/<site slug>`. Confirm that the plan card is shown and matches the design.
<img width="1341" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/a133f21d-fa63-41e0-ad60-e4e735d77ea1">

* Click on the "Pay annually" option in the toggle. Confirm that the plan card is shown and has the details for the yearly equivalent of the current monthly plan.
<img width="1341" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/fc6e8293-65f7-41c2-b893-c3067207fc73">

-----

* On a site with a 1Y/2Y/3Y paid plan, go to `/plans/<site slug>`. Confirm that the plan card is shown and matches the design.
<img width="1418" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/c15f6a47-57d4-4f71-9aed-dc30ad5ef321">

### Testing for regressions
Check the following flows and confirm that the current plan card is NOT shown.
* `/plans/yearly/<site slug>?domain=true&domainAndPlanPackage=true`
* `/start/plans`
* `/setup/newsletter/plans`
* `/start/launch-site?siteSlug=<site slug>`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?