### PR TITLE
Subscribers Page: Hide the Subscribers tab on the Users page and redirect underlying URL to the new Subscribers page

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -64,12 +64,14 @@ export default {
 	},
 
 	subscribers( context, next ) {
-		const state = context.store.getState();
-		const siteSlug = getSelectedSiteSlug( state );
-		const redirectURL = '/subscribers/' + ( siteSlug ? siteSlug : '' );
-		page.redirect( redirectURL );
-
-		renderSubscribers( context, next );
+		if ( isEnabled( 'subscribers-page-new' ) ) {
+			const state = context.store.getState();
+			const siteSlug = getSelectedSiteSlug( state );
+			const redirectURL = '/subscribers/' + ( siteSlug ? siteSlug : '' );
+			page.redirect( redirectURL );
+		} else {
+			renderSubscribers( context, next );
+		}
 	},
 
 	subscriberDetails( context, next ) {

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -79,7 +79,14 @@ export default {
 	},
 
 	peopleAddSubscribers( context, next ) {
-		renderPeopleAddSubscribers( context, next );
+		if ( isEnabled( 'subscribers-page-new' ) ) {
+			const state = context.store.getState();
+			const siteSlug = getSelectedSiteSlug( state );
+			const redirectURL = '/subscribers/' + ( siteSlug ? siteSlug : '' );
+			page.redirect( redirectURL );
+		} else {
+			renderPeopleAddSubscribers( context, next );
+		}
 	},
 };
 

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -5,7 +5,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { getSiteFragment } from 'calypso/lib/route';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import EditTeamMember from './edit-team-member-form';
 import InvitePeople from './invite-people';
 import PeopleList from './main';
@@ -64,6 +64,11 @@ export default {
 	},
 
 	subscribers( context, next ) {
+		const state = context.store.getState();
+		const siteSlug = getSelectedSiteSlug( state );
+		const redirectURL = '/subscribers/' + ( siteSlug ? siteSlug : '' );
+		page.redirect( redirectURL );
+
 		renderSubscribers( context, next );
 	},
 

