### PR TITLE
Blog Onboarding: Clear site-intent if site is launched

### DIFF
--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -2,6 +2,7 @@ import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores'
 import { useLocale } from '@automattic/i18n-utils';
 import { DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import { useSelector } from 'react-redux';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
@@ -76,9 +77,11 @@ const designFirst: Flow = {
 		// We need to check if the site is launched and if so, clear the site_intent to avoid errors.
 		// See https://github.com/Automattic/dotcom-forge/issues/2886
 		const isSiteLaunched = site?.launch_status === 'launched' || false;
-		if ( isSiteLaunched ) {
-			setIntentOnSite( siteSlug, '' );
-		}
+		useEffect( () => {
+			if ( isSiteLaunched ) {
+				setIntentOnSite( siteSlug, '' );
+			}
+		}, [ siteSlug, setIntentOnSite, isSiteLaunched ] );
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -72,6 +72,14 @@ const designFirst: Flow = {
 		).getState();
 		const site = useSite();
 
+		// This flow clear the site_intent when flow is completed.
+		// We need to check if the site is launched and if so, clear the site_intent to avoid errors.
+		// See https://github.com/Automattic/dotcom-forge/issues/2886
+		const isSiteLaunched = site?.launch_status === 'launched' || false;
+		if ( isSiteLaunched ) {
+			setIntentOnSite( siteSlug, '' );
+		}
+
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );
 

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -70,6 +70,14 @@ const startWriting: Flow = {
 		).getState();
 		const site = useSite();
 
+		// This flow clear the site_intent when flow is completed.
+		// We need to check if the site is launched and if so, clear the site_intent to avoid errors.
+		// See https://github.com/Automattic/dotcom-forge/issues/2886
+		const isSiteLaunched = site?.launch_status === 'launched' || false;
+		if ( isSiteLaunched ) {
+			setIntentOnSite( siteSlug, '' );
+		}
+
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );
 

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -2,6 +2,7 @@ import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores'
 import { useLocale } from '@automattic/i18n-utils';
 import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
 import {
@@ -74,9 +75,11 @@ const startWriting: Flow = {
 		// We need to check if the site is launched and if so, clear the site_intent to avoid errors.
 		// See https://github.com/Automattic/dotcom-forge/issues/2886
 		const isSiteLaunched = site?.launch_status === 'launched' || false;
-		if ( isSiteLaunched ) {
-			setIntentOnSite( siteSlug, '' );
-		}
+		useEffect( () => {
+			if ( isSiteLaunched ) {
+				setIntentOnSite( siteSlug, '' );
+			}
+		}, [ siteSlug, setIntentOnSite, isSiteLaunched ] );
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2886

## Proposed Changes

`start-writing` and `design-first` flows are the only ones that clear the `site-intent` when the flow is completed.
With the `site-intent` not cleared, the editor hides some features and redirect the user to the launchpad when save a post.

On Launchpad, if the site is launched and the `site-intent` is `start-writing` or `design-first`, we clear the site intent.

This should solve issues like [this one](p1688051377866599-slack-CKZHG0QCR)


## Testing Instructions

* With a new user or a user with no sites, go to `/setup/start-writing` or `/setup/design-first`
* Complete some steps but not launch the blog.
* Go to `/settings` and launch the site.
* Create or edit a post.
* This should redirect to the launchpad and then to home << here is when we clear the `site_intent`
* Try to Create or edit a post again. It should works as it should.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
