### PR TITLE
Theme Detail: Dynamically set the large preview height

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -15,7 +15,6 @@ import {
 	isDefaultGlobalStylesVariationSlug,
 } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { withDesktopBreakpoint } from '@automattic/viewport-react';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import classNames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';
@@ -524,13 +523,7 @@ class ThemeSheet extends Component {
 	}
 
 	renderWebPreview = () => {
-		const {
-			isBreakpointActive: isDesktop,
-			locale,
-			stylesheet,
-			styleVariations,
-			themeId,
-		} = this.props;
+		const { locale, stylesheet, styleVariations, themeId } = this.props;
 		const baseStyleVariation = styleVariations.find( ( style ) =>
 			isDefaultGlobalStylesVariationSlug( style.slug )
 		);
@@ -546,7 +539,7 @@ class ThemeSheet extends Component {
 				<ThemeWebPreview
 					url={ url }
 					inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }
-					iframeScaleRatio={ isDesktop ? 0.5 : 1 }
+					iframeScaleRatio={ 0.5 }
 					isShowFrameBorder={ false }
 					isShowDeviceSwitcher={ false }
 					isFitHeight
@@ -1609,4 +1602,4 @@ export default connect(
 		errorNotice,
 		setProductToBeInstalled: productToBeInstalled,
 	}
-)( withDesktopBreakpoint( withSiteGlobalStylesStatus( localize( ThemeSheetWithOptions ) ) ) );
+)( withSiteGlobalStylesStatus( localize( ThemeSheetWithOptions ) ) );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -15,6 +15,7 @@ import {
 	isDefaultGlobalStylesVariationSlug,
 } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { withDesktopBreakpoint } from '@automattic/viewport-react';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import classNames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';
@@ -523,7 +524,13 @@ class ThemeSheet extends Component {
 	}
 
 	renderWebPreview = () => {
-		const { locale, stylesheet, styleVariations, themeId } = this.props;
+		const {
+			isBreakpointActive: isDesktop,
+			locale,
+			stylesheet,
+			styleVariations,
+			themeId,
+		} = this.props;
 		const baseStyleVariation = styleVariations.find( ( style ) =>
 			isDefaultGlobalStylesVariationSlug( style.slug )
 		);
@@ -539,7 +546,7 @@ class ThemeSheet extends Component {
 				<ThemeWebPreview
 					url={ url }
 					inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }
-					iframeScaleRatio={ 0.5 }
+					iframeScaleRatio={ isDesktop ? 0.5 : 1 }
 					isShowFrameBorder={ false }
 					isShowDeviceSwitcher={ false }
 					isFitHeight
@@ -1602,4 +1609,4 @@ export default connect(
 		errorNotice,
 		setProductToBeInstalled: productToBeInstalled,
 	}
-)( withSiteGlobalStylesStatus( localize( ThemeSheetWithOptions ) ) );
+)( withDesktopBreakpoint( withSiteGlobalStylesStatus( localize( ThemeSheetWithOptions ) ) ) );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -531,7 +531,7 @@ class ThemeSheet extends Component {
 		const selectedStyleVariationInlineCss = this.getSelectedStyleVariation()?.inline_css || '';
 		const url = getDesignPreviewUrl(
 			{ slug: themeId, recipe: { stylesheet } },
-			{ language: locale }
+			{ language: locale, viewport_unit_to_px: true }
 		);
 
 		return (
@@ -539,8 +539,10 @@ class ThemeSheet extends Component {
 				<ThemeWebPreview
 					url={ url }
 					inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }
+					iframeScaleRatio={ 0.5 }
 					isShowFrameBorder={ false }
 					isShowDeviceSwitcher={ false }
+					isFitHeight
 				/>
 			</div>
 		);

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -18,7 +18,6 @@ $theme-sheet-content-max-width: 1462px;
 
 		.theme__sheet-web-preview {
 			@include breakpoint-deprecated( ">960px" ) {
-				height: calc(100vh - 96px);
 				top: calc(var(--masterbar-height) + 16px);
 			}
 		}
@@ -383,10 +382,11 @@ $theme-sheet-content-max-width: 1462px;
 }
 
 .theme__sheet-web-preview {
+	// The iframe viewport height is set at 1040px, scaled at 0.5.
+	min-height: 520px;
 	pointer-events: none;
 
 	@include breakpoint-deprecated( ">960px" ) {
-		height: calc(100vh - 64px);
 		pointer-events: all;
 		position: sticky;
 		top: 16px;
@@ -394,9 +394,12 @@ $theme-sheet-content-max-width: 1462px;
 		.theme-preview__frame-wrapper .theme-preview__frame {
 			height: 200%;
 			max-width: 200%;
-			transform: scale(0.5) !important;
 			width: 200%;
 		}
+	}
+
+	.theme-preview__container {
+		position: relative;
 	}
 }
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -394,7 +394,7 @@ $theme-sheet-content-max-width: 1462px;
 		top: 16px;
 
 		.theme-preview__frame-wrapper {
-			max-height: 100vh;
+			max-height: calc(100vh - 32px - var(--masterbar-height));
 
 			.theme-preview__frame {
 				height: 200%;

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -393,11 +393,16 @@ $theme-sheet-content-max-width: 1462px;
 		position: sticky;
 		top: 16px;
 
-		.theme-preview__frame-wrapper .theme-preview__frame {
-			height: 200%;
-			max-width: 200%;
-			min-height: $iframe-viewport-height-scaled;
-			width: 200%;
+		.theme-preview__frame-wrapper {
+			max-height: 100vh;
+
+			.theme-preview__frame {
+				height: 200%;
+				max-height: 200vh;
+				max-width: 200%;
+				min-height: $iframe-viewport-height-scaled;
+				width: 200%;
+			}
 		}
 	}
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -382,8 +382,10 @@ $theme-sheet-content-max-width: 1462px;
 }
 
 .theme__sheet-web-preview {
-	// The iframe viewport height is set at 1040px, scaled at 0.5.
-	min-height: 520px;
+	$iframe-viewport-height: 1040px;
+	$iframe-viewport-height-scaled: calc($iframe-viewport-height / 2);
+
+	min-height: $iframe-viewport-height-scaled;
 	pointer-events: none;
 
 	@include breakpoint-deprecated( ">960px" ) {
@@ -394,6 +396,7 @@ $theme-sheet-content-max-width: 1462px;
 		.theme-preview__frame-wrapper .theme-preview__frame {
 			height: 200%;
 			max-width: 200%;
+			min-height: $iframe-viewport-height-scaled;
 			width: 200%;
 		}
 	}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -20,6 +20,12 @@ $theme-sheet-content-max-width: 1462px;
 			@include breakpoint-deprecated( ">960px" ) {
 				top: calc(var(--masterbar-height) + 16px);
 			}
+
+			.theme-preview__frame-wrapper {
+				@include breakpoint-deprecated( ">960px" ) {
+					max-height: calc(100vh - 32px - var(--masterbar-height));
+				}
+			}
 		}
 	}
 
@@ -394,13 +400,14 @@ $theme-sheet-content-max-width: 1462px;
 		top: 16px;
 
 		.theme-preview__frame-wrapper {
-			max-height: calc(100vh - 32px - var(--masterbar-height));
+			max-height: calc(100vh - var(--masterbar-height));
 
 			.theme-preview__frame {
 				height: 200%;
 				max-height: 200vh;
 				max-width: 200%;
 				min-height: $iframe-viewport-height-scaled;
+				transform: scale(0.5) !important;
 				width: 200%;
 			}
 		}
@@ -408,6 +415,10 @@ $theme-sheet-content-max-width: 1462px;
 
 	.theme-preview__container {
 		position: relative;
+	}
+
+	.theme-preview__frame {
+		transform: none !important;
 	}
 }
 

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -17,6 +17,7 @@ interface ThemePreviewProps {
 	url: string;
 	inlineCss?: string;
 	viewportWidth?: number;
+	iframeScaleRatio?: number;
 	isFitHeight?: boolean;
 	isShowFrameBorder?: boolean;
 	isShowDeviceSwitcher?: boolean;
@@ -32,6 +33,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	url,
 	inlineCss,
 	viewportWidth,
+	iframeScaleRatio = 1,
 	isFitHeight,
 	isShowFrameBorder,
 	isShowDeviceSwitcher,
@@ -44,7 +46,15 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	const [ viewport, setViewport ] = useState< Viewport >();
 	const [ containerResizeListener, { width: containerWidth } ] = useResizeObserver();
 	const calypso_token = useMemo( () => uuid(), [] );
-	const scale = containerWidth && viewportWidth ? containerWidth / viewportWidth : 1;
+	const scale = containerWidth && viewportWidth ? containerWidth / viewportWidth : iframeScaleRatio;
+
+	const wrapperHeight = useMemo( () => {
+		if ( ! viewport || iframeScaleRatio === 1 ) {
+			return 0;
+		}
+
+		return viewport.height * iframeScaleRatio;
+	}, [ viewport?.height, iframeScaleRatio ] );
 
 	useEffect( () => {
 		const handleMessage = ( event: MessageEvent ) => {
@@ -107,7 +117,12 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 			onDeviceChange={ recordDeviceClick }
 		>
 			{ containerResizeListener }
-			<div className="theme-preview__frame-wrapper">
+			<div
+				className="theme-preview__frame-wrapper"
+				style={ {
+					...( wrapperHeight > 0 && { height: wrapperHeight } ),
+				} }
+			>
 				{ ! isLoaded && (
 					<div className="theme-preview__frame-message">
 						<Spinner />

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -138,7 +138,6 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 						transform: `scale(${ scale })`,
 					} }
 					src={ addQueryArgs( url, { calypso_token } ) }
-					scrolling={ isFitHeight ? 'no' : 'yes' }
 					tabIndex={ -1 }
 				/>
 			</div>

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -144,6 +144,7 @@ export interface DesignPreviewOptions {
 	disable_viewport_height?: boolean;
 	remove_assets?: boolean;
 	style_variation?: StyleVariation;
+	viewport_unit_to_px?: boolean;
 }
 
 /** @deprecated used for Gutenboarding (/new flow) */

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -40,6 +40,9 @@ export const getDesignPreviewUrl = (
 			options.style_variation.slug !== 'default' && {
 				style_variation: options.style_variation.title,
 			} ),
+		...( options.viewport_unit_to_px && {
+			viewport_unit_to_px: options.viewport_unit_to_px,
+		} ),
 	} );
 
 	// The preview url is sometimes used in a `background-image: url()` CSS rule and unescaped


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77416

## Proposed Changes

This PR improves the Theme Detail page by making the large preview auto-resize, and fit the demo site height. Note that currently, only themes with style variations uses iframe for the large preview. Otherwise, the large preview will just be the theme screenshot. 

| Before | After |
| --- | --- |
| ![Screenshot 2023-07-05 at 3 22 30 PM](https://github.com/Automattic/wp-calypso/assets/797888/8d43ba54-6231-4543-ae11-266950c6db8a) | ![Screenshot 2023-07-05 at 3 22 47 PM](https://github.com/Automattic/wp-calypso/assets/797888/e94a2166-a874-4683-8186-0792a9be2bb3) |

| Before | After |
| --- | --- |
| ![Screenshot 2023-07-05 at 3 24 18 PM](https://github.com/Automattic/wp-calypso/assets/797888/fcca05a3-a42b-431f-99e3-e80b506e5ab1) | ![Screenshot 2023-07-05 at 3 24 05 PM](https://github.com/Automattic/wp-calypso/assets/797888/08e19666-842b-4439-ab06-a876c7cfedd4) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/themes`.
* Select any theme with style variations.
* Ensure that the theme's Theme Detail page, the large preview will resize to fit its height to the one of the demo site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
