### PR TITLE
/read/subscriptions/: Implement custom site subscriptions list "not found" state component, and hide RecommendedSites component on search

### DIFF
--- a/client/reader/site-subscriptions-manager/not-found-site-subscriptions.tsx
+++ b/client/reader/site-subscriptions-manager/not-found-site-subscriptions.tsx
@@ -1,0 +1,25 @@
+import { SubscriptionManager } from '@automattic/data-stores';
+import { useTranslate } from 'i18n-calypso';
+
+const NotFoundSiteSubscriptions = () => {
+	const translate = useTranslate();
+	const { searchTerm } = SubscriptionManager.useSiteSubscriptionsQueryProps();
+
+	return (
+		<div className="not-found-site-subscriptions">
+			{
+				/* translators: the string is the exact text that the user entered into the search input in site subscriptions manager in Reader */
+				translate(
+					'No results found for “%s” in your subscribed sites. Below are some recommended sites for you.',
+					{
+						args: searchTerm,
+						comment:
+							"When users type something into the search field of their site subscriptions manager in Reader, they'll see this message if their search doesn't find any of the websites they're currently subscribed to.",
+					}
+				)
+			}
+		</div>
+	);
+};
+
+export default NotFoundSiteSubscriptions;

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -1,4 +1,3 @@
-import { SubscriptionManager } from '@automattic/data-stores';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -12,18 +11,14 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import {
-	SiteSubscriptionsList,
-	SiteSubscriptionsListActionsBar,
-} from 'calypso/landing/subscriptions/components/site-subscriptions-list';
-import {
 	SubscriptionsPortal,
 	SubscriptionManagerContextProvider,
 } from 'calypso/landing/subscriptions/components/subscription-manager-context';
 import { SubscriptionsEllipsisMenu } from 'calypso/landing/subscriptions/components/subscriptions-ellipsis-menu';
 import { downloadCloud, uploadCloud } from 'calypso/reader/icons';
-import { RecommendedSites } from 'calypso/reader/recommended-sites';
 import { useDispatch } from 'calypso/state';
 import { markFollowsAsStale } from 'calypso/state/reader/follows/actions';
+import SiteSubscriptions from './site-subscriptions';
 import './style.scss';
 
 const useMarkFollowsAsStaleOnUnmount = () => {
@@ -71,11 +66,7 @@ const SiteSubscriptionsManager = () => {
 					</SubscriptionsEllipsisMenu>
 				</HStack>
 
-				<SubscriptionManager.SiteSubscriptionsQueryPropsProvider>
-					<SiteSubscriptionsListActionsBar />
-					<RecommendedSites />
-					<SiteSubscriptionsList />
-				</SubscriptionManager.SiteSubscriptionsQueryPropsProvider>
+				<SiteSubscriptions />
 			</Main>
 		</SubscriptionManagerContextProvider>
 	);

--- a/client/reader/site-subscriptions-manager/site-subscriptions.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions.tsx
@@ -1,0 +1,26 @@
+import { SubscriptionManager } from '@automattic/data-stores';
+import {
+	SiteSubscriptionsList,
+	SiteSubscriptionsListActionsBar,
+} from 'calypso/landing/subscriptions/components/site-subscriptions-list';
+import { RecommendedSites } from '../recommended-sites';
+import NotFoundSiteSubscriptions from './not-found-site-subscriptions';
+
+const SiteSubscriptions = () => {
+	const { searchTerm } = SubscriptionManager.useSiteSubscriptionsQueryProps();
+	return (
+		<>
+			<SiteSubscriptionsListActionsBar />
+			{ ! searchTerm && <RecommendedSites /> }
+			<SiteSubscriptionsList notFoundComponent={ NotFoundSiteSubscriptions } />
+		</>
+	);
+};
+
+export default () => {
+	return (
+		<SubscriptionManager.SiteSubscriptionsQueryPropsProvider>
+			<SiteSubscriptions />
+		</SubscriptionManager.SiteSubscriptionsQueryPropsProvider>
+	);
+};

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -63,4 +63,12 @@
 			}
 		}
 	}
+
+	.not-found-site-subscriptions {
+		color: $studio-gray-60;
+		font-size: $font-body-small;
+		font-weight: 500;
+		font-family: "SF Pro Text", $sans;
+		line-height: $font-title-small;
+	}
 }


### PR DESCRIPTION
![nVmevo.png](https://github.com/Automattic/wp-calypso/assets/2019970/3cdd0262-fe02-41f8-b7de-d8aa13810c16)

![jCKXOy.png](https://github.com/Automattic/wp-calypso/assets/2019970/aab3f68e-3b47-4360-9520-c226381f58d0)
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

![lqF0Lm.png](https://github.com/Automattic/wp-calypso/assets/2019970/747ddf59-dddd-4b85-8140-e2884dde46b9)

![IhOhRx.png](https://github.com/Automattic/wp-calypso/assets/2019970/5b2ce0e1-a108-4b47-8ea4-a6a2e575be74)

Fixes https://github.com/Automattic/wp-calypso/issues/78631

## Proposed Changes

* Add custom `NotFoundSiteSubscriptions` component in Reader, as per the Figma design: inDLaEQV8jJ21O4WXawIsJ-fi-3751_61105
* Hide the "Recommended sites" component when a search text is entered

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to http://calypso.localhost:3000/read/subscriptions
2. Enter some search string
3. Ensure the "Recommended sites" component is not displayed, once the search text is entered
4. Remove the search text
5. Ensure the Recommended sites are displayed once again
6. Enter a search string that does not match any of your site subscriptions, and ensure the expected text is displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?