### PR TITLE
Hosting onboarding: use `ref=hosting-flow` in Sites CTAs

### DIFF
--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -10,9 +10,8 @@ import SiteCreationStep from 'calypso/landing/stepper/declarative-flow/internals
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
-import { useSelector } from 'calypso/state';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
-import { isInHostingFlow } from '../utils/is-in-hosting-flow';
+import { useIsCurrentlyHostingFlow } from '../utils/hosting-flow';
 import Import from './internals/steps-repository/import';
 import ImportReady from './internals/steps-repository/import-ready';
 import ImportReadyNot from './internals/steps-repository/import-ready-not';
@@ -49,7 +48,7 @@ const importHostedSiteFlow: Flow = {
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
-		const hostingFlow = useSelector( isInHostingFlow );
+		const hostingFlow = useIsCurrentlyHostingFlow();
 		const { setStepProgress, setPendingAction } = useDispatch( ONBOARD_STORE );
 		const urlQueryParams = useQuery();
 		const fromParam = urlQueryParams.get( 'from' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -34,7 +34,7 @@ import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { isInHostingFlow } from 'calypso/landing/stepper/utils/is-in-hosting-flow';
+import { startedInHostingFlow } from 'calypso/landing/stepper/utils/hosting-flow';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -276,6 +276,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 export default connect( ( state ) => {
 	return {
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
-		hostingFlow: isInHostingFlow( state ),
+		hostingFlow: startedInHostingFlow( state ),
 	};
 } )( localize( PlansWrapper ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -17,7 +17,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
 import { useGetSiteSuggestionsQuery } from 'calypso/landing/stepper/hooks/use-get-site-suggestions-query';
-import { isInHostingFlow } from 'calypso/landing/stepper/utils/is-in-hosting-flow';
+import { startedInHostingFlow } from 'calypso/landing/stepper/utils/hosting-flow';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { tip } from 'calypso/signup/icons';
 import { ONBOARD_STORE } from '../../../../stores';
@@ -36,7 +36,7 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 		} ),
 		[]
 	);
-	const hostingFlow = useSelector( isInHostingFlow );
+	const hostingFlow = useSelector( startedInHostingFlow );
 	const { goBack, submit } = navigation;
 	const [ siteTitle, setSiteTitle ] = React.useState( currentSiteTitle ?? '' );
 	const [ siteGeoAffinity, setSiteGeoAffinity ] = React.useState( currentSiteGeoAffinity ?? '' );

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -10,7 +10,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useQuery } from '../hooks/use-query';
 import { ONBOARD_STORE } from '../stores';
