### PR TITLE
Domains: Fix all navigation links inside domains

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-done.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-done.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import domainConnectedIllustration from 'calypso/assets/images/domains/connect.svg';
 import CardHeading from 'calypso/components/card-heading';
+import { useCurrentRoute } from 'calypso/components/route';
 import { isSubdomain } from 'calypso/lib/domains';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -22,7 +23,8 @@ const ConnectDomainStepDone = ( {
 	queryErrorDescription,
 } ) => {
 	const { __ } = useI18n();
-	const siteDomainsUrl = domainManagementList( selectedSiteSlug );
+	const { currentRoute } = useCurrentRoute();
+	const siteDomainsUrl = domainManagementList( selectedSiteSlug, currentRoute );
 
 	const illustration = domainConnectedIllustration && (
 		<img src={ domainConnectedIllustration } alt="" width={ 150 } />

--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -20,8 +20,10 @@ import {
 	domainManagementList,
 	domainUseMyDomain,
 	domainMappingSetup,
+	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectDomainStepSwitchSetupInfoLink from './connect-domain-step-switch-setup-info-link';
@@ -43,6 +45,7 @@ function ConnectDomainStep( {
 	isFirstVisit,
 	queryError,
 	queryErrorDescription,
+	currentRoute,
 } ) {
 	const { __ } = useI18n();
 	const stepsDefinition = isSubdomain( domain )
@@ -204,7 +207,7 @@ function ConnectDomainStep( {
 	const renderBreadcrumbs = () => {
 		let items = [
 			{
-				label: __( 'Domains' ),
+				label: isUnderDomainManagementAll( currentRoute ) ? __( 'All Domains' ) : __( 'Domains' ),
 				href: domainManagementList( selectedSite.slug, domain ),
 			},
 			{
@@ -376,5 +379,6 @@ export default connect( ( state ) => {
 		domains: getDomainsBySiteId( state, siteId ),
 		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, siteId ),
 		selectedSite,
+		currentRoute: getCurrentRoute( state ),
 	};
 } )( ConnectDomainStep );

--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -231,18 +231,18 @@ function ConnectDomainStep( {
 			items = [
 				{
 					label: __( 'Domains' ),
-					href: domainManagementList( selectedSite.slug, domain ),
+					href: domainManagementList( selectedSite.slug, currentRoute ),
 				},
 				{
 					label: domain,
-					href: domainManagementEdit( selectedSite.slug, domain ),
+					href: domainManagementEdit( selectedSite.slug, domain, currentRoute ),
 				},
 				{ label: __( 'Connect' ) },
 			];
 
 			mobileItem = {
 				label: __( 'Back' ),
-				href: domainManagementEdit( selectedSite.slug, domain ),
+				href: domainManagementEdit( selectedSite.slug, domain, currentRoute ),
 				showBackArrow: true,
 			};
 		}
@@ -254,7 +254,7 @@ function ConnectDomainStep( {
 		if ( prevPageSlug ) {
 			setPageSlug( prevPageSlug );
 		} else {
-			page( domainManagementList( selectedSite.slug ) );
+			page( domainManagementList( selectedSite.slug, currentRoute ) );
 		}
 	};
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -48,6 +48,7 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import TransferDomainPrecheck from './transfer-domain-precheck';
@@ -296,12 +297,12 @@ class TransferDomainStep extends Component {
 	}
 
 	startPendingInboundTransfer = ( domain, authCode ) => {
-		const { selectedSite, translate } = this.props;
+		const { currentRoute, selectedSite, translate } = this.props;
 
 		startInboundTransfer( selectedSite.ID, domain, authCode )
 			.then( () => {
 				this.props.fetchSiteDomains( selectedSite.ID );
-				page( domainManagementTransferIn( selectedSite.slug, domain ) );
+				page( domainManagementTransferIn( selectedSite.slug, domain, currentRoute ) );
 			} )
 			.catch( () => {
 				this.props.errorNotice( translate( 'We were unable to start the transfer.' ) );
@@ -712,6 +713,7 @@ const recordMapDomainButtonClick = ( section ) =>
 
 export default connect(
 	( state ) => ( {
+		currentRoute: getCurrentRoute( state ),
 		currentUser: getCurrentUser( state ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		selectedSite: getSelectedSite( state ),

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -22,6 +22,7 @@ import {
 } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getSiteMigrationStatus from 'calypso/state/selectors/get-site-migration-status';
@@ -216,6 +217,7 @@ class MasterbarLoggedIn extends Component {
 			translate,
 			isCustomerHomeEnabled,
 			section,
+			currentRoute,
 		} = this.props;
 		const { isMenuOpen, isResponsiveMenu } = this.state;
 
@@ -223,7 +225,9 @@ class MasterbarLoggedIn extends Component {
 			? `/home/${ siteSlug }`
 			: getStatsPathForTab( 'day', siteSlug );
 
-		let mySitesUrl = domainOnlySite ? domainManagementList( siteSlug ) : homeUrl;
+		let mySitesUrl = domainOnlySite
+			? domainManagementList( siteSlug, currentRoute, true )
+			: homeUrl;
 
 		const icon =
 			this.state.isMobile && this.props.isInEditor ? 'chevron-left' : this.wordpressIcon();
@@ -599,6 +603,7 @@ export default connect(
 			// If the user is newer than new navigation shipping date, don't tell them this nav is new. Everything is new to them.
 			isUserNewerThanNewNavigation:
 				new Date( getCurrentUserDate( state ) ).getTime() > NEW_MASTERBAR_SHIPPING_DATE,
+			currentRoute: getCurrentRoute( state ),
 		};
 	},
 	{

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -254,7 +254,11 @@ export function resolveDomainStatus(
 								components: {
 									a: (
 										<a
-											href={ domainManagementEditContactInfo( siteSlug as string, domain.name ) }
+											href={ domainManagementEditContactInfo(
+												siteSlug as string,
+												domain.name,
+												currentRoute
+											) }
 										></a>
 									),
 								},
@@ -485,7 +489,11 @@ export function resolveDomainStatus(
 						{
 							components: {
 								strong: <strong />,
-								a: <a href={ domainManagementEdit( siteSlug as string, domain.domain ) } />,
+								a: (
+									<a
+										href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute ) }
+									/>
+								),
 							},
 						}
 					),

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -44,6 +44,7 @@ export type ResolveDomainStatusOptionsBag = {
 	isSiteAutomatedTransfer?: boolean | null;
 	isDomainOnlySite?: boolean | null;
 	siteSlug?: string | null;
+	currentRoute?: string | null;
 	getMappingErrors?: boolean | null;
 };
 
@@ -58,6 +59,7 @@ export function resolveDomainStatus(
 		isDomainOnlySite = null,
 		siteSlug = null,
 		getMappingErrors = false,
+		currentRoute = null,
 	}: ResolveDomainStatusOptionsBag = {}
 ): ResolveDomainStatusReturn {
 	const transferOptions = {

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import Count from 'calypso/components/count';
+import { useCurrentRoute } from 'calypso/components/route';
 import { useGetEmailAccountsQuery } from 'calypso/data/emails/use-get-email-accounts-query';
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import { type as domainType } from 'calypso/lib/domains/constants';
@@ -15,6 +16,7 @@ const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ) =>
 		selectedSite.ID,
 		domain.name
 	);
+	const { currentRoute } = useCurrentRoute();
 
 	let emailAddresses: string[] = [];
 
@@ -44,7 +46,7 @@ const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ) =>
 	) : (
 		<DomainInfoCard
 			type="href"
-			href={ emailManagement( selectedSite.slug, domain.name ) }
+			href={ emailManagement( selectedSite.slug, domain.name, currentRoute ) }
 			title={
 				<>
 					{ translate( 'Email' ) }

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -1,5 +1,6 @@
 import { Icon, lock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useCurrentRoute } from 'calypso/components/route';
 import { type as domainType } from 'calypso/lib/domains/constants';
 import { domainManagementTransfer } from 'calypso/my-sites/domains/paths';
 import DomainInfoCard from '..';
@@ -8,6 +9,7 @@ import type { DomainInfoCardProps } from '../types';
 const DomainTransferInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ) => {
 	const typesUnableToTransfer = [ domainType.TRANSFER, domainType.SITE_REDIRECT ] as const;
 	const translate = useTranslate();
+	const { currentRoute } = useCurrentRoute();
 
 	if (
 		! domain.currentUserIsOwner ||
@@ -31,7 +33,7 @@ const DomainTransferInfoCard = ( { domain, selectedSite }: DomainInfoCardProps )
 	return (
 		<DomainInfoCard
 			type="href"
-			href={ domainManagementTransfer( selectedSite.slug, domain.name ) }
+			href={ domainManagementTransfer( selectedSite.slug, domain.name, currentRoute ) }
 			title={ translate( 'Transfer' ) }
 			description={
 				domain.isLocked ? (

--- a/client/my-sites/domains/domain-management/components/icann-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/icann-verification/index.jsx
@@ -9,6 +9,7 @@ import { EMAIL_VALIDATION_AND_VERIFICATION } from 'calypso/lib/url/support';
 import EmailVerificationCard from 'calypso/my-sites/domains/domain-management/components/email-verification';
 import { domainManagementEditContactInfo } from 'calypso/my-sites/domains/paths';
 import { errorNotice } from 'calypso/state/notices/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getRegistrantWhois from 'calypso/state/selectors/get-registrant-whois';
 
 class IcannVerificationCard extends Component {
@@ -62,8 +63,19 @@ class IcannVerificationCard extends Component {
 	}
 
 	render() {
-		const { contactDetails, selectedDomainName, selectedSiteSlug, translate, compact } = this.props;
-		const changeEmailHref = domainManagementEditContactInfo( selectedSiteSlug, selectedDomainName );
+		const {
+			contactDetails,
+			selectedDomainName,
+			selectedSiteSlug,
+			translate,
+			compact,
+			currentRoute,
+		} = this.props;
+		const changeEmailHref = domainManagementEditContactInfo(
+			selectedSiteSlug,
+			selectedDomainName,
+			currentRoute
+		);
 
 		if ( ! contactDetails ) {
 			return <QueryWhois domain={ selectedDomainName } />;
@@ -89,6 +101,7 @@ class IcannVerificationCard extends Component {
 export default connect(
 	( state, ownProps ) => {
 		return {
+			currentRoute: getCurrentRoute( state ),
 			contactDetails: getRegistrantWhois( state, ownProps.selectedDomainName ),
 		};
 	},

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -51,7 +51,7 @@ class AddDnsRecord extends Component {
 					: translate( 'Domains' ),
 				href: domainManagementList(
 					selectedSite?.slug,
-					selectedDomainName,
+					currentRoute,
 					selectedSite?.options?.is_domain_only
 				),
 			},
@@ -82,8 +82,8 @@ class AddDnsRecord extends Component {
 	}
 
 	goBack = () => {
-		const { selectedSite, selectedDomainName } = this.props;
-		page( domainManagementDns( selectedSite?.slug, selectedDomainName ) );
+		const { selectedSite, selectedDomainName, currentRoute } = this.props;
+		page( domainManagementDns( selectedSite?.slug, selectedDomainName, currentRoute ) );
 	};
 
 	renderMain() {

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -14,6 +14,7 @@ import {
 	domainManagementDns,
 	domainManagementEdit,
 	domainManagementList,
+	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
 import { fetchDns } from 'calypso/state/domains/dns/actions';
 import { getDomainDns } from 'calypso/state/domains/dns/selectors';
@@ -45,7 +46,9 @@ class AddDnsRecord extends Component {
 
 		const items = [
 			{
-				label: translate( 'Domains' ),
+				label: isUnderDomainManagementAll( currentRoute )
+					? translate( 'All Domains' )
+					: translate( 'Domains' ),
 				href: domainManagementList(
 					selectedSite?.slug,
 					selectedDomainName,

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -61,7 +61,7 @@ class AddDnsRecord extends Component {
 			},
 			{
 				label: translate( 'DNS records' ),
-				href: domainManagementDns( selectedSite?.slug, selectedDomainName ),
+				href: domainManagementDns( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{
 				label: recordBeingEdited
@@ -74,7 +74,7 @@ class AddDnsRecord extends Component {
 			label: translate( 'Back to DNS records', {
 				comment: 'Link to return to the DNs records management page of a domain ',
 			} ),
-			href: domainManagementDns( selectedSite?.slug, selectedDomainName ),
+			href: domainManagementDns( selectedSite?.slug, selectedDomainName, currentRoute ),
 			showBackArrow: true,
 		};
 

--- a/client/my-sites/domains/domain-management/dns/dns-add-new-record-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new-record-button.tsx
@@ -2,18 +2,20 @@ import { Button } from '@automattic/components';
 import { Icon, plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
+import { useCurrentRoute } from 'calypso/components/route';
 import { domainManagementDnsAddRecord } from 'calypso/my-sites/domains/paths';
 import { DndAddNewRecordButtonProps } from './types';
 
 function DnsAddNewRecordButton( { site, domain, isMobile }: DndAddNewRecordButtonProps ) {
 	const { __ } = useI18n();
+	const { currentRoute } = useCurrentRoute();
 	const className = classNames( 'dns__breadcrumb-button add-record', {
 		'is-icon-button': isMobile,
 	} );
 	return (
 		<Button
 			borderless={ isMobile }
-			href={ domainManagementDnsAddRecord( site, domain ) }
+			href={ domainManagementDnsAddRecord( site, domain, currentRoute ) }
 			className={ className }
 		>
 			<Icon icon={ plus } viewBox="4 4 16 16" size={ 16 } />

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -14,6 +14,7 @@ import { domainManagementDns } from 'calypso/my-sites/domains/paths';
 import { addDns, updateDns } from 'calypso/state/domains/dns/actions';
 import { validateAllFields, getNormalizedData } from 'calypso/state/domains/dns/utils';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ARecord from './a-record';
 import CnameRecord from './cname-record';
@@ -208,9 +209,9 @@ class DnsAddNew extends React.Component {
 	};
 
 	handleSuccess = ( message ) => {
-		const { selectedSite, selectedDomainName } = this.props;
+		const { currentRoute, selectedSite, selectedDomainName } = this.props;
 
-		page( domainManagementDns( selectedSite.slug, selectedDomainName ) );
+		page( domainManagementDns( selectedSite.slug, selectedDomainName, currentRoute ) );
 		this.props.successNotice( message, { duration: 3000 } );
 	};
 
@@ -302,7 +303,8 @@ class DnsAddNew extends React.Component {
 export default connect(
 	( state ) => {
 		const selectedSite = getSelectedSite( state );
-		return { selectedSite };
+		const currentRoute = getCurrentRoute( state );
+		return { selectedSite, currentRoute };
 	},
 	{
 		addDns,

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -10,6 +10,7 @@ import DnsRecordsListHeader from 'calypso/my-sites/domains/domain-management/dns
 import { domainManagementDnsEditRecord } from 'calypso/my-sites/domains/paths';
 import { addDns, deleteDns } from 'calypso/state/domains/dns/actions';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import DeleteEmailForwardsDialog from './delete-email-forwards-dialog';
 import DnsRecordData from './dns-record-data';
 import DomainConnectInfoDialog from './domain-connect-info-dialog';
@@ -109,8 +110,15 @@ class DnsRecordsList extends Component {
 	};
 
 	editDns = ( record ) => {
-		const { selectedDomainName, selectedSite } = this.props;
-		page( domainManagementDnsEditRecord( selectedSite.slug, selectedDomainName, record.id ) );
+		const { currentRoute, selectedDomainName, selectedSite } = this.props;
+		page(
+			domainManagementDnsEditRecord(
+				selectedSite.slug,
+				selectedDomainName,
+				record.id,
+				currentRoute
+			)
+		);
 	};
 
 	deleteDns = ( record, action = 'delete', confirmed = false ) => {
@@ -272,10 +280,15 @@ class DnsRecordsList extends Component {
 	}
 }
 
-export default connect( null, {
-	addDns,
-	deleteDns,
-	errorNotice,
-	removeNotice,
-	successNotice,
-} )( localize( DnsRecordsList ) );
+export default connect(
+	( state ) => ( {
+		currentRoute: getCurrentRoute( state ),
+	} ),
+	{
+		addDns,
+		deleteDns,
+		errorNotice,
+		removeNotice,
+		successNotice,
+	}
+)( localize( DnsRecordsList ) );

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -12,7 +12,11 @@ import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/co
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
 import DnsRecordsList from 'calypso/my-sites/domains/domain-management/dns/dns-records-list';
 import EmailSetup from 'calypso/my-sites/domains/domain-management/email-setup';
-import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
+import {
+	domainManagementEdit,
+	domainManagementList,
+	isUnderDomainManagementAll,
+} from 'calypso/my-sites/domains/paths';
 import { fetchDns } from 'calypso/state/domains/dns/actions';
 import { getDomainDns } from 'calypso/state/domains/dns/selectors';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
@@ -40,7 +44,9 @@ class DnsRecords extends Component {
 
 		const items = [
 			{
-				label: translate( 'Domains' ),
+				label: isUnderDomainManagementAll( currentRoute )
+					? translate( 'All Domains' )
+					: translate( 'Domains' ),
 				href: domainManagementList(
 					selectedSite?.slug,
 					selectedDomainName,

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -49,7 +49,7 @@ class DnsRecords extends Component {
 					: translate( 'Domains' ),
 				href: domainManagementList(
 					selectedSite?.slug,
-					selectedDomainName,
+					currentRoute,
 					selectedSite?.options?.is_domain_only
 				),
 			},

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -15,6 +15,7 @@ import {
 	domainManagementEdit,
 	domainManagementList,
 	domainManagementContactsPrivacy,
+	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isRequestingWhois from 'calypso/state/selectors/is-requesting-whois';
@@ -58,7 +59,9 @@ const EditContactInfoPage = ( {
 
 		const items = [
 			{
-				label: translate( 'Domains' ),
+				label: isUnderDomainManagementAll( currentRoute )
+					? translate( 'All Domains' )
+					: translate( 'Domains' ),
 				href: domainManagementList(
 					selectedSite?.slug,
 					currentRoute,

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -26,6 +26,7 @@ import {
 	getWhoisSaveSuccess,
 } from 'calypso/state/domains/management/selectors';
 import { errorNotice, successNotice, infoNotice } from 'calypso/state/notices/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
 import getPreviousPath from '../../../../state/selectors/get-previous-path';
 
@@ -377,8 +378,16 @@ class EditContactInfoFormCard extends Component {
 	getReturnDestination = () => {
 		const domainName = this.props.selectedDomain.name;
 		const siteSlug = this.props.selectedSite.slug;
-		const domainSettingsPage = domainManagementEdit( siteSlug, domainName );
-		const contactsPrivacyPage = domainManagementContactsPrivacy( siteSlug, domainName );
+		const domainSettingsPage = domainManagementEdit(
+			siteSlug,
+			domainName,
+			this.props.currentRoute
+		);
+		const contactsPrivacyPage = domainManagementContactsPrivacy(
+			siteSlug,
+			domainName,
+			this.props.currentRoute
+		);
 
 		return this.props.previousPath?.startsWith( domainSettingsPage )
 			? domainSettingsPage
@@ -495,6 +504,7 @@ class EditContactInfoFormCard extends Component {
 export default connect(
 	( state, ownProps ) => {
 		return {
+			currentRoute: getCurrentRoute( state ),
 			currentUser: getCurrentUser( state ),
 			isUpdatingWhois: isUpdatingWhois( state, ownProps.selectedDomain.name ),
 			previousPath: getPreviousPath( state ),

--- a/client/my-sites/domains/domain-management/edit-contact-info/privacy-enabled-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/privacy-enabled-card.jsx
@@ -1,12 +1,14 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import { useCurrentRoute } from 'calypso/components/route';
 import { domainManagementContactsPrivacy } from 'calypso/my-sites/domains/paths';
 
 import './privacy-enabled-card.scss';
 
 function EditContactInfoPrivacyEnabledCard( { selectedDomainName, selectedSiteSlug } ) {
 	const translate = useTranslate();
+	const { currentRoute } = useCurrentRoute();
 
 	return (
 		<Card className="edit-contact-info__privacy-enabled-card">
@@ -18,7 +20,11 @@ function EditContactInfoPrivacyEnabledCard( { selectedDomainName, selectedSiteSl
 						components: {
 							a: (
 								<a
-									href={ domainManagementContactsPrivacy( selectedSiteSlug, selectedDomainName ) }
+									href={ domainManagementContactsPrivacy(
+										selectedSiteSlug,
+										selectedDomainName,
+										currentRoute
+									) }
 									rel="noopener noreferrer"
 								/>
 							),

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -11,12 +11,21 @@ import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import { domainManagementEdit, createSiteFromDomainOnly } from 'calypso/my-sites/domains/paths';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 import './domain-only.scss';
 
-const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, translate } ) => {
+const DomainOnly = ( {
+	currentRoute,
+	primaryDomain,
+	hasNotice,
+	recordTracks,
+	siteId,
+	slug,
+	translate,
+} ) => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	if ( ! primaryDomain ) {
 		return (
@@ -52,7 +61,7 @@ const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, tra
 				action={ canCreateSite && translate( 'Create site' ) }
 				actionURL={ canCreateSite && createSiteUrl }
 				secondaryAction={ translate( 'Manage domain' ) }
-				secondaryActionURL={ domainManagementEdit( slug, domainName ) }
+				secondaryActionURL={ domainManagementEdit( slug, domainName, currentRoute ) }
 				illustration={ Illustration }
 			>
 				<Button
@@ -86,6 +95,7 @@ DomainOnly.propTypes = {
 export default connect(
 	( state, ownProps ) => {
 		return {
+			currentRoute: getCurrentRoute( state ),
 			slug: getSiteSlug( state, ownProps.siteId ),
 			primaryDomain: getPrimaryDomainBySiteId( state, ownProps.siteId ),
 		};

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -28,10 +28,10 @@ import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
 import TransferConnectedDomainNudge from 'calypso/my-sites/domains/domain-management/components/transfer-connected-domain-nudge';
 import {
-	domainManagementList,
 	createSiteFromDomainOnly,
-	domainManagementEditContactInfo,
 	domainManagementDns,
+	domainManagementEditContactInfo,
+	domainManagementList,
 	domainUseMyDomain,
 } from 'calypso/my-sites/domains/paths';
 import {
@@ -40,6 +40,7 @@ import {
 } from 'calypso/my-sites/email/paths';
 import { useOdysseusAssistantContext } from 'calypso/odysseus/context';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 import './domain-row.scss';
 
@@ -95,10 +96,10 @@ class DomainRow extends PureComponent {
 	}
 
 	renderSite() {
-		const { site } = this.props;
+		const { site, currentRoute } = this.props;
 		return (
 			<div className="domain-row__site-cell">
-				<Button href={ domainManagementList( site?.slug ) } plain>
+				<Button href={ domainManagementList( site?.slug, currentRoute ) } plain>
 					{ site?.title || site?.slug }
 				</Button>
 			</div>
@@ -540,4 +541,9 @@ function withOdysseusAssistantContext( Component ) {
 	};
 }
 
-export default connect()( withOdysseusAssistantContext( localize( DomainRow ) ) );
+export default connect( ( state ) => {
+	const currentRoute = getCurrentRoute( state );
+	return {
+		currentRoute,
+	};
+} )( withOdysseusAssistantContext( localize( DomainRow ) ) );

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -124,10 +124,11 @@ class DomainRow extends PureComponent {
 	}
 
 	renderDomainStatus() {
-		const { domain, site, isLoadingDomainDetails, translate, dispatch } = this.props;
+		const { currentRoute, domain, site, isLoadingDomainDetails, translate, dispatch } = this.props;
 		const { status, statusClass } = resolveDomainStatus( domain, null, translate, dispatch, {
 			siteSlug: site?.slug,
 			getMappingErrors: true,
+			currentRoute,
 		} );
 
 		const domainStatusClass = classnames( 'domain-row__status-cell', {
@@ -473,8 +474,16 @@ class DomainRow extends PureComponent {
 	}
 
 	render() {
-		const { domain, isManagingAllSites, site, showCheckbox, purchase, translate, dispatch } =
-			this.props;
+		const {
+			currentRoute,
+			domain,
+			isManagingAllSites,
+			site,
+			showCheckbox,
+			purchase,
+			translate,
+			dispatch,
+		} = this.props;
 		const domainTypeText = getDomainTypeText( domain, translate, domainInfoContext.DOMAIN_ROW );
 		const expiryDate = domain?.expiry ? moment.utc( domain?.expiry ) : null;
 		const { noticeText, statusClass } = resolveDomainStatus(
@@ -485,6 +494,7 @@ class DomainRow extends PureComponent {
 			{
 				siteSlug: site?.slug,
 				getMappingErrors: true,
+				currentRoute,
 			}
 		);
 

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -233,7 +233,7 @@ export class SiteDomains extends Component {
 	}
 
 	renderDomainTableFilterButton() {
-		const { selectedSite, domains, context, translate } = this.props;
+		const { selectedSite, domains, context, translate, currentRoute } = this.props;
 
 		const selectedFilter = context?.query?.filter;
 		const nonWpcomDomains = filterOutWpcomDomains( domains );
@@ -242,21 +242,23 @@ export class SiteDomains extends Component {
 			{
 				label: translate( 'Site domains' ),
 				value: '',
-				path: domainManagementList( selectedSite?.slug ),
+				path: domainManagementList( selectedSite?.slug, currentRoute ),
 				count: nonWpcomDomains?.length,
 			},
 			{
 				label: translate( 'Owned by me' ),
 				value: 'owned-by-me',
 				path:
-					domainManagementList( selectedSite?.slug ) + '?' + stringify( { filter: 'owned-by-me' } ),
+					domainManagementList( selectedSite?.slug, currentRoute ) +
+					'?' +
+					stringify( { filter: 'owned-by-me' } ),
 				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-me' )?.length,
 			},
 			{
 				label: translate( 'Owned by others' ),
 				value: 'owned-by-others',
 				path:
-					domainManagementList( selectedSite?.slug ) +
+					domainManagementList( selectedSite?.slug, currentRoute ) +
 					'?' +
 					stringify( { filter: 'owned-by-others' } ),
 				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-others' )?.length,
@@ -389,7 +391,7 @@ export class SiteDomains extends Component {
 
 	async setPrimaryDomain( domainName ) {
 		await this.props.dispatch( setPrimaryDomain( this.props.selectedSite.ID, domainName ) );
-		page.redirect( domainManagementList( this.props.selectedSite.slug ) );
+		page.redirect( domainManagementList( this.props.selectedSite.slug, this.props.currentRoute ) );
 	}
 
 	handleUpdatePrimaryDomainWpcom = ( domainName ) => {

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -148,7 +148,7 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 		);
 	};
 
-	const { selectedDomainName, canManageConsent } = props;
+	const { selectedDomainName, canManageConsent, currentRoute } = props;
 
 	return (
 		<div>
@@ -160,7 +160,7 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 							href={ domainManagementEditContactInfo(
 								props.selectedSite.slug,
 								props.selectedDomainName,
-								props.currentRoute as undefined
+								currentRoute
 							) }
 						>
 							{ translate( 'Edit' ) }
@@ -170,7 +170,7 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 								href={ domainManagementManageConsent(
 									props.selectedSite.slug,
 									props.selectedDomainName,
-									props.currentRoute as undefined
+									currentRoute
 								) }
 							>
 								{ translate( 'Manage consent' ) }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -408,7 +408,9 @@ const Settings = ( {
 		}
 
 		const contactInformationUpdateLink =
-			selectedSite && domain && domainManagementEditContactInfo( selectedSite?.slug, domain.name );
+			selectedSite &&
+			domain &&
+			domainManagementEditContactInfo( selectedSite?.slug, domain.name, currentRoute );
 
 		return (
 			<Accordion

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import Badge from 'calypso/components/badge';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useCurrentRoute } from 'calypso/components/route';
 import { resolveDomainStatus } from 'calypso/lib/domains';
 import { type as DomainType } from 'calypso/lib/domains/constants';
 import TransferConnectedDomainNudge from 'calypso/my-sites/domains/domain-management/components/transfer-connected-domain-nudge';
@@ -26,6 +27,7 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 	const { __ } = useI18n();
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { currentRoute } = useCurrentRoute();
 
 	const renderCircle = () => (
 		<SVG viewBox="0 0 24 24" height={ 8 } width={ 8 }>
@@ -77,7 +79,9 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 	};
 
 	const renderStatusBadge = ( domain: ResponseDomain ) => {
-		const { status, statusClass } = resolveDomainStatus( domain, null, translate, dispatch );
+		const { status, statusClass } = resolveDomainStatus( domain, null, translate, dispatch, {
+			currentRoute,
+		} );
 
 		if ( status ) {
 			return statusClass === 'status-success'
@@ -114,6 +118,7 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 			{
 				siteSlug: site.slug,
 				getMappingErrors: true,
+				currentRoute,
 			}
 		);
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -30,6 +30,7 @@ import {
 	domainManagementList,
 	domainManagementTransferToAnotherUser,
 	domainManagementTransferToOtherSite,
+	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
 import { useDispatch } from 'calypso/state';
 import {
@@ -80,7 +81,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 		const items = [
 			{
 				// translators: Internet domains, e.g. mygroovydomain.com
-				label: __( 'Domains' ),
+				label: isUnderDomainManagementAll( currentRoute ) ? __( 'All Domains' ) : __( 'Domains' ),
 				href: domainManagementList(
 					selectedSite?.slug,
 					selectedDomainName,

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -84,7 +84,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 				label: isUnderDomainManagementAll( currentRoute ) ? __( 'All Domains' ) : __( 'Domains' ),
 				href: domainManagementList(
 					selectedSite?.slug,
-					selectedDomainName,
+					currentRoute,
 					selectedSite?.options?.is_domain_only
 				),
 			},

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -74,7 +74,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		targetSite: TransferDomainToOtherSiteProps[ 'selectedSite' ],
 		closeDialog: () => void
 	): void => {
-		const { selectedDomainName, selectedSite } = this.props;
+		const { selectedDomainName, selectedSite, currentRoute } = this.props;
 		const targetSiteTitle = targetSite.title;
 		const successMessage = this.props.translate(
 			'%(selectedDomainName)s has been transferred to site: %(targetSiteTitle)s',
@@ -98,9 +98,9 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 					if ( this.props.isDomainOnly ) {
 						this.props.requestSites();
 						const transferedTo = this.props.sites.find( ( site ) => site.ID === targetSite.ID );
-						page( domainManagementList( transferedTo?.slug ?? '' ) );
+						page( domainManagementList( transferedTo?.slug ?? '', currentRoute ) );
 					} else {
-						page( domainManagementList( this.props.selectedSite?.slug ) );
+						page( domainManagementList( this.props.selectedSite?.slug, currentRoute ) );
 					}
 				},
 				( error: Error ) => {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -18,6 +18,7 @@ import {
 	domainManagementEdit,
 	domainManagementList,
 	domainManagementTransfer,
+	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -164,7 +165,9 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 
 		const items = [
 			{
-				label: translate( 'Domains' ),
+				label: isUnderDomainManagementAll( currentRoute )
+					? translate( 'All Domains' )
+					: translate( 'Domains' ),
 				href: domainManagementList(
 					selectedSite?.slug,
 					selectedDomainName,

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -26,6 +26,7 @@ import {
 	domainManagementEdit,
 	domainManagementList,
 	domainManagementTransfer,
+	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
@@ -145,7 +146,9 @@ class TransferDomainToOtherUser extends Component {
 
 		const items = [
 			{
-				label: translate( 'Domains' ),
+				label: isUnderDomainManagementAll( currentRoute )
+					? translate( 'All Domains' )
+					: translate( 'Domains' ),
 				href: domainManagementList(
 					selectedSite?.slug,
 					selectedDomainName,

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -43,6 +43,7 @@ import {
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isSiteOnMonthlyPlan from 'calypso/state/selectors/is-site-on-monthly-plan';
 import isSiteUpgradeable from 'calypso/state/selectors/is-site-upgradeable';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
@@ -247,6 +248,7 @@ class DomainSearch extends Component {
 			isDomainAndPlanPackageFlow,
 			isDomainUpsell,
 			isEcommerceSite,
+			currentRoute,
 		} = this.props;
 
 		if ( ! selectedSite ) {
@@ -309,7 +311,7 @@ class DomainSearch extends Component {
 						{ ! isDomainAndPlanPackageFlow && (
 							<BackButton
 								className="domain-search__go-back"
-								href={ domainManagementList( selectedSiteSlug ) }
+								href={ domainManagementList( selectedSiteSlug, currentRoute ) }
 							>
 								<Gridicon icon="arrow-left" size={ 18 } />
 								{ translate( 'Back' ) }
@@ -409,6 +411,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
+			currentRoute: getCurrentRoute( state ),
 			domains: getDomainsBySiteId( state, siteId ),
 			selectedSite: getSelectedSite( state ),
 			selectedSiteId: siteId,

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -18,6 +18,7 @@ import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isSiteOnPaidPlan from 'calypso/state/selectors/is-site-on-paid-plan';
 import isSiteUpgradeable from 'calypso/state/selectors/is-site-upgradeable';
 import {
@@ -50,7 +51,7 @@ export class MapDomain extends Component {
 	};
 
 	goBack = () => {
-		const { selectedSite, selectedSiteSlug } = this.props;
+		const { currentRoute, selectedSite, selectedSiteSlug } = this.props;
 
 		if ( ! selectedSite ) {
 			page( '/domains/add' );
@@ -58,7 +59,7 @@ export class MapDomain extends Component {
 		}
 
 		if ( selectedSite.is_vip ) {
-			page( domainManagementList( selectedSiteSlug ) );
+			page( domainManagementList( selectedSiteSlug, currentRoute ) );
 			return;
 		}
 
@@ -96,7 +97,7 @@ export class MapDomain extends Component {
 	};
 
 	handleMapDomain = ( domain ) => {
-		const { selectedSite, selectedSiteSlug, translate } = this.props;
+		const { currentRoute, selectedSite, selectedSiteSlug, translate } = this.props;
 
 		this.setState( {
 			errorMessage: null,
@@ -111,7 +112,7 @@ export class MapDomain extends Component {
 				.post( `/sites/${ selectedSite.ID }/vip-domain-mapping`, { domain } )
 				.then(
 					() => {
-						page( domainManagementList( selectedSiteSlug ) );
+						page( domainManagementList( selectedSiteSlug, currentRoute ) );
 					},
 					( error ) => {
 						this.setState( { errorMessage: error.message } );
@@ -230,6 +231,7 @@ export default connect(
 	( state ) => {
 		const selectedSiteId = getSelectedSiteId( state );
 		return {
+			currentRoute: getCurrentRoute( state ),
 			selectedSite: getSelectedSite( state ),
 			selectedSiteId,
 			selectedSiteSlug: getSelectedSiteSlug( state ),

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -7,6 +7,7 @@ import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useCurrentRoute } from 'calypso/components/route';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
@@ -98,6 +99,7 @@ function WebsiteContentSubmissionPending( { primaryDomain, siteId, siteSlug }: P
 function WebsiteContentSubmitted( { primaryDomain, siteSlug }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { currentRoute } = useCurrentRoute();
 
 	const domainName = primaryDomain.name;
 	const hasEmailWithUs = hasGSuiteWithUs( primaryDomain ) || hasTitanMailWithUs( primaryDomain );
@@ -134,7 +136,7 @@ function WebsiteContentSubmitted( { primaryDomain, siteSlug }: Props ) {
 				}
 			) }
 			action={ translate( 'Manage domain' ) }
-			actionURL={ domainManagementList( siteSlug ) }
+			actionURL={ domainManagementList( siteSlug, currentRoute ) }
 			secondaryAction={ hasEmailWithUs ? translate( 'Manage email' ) : translate( 'Add email' ) }
 			secondaryActionURL={ emailManagement( siteSlug, null ) }
 			secondaryActionCallback={ recordEmailClick }


### PR DESCRIPTION
Some domain links/navigation are not working properly in some specific contexts - for example, a few "All domains" navigation routes. For them to work properly, we need to pass the `currentRoute` argument, so that the navigation can go back to the correct page and keep the components in the same context. This PR fixes this behavior.

## Testing Instructions
- Go to "All domains";
- Select any domain and navigate through a few management routes. Some examples:
  - DNS records > Manage > Add new DNS > Cancel;
  - Transfer > Click on the "All domains" breadcrumb item;
  - Contact Information > Edit > Click on the "All domains" breadcrumb item;
- Ensure these are all working;
- Ensure all unit tests pass.

### Before
https://github.com/Automattic/wp-calypso/assets/18705930/cbd795cf-d97e-4fd4-80b3-87e652621a72

### After
https://github.com/Automattic/wp-calypso/assets/18705930/364f98e6-0fd6-4c48-b4c6-fd4d4264b205

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
