### PR TITLE
Reintegrate "Customize Woo Express and free trial themes screen"

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -20,7 +20,11 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import {
+	getCurrentPlan,
+	isSiteOnECommerceTrial,
+	isSiteOnWooExpress,
+} from 'calypso/state/sites/plans/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -75,6 +79,7 @@ export const UpsellNudge = ( {
 	tracksImpressionName,
 	tracksImpressionProperties,
 	displayAsLink,
+	isSiteWooExpressOrEcomFreeTrial,
 } ) => {
 	const shouldNotDisplay =
 		isVip ||
@@ -113,7 +118,8 @@ export const UpsellNudge = ( {
 		{ 'is-upgrade-business': plan && isBusinessPlan( plan ) },
 		{ 'is-upgrade-ecommerce': plan && isEcommercePlan( plan ) },
 		{ 'is-jetpack-plan': plan && planMatches( plan, { group: GROUP_JETPACK } ) },
-		{ 'is-wpcom-plan': plan && planMatches( plan, { group: GROUP_WPCOM } ) }
+		{ 'is-wpcom-plan': plan && planMatches( plan, { group: GROUP_WPCOM } ) },
+		{ 'is-wooexpress-or-free-trial-plan': isSiteWooExpressOrEcomFreeTrial }
 	);
 
 	if ( dismissPreferenceName && forceHref && href ) {
@@ -176,6 +182,8 @@ export default connect( ( state, ownProps ) => {
 		isJetpack: isJetpackSite( state, siteId ),
 		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isVip: isVipSite( state, siteId ),
+		isSiteWooExpressOrEcomFreeTrial:
+			isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId ),
 		currentPlan: getCurrentPlan( state, siteId ),
 		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
 		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -90,6 +90,9 @@ class ThemeShowcase extends Component {
 		loggedOutComponent: PropTypes.bool,
 		isAtomicSite: PropTypes.bool,
 		isJetpackSite: PropTypes.bool,
+		isSiteECommerceFreeTrial: PropTypes.bool,
+		isSiteWooExpress: PropTypes.bool,
+		isSiteWooExpressOrEcomFreeTrial: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -180,17 +183,24 @@ class ThemeShowcase extends Component {
 	};
 
 	getTiers = () => {
-		return [
+		const { isSiteWooExpressOrEcomFreeTrial } = this.props;
+		const tiers = [
 			{ value: 'all', label: this.props.translate( 'All' ) },
 			{ value: 'free', label: this.props.translate( 'Free' ) },
-			{ value: 'premium', label: this.props.translate( 'Premium' ) },
-			{
-				value: 'marketplace',
-				label: this.props.translate( 'Paid', {
-					context: 'Refers to paid service, such as paid theme',
-				} ),
-			},
 		];
+
+		if ( ! isSiteWooExpressOrEcomFreeTrial ) {
+			tiers.push( { value: 'premium', label: this.props.translate( 'Premium' ) } );
+		}
+
+		tiers.push( {
+			value: 'marketplace',
+			label: this.props.translate( 'Paid', {
+				context: 'Refers to paid service, such as paid theme',
+			} ),
+		} );
+
+		return tiers;
 	};
 
 	findTabFilter = ( tabFilters, filterKey ) =>
@@ -447,11 +457,9 @@ class ThemeShowcase extends Component {
 			isMultisite,
 			locale,
 			premiumThemesEnabled,
-			isSiteECommerceFreeTrial,
-			isSiteWooExpress,
+			isSiteWooExpressOrEcomFreeTrial,
 		} = this.props;
 		const tier = this.props.tier || '';
-		const isSiteWooExpressOrEcomFreeTrial = isSiteECommerceFreeTrial || isSiteWooExpress;
 
 		const canonicalUrl = 'https://wordpress.com' + pathName;
 
@@ -621,6 +629,8 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
 		isUpsellCardDisplayed: isUpsellCardDisplayedSelector( state ),
 		isSiteECommerceFreeTrial: isSiteOnECommerceTrial( state, siteId ),
 		isSiteWooExpress: isSiteOnWooExpress( state, siteId ),
+		isSiteWooExpressOrEcomFreeTrial:
+			isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId ),
 	};
 };
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -141,6 +141,10 @@
 		padding: 24px 30px;
 		border-radius: 4px;
 
+		&.is-wooexpress-or-free-trial-plan {
+			margin-bottom: 32px;
+		}
+
 		&.is-dismissible {
 			.dismissible-card__close-button {
 				height: 16px;

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -27,6 +27,7 @@ import {
 	isInstallingTheme,
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
+import { getThemeHiddenFilters } from 'calypso/state/themes/selectors/get-theme-hidden-filters';
 import { addStyleVariation, trackClick, interlaceThemes } from './helpers';
 import SearchThemesTracks from './search-themes-tracks';
 import './themes-selection.scss';
@@ -313,6 +314,7 @@ export const ConnectedThemesSelection = connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		const isAtomic = isSiteAutomatedTransfer( state, siteId );
 		const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
+		const hiddenFilters = getThemeHiddenFilters( state, siteId );
 		const hasUnlimitedPremiumThemes = siteHasFeature(
 			state,
 			siteId,
@@ -340,7 +342,7 @@ export const ConnectedThemesSelection = connect(
 			search,
 			page,
 			tier: premiumThemesEnabled ? tier : 'free',
-			filter: compact( [ filter, vertical ] ).join( ',' ),
+			filter: compact( [ filter, vertical ] ).concat( hiddenFilters ).join( ',' ),
 			number,
 		};
 

--- a/client/state/sites/plans/selectors/is-site-on-ecommerce-trial.ts
+++ b/client/state/sites/plans/selectors/is-site-on-ecommerce-trial.ts
@@ -1,4 +1,5 @@
 import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { getSite } from 'calypso/state/sites/selectors';
 import { getCurrentPlan } from '.';
 import type { AppState } from 'calypso/types';
 
@@ -11,10 +12,8 @@ import type { AppState } from 'calypso/types';
  */
 export default function isSiteOnECommerceTrial( state: AppState, siteId: number ) {
 	const currentPlan = getCurrentPlan( state, siteId );
+	const site = getSite( state, siteId );
+	const productSlug = currentPlan?.productSlug || site?.plan?.product_slug;
 
-	if ( ! currentPlan ) {
-		return false;
-	}
-
-	return currentPlan.productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+	return productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 }

--- a/client/state/sites/plans/selectors/is-site-on-woo-express.ts
+++ b/client/state/sites/plans/selectors/is-site-on-woo-express.ts
@@ -4,6 +4,7 @@ import {
 	PLAN_WOOEXPRESS_SMALL,
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 } from '@automattic/calypso-products';
+import { getSite } from 'calypso/state/sites/selectors';
 import { getCurrentPlan } from '.';
 import type { AppState } from 'calypso/types';
 
@@ -16,6 +17,7 @@ import type { AppState } from 'calypso/types';
  */
 export default function isSiteOnWooExpress( state: AppState, siteId: number ) {
 	const currentPlan = getCurrentPlan( state, siteId );
+	const site = getSite( state, siteId );
 	const wooExpressPlans = [
 		PLAN_WOOEXPRESS_MEDIUM,
 		PLAN_WOOEXPRESS_SMALL,
@@ -23,9 +25,11 @@ export default function isSiteOnWooExpress( state: AppState, siteId: number ) {
 		PLAN_WOOEXPRESS_SMALL_MONTHLY,
 	];
 
-	if ( ! currentPlan ) {
+	const productSlug = currentPlan?.productSlug || site?.plan?.product_slug;
+
+	if ( ! productSlug ) {
 		return false;
 	}
 
-	return wooExpressPlans.includes( currentPlan.productSlug );
+	return wooExpressPlans.includes( productSlug );
 }

--- a/client/state/themes/selectors/get-theme-hidden-filters.js
+++ b/client/state/themes/selectors/get-theme-hidden-filters.js
@@ -1,0 +1,18 @@
+import { isSiteOnECommerceTrial, isSiteOnWooExpress } from 'calypso/state/sites/plans/selectors';
+
+/**
+ * Returns theme filters that are not shown in the UI nor navigation URL.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {?number} siteId  Site ID to optionally use as context
+ * @returns {Array}          Array of filter slugs
+ */
+export function getThemeHiddenFilters( state, siteId ) {
+	const filters = [];
+
+	if ( isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId ) ) {
+		filters.push( 'store' );
+	}
+
+	return filters;
+}

--- a/client/state/themes/selectors/should-redirect-to-thank-you-page.js
+++ b/client/state/themes/selectors/should-redirect-to-thank-you-page.js
@@ -1,6 +1,6 @@
 import 'calypso/state/themes/init';
 
-import { getTheme, doesThemeBundleSoftwareSet, isExternallyManagedTheme } from '.';
+import { getTheme, isExternallyManagedTheme } from '.';
 
 /**
  * Returns whether it should redirect to thank you page
@@ -11,8 +11,7 @@ import { getTheme, doesThemeBundleSoftwareSet, isExternallyManagedTheme } from '
  * @returns {boolean}
  */
 export function shouldRedirectToThankYouPage( state, themeId ) {
-	const isWooTheme = doesThemeBundleSoftwareSet( state, themeId );
 	const isDotComTheme = !! getTheme( state, 'wpcom', themeId );
 	const isExternallyManaged = isExternallyManagedTheme( state, themeId );
-	return isDotComTheme && ! isWooTheme && ! isExternallyManaged;
+	return isDotComTheme && ! isExternallyManaged;
 }


### PR DESCRIPTION
This is a reintegration from the previous revert, https://github.com/Automattic/wp-calypso/pull/78732 with additional changes.

For reviewing code, this is the only new commit 69401995c9eb598b979f80a4ad1374697d4e383e

## Proposed Changes

* Apply back the changes in the PR https://github.com/Automattic/wp-calypso/pull/78570:
    * Add a hidden theme filter mechanism to append filters that do not show up in UI or URL
    * Add a `store` hidden filter for Woo Express and free trial sites
    * Hide theme categories from theme filters UI
    * Update `WooCommerce` themes to show the congratulations page after activating
    * Update Woo Express and free trial selectors to optimistically use `site` state data while plan data is loaded
* Additionally, remove the `Premium` tier from Woo Express and free trial sites (p1688357591038029/1687889632.741609-slack-C03Q87XT1QF)

<img width="982" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/afd47e97-d2fc-44e0-b118-7f39c393ce48">

## Testing Instructions

* In a free trial or Woo Express site, go to Appearance > Themes
* Observe that only WooCommerce themes appear
* Observe that the categories filter is not shown
* Observe `Premium` tier is not shown
* Observe that the banner copy is `Upgrade to a plan to upload your own themes!`
* Click on the banner CTA, it should navigate you to the plans page
* Go back to Appearance > Themes and activate a theme different to your current theme
* Observe that you're redirected to the [Congratulations screen](https://github.com/Automattic/wp-calypso/assets/3747241/c66d6c51-2a88-4f42-8589-efddbc5c8acc)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?