### PR TITLE
Using InfoPopover component in Subscription Manager

### DIFF
--- a/client/components/info-popover/style.scss
+++ b/client/components/info-popover/style.scss
@@ -14,6 +14,8 @@
 }
 
 .popover.info-popover__tooltip {
+	outline: none;
+
 	.popover__inner {
 		color: var(--color-neutral-50);
 		font-size: $font-body-small;

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
@@ -1,11 +1,11 @@
 import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
+import InfoPopover from 'calypso/components/info-popover';
 import TimeSince from 'calypso/components/time-since';
-import Tooltip from 'calypso/components/tooltip';
 import {
 	useRecordSiteUnsubscribed,
 	useRecordSiteResubscribed,
@@ -24,27 +24,6 @@ import { Link } from '../link';
 import { SiteSettingsPopover } from '../settings';
 import { SiteIcon } from '../site-icon';
 import { useSubscriptionManagerContext } from '../subscription-manager-context';
-
-interface NotificationStatusProps {
-	tooltipRef: React.RefObject< SVGSVGElement >;
-	setTooltipVisible: React.Dispatch< React.SetStateAction< boolean > >;
-	notificationDisabled: boolean;
-}
-
-const NotificationStatus: React.FC< NotificationStatusProps > = ( {
-	tooltipRef,
-	setTooltipVisible,
-	notificationDisabled,
-} ) => (
-	<Gridicon
-		ref={ tooltipRef }
-		icon={ notificationDisabled ? 'cross' : 'checkmark' }
-		size={ 16 }
-		className={ notificationDisabled ? 'red' : 'green' }
-		onMouseEnter={ () => setTooltipVisible( true ) }
-		onMouseLeave={ () => setTooltipVisible( false ) }
-	/>
-);
 
 const useDeliveryFrequencyLabel = ( deliveryFrequencyValue?: Reader.EmailDeliveryFrequency ) => {
 	const translate = useTranslate();
@@ -104,8 +83,6 @@ const SiteRow = ( {
 }: SiteRowProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const [ isTooltipVisible, setTooltipVisible ] = useState< boolean >( false );
-	const tooltip = useRef< SVGSVGElement >( null );
 
 	const unsubscribeInProgress = useRef( false );
 	const resubscribePending = useRef( false );
@@ -276,28 +253,19 @@ const SiteRow = ( {
 			) }
 			{ isLoggedIn && (
 				<span className="new-comments-cell" role="cell">
-					<NotificationStatus
-						tooltipRef={ tooltip }
-						setTooltipVisible={ setTooltipVisible }
-						notificationDisabled={ ! delivery_methods.email?.send_comments }
-					/>
-					<Tooltip
-						className="new-comments-tooltip"
-						isVisible={ isTooltipVisible }
+					<InfoPopover
 						position="top"
-						context={ tooltip.current }
-						showOnMobile
+						icon={ ! delivery_methods.email?.send_comments ? 'cross' : 'checkmark' }
+						iconSize={ 16 }
+						className={ ! delivery_methods.email?.send_comments ? 'red' : 'green' }
+						showOnHover={ true }
 					>
-						<div className="new-comments-tooltip__content">
-							{ delivery_methods.email?.send_comments
-								? translate(
-										'You will receive emails notifications for new comments on this site.'
-								  )
-								: translate(
-										"You won't receive email notifications for new comments on this site."
-								  ) }
-						</div>
-					</Tooltip>
+						{ delivery_methods.email?.send_comments
+							? translate( 'You will receive emails notifications for new comments on this site.' )
+							: translate(
+									"You won't receive email notifications for new comments on this site."
+							  ) }
+					</InfoPopover>
 				</span>
 			) }
 			<span className="email-frequency-cell" role="cell">

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -105,14 +105,18 @@
 
 		.new-posts-cell,
 		.new-comments-cell {
+			.green,
+			.red {
+				margin-top: 4px;
+				vertical-align: text-bottom;
+			}
+
 			.green {
 				fill: var(--color-success);
-				vertical-align: text-bottom;
 			}
 
 			.red {
 				fill: var(--color-error);
-				vertical-align: text-bottom;
 			}
 		}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78791

## Proposed Changes

This PR changes the component used for the popup on hovering the status icon in the New Comments column in Subscription Manager. The component used before was `Tooltip`; now we are using `InfoPopover`. This change was performed to make the look and feel consistent with the rest of Calypso.

## Testing Instructions

1. Apply this PR and start the application.
2. Go to `http://calypso.localhost:3000/subscriptions/sites` and hover over the icons in the New Comments column. You should see a popover like this one:

<img width="1040" alt="Screenshot 2023-07-03 at 11 11 02 (1)" src="https://github.com/Automattic/wp-calypso/assets/3832570/44c0d118-7327-41fe-9737-bfc09c509bd1">

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
