### PR TITLE
Adding truncation to site titles in reader sidebar

### DIFF
--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -661,6 +661,19 @@
 			overflow: hidden;
 			-webkit-line-clamp: 1;
 			-webkit-box-orient: vertical;
+			white-space: nowrap;
+			width: 225px;
+			position: relative;
+
+			&::after {
+				content: "";
+				position: absolute;
+				bottom: 0;
+				right: 0;
+				width: 25px;
+				height: 25px;
+				background: linear-gradient(42deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+			}
 		}
 	}
 

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -666,13 +666,7 @@
 			position: relative;
 
 			&::after {
-				content: "";
-				position: absolute;
-				bottom: 0;
-				right: 0;
-				width: 25px;
-				height: 25px;
-				background: linear-gradient(42deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+				@include long-content-fade( $size: 5% );
 			}
 		}
 	}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -662,10 +662,12 @@
 			-webkit-line-clamp: 1;
 			-webkit-box-orient: vertical;
 			white-space: nowrap;
-			width: 225px;
 			position: relative;
 
-			&::after {
+			.stream__two-column & {
+				width: 225px;
+			}
+			.stream__two-column &::after {
 				@include long-content-fade( $size: 5% );
 			}
 		}


### PR DESCRIPTION
## Description

@saygunnyc highlighted that site titles in the right reader sidebar had no truncation on them, so they could go on indefinitely. This PR aims to fix this issue.

### Before

![CleanShot 2023-06-30 at 13 31 52](https://github.com/Automattic/wp-calypso/assets/5634774/06a837f6-dd24-44dc-b5e0-d7e9a043315b)

### After

![CleanShot 2023-06-30 at 14 02 46](https://github.com/Automattic/wp-calypso/assets/5634774/cfe474ef-df62-43f6-811b-1e11a956a1d6)

## Testing

- Apply this PR
- Go to /read
- Use dev tools to update the string of any site title in the right nav to something long like "supercalifragilisticexpialidocioussupercalifragilisticexpialidocious"