### PR TITLE
Global Styles: Avoid registering core blocks multiple times

### DIFF
--- a/packages/global-styles/src/components/global-styles-provider/index.tsx
+++ b/packages/global-styles/src/components/global-styles-provider/index.tsx
@@ -84,10 +84,18 @@ interface Props {
 	placeholder: JSX.Element | null;
 }
 
+let blocksRegistered = false;
+
 const GlobalStylesProvider = ( { siteId, stylesheet, children, placeholder = null }: Props ) => {
 	const context = useGlobalStylesContext( siteId, stylesheet );
 
 	useEffect( () => {
+		if ( blocksRegistered ) {
+			return;
+		}
+
+		blocksRegistered = true;
+
 		// The block-level styles have effects only when the specific blocks are registered so we have to register core blocks.
 		// See https://github.com/WordPress/gutenberg/blob/16486bd946f918d581e4818b73ceaaed82349f71/packages/block-editor/src/components/global-styles/use-global-styles-output.js#L1190
 		import( '@wordpress/block-library' ).then(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/78774#issuecomment-1617746013

## Proposed Changes

* Use a global variable to avoid registering core blocks multiple times.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>
* Continue until you land on the Design Picker
* Preview the design with the style variations
* Go back and preview another design with the style variations
* Ensure the console won't have the errors below
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6d2d7a9c-4bd4-4268-9d2f-1ce781d07415)
 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
