### PR TITLE
Domain transfer: Handle 400 error from code EP

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -1,7 +1,7 @@
-import { useIsDomainCodeValid } from '@automattic/data-stores';
 import { doesStringResembleDomain } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import { useDebounce } from 'use-debounce';
+import { useIsDomainCodeValid } from 'calypso/landing/stepper/hooks/use-is-domain-code-valid';
 import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
 
 export function useValidationMessage( domain: string, auth: string, hasDuplicates: boolean ) {
@@ -74,6 +74,12 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 			loading: false,
 			message: __( 'This domain is unlocked and ready to be transferred.' ),
 		};
+	} else if ( availabilityNotice?.message ) {
+		return {
+			valid: false,
+			loading: false,
+			message: availabilityNotice?.message,
+		};
 	} else if ( validationResult?.auth_code_valid === false ) {
 		// the auth check API has a bug and returns error 400 for incorrect auth codes,
 		// in which case, the `useIsDomainCodeValid` hook returns `false`.
@@ -81,12 +87,6 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 			valid: false,
 			loading: false,
 			message: __( 'This domain is unlocked but the authentication code seems incorrect.' ),
-		};
-	} else if ( availabilityNotice?.message ) {
-		return {
-			valid: false,
-			loading: false,
-			message: availabilityNotice?.message,
 		};
 	}
 

--- a/client/landing/stepper/hooks/index.d.ts
+++ b/client/landing/stepper/hooks/index.d.ts
@@ -1,0 +1,7 @@
+type SHA256 = {
+	update( data: string ): SHA256;
+	digest( encoding: 'hex' ): string;
+};
+declare module 'hash.js/lib/hash/sha/256' {
+	export default function sha256(): SHA256;
+}

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import sha256 from 'hash.js/lib/hash/sha/256';
 import wpcomRequest from 'wpcom-proxy-request';
 
-const VERSION = 1;
+const VERSION = 2;
 
 /**
  * Irreversibly hash the auth code to avoid storing it as query key.

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -31,7 +31,6 @@ export * from './domain-suggestions/types';
 export * from './plans/types';
 export * from './user/types';
 export * from './queries/use-launchpad';
-export * from './queries/use-is-domain-code-valid';
 
 const { SubscriptionManager } = Reader;
 

--- a/packages/data-stores/src/types.d.ts
+++ b/packages/data-stores/src/types.d.ts
@@ -1,9 +1,1 @@
 declare const __i18n_text_domain__: string;
-
-type SHA256 = {
-	update( data: string ): SHA256;
-	digest( encoding: 'hex' ): string;
-};
-declare module 'hash.js/lib/hash/sha/256' {
-	export default function sha256(): SHA256;
-}


### PR DESCRIPTION
Follow up for https://github.com/Automattic/wp-calypso/pull/78859

### Testing

1. Go to https://wordpress.com/setup/domain-transfer/domains
2. Enter any domain that is certainly locked, like omar.com.
3. It will wrongly tell you that "This domain is unlocked but the authentication code seems incorrect.". 
4. Using the live link, visit the same URL but for this branch. 
5. Enter omar.com, it should tell you it's locked.
6. Enter hambai.dev (unlocked) and enter an incorrect auth code. It should tell you that it is unlocked, but the authcode is invalid.