### PR TITLE
Subscribers Page: Fix expanding width on add subscriber modal.

### DIFF
--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -1,4 +1,3 @@
-
 @import "@wordpress/base-styles/breakpoints";
 
 // On-boarding flow

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -1,3 +1,6 @@
+
+@import "@wordpress/base-styles/breakpoints";
+
 // On-boarding flow
 .step-container.subscribers {
 	padding: 0 1.5rem;
@@ -44,6 +47,16 @@
 
 	.add-subscriber__form-submit-btn {
 		margin-top: 0.5rem;
+	}
+}
+
+.is-section-subscribers {
+	.add-subscriber__form--container {
+		width: 420px;
+
+		@media ( max-width: $break-small ) {
+			width: auto;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fixes modal expanding after an email is entered.

## Testing Instructions

* Go to `/subscribers`.
* Enter an email. The modal should not expand.
* Resize to mobile view.
* The layout should render just fine.

https://github.com/Automattic/wp-calypso/assets/1287077/66fda879-a64e-4ee3-a059-d2ee08118509

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
