### PR TITLE
add null check to fix issue on wordpress.com/tag/$tag

### DIFF
--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -20,6 +20,10 @@ const ReaderListFollowingItem = ( props ) => {
 	const siteIcon = site ? site.site_icon ?? get( site, 'icon.img' ) : null;
 	let feedIcon = get( follow, 'site_icon' );
 
+	if ( ! follow ) {
+		return null;
+	}
+
 	// If feed available, check feed for feed icon
 	if ( feed && feed.image ) {
 		feedIcon = get( feed, 'image' );


### PR DESCRIPTION
I'm still investigating the cause of this, but a WSOD seems to be happening on wordpress.com but not local test environments on some tag pages.

/tag/arts displays an error because `follow` is null and the component tries to access properties of follow

### Test instructions
N/A 