### PR TITLE
Launchpad: Added share site task

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -163,7 +163,7 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 };
 
 const ConnectedLaunchpadKeepBuilding = connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
+	const siteId = getSelectedSiteId( state ) || undefined;
 	// The type definition for getSite is incorrect, it returns a SiteDetails object
 	const site = getSite( state as object, siteId ) as any as SiteDetails;
 

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -4,21 +4,26 @@ import { Launchpad, Task } from '@automattic/launchpad';
 import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import ShareSiteModal from '../../components/share-site-modal';
+import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
 
 const checklistSlug = 'keep-building';
 
 interface LaunchpadKeepBuildingProps {
-	siteSlug: string | null;
+	site: SiteDetails | null;
 }
 
-const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.Element => {
+const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Element => {
 	const translate = useTranslate();
+	const siteSlug = site?.slug;
+
 	const {
 		data: { checklist },
 	} = useLaunchpad( siteSlug, checklistSlug );
@@ -54,6 +59,8 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 		number_of_completed_steps: completedSteps,
 		context: 'customer-home',
 	} );
+
+	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
 		const completedTasks = tasks.filter( ( task: Task ) => task.completed );
@@ -113,6 +120,13 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 						window.location.assign( `/page/${ siteSlug }` );
 					};
 					break;
+
+				case 'share_site':
+					actionDispatch = () => {
+						recordTaskClickTracksEvent( task );
+						setShareSiteModalIsOpen( true );
+					};
+					break;
 			}
 
 			return { ...task, actionDispatch };
@@ -120,35 +134,39 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 	};
 
 	return (
-		<div className="launchpad-keep-building">
-			<div className="launchpad-keep-building__header">
-				<h2 className="launchpad-keep-building__title">
-					{ translate( 'Next steps for your site' ) }
-				</h2>
-				<div className="launchpad-keep-building__progress-bar-container">
-					<CircularProgressBar
-						size={ 40 }
-						enableDesktopScaling
-						numberOfSteps={ numberOfSteps }
-						currentStep={ completedSteps }
-					/>
+		<>
+			<div className="launchpad-keep-building">
+				<div className="launchpad-keep-building__header">
+					<h2 className="launchpad-keep-building__title">
+						{ translate( 'Next steps for your site' ) }
+					</h2>
+					<div className="launchpad-keep-building__progress-bar-container">
+						<CircularProgressBar
+							size={ 40 }
+							enableDesktopScaling
+							numberOfSteps={ numberOfSteps }
+							currentStep={ completedSteps }
+						/>
+					</div>
 				</div>
+				<Launchpad
+					siteSlug={ siteSlug }
+					checklistSlug={ checklistSlug }
+					taskFilter={ sortedTasksWithActions }
+				/>
 			</div>
-			<Launchpad
-				siteSlug={ siteSlug }
-				checklistSlug={ checklistSlug }
-				taskFilter={ sortedTasksWithActions }
-			/>
-		</div>
+			{ shareSiteModalIsOpen && (
+				<ShareSiteModal setModalIsOpen={ setShareSiteModalIsOpen } site={ site } />
+			) }
+		</>
 	);
 };
 
 const ConnectedLaunchpadKeepBuilding = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
+	const site = getSite( state, siteId );
 
-	return {
-		siteSlug: getSiteSlug( state, siteId ),
-	};
+	return { site };
 } )( LaunchpadKeepBuilding );
 
 export default ConnectedLaunchpadKeepBuilding;

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -164,7 +164,8 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 
 const ConnectedLaunchpadKeepBuilding = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const site = getSite( state, siteId );
+	// The type definition for getSite is incorrect, it returns a SiteDetails object
+	const site = getSite( state, siteId ) as any as SiteDetails;
 
 	return { site };
 } )( LaunchpadKeepBuilding );

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -6,6 +6,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { connect } from 'react-redux';
+import { IAppState } from 'state/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -162,7 +163,7 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 	);
 };
 
