### PR TITLE
Subscribers Page: Add "no search results" state

### DIFF
--- a/client/my-sites/subscribers/components/no-search-results/index.ts
+++ b/client/my-sites/subscribers/components/no-search-results/index.ts
@@ -1,0 +1,1 @@
+export { default as NoSearchResults } from './no-search-results';

--- a/client/my-sites/subscribers/components/no-search-results/no-search-results.tsx
+++ b/client/my-sites/subscribers/components/no-search-results/no-search-results.tsx
@@ -20,12 +20,14 @@ const NoSearchResults = ( { searchTerm, setShowAddSubscribersModal }: NoSearchRe
 			<p className="no-search-results__query">
 				{ translate( '“%(searchTerm)s” did not match any current subscribers.', {
 					args: { searchTerm },
+					comment: '%(searchTerm)s is the search term the user entered.',
 				} ) }
 			</p>
 			{ siteTitle && (
 				<p>
 					{ translate( 'Do you want to invite someone to join %(siteTitle)s?', {
 						args: { siteTitle },
+						comment: '%(siteTitle)s is the name of the site where the user is currently on.',
 					} ) }
 				</p>
 			) }
@@ -41,6 +43,7 @@ const NoSearchResults = ( { searchTerm, setShowAddSubscribersModal }: NoSearchRe
 							/>
 						),
 					},
+					comment: 'The button opens a modal where users can import their subscribers.',
 				} ) }
 			</p>
 		</div>

