### PR TITLE
Hosting onboarding: allow going back when in the onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -10,7 +10,9 @@ import SiteCreationStep from 'calypso/landing/stepper/declarative-flow/internals
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
+import { useSelector } from 'calypso/state';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
+import { isInHostingFlow } from '../utils/is-in-hosting-flow';
 import Import from './internals/steps-repository/import';
 import ImportReady from './internals/steps-repository/import-ready';
 import ImportReadyNot from './internals/steps-repository/import-ready-not';
@@ -47,6 +49,7 @@ const importHostedSiteFlow: Flow = {
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
+		const hostingFlow = useSelector( isInHostingFlow );
 		const { setStepProgress, setPendingAction } = useDispatch( ONBOARD_STORE );
 		const urlQueryParams = useQuery();
 		const fromParam = urlQueryParams.get( 'from' );
@@ -181,7 +184,7 @@ const importHostedSiteFlow: Flow = {
 		const goBack = () => {
 			switch ( _currentStep ) {
 				case 'import':
-					return window.location.assign( '/sites' );
+					return window.location.assign( hostingFlow ? '/sites?hosting-flow=true' : '/sites' );
 
 				case 'importerWordpress':
 					// remove the siteSlug in case they want to change the destination site

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -4,15 +4,12 @@ import {
 	isNewHostedSiteCreationFlow,
 	StepContainer,
 } from '@automattic/onboarding';
-import { useSelector } from 'react-redux';
-import { isInHostingFlow } from 'calypso/landing/stepper/utils/is-in-hosting-flow';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PlansWrapper from './plans-wrapper';
 import type { ProvidedDependencies, Step } from '../../types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const plans: Step = function Plans( { navigation, flow } ) {
-	const hostingFlow = useSelector( isInHostingFlow );
 	const { goBack, submit } = navigation;
 
 	const handleSubmit = ( plan: MinimalRequestCartProduct | null ) => {
@@ -27,8 +24,7 @@ const plans: Step = function Plans( { navigation, flow } ) {
 		submit?.( providedDependencies );
 	};
 
-	const isAllowedToGoBack =
-		isDomainUpsellFlow( flow ) || ( isNewHostedSiteCreationFlow( flow ) && hostingFlow );
+	const isAllowedToGoBack = isDomainUpsellFlow( flow ) || isNewHostedSiteCreationFlow( flow );
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -180,9 +180,7 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 			<DocumentHead title={ headerText } />
 			<StepContainer
 				stepName="site-options"
-				shouldHideNavButtons
 				backLabelText={ __( 'Back' ) }
-				hideBack={ hostingFlow }
 				goBack={ goBack }
 				hideSkip={ true }
 				isHorizontalLayout

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -112,6 +112,10 @@ const hosting: Flow = {
 
 		if ( hostingFlow ) {
 			const goBack = () => {
+				if ( _currentStepSlug === 'options' ) {
+					return window.location.assign( '/sites?hosting-flow=true' );
+				}
+
 				if ( _currentStepSlug === 'plans' ) {
 					navigate( 'options' );
 				}
@@ -157,6 +161,10 @@ const hosting: Flow = {
 		}
 
 		const goBack = () => {
+			if ( _currentStepSlug === 'plans' ) {
+				return window.location.assign( '/sites' );
+			}
+
 			if ( _currentStepSlug === 'options' ) {
 				navigate( 'plans' );
 			}


### PR DESCRIPTION
## Proposed Changes

This PR fixes the back button behavior for both hosting onboarding flows. It also now preserves the `hosting-flow=true` query parameter, preserving the continuity of the flow.

## Testing Instructions

Browse `/sites?hosting-flow=true` and click "Create a site":
- Verify that the back button is showing and clicking it sends you to `/sites?hosting-flow=true` again.

Browse `/sites?hosting-flow=true` and click "Migrate a site":
- Verify that the back button is showing and clicking it sends you to `/sites?hosting-flow=true` again.

Browse `/sites` as a developer and click "Add new site":
- Verify that the back button is showing and clicking it sends you to `/sites` again.

Browse `/sites` as a developer and click "Import an existing site":
- Verify that the back button is showing and clicking it sends you to `/sites` again.