### PR TITLE
My Sites: Remove manage domains from site selector

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -240,10 +240,6 @@ export class SiteSelector extends Component {
 		this.props.recordTracksEvent( 'calypso_manage_sites_click' );
 	};
 
-	onManageDomainsClick = () => {
-		this.props.recordTracksEvent( 'calypso_manage_domains_click' );
-	};
-
 	onSiteHover = ( event, siteId ) => {
 		if ( this.lastMouseHover !== siteId ) {
 			debug( `${ siteId } hovered` );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -58,7 +58,6 @@ export class SiteSelector extends Component {
 		navigateToSite: PropTypes.func.isRequired,
 		isReskinned: PropTypes.bool,
 		showManageSitesButton: PropTypes.bool,
-		showManageDomainsButton: PropTypes.bool,
 		showHiddenSites: PropTypes.bool,
 		maxResults: PropTypes.number,
 		hasSiteWithPlugins: PropTypes.bool,
@@ -67,7 +66,6 @@ export class SiteSelector extends Component {
 	static defaultProps = {
 		sites: {},
 		showManageSitesButton: false,
-		showManageDomainsButton: false,
 		showAddNewSite: false,
 		showAllSites: false,
 		showHiddenSites: false,
@@ -470,15 +468,8 @@ export class SiteSelector extends Component {
 						</span>
 					) }
 				</div>
-				{ ( this.props.showManageSitesButton ||
-					this.props.showAddNewSite ||
-					this.props.showManageDomainsButton ) && (
+				{ ( this.props.showManageSitesButton || this.props.showAddNewSite ) && (
 					<div className="site-selector__actions">
-						{ this.props.showManageDomainsButton && (
-							<Button transparent onClick={ this.onManageDomainsClick } href="/domains/manage">
-								{ this.props.translate( 'Manage domains' ) }
-							</Button>
-						) }
 						{ this.props.showManageSitesButton && (
 							<Button
 								transparent

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -33,7 +33,6 @@ class MySitesNavigation extends Component {
 
 			sitePickerProps = {
 				showManageSitesButton: true,
-				showManageDomainsButton: true,
 				showHiddenSites: true,
 				maxResults: 50,
 			};

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -30,7 +30,6 @@ class SitePicker extends Component {
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		setLayoutFocus: PropTypes.func.isRequired,
 		showManageSitesButton: PropTypes.bool,
-		showManageDomainsButton: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -104,7 +103,6 @@ class SitePicker extends Component {
 					maxResults={ this.props.maxResults }
 					showHiddenSites={ this.props.showHiddenSites }
 					showManageSitesButton={ this.props.showManageSitesButton }
-					showManageDomainsButton={ this.props.showManageDomainsButton }
 					isPlaceholder={ ! this.state.isRendered }
 					indicator={ true }
 					showAddNewSite={ true }

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -97,6 +97,7 @@ function recordSubmitStep( flow, stepName, providedDependencies, optionalProps )
 	);
 
 	const device = resolveDeviceTypeByViewPort();
+
 	return recordTracksEvent( 'calypso_signup_actions_submit_step', {
 		device,
 		flow,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See p9Jlb4-82a-p2

We initially discussed some options and then design later did a pass. I'm removing this button as design made other recommendations.

## Proposed Changes

* Remove manage domains button from site selector.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout patch
* Navigate to site
* Click switch sites
* Ensure no "Manage Domains" button

<img width="287" alt="Screenshot 2023-06-30 at 12 02 57 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/eb2dd4d4-bb83-443a-b3c1-c9b4cc35cf57">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?