-const ConnectedLaunchpadKeepBuilding = connect( ( state ) => {
+const ConnectedLaunchpadKeepBuilding = connect( ( state: IAppState ) => {
 	const siteId = getSelectedSiteId( state );
 	// The type definition for getSite is incorrect, it returns a SiteDetails object
 	const site = getSite( state, siteId ) as any as SiteDetails;

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -6,7 +6,6 @@ import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { connect } from 'react-redux';
-import { IAppState } from 'state/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -163,10 +162,10 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 	);
 };
 
-const ConnectedLaunchpadKeepBuilding = connect( ( state: IAppState ) => {
+const ConnectedLaunchpadKeepBuilding = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	// The type definition for getSite is incorrect, it returns a SiteDetails object
-	const site = getSite( state, siteId ) as any as SiteDetails;
+	const site = getSite( state as object, siteId ) as any as SiteDetails;
 
 	return { site };
 } )( LaunchpadKeepBuilding );

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -22,7 +22,7 @@ interface LaunchpadKeepBuildingProps {
 
 const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Element => {
 	const translate = useTranslate();
-	const siteSlug = site?.slug;
+	const siteSlug = site?.slug || null;
 
 	const {
 		data: { checklist },

--- a/client/my-sites/customer-home/components/share-site-modal.scss
+++ b/client/my-sites/customer-home/components/share-site-modal.scss
@@ -1,0 +1,138 @@
+.share-site-modal__modal {
+	max-width: 640px;
+
+	.components-modal__header {
+		padding: 48px;
+	}
+
+	.components-modal__content {
+		margin: 0;
+		padding: 0;
+	}
+
+	.share-site-modal__modal-content {
+		padding: 48px;
+		padding-bottom: 40px;
+		display: flex;
+		flex-direction: column;
+		gap: 32px;
+	}
+
+	.share-site-modal__modal-heading {
+		color: var(--studio-gray-100);
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		font-size: 2rem;
+		line-height: 40px;
+		font-weight: 400;
+		letter-spacing: 0.2px;
+		margin: 0;
+		padding-bottom: 8px;
+	}
+
+	.share-site-modal__modal-domain {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+
+	.share-site-modal__modal-body,
+	.share-site-modal__modal-domain-text {
+		margin: 0;
+		color: var(--studio-gray-80);
+		font-size: 1rem;
+		line-height: 24px;
+	}
+
+	.share-site-modal__modal-domain-text {
+		padding: 0 8px;
+
+		// prevent text overflow
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
+	}
+
+	.share-site-modal__modal-buttons {
+		display: flex;
+		flex-direction: row;
+		justify-content: end;
+		gap: 16px;
+	}
+
+	.share-site-modal__modal-site {
+		padding: 8px;
+		background: var(--studio-gray-0);
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.launchpad__clipboard-button {
+		opacity: 0;
+	}
+
+	.launchpad__clipboard-button:focus {
+		opacity: 1;
+	}
+
+	.share-site-modal__modal-site:hover {
+		.launchpad__clipboard-button {
+			opacity: 1;
+		}
+	}
+
+	.share-site-modal__modal-customize {
+		color: var(--studio-blue-50);
+		font-size: 0.875rem;
+		display: inline-flex;
+		flex-direction: row;
+		justify-content: start;
+		gap: 6px;
+		padding: 0;
+		margin: 0;
+		margin-top: 16px;
+	}
+
+	.share-site-modal__modal-upsell {
+		border-top: 1px solid var(--studio-gray-5);
+		background: var(--studio-gray-0);
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		padding: 32px 48px;
+		gap: 32px;
+
+		.components-button {
+			height: 42px;
+		}
+	}
+
+	.share-site-modal__modal-upsell-content p {
+		margin-bottom: 0;
+	}
+
+	.share-site-modal__modal-upsell-content-highlight {
+		font-weight: bold;
+	}
+
+	.share-site-modal__modal-view-site {
+		display: flex;
+		gap: 4px;
+
+		font-weight: 500;
+		/* stylelint-disable-next-line */
+		font-size: 14px;
+		line-height: 20px;
+		letter-spacing: -0.154px;
+		color: #101517;
+	}
+
+	.share-site-modal__modal-view-site:visited {
+		color: #101517;
+	}
+
+	.share-site-modal__modal-view-site:hover {
+		text-decoration: underline;
+	}
+}

--- a/client/my-sites/customer-home/components/share-site-modal.tsx
+++ b/client/my-sites/customer-home/components/share-site-modal.tsx
@@ -21,7 +21,7 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 
 	const copyHandler = () => {
 		navigator.clipboard.writeText( `https://${ site?.slug }` );
-		updateLaunchpadSettings( site?.slug, {
+		updateLaunchpadSettings( site?.slug || null, {
 			checklist_statuses: { share_site: true },
 		} );
 		setClipboardCopied( true );
@@ -30,7 +30,11 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 
 	return (
 		<>
-			<Modal onRequestClose={ () => setModalIsOpen( false ) } className="share-site-modal__modal">
+			<Modal
+				onRequestClose={ () => setModalIsOpen( false ) }
+				className="share-site-modal__modal"
+				title="Share site"
+			>
 				<div className="share-site-modal__modal-content">
 					<div className="share-site-modal__modal-text">
 						<h1 className="share-site-modal__modal-heading">{ translate( 'Share your site' ) }</h1>

--- a/client/my-sites/customer-home/components/share-site-modal.tsx
+++ b/client/my-sites/customer-home/components/share-site-modal.tsx
@@ -1,0 +1,71 @@
+import { Gridicon } from '@automattic/components';
+import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { Button, Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useRef } from 'react';
+import Tooltip from 'calypso/components/tooltip';
+import type { SiteDetails } from '@automattic/data-stores';
+
+import './share-site-modal.scss';
+
+interface ShareSiteModalProps {
+	setModalIsOpen: ( isOpen: boolean ) => void;
+	site: SiteDetails;
+}
+
+const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
+	const translate = useTranslate();
+
+	const [ clipboardCopied, setClipboardCopied ] = useState( false );
+	const clipboardTextEl = useRef( null );
+
+	const copyHandler = () => {
+		navigator.clipboard.writeText( `https://${ site.slug }` );
+		updateLaunchpadSettings( site.slug, {
+			checklist_statuses: { share_site: true },
+		} );
+		setClipboardCopied( true );
+		setTimeout( () => setClipboardCopied( false ), 3000 );
+	};
+
+	return (
+		<>
+			<Modal onRequestClose={ () => setModalIsOpen( false ) } className="share-site-modal__modal">
+				<div className="share-site-modal__modal-content">
+					<div className="share-site-modal__modal-text">
+						<h1 className="share-site-modal__modal-heading">{ translate( 'Share your site' ) }</h1>
+						<p className="share-site-modal__modal-body">
+							{ translate( 'Now you can head over to your site and share it with the world.' ) }
+						</p>
+					</div>
+					<div className="share-site-modal__modal-actions">
+						<div className="share-site-modal__modal-site">
+							<div className="share-site-modal__modal-domain">
+								<p className="share-site-modal__modal-domain-text" ref={ clipboardTextEl }>
+									{ site.slug }
+								</p>
+
+								<Tooltip
+									context={ clipboardTextEl.current }
+									isVisible={ clipboardCopied }
+									position="top"
+								>
+									{ translate( 'Copied to clipboard!' ) }
+								</Tooltip>
+							</div>
+
+							<Button onClick={ copyHandler } className="share-site-modal__modal-view-site">
+								<Gridicon icon="link" size={ 18 } />
+								<span className="share-site-modal__modal-view-site-text">
+									{ translate( 'Copy' ) }
+								</span>
+							</Button>
+						</div>
+					</div>
+				</div>
+			</Modal>
+		</>
+	);
+};
+
+export default ShareSiteModal;

--- a/client/my-sites/customer-home/components/share-site-modal.tsx
+++ b/client/my-sites/customer-home/components/share-site-modal.tsx
@@ -10,7 +10,7 @@ import './share-site-modal.scss';
 
 interface ShareSiteModalProps {
 	setModalIsOpen: ( isOpen: boolean ) => void;
-	site: SiteDetails;
+	site: SiteDetails | null;
 }
 
 const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
@@ -20,8 +20,8 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 	const clipboardTextEl = useRef( null );
 
 	const copyHandler = () => {
-		navigator.clipboard.writeText( `https://${ site.slug }` );
-		updateLaunchpadSettings( site.slug, {
+		navigator.clipboard.writeText( `https://${ site?.slug }` );
+		updateLaunchpadSettings( site?.slug, {
 			checklist_statuses: { share_site: true },
 		} );
 		setClipboardCopied( true );
@@ -42,7 +42,7 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 						<div className="share-site-modal__modal-site">
 							<div className="share-site-modal__modal-domain">
 								<p className="share-site-modal__modal-domain-text" ref={ clipboardTextEl }>
-									{ site.slug }
+									{ site?.slug }
 								</p>
 
 								<Tooltip

--- a/client/my-sites/customer-home/components/share-site-modal.tsx
+++ b/client/my-sites/customer-home/components/share-site-modal.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { useQueryClient } from '@tanstack/react-query';
 import { Button, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
@@ -15,15 +16,17 @@ interface ShareSiteModalProps {
 
 const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 	const translate = useTranslate();
+	const queryClient = useQueryClient();
 
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const clipboardTextEl = useRef( null );
 
-	const copyHandler = () => {
+	const copyHandler = async () => {
 		navigator.clipboard.writeText( `https://${ site?.slug }` );
-		updateLaunchpadSettings( site?.slug || null, {
+		await updateLaunchpadSettings( site?.slug || null, {
 			checklist_statuses: { share_site: true },
 		} );
+		queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
 		setClipboardCopied( true );
 		setTimeout( () => setClipboardCopied( false ), 3000 );
 	};
@@ -33,7 +36,7 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 			<Modal
 				onRequestClose={ () => setModalIsOpen( false ) }
 				className="share-site-modal__modal"
-				title="Share site"
+				title=""
 			>
 				<div className="share-site-modal__modal-content">
 					<div className="share-site-modal__modal-text">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78856

## Proposed Changes

* Added "Share site" task to  `keep-building` checklist
* Some of the styles are a bit different from the design to keep consistent with other similar modals.

Works together with https://github.com/Automattic/jetpack/pull/31657

## Testing

* Create a new site with `build` intent (`/start`)
* Launch the site and go to customer home
* Check the Launchpad
* Click on the `Share Site` task
* Click on the `Copy` button
* Check the URL is copied
* Check the task is marked as completed

Design:

![image](https://github.com/Automattic/wp-calypso/assets/3801502/02e540b5-56c2-4f64-8846-947b9b2be6e2)


Screenshots:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/488ef521-d132-4786-8c05-23108e231a90)
![image](https://github.com/Automattic/wp-calypso/assets/3801502/8bcf9a74-e080-467f-8706-c1683046f84b)

