### PR TITLE
Fix spacing and update text on checkout security seals

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -715,16 +715,16 @@ const JetpackCheckoutSeals = () => {
 	);
 	const moneybackGuaranteeHeader =
 		show7DayGuarantee || show14DayGuarantee ? (
-			translate( '%(dayCount)s day money back guarantee', {
+			translate( '%(dayCount)s-day money back guarantee', {
 				args: {
 					dayCount: show7DayGuarantee ? 7 : 14,
 				},
 			} )
 		) : (
 			<>
-				{ translate( '14 day money back guarantee on yearly subscriptions' ) }
+				{ translate( '14-day money back guarantee on yearly subscriptions' ) }
 				<br />
-				{ translate( '7 day money back guarantee on monthly subscriptions' ) }
+				{ translate( '7-day money back guarantee on monthly subscriptions' ) }
 			</>
 		);
 	let moneybackGuaranteeIcon = badgeGenericSrc;
@@ -773,7 +773,7 @@ const JetpackCheckoutSealsWrapper = styled.div< React.HTMLAttributes< HTMLDivEle
 
 const JetpackCheckoutSealsSection = styled.div< React.HTMLAttributes< HTMLDivElement > >`
 	display: flex;
-	align-items: flex-start;
+	align-items: center;
 
 	color: ${ ( props ) => props.theme.colors.textColor };
 `;


### PR DESCRIPTION
Related to #

## Proposed Changes

* Center align text with security seal icons
* Add dash between day number and "day"

## Testing Instructions

1. Use the calypso live link and go to `/checkout/jetpack/jetpack_backup_t1_yearly`
2. Make sure the text is now center aligned vertically and that the "x-day money back guarantee" now has a dash between the x and "day"
![image](https://github.com/Automattic/wp-calypso/assets/65001528/3f939006-5163-42cc-ba7a-fa37959a589c)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