--- a/client/my-sites/subscribers/components/no-search-results/no-search-results.tsx
+++ b/client/my-sites/subscribers/components/no-search-results/no-search-results.tsx
@@ -13,9 +13,9 @@ const NoSearchResults = ( { searchTerm }: NoSearchResultsProps ) => {
 	const siteTitle = useSelector( ( state ) => getSiteTitle( state, selectedSiteId ) );
 
 	return (
-		<div className="subscriber-list-container__no-results">
-			{ translate( '0 subscribers found' ) }
-			<p>
+		<div className="no-search-results">
+			<p className="no-search-results__heading">{ translate( '0 subscribers found' ) }</p>
+			<p className="no-search-results__query">
 				{ translate( '“%(searchTerm)s” did not match any current subscribers.', {
 					args: { searchTerm },
 				} ) }

--- a/client/my-sites/subscribers/components/no-search-results/no-search-results.tsx
+++ b/client/my-sites/subscribers/components/no-search-results/no-search-results.tsx
@@ -1,0 +1,42 @@
+import { translate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getSiteTitle } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import './style.scss';
+
+type NoSearchResultsProps = {
+	searchTerm: string;
+};
+
+const NoSearchResults = ( { searchTerm }: NoSearchResultsProps ) => {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const siteTitle = useSelector( ( state ) => getSiteTitle( state, selectedSiteId ) );
+
+	return (
+		<div className="subscriber-list-container__no-results">
+			{ translate( '0 subscribers found' ) }
+			<p>
+				{ translate( '“%(searchTerm)s” did not match any current subscribers.', {
+					args: { searchTerm },
+				} ) }
+			</p>
+			{ siteTitle && (
+				<p>
+					{ translate( 'Do you want to invite someone to join %(siteTitle)s?', {
+						args: { siteTitle },
+					} ) }
+				</p>
+			) }
+
+			<p>
+				{ translate( 'You can easily {{a}}import existing subscribers{{/a}}.', {
+					components: {
+						a: <a href="https://wordpress.com" target="_blank" rel="noopener noreferrer" />,
+					},
+				} ) }
+			</p>
+		</div>
+	);
+};
+
+export default NoSearchResults;

--- a/client/my-sites/subscribers/components/no-search-results/no-search-results.tsx
+++ b/client/my-sites/subscribers/components/no-search-results/no-search-results.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { getSiteTitle } from 'calypso/state/sites/selectors';
@@ -6,9 +7,10 @@ import './style.scss';
 
 type NoSearchResultsProps = {
 	searchTerm: string;
+	setShowAddSubscribersModal: React.Dispatch< React.SetStateAction< boolean > >;
 };
 
-const NoSearchResults = ( { searchTerm }: NoSearchResultsProps ) => {
+const NoSearchResults = ( { searchTerm, setShowAddSubscribersModal }: NoSearchResultsProps ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const siteTitle = useSelector( ( state ) => getSiteTitle( state, selectedSiteId ) );
 
@@ -29,9 +31,15 @@ const NoSearchResults = ( { searchTerm }: NoSearchResultsProps ) => {
 			) }
 
 			<p>
-				{ translate( 'You can easily {{a}}import existing subscribers{{/a}}.', {
+				{ translate( 'You can easily {{button}}import existing subscribers{{/button}}.', {
 					components: {
-						a: <a href="https://wordpress.com" target="_blank" rel="noopener noreferrer" />,
+						button: (
+							<Button
+								plain
+								className="no-search-results__cta"
+								onClick={ () => setShowAddSubscribersModal( true ) }
+							/>
+						),
 					},
 				} ) }
 			</p>

--- a/client/my-sites/subscribers/components/no-search-results/style.scss
+++ b/client/my-sites/subscribers/components/no-search-results/style.scss
@@ -17,11 +17,6 @@
 		margin-bottom: 0;
 	}
 
-	a {
-		color: $studio-gray-100;
-		text-decoration: underline;
-	}
-
 	.no-search-results__heading {
 		font-size: $font-title-small;
 		font-weight: 500;
@@ -32,6 +27,10 @@
 
 	.no-search-results__query {
 		margin-bottom: 24px;
+	}
+
+	.no-search-results__cta {
+		border-bottom: 1px solid $studio-gray-100;
 	}
 }
 

--- a/client/my-sites/subscribers/components/no-search-results/style.scss
+++ b/client/my-sites/subscribers/components/no-search-results/style.scss
@@ -1,3 +1,44 @@
-.subscriber-list-container__no-results {
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
+.no-search-results {
 	text-align: center;
+	color: $studio-gray-100;
+	font-size: $font-body;
+	font-family: "SF Pro Text", $sans;
+	line-height: rem(24px);
+	letter-spacing: -0.32px;
+	padding-top: 32px;
+	padding-bottom: 32px;
+	margin-bottom: 295px;
+
+	p {
+		margin-bottom: 0;
+	}
+
+	a {
+		color: $studio-gray-100;
+		text-decoration: underline;
+	}
+
+	.no-search-results__heading {
+		font-size: $font-title-small;
+		font-weight: 500;
+		line-height: rem(26px);
+		letter-spacing: 0.38px;
+		margin-bottom: 8px;
+	}
+
+	.no-search-results__query {
+		margin-bottom: 24px;
+	}
+}
+
+@media screen and (max-width: $break-large) {
+	.no-search-results {
+		padding-top: 48px;
+		padding-bottom: 48px;
+		margin-bottom: 64px;
+	}
 }

--- a/client/my-sites/subscribers/components/no-search-results/style.scss
+++ b/client/my-sites/subscribers/components/no-search-results/style.scss
@@ -1,0 +1,3 @@
+.subscriber-list-container__no-results {
+	text-align: center;
+}

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -1,6 +1,7 @@
 import { translate } from 'i18n-calypso';
 import Pagination from 'calypso/components/pagination';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
+import { NoSearchResults } from 'calypso/my-sites/subscribers/components/no-search-results';
 import { SubscriberList } from 'calypso/my-sites/subscribers/components/subscriber-list';
 import { SubscriberListActionsBar } from 'calypso/my-sites/subscribers/components/subscriber-list-actions-bar';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
@@ -14,19 +15,11 @@ type SubscriberListContainerProps = {
 	onClickUnsubscribe: ( subscriber: Subscriber ) => void;
 };
 
-const NoSearchResults = () => {
-	return (
-		<div className="subscriber-list-container__no-results">
-			{ translate( 'No subscribers found.' ) }
-		</div>
-	);
-};
-
 const SubscriberListContainer = ( {
 	onClickView,
 	onClickUnsubscribe,
 }: SubscriberListContainerProps ) => {
-	const { grandTotal, total, perPage, page, pageClickCallback } = useSubscribersPage();
+	const { grandTotal, total, perPage, page, pageClickCallback, searchTerm } = useSubscribersPage();
 	useRecordSearch();
 
 	return (
@@ -42,7 +35,7 @@ const SubscriberListContainer = ( {
 					{ total ? (
 						<SubscriberList onView={ onClickView } onUnsubscribe={ onClickUnsubscribe } />
 					) : (
-						<NoSearchResults />
+						<NoSearchResults searchTerm={ searchTerm } />
 					) }
 
 					<Pagination

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -14,6 +14,14 @@ type SubscriberListContainerProps = {
 	onClickUnsubscribe: ( subscriber: Subscriber ) => void;
 };
 
+const NoSearchResults = () => {
+	return (
+		<div className="subscriber-list-container__no-results">
+			{ translate( 'No subscribers found.' ) }
+		</div>
+	);
+};
+
 const SubscriberListContainer = ( {
 	onClickView,
 	onClickUnsubscribe,
@@ -31,7 +39,11 @@ const SubscriberListContainer = ( {
 					</div>
 					<SubscriberListActionsBar />
 
-					<SubscriberList onView={ onClickView } onUnsubscribe={ onClickUnsubscribe } />
+					{ total ? (
+						<SubscriberList onView={ onClickView } onUnsubscribe={ onClickUnsubscribe } />
+					) : (
+						<NoSearchResults />
+					) }
 
 					<Pagination
 						className="subscriber-list-container__pagination"

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -13,11 +13,13 @@ import './style.scss';
 type SubscriberListContainerProps = {
 	onClickView: ( subscriber: Subscriber ) => void;
 	onClickUnsubscribe: ( subscriber: Subscriber ) => void;
+	setShowAddSubscribersModal: React.Dispatch< React.SetStateAction< boolean > >;
 };
 
 const SubscriberListContainer = ( {
 	onClickView,
 	onClickUnsubscribe,
+	setShowAddSubscribersModal,
 }: SubscriberListContainerProps ) => {
 	const { grandTotal, total, perPage, page, pageClickCallback, searchTerm } = useSubscribersPage();
 	useRecordSearch();
@@ -35,7 +37,10 @@ const SubscriberListContainer = ( {
 					{ total ? (
 						<SubscriberList onView={ onClickView } onUnsubscribe={ onClickUnsubscribe } />
 					) : (
-						<NoSearchResults searchTerm={ searchTerm } />
+						<NoSearchResults
+							searchTerm={ searchTerm }
+							setShowAddSubscribersModal={ setShowAddSubscribersModal }
+						/>
 					) }
 
 					<Pagination

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -93,6 +93,7 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 				<SubscriberListContainer
 					onClickView={ onClickView }
 					onClickUnsubscribe={ onClickUnsubscribe }
+					setShowAddSubscribersModal={ setShowAddSubscribersModal }
 				/>
 
 				<UnsubscribeModal


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/78797.

The proposed changes inform the user that their search term doesn't produce any results.

| Before | After |
|--------|--------|
| ![Markup on 2023-07-04 at 11:12:41](https://github.com/Automattic/wp-calypso/assets/25105483/97d4d240-662c-4b3e-9fcd-8dee975fa4e3) | ![Markup on 2023-07-04 at 11:13:14](https://github.com/Automattic/wp-calypso/assets/25105483/9c828daf-c92d-41e8-9889-50053a2d8b8c) | 

TODOs:

- [x] fix styling - especially the mobile view
- [x] add comments for translators
- [x] add correct link - to the modal

## Proposed Changes

* add new `NoSearchResults` component

Design: h8tMpJlCqNFemEerU9owHI-fi-2890:105967

## Testing Instructions

1. Checkout the branch PR and build the app.
2. Navigate to Users → Subscribers and enter a random search phrase that doesn't match any subscriber.
3. The `NoSearchResults` component should render.
4. The component should match the design h8tMpJlCqNFemEerU9owHI-fi-2890:105967 on mobile and desktop.
5. Clicking on the `import existing subscribers` link should open up the `AddSubscribersModal`.

ℹ️ We have agreed not to add language fallback and display the `NoSearchResults` component even before it is fully translated.

ℹ️ Please note that the margins / paddings above the `NoSearchResults` component are not adjusted by this PR - as they are related to the other changes (e.g. filter introduction). There's also the following related task open: https://github.com/Automattic/wp-calypso/issues/78900.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?