### PR TITLE
Added filters to Subscribers Page

### DIFF
--- a/client/landing/subscriptions/hooks/index.ts
+++ b/client/landing/subscriptions/hooks/index.ts
@@ -2,3 +2,4 @@ export { default as usePopoverToggle } from './use-popover-toggle';
 export { default as useSearch } from './use-search';
 export { default as useSubheaderText } from './use-subheader-text';
 export { default as useSiteSubscriptionsFilterOptions } from './use-site-subscriptions-filter-options';
+export { default as useSubscribersFilterOptions } from './use-subscribers-filter-options';

--- a/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
+++ b/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
@@ -9,8 +9,8 @@ const useSubscribersFilterOptions = () => {
 	return useMemo(
 		() => [
 			{ value: FilterBy.All, label: translate( 'All' ) },
-			{ value: FilterBy.Email, label: translate( 'Email' ) },
-			{ value: FilterBy.WPCOM, label: translate( 'WPCOM' ) },
+			{ value: FilterBy.Email, label: translate( 'Email subscriber' ) },
+			{ value: FilterBy.WPCOM, label: translate( 'Follower' ) },
 		],
 		[ translate ]
 	);

--- a/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
+++ b/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
@@ -1,0 +1,19 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { SubscribersFilterBy } from 'calypso/my-sites/subscribers/constants';
+
+const FilterBy = SubscribersFilterBy;
+
+const useSubscribersFilterOptions = () => {
+	const translate = useTranslate();
+	return useMemo(
+		() => [
+			{ value: FilterBy.All, label: translate( 'All' ) },
+			{ value: FilterBy.Email, label: translate( 'Email' ) },
+			{ value: FilterBy.WPCOM, label: translate( 'WPCOM' ) },
+		],
+		[ translate ]
+	);
+};
+
+export default useSubscribersFilterOptions;

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/style.scss
@@ -8,6 +8,19 @@
 	gap: 8px;
 	flex-wrap: wrap;
 
+	.subscribers__filter-control {
+		min-width: 115px;
+
+		&.select-dropdown,
+		.select-dropdown__header {
+			height: 48px;
+		}
+
+		.select-dropdown__item.is-selected {
+			background-color: var(--color-primary);
+		}
+	}
+
 	.search-component {
 		min-width: min(400px, 100%);
 		flex: 1;

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/style.scss
@@ -14,6 +14,15 @@
 		&.select-dropdown,
 		.select-dropdown__header {
 			height: 48px;
+			justify-content: normal;
+
+			.gridicon {
+				margin-left: 10px;
+			}
+
+			.select-dropdown__header-text {
+				font-weight: 400;
+			}
 		}
 
 		.select-dropdown__item.is-selected {

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -38,7 +38,7 @@ const ListActionsBar = () => {
 				onSelect={ ( selectedOption: Option< SubscribersFilterBy > ) =>
 					setFilterOption( selectedOption.value )
 				}
-				selectedText={ translate( 'Subscription Type: %s', {
+				selectedText={ translate( 'Subscriber type: %s', {
 					args: getOptionLabel( filterOptions, filterOption ) || '',
 				} ) }
 			/>

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -1,10 +1,13 @@
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import SelectDropdown from 'calypso/components/select-dropdown';
 import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
-import { SortControls } from 'calypso/landing/subscriptions/components/sort-controls';
+import { Option, SortControls } from 'calypso/landing/subscriptions/components/sort-controls';
+import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
+import { useSubscribersFilterOptions } from 'calypso/landing/subscriptions/hooks';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
-import { SubscribersSortBy } from '../../constants';
+import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
 import './style.scss';
 import { useRecordSort } from '../../tracks';
 
@@ -15,9 +18,11 @@ const getSortOptions = ( translate: ReturnType< typeof useTranslate > ) => [
 
 const ListActionsBar = () => {
 	const translate = useTranslate();
-	const { handleSearch, sortTerm, setSortTerm } = useSubscribersPage();
+	const { handleSearch, sortTerm, setSortTerm, filterOption, setFilterOption } =
+		useSubscribersPage();
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
 	const recordSort = useRecordSort();
+	const filterOptions = useSubscribersFilterOptions();
 
 	return (
 		<div className="list-actions-bar">
@@ -25,6 +30,17 @@ const ListActionsBar = () => {
 				placeholder={ translate( 'Search by name, username or email…' ) }
 				searchIcon={ <SearchIcon size={ 18 } /> }
 				onSearch={ handleSearch }
+			/>
+
+			<SelectDropdown
+				className="subscribers__filter-control"
+				options={ filterOptions }
+				onSelect={ ( selectedOption: Option< SubscribersFilterBy > ) =>
+					setFilterOption( selectedOption.value )
+				}
+				selectedText={ translate( 'Subscription Type: %s', {
+					args: getOptionLabel( filterOptions, filterOption ) || '',
+				} ) }
 			/>
 
 			<SortControls

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useState, useContext, useEffect, useCallback } fr
 import { useDebounce } from 'use-debounce';
 import { usePagination } from 'calypso/my-sites/subscribers/hooks';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
-import { SubscribersSortBy } from '../../constants';
+import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
 import { useSubscribersQuery } from '../../queries';
 
 type SubscribersPageProviderProps = {
@@ -24,6 +24,8 @@ type SubscribersPageContextProps = {
 	pageClickCallback: ( page: number ) => void;
 	sortTerm: SubscribersSortBy;
 	setSortTerm: ( term: SubscribersSortBy ) => void;
+	filterOption: SubscribersFilterBy;
+	setFilterOption: ( option: SubscribersFilterBy ) => void;
 };
 
 const SubscribersPageContext = createContext< SubscribersPageContextProps | undefined >(
@@ -41,6 +43,7 @@ export const SubscribersPageProvider = ( {
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ perPage, setPerPage ] = useState( DEFAULT_PER_PAGE );
 	const [ sortTerm, setSortTerm ] = useState( SubscribersSortBy.DateSubscribed );
+	const [ filterOption, setFilterOption ] = useState( SubscribersFilterBy.All );
 
 	const handleSearch = useCallback( ( term: string ) => {
 		setSearchTerm( term );
@@ -57,6 +60,7 @@ export const SubscribersPageProvider = ( {
 		search: debouncedSearchTerm,
 		siteId,
 		sortTerm,
+		filterOption,
 	} );
 
 	const { total, per_page, subscribers } = subscribersQueryResult.data || {
@@ -91,6 +95,8 @@ export const SubscribersPageProvider = ( {
 				pageClickCallback,
 				sortTerm,
 				setSortTerm,
+				filterOption,
+				setFilterOption,
 			} }
 		>
 			{ children }

--- a/client/my-sites/subscribers/constants.ts
+++ b/client/my-sites/subscribers/constants.ts
@@ -2,3 +2,9 @@ export enum SubscribersSortBy {
 	Name = 'name',
 	DateSubscribed = 'date_subscribed',
 }
+
+export enum SubscribersFilterBy {
+	All = 'all',
+	Email = 'email',
+	WPCOM = 'wpcom',
+}

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -10,7 +10,8 @@ const getSubscribersCacheKey = (
 	currentPage?: number,
 	perPage?: number,
 	search?: string,
-	sortTerm?: string
+	sortTerm?: string,
+	filterOption?: string
 ) => {
 	const cacheKey = [ 'subscribers', siteId ];
 	if ( currentPage ) {
@@ -24,6 +25,9 @@ const getSubscribersCacheKey = (
 	}
 	if ( sortTerm ) {
 		cacheKey.push( 'sort-term', sortTerm );
+	}
+	if ( filterOption ) {
+		cacheKey.push( 'filter-option', filterOption );
 	}
 	return cacheKey;
 };

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,8 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
 import wpcom from 'calypso/lib/wp';
-import { SubscribersSortBy } from '../constants';
+import { SubscribersFilterBy, SubscribersSortBy } from '../constants';
 import { getSubscribersCacheKey } from '../helpers';
-import type { SubscriberEndpointResponse } from '../types';
+import type { Subscriber, SubscriberEndpointResponse } from '../types';
 
 type SubscriberQueryParams = {
 	siteId: number | null;
@@ -10,6 +11,7 @@ type SubscriberQueryParams = {
 	perPage?: number;
 	search?: string;
 	sortTerm?: SubscribersSortBy;
+	filterOption?: SubscribersFilterBy;
 };
 
 const useSubscribersQuery = ( {
@@ -18,16 +20,37 @@ const useSubscribersQuery = ( {
 	perPage = 10,
 	search,
 	sortTerm = SubscribersSortBy.DateSubscribed,
+	filterOption = SubscribersFilterBy.All,
 }: SubscriberQueryParams ) => {
+	const filterFunction = useCallback(
+		( item: Subscriber ) => {
+			switch ( filterOption ) {
+				case SubscribersFilterBy.Email:
+					return item.user_id === 0;
+				case SubscribersFilterBy.WPCOM:
+					return item.user_id !== 0;
+				case SubscribersFilterBy.All:
+				default:
+					return true;
+			}
+		},
+		[ filterOption ]
+	);
+
 	return useQuery< SubscriberEndpointResponse >( {
-		queryKey: getSubscribersCacheKey( siteId, page, perPage, search, sortTerm ),
+		queryKey: getSubscribersCacheKey( siteId, page, perPage, search, sortTerm, filterOption ),
 		queryFn: () =>
-			wpcom.req.get( {
-				path: `/sites/${ siteId }/subscribers?per_page=${ perPage }&page=${ page }${
-					search ? `&search=${ encodeURIComponent( search ) }` : ''
-				}${ sortTerm ? `&sort=${ sortTerm }` : '' }`,
-				apiNamespace: 'wpcom/v2',
-			} ),
+			wpcom.req
+				.get( {
+					path: `/sites/${ siteId }/subscribers?per_page=${ perPage }&page=${ page }${
+						search ? `&search=${ encodeURIComponent( search ) }` : ''
+					}${ sortTerm ? `&sort=${ sortTerm }` : '' }`,
+					apiNamespace: 'wpcom/v2',
+				} )
+				.then( ( response: SubscriberEndpointResponse ) => {
+					const subscribers = response.subscribers.filter( filterFunction );
+					return { ...response, subscribers };
+				} ),
 		enabled: !! siteId,
 		keepPreviousData: true,
 	} );

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,9 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
-import { useCallback } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { SubscribersFilterBy, SubscribersSortBy } from '../constants';
 import { getSubscribersCacheKey } from '../helpers';
-import type { Subscriber, SubscriberEndpointResponse } from '../types';
+import type { SubscriberEndpointResponse } from '../types';
 
 type SubscriberQueryParams = {
 	siteId: number | null;
@@ -22,35 +21,17 @@ const useSubscribersQuery = ( {
 	sortTerm = SubscribersSortBy.DateSubscribed,
 	filterOption = SubscribersFilterBy.All,
 }: SubscriberQueryParams ) => {
-	const filterFunction = useCallback(
-		( item: Subscriber ) => {
-			switch ( filterOption ) {
-				case SubscribersFilterBy.Email:
-					return item.user_id === 0;
-				case SubscribersFilterBy.WPCOM:
-					return item.user_id !== 0;
-				case SubscribersFilterBy.All:
-				default:
-					return true;
-			}
-		},
-		[ filterOption ]
-	);
-
 	return useQuery< SubscriberEndpointResponse >( {
 		queryKey: getSubscribersCacheKey( siteId, page, perPage, search, sortTerm, filterOption ),
 		queryFn: () =>
-			wpcom.req
-				.get( {
-					path: `/sites/${ siteId }/subscribers?per_page=${ perPage }&page=${ page }${
-						search ? `&search=${ encodeURIComponent( search ) }` : ''
-					}${ sortTerm ? `&sort=${ sortTerm }` : '' }`,
-					apiNamespace: 'wpcom/v2',
-				} )
-				.then( ( response: SubscriberEndpointResponse ) => {
-					const subscribers = response.subscribers.filter( filterFunction );
-					return { ...response, subscribers };
-				} ),
+			wpcom.req.get( {
+				path: `/sites/${ siteId }/subscribers?per_page=${ perPage }&page=${ page }${
+					search ? `&search=${ encodeURIComponent( search ) }` : ''
+				}${ sortTerm ? `&sort=${ sortTerm }` : '' }${
+					filterOption ? `&filter=${ filterOption }` : ''
+				}`,
+				apiNamespace: 'wpcom/v2',
+			} ),
 		enabled: !! siteId,
 		keepPreviousData: true,
 	} );


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78889

## Proposed Changes

This PR adds filters to the Subscribers Page:

<img width="1426" alt="Screenshot 2023-07-03 at 16 43 08 (1)" src="https://github.com/Automattic/wp-calypso/assets/3832570/eb4f6470-493e-4729-85ff-b5c96824d37c">

## Testing Instructions

**Note:** To test this properly you need to have email and WordPress.com subscribers in your site.

1. Apply this PR and run the application.
2. Apply this patch in your sandbox and follow the testing instructions in the patch description: D115163-code .
3. Go to `http://calypso.localhost:3000/subscribers/[domain-of-your-site]`.
4. Select different filters and check that the results correspond to your selection.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?