--- a/client/my-sites/people/people-section-nav-compact/index.tsx
+++ b/client/my-sites/people/people-section-nav-compact/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -34,7 +35,7 @@ function PeopleSectionNavCompact( props: Props ) {
 		<>
 			<NavTabs>
 				{ filters.map( function ( filterItem ) {
-					if ( filterItem.id === 'subscribers' ) {
+					if ( isEnabled( 'subscribers-page-new' ) && filterItem.id === 'subscribers' ) {
 						return null;
 					}
 					return (

--- a/client/my-sites/people/people-section-nav-compact/index.tsx
+++ b/client/my-sites/people/people-section-nav-compact/index.tsx
@@ -34,6 +34,9 @@ function PeopleSectionNavCompact( props: Props ) {
 		<>
 			<NavTabs>
 				{ filters.map( function ( filterItem ) {
+					if ( filterItem.id === 'subscribers' ) {
+						return null;
+					}
 					return (
 						<NavItem
 							key={ filterItem.id }

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -1,4 +1,6 @@
-import { localizeUrl } from '@automattic/i18n-utils';
+import { isEnabled } from '@automattic/calypso-config';
+import { localizeUrl, useLocale } from '@automattic/i18n-utils';
+import { useI18n } from '@wordpress/react-i18n/';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -48,6 +50,48 @@ function SubscribersTeam( props: Props ) {
 	) as unknown as FollowersQuery;
 	const usersQuery = useUsersQuery( site?.ID, teamFetchOptions ) as unknown as UsersQuery;
 
+	const locale = useLocale();
+	const { hasTranslation } = useI18n();
+
+	const getSubheaderText = () => {
+		const subHeaderTextOld = translate(
+			'Invite subscribers and team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}.',
+			{
+				components: {
+					learnMore: (
+						<InlineSupportLink
+							showIcon={ false }
+							supportLink={ localizeUrl( 'https://wordpress.com/support/invite-people/' ) }
+						/>
+					),
+				},
+			}
+		);
+
+		const subHeaderTextNew = translate(
+			'Invite team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}.',
+			{
+				components: {
+					learnMore: (
+						<InlineSupportLink
+							showIcon={ false }
+							supportLink={ localizeUrl( 'https://wordpress.com/support/invite-people/' ) }
+						/>
+					),
+				},
+			}
+		);
+
+		const useNewSubHeaderText =
+			isEnabled( 'subscribers-page-new' ) &&
+			( locale === 'en' ||
+				hasTranslation(
+					'Invite team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}.'
+				) );
+
+		return useNewSubHeaderText ? subHeaderTextNew : subHeaderTextOld;
+	};
+
 	return (
 		<Main>
 			<ScreenOptionsTab wpAdminPath="users.php" />
@@ -55,19 +99,7 @@ function SubscribersTeam( props: Props ) {
 				brandFont
 				className="people__page-heading"
 				headerText={ translate( 'Users' ) }
-				subHeaderText={ translate(
-					'Invite subscribers and team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}.',
-					{
-						components: {
-							learnMore: (
-								<InlineSupportLink
-									showIcon={ false }
-									supportLink={ localizeUrl( 'https://wordpress.com/support/invite-people/' ) }
-								/>
-							),
-						},
-					}
-				) }
+				subHeaderText={ getSubheaderText() }
 				align="left"
 				hasScreenOptions
 			/>

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -84,7 +84,7 @@ function SubscribersTeam( props: Props ) {
 
 		const useNewSubHeaderText =
 			isEnabled( 'subscribers-page-new' ) &&
-			( locale === 'en' ||
+			( locale.startsWith( 'en' ) ||
 				hasTranslation(
 					'Invite team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}.'
 				) );

--- a/client/my-sites/people/team-invite/index.tsx
+++ b/client/my-sites/people/team-invite/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
@@ -59,7 +60,7 @@ function TeamInvite( props: Props ) {
 						args: { sitename: site.name ?? translate( 'this site' ) },
 					} ) }
 				</HeaderCake>
-				<PeopleSectionAddNav selectedFilter="team" />
+				{ isEnabled( 'subscribers-page-new' ) || <PeopleSectionAddNav selectedFilter="team" /> }
 				<EmptyContent
 					title={ translate( 'Oops, only administrators can invite other people' ) }
 					illustration="/calypso/images/illustrations/illustration-empty-results.svg"
@@ -80,7 +81,7 @@ function TeamInvite( props: Props ) {
 				} ) }
 			</HeaderCake>
 
-			<PeopleSectionAddNav selectedFilter="team" />
+			{ isEnabled( 'subscribers-page-new' ) || <PeopleSectionAddNav selectedFilter="team" /> }
 
 			{ isSiteForTeams && <P2TeamBanner context="invite" site={ site } /> }
 

--- a/config/development.json
+++ b/config/development.json
@@ -189,6 +189,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
+		"subscribers-page-new": true,
 		"subscription-gifting": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -126,6 +126,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
+		"subscribers-page-new": false,
 		"subscription-gifting": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,

--- a/config/production.json
+++ b/config/production.json
@@ -153,6 +153,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
+		"subscribers-page-new": false,
 		"subscription-gifting": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -147,6 +147,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
+		"subscribers-page-new": false,
 		"subscription-gifting": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -159,6 +159,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
+		"subscribers-page-new": false,
 		"subscription-gifting": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/78893.

TODOs:

- [x] update the copy on the Users page (with the fallback)
- [x] add feature flag and hide the changes behind it
- [x] consider hiding "Add subscribers" page / tab at `/people/add-subscribers` and redirecting the related URL (https://github.com/Automattic/wp-calypso/issues/78893#issuecomment-1620528242)
- [x] create a task / PR for the feature flag switch → https://github.com/Automattic/wp-calypso/issues/79183
- [x] create a task for feature flag clean-up → https://github.com/Automattic/wp-calypso/issues/79169

## Proposed Changes

* introduce a new feature flag `subscribers-page-new`
* hide the `Subscribers` tab on the _Users → All users_ page (and redirect the related URL `/people/subscribers` to `/subscribers`)
* introduce a new `subHeading` text for the Users page (with language fallback)
* hide both tabs on the _Users → Add new_ page  (and redirect the URL related to "Add subscribers" tab `/people/add-subscribers` to 
`/subscribers`

_Users → All users_ page:

| Before | After |
|--------|--------|
| ![Markup on 2023-07-04 at 19:16:38](https://github.com/Automattic/wp-calypso/assets/25105483/c063779e-e3f5-4797-93b7-ef92766ca04e) | ![Markup on 2023-07-04 at 19:11:11](https://github.com/Automattic/wp-calypso/assets/25105483/441436cd-b488-4f1e-b8d7-45bcc9a2abe1) | 

_Users → Add new_ page:

| Before | After |
|--------|--------|
| ![Markup on 2023-07-07 at 16:31:00](https://github.com/Automattic/wp-calypso/assets/25105483/34691b05-2578-46ce-85dc-dac7224cd5f7) | ![Markup on 2023-07-07 at 16:29:54](https://github.com/Automattic/wp-calypso/assets/25105483/40553634-6aa8-496b-9ea8-01928d097e9e) | 

## Testing Instructions

1. Check out the PR branch and build the app.
2. Navigate to _Users → All users_ page `http://calypso.localhost:3000/people/team/[your-test-site-slug]?flags=subscribers-page-new` (with the `subscribers-page-new` feature flag in the URL).
3. The "Subscribers" tab should not be present.
4. If your locale is set to English, the new copy should display on the page as well (as can be seen in the _After_ screenshot above).
5. Navigate to `http://calypso.localhost:3000/people/subscribers/[your-test-site-slug]?flags=subscribers-page-new` (with the `subscribers-page-new` feature flag in the URL).
6. You should be redirected to the new Subscribers page.
7. Navigate to _Users → Add new_ page `http://calypso.localhost:3000/people/new/[your-test-site-slug]?flags=subscribers-page-new` (with the `subscribers-page-new` feature flag in the URL).
8. None of the tabs on the page should display (as can be seen in _after_ the screenshot above).
9. Navigate to `http://calypso.localhost:3000/people/add-subscribers/[your-test-site-slug]?flags=subscribers-page-new` (with the `subscribers-page-new` feature flag in the URL).
10. If the feature flag is disabled (with using `?flags=-subscribers-page-new` URL parameter), none of the changes introduced in this PR should be applied.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
