### PR TITLE
Design Preview: Fix style variations might not work

### DIFF
--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -78,7 +78,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 		let inlineCss = INJECTED_CSS;
 
 		if ( globalStyles ) {
-			inlineCss += transformStyles( globalStyles );
+			inlineCss += transformStyles( globalStyles ).filter( Boolean ).join( '' );
 		}
 
 		if ( variations && selectedVariation ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/78774#issuecomment-1617746013

## Proposed Changes

* We found the style variations might not work when you're previewing the theme in the Onboarding Design Picker. The reason is the usage of the `transformStyles` is not correct as it might contain empty styles. So, filter the empty styles to fix the issue.

```js
// The empty style
{
  css: '',
  isGlobalStyles: true
}
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Continue until you land on the Design Picker
* Preview the design with the style variations, e.g.: Byrne
* Check every style variations work well on the large preview

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
