### PR TITLE
GS on Personal A/B: Site editor notice show the correct message

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -161,16 +161,19 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 		true
 	);
 	wp_set_script_translations( 'wpcom-global-styles-editor', 'full-site-editing' );
-	$plan = wpcom_site_has_global_styles_in_personal_plan() ? 'personal-bundle' : 'value_bundle';
-	wp_localize_script(
-		'wpcom-global-styles-editor',
-		'wpcomGlobalStyles',
-		array(
-			'assetsUrl'   => plugins_url( 'dist/', __FILE__ ),
-			'upgradeUrl'  => "$calypso_domain/plans/$site_slug?plan=$plan&feature=style-customization",
-			'wpcomBlogId' => wpcom_global_styles_get_wpcom_current_blog_id(),
-		)
+	$is_global_styles_in_personal_plan = wpcom_site_has_global_styles_in_personal_plan();
+	$plan                              = $is_global_styles_in_personal_plan ? 'personal-bundle' : 'value_bundle';
+	$data                              = array(
+		'assetsUrl'   => plugins_url( 'dist/', __FILE__ ),
+		'upgradeUrl'  => "$calypso_domain/plans/$site_slug?plan=$plan&feature=style-customization",
+		'wpcomBlogId' => wpcom_global_styles_get_wpcom_current_blog_id(),
 	);
+
+	if ( $is_global_styles_in_personal_plan ) {
+		$data['globalStylesInPersonalPlan'] = $is_global_styles_in_personal_plan;
+	}
+
+	wp_localize_script( 'wpcom-global-styles-editor', 'wpcomGlobalStyles', $data );
 	wp_enqueue_style(
 		'wpcom-global-styles-editor',
 		plugins_url( 'dist/wpcom-global-styles.css', __FILE__ ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -163,14 +163,20 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 	wp_set_script_translations( 'wpcom-global-styles-editor', 'full-site-editing' );
 	$is_global_styles_in_personal_plan = wpcom_site_has_global_styles_in_personal_plan();
 	$plan                              = $is_global_styles_in_personal_plan ? 'personal-bundle' : 'value_bundle';
+
+	$reset_global_styles_support_url = 'https://wordpress.com/support/using-styles/#reset-all-styles';
+	if ( class_exists( 'WPCom_Languages' ) ) {
+		$reset_global_styles_support_url = WPCom_Languages::localize_url( $reset_global_styles_support_url );
+	}
 	wp_localize_script(
 		'wpcom-global-styles-editor',
 		'wpcomGlobalStyles',
 		array(
-			'assetsUrl'                  => plugins_url( 'dist/', __FILE__ ),
-			'upgradeUrl'                 => "$calypso_domain/plans/$site_slug?plan=$plan&feature=style-customization",
-			'wpcomBlogId'                => wpcom_global_styles_get_wpcom_current_blog_id(),
-			'globalStylesInPersonalPlan' => $is_global_styles_in_personal_plan,
+			'assetsUrl'                   => plugins_url( 'dist/', __FILE__ ),
+			'upgradeUrl'                  => "$calypso_domain/plans/$site_slug?plan=$plan&feature=style-customization",
+			'wpcomBlogId'                 => wpcom_global_styles_get_wpcom_current_blog_id(),
+			'globalStylesInPersonalPlan'  => $is_global_styles_in_personal_plan,
+			'resetGlobalStylesSupportUrl' => $reset_global_styles_support_url,
 		)
 	);
 	wp_enqueue_style(

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -163,17 +163,16 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 	wp_set_script_translations( 'wpcom-global-styles-editor', 'full-site-editing' );
 	$is_global_styles_in_personal_plan = wpcom_site_has_global_styles_in_personal_plan();
 	$plan                              = $is_global_styles_in_personal_plan ? 'personal-bundle' : 'value_bundle';
-	$data                              = array(
-		'assetsUrl'   => plugins_url( 'dist/', __FILE__ ),
-		'upgradeUrl'  => "$calypso_domain/plans/$site_slug?plan=$plan&feature=style-customization",
-		'wpcomBlogId' => wpcom_global_styles_get_wpcom_current_blog_id(),
+	wp_localize_script(
+		'wpcom-global-styles-editor',
+		'wpcomGlobalStyles',
+		array(
+			'assetsUrl'                  => plugins_url( 'dist/', __FILE__ ),
+			'upgradeUrl'                 => "$calypso_domain/plans/$site_slug?plan=$plan&feature=style-customization",
+			'wpcomBlogId'                => wpcom_global_styles_get_wpcom_current_blog_id(),
+			'globalStylesInPersonalPlan' => $is_global_styles_in_personal_plan,
+		)
 	);
-
-	if ( $is_global_styles_in_personal_plan ) {
-		$data['globalStylesInPersonalPlan'] = $is_global_styles_in_personal_plan;
-	}
-
-	wp_localize_script( 'wpcom-global-styles-editor', 'wpcomGlobalStyles', $data );
 	wp_enqueue_style(
 		'wpcom-global-styles-editor',
 		plugins_url( 'dist/wpcom-global-styles.css', __FILE__ ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -5,11 +5,12 @@ import { ExternalLink, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement, render, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { useCanvas } from './use-canvas';
 import { useGlobalStylesConfig } from './use-global-styles-config';
 import { usePreview } from './use-preview';
 import './notice.scss';
+
+const GLOBAL_STYLES_TREATMENT_GROUP = '1';
 
 const trackEvent = ( eventName, isSiteEditor = true ) =>
 	recordTracksEvent( eventName, {
@@ -19,7 +20,6 @@ const trackEvent = ( eventName, isSiteEditor = true ) =>
 
 function GlobalStylesWarningNotice() {
 	const { globalStylesInUse } = useGlobalStylesConfig();
-	const { globalStylesInPersonalPlan } = useSiteGlobalStylesStatus();
 
 	useEffect( () => {
 		if ( globalStylesInUse ) {
@@ -32,7 +32,7 @@ function GlobalStylesWarningNotice() {
 	}
 
 	let upgradeTranslation;
-	if ( globalStylesInPersonalPlan ) {
+	if ( wpcomGlobalStyles?.globalStylesInPersonalPlan === GLOBAL_STYLES_TREATMENT_GROUP ) {
 		upgradeTranslation = __(
 			'Your site includes customized styles that are only visible to visitors after <a>upgrading to the Personal plan or higher</a>.',
 			'full-site-editing'
@@ -167,16 +167,29 @@ function GlobalStylesEditNotice() {
 				: 'wpcom-global-styles-action-has-icon wpcom-global-styles-action-is-external wpcom-global-styles-action-is-support',
 		} );
 
-		createWarningNotice(
-			__(
-				'Your site includes customized styles that are only visible to visitors after upgrading to the Premium plan or higher.',
-				'full-site-editing'
-			),
-			{
-				id: NOTICE_ID,
-				actions: actions,
-			}
-		);
+		if ( wpcomGlobalStyles?.globalStylesInPersonalPlan === GLOBAL_STYLES_TREATMENT_GROUP ) {
+			createWarningNotice(
+				__(
+					'Your site includes customized styles that are only visible to visitors after upgrading to the Personal plan or higher.',
+					'full-site-editing'
+				),
+				{
+					id: NOTICE_ID,
+					actions: actions,
+				}
+			);
+		} else {
+			createWarningNotice(
+				__(
+					'Your site includes customized styles that are only visible to visitors after upgrading to the Premium plan or higher.',
+					'full-site-editing'
+				),
+				{
+					id: NOTICE_ID,
+					actions: actions,
+				}
+			);
+		}
 
 		trackEvent( 'calypso_global_styles_gating_notice_show', isSiteEditor );
 	}, [

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -1,6 +1,5 @@
 /* global wpcomGlobalStyles */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { ExternalLink, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement, render, useCallback, useEffect } from '@wordpress/element';
@@ -127,12 +126,7 @@ function GlobalStylesEditNotice() {
 	}, [ editEntityRecord, globalStylesId, isSiteEditor ] );
 
 	const openResetGlobalStylesSupport = useCallback( () => {
-		window
-			.open(
-				localizeUrl( 'https://wordpress.com/support/using-styles/#reset-all-styles' ),
-				'_blank'
-			)
-			.focus();
+		window.open( wpcomGlobalStyles.resetGlobalStylesSupportUrl, '_blank' ).focus();
 		trackEvent( 'calypso_global_styles_gating_notice_reset_support_click', isSiteEditor );
 	}, [ isSiteEditor ] );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2864

## Proposed Changes

Changed the Global Styles notice.js component so that it reads if the user is GS on Personal A/B context and displays the message accordingly.
We register the `globalStylesInPersonalPlan` property in the `wpcomGlobalStyles` global variable used within the editor context.


| Before | After |
-----|-----
|![Captura de Pantalla 2023-07-04 a las 16 01 37](https://github.com/Automattic/wp-calypso/assets/1989914/50fcc205-e646-43d3-aa7c-59545ad96512)|![Captura de Pantalla 2023-07-04 a las 15 59 21](https://github.com/Automattic/wp-calypso/assets/1989914/971d9f58-e7f0-449f-893b-7b713ea97ca9)

| Before | After |
-----|-----
![Captura de Pantalla 2023-07-04 a las 16 01 01](https://github.com/Automattic/wp-calypso/assets/1989914/161a0dd0-a6bf-4acf-8247-e1649f66dac3)|![Captura de Pantalla 2023-07-04 a las 15 59 52](https://github.com/Automattic/wp-calypso/assets/1989914/4e734033-5d36-4d25-bf2e-4f982d82583c)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* `install-plugin.sh editing-toolkit add/gs-notice-is-gs-on-personal-ab-aware`
* On a free site and in the treatment group.
* Choose a paid variation, you should see that the message displayed has the correct text. `https://yoursite/wp-admin/site-editor.php`
* Change or add global styles to your site. `https://{yoursite}/wp-admin/site-editor.php?canvas=edit`
* You should see that the edit message displays the correct text. 
* Change your group from treatment to control and repeat.

You can change your group here (21268-explat-experiment), you also need to clear the cache when switching between groups by executing this command in your sandbox:
`wp_cache_delete( 'global-styles-on-personal-{siteId}', 'a8c_experiments' );` 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
