### PR TITLE
Assembler - All sites set the option wpcom_site_setup

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -385,7 +385,7 @@ const PatternAssembler = ( {
 
 	const onSubmit = () => {
 		const design = getDesign();
-		const stylesheet = design?.recipe?.stylesheet ?? '';
+		const stylesheet = design.recipe?.stylesheet ?? '';
 		const themeId = getThemeIdFromStylesheet( stylesheet );
 
 		if ( ! siteSlugOrId || ! site?.ID || ! themeId ) {
@@ -414,8 +414,8 @@ const PatternAssembler = ( {
 							globalStyles: syncedGlobalStylesUserConfig,
 							// Newly created sites should reset the starter content created from the default Headstart annotation
 							shouldResetContent: isNewSite,
-							// Also, new sites except for virtual themes set the option wpcom_site_setup=assembler
-							siteSetupOption: isNewSite && ! design.is_virtual ? 'assembler' : '',
+							// All sites using the assembler set the option wpcom_site_setup
+							siteSetupOption: design.is_virtual ? 'assembler-virtual-theme' : 'assembler',
 						} )
 					)
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71988 #77426
pekYwv-1YV-p2#comment-1557

## Proposed Changes

* All sites that use the assembler set the option `wpcom_site_setup` as
  * `assembler-virtual-theme` for virtual themes
  * `assembler` for the rest, newly created and existent sites

### Follow-up tasks

To make it work on Simple sites:

- [X] Update the enum in `site-assembler` endpoint to support `assembler-virtual-theme`. See D115076-code

To make it work on Atomic sites:

- [x] Enable the jetpack sync between Dotcom and Jetpack for Atomic sites - See FG page `/syncing-a-new-wordpress-option-with-jetpack-sync/`. See D115078-code
- [ ] Add to `atomic-v2.php` to carry the option from Simple to Atomic when the site is transferred. I'm not sure about this change. See D115078-code
- [x] Add to whitelist in Jetpack to be able to update the option on Atomic sites using `wpcom_update_site_option` otherwise we get the error `option_name_not_in_whitelist`. See https://github.com/Automattic/jetpack/pull/31662

To fetch the option from Atomic sites:

- [x] Update `WPCOM_JSON_API_GET_Site_Endpoint` in Jetpack to allow getting the option from Atomic sites. See https://github.com/Automattic/jetpack/pull/31664

Docs:

- [x] Update the section about `wpcom_site_setup` on the FG page  `/site-onboarding-flows/blank-canvas-pattern-assembler-onboarding-flow`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Note: only works on simple sites for now.**

### **From the Design picker**

- Create a new site from `/start`
- Continue until the Design picker and
  - **Test 1**) Click "Start designing" on the "Design your own" CTA
  - **Test 2**) Choose a Virtual theme (for instance "Sketchbook" or "Project Detail")
- Continue to complete the assembler flow
- Verify that the site has the site option as `wpcom_site_setup=assembler` for test 1 or `wpcom_site_setup=assembler-virtual-theme` for test 2 in `{ YOUR SITE }/wp-admin/options.php`

### **From the logged-in theme showcase**

- From the logged-in theme showcase `/themes`
- Click on "Start designing" on the "Design your own" CTA
- Click "Continue" to complete the assembler
- Verify that the site has the site option `wpcom_site_setup=assembler` in `{ YOUR SITE }/wp-admin/options.php`

### **From the logged-out theme showcase**

- From the logged-out theme showcase `/themes`
- Click on "Start designing" on the "Design your own" CTA
- Log in, choose a domain, and a plan
- Click "Continue" to complete the assembler
- Verify that the site has the site option `wpcom_site_setup=assembler` in `{ YOUR SITE }/wp-admin/options.php`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?