### PR TITLE
Edge Cache i1: remove dispatch when recordTracksEvent to fix toggle regression

### DIFF
--- a/client/my-sites/hosting/cache-card/index.js
+++ b/client/my-sites/hosting/cache-card/index.js
@@ -3,7 +3,6 @@ import config from '@automattic/calypso-config';
 import { Button, Card } from '@automattic/components';
 import styled from '@emotion/styled';
 import { ToggleControl } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
@@ -68,7 +67,6 @@ export const CacheCard = ( {
 	siteSlug,
 	translate,
 } ) => {
-	const dispatch = useDispatch();
 	const showEdgeCache = config.isEnabled( 'yolo/edge-cache-i1' );
 	const {
 		isLoading: getEdgeCacheLoading,
@@ -85,26 +83,22 @@ export const CacheCard = ( {
 		{
 			onSettled: ( ...args ) => {
 				const active = args[ 2 ];
-				dispatch(
-					recordTracksEvent(
-						active
-							? 'calypso_hosting_configuration_edge_cache_enable'
-							: 'calypso_hosting_configuration_edge_cache_disable',
-						{
-							site_id: siteId,
-						}
-					)
+				recordTracksEvent(
+					active
+						? 'calypso_hosting_configuration_edge_cache_enable'
+						: 'calypso_hosting_configuration_edge_cache_disable',
+					{
+						site_id: siteId,
+					}
 				);
 			},
 		}
 	);
 	const { clearEdgeCache, isLoading: clearEdgeCacheLoading } = useClearEdgeCacheMutation( siteId, {
 		onSuccess: () => {
-			dispatch(
-				recordTracksEvent( 'calypso_hosting_configuration_clear_wordpress_cache', {
-					site_id: siteId,
-				} )
-			);
+			recordTracksEvent( 'calypso_hosting_configuration_clear_wordpress_cache', {
+				site_id: siteId,
+			} );
 		},
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Fixes https://github.com/Automattic/dotcom-forge/issues/2908

## Proposed Changes

* Fixes the tracks event calls.
* Fixes the toggle glitch.
The error came from running `onSettle` twice, because `dispatch( recordTracksEvent( ...` was raising an error.
On development the error appeared on console:
```
react_devtools_backend_compact.js:2367 TypeError: Cannot read properties of undefined (reading 'name')
    at getStoreName (registry.js:55:100)
    at dispatch (registry.js:206:23)
    at eval (registry.js:226:30)
    at Object.onSettled (index.js:147:7)
    at Object.onSettled (use-toggle-edge-cache.ts:49:27)
    at Mutation.execute (mutation.mjs:153:123)
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On an atomic site, Go to `Settings` > `Hosting configuration`
* Find the edge cache block
* Click once on the edge cache toggle to active it
* Observe the toggle displays the correct value all the time.
* Install Tracks Vigilante or enable Info log: p7H4VZ-3cB-p2 
* Observe the events `calypso_hosting_configuration_edge_cache_enable` and `calypso_hosting_configuration_edge_cache_disable` are triggered when the toggle changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?