### PR TITLE
Domains: Allow bulk domain transfer of domains that are already connected to a WPCOM site

### DIFF
--- a/packages/data-stores/src/queries/use-is-domain-code-valid.ts
+++ b/packages/data-stores/src/queries/use-is-domain-code-valid.ts
@@ -44,7 +44,15 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 					path: `/domains/${ encodeURIComponent( pair.domain ) }/is-available`,
 				} );
 
-				const isUnlocked = availability.status === 'transferrable';
+				// The "mapped_*" statuses here are a quick and dirty fix to allow bulk domain transfer for now - the "transferrable"
+				// status should be the only one that indicates a domain can be transferred. There are some domains that can be mapped
+				// but can't be transferred
+				const isUnlocked = [
+					'transferrable',
+					'mapped_to_other_site_same_user',
+					'mapped_to_same_site_transferrable',
+					'mapped_domain',
+				].includes( availability.status );
 
 				if ( ! isUnlocked ) {
 					return {

--- a/packages/data-stores/src/queries/use-is-domain-code-valid.ts
+++ b/packages/data-stores/src/queries/use-is-domain-code-valid.ts
@@ -45,8 +45,8 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 				} );
 
 				// The "mapped_*" statuses here are a quick and dirty fix to allow bulk transfer of already connected domains for now.
-				// The "transferrable" status should be the only one that indicates a domain can be transferred. There are some domains that
-				// can be mapped but can't be transferred
+				// The "transferrable" status should be the only one that indicates a domain can be transferred because there are some
+				// domains that can be mapped but can't be transferred
 				const isUnlocked = [
 					'transferrable',
 					'mapped_to_other_site_same_user',

--- a/packages/data-stores/src/queries/use-is-domain-code-valid.ts
+++ b/packages/data-stores/src/queries/use-is-domain-code-valid.ts
@@ -44,9 +44,9 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 					path: `/domains/${ encodeURIComponent( pair.domain ) }/is-available`,
 				} );
 
-				// The "mapped_*" statuses here are a quick and dirty fix to allow bulk domain transfer for now - the "transferrable"
-				// status should be the only one that indicates a domain can be transferred. There are some domains that can be mapped
-				// but can't be transferred
+				// The "mapped_*" statuses here are a quick and dirty fix to allow bulk transfer of already connected domains for now.
+				// The "transferrable" status should be the only one that indicates a domain can be transferred. There are some domains that
+				// can be mapped but can't be transferred
 				const isUnlocked = [
 					'transferrable',
 					'mapped_to_other_site_same_user',


### PR DESCRIPTION
## Proposed Changes

This PR updates the bulk domain transfer flow to allow transferring domains that are already connected to a WPCOM site. 

Transferring already connected domains wasn't possible in that flow because only the `transferrable` availability status was being considered - that's correct, but we want to make it easier to transfer domains to us.

### Screenshots

- Before

![Annotation on 2023-07-03 at 16-16-39](https://github.com/Automattic/wp-calypso/assets/5324818/4f11e413-6476-40f1-93cb-b44c9d217f2e)

- After

![Annotation on 2023-07-03 at 16-15-19](https://github.com/Automattic/wp-calypso/assets/5324818/4cad4035-1a34-4c99-ab29-f0831c738c82)

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Connect an external domain you own to a WPCOM site
- Unlock that domain and get its auth code
- Go to `/setup/bulk-domain-transfer/domains`
- Input that domain and its auth code in the form
- Ensure it's validated correctly and you are able to proceed 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
