### PR TITLE
Refactor : Reduce complexity in the logins URL implementation

### DIFF
--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -57,13 +57,9 @@ export const useLoginUrl = ( {
 } ): string => {
 	const locale = useLocale();
 	const localizedLoginPath = locale && locale !== 'en' ? `${ loginPath }${ locale }` : loginPath;
-
-	const nonEmptyQueryParameters = {
-		...( flowName && { variationName: flowName } ),
-		...( redirectTo && { redirect_to: redirectTo } ),
-		...( pageTitle && { pageTitle } ),
-		toStepper: 'true',
-	};
-
-	return addQueryArgs( localizedLoginPath, nonEmptyQueryParameters );
+	return addQueryArgs( localizedLoginPath, {
+		variationName: flowName,
+		redirect_to: redirectTo,
+		pageTitle,
+	} );
 };

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -61,5 +61,6 @@ export const useLoginUrl = ( {
 		variationName: flowName,
 		redirect_to: redirectTo,
 		pageTitle,
+		toStepper: true,
 	} );
 };

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -44,31 +44,26 @@ export function useLangRouteParam() {
 	return match?.params.lang;
 }
 
-export const useLoginUrl = ( params: {
+export const useLoginUrl = ( {
+	flowName,
+	redirectTo,
+	pageTitle,
+	loginPath = `/start/account/user/`,
+}: {
 	flowName?: string;
 	redirectTo?: string;
 	pageTitle?: string;
 	loginPath?: string;
 } ): string => {
 	const locale = useLocale();
-
-	const loginPath = params.loginPath ?? `/start/account/user/`;
 	const localizedLoginPath = locale && locale !== 'en' ? `${ loginPath }${ locale }` : loginPath;
 
-	const nonEmptyQueryParameters = Object.entries( params )
-		.filter( ( [ , value ] ) => value )
-		.map( ( [ key, value ] ) => {
-			switch ( key ) {
-				case 'redirectTo':
-					return [ 'redirect_to', value ];
-				case 'flowName':
-					return [ 'variationName', value ];
-				default:
-					return [ key, value ];
-			}
-		} );
+	const nonEmptyQueryParameters = {
+		...( flowName && { variationName: flowName } ),
+		...( redirectTo && { redirect_to: redirectTo } ),
+		...( pageTitle && { pageTitle } ),
+		toStepper: 'true',
+	};
 
-	nonEmptyQueryParameters.push( [ 'toStepper', 'true' ] );
-
-	return addQueryArgs( localizedLoginPath, Object.fromEntries( nonEmptyQueryParameters ) );
+	return addQueryArgs( localizedLoginPath, nonEmptyQueryParameters );
 };


### PR DESCRIPTION
As [suggested](https://github.com/Automattic/wp-calypso/pull/78323#discussion_r1247166515) by @chriskmnds this reduces the complexity introduced piece of following code.

https://github.com/Automattic/wp-calypso/blob/9fe64cb529399d2e72c17974661eaaabc3e16913/client/landing/stepper/utils/path.ts#L57-L68

- Related to #78323

## Testing Instructions
* Open incognito window
* Go to the newsletter stepper flow `/setup/newsletter`
* Make sure the login redirect works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
