### PR TITLE
GS on personal A/B: Show correct upgrade message in the launch banner when GS are in use

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -161,12 +161,13 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 		true
 	);
 	wp_set_script_translations( 'wpcom-global-styles-editor', 'full-site-editing' );
+	$plan = wpcom_site_has_global_styles_in_personal_plan() ? 'personal-bundle' : 'value_bundle';
 	wp_localize_script(
 		'wpcom-global-styles-editor',
 		'wpcomGlobalStyles',
 		array(
 			'assetsUrl'   => plugins_url( 'dist/', __FILE__ ),
-			'upgradeUrl'  => "$calypso_domain/plans/$site_slug?plan=value_bundle&feature=style-customization",
+			'upgradeUrl'  => "$calypso_domain/plans/$site_slug?plan=$plan&feature=style-customization",
 			'wpcomBlogId' => wpcom_global_styles_get_wpcom_current_blog_id(),
 		)
 	);
@@ -427,7 +428,8 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 		$site_slug = wp_parse_url( $home_url, PHP_URL_HOST );
 	}
 
-	$upgrade_url = 'https://wordpress.com/plans/' . $site_slug . '?plan=value_bundle&feature=style-customization';
+	$plan        = wpcom_site_has_global_styles_in_personal_plan() ? 'personal-bundle' : 'value_bundle';
+	$upgrade_url = "https://wordpress.com/plans/$site_slug?plan=$plan&feature=style-customization";
 
 	if ( wpcom_is_previewing_global_styles() ) {
 		$preview_location = add_query_arg( 'hide-global-styles', '' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -464,11 +464,26 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 				</div>
 				<div class="launch-bar-global-styles-message">
 					<?php
-					$message = sprintf(
+					// @TODO Remove after global styles on personal plans A/B test is complete.
+					if ( wpcom_site_has_global_styles_in_personal_plan() ) {
+						$message = sprintf(
 						/* translators: %s - documentation URL. */
-						__( 'Your site includes <a href="%s" target="_blank">customized styles</a> that are only visible to visitors after upgrading to the Premium plan or higher.', 'full-site-editing' ),
-						'https://wordpress.com/support/using-styles/'
-					);
+							__(
+								'Your site includes <a href="%s" target="_blank">customized styles</a> that are only visible to visitors after upgrading to the Personal plan or higher.',
+								'full-site-editing'
+							),
+							'https://wordpress.com/support/using-styles/'
+						);
+					} else {
+						$message = sprintf(
+						/* translators: %s - documentation URL. */
+							__(
+								'Your site includes <a href="%s" target="_blank">customized styles</a> that are only visible to visitors after upgrading to the Premium plan or higher.',
+								'full-site-editing'
+							),
+							'https://wordpress.com/support/using-styles/'
+						);
+					}
 					echo sprintf(
 						wp_kses(
 							$message,


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2865

## Proposed Changes

This PR introduces an A/B test that assesses the impact of displaying customized styles in Personal plans as opposed to only in Premium plans or higher. We've added a conditional check in the `wpcom_display_global_styles_launch_bar` function that displays a different message to the users based on the user's plan if the experiment is active.

| Before | After |
-----|-----
![Captura de Pantalla 2023-07-04 a las 11 26 01](https://github.com/Automattic/wp-calypso/assets/1989914/8fc04d29-08f3-414f-8bbf-e249c71953c3)|![Captura de Pantalla 2023-07-04 a las 11 30 59](https://github.com/Automattic/wp-calypso/assets/1989914/ff8cfb84-f393-4809-8f54-ea62cd06a434)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this version of ETK on your sandbox
* Add GS to a free site.
* Open the site's front page.
* Verify that the message aligns with your plan and group.

You can change your group here (21268-explat-experiment), you also need to clear the cache when switching between groups by executing this command in your sandbox:
`wp_cache_delete( 'global-styles-on-personal-{siteId}', 'a8c_experiments' );` 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?