### PR TITLE
reader: fix related sites section on tags stream page

### DIFF
--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -37,7 +37,7 @@ const ReaderTagSidebar = ( { tag } ) => {
 		<TagLink tag={ relatedTag } key={ relatedTag.slug } onClick={ handleTagSidebarClick } />
 	) );
 	const relatedSitesLinks = relatedMetaByTag.data?.related_sites?.map( ( relatedSite ) => (
-		<ReaderListFollowingItem key={ relatedSite.feed_ID } site={ relatedSite } path="/" />
+		<ReaderListFollowingItem key={ relatedSite.feed_ID } follow={ relatedSite } path="/" />
 	) );
 
 	return (


### PR DESCRIPTION
simple fix, to fix a bug introduced on Friday for the tags stream page.


ReaderListFollowingItem was updated to take 'follow' instead of 'site' but the tags page usage wasn't updated.


### Testing instructions
View tag page, assert that the related sites section is shown