### PR TITLE
Bulk Domain Transfer: Align Jetpack logo

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -59,6 +59,11 @@
 		@media ( max-width: $break-medium ) {
 			padding: 0 20px;
 		}
+
+		.step-container__jetpack-powered {
+			margin-top: auto;
+			margin-bottom: 56px;
+		}
 	}
 
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -29,6 +29,9 @@ $heading-font-family: "SF Pro Display", $sans;
 
 		.step-container.intro {
 			font-family: $font-family;
+			display: flex;
+			flex-direction: column;
+			height: 100%;
 
 			@media (max-width: $break-medium ) {
 				padding: 0;
@@ -125,7 +128,8 @@ $heading-font-family: "SF Pro Display", $sans;
 			}
 
 			.step-container__jetpack-powered {
-				margin-top: 22px;
+				margin-top: auto;
+				margin-bottom: 56px;
 			}
 		}
 	}


### PR DESCRIPTION
This PR aligns the jetpack logo on the bottom of the domain transfer flow.

## Testing
1. Live link and visit `/setup/domain-transfer`
2. Check intro and domains step, logo should be aligned
3. Check mobile