### PR TITLE
GS on Personal A/B: Neutralise style variation wording in assembler

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -609,6 +609,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					selectedFontVariation={ selectedFontVariation }
 					onSelectFontVariation={ setSelectedFontVariation }
 					onGlobalStylesChange={ setGlobalStyles }
+					limitGlobalStyles={ shouldLimitGlobalStyles }
 				/>
 			</>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { ColorPaletteVariations } from '@automattic/global-styles';
 import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import NavigatorHeader from './navigator-header';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 
@@ -23,6 +24,7 @@ const ScreenColorPalettes = ( {
 	onDoneClick,
 }: Props ) => {
 	const translate = useTranslate();
+	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles( siteId );
 
 	return (
 		<>
@@ -39,6 +41,7 @@ const ScreenColorPalettes = ( {
 					stylesheet={ stylesheet }
 					selectedColorPaletteVariation={ selectedColorPaletteVariation }
 					onSelect={ onSelect }
+					limitGlobalStyles={ shouldLimitGlobalStyles }
 				/>
 			</div>
 			<div className="screen-container__footer">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { ColorPaletteVariations } from '@automattic/global-styles';
 import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
+import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import NavigatorHeader from './navigator-header';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 
@@ -24,7 +24,7 @@ const ScreenColorPalettes = ( {
 	onDoneClick,
 }: Props ) => {
 	const translate = useTranslate();
-	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles( siteId );
+	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { FontPairingVariations } from '@automattic/global-styles';
 import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
+import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import NavigatorHeader from './navigator-header';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 
@@ -24,7 +24,7 @@ const ScreenFontPairings = ( {
 	onDoneClick,
 }: Props ) => {
 	const translate = useTranslate();
-	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles( siteId );
+	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { FontPairingVariations } from '@automattic/global-styles';
 import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import NavigatorHeader from './navigator-header';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 
@@ -23,6 +24,7 @@ const ScreenFontPairings = ( {
 	onDoneClick,
 }: Props ) => {
 	const translate = useTranslate();
+	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles( siteId );
 
 	return (
 		<>
@@ -39,6 +41,7 @@ const ScreenFontPairings = ( {
 					stylesheet={ stylesheet }
 					selectedFontPairingVariation={ selectedFontPairingVariation }
 					onSelect={ onSelect }
+					limitGlobalStyles={ shouldLimitGlobalStyles }
 				/>
 			</div>
 			<div className="screen-container__footer">

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -33,6 +33,7 @@ interface DesignPreviewProps {
 	selectedFontVariation: GlobalStylesObject | null;
 	onSelectFontVariation: ( variation: GlobalStylesObject | null ) => void;
 	onGlobalStylesChange: ( globalStyles: GlobalStylesObject | null ) => void;
+	limitGlobalStyles: boolean;
 }
 
 const INJECTED_CSS = `body{ transition: background-color 0.2s linear, color 0.2s linear; }`;
@@ -63,6 +64,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	selectedFontVariation,
 	onSelectFontVariation,
 	onGlobalStylesChange,
+	limitGlobalStyles,
 } ) => {
 	const selectedVariations = useMemo(
 		() =>
@@ -115,6 +117,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 				onSelectColorVariation={ onSelectColorVariation }
 				selectedFontVariation={ selectedFontVariation }
 				onSelectFontVariation={ onSelectFontVariation }
+				limitGlobalStyles={ limitGlobalStyles }
 			/>
 			<SitePreview
 				url={ previewUrl }
@@ -130,6 +133,7 @@ const DesignPreview = ( props: DesignPreviewProps ) => (
 		siteId={ props.siteId }
 		stylesheet={ props.stylesheet }
 		placeholder={ null }
+		limitGlobalStyles={ props.limitGlobalStyles }
 	>
 		<Preview { ...props } />
 	</GlobalStylesProvider>

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -133,7 +133,6 @@ const DesignPreview = ( props: DesignPreviewProps ) => (
 		siteId={ props.siteId }
 		stylesheet={ props.stylesheet }
 		placeholder={ null }
-		limitGlobalStyles={ props.limitGlobalStyles }
 	>
 		<Preview { ...props } />
 	</GlobalStylesProvider>

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -157,6 +157,7 @@ const Sidebar: React.FC< SidebarProps > = ( {
 								stylesheet={ stylesheet }
 								selectedFontPairingVariation={ selectedFontVariation }
 								onSelect={ onSelectFontVariation }
+								limitGlobalStyles={ limitGlobalStyles }
 							/>
 						</div>
 					) }

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -49,6 +49,7 @@ interface SidebarProps {
 	onSelectColorVariation: ( variation: GlobalStylesObject | null ) => void;
 	selectedFontVariation: GlobalStylesObject | null;
 	onSelectFontVariation: ( variation: GlobalStylesObject | null ) => void;
+	limitGlobalStyles: boolean;
 }
 
 const Sidebar: React.FC< SidebarProps > = ( {
@@ -70,6 +71,7 @@ const Sidebar: React.FC< SidebarProps > = ( {
 	onSelectColorVariation,
 	selectedFontVariation,
 	onSelectFontVariation,
+	limitGlobalStyles,
 } ) => {
 	const translate = useTranslate();
 	const [ isShowFullDescription, setIsShowFullDescription ] = useState( false );
@@ -142,6 +144,7 @@ const Sidebar: React.FC< SidebarProps > = ( {
 								stylesheet={ stylesheet }
 								selectedColorPaletteVariation={ selectedColorVariation }
 								onSelect={ onSelectColorVariation }
+								limitGlobalStyles={ limitGlobalStyles }
 							/>
 						</div>
 					) }

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -26,6 +26,7 @@ interface ColorPaletteVariationsProps {
 	stylesheet: string;
 	selectedColorPaletteVariation: GlobalStylesObject | null;
 	onSelect: ( colorPaletteVariation: GlobalStylesObject | null ) => void;
+	limitGlobalStyles: boolean;
 }
 
 const ColorPaletteVariation = ( {
@@ -74,6 +75,7 @@ const ColorPaletteVariations = ( {
 	stylesheet,
 	selectedColorPaletteVariation,
 	onSelect,
+	limitGlobalStyles,
 }: ColorPaletteVariationsProps ) => {
 	const { base } = useContext( GlobalStylesContext );
 	const colorPaletteVariations = useColorPaletteVariations( siteId, stylesheet ) ?? [];
@@ -97,11 +99,13 @@ const ColorPaletteVariations = ( {
 			</div>
 			<h3 className="global-styles-variation__title">
 				{ translate( 'Custom styles' ) }
-				<PremiumBadge
-					shouldHideTooltip
-					shouldCompactWithAnimation
-					labelText={ translate( 'Paid' ) }
-				/>
+				{ limitGlobalStyles && (
+					<PremiumBadge
+						shouldHideTooltip
+						shouldCompactWithAnimation
+						labelText={ translate( 'Upgrade' ) }
+					/>
+				) }
 			</h3>
 			<div className="color-palette-variations">
 				{ colorPaletteVariations.map( ( colorPaletteVariation, index ) => (

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -96,8 +96,12 @@ const ColorPaletteVariations = ( {
 				/>
 			</div>
 			<h3 className="global-styles-variation__title">
-				{ translate( 'Premium styles' ) }
-				<PremiumBadge shouldHideTooltip shouldCompactWithAnimation />
+				{ translate( 'Custom styles' ) }
+				<PremiumBadge
+					shouldHideTooltip
+					shouldCompactWithAnimation
+					labelText={ translate( 'Paid' ) }
+				/>
 			</h3>
 			<div className="color-palette-variations">
 				{ colorPaletteVariations.map( ( colorPaletteVariation, index ) => (

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -97,8 +97,12 @@ const FontPairingVariations = ( {
 				/>
 			</div>
 			<h3 className="global-styles-variation__title">
-				{ translate( 'Premium fonts' ) }
-				<PremiumBadge shouldHideTooltip shouldCompactWithAnimation />
+				{ translate( 'Custom fonts' ) }
+				<PremiumBadge
+					shouldHideTooltip
+					shouldCompactWithAnimation
+					labelText={ translate( 'Paid' ) }
+				/>
 			</h3>
 			<div className="font-pairing-variations">
 				{ fontPairingVariations.map( ( fontPairingVariation, index ) => (

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -26,6 +26,7 @@ interface FontPairingVariationsProps {
 	stylesheet: string;
 	selectedFontPairingVariation: GlobalStylesObject | null;
 	onSelect: ( fontPairingVariation: GlobalStylesObject | null ) => void;
+	limitGlobalStyles: boolean;
 }
 
 const FontPairingVariation = ( {
@@ -75,6 +76,7 @@ const FontPairingVariations = ( {
 	stylesheet,
 	selectedFontPairingVariation,
 	onSelect,
+	limitGlobalStyles,
 }: FontPairingVariationsProps ) => {
 	// The theme font pairings don't include the default font pairing
 	const fontPairingVariations = useFontPairingVariations( siteId, stylesheet ) ?? [];
@@ -98,11 +100,13 @@ const FontPairingVariations = ( {
 			</div>
 			<h3 className="global-styles-variation__title">
 				{ translate( 'Custom fonts' ) }
-				<PremiumBadge
-					shouldHideTooltip
-					shouldCompactWithAnimation
-					labelText={ translate( 'Paid' ) }
-				/>
+				{ limitGlobalStyles && (
+					<PremiumBadge
+						shouldHideTooltip
+						shouldCompactWithAnimation
+						labelText={ translate( 'Upgrade' ) }
+					/>
+				) }
 			</h3>
 			<div className="font-pairing-variations">
 				{ fontPairingVariations.map( ( fontPairingVariation, index ) => (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2860

## Proposed Changes

We're changing the style variation related wording in the assembler to always say 'Custom' rather than 'Premium' to remove the association with the Premium plan. This will allow us to experiment with paywalling style variations behind different plans.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso live link
2. Go through the /start process on a free plan until you reach the design picker grid
3. Go to the bottom and use the assembler CTA
4. It should have a nav item that says Colours, click that
5. The page should have a heading that says 'Custom styles' with a star next to it, hovering over the Star should make that expand to say 'Upgrade'
6. Press 'Save colors', and repeat for fonts.

Repeat again with a Premium plan and this time the Upgrade star should not appear

Repeat both scenarios again but choose a non-virtual theme without any style variations and adding this GET param: `flags=signup/design-picker-preview-colors`, the results should be unsurprising.

Before | After (free) | After (premium)
-------|--------------|--------------
<img width="349" alt="Screenshot 2023-06-30 at 14 34 30" src="https://github.com/Automattic/wp-calypso/assets/93301/5ac114ff-b808-41fa-a3dd-426d8fd324c3"> | <img width="350" alt="Screenshot 2023-07-03 at 17 26 36" src="https://github.com/Automattic/wp-calypso/assets/93301/d472eae8-139a-4624-bd40-adc9c97343f7"> | <img width="350" alt="Screenshot 2023-07-03 at 17 25 54" src="https://github.com/Automattic/wp-calypso/assets/93301/5612fb61-5be9-4745-89f8-50052fad2551">
<img width="349" alt="Screenshot 2023-06-30 at 14 34 58" src="https://github.com/Automattic/wp-calypso/assets/93301/45b35333-6bad-418a-9b6d-7a58eaf81bc3"> | <img width="350" alt="Screenshot 2023-07-03 at 17 23 11" src="https://github.com/Automattic/wp-calypso/assets/93301/c1b3da1e-eb38-4775-b1d8-ea6f9d920c70"> | <img width="350" alt="Screenshot 2023-07-03 at 17 24 56" src="https://github.com/Automattic/wp-calypso/assets/93301/2c542015-145b-4d59-9b4e-18d50e1c631a"> 
<img width="553" alt="image" src="https://github.com/Automattic/wp-calypso/assets/93301/543cf234-bfa2-413b-876f-e9e0cc7b9042">| <img width="553" alt="Screenshot 2023-07-03 at 18 39 12" src="https://github.com/Automattic/wp-calypso/assets/93301/1d09b9f9-50dc-4153-af3e-9950794c1c25"> | <img width="553" alt="Screenshot 2023-07-03 at 18 34 12" src="https://github.com/Automattic/wp-calypso/assets/93301/a3cea391-5fd9-4ce5-8db6-553dd007a1d7">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
