### PR TITLE
Blog onboarding: Launch site text change to Checkout and launch

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -341,11 +341,7 @@ export function getEnhancedTasks(
 				case 'blog_launched': {
 					const onboardingCartItems = [ planCartItem, domainCartItem ].filter( Boolean );
 					let title = task.title;
-					if (
-						( isStartWritingFlow( flow ) || isDesignFirstFlow( flow ) ) &&
-						planCompleted &&
-						onboardingCartItems.length
-					) {
+					if ( isBlogOnboardingFlow( flow ) && planCompleted && onboardingCartItems.length ) {
 						title = translate( 'Checkout and launch' );
 					}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -2,7 +2,6 @@ import {
 	FEATURE_VIDEO_UPLOADS,
 	planHasFeature,
 	PLAN_PREMIUM,
-	PLAN_FREE,
 	FEATURE_STYLE_CUSTOMIZATION,
 } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -339,8 +338,19 @@ export function getEnhancedTasks(
 						},
 					};
 					break;
-				case 'blog_launched':
+				case 'blog_launched': {
+					const onboardingCartItems = [ planCartItem, domainCartItem ].filter( Boolean );
+					let title = task.title;
+					if (
+						( isStartWritingFlow( flow ) || isDesignFirstFlow( flow ) ) &&
+						planCompleted &&
+						onboardingCartItems.length
+					) {
+						title = translate( 'Checkout and launch' );
+					}
+
 					taskData = {
+						title,
 						disabled:
 							( isStartWritingFlow( flow ) &&
 								( ! firstPostPublished ||
@@ -382,14 +392,9 @@ export function getEnhancedTasks(
 								submit?.();
 							}
 						},
-						title:
-							( isStartWritingFlow( flow ) || isDesignFirstFlow( flow ) ) &&
-							planCompleted &&
-							productSlug !== PLAN_FREE
-								? translate( 'Checkout and launch' )
-								: task.title,
 					};
 					break;
+				}
 				case 'videopress_upload':
 					taskData = {
 						actionUrl: launchpadUploadVideoLink,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -2,6 +2,7 @@ import {
 	FEATURE_VIDEO_UPLOADS,
 	planHasFeature,
 	PLAN_PREMIUM,
+	PLAN_FREE,
 	FEATURE_STYLE_CUSTOMIZATION,
 } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -381,6 +382,12 @@ export function getEnhancedTasks(
 								submit?.();
 							}
 						},
+						title:
+							( isStartWritingFlow( flow ) || isDesignFirstFlow( flow ) ) &&
+							planCompleted &&
+							productSlug !== PLAN_FREE
+								? translate( 'Checkout and launch' )
+								: task.title,
 					};
 					break;
 				case 'videopress_upload':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/lib/fixtures.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/lib/fixtures.ts
@@ -5,6 +5,7 @@ import { Task } from '../../types';
 export const defaultSiteDetails: SiteDetails = {
 	ID: 211078228,
 	name: 'testLinkInBio',
+	title: 'Site Title',
 	description: 'test link in bio',
 	URL: 'https://testlinkinbio.wordpress.com',
 	domain: '',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -283,6 +283,12 @@ describe( 'StepContent', () => {
 
 			expect( screen.getByTitle( 'Preview' ) ).toBeInTheDocument();
 		} );
+
+		it( 'renders correct launch CTA text when plan not free', () => {
+			renderStepContent( false, START_WRITING_FLOW );
+
+			expect( screen.getByText( 'Checkout and launch' ) ).toBeInTheDocument();
+		} );
 	} );
 
 	describe( 'when flow is Design first', () => {
@@ -323,6 +329,12 @@ describe( 'StepContent', () => {
 			renderStepContent( false, DESIGN_FIRST_FLOW );
 
 			expect( screen.getByTitle( 'Preview' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders correct launch CTA text when plan not free', () => {
+			renderStepContent( false, DESIGN_FIRST_FLOW );
+
+			expect( screen.getByText( 'Checkout and launch' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -12,7 +12,7 @@ import { getInitialState, getStateFromCache } from 'calypso/state/initial-state'
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
 import StepContent from '../step-content';
-import { defaultSiteDetails } from './lib/fixtures';
+import { defaultSiteDetails, buildDomainResponse } from './lib/fixtures';
 
 const mockSite = {
 	...defaultSiteDetails,
@@ -38,7 +38,7 @@ jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
 } ) );
 
 jest.mock( 'react-router-dom', () => ( {
-	...jest.requireActual( 'react-router-dom' ),
+	...( jest.requireActual( 'react-router-dom' ) as object ),
 	useLocation: jest.fn().mockImplementation( () => ( {
 		pathname: '/setup/launchpad',
 		search: `?flow=newsletter&siteSlug=testlinkinbio.wordpress.com`,
@@ -48,7 +48,7 @@ jest.mock( 'react-router-dom', () => ( {
 } ) );
 
 jest.mock( '@automattic/data-stores', () => ( {
-	...jest.requireActual( '@automattic/data-stores' ),
+	...( jest.requireActual( '@automattic/data-stores' ) as object ),
 	useLaunchpad: ( siteSlug, siteIntentOption ) => {
 		let checklist = [];
 
@@ -182,6 +182,15 @@ describe( 'StepContent', () => {
 				launchpad_screen: 'full',
 				site_intent: '',
 			} );
+		nock( 'https://public-api.wordpress.com' )
+			.get( `/rest/v1.2/sites/211078228/domains` )
+			.reply(
+				200,
+				buildDomainResponse( {
+					sslStatus: null,
+					isWPCOMDomain: true,
+				} )
+			);
 	} );
 
 	afterEach( () => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2591

## Proposed Changes

* Override launch task title text when items are in the cart to say "Checkout and launch" instead of "Launch your site"

## Todo:
- [ ] Unit tests need a fix to mock the existence of cart items. Checklist data above test code could also be mocked but that would kind of defeat the purpose of the test.

## Testing Instructions

* New user or delete all user sites
* http://calypso.localhost:3000/setup/blog
* Test both start writing and design flows.
* Adding a plan or setting a domain should trigger the new cta text.

Before

![Screenshot 2023-07-03 at 16-55-51 Almost ready to launch — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/0c1d1c6a-a2f1-463f-93f2-e12110f0c005)

After

![Screenshot 2023-07-03 at 16-56-05 Almost ready to launch — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/155bc827-5c9f-45c0-8132-2a324833762a)