### PR TITLE
Unify Design Preview: Support mobile layout with the navigator

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -607,20 +607,12 @@ $design-button-primary-color: rgb(17, 122, 201);
 				position: fixed;
 				top: auto;
 
-				.navigation-link {
-					margin-top: -2px;
-				}
-
 				@include break-xlarge {
 					inset-inline-start: 72px;
 					inset-inline-end: 24px;
 					padding: 1px 0 0;
 					position: absolute;
 					top: 8px;
-
-					.navigation-link {
-						margin-top: 0;
-					}
 
 					button.is-primary {
 						display: none;
@@ -640,7 +632,7 @@ $design-button-primary-color: rgb(17, 122, 201);
 			overflow: hidden;
 			padding: 0;
 			position: relative;
-			z-index: 1;
+			// z-index: 1;
 		}
 
 		@include break-xlarge {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -72,7 +72,7 @@ $design-button-primary-color: rgb(17, 122, 201);
 				text-align: start;
 				margin: 0;
 
-				@include break-xlarge {
+				@include break-large {
 					font-size: 2.75rem;
 				}
 			}
@@ -570,7 +570,7 @@ $design-button-primary-color: rgb(17, 122, 201);
 			font-weight: 500;
 			line-height: 20px;
 
-			@include break-xlarge {
+			@include break-large {
 				display: none;
 			}
 
@@ -594,13 +594,17 @@ $design-button-primary-color: rgb(17, 122, 201);
 				padding: 0 20px;
 				position: fixed;
 				top: auto;
+				box-shadow: inset 0 1px 0 #e2e4e7;
+				background-color: $white;
 
-				@include break-xlarge {
+				@include break-large {
 					inset-inline-start: 72px;
 					inset-inline-end: 24px;
 					padding: 1px 0 0;
 					position: absolute;
 					top: 8px;
+					box-shadow: none;
+					background-color: transparent;
 
 					button.is-primary {
 						display: none;
@@ -613,7 +617,7 @@ $design-button-primary-color: rgb(17, 122, 201);
 			display: none;
 		}
 
-		@include break-xlarge {
+		@include break-large {
 			max-width: none;
 			padding-inline-start: 32px;
 			padding-inline-end: 32px;
@@ -630,8 +634,8 @@ $design-button-primary-color: rgb(17, 122, 201);
 			}
 
 			.design-preview__sidebar {
-				margin: 72px -16px 0 -8px;
-				padding: 0 16px 0 8px;
+				margin: 0 -16px 0 -8px;
+				padding: 72px 16px 0 8px;
 			}
 		}
 	}
@@ -652,5 +656,4 @@ $design-button-primary-color: rgb(17, 122, 201);
 			}
 		}
 	}
-
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -221,25 +221,8 @@ $design-button-primary-color: rgb(17, 122, 201);
 		}
 
 		.step-container__content {
-			height: calc(100vh - 245px);
-			margin-top: 74px;
-
-			@include break-small {
-				height: calc(100vh - 225px);
-				margin-top: 32px;
-			}
-
 			@include break-small {
 				max-height: 1080px;
-			}
-
-			@include break-medium {
-				height: calc(100vh - 148px);
-			}
-
-			.design-preview__site-preview {
-				height: calc(100vh - 120px);
-				margin-bottom: 90px;
 			}
 
 			.web-preview__inner {
@@ -273,15 +256,6 @@ $design-button-primary-color: rgb(17, 122, 201);
 		@include break-small {
 			.design-setup__preview-content {
 				max-height: 1080px;
-			}
-		}
-
-		@include break-xlarge {
-			.step-container__content {
-				.design-preview__site-preview {
-					height: auto;
-					margin-bottom: 32px;
-				}
 			}
 		}
 	}
@@ -637,15 +611,6 @@ $design-button-primary-color: rgb(17, 122, 201);
 
 		.step-container__header {
 			display: none;
-		}
-
-		.step-container__content {
-			height: auto;
-			margin: 50px 0 0;
-			overflow: hidden;
-			padding: 0;
-			position: relative;
-			// z-index: 1;
 		}
 
 		@include break-xlarge {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -237,6 +237,11 @@ $design-button-primary-color: rgb(17, 122, 201);
 				height: calc(100vh - 148px);
 			}
 
+			.design-preview__site-preview {
+				height: calc(100vh - 120px);
+				margin-bottom: 90px;
+			}
+
 			.web-preview__inner {
 				transform: translateY(-48px);
 			}
@@ -268,6 +273,15 @@ $design-button-primary-color: rgb(17, 122, 201);
 		@include break-small {
 			.design-setup__preview-content {
 				max-height: 1080px;
+			}
+		}
+
+		@include break-xlarge {
+			.step-container__content {
+				.design-preview__site-preview {
+					height: auto;
+					margin-bottom: 32px;
+				}
 			}
 		}
 	}
@@ -626,9 +640,8 @@ $design-button-primary-color: rgb(17, 122, 201);
 		}
 
 		.step-container__content {
-			// 156px = .design-preview__sidebar + step-container__navigation.action-buttons
-			height: calc(100vh - 156px);
-			margin: 36px 0 0;
+			height: auto;
+			margin: 50px 0 0;
 			overflow: hidden;
 			padding: 0;
 			position: relative;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -85,7 +85,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const siteDescription = site?.description;
 	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
 	const isDesignFirstFlow = queryParams.get( 'flowToReturnTo' ) === 'design-first';
-	const [ shouldHideBack, setShouldHideBack ] = useState( false );
+	const [ shouldHideActionButtons, setShouldHideActionButtons ] = useState( false );
 
 	const { goToCheckout } = useCheckout();
 
@@ -519,7 +519,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	function getPrimaryActionButton() {
 		if ( shouldUpgrade ) {
 			return (
-				<Button primary borderless={ false } onClick={ upgradePlan }>
+				<Button className="navigation-link" primary borderless={ false } onClick={ upgradePlan }>
 					{ translate( 'Unlock theme' ) }
 				</Button>
 			);
@@ -534,7 +534,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		};
 
 		return (
-			<Button primary borderless={ false } onClick={ selectStyle }>
+			<Button className="navigation-link" primary borderless={ false } onClick={ selectStyle }>
 				{ translate( 'Continue' ) }
 			</Button>
 		);
@@ -610,7 +610,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					selectedFontVariation={ selectedFontVariation }
 					onSelectFontVariation={ setSelectedFontVariation }
 					onGlobalStylesChange={ setGlobalStyles }
-					onNavigatorPathChange={ ( path: string ) => setShouldHideBack( path !== '/' ) }
+					onNavigatorPathChange={ ( path: string ) => setShouldHideActionButtons( path !== '/' ) }
 				/>
 			</>
 		);
@@ -620,10 +620,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				stepName={ STEP_NAME }
 				stepContent={ stepContent }
 				hideSkip
-				hideBack={ shouldHideBack }
+				hideBack={ shouldHideActionButtons }
 				className="design-setup__preview design-setup__preview__has-more-info"
 				goBack={ handleBackClick }
-				customizedActionButtons={ actionButtons }
+				customizedActionButtons={ ! shouldHideActionButtons ? actionButtons : undefined }
 				recordTracksEvent={ recordStepContainerTracksEvent }
 			/>
 		);

--- a/packages/components/src/device-switcher/device-switcher.scss
+++ b/packages/components/src/device-switcher/device-switcher.scss
@@ -35,12 +35,14 @@
 	transition: max-width 0.2s ease-out, max-height 0.2s ease-out;
 	max-width: 100%;
 	max-height: 100%;
+	box-sizing: border-box;
 	// Create a new stacking context to fix border-radius with overflow hidden issue on safari
 	// See https://github.com/Automattic/wp-calypso/issues/71440
 	isolation: isolate;
 
 	.device-switcher__container--frame-bordered & {
 		--device-switcher-border-width: 10px;
+		border: var(--device-switcher-border-width) solid var(--color-print);
 		border-radius: var(--device-switcher-border-radius);
 
 		@include break-small {
@@ -76,7 +78,7 @@
 	.device-switcher__container--is-phone & {
 		--device-switcher-border-radius: 40px; /* stylelint-disable-line scales/radii */
 		max-width: 480px;
-		max-height: 680px;
+		max-height: 844px;
 
 		.device-switcher__container--frame-shadow & {
 			box-shadow:

--- a/packages/components/src/device-switcher/device-switcher.scss
+++ b/packages/components/src/device-switcher/device-switcher.scss
@@ -74,6 +74,7 @@
 	}
 
 	.device-switcher__container--is-phone & {
+		--device-switcher-border-radius: 40px; /* stylelint-disable-line scales/radii */
 		max-width: 480px;
 		max-height: 844px;
 

--- a/packages/components/src/device-switcher/device-switcher.scss
+++ b/packages/components/src/device-switcher/device-switcher.scss
@@ -91,6 +91,11 @@
 		}
 	}
 
+	.device-switcher__container--is-fullscreen & {
+		max-height: 100vh;
+		max-width: 100vw;
+	}
+
 	.device-switcher__container--frame-fixed-viewport & {
 		--viewport-width-px: calc(var(--viewport-width) * 1px);
 		--viewport-height: calc(100% / var(--viewport-scale));

--- a/packages/components/src/device-switcher/device-switcher.scss
+++ b/packages/components/src/device-switcher/device-switcher.scss
@@ -41,13 +41,12 @@
 	isolation: isolate;
 
 	.device-switcher__container--frame-bordered & {
+		--device-switcher-border-radius: 40px; /* stylelint-disable-line scales/radii */
 		--device-switcher-border-width: 10px;
 		border: var(--device-switcher-border-width) solid var(--color-print);
 		border-radius: var(--device-switcher-border-radius);
 
 		@include break-small {
-			--device-switcher-border-radius: 40px; /* stylelint-disable-line scales/radii */
-			border: var(--device-switcher-border-width) solid var(--color-print);
 			box-sizing: border-box;
 
 			.device-switcher__container--frame-shadow & {
@@ -59,7 +58,6 @@
 
 		@include break-large {
 			--device-switcher-border-radius: 20px; /* stylelint-disable-line scales/radii */
-			border: var(--device-switcher-border-width) solid var(--color-print);
 			margin-top: 0;
 
 			.device-switcher__container--frame-shadow & {
@@ -76,7 +74,6 @@
 	}
 
 	.device-switcher__container--is-phone & {
-		--device-switcher-border-radius: 40px; /* stylelint-disable-line scales/radii */
 		max-width: 480px;
 		max-height: 844px;
 

--- a/packages/components/src/device-switcher/device-switcher.tsx
+++ b/packages/components/src/device-switcher/device-switcher.tsx
@@ -15,6 +15,7 @@ interface Props {
 	isShowFrameBorder?: boolean;
 	isShowFrameShadow?: boolean;
 	isFixedViewport?: boolean;
+	isFullscreen?: boolean;
 	frameRef?: React.MutableRefObject< HTMLDivElement | null >;
 	onDeviceChange?: ( device: Device ) => void;
 	onViewportChange?: ( height?: number ) => void;
@@ -31,6 +32,7 @@ const DeviceSwitcher = ( {
 	isShowFrameBorder,
 	isShowFrameShadow = true,
 	isFixedViewport,
+	isFullscreen,
 	frameRef,
 	onDeviceChange,
 	onViewportChange,
@@ -92,6 +94,7 @@ const DeviceSwitcher = ( {
 				'device-switcher__container--is-computer': device === 'computer',
 				'device-switcher__container--is-tablet': device === 'tablet',
 				'device-switcher__container--is-phone': device === 'phone',
+				'device-switcher__container--is-fullscreen': isFullscreen,
 			} ) }
 		>
 			{ isShowDeviceSwitcherToolbar && (

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -1,6 +1,6 @@
-import { DeviceSwitcher } from '@automattic/components';
+import { DeviceSwitcher, DEVICE_TYPES } from '@automattic/components';
 import { Spinner } from '@wordpress/components';
-import { useResizeObserver } from '@wordpress/compose';
+import { useResizeObserver, useViewportMatch } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
@@ -43,6 +43,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	const [ isFullyLoaded, setIsFullyLoaded ] = useState( ! isUrlWpcomApi( url ) );
 	const [ viewport, setViewport ] = useState< Viewport >();
 	const [ containerResizeListener, { width: containerWidth } ] = useResizeObserver();
+	const isDesktop = useViewportMatch( 'large' );
 	const calypso_token = useMemo( () => uuid(), [] );
 	const scale = containerWidth && viewportWidth ? containerWidth / viewportWidth : 1;
 
@@ -102,6 +103,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 			className={ classnames( 'theme-preview__container', {
 				'theme-preview__container--loading': ! isLoaded && ! isFullyLoaded,
 			} ) }
+			defaultDevice={ isDesktop ? DEVICE_TYPES.COMPUTER : DEVICE_TYPES.PHONE }
 			isShowDeviceSwitcherToolbar={ isShowDeviceSwitcher }
 			isShowFrameBorder={ isShowFrameBorder }
 			onDeviceChange={ recordDeviceClick }

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -1,6 +1,6 @@
-import { DeviceSwitcher, DEVICE_TYPES } from '@automattic/components';
+import { DeviceSwitcher } from '@automattic/components';
 import { Spinner } from '@wordpress/components';
-import { useResizeObserver, useViewportMatch } from '@wordpress/compose';
+import { useResizeObserver } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
@@ -45,7 +45,6 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	const [ isFullyLoaded, setIsFullyLoaded ] = useState( ! isUrlWpcomApi( url ) );
 	const [ viewport, setViewport ] = useState< Viewport >();
 	const [ containerResizeListener, { width: containerWidth } ] = useResizeObserver();
-	const isDesktop = useViewportMatch( 'large' );
 	const calypso_token = useMemo( () => uuid(), [] );
 	const scale = containerWidth && viewportWidth ? containerWidth / viewportWidth : 1;
 
@@ -105,7 +104,6 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 			className={ classnames( 'theme-preview__container', {
 				'theme-preview__container--loading': ! isLoaded && ! isFullyLoaded,
 			} ) }
-			defaultDevice={ isDesktop ? DEVICE_TYPES.COMPUTER : DEVICE_TYPES.PHONE }
 			isShowDeviceSwitcherToolbar={ isShowDeviceSwitcher }
 			isShowFrameBorder={ isShowFrameBorder }
 			isFullscreen={ isFullscreen }

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -20,6 +20,7 @@ interface ThemePreviewProps {
 	isFitHeight?: boolean;
 	isShowFrameBorder?: boolean;
 	isShowDeviceSwitcher?: boolean;
+	isFullscreen?: boolean;
 	recordDeviceClick?: ( device: string ) => void;
 }
 
@@ -35,6 +36,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	isFitHeight,
 	isShowFrameBorder,
 	isShowDeviceSwitcher,
+	isFullscreen,
 	recordDeviceClick,
 } ) => {
 	const { __ } = useI18n();
@@ -106,6 +108,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 			defaultDevice={ isDesktop ? DEVICE_TYPES.COMPUTER : DEVICE_TYPES.PHONE }
 			isShowDeviceSwitcherToolbar={ isShowDeviceSwitcher }
 			isShowFrameBorder={ isShowFrameBorder }
+			isFullscreen={ isFullscreen }
 			onDeviceChange={ recordDeviceClick }
 		>
 			{ containerResizeListener }

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -1,6 +1,7 @@
 import { GlobalStylesProvider, useSyncGlobalStylesUserConfig } from '@automattic/global-styles';
+import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useInlineCss, useScreens } from '../hooks';
 import Sidebar from './sidebar';
 import SitePreview from './site-preview';
@@ -60,6 +61,8 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	limitGlobalStyles,
 	onNavigatorPathChange,
 } ) => {
+	const isDesktop = useViewportMatch( 'large' );
+	const [ isInitialScreen, setIsInitialScreen ] = useState( true );
 	const selectedVariations = useMemo(
 		() =>
 			[ selectedColorVariation, selectedFontVariation ].filter( Boolean ) as GlobalStylesObject[],
@@ -82,12 +85,21 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 		onSelectFontVariation,
 	} );
 
+	const isFullscreen = ! isDesktop && ( screens.length === 1 || ! isInitialScreen );
+
+	const handleNavigatorPathChange = ( path: string ) => {
+		setIsInitialScreen( path === '/' );
+		onNavigatorPathChange?.( path );
+	};
+
 	useSyncGlobalStylesUserConfig( selectedVariations, onGlobalStylesChange );
 
 	return (
 		<div
 			className={ classnames( 'design-preview', {
+				'design-preview--is-initial-screen': isInitialScreen,
 				'design-preview--has-multiple-screens': screens.length > 1,
+				'design-preview--is-fullscreen': isFullscreen,
 			} ) }
 		>
 			<Sidebar
@@ -100,11 +112,12 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 				screens={ screens }
 				actionButtons={ actionButtons }
 				onClickCategory={ onClickCategory }
-				onNavigatorPathChange={ onNavigatorPathChange }
+				onNavigatorPathChange={ handleNavigatorPathChange }
 			/>
 			<SitePreview
 				url={ previewUrl }
 				inlineCss={ inlineCss }
+				isFullscreen={ isFullscreen }
 				recordDeviceClick={ recordDeviceClick }
 			/>
 		</div>

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -97,7 +97,6 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	return (
 		<div
 			className={ classnames( 'design-preview', {
-				'design-preview--is-initial-screen': isInitialScreen,
 				'design-preview--has-multiple-screens': screens.length > 1,
 				'design-preview--is-fullscreen': isFullscreen,
 			} ) }

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -1,4 +1,5 @@
 import { GlobalStylesProvider, useSyncGlobalStylesUserConfig } from '@automattic/global-styles';
+import classnames from 'classnames';
 import { useMemo } from 'react';
 import { useInlineCss, useScreens } from '../hooks';
 import Sidebar from './sidebar';
@@ -84,7 +85,11 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	useSyncGlobalStylesUserConfig( selectedVariations, onGlobalStylesChange );
 
 	return (
-		<div className="design-preview">
+		<div
+			className={ classnames( 'design-preview', {
+				'design-preview--has-multiple-screens': screens.length > 1,
+			} ) }
+		>
 			<Sidebar
 				title={ title }
 				author={ author }

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -57,59 +57,57 @@ const Sidebar: React.FC< SidebarProps > = ( {
 
 	return (
 		<div className="design-preview__sidebar">
-			<div className="design-preview__sidebar-content">
-				<NavigatorScreens screens={ screens } onNavigatorPathChange={ onNavigatorPathChange }>
-					<>
-						<div className="design-preview__sidebar-header">
-							<div className="design-preview__sidebar-title">
-								<h1>{ title }</h1>
-							</div>
-							{ author && (
-								<div className="design-preview__sidebar-author">
-									{ translate( 'By %(author)s', { args: { author } } ) }
-								</div>
-							) }
-							{ ( pricingBadge || categories.length > 0 ) && (
-								<div className="design-preview__sidebar-badges">
-									{ pricingBadge }
-									{ categories.map( ( category ) => (
-										<CategoryBadge
-											key={ category.slug }
-											category={ category }
-											onClick={ onClickCategory }
-										/>
-									) ) }
-								</div>
-							) }
-							{ ( description || shortDescription ) && (
-								<div className="design-preview__sidebar-description">
-									<p>
-										{ isShowDescriptionToggle ? (
-											<>
-												{ isShowFullDescription ? description : shortDescription }
-												<Button
-													borderless
-													onClick={ () => setIsShowFullDescription( ! isShowFullDescription ) }
-												>
-													{ isShowFullDescription
-														? translate( 'Read less' )
-														: translate( 'Read more' ) }
-												</Button>
-											</>
-										) : (
-											description ?? shortDescription
-										) }
-									</p>
-								</div>
-							) }
+			<NavigatorScreens screens={ screens } onNavigatorPathChange={ onNavigatorPathChange }>
+				<>
+					<div className="design-preview__sidebar-header">
+						<div className="design-preview__sidebar-title">
+							<h1>{ title }</h1>
 						</div>
-						{ navigatorButtons }
-						{ actionButtons && (
-							<div className="design-preview__sidebar-action-buttons">{ actionButtons }</div>
+						{ author && (
+							<div className="design-preview__sidebar-author">
+								{ translate( 'By %(author)s', { args: { author } } ) }
+							</div>
 						) }
-					</>
-				</NavigatorScreens>
-			</div>
+						{ ( pricingBadge || categories.length > 0 ) && (
+							<div className="design-preview__sidebar-badges">
+								{ pricingBadge }
+								{ categories.map( ( category ) => (
+									<CategoryBadge
+										key={ category.slug }
+										category={ category }
+										onClick={ onClickCategory }
+									/>
+								) ) }
+							</div>
+						) }
+						{ ( description || shortDescription ) && (
+							<div className="design-preview__sidebar-description">
+								<p>
+									{ isShowDescriptionToggle ? (
+										<>
+											{ isShowFullDescription ? description : shortDescription }
+											<Button
+												borderless
+												onClick={ () => setIsShowFullDescription( ! isShowFullDescription ) }
+											>
+												{ isShowFullDescription
+													? translate( 'Read less' )
+													: translate( 'Read more' ) }
+											</Button>
+										</>
+									) : (
+										description ?? shortDescription
+									) }
+								</p>
+							</div>
+						) }
+					</div>
+					{ navigatorButtons }
+					{ actionButtons && (
+						<div className="design-preview__sidebar-action-buttons">{ actionButtons }</div>
+					) }
+				</>
+			</NavigatorScreens>
 		</div>
 	);
 };

--- a/packages/design-preview/src/components/site-preview.tsx
+++ b/packages/design-preview/src/components/site-preview.tsx
@@ -3,12 +3,14 @@ import { ThemePreview } from '@automattic/design-picker';
 interface SitePreviewProps {
 	url: string;
 	inlineCss?: string;
+	isFullscreen?: boolean;
 	recordDeviceClick: ( device: string ) => void;
 }
 
 const SitePreview: React.FC< SitePreviewProps > = ( {
 	url,
 	inlineCss = '',
+	isFullscreen,
 	recordDeviceClick,
 } ) => {
 	return (
@@ -16,8 +18,9 @@ const SitePreview: React.FC< SitePreviewProps > = ( {
 			<ThemePreview
 				url={ url }
 				inlineCss={ inlineCss }
-				isShowFrameBorder
+				isShowFrameBorder={ ! isFullscreen }
 				isShowDeviceSwitcher
+				isFullscreen={ isFullscreen }
 				recordDeviceClick={ recordDeviceClick }
 			/>
 		</div>

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -8,36 +8,30 @@ $design-preview-sidebar-width: 311px;
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+	padding: 0 20px;
 
 	&.design-preview--has-multiple-screens {
-		&.design-preview--is-initial-screen {
-			padding: 0 20px;
-
-			.design-preview__sidebar {
-				position: relative;
-				width: 100%;
-				padding: 0 0 34px;
-				border: none;
-				box-shadow: none;
-				overflow: visible;
-
-				@include break-xlarge {
-					width: $design-preview-sidebar-width;
-				}
-			}
-
-			.design-preview__site-preview {
-				height: calc(100vh - 120px);
-				margin-bottom: 90px;
-
-				@include break-xlarge {
-					height: auto;
-					margin-bottom: 32px;
-				}
-			}
+		.design-preview__sidebar {
+			position: relative;
+			width: 100%;
+			padding-bottom: 34px;
+			border: none;
+			box-shadow: none;
+			overflow: visible;
 
 			@include break-xlarge {
-				padding: 0;
+				width: $design-preview-sidebar-width;
+				padding-bottom: 0;
+			}
+		}
+
+		.design-preview__site-preview {
+			height: calc(100vh - 120px);
+			margin-bottom: 90px;
+
+			@include break-xlarge {
+				height: auto;
+				margin-bottom: 32px;
 			}
 		}
 
@@ -51,24 +45,36 @@ $design-preview-sidebar-width: 311px;
 		top: 0;
 		left: 0;
 		right: 0;
-		padding-bottom: 60px;
+		padding: 0 0 60px;
 		box-sizing: border-box;
 		z-index: 1;
 
+		.design-preview__sidebar {
+			padding: 8px 8px 0;
+			overflow: auto;
+		}
+
+		.design-preview__site-preview {
+			height: 100%;
+			margin-bottom: 0;
+		}
+
 		@include break-xlarge {
 			position: relative;
-			padding-bottom: 0;
+			padding: 0;
 		}
 	}
 
 	@include break-xlarge {
 		flex-direction: row;
+		padding: 0;
 		margin: 0;
 		gap: 32px;
 	}
 }
 
 .design-preview__sidebar {
+	flex-shrink: 0;
 	align-items: center;
 	background-color: var(--color-body-background);
 	border-bottom: 1px solid rgb(0 0 0 / 5%);
@@ -78,7 +84,6 @@ $design-preview-sidebar-width: 311px;
 	inset-inline-start: 0;
 	inset-inline-end: 0;
 	overflow: auto;
-	padding: 8px 8px 0;
 	z-index: z-index(".is-section-stepper", ".design-preview__sticky-variations");
 
 	@include break-small {

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -15,11 +15,9 @@ $design-preview-sidebar-width: 311px;
 			position: relative;
 			width: 100%;
 			padding-bottom: 34px;
-			border: none;
-			box-shadow: none;
 			overflow: visible;
 
-			@include break-xlarge {
+			@include break-large {
 				width: $design-preview-sidebar-width;
 				padding-bottom: 0;
 			}
@@ -29,7 +27,7 @@ $design-preview-sidebar-width: 311px;
 			height: calc(100vh - 120px);
 			margin-bottom: 90px;
 
-			@include break-xlarge {
+			@include break-large {
 				height: auto;
 				margin-bottom: 32px;
 			}
@@ -50,7 +48,9 @@ $design-preview-sidebar-width: 311px;
 		z-index: 1;
 
 		.design-preview__sidebar {
-			padding: 8px 8px 0;
+			padding: 0;
+			border-bottom: 1px solid rgb(0 0 0 / 5%);
+			box-shadow: -4px 0 8px rgb(0 0 0 / 7%);
 			overflow: auto;
 		}
 
@@ -59,13 +59,13 @@ $design-preview-sidebar-width: 311px;
 			margin-bottom: 0;
 		}
 
-		@include break-xlarge {
+		@include break-large {
 			position: relative;
 			padding: 0;
 		}
 	}
 
-	@include break-xlarge {
+	@include break-large {
 		flex-direction: row;
 		padding: 0;
 		margin: 0;
@@ -77,28 +77,47 @@ $design-preview-sidebar-width: 311px;
 	flex-shrink: 0;
 	align-items: center;
 	background-color: var(--color-body-background);
-	border-bottom: 1px solid rgb(0 0 0 / 5%);
-	box-shadow: -4px 0 8px rgb(0 0 0 / 7%);
 	box-sizing: border-box;
 	display: flex;
 	inset-inline-start: 0;
 	inset-inline-end: 0;
 	overflow: auto;
-	z-index: z-index(".is-section-stepper", ".design-preview__sticky-variations");
 
-	@include break-small {
-		align-items: center;
-		justify-content: center;
+	/**
+	 * Global Styles Variations
+	 */
+	.global-styles-variations__type.combined-variations {
+		.global-styles-variations__header {
+			display: none;
+			@include break-large {
+				display: flex;
+			}
+		}
 	}
 
-	@include break-xlarge {
-		border: 0;
-		box-shadow: none;
-		display: block;
-		height: auto;
-		padding: 0;
+	/**
+	 * Gutenberg Components
+	 */
+	.components-navigator-provider,
+	.components-navigator-screen {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		overflow-x: visible;
+		// Disable the animation of the transform on the mobile
+		transform: none !important;
+
+		@include break-large {
+			transform: initial;
+		}
+	}
+
+	@include break-large {
 		position: relative;
 		width: $design-preview-sidebar-width;
+		height: 100%;
+		flex-direction: column;
+		justify-content: flex-start;
 	}
 }
 
@@ -117,7 +136,7 @@ $design-preview-sidebar-width: 311px;
 		box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
 	}
 
-	@include break-xlarge {
+	@include break-large {
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
@@ -126,155 +145,120 @@ $design-preview-sidebar-width: 311px;
 	}
 }
 
-.design-preview__sidebar-content {
-	.global-styles-variations__type.combined-variations {
-		.global-styles-variations__header {
-			display: none;
-			@include break-xlarge {
-				display: flex;
-			}
-		}
+.design-preview__sidebar-header {
+	display: none;
+	margin-bottom: 32px;
+
+	.design-preview__sidebar--has-multiple-screens & {
+		display: block;
 	}
 
-	.design-preview__sidebar-header {
-		display: none;
-		margin-bottom: 32px;
+	@include break-large {
+		display: block;
+	}
+}
 
-		.design-preview__sidebar--has-multiple-screens & {
-			display: block;
-		}
+.design-preview__sidebar-title {
+	margin: 0;
 
-		@include break-xlarge {
-			display: block;
-		}
+	h1 {
+		color: var(--studio-gray-100);
+		font-family: $brand-serif;
+		font-size: 2rem;
+		font-weight: 400;
+		letter-spacing: -0.4px;
+		line-height: 32px;
 	}
 
-	.design-preview__sidebar-title {
-		margin: 0;
+	.design-picker-design-title__container {
+		align-items: flex-start;
+		display: flex;
+		flex-direction: column-reverse;
+		gap: 16px;
+		justify-content: center;
 
-		h1 {
-			color: var(--studio-gray-100);
-			font-family: $brand-serif;
-			font-size: 2rem;
-			font-weight: 400;
-			letter-spacing: -0.4px;
-			line-height: 32px;
-		}
-
-		.design-picker-design-title__container {
-			align-items: flex-start;
-			display: flex;
-			flex-direction: column-reverse;
-			gap: 16px;
-			justify-content: center;
-
-			.premium-badge,
-			.woocommerce-bundled-badge {
-				letter-spacing: 0.2px;
-				margin: 0;
-			}
-		}
-
-		@include break-xlarge {
-			display: block;
-		}
-	}
-
-	.design-preview__sidebar-author {
-		font-size: $font-body-small;
-
-		@include break-xlarge {
-			display: block;
-			margin-top: 0.25rem;
-		}
-	}
-
-	.design-preview__sidebar-badges {
 		.premium-badge,
 		.woocommerce-bundled-badge {
 			letter-spacing: 0.2px;
 			margin: 0;
 		}
+	}
 
-		.design-preview__sidebar-badge-category {
-			background-color: rgba(0, 0, 0, 0.05);
-			color: var(--studio-gray-100);
-			border-radius: 4px;
-			font-size: $font-body-extra-small;
-			height: 20px;
-			line-height: 20px;
-			padding: 0 10px;
+	@include break-large {
+		display: block;
+	}
+}
 
-			&:is(button) {
-				cursor: pointer;
-			}
-		}
+.design-preview__sidebar-author {
+	font-size: $font-body-small;
 
-		@include break-xlarge {
-			display: flex;
-			flex-wrap: wrap;
-			gap: 8px 4px;
-			margin-top: 0.75rem;
+	@include break-large {
+		display: block;
+		margin-top: 0.25rem;
+	}
+}
+
+.design-preview__sidebar-badges {
+	.premium-badge,
+	.woocommerce-bundled-badge {
+		letter-spacing: 0.2px;
+		margin: 0;
+	}
+
+	.design-preview__sidebar-badge-category {
+		background-color: rgba(0, 0, 0, 0.05);
+		color: var(--studio-gray-100);
+		border-radius: 4px;
+		font-size: $font-body-extra-small;
+		height: 20px;
+		line-height: 20px;
+		padding: 0 10px;
+
+		&:is(button) {
+			cursor: pointer;
 		}
 	}
 
-	.design-preview__sidebar-description {
-		margin-top: 16px;
+	@include break-large {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px 4px;
+		margin-top: 0.75rem;
+	}
+}
 
-		> p {
-			color: var(--studio-gray-80);
+.design-preview__sidebar-description {
+	margin-top: 16px;
+
+	> p {
+		color: var(--studio-gray-80);
+		font-size: 1rem;
+		line-height: 24px;
+
+		button {
+			color: var(--color-link);
+			display: block;
 			font-size: 1rem;
 			line-height: 24px;
+			padding: 0;
 
-			button {
+			&:active,
+			&:focus {
 				color: var(--color-link);
-				display: block;
-				font-size: 1rem;
-				line-height: 24px;
-				padding: 0;
-
-				&:active,
-				&:focus {
-					color: var(--color-link);
-				}
 			}
 		}
-
-		@include break-xlarge {
-			display: block;
-			margin-top: 32px;
-		}
 	}
 
-	@include break-xlarge {
-		display: flex;
-		flex-direction: column;
-		height: 100%;
-	}
-
-	/**
-	 * Gutenberg Components
-	 */
-	.components-navigator-provider,
-	.components-navigator-screen {
-		display: flex;
-		flex-direction: column;
-		height: 100%;
-		overflow-x: visible;
-		// Disable the animation of the transform on the mobile
-		transform: none !important;
-
-		@include break-xlarge {
-			transform: initial;
-		}
+	@include break-large {
+		display: block;
+		margin-top: 32px;
 	}
 }
 
 .design-preview__sidebar-variations {
 	display: block;
-	padding: 2px 16px;
+	padding: 16px 24px 8px 32px;
 	margin: 0 -16px;
-	overflow-y: auto;
 
 	> p {
 		color: var(--studio-gray-100);
@@ -302,25 +286,24 @@ $design-preview-sidebar-width: 311px;
 		}
 	}
 
-	.color-palette-variations {
-		display: flex;
-		margin: 6px 0;
-
-		.global-styles-variation__item {
-			width: 83px;
-		}
-	}
-
+	.color-palette-variations,
 	.font-pairing-variations {
 		display: flex;
-		margin: 6px 0;
-
-		.global-styles-variation__item {
-			width: 120px;
-		}
+		margin: 12px -2px 6px;
 	}
 
-	@include break-xlarge {
+	.color-palette-variations .global-styles-variation__item {
+		width: 83px;
+	}
+
+	.font-pairing-variations .global-styles-variation__item {
+		width: 120px;
+	}
+
+	@include break-large {
+		padding: 8px 16px 0;
+		overflow-y: auto;
+
 		> p {
 			display: block;
 		}
@@ -356,13 +339,13 @@ $design-preview-sidebar-width: 311px;
 	flex-grow: 1;
 	position: relative;
 
-	@include break-xlarge {
+	@include break-large {
 		margin-bottom: 32px;
 	}
 
 	.theme-preview__frame-wrapper {
 		.theme-preview__frame {
-			@media ( max-width: $break-xlarge ) {
+			@media ( max-width: $break-large ) {
 				border: 0;
 				border-radius: 0;
 				box-shadow: none;
@@ -377,7 +360,7 @@ $design-preview-sidebar-width: 311px;
 		display: none;
 		margin-top: -11px;
 
-		@include break-xlarge {
+		@include break-large {
 			display: block;
 		}
 	}

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -102,14 +102,12 @@ $design-preview-sidebar-width: 311px;
 	.components-navigator-screen {
 		display: flex;
 		flex-direction: column;
+		width: 100%;
 		height: 100%;
 		overflow-x: visible;
+
 		// Disable the animation of the transform on the mobile
 		transform: none !important;
-
-		@include break-large {
-			transform: initial;
-		}
 	}
 
 	@include break-large {

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -2,10 +2,35 @@
 @import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/fonts";
 
+$design-preview-sidebar-width: 311px;
+
 .design-preview {
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+
+	&.design-preview--has-multiple-screens {
+		padding: 0 20px;
+
+		.design-preview__sidebar {
+			position: relative;
+			width: 100%;
+			padding: 0 0 34px;
+			border: none;
+			box-shadow: none;
+			overflow: visible;
+		}
+
+		.design-preview__sidebar-header {
+			display: block;
+		}
+
+		@include break-xlarge {
+			.design-preview__sidebar {
+				width: $design-preview-sidebar-width;
+			}
+		}
+	}
 
 	@include break-xlarge {
 		flex-direction: row;
@@ -29,30 +54,6 @@
 	top: 0;
 	z-index: z-index(".is-section-stepper", ".design-preview__sticky-variations");
 
-	.design-preview__sidebar-action-buttons {
-		display: none;
-		position: sticky;
-		bottom: 0;
-		width: 100%;
-		background-color: var(--studio-white);
-		z-index: z-index("root", ".design-preview__sidebar-action-buttons");
-
-		a,
-		button {
-			width: 100%;
-			border-radius: 4px;
-			box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
-		}
-
-		@include break-xlarge {
-			display: flex;
-			flex-direction: column;
-			gap: 8px;
-			padding: 32px 16px;
-			margin: 0 -16px;
-		}
-	}
-
 	@include break-small {
 		align-items: center;
 		justify-content: center;
@@ -65,7 +66,31 @@
 		height: auto;
 		padding: 0;
 		position: relative;
-		width: 311px;
+		width: $design-preview-sidebar-width;
+	}
+}
+
+.design-preview__sidebar-action-buttons {
+	display: none;
+	position: sticky;
+	bottom: 0;
+	width: 100%;
+	background-color: var(--studio-white);
+	z-index: z-index("root", ".design-preview__sidebar-action-buttons");
+
+	a,
+	button {
+		width: 100%;
+		border-radius: 4px;
+		box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
+	}
+
+	@include break-xlarge {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 32px 16px;
+		margin: 0 -16px;
 	}
 }
 
@@ -80,13 +105,19 @@
 	}
 
 	.design-preview__sidebar-header {
+		display: none;
+		margin-bottom: 32px;
+
+		.design-preview__sidebar--has-multiple-screens & {
+			display: block;
+		}
+
 		@include break-xlarge {
-			margin-bottom: 2rem;
+			display: block;
 		}
 	}
 
 	.design-preview__sidebar-title {
-		display: none;
 		margin: 0;
 
 		h1 {
@@ -118,7 +149,6 @@
 	}
 
 	.design-preview__sidebar-author {
-		display: none;
 		font-size: $font-body-small;
 
 		@include break-xlarge {
@@ -128,8 +158,6 @@
 	}
 
 	.design-preview__sidebar-badges {
-		display: none;
-
 		.premium-badge,
 		.woocommerce-bundled-badge {
 			letter-spacing: 0.2px;
@@ -159,7 +187,7 @@
 	}
 
 	.design-preview__sidebar-description {
-		display: none;
+		margin-top: 16px;
 
 		> p {
 			color: var(--studio-gray-80);
@@ -182,7 +210,7 @@
 
 		@include break-xlarge {
 			display: block;
-			margin-top: 2rem;
+			margin-top: 32px;
 		}
 	}
 

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -10,25 +10,54 @@ $design-preview-sidebar-width: 311px;
 	height: 100%;
 
 	&.design-preview--has-multiple-screens {
-		padding: 0 20px;
+		&.design-preview--is-initial-screen {
+			padding: 0 20px;
 
-		.design-preview__sidebar {
-			position: relative;
-			width: 100%;
-			padding: 0 0 34px;
-			border: none;
-			box-shadow: none;
-			overflow: visible;
+			.design-preview__sidebar {
+				position: relative;
+				width: 100%;
+				padding: 0 0 34px;
+				border: none;
+				box-shadow: none;
+				overflow: visible;
+
+				@include break-xlarge {
+					width: $design-preview-sidebar-width;
+				}
+			}
+
+			.design-preview__site-preview {
+				height: calc(100vh - 120px);
+				margin-bottom: 90px;
+
+				@include break-xlarge {
+					height: auto;
+					margin-bottom: 32px;
+				}
+			}
+
+			@include break-xlarge {
+				padding: 0;
+			}
 		}
 
 		.design-preview__sidebar-header {
 			display: block;
 		}
+	}
+
+	&.design-preview--is-fullscreen {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		padding-bottom: 60px;
+		box-sizing: border-box;
+		z-index: 1;
 
 		@include break-xlarge {
-			.design-preview__sidebar {
-				width: $design-preview-sidebar-width;
-			}
+			position: relative;
+			padding-bottom: 0;
 		}
 	}
 
@@ -50,8 +79,6 @@ $design-preview-sidebar-width: 311px;
 	inset-inline-end: 0;
 	overflow: auto;
 	padding: 8px 8px 0;
-	position: fixed;
-	top: 0;
 	z-index: z-index(".is-section-stepper", ".design-preview__sticky-variations");
 
 	@include break-small {
@@ -229,6 +256,12 @@ $design-preview-sidebar-width: 311px;
 		flex-direction: column;
 		height: 100%;
 		overflow-x: visible;
+		// Disable the animation of the transform on the mobile
+		transform: none !important;
+
+		@include break-xlarge {
+			transform: initial;
+		}
 	}
 }
 

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -127,7 +127,6 @@ $design-preview-sidebar-width: 311px;
 	bottom: 0;
 	width: 100%;
 	background-color: var(--studio-white);
-	z-index: z-index("root", ".design-preview__sidebar-action-buttons");
 
 	a,
 	button {

--- a/packages/global-styles/src/components/global-styles-variations/style.scss
+++ b/packages/global-styles/src/components/global-styles-variations/style.scss
@@ -5,7 +5,7 @@
 	display: flex;
 	gap: 12px;
 	flex-direction: row;
-	@include break-xlarge {
+	@include break-large {
 		flex-direction: column;
 	}
 }
@@ -15,7 +15,7 @@
 	flex-wrap: wrap;
 	gap: 8px;
 	overflow: scroll;
-	padding: 6px 2px 12px 2px;
+	padding: 6px 2px;
 
 	scrollbar-width: none;
 
@@ -23,7 +23,7 @@
 		display: none;
 	}
 
-	@include break-xlarge {
+	@include break-large {
 		padding-top: 12px;
 	}
 
@@ -48,7 +48,7 @@
 		display: none;
 	}
 
-	@include break-xlarge {
+	@include break-large {
 		.global-styles-variations__free-badge {
 			display: inline-flex;
 		}
@@ -74,7 +74,7 @@
 	margin: 0;
 
 	display: none;
-	@include break-xlarge {
+	@include break-large {
 		display: block;
 	}
 }
@@ -137,7 +137,7 @@
 		position: absolute;
 		top: 9px;
 		left: 0;
-		@include break-xlarge {
+		@include break-large {
 			display: none;
 		}
 	}

--- a/packages/onboarding/src/navigator/navigator-header/style.scss
+++ b/packages/onboarding/src/navigator/navigator-header/style.scss
@@ -6,7 +6,7 @@
 	display: none;
 	margin-bottom: 30px;
 
-	@include break-xlarge {
+	@include break-large {
 		display: block;
 	}
 }

--- a/packages/onboarding/src/navigator/navigator-screens/hooks/use-navigator-screens.tsx
+++ b/packages/onboarding/src/navigator/navigator-screens/hooks/use-navigator-screens.tsx
@@ -1,12 +1,15 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import {
 	__experimentalNavigatorBackButton as NavigatorBackButton,
 	__experimentalNavigatorScreen as NavigatorScreen,
 } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import NavigatorHeader from '../../navigator-header';
 import type { NavigatorScreenObject } from '../types';
 
 const useNavigatorScreens = ( screens: NavigatorScreenObject[] ) => {
+	const translate = useTranslate();
+
 	return screens.map(
 		( { path, label, title, description, hideBack, content, actionText, onSubmit, onBack } ) => (
 			<NavigatorScreen key={ path } path={ path }>
@@ -19,6 +22,17 @@ const useNavigatorScreens = ( screens: NavigatorScreenObject[] ) => {
 					/>
 					{ content }
 					<div className="navigator-screen__footer">
+						<NavigatorBackButton
+							className="navigator-screen__footer-back-button"
+							as={ Button }
+							title={ translate( 'Back' ) }
+							borderless={ true }
+							aria-label={ translate( 'Navigate to the previous view' ) }
+							onClick={ onBack }
+						>
+							<Gridicon icon="chevron-left" size={ 18 } />
+							{ translate( 'Back' ) }
+						</NavigatorBackButton>
 						<NavigatorBackButton as={ Button } primary onClick={ onSubmit }>
 							{ actionText }
 						</NavigatorBackButton>

--- a/packages/onboarding/src/navigator/navigator-screens/navigator-screens.scss
+++ b/packages/onboarding/src/navigator/navigator-screens/navigator-screens.scss
@@ -2,24 +2,58 @@
 @import "@wordpress/base-styles/mixins";
 
 .navigator-screen__footer {
-	display: none;
-	position: sticky;
+	display: flex;
+	position: fixed;
+	align-items: center;
+	justify-content: space-between;
+	left: 0;
+	right: 0;
 	bottom: 0;
 	width: 100%;
+	height: 60px;
+	padding: 0 20px;
+	box-shadow: inset 0 1px 0 #e2e4e7;
+	box-sizing: border-box;
 	background-color: var(--studio-white);
 
 	a,
 	button {
-		width: 100%;
 		border-radius: 4px;
 		box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
+	}
+
+	.navigator-screen__footer-back-button {
+		display: block;
+		color: #101517;
+		font-size: $font-body-small;
+		font-weight: 600;
+
+		svg.gridicon {
+			width: 20px;
+			height: 20px;
+			top: 5px;
+			margin-right: 2px;
+
+			.rtl & {
+				transform: scaleX(-1);
+			}
+		}
 	}
 
 	@include break-xlarge {
 		display: flex;
 		flex-direction: column;
+		align-items: initial;
+		position: sticky;
+		height: auto;
 		gap: 8px;
 		padding: 32px 16px;
 		margin: 0 -16px;
+		box-shadow: none;
+		box-sizing: content-box;
+
+		.navigator-screen__footer-back-button {
+			display: none;
+		}
 	}
 }

--- a/packages/onboarding/src/navigator/navigator-screens/navigator-screens.scss
+++ b/packages/onboarding/src/navigator/navigator-screens/navigator-screens.scss
@@ -41,7 +41,7 @@
 		}
 	}
 
-	@include break-xlarge {
+	@include break-large {
 		display: flex;
 		flex-direction: column;
 		align-items: initial;

--- a/packages/onboarding/src/navigator/navigator-screens/navigator-screens.scss
+++ b/packages/onboarding/src/navigator/navigator-screens/navigator-screens.scss
@@ -1,3 +1,4 @@
+@import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78419

## Proposed Changes

* `@automattic/design-preview`: Now it can deal with the height by itself.
  * On the main screen (with navigator buttons), the height grows automatically
  * On the other screens, the height is the same as the viewport height reducing the height of the navigator footer. Also, the navigator screen will stick to the top of the screen on mobile.
* `DeviceSwitcher`: Introduce a new prop called `isFullscreen` to eliminate the max width/height
* Adjust lots of the styles to support mobile layout.

**Screenshots**

| Main | Bottom of Main | Colors | Fonts |
| - | - | - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/a7bb4ce7-c210-4334-9b01-8b0be45f4786) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/97b6cbd5-38d4-4823-90b4-b1275f7cfab9) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/835777ca-922e-4b47-992d-4c5210694d56) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/c0382f21-3ff1-4609-a52b-9306cba89a61) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the URLs below, especially for the mobile screen
  * /setup?siteSlug=<your_site>: Fonts only
  * /setup?siteSlug=<your_site>&flags=signup/design-picker-preview-colors: Colors & Fonts
* Continue until you land on the Design Picker
* Preview the design with style variation, everything should be good as before
* Preview the design without the style variation, and ensure you're able to navigate between screens

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