-import { isInHostingFlow } from '../utils/is-in-hosting-flow';
+import { startedInHostingFlow } from '../utils/hosting-flow';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect } from '@automattic/data-stores';
@@ -54,7 +54,7 @@ const hosting: Flow = {
 		];
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {
-		const hostingFlow = useSelector( isInHostingFlow );
+		const hostingFlow = useSelector( startedInHostingFlow );
 		const { setSiteTitle, setPlanCartItem, setSiteGeoAffinity } = useDispatch( ONBOARD_STORE );
 		const { siteGeoAffinity, planCartItem } = useSelect(
 			( select ) => ( {

--- a/client/landing/stepper/utils/hosting-flow.ts
+++ b/client/landing/stepper/utils/hosting-flow.ts
@@ -1,0 +1,12 @@
+import { useSelector } from 'calypso/state';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import { AppState } from 'calypso/types';
+
+export const startedInHostingFlow = ( state: AppState ) =>
+	getInitialQueryArguments( state )?.[ 'hosting-flow' ] === 'true';
+
+export const useIsCurrentlyHostingFlow = () =>
+	useSelector(
+		( state: AppState ) => getCurrentQueryArguments( state )?.[ 'hosting-flow' ] === 'true'
+	);

--- a/client/landing/stepper/utils/is-in-hosting-flow.ts
+++ b/client/landing/stepper/utils/is-in-hosting-flow.ts
@@ -1,5 +1,0 @@
-import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
-import { AppState } from 'calypso/types';
-
-export const isInHostingFlow = ( state: AppState ) =>
-	getInitialQueryArguments( state )?.[ 'hosting-flow' ] === 'true';

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -27,7 +27,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
-import { isInHostingFlow } from 'calypso/landing/stepper/utils/is-in-hosting-flow';
+import { startedInHostingFlow } from 'calypso/landing/stepper/utils/hosting-flow';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import {
 	recordSignupStart,
@@ -912,7 +912,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state ) || getSiteId( state, signupDependencies.siteSlug );
 		const siteDomains = getDomainsBySiteId( state, siteId );
 		const oauth2Client = getCurrentOAuth2Client( state );
-		const hostingFlow = isInHostingFlow( state );
+		const hostingFlow = startedInHostingFlow( state );
 
 		return {
 			domainsWithPlansOnly: getCurrentUser( state )

--- a/client/sites-dashboard/components/empty-sites-dashboard.tsx
+++ b/client/sites-dashboard/components/empty-sites-dashboard.tsx
@@ -48,7 +48,7 @@ export const EmptySitesDashboard = ( { siteCount }: EmptySitesDashboardProps ) =
 					},
 				} }
 			>
-				<CreateSiteCTA siteCount={ siteCount } />
+				<CreateSiteCTA />
 				<div
 					css={ {
 						margin: '32px 0',
@@ -65,7 +65,7 @@ export const EmptySitesDashboard = ( { siteCount }: EmptySitesDashboardProps ) =
 						},
 					} }
 				/>
-				<MigrateSiteCTA siteCount={ siteCount } />
+				<MigrateSiteCTA />
 			</div>
 		</EmptyContent>
 	);

--- a/client/sites-dashboard/components/sites-dashboard-ctas.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-ctas.tsx
@@ -1,19 +1,16 @@
 import { useI18n } from '@wordpress/react-i18n';
+import { useIsCurrentlyHostingFlow } from 'calypso/landing/stepper/utils/hosting-flow';
 import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
 import { TRACK_SOURCE_NAME } from '../utils';
 import { EmptyStateCTA } from './empty-state-cta';
 
-interface SitesDashboardCTAProps {
-	siteCount: number;
-}
-
-export const CreateSiteCTA = ( { siteCount }: SitesDashboardCTAProps ) => {
+export const CreateSiteCTA = () => {
 	const { __ } = useI18n();
 
 	const createSiteUrl = useAddNewSiteUrl( {
 		source: TRACK_SOURCE_NAME,
-		ref: siteCount === 0 ? 'calypso-nosites' : null,
+		ref: useIsCurrentlyHostingFlow() ? 'hosting-flow' : 'calypso-nosites',
 	} );
 
 	return (
@@ -25,10 +22,10 @@ export const CreateSiteCTA = ( { siteCount }: SitesDashboardCTAProps ) => {
 	);
 };
 
-export const MigrateSiteCTA = ( { siteCount }: SitesDashboardCTAProps ) => {
+export const MigrateSiteCTA = () => {
 	const { __ } = useI18n();
 	const importSiteUrl = useSitesDashboardImportSiteUrl( {
-		ref: siteCount === 0 ? 'calypso-nosites' : null,
+		ref: useIsCurrentlyHostingFlow() ? 'hosting-flow' : 'calypso-nosites',
 	} );
 
 	return (


### PR DESCRIPTION
## Proposed Changes

Let's use an appropriate reference to differentiate the CTAs given their context. 

I also abstracted the query parameter verification logic to its own hook.

## Testing Instructions

Browse `/sites?hosting-flow=true`. Verify that:
- "Create a site" has `ref=hosting-flow` attached to the URL;
- "Migrate a site" has `ref=hosting-flow` attached to the URL.

Browse `/sites` in an account with no sites. Verify that:  

- "Create a site" has `ref=calypso-nosites` attached to the URL;
- "Migrate a site" has `ref=calypso-nosites` attached to the URL.