### PR TITLE
reader: add signup link to logged out tags page

### DIFF
--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -1,7 +1,7 @@
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
 import { useRelatedMetaByTag } from 'calypso/data/reader/use-related-meta-by-tag';
 import { useTagStats } from 'calypso/data/reader/use-tag-stats';
@@ -9,6 +9,7 @@ import formatNumberCompact from 'calypso/lib/format-number-compact';
 import { createAccountUrl } from 'calypso/lib/paths';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import ReaderListFollowingItem from 'calypso/reader/stream/reader-list-followed-sites/item';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import '../style.scss';
 
@@ -17,15 +18,16 @@ const ReaderTagSidebar = ( { tag } ) => {
 	const relatedMetaByTag = useRelatedMetaByTag( tag );
 	const tagStats = useTagStats( tag );
 	const dispatch = useDispatch();
-	if ( relatedMetaByTag === undefined ) {
-		return null;
-	}
-	const showCreateAccountPrompt = true;
+	const showCreateAccountButton = useSelector( ( state ) => ! isUserLoggedIn( state ) );
 	const { pathname } = getUrlParts( window.location.href );
 	const signupUrl = createAccountUrl( {
 		redirectTo: pathname,
 		ref: 'reader-tag-sidebar',
 	} );
+
+	if ( relatedMetaByTag === undefined ) {
+		return null;
+	}
 
 	const handleTagSidebarClick = () => {
 		recordAction( 'clicked_reader_sidebar_tag' );
@@ -87,8 +89,8 @@ const ReaderTagSidebar = ( { tag } ) => {
 					{ relatedSitesLinks }
 				</div>
 			) }
-			{ showCreateAccountPrompt && (
-				<div className="reader-tag-sidebar-create-account-prompt">
+			{ showCreateAccountButton && (
+				<div>
 					<Button primary onClick={ trackSignupClick } href={ signupUrl }>
 						{ translate( 'Join the WordPress.com community' ) }
 					</Button>

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -1,9 +1,12 @@
+import { getUrlParts } from '@automattic/calypso-url';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
 import { useRelatedMetaByTag } from 'calypso/data/reader/use-related-meta-by-tag';
 import { useTagStats } from 'calypso/data/reader/use-tag-stats';
 import formatNumberCompact from 'calypso/lib/format-number-compact';
+import { createAccountUrl } from 'calypso/lib/paths';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import ReaderListFollowingItem from 'calypso/reader/stream/reader-list-followed-sites/item';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
@@ -17,6 +20,12 @@ const ReaderTagSidebar = ( { tag } ) => {
 	if ( relatedMetaByTag === undefined ) {
 		return null;
 	}
+	const showCreateAccountPrompt = true;
+	const { pathname } = getUrlParts( window.location.href );
+	const signupUrl = createAccountUrl( {
+		redirectTo: pathname,
+		ref: 'reader-tag-sidebar',
+	} );
 
 	const handleTagSidebarClick = () => {
 		recordAction( 'clicked_reader_sidebar_tag' );
@@ -31,6 +40,11 @@ const ReaderTagSidebar = ( { tag } ) => {
 	const trackTagsPageLinkClick = () => {
 		recordAction( 'clicked_reader_sidebar_tags_page_link' );
 		dispatch( recordReaderTracksEvent( 'calypso_reader_sidebar_tags_page_link_clicked' ) );
+	};
+
+	const trackSignupClick = () => {
+		recordAction( 'clicked_reader_sidebar_signup' );
+		dispatch( recordReaderTracksEvent( 'calypso_reader_sidebar_signup_clicked' ) );
 	};
 
 	const tagLinks = relatedMetaByTag.data?.related_tags?.map( ( relatedTag ) => (
@@ -71,6 +85,13 @@ const ReaderTagSidebar = ( { tag } ) => {
 				<div className="reader-tag-sidebar-related-sites">
 					<h2>{ translate( 'Related Sites' ) }</h2>
 					{ relatedSitesLinks }
+				</div>
+			) }
+			{ showCreateAccountPrompt && (
+				<div className="reader-tag-sidebar-create-account-prompt">
+					<Button primary onClick={ trackSignupClick } href={ signupUrl }>
+						{ translate( 'Join the WordPress.com community' ) }
+					</Button>
 				</div>
 			) }
 		</>

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -719,6 +719,7 @@
 	}
 	.reader-tag-sidebar-related-tags,
 	.reader-tag-sidebar-related-sites {
+		margin-bottom: 32px;
 		h2 {
 			font-size: $font-body;
 			margin-bottom: 14px;


### PR DESCRIPTION
Simple change to add a signup link to the tags page when logged out 

Part of pe7F0s-Xe-p2

### Testing instructions

Notice signup link shown on /tag/$tag page when logged out, link should not be shown when logged in.
