### PR TITLE
Jetpack Partner Portal: implement URL support to show more info modal about the license in the issue license page

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -561,3 +561,52 @@ export function useProductDescription( productSlug: string ): {
 		};
 	}, [ productSlug, translate ] );
 }
+
+type Params = Array< { key: string; value: string } >;
+
+export const useURLQueryParams = (): {
+	getParamValue: ( paramKey: string ) => any;
+	setParams: ( params: Params ) => void;
+	resetParams: ( params: string[] ) => void;
+} => {
+	const pushState = useCallback( ( queryParams: { toString: () => string } ) => {
+		const queryParamString = queryParams.toString();
+		const newURL =
+			window.location.origin +
+			window.location.pathname +
+			( queryParamString ? `?${ queryParamString }` : '' );
+		window.history.pushState( {}, '', newURL );
+	}, [] );
+
+	const setParams = useCallback(
+		( params: Params ) => {
+			const queryParams = new URLSearchParams( window.location.search );
+			params.forEach( ( param ) => {
+				queryParams.set( param.key, param.value );
+			} );
+			pushState( queryParams );
+		},
+		[ pushState ]
+	);
+
+	const resetParams = useCallback(
+		( params: string[] ) => {
+			const queryParams = new URLSearchParams( window.location.search );
+			params.forEach( ( param ) => {
+				queryParams.delete( param );
+			} );
+			pushState( queryParams );
+		},
+		[ pushState ]
+	);
+
+	const getParamValue = useCallback( ( paramKey: string ) => {
+		return getQueryArg( window.location.href, paramKey );
+	}, [] );
+
+	return {
+		getParamValue,
+		setParams,
+		resetParams,
+	};
+};

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -71,6 +71,8 @@ export default function IssueMultipleLicensesForm( {
 		[]
 	);
 
+	const licenseModalToBeShown = getQueryArg( window.location.href, 'show_license_modal' );
+
 	useEffect( () => {
 		// Select the slugs included in the URL
 		defaultProductSlugs &&
@@ -202,6 +204,7 @@ export default function IssueMultipleLicensesForm( {
 									isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
 									tabIndex={ 100 + i }
 									suggestedProduct={ suggestedProduct }
+									showLicenseInfoModal={ licenseModalToBeShown === productOption.slug }
 								/>
 							) ) }
 					</div>
@@ -219,6 +222,7 @@ export default function IssueMultipleLicensesForm( {
 									product={ productOption }
 									onSelectProduct={ onSelectProduct }
 									tabIndex={ 100 + ( products?.length || 0 ) + i }
+									showLicenseInfoModal={ licenseModalToBeShown === productOption.slug }
 								/>
 							) ) }
 					</div>

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -71,8 +71,6 @@ export default function IssueMultipleLicensesForm( {
 		[]
 	);
 
-	const licenseModalToBeShown = getQueryArg( window.location.href, 'show_license_modal' );
-
 	useEffect( () => {
 		// Select the slugs included in the URL
 		defaultProductSlugs &&
@@ -204,7 +202,6 @@ export default function IssueMultipleLicensesForm( {
 									isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
 									tabIndex={ 100 + i }
 									suggestedProduct={ suggestedProduct }
-									showLicenseInfoModal={ licenseModalToBeShown === productOption.slug }
 								/>
 							) ) }
 					</div>
@@ -222,7 +219,6 @@ export default function IssueMultipleLicensesForm( {
 									product={ productOption }
 									onSelectProduct={ onSelectProduct }
 									tabIndex={ 100 + ( products?.length || 0 ) + i }
-									showLicenseInfoModal={ licenseModalToBeShown === productOption.slug }
 								/>
 							) ) }
 					</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
@@ -4,11 +4,11 @@ import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
-import { useProductDescription } from '../hooks';
+import { useProductDescription, useURLQueryParams } from '../hooks';
 import LicenseLightbox from '../license-lightbox';
 import LicenseLightboxLink from '../license-lightbox-link';
 import ProductPriceWithDiscount from '../primary/product-price-with-discount-info';
-import { getProductTitle } from '../utils';
+import { getProductTitle, LICENSE_INFO_MODAL_ID } from '../utils';
 
 import './style.scss';
 
@@ -16,13 +16,15 @@ interface Props {
 	tabIndex: number;
 	product: APIProductFamilyProduct;
 	onSelectProduct: ( value: APIProductFamilyProduct ) => void | null;
-	showLicenseInfoModal: boolean;
 }
 
 export default function LicenseBundleCard( props: Props ) {
+	const { setParams, resetParams, getParamValue } = useURLQueryParams();
+	const modalParamValue = getParamValue( LICENSE_INFO_MODAL_ID );
+
 	const { tabIndex, product, onSelectProduct } = props;
 	const productTitle = getProductTitle( product.name );
-	const [ showLightbox, setShowLightbox ] = useState( props.showLicenseInfoModal );
+	const [ showLightbox, setShowLightbox ] = useState( modalParamValue === product.slug );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -42,14 +44,21 @@ export default function LicenseBundleCard( props: Props ) {
 				} )
 			);
 
+			setParams( [
+				{
+					key: LICENSE_INFO_MODAL_ID,
+					value: product.slug,
+				},
+			] );
 			setShowLightbox( true );
 		},
