### PR TITLE
Hosting onboarding: hide masterbar

### DIFF
--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -8,6 +8,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { removeNotice } from 'calypso/state/notices/actions';
+import { hideMasterbar } from 'calypso/state/ui/actions';
 import { EmptySitesDashboard } from './components/empty-sites-dashboard';
 import { SitesDashboard } from './components/sites-dashboard';
 import { MEDIA_QUERIES } from './utils';
@@ -49,6 +50,7 @@ export function maybeSitesDashboard( context: PageJSContext, next: () => void ) 
 	const siteCount = getCurrentUser( context.store.getState() )?.site_count ?? 0;
 
 	if ( context.query[ 'hosting-flow' ] || siteCount === 0 ) {
+		context.store.dispatch( hideMasterbar() );
 		return emptySites( context, siteCount, next );
 	}
 


### PR DESCRIPTION
Related to pet6gk-tn-p2#comment-458.

## Proposed Changes

Let's hide the master bar when in the hosting flow, removing the distractions.

## Testing Instructions

Open `/sites?hosting-flow=true` and check that the master bar is gone for that specific session:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/3f832e4a-927d-4ca1-ab1d-53175597a70b)

Refreshing the page or going to checkout restores the master bar.