### PR TITLE
Global Styles on Personal A/B: Do not fetch assigment on LOTS

### DIFF
--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -72,6 +73,7 @@ export function useSiteGlobalStylesStatus(
 	siteIdOrSlug: number | string | null = null
 ): GlobalStylesStatus {
 	const selectedSiteId = useSelector( getSelectedSiteId );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	// When site id is null it means that the site hasn't been created yet.
 	const siteId = useSelector( ( state ) => {
@@ -89,7 +91,7 @@ export function useSiteGlobalStylesStatus(
 		queryFn: () => getExperimentAssignment( 'calypso_global_styles_personal' ),
 		placeholderData: null,
 		refetchOnWindowFocus: false,
-		enabled: typeof window !== undefined && siteId === null,
+		enabled: typeof window !== undefined && siteId === null && isLoggedIn,
 	} );
 	const currentUserHasGlobalStylesInPersonalPlan =
 		globalStylesOnPersonalExperimentAssignment === 'treatment';

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -28,7 +28,7 @@ const getExperimentAssignment = ( experimentName: string ): string | null => {
 		.get(
 			{
 				path: '/experiments/0.1.0/assignments/calypso',
-				apiNamespace: 'wpcom/v2/',
+				apiNamespace: 'wpcom/v2',
 			},
 			{
 				experiment_name: experimentName,


### PR DESCRIPTION
Follow-up of #78895.

## Proposed Changes

Stops calling the experiment assignment endpoint in the logged-out theme showcase since it was causing a "endpoint not found" error

## Testing Instructions

- Use the Calypso live link below
- Open an incognito window
- Go to `/themes`
- Inspect the XHR request
- Make sure there are no requests to `wpcom/v2/experiments/0.1.0/assignments/calypso`