### PR TITLE
Hosting onboarding: preserve hosting flow even for already existing users

### DIFF
--- a/client/sites-dashboard/components/empty-sites-dashboard.tsx
+++ b/client/sites-dashboard/components/empty-sites-dashboard.tsx
@@ -3,7 +3,11 @@ import EmptyContent from 'calypso/components/empty-content';
 import { MEDIA_QUERIES } from '../utils';
 import { CreateSiteCTA, MigrateSiteCTA } from './sites-dashboard-ctas';
 
-export const EmptySitesDashboard = () => {
+interface EmptySitesDashboardProps {
+	siteCount: number;
+}
+
+export const EmptySitesDashboard = ( { siteCount }: EmptySitesDashboardProps ) => {
 	const { __ } = useI18n();
 
 	return (
@@ -30,14 +34,13 @@ export const EmptySitesDashboard = () => {
 						fontFamily: 'Recoleta, sans-serif',
 					} }
 				>
-					{ __( 'Let’s add your first site' ) }
+					{ siteCount === 0 ? __( 'Let’s add your first site' ) : __( 'Let’s add a site' ) }
 				</span>
 			}
 			illustration=""
 		>
 			<div
 				css={ {
-					width: '85%',
 					display: 'flex',
 					flexDirection: 'column',
 					[ MEDIA_QUERIES.small ]: {
@@ -45,7 +48,7 @@ export const EmptySitesDashboard = () => {
 					},
 				} }
 			>
-				<CreateSiteCTA />
+				<CreateSiteCTA siteCount={ siteCount } />
 				<div
 					css={ {
 						margin: '32px 0',
@@ -62,7 +65,7 @@ export const EmptySitesDashboard = () => {
 						},
 					} }
 				/>
-				<MigrateSiteCTA />
+				<MigrateSiteCTA siteCount={ siteCount } />
 			</div>
 		</EmptyContent>
 	);

--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -4,12 +4,16 @@ import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-imp
 import { TRACK_SOURCE_NAME } from '../utils';
 import { EmptyStateCTA } from './empty-state-cta';
 
-export const CreateSiteCTA = () => {
+interface SitesDashboardCTAProps {
+	siteCount: number;
+}
+
+export const CreateSiteCTA = ( { siteCount }: SitesDashboardCTAProps ) => {
 	const { __ } = useI18n();
 
 	const createSiteUrl = useAddNewSiteUrl( {
 		source: TRACK_SOURCE_NAME,
-		ref: 'calypso-nosites',
+		ref: siteCount === 0 ? 'calypso-nosites' : null,
 	} );
 
 	return (
@@ -21,10 +25,10 @@ export const CreateSiteCTA = () => {
 	);
 };
 
-export const MigrateSiteCTA = () => {
+export const MigrateSiteCTA = ( { siteCount }: SitesDashboardCTAProps ) => {
 	const { __ } = useI18n();
 	const importSiteUrl = useSitesDashboardImportSiteUrl( {
-		ref: 'calypso-nosites',
+		ref: siteCount === 0 ? 'calypso-nosites' : null,
 	} );
 
 	return (

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -46,16 +46,16 @@ export function sanitizeQueryParameters( context: PageJSContext, next: () => voi
 }
 
 export function maybeSitesDashboard( context: PageJSContext, next: () => void ) {
-	const siteCount = getCurrentUser( context.store.getState() )?.site_count;
+	const siteCount = getCurrentUser( context.store.getState() )?.site_count ?? 0;
 
-	if ( ! context.query[ 'new-site' ] && siteCount === 0 ) {
-		return emptySites( context, next );
+	if ( context.query[ 'hosting-flow' ] || siteCount === 0 ) {
+		return emptySites( context, siteCount, next );
 	}
 
 	return sitesDashboard( context, next );
 }
 
-function emptySites( context: PageJSContext, next: () => void ) {
+function emptySites( context: PageJSContext, siteCount: number, next: () => void ) {
 	const emptySitesDashboardGlobalStyles = css`
 		body.is-group-sites-dashboard {
 			background: #fff;
@@ -85,7 +85,7 @@ function emptySites( context: PageJSContext, next: () => void ) {
 		<>
 			<PageViewTracker path="/sites" title="Sites Management Page" delay={ 500 } />
 			<Global styles={ emptySitesDashboardGlobalStyles } />
-			<EmptySitesDashboard />
+			<EmptySitesDashboard siteCount={ siteCount } />
 		</>
 	);
 

--- a/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
+++ b/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
@@ -1,3 +1,4 @@
+import { Primitive } from 'utility-types';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -6,7 +7,7 @@ import { AppState } from 'calypso/types';
 import { TRACK_SOURCE_NAME } from '../utils';
 
 export const useSitesDashboardImportSiteUrl = (
-	additionalParameters: Record< string, string >
+	additionalParameters: Record< string, Primitive >
 ) => {
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
 
@@ -20,6 +21,6 @@ export const useSitesDashboardImportSiteUrl = (
 			...additionalParameters,
 			'hosting-flow': isHostingFlow ? true : null,
 		},
-		isDevAccount ? '/setup/import-hosted-site' : '/start/import'
+		isDevAccount || isHostingFlow ? '/setup/import-hosted-site' : '/start/import'
 	);
 };


### PR DESCRIPTION
Related to pet6gk-tn-p2#comment-464

## Proposed Changes

We should show the empty sites dashboard CTAs when the user comes from `/start/hosting`, even if they already have sites. Not doing so breaks continuity.

## Testing Instructions

On your existing WPCOM account with sites, browse `/start/hosting` and continue.

You should be redirected to `/sites` and see the centralized CTAs asking whether you'd like to create or import a site (instead of the sites list):

![image](https://github.com/Automattic/wp-calypso/assets/26530524/9c161bc7-5907-4821-bba6-6d40e59d842a)

"Migrate a site" should point to `/setup/import-hosted-site?source=sites-dashboard&hosting-flow=true`.

Also verify that `ref=calypso-nosites` is _NOT_ added as a query parameter if your account already has a site.