### PR TITLE
Add "Latest" tab to discover navigation header

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -166,6 +166,13 @@ const DiscoverStream = ( props ) => {
 					>
 						{ translate( 'Recommended' ) }
 					</SegmentedControl.Item>
+					<SegmentedControl.Item
+						key="latest"
+						selected={ 'latest' === selectedTab }
+						onClick={ () => menuTabClick( 'latest' ) }
+					>
+						{ translate( 'Latest' ) }
+					</SegmentedControl.Item>
 					{ recommendedTags.map( ( tag ) => {
 						return (
 							<SegmentedControl.Item
@@ -193,14 +200,15 @@ const DiscoverStream = ( props ) => {
 		streamKey += recommendedStreamTags.reduce( ( acc, val ) => acc + `-${ val }`, '' );
 	}
 
-	const streamSidebar = isDefaultTab ? (
-		<ReaderPopularSitesSidebar
-			items={ recommendedSites }
-			followSource={ READER_DISCOVER_POPULAR_SITES }
-		/>
-	) : (
-		<ReaderTagSidebar tag={ selectedTab } />
-	);
+	const streamSidebar =
+		isDefaultTab || selectedTab === 'latest' ? (
+			<ReaderPopularSitesSidebar
+				items={ recommendedSites }
+				followSource={ READER_DISCOVER_POPULAR_SITES }
+			/>
+		) : (
+			<ReaderTagSidebar tag={ selectedTab } />
+		);
 
 	const streamProps = {
 		...props,

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -201,10 +201,12 @@ const streamApis = {
 	},
 	discover: {
 		path: ( { streamKey } ) => {
-			if ( ! streamKeySuffix( streamKey ).includes( 'recommended' ) ) {
-				return `/read/tags/${ streamKeySuffix( streamKey ) }/posts`;
+			if ( streamKeySuffix( streamKey ).includes( 'recommended' ) ) {
+				return '/read/tags/cards';
+			} else if ( streamKeySuffix( streamKey ).includes( 'latest' ) ) {
+				return '/read/tags/posts';
 			}
-			return '/read/tags/cards';
+			return `/read/tags/${ streamKeySuffix( streamKey ) }/posts`;
 		},
 		dateProperty: 'date',
 		query: ( extras, { tags } ) =>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2880

## Proposed Changes

* Adds a latest tab to the reader discover section

## Testing Instructions

* http://calypso.localhost:3000/discover
* Click "Latest"
* Should see latest posts show up in the feed
* Change locale to something non english
* Should now see latest posts show up in said locale e.g. french

Before
![Screenshot(47)](https://github.com/Automattic/wp-calypso/assets/811776/ff00c207-ad92-4a87-9fae-7a68514efbe6)

After
![Screenshot(49)](https://github.com/Automattic/wp-calypso/assets/811776/09990491-3d79-46f8-a15a-534c6e01c1f8)
