### PR TITLE
Initial fixes for the Wapuu Widget

### DIFF
--- a/client/odysseus/index.tsx
+++ b/client/odysseus/index.tsx
@@ -1,4 +1,5 @@
 import { TextControl, Button } from '@wordpress/components';
+import classnames from 'classnames';
 import { useRef, useEffect, useState } from 'react';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -20,6 +21,8 @@ const OdysseusAssistant = () => {
 	const [ messages, setMessages ] = useState< Message[] >( [
 		{ content: 'Hello, I am Wapuu! Your personal assistant.', role: 'assistant' },
 	] );
+
+	const environmentBadge = document.querySelector( 'body > .environment-badge' );
 
 	// Clear messages when switching sections
 	useEffect( () => {
@@ -108,7 +111,13 @@ const OdysseusAssistant = () => {
 	}
 
 	return (
-		<div className={ `chatbox ${ isVisible ? 'chatbox-show' : 'chatbox-hide' }` }>
+		<div
+			className={ classnames( 'chatbox', {
+				'chatbox-show': isVisible,
+				'chatbox-hide': ! isVisible,
+				'using-environment-badge': environmentBadge,
+			} ) }
+		>
 			<WapuuRibbon
 				onToggleVisibility={ handleToggleVisibility }
 				isNudging={ isNudging }
@@ -119,13 +128,13 @@ const OdysseusAssistant = () => {
 				<div className="chatbox-messages">
 					{ messages.map( ( message, index ) => (
 						<div
+							ref={ index === messages.length - 1 ? messagesEndRef : null }
 							className={ `chatbox-message ${ message.role === 'user' ? 'user' : 'wapuu' }` }
 							key={ index }
 						>
 							{ message.content }
 						</div>
 					) ) }
-					<div ref={ messagesEndRef } />
 				</div>
 				<form onSubmit={ handleFormSubmit }>
 					<div className="chatbox-input-area">

--- a/client/odysseus/style.scss
+++ b/client/odysseus/style.scss
@@ -1,6 +1,6 @@
 .chatbox {
 	position: fixed;
-	bottom: 64px;
+	bottom: 20px;
 	right: 20px;
 	width: 300px;
 	height: 400px;
@@ -51,7 +51,7 @@
 }
 
 .chatbox-messages {
-	overflow-y: scroll;
+	overflow-y: auto;
 	word-wrap: break-word;
 	padding: 12px;
 	border-radius: 4px;
@@ -61,7 +61,7 @@
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	max-height: 294px;
+	max-height: 284px;
 	padding-bottom: 4px;
 }
 
@@ -178,6 +178,11 @@
 		transform: rotate(15deg);
 	}
 }
+
 .chat-box-message-container {
 	width: 100%;
+}
+
+.using-environment-badge {
+	bottom: 64px;
 }


### PR DESCRIPTION
Related to 

https://github.com/Automattic/ai-services/issues/51
https://github.com/Automattic/ai-services/issues/52
https://github.com/Automattic/ai-services/issues/53

## Proposed Changes

We are improving the way of handling classNames with the library classnames that usually is used around Calypso. That allows us easier classNames handlers, in order to, for example, add new classNames when the environment badge is present.

We are also changing the target of the automatic scroll, instead of scrolling to the bottom of the last message, we scroll to the top of the last message, which feels more natural

Lastly, we are fixing a padding issue due to the chat-messages container growing more than the sum of all heights for the chat box allows.

## Testing Instructions

1. Sandbox your WordPress site
2. Navigate to Upgrades
3. Add the features flag: odysseus. eg. append to the end of the url `?flags=odysseus`
4. Assert that the chat box appears correctly (not hiding the environment badge) by clicking on Wapuu's ear
5. Reload
6. Inspect DOM and remove the environment badge, which is the second child of the body (usually)
7. Click on Wapuu ear, the chatbox should be now a bit more at the bottom
8. Within that chatbox, speaks a bit with Wapuu until the messages are flooding the space (eg, you can scroll within the chatbox)
9. Assert that the bottom "toolbar" is correctly displayed