### PR TITLE
Excerpt and Permalink: Update and localize Learn More

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { addFilter } from '@wordpress/hooks';
 import './style.css';
 
@@ -12,20 +13,22 @@ function overrideCoreDocumentationLinksToWpcom( translation: string, text: strin
 	switch ( text ) {
 		case 'https://wordpress.org/support/article/excerpt/':
 		case 'https://wordpress.org/support/article/settings-sidebar/#excerpt':
-			return 'https://wordpress.com/support/excerpts/';
+		case 'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt':
+			return localizeUrl( 'https://wordpress.com/support/excerpts/' );
 		case 'https://wordpress.org/support/article/writing-posts/#post-field-descriptions':
 		case 'https://wordpress.org/support/article/settings-sidebar/#permalink':
-			return 'https://wordpress.com/support/permalinks-and-slugs/';
+		case 'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink':
+			return localizeUrl( 'https://wordpress.com/support/permalinks-and-slugs/' );
 		case 'https://wordpress.org/support/article/wordpress-editor/':
-			return 'https://wordpress.com/support/wordpress-editor/';
+			return localizeUrl( 'https://wordpress.com/support/wordpress-editor/' );
 		case 'https://wordpress.org/support/article/site-editor/':
-			return 'https://wordpress.com/support/site-editor/';
+			return localizeUrl( 'https://wordpress.com/support/site-editor/' );
 		case 'https://wordpress.org/support/article/block-based-widgets-editor/':
-			return 'https://wordpress.com/support/widgets/';
+			return localizeUrl( 'https://wordpress.com/support/widgets/' );
 		case 'https://wordpress.org/plugins/classic-widgets/':
-			return 'https://wordpress.com/plugins/classic-widgets';
+			return localizeUrl( 'https://wordpress.com/plugins/classic-widgets' );
 		case 'https://wordpress.org/support/article/styles-overview/':
-			return 'https://wordpress.com/support/using-styles/';
+			return localizeUrl( 'https://wordpress.com/support/using-styles/' );
 	}
 
 	return translation;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
@@ -6,6 +6,7 @@ declare global {
 	interface Window {
 		_currentSiteId: number;
 		_currentSiteType: string;
+		wpcomDocumentationLinksLocale: string;
 	}
 }
 
@@ -14,21 +15,42 @@ function overrideCoreDocumentationLinksToWpcom( translation: string, text: strin
 		case 'https://wordpress.org/support/article/excerpt/':
 		case 'https://wordpress.org/support/article/settings-sidebar/#excerpt':
 		case 'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt':
-			return localizeUrl( 'https://wordpress.com/support/excerpts/' );
+			return localizeUrl(
+				'https://wordpress.com/support/excerpts/',
+				window.wpcomDocumentationLinksLocale
+			);
 		case 'https://wordpress.org/support/article/writing-posts/#post-field-descriptions':
 		case 'https://wordpress.org/support/article/settings-sidebar/#permalink':
 		case 'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink':
-			return localizeUrl( 'https://wordpress.com/support/permalinks-and-slugs/' );
+			return localizeUrl(
+				'https://wordpress.com/support/permalinks-and-slugs/',
+				window.wpcomDocumentationLinksLocale
+			);
 		case 'https://wordpress.org/support/article/wordpress-editor/':
-			return localizeUrl( 'https://wordpress.com/support/wordpress-editor/' );
+			return localizeUrl(
+				'https://wordpress.com/support/wordpress-editor/',
+				window.wpcomDocumentationLinksLocale
+			);
 		case 'https://wordpress.org/support/article/site-editor/':
-			return localizeUrl( 'https://wordpress.com/support/site-editor/' );
+			return localizeUrl(
+				'https://wordpress.com/support/site-editor/',
+				window.wpcomDocumentationLinksLocale
+			);
 		case 'https://wordpress.org/support/article/block-based-widgets-editor/':
-			return localizeUrl( 'https://wordpress.com/support/widgets/' );
+			return localizeUrl(
+				'https://wordpress.com/support/widgets/',
+				window.wpcomDocumentationLinksLocale
+			);
 		case 'https://wordpress.org/plugins/classic-widgets/':
-			return localizeUrl( 'https://wordpress.com/plugins/classic-widgets' );
+			return localizeUrl(
+				'https://wordpress.com/plugins/classic-widgets',
+				window.wpcomDocumentationLinksLocale
+			);
 		case 'https://wordpress.org/support/article/styles-overview/':
-			return localizeUrl( 'https://wordpress.com/support/using-styles/' );
+			return localizeUrl(
+				'https://wordpress.com/support/using-styles/',
+				window.wpcomDocumentationLinksLocale
+			);
 	}
 
 	return translation;


### PR DESCRIPTION
#### Proposed Changes

Context: https://github.com/Automattic/wp-calypso/issues/68009#issuecomment-1617083828

In Calypso, "Learn More" links in the editor, in the sidebar, point to .org articles. This will point them to .com articles.

Links are also now localized.

 **Permalinks**: `https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink` -> https://wordpress.com/support/permalinks-and-slugs/
 **Excerpt**: `https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt` -> https://wordpress.com/support/excerpts/

These are the links:
![immagine](https://user-images.githubusercontent.com/52076348/193084569-37b51660-47e8-4d0d-88c9-06a3b8cb4f81.png)
![immagine](https://user-images.githubusercontent.com/52076348/193084603-e613762c-8a27-473b-a88c-78566ecc37f4.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* `yarn dev --sync` from `apps/editing-toolkit`
* Go to the editor
* Open settings
* Find the links and check that they bring you to the correct url

