### PR TITLE
Site Transfers: Tweak design of `<ChooseUserLoadingPlaceholder />`

### DIFF
--- a/client/my-sites/site-settings/site-owner-transfer/choose-user-loading-placeholder.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/choose-user-loading-placeholder.tsx
@@ -1,27 +1,28 @@
 import { LoadingPlaceholder } from '@automattic/components';
 import styled from '@emotion/styled';
 
-const Root = styled.div( {
-	display: 'flex',
-	gap: '1em',
-	flexDirection: 'column',
-} );
-
 const ButtonPlaceholder = styled( LoadingPlaceholder )( {
 	width: '100px',
 	height: '32px',
+	marginTop: '1em',
+	marginBottom: '1.5em',
 } );
 
-const LoadingPlaceholderStyled = styled( LoadingPlaceholder )( {
+const LoadingPlaceholderStyledOne = styled( LoadingPlaceholder )( {
 	height: '1.7em',
+	marginBottom: '.5em',
+} );
+
+const LoadingPlaceholderStyledTwo = styled( LoadingPlaceholderStyledOne )( {
+	width: '50%',
 } );
 
 export function ChooseUserLoadingPlaceholder() {
 	return (
-		<Root>
-			<LoadingPlaceholderStyled />
-			<LoadingPlaceholderStyled />
+		<div>
+			<LoadingPlaceholderStyledOne />
+			<LoadingPlaceholderStyledTwo />
 			<ButtonPlaceholder />
-		</Root>
+		</div>
 	);
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2903

## Proposed Changes

Tweaks the design of `<ChooseUserLoadingPlaceholder />`.

<img width="1448" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/ffef02bf-da20-48d5-a699-6254341d7505">


## Testing Instructions

1. Apply the following diff:

```diff
diff --git a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
index 4a85f84775..deb74b0853 100644
--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -113,6 +113,7 @@ const SiteOwnerTransferEligibility = ( {
 	if ( isLoading ) {
 		return <ChooseUserLoadingPlaceholder />;
 	}
+	return <ChooseUserLoadingPlaceholder />;
 
 	if ( ! administrators || administrators.length === 0 ) {
 		return <NoAdministrators href={ addUsersHref } siteSlug={ siteSlug } />;
```

2. Navigate to General Settings ->  Transfer site in your localhost environment.
3. Verify the placeholder appears as expected.
4. Compare the placeholder to the screen that appears in the wpcalypso environment.