### PR TITLE
Sending hotjarSiteSettings to BlazePress.render call

### DIFF
--- a/client/lib/analytics/hotjar.js
+++ b/client/lib/analytics/hotjar.js
@@ -7,15 +7,21 @@ const hotjarDebug = debug( 'calypso:analytics:hotjar' );
 
 let hotJarScriptLoaded = false;
 
+export function mayWeLoadHotJarScript() {
+	return config( 'hotjar_enabled' ) && mayWeTrackByTracker( 'hotjar' );
+}
+
+export function getHotjarSiteSettings() {
+	return isJetpackCloud()
+		? { hjid: 3165344, hjsv: 6 } // Calypso green (cloud.jetpack.com)
+		: { hjid: 227769, hjsv: 5 }; // Calypso blue (wordpress.com)
+}
+
 export function addHotJarScript() {
-	if ( hotJarScriptLoaded || ! config( 'hotjar_enabled' ) || ! mayWeTrackByTracker( 'hotjar' ) ) {
+	if ( hotJarScriptLoaded || ! mayWeLoadHotJarScript() ) {
 		hotjarDebug( 'Not loading HotJar script' );
 		return;
 	}
-
-	const hotjarSiteSettings = isJetpackCloud()
-		? { hjid: 3165344, hjsv: 6 } // Calypso green (cloud.jetpack.com)
-		: { hjid: 227769, hjsv: 5 }; // Calypso blue (wordpress.com)
 
 	( function ( h, o, t, j, a, r ) {
 		hotjarDebug( 'Loading HotJar script' );
@@ -24,7 +30,7 @@ export function addHotJarScript() {
 			function () {
 				( h.hj.q = h.hj.q || [] ).push( arguments );
 			};
-		h._hjSettings = hotjarSiteSettings;
+		h._hjSettings = getHotjarSiteSettings();
 		a = o.getElementsByTagName( 'head' )[ 0 ];
 		r = o.createElement( 'script' );
 		r.async = 1;

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { loadScript } from '@automattic/load-script';
 import { __ } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso/types';
+import { getHotjarSiteSettings, mayWeLoadHotJarScript } from 'calypso/lib/analytics/hotjar';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
@@ -46,6 +47,7 @@ declare global {
 					headerNonce: string;
 				};
 				isV2?: boolean;
+				hotjarSiteSettings?: object;
 			} ) => void;
 			strings: any;
 		};
@@ -118,6 +120,7 @@ export async function showDSP(
 					  }
 					: undefined,
 				isV2,
+				hotjarSiteSettings: { ...getHotjarSiteSettings(), isEnabled: mayWeLoadHotJarScript() },
 			} );
 		} else {
 			reject( false );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2775-gh-Automattic/dotcom-forge

## Proposed Changes

Calypso [has a special gate logic](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/analytics/hotjar.js#L11) to define if we can use Hotjar or not, since `HotJar is behind our cookie banner, so it only loads in GDPR countries when a user consents to cookies`, more context: pau2Xa-9P-p2

* Sending Hotjar information to BlazePress widget so it can decide whether or not to load it and which configurations to use
* We'll use these informations at [the sibling Tumblr PR changes](https://github.tumblr.net/Tumblr/a8c-dsp/pull/241).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Stop your Calypso yarn start watcher
* Edit the file [config/development.json](https://github.com/Automattic/wp-calypso/blob/trunk/config/development.json#L33) by changing ad-tracking to true
* Restart your watcher with yarn start
* Open [/advertising page](https://wordpress.com/advertising/) and ensure you see the Hotjar script loaded
* In your browser F12 console terminal, create this function: `const myFunction = (data) => console.log(data);` and assign BlazePress call to it: `window.BlazePress = { render: {} }; window.BlazePress.render = myFunction;`
* Call BlazePress widget by clicking in `Promote` button
* You should see the new `hotjarSiteSettings` parameters being sent to BlazePress.render function:

<img width="617" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/affaa3a9-1b0b-4fe4-8d38-25bc3e32b198">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?