### PR TITLE
Site Transfers: Launch Site Transfers Feature

### DIFF
--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { compose } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
@@ -206,9 +205,7 @@ export default compose( [
 				sourceSlug: siteSlug,
 			} );
 
-			const showStartSiteTransfer =
-				isEnabled( 'yolo/site-transfers-i1' ) &&
-				canCurrentUserStartSiteOwnerTransfer( state, siteId );
+			const showStartSiteTransfer = canCurrentUserStartSiteOwnerTransfer( state, siteId );
 
 			return {
 				site,

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { compose } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
@@ -205,7 +206,9 @@ export default compose( [
 				sourceSlug: siteSlug,
 			} );
 
-			const showStartSiteTransfer = canCurrentUserStartSiteOwnerTransfer( state, siteId );
+			const showStartSiteTransfer =
+				isEnabled( 'yolo/site-transfers-i1' ) &&
+				canCurrentUserStartSiteOwnerTransfer( state, siteId );
 
 			return {
 				site,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -144,7 +144,8 @@
 		"user-management-revamp": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true
+		"wpcom-user-bootstrap": true,
+		"yolo/site-transfers-i1": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -172,7 +172,8 @@
 		"user-management-revamp": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true
+		"wpcom-user-bootstrap": true,
+		"yolo/site-transfers-i1": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -167,7 +167,8 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"newsletter/stats": false
+		"newsletter/stats": false,
+		"yolo/site-transfers-i1": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/test.json
+++ b/config/test.json
@@ -108,6 +108,7 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": false
+		"wpcom-user-bootstrap": false,
+		"yolo/site-transfers-i1": true
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* This PR removes the feature flag for site transfers from **Settings > General** and makes the feature available for customers on WordPress.com

## Testing Instructions

* Make sure that **Transfer your site** option is live and appears under **Settings > General** for both Simple and Atomic sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