-		[ dispatch, product ]
+		[ dispatch, product.slug, setParams ]
 	);
 
 	const onHideLightbox = useCallback( () => {
+		resetParams( [ LICENSE_INFO_MODAL_ID ] );
 		setShowLightbox( false );
-	}, [] );
+	}, [ resetParams ] );
 
 	return (
 		<>

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
@@ -16,12 +16,13 @@ interface Props {
 	tabIndex: number;
 	product: APIProductFamilyProduct;
 	onSelectProduct: ( value: APIProductFamilyProduct ) => void | null;
+	showLicenseInfoModal: boolean;
 }
 
 export default function LicenseBundleCard( props: Props ) {
 	const { tabIndex, product, onSelectProduct } = props;
 	const productTitle = getProductTitle( product.name );
-	const [ showLightbox, setShowLightbox ] = useState( false );
+	const [ showLightbox, setShowLightbox ] = useState( props.showLicenseInfoModal );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -21,6 +21,7 @@ interface Props {
 	onSelectProduct: ( value: APIProductFamilyProduct ) => void | null;
 	suggestedProduct?: string | null;
 	isMultiSelect?: boolean;
+	showLicenseInfoModal: boolean;
 }
 
 export default function LicenseProductCard( props: Props ) {
@@ -32,9 +33,10 @@ export default function LicenseProductCard( props: Props ) {
 		onSelectProduct,
 		suggestedProduct,
 		isMultiSelect,
+		showLicenseInfoModal,
 	} = props;
 	const productTitle = getProductTitle( product.name );
-	const [ showLightbox, setShowLightbox ] = useState( false );
+	const [ showLightbox, setShowLightbox ] = useState( showLicenseInfoModal );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -5,11 +5,11 @@ import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
-import { useProductDescription } from '../hooks';
+import { useProductDescription, useURLQueryParams } from '../hooks';
 import LicenseLightbox from '../license-lightbox';
 import LicenseLightboxLink from '../license-lightbox-link';
 import ProductPriceWithDiscount from '../primary/product-price-with-discount-info';
-import { getProductTitle } from '../utils';
+import { getProductTitle, LICENSE_INFO_MODAL_ID } from '../utils';
 
 import './style.scss';
 
@@ -21,7 +21,6 @@ interface Props {
 	onSelectProduct: ( value: APIProductFamilyProduct ) => void | null;
 	suggestedProduct?: string | null;
 	isMultiSelect?: boolean;
-	showLicenseInfoModal: boolean;
 }
 
 export default function LicenseProductCard( props: Props ) {
@@ -33,10 +32,11 @@ export default function LicenseProductCard( props: Props ) {
 		onSelectProduct,
 		suggestedProduct,
 		isMultiSelect,
-		showLicenseInfoModal,
 	} = props;
+	const { setParams, resetParams, getParamValue } = useURLQueryParams();
+	const modalParamValue = getParamValue( LICENSE_INFO_MODAL_ID );
 	const productTitle = getProductTitle( product.name );
-	const [ showLightbox, setShowLightbox ] = useState( showLicenseInfoModal );
+	const [ showLightbox, setShowLightbox ] = useState( modalParamValue === product.slug );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -81,14 +81,21 @@ export default function LicenseProductCard( props: Props ) {
 				} )
 			);
 
+			setParams( [
+				{
+					key: LICENSE_INFO_MODAL_ID,
+					value: product.slug,
+				},
+			] );
 			setShowLightbox( true );
 		},
-		[ dispatch, product ]
+		[ dispatch, product.slug, setParams ]
 	);
 
 	const onHideLightbox = useCallback( () => {
+		resetParams( [ LICENSE_INFO_MODAL_ID ] );
 		setShowLightbox( false );
-	}, [] );
+	}, [ resetParams ] );
 
 	return (
 		<>

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -222,3 +222,5 @@ export function areLicenseKeysAssignableToMultisite( licenseKeys: Array< string 
 	// If any license keys are not Jetpack Backup or Scan, they can be assigned to multisite.
 	return licenseKeys.some( ( key ) => ! /^jetpack-(backup|scan)/.test( key ) );
 }
+
+export const LICENSE_INFO_MODAL_ID = 'show_license_modal';


### PR DESCRIPTION
Related to 1202619025189113-as-1204942360069653

## Proposed Changes

This PR implements URL support to show more info modal about the license in the /partner-portal/issue-license page. You can now append the URL(/partner-portal/issue-license) with `show_license_modal={product_slug}`, which will open the product info modal.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/url-support-open-license-info-popup` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link. 
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Visit http://jetpack.cloud.localhost:3001/partner-portal/issue-license?show_license_modal=jetpack-ai and verify that the product info modal for AI Assistant opens up. Verify the same for other products(jetpack-scan) and bundles - http://jetpack.cloud.localhost:3001/partner-portal/issue-license?show_license_modal=jetpack-complete
4. Click the `More about {product}` button and verify that the URL is appended with the query param.

<img width="646" alt="Screenshot 2023-06-30 at 7 14 07 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f7b9e5c6-ea28-46a3-afcf-ee2d27bff922">

<img width="1257" alt="Screenshot 2023-06-30 at 7 14 11 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ae387911-855a-4d47-b26f-2cd34d5d2d69">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?