### PR TITLE
Bumping version number and adding latest changes in changelog for privacy-toolset

### DIFF
--- a/packages/privacy-toolset/CHANGELOG.md
+++ b/packages/privacy-toolset/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## next
 
-## 1.1.1
+## 2.0.0
 
 - Update the default bucket selection when the cookie banner expands, leaving "advertising unticked.
 - Update to React 18.2

--- a/packages/privacy-toolset/CHANGELOG.md
+++ b/packages/privacy-toolset/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## next
 
 ## 1.1.1
+
 - Update the default bucket selection when the cookie banner expands, leaving "advertising unticked.
 - Update to React 18.2
+
 ## 1.1.0
 
 - Add Do Not Sell Dialog (DNSD) component

--- a/packages/privacy-toolset/CHANGELOG.md
+++ b/packages/privacy-toolset/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.1
 - Update the default bucket selection when the cookie banner expands, leaving "advertising unticked.
+- Update to React 18.2
 ## 1.1.0
 
 - Add Do Not Sell Dialog (DNSD) component

--- a/packages/privacy-toolset/CHANGELOG.md
+++ b/packages/privacy-toolset/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## next
 
+## 1.1.1
+- Update the default bucket selection when the cookie banner expands, leaving "advertising unticked.
 ## 1.1.0
 
 - Add Do Not Sell Dialog (DNSD) component

--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/privacy-toolset",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Privacy tools and components for Automattic solutions",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/privacy-toolset",
-	"version": "1.1.1",
+	"version": "2.0.0",
 	"description": "Privacy tools and components for Automattic solutions",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #Automattic/martech#1898

## Proposed Changes

This bumps the version number to 1.1.1 and adds the latest changes in the changelog file. These changes are related to https://github.com/Automattic/wp-calypso/pull/78805 where we changed the default ticked buckets when the cookie banner is expanded to leave advertising un-ticked.

## Testing Instructions

This does not change any functionality. We just need to merge this before pushing to npmjs, ref: https://github.com/Automattic/wp-calypso/blob/trunk/docs/monorepo.md#publishing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
