### PR TITLE
Plans 2023: add sticky behaviour to the CTA bar

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -6,8 +6,10 @@ import {
 	TERM_TRIENNIALLY,
 	planMatches,
 	TERM_ANNUALLY,
+	PlanSlug,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { formatCurrency } from '@automattic/format-currency';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
@@ -16,7 +18,9 @@ import i18n, { localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getPlanBillPeriod } from 'calypso/state/plans/selectors';
+import { usePlanPricesDisplay } from '../hooks/use-plan-prices-display';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import type { PlanActionOverrides } from '../types';
 
@@ -33,13 +37,16 @@ type PlanFeaturesActionsButtonProps = {
 	isLaunchPage?: boolean | null;
 	onUpgradeClick: () => void;
 	planName: TranslateResult;
-	planType: string;
+	planSlug: string;
 	flowName?: string | null;
 	buttonText?: string;
 	isWpcomEnterpriseGridPlan: boolean;
 	isWooExpressPlusPlan?: boolean;
 	selectedSiteSlug: string | null;
 	planActionOverrides?: PlanActionOverrides;
+	showMonthlyPrice: boolean;
+	siteId?: number | null;
+	isStuck: boolean;
 };
 
 const DummyDisabledButton = styled.div`
@@ -58,11 +65,15 @@ const SignupFlowPlanFeatureActionButton = ( {
 	freePlan,
 	planName,
 	classes,
+	priceString,
+	isStuck,
 	handleUpgradeButtonClick,
 }: {
 	freePlan: boolean;
 	planName: TranslateResult;
 	classes: string;
+	priceString: string | null;
+	isStuck: boolean;
 	handleUpgradeButtonClick: () => void;
 } ) => {
 	const translate = useTranslate();
@@ -70,6 +81,13 @@ const SignupFlowPlanFeatureActionButton = ( {
 
 	if ( freePlan ) {
 		btnText = translate( 'Start with Free' );
+	} else if ( isStuck ) {
+		btnText = translate( 'Get %(plan)s – %(priceString)s', {
+			args: {
+				plan: planName,
+				priceString: priceString ?? '',
+			},
+		} );
 	} else {
 		btnText = translate( 'Get %(plan)s', {
 			args: {
@@ -89,11 +107,15 @@ const LaunchPagePlanFeatureActionButton = ( {
 	freePlan,
 	planName,
 	classes,
+	priceString,
+	isStuck,
 	handleUpgradeButtonClick,
 }: {
 	freePlan: boolean;
 	planName: TranslateResult;
 	classes: string;
+	priceString: string | null;
+	isStuck: boolean;
 	handleUpgradeButtonClick: () => void;
 } ) => {
 	const translate = useTranslate();
@@ -109,16 +131,32 @@ const LaunchPagePlanFeatureActionButton = ( {
 		);
 	}
 
+	let buttonText;
+
+	if ( isStuck ) {
+		buttonText = translate( 'Select %(plan)s – %(priceString)s', {
+			args: {
+				plan: planName,
+				priceString: priceString ?? '',
+			},
+			context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
+			comment:
+				'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+		} );
+	} else {
+		buttonText = translate( 'Select %(plan)s', {
+			args: {
+				plan: planName,
+			},
+			context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
+			comment:
+				'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+		} );
+	}
+
 	return (
 		<Button className={ classes } onClick={ handleUpgradeButtonClick }>
-			{ translate( 'Select %(plan)s', {
-				args: {
-					plan: planName,
-				},
-				context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
-				comment:
-					'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
-			} ) }
+			{ buttonText }
 		</Button>
 	);
 };
@@ -127,8 +165,10 @@ const LoggedInPlansFeatureActionButton = ( {
 	freePlan,
 	availableForPurchase,
 	classes,
+	priceString,
+	isStuck,
 	handleUpgradeButtonClick,
-	planType,
+	planSlug,
 	current,
 	manageHref,
 	canUserPurchasePlan,
@@ -139,8 +179,10 @@ const LoggedInPlansFeatureActionButton = ( {
 	freePlan: boolean;
 	availableForPurchase?: boolean;
 	classes: string;
+	priceString: string | null;
+	isStuck: boolean;
 	handleUpgradeButtonClick: () => void;
-	planType: string;
+	planSlug: string;
 	current?: boolean;
 	manageHref?: string;
 	canUserPurchasePlan?: boolean | null;
@@ -154,7 +196,7 @@ const LoggedInPlansFeatureActionButton = ( {
 		return currentSitePlanSlug ? getPlanBillPeriod( state, currentSitePlanSlug ) : null;
 	} );
 	const gridPlanBillPeriod = useSelector( ( state ) => {
-		return planType ? getPlanBillPeriod( state, planType ) : null;
+		return planSlug ? getPlanBillPeriod( state, planSlug ) : null;
 	} );
 
 	if ( freePlan ) {
@@ -177,7 +219,7 @@ const LoggedInPlansFeatureActionButton = ( {
 		);
 	}
 
-	if ( current && planType !== PLAN_P2_FREE ) {
+	if ( current && planSlug !== PLAN_P2_FREE ) {
 		return (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				{ canUserPurchasePlan ? translate( 'Manage plan' ) : translate( 'View plan' ) }
@@ -207,10 +249,10 @@ const LoggedInPlansFeatureActionButton = ( {
 		availableForPurchase &&
 		currentSitePlanSlug &&
 		! current &&
-		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug ) &&
+		getPlanClass( planSlug ) === getPlanClass( currentSitePlanSlug ) &&
 		currentSitePlanSlug !== PLAN_ECOMMERCE_TRIAL_MONTHLY
 	) {
-		if ( planMatches( planType, { term: TERM_TRIENNIALLY } ) ) {
+		if ( planMatches( planSlug, { term: TERM_TRIENNIALLY } ) ) {
 			return (
 				<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 					{ buttonText || translate( 'Upgrade to Triennial' ) }
@@ -218,7 +260,7 @@ const LoggedInPlansFeatureActionButton = ( {
 			);
 		}
 
-		if ( planMatches( planType, { term: TERM_BIENNIALLY } ) ) {
+		if ( planMatches( planSlug, { term: TERM_BIENNIALLY } ) ) {
 			return (
 				<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 					{ buttonText || translate( 'Upgrade to Biennial' ) }
@@ -226,7 +268,7 @@ const LoggedInPlansFeatureActionButton = ( {
 			);
 		}
 
-		if ( planMatches( planType, { term: TERM_ANNUALLY } ) ) {
+		if ( planMatches( planSlug, { term: TERM_ANNUALLY } ) ) {
 			return (
 				<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 					{ buttonText || translate( 'Upgrade to Yearly' ) }
@@ -235,7 +277,18 @@ const LoggedInPlansFeatureActionButton = ( {
 		}
 	}
 
-	const buttonTextFallback = buttonText ?? translate( 'Upgrade', { context: 'verb' } );
+	let buttonTextFallback;
+
+	if ( buttonText ) {
+		buttonTextFallback = buttonText;
+	} else if ( isStuck ) {
+		buttonTextFallback = translate( 'Upgrade – %(priceString)s', {
+			context: 'verb',
+			args: { priceString: priceString ?? '' },
+		} );
+	} else {
+		buttonTextFallback = translate( 'Upgrade', { context: 'verb' } );
+	}
 
 	if ( availableForPurchase ) {
 		return (
@@ -273,26 +326,37 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	isLaunchPage,
 	onUpgradeClick,
 	planName,
-	planType,
+	planSlug,
 	flowName,
 	buttonText,
 	isWpcomEnterpriseGridPlan = false,
 	isWooExpressPlusPlan = false,
 	selectedSiteSlug,
 	planActionOverrides,
+	showMonthlyPrice,
+	siteId,
+	isStuck,
 } ) => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
 	const classes = classNames( 'plan-features-2023-grid__actions-button', className, {
 		'is-current-plan': current,
+	} );
+
+	const planPrices = usePlanPricesDisplay( {
+		planSlug: planSlug as PlanSlug,
+		returnMonthly: showMonthlyPrice,
+		currentSitePlanSlug,
+		siteId,
 	} );
 
 	const handleUpgradeButtonClick = () => {
 		if ( ! freePlan ) {
 			recordTracksEvent( 'calypso_plan_features_upgrade_click', {
 				current_plan: currentSitePlanSlug,
-				upgrading_to: planType,
+				upgrading_to: planSlug,
 			} );
 		}
 
@@ -328,7 +392,9 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 					  } ) }
 			</Button>
 		);
-	} else if ( isWooExpressPlusPlan ) {
+	}
+
+	if ( isWooExpressPlusPlan ) {
 		return (
 			<ExternalLinkWithTracking
 				className={ classNames( classes ) }
@@ -340,21 +406,36 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 				{ translate( 'Get in touch' ) }
 			</ExternalLinkWithTracking>
 		);
-	} else if ( isLaunchPage ) {
+	}
+
+	const priceString = formatCurrency(
+		planPrices.discountedPrice || planPrices.originalPrice,
+		currencyCode || 'USD',
+		{
+			stripZeros: true,
+		}
+	);
+
+	if ( isLaunchPage ) {
 		return (
 			<LaunchPagePlanFeatureActionButton
 				freePlan={ freePlan }
 				planName={ planName }
 				classes={ classes }
+				priceString={ priceString }
+				isStuck={ isStuck }
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
 			/>
 		);
-	} else if ( isInSignup ) {
+	}
+	if ( isInSignup ) {
 		return (
 			<SignupFlowPlanFeatureActionButton
 				freePlan={ freePlan }
 				planName={ planName }
 				classes={ classes }
+				priceString={ priceString }
+				isStuck={ isStuck }
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
 			/>
 		);
@@ -366,7 +447,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			availableForPurchase={ availableForPurchase }
 			classes={ classes }
 			handleUpgradeButtonClick={ handleUpgradeButtonClick }
-			planType={ planType }
+			planSlug={ planSlug }
 			current={ current }
 			manageHref={ manageHref }
 			canUserPurchasePlan={ canUserPurchasePlan }
@@ -374,6 +455,8 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			buttonText={ buttonText }
 			selectedSiteSlug={ selectedSiteSlug }
 			planActionOverrides={ planActionOverrides }
+			priceString={ priceString }
+			isStuck={ isStuck }
 		/>
 	);
 };

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -46,7 +46,7 @@ type PlanFeaturesActionsButtonProps = {
 	showMonthlyPrice: boolean;
 	siteId?: number | null;
 	isStuck: boolean;
-	isLargeCurrency: boolean;
+	isLargeCurrency?: boolean;
 	currencyCode: string;
 };
 

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -442,7 +442,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 				classes={ classes }
 				priceString={ priceString }
 				isStuck={ isStuck }
-				isLargeCurrency={ isLargeCurrency }
+				isLargeCurrency={ !! isLargeCurrency }
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
 			/>
 		);
@@ -455,7 +455,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 				classes={ classes }
 				priceString={ priceString }
 				isStuck={ isStuck }
-				isLargeCurrency={ isLargeCurrency }
+				isLargeCurrency={ !! isLargeCurrency }
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
 			/>
 		);
@@ -477,7 +477,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			planActionOverrides={ planActionOverrides }
 			priceString={ priceString }
 			isStuck={ isStuck }
-			isLargeCurrency={ isLargeCurrency }
+			isLargeCurrency={ !! isLargeCurrency }
 			planName={ planName }
 		/>
 	);

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -46,6 +46,7 @@ type PlanFeaturesActionsButtonProps = {
 	showMonthlyPrice: boolean;
 	siteId?: number | null;
 	isStuck: boolean;
+	isLargeCurrency: boolean;
 	currencyCode: string;
 };
 
@@ -67,6 +68,7 @@ const SignupFlowPlanFeatureActionButton = ( {
 	classes,
 	priceString,
 	isStuck,
+	isLargeCurrency,
 	handleUpgradeButtonClick,
 }: {
 	freePlan: boolean;
@@ -74,6 +76,7 @@ const SignupFlowPlanFeatureActionButton = ( {
 	classes: string;
 	priceString: string | null;
 	isStuck: boolean;
+	isLargeCurrency: boolean;
 	handleUpgradeButtonClick: () => void;
 } ) => {
 	const translate = useTranslate();
@@ -81,7 +84,7 @@ const SignupFlowPlanFeatureActionButton = ( {
 
 	if ( freePlan ) {
 		btnText = translate( 'Start with Free' );
-	} else if ( isStuck ) {
+	} else if ( isStuck && ! isLargeCurrency ) {
 		btnText = translate( 'Get %(plan)s – %(priceString)s', {
 			args: {
 				plan: planName,
@@ -111,6 +114,7 @@ const LaunchPagePlanFeatureActionButton = ( {
 	classes,
 	priceString,
 	isStuck,
+	isLargeCurrency,
 	handleUpgradeButtonClick,
 }: {
 	freePlan: boolean;
@@ -118,6 +122,7 @@ const LaunchPagePlanFeatureActionButton = ( {
 	classes: string;
 	priceString: string | null;
 	isStuck: boolean;
+	isLargeCurrency: boolean;
 	handleUpgradeButtonClick: () => void;
 } ) => {
 	const translate = useTranslate();
@@ -135,7 +140,7 @@ const LaunchPagePlanFeatureActionButton = ( {
 
 	let buttonText;
 
-	if ( isStuck ) {
+	if ( isStuck && ! isLargeCurrency ) {
 		buttonText = translate( 'Select %(plan)s – %(priceString)s', {
 			args: {
 				plan: planName,
@@ -168,6 +173,8 @@ const LoggedInPlansFeatureActionButton = ( {
 	classes,
 	priceString,
 	isStuck,
+	isLargeCurrency,
+	planName,
 	handleUpgradeButtonClick,
 	planSlug,
 	current,
@@ -182,6 +189,8 @@ const LoggedInPlansFeatureActionButton = ( {
 	classes: string;
 	priceString: string | null;
 	isStuck: boolean;
+	isLargeCurrency: boolean;
+	planName: TranslateResult;
 	handleUpgradeButtonClick: () => void;
 	planSlug: string;
 	current?: boolean;
@@ -282,12 +291,17 @@ const LoggedInPlansFeatureActionButton = ( {
 
 	if ( buttonText ) {
 		buttonTextFallback = buttonText;
-	} else if ( isStuck ) {
+	} else if ( isStuck && ! isLargeCurrency ) {
 		buttonTextFallback = translate( 'Upgrade – %(priceString)s', {
 			context: 'verb',
 			args: { priceString: priceString ?? '' },
-			comment:
-				'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Upgrade - $10',
+			comment: '%(priceString)s is the full price including the currency. Eg: Get Upgrade - $10',
+		} );
+	} else if ( isStuck && isLargeCurrency ) {
+		buttonTextFallback = translate( 'Upgrade – %(plan)s', {
+			context: 'verb',
+			args: { plan: planName ?? '' },
+			comment: '%(plan)s is the name of the plan ',
 		} );
 	} else {
 		buttonTextFallback = translate( 'Upgrade', { context: 'verb' } );
@@ -340,6 +354,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	siteId,
 	currencyCode,
 	isStuck,
+	isLargeCurrency,
 } ) => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
@@ -427,6 +442,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 				classes={ classes }
 				priceString={ priceString }
 				isStuck={ isStuck }
+				isLargeCurrency={ isLargeCurrency }
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
 			/>
 		);
@@ -439,6 +455,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 				classes={ classes }
 				priceString={ priceString }
 				isStuck={ isStuck }
+				isLargeCurrency={ isLargeCurrency }
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
 			/>
 		);
@@ -460,6 +477,8 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			planActionOverrides={ planActionOverrides }
 			priceString={ priceString }
 			isStuck={ isStuck }
+			isLargeCurrency={ isLargeCurrency }
+			planName={ planName }
 		/>
 	);
 };

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -18,7 +18,6 @@ import i18n, { localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getPlanBillPeriod } from 'calypso/state/plans/selectors';
 import { usePlanPricesDisplay } from '../hooks/use-plan-prices-display';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
@@ -47,6 +46,7 @@ type PlanFeaturesActionsButtonProps = {
 	showMonthlyPrice: boolean;
 	siteId?: number | null;
 	isStuck: boolean;
+	currencyCode: string;
 };
 
 const DummyDisabledButton = styled.div`
@@ -335,11 +335,11 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	planActionOverrides,
 	showMonthlyPrice,
 	siteId,
+	currencyCode,
 	isStuck,
 } ) => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
 	const classes = classNames( 'plan-features-2023-grid__actions-button', className, {
 		'is-current-plan': current,

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -87,6 +87,8 @@ const SignupFlowPlanFeatureActionButton = ( {
 				plan: planName,
 				priceString: priceString ?? '',
 			},
+			comment:
+				'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Premium - $10',
 		} );
 	} else {
 		btnText = translate( 'Get %(plan)s', {
@@ -139,9 +141,8 @@ const LaunchPagePlanFeatureActionButton = ( {
 				plan: planName,
 				priceString: priceString ?? '',
 			},
-			context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
 			comment:
-				'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+				'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Select Premium - $10',
 		} );
 	} else {
 		buttonText = translate( 'Select %(plan)s', {
@@ -285,6 +286,8 @@ const LoggedInPlansFeatureActionButton = ( {
 		buttonTextFallback = translate( 'Upgrade – %(priceString)s', {
 			context: 'verb',
 			args: { priceString: priceString ?? '' },
+			comment:
+				'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Upgrade - $10',
 		} );
 	} else {
 		buttonTextFallback = translate( 'Upgrade', { context: 'verb' } );

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -466,11 +466,14 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 				isInSignup={ isInSignup }
 				isLaunchPage={ isLaunchPage }
 				planName={ planConstantObj.getTitle() }
-				planType={ planName }
+				planSlug={ planName }
 				flowName={ flowName }
 				selectedSiteSlug={ selectedSiteSlug }
 				onUpgradeClick={ () => onUpgradeClick( planProperties ) }
 				planActionOverrides={ planActionOverrides }
+				currencyCode=""
+				showMonthlyPrice={ false }
+				isStuck={ false }
 			/>
 		</Cell>
 	);

--- a/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
@@ -25,14 +25,21 @@ export function StickyContainer( props: Props ) {
 	/**
 	 * This effect sets the value of `isStuck` state when it detects that
 	 * the element is sticky.
+	 * The top property of the root margin is set at -1px (plus optional offset).
+	 * So when position:sticky takes effect, the intersection ratio will always be ~99%
 	 */
 	useLayoutEffect( () => {
 		const observer = new IntersectionObserver(
-			( [ e ] ) => {
-				if ( e.intersectionRatio === 0 ) {
+			( [ entry ] ) => {
+				if ( entry.intersectionRatio === 0 ) {
+					// The element is out of view
+					setIsStuck( false );
+				} else if ( entry.intersectionRect.bottom === entry.rootBounds?.bottom ) {
+					// The element is intersecting, but it is at the bottom of the screen
 					setIsStuck( false );
 				} else {
-					setIsStuck( e.intersectionRatio < 1 );
+					// The element is in the "stuck" state
+					setIsStuck( entry.intersectionRatio < 1 );
 				}
 			},
 			{

--- a/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
@@ -1,10 +1,9 @@
 import { Global, css } from '@emotion/react';
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import styled from '@emotion/styled';
-import { useRef, type ElementType, useState, useLayoutEffect } from 'react';
+import { useRef, type ElementType, useState, useLayoutEffect, ReactNode } from 'react';
 
 type Props = {
-	children: ( isStuck: boolean ) => EmotionJSX.Element[];
+	children: ( isStuck: boolean ) => ReactNode;
 	stickyClass?: string;
 	element?: ElementType;
 	stickyOffset?: number; // offset from the top of the scrolling container to control when the element should start sticking, default 0

--- a/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
@@ -1,0 +1,102 @@
+import { Global, css } from '@emotion/react';
+import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import styled from '@emotion/styled';
+import { useRef, type ElementType, useState, useLayoutEffect } from 'react';
+
+type Props = {
+	children: ( isStuck: boolean ) => EmotionJSX.Element[];
+	stickyClass: string;
+	element?: ElementType;
+	blockOffset?: number;
+};
+
+const Container = styled.div< { blockOffset: number } >`
+	position: sticky;
+	inset-block-start: ${ ( props ) => props.blockOffset + 'px' };
+	z-index: 1;
+`;
+
+export function StickyContainer( props: Props ) {
+	const stickyRef = useRef( null );
+
+	const [ isStuck, setIsStuck ] = useState( false );
+	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
+
+	// Measure height of masterbar as we need it for the THead styles
+	useLayoutEffect( () => {
+		const masterbarElement = document.querySelector< HTMLDivElement >( 'header.masterbar' );
+
+		if ( ! masterbarElement ) {
+			return;
+		}
+
+		if ( ! window.ResizeObserver ) {
+			setMasterbarHeight( masterbarElement.offsetHeight );
+			return;
+		}
+
+		let lastHeight = masterbarElement.offsetHeight;
+
+		const observer = new ResizeObserver(
+			( [ masterbar ]: Parameters< ResizeObserverCallback >[ 0 ] ) => {
+				const currentHeight = masterbar.contentRect.height;
+
+				if ( currentHeight !== lastHeight ) {
+					setMasterbarHeight( currentHeight );
+					lastHeight = currentHeight;
+				}
+			}
+		);
+
+		observer.observe( masterbarElement );
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [] );
+
+	// This effect adds the `stickyClass` to the element when the element is "stuck"
+	useLayoutEffect( () => {
+		const observer = new IntersectionObserver(
+			( [ e ] ) => {
+				e.target.classList.toggle( props.stickyClass, e.intersectionRatio < 1 );
+				setIsStuck( e.intersectionRatio < 1 );
+			},
+			{
+				rootMargin: `-${ masterbarHeight + 1 }px 0px 0px 0px`,
+				threshold: [ 1 ],
+			}
+		);
+
+		const ref = stickyRef.current;
+
+		if ( ref ) {
+			observer.observe( ref );
+		}
+		return () => {
+			if ( ref ) {
+				observer.unobserve( ref );
+			}
+		};
+	}, [ masterbarHeight, props.stickyClass ] );
+
+	return (
+		<>
+			<Global
+				styles={ css`
+					.layout__content {
+						overflow: unset;
+					}
+				` }
+			/>
+			<Container
+				{ ...props }
+				as={ props.element ?? 'div' }
+				ref={ stickyRef }
+				blockOffset={ masterbarHeight }
+			>
+				{ props.children( isStuck ) }
+			</Container>
+		</>
+	);
+}

--- a/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
@@ -7,64 +7,31 @@ type Props = {
 	children: ( isStuck: boolean ) => EmotionJSX.Element[];
 	stickyClass: string;
 	element?: ElementType;
-	blockOffset?: number;
+	blockOffset: number;
 };
 
 const Container = styled.div< { blockOffset: number } >`
 	position: sticky;
-	inset-block-start: ${ ( props ) => props.blockOffset + 'px' };
+	top: ${ ( props ) => props.blockOffset + 'px' };
 	z-index: 1;
 `;
 
 export function StickyContainer( props: Props ) {
 	const stickyRef = useRef( null );
-
 	const [ isStuck, setIsStuck ] = useState( false );
-	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
 
-	// Measure height of masterbar as we need it for the THead styles
-	useLayoutEffect( () => {
-		const masterbarElement = document.querySelector< HTMLDivElement >( 'header.masterbar' );
-
-		if ( ! masterbarElement ) {
-			return;
-		}
-
-		if ( ! window.ResizeObserver ) {
-			setMasterbarHeight( masterbarElement.offsetHeight );
-			return;
-		}
-
-		let lastHeight = masterbarElement.offsetHeight;
-
-		const observer = new ResizeObserver(
-			( [ masterbar ]: Parameters< ResizeObserverCallback >[ 0 ] ) => {
-				const currentHeight = masterbar.contentRect.height;
-
-				if ( currentHeight !== lastHeight ) {
-					setMasterbarHeight( currentHeight );
-					lastHeight = currentHeight;
-				}
-			}
-		);
-
-		observer.observe( masterbarElement );
-
-		return () => {
-			observer.disconnect();
-		};
-	}, [] );
-
-	// This effect adds the `stickyClass` to the element when the element is "stuck"
 	useLayoutEffect( () => {
 		const observer = new IntersectionObserver(
 			( [ e ] ) => {
-				e.target.classList.toggle( props.stickyClass, e.intersectionRatio < 1 );
-				setIsStuck( e.intersectionRatio < 1 );
+				if ( e.intersectionRatio === 0 ) {
+					setIsStuck( false );
+				} else {
+					setIsStuck( e.intersectionRatio < 1 );
+				}
 			},
 			{
-				rootMargin: `-${ masterbarHeight + 1 }px 0px 0px 0px`,
-				threshold: [ 1 ],
+				rootMargin: `-${ props.blockOffset + 1 }px 0px 0px 0px`,
+				threshold: [ 0, 1 ],
 			}
 		);
 
@@ -78,7 +45,7 @@ export function StickyContainer( props: Props ) {
 				observer.unobserve( ref );
 			}
 		};
-	}, [ masterbarHeight, props.stickyClass ] );
+	}, [ props.blockOffset, props.stickyClass ] );
 
 	return (
 		<>
@@ -93,7 +60,8 @@ export function StickyContainer( props: Props ) {
 				{ ...props }
 				as={ props.element ?? 'div' }
 				ref={ stickyRef }
-				blockOffset={ masterbarHeight }
+				blockOffset={ props.blockOffset }
+				className={ isStuck ? props.stickyClass : '' }
 			>
 				{ props.children( isStuck ) }
 			</Container>

--- a/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
@@ -51,6 +51,10 @@ export function StickyContainer( props: Props ) {
 		<>
 			<Global
 				styles={ css`
+					/**
+				 * .layout__content has overflow set to hidden, which prevents position: sticky from working.
+				 * Instead of removing it globally, this CSS only unsets the property when the StickyContainer is rendered.
+				 */
 					.layout__content {
 						overflow: unset;
 					}

--- a/client/my-sites/plan-features-2023-grid/components/test/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/test/actions.tsx
@@ -37,6 +37,7 @@ jest.mock( 'react-redux', () => ( {
 jest.mock( 'calypso/state/plans/selectors', () => ( {
 	getPlanBillPeriod: jest.fn(),
 } ) );
+jest.mock( '../../hooks/use-plan-prices-display', () => ( { usePlanPricesDisplay: jest.fn() } ) );
 
 import {
 	PLAN_ANNUAL_PERIOD,
@@ -52,7 +53,10 @@ import { render, screen } from '@testing-library/react';
 import { useDispatch } from '@wordpress/data';
 import React from 'react';
 import { getPlanBillPeriod } from 'calypso/state/plans/selectors';
+import { usePlanPricesDisplay } from '../../hooks/use-plan-prices-display';
 import PlanFeatures2023GridActions from '../actions';
+
+type PlanPricesDisplay = ReturnType< typeof usePlanPricesDisplay >;
 
 describe( 'PlanFeatures2023GridActions', () => {
 	beforeEach( () => {
@@ -80,7 +84,14 @@ describe( 'PlanFeatures2023GridActions', () => {
 			selectedSiteSlug: 'foo.wordpress.com',
 			isStuck: false,
 			showMonthlyPrice: true,
+			currencyCode: 'USD',
 		};
+
+		const planPrices: PlanPricesDisplay = {
+			discountedPrice: 50,
+			originalPrice: 100,
+		};
+		usePlanPricesDisplay.mockImplementation( () => planPrices );
 
 		test( `should render ${ contactSupport } when current plan is on a lower tier but longer term than the grid plan`, () => {
 			getPlanBillPeriod.mockImplementation( ( _state, planSlug ) =>

--- a/client/my-sites/plan-features-2023-grid/components/test/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/test/actions.tsx
@@ -173,6 +173,20 @@ describe( 'PlanFeatures2023GridActions', () => {
 
 				expect( upgradeButton ).toBeEnabled();
 			} );
+
+			test( 'should render the price when isStuck is true', () => {
+				render(
+					<PlanFeatures2023GridActions
+						{ ...defaultProps }
+						planName={ PLAN_BUSINESS_3_YEARS }
+						planSlug={ PLAN_BUSINESS_3_YEARS }
+						isStuck={ true }
+					/>
+				);
+				const upgradeButton = screen.getByRole( 'button', { name: 'Upgrade – $50' } );
+
+				expect( upgradeButton ).toHaveTextContent( 'Upgrade – $50' );
+			} );
 		} );
 	} );
 } );

--- a/client/my-sites/plan-features-2023-grid/components/test/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/test/actions.tsx
@@ -78,6 +78,8 @@ describe( 'PlanFeatures2023GridActions', () => {
 			flowName: 'foo-flow',
 			isWpcomEnterpriseGridPlan: false,
 			selectedSiteSlug: 'foo.wordpress.com',
+			isStuck: false,
+			showMonthlyPrice: true,
 		};
 
 		test( `should render ${ contactSupport } when current plan is on a lower tier but longer term than the grid plan`, () => {
@@ -90,7 +92,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 					{ ...defaultProps }
 					currentSitePlanSlug={ PLAN_PREMIUM_2_YEARS }
 					planName={ PLAN_BUSINESS }
-					planType={ PLAN_BUSINESS }
+					planSlug={ PLAN_BUSINESS }
 				/>
 			);
 
@@ -106,7 +108,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 					{ ...defaultProps }
 					currentSitePlanSlug={ PLAN_PREMIUM }
 					planName={ PLAN_BUSINESS }
-					planType={ PLAN_BUSINESS }
+					planSlug={ PLAN_BUSINESS }
 				/>
 			);
 
@@ -122,7 +124,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 						{ ...defaultProps }
 						currentSitePlanSlug={ PLAN_BUSINESS_MONTHLY }
 						planName={ PLAN_BUSINESS }
-						planType={ PLAN_BUSINESS }
+						planSlug={ PLAN_BUSINESS }
 					/>
 				);
 
@@ -137,7 +139,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 						{ ...defaultProps }
 						currentSitePlanSlug={ PLAN_BUSINESS_MONTHLY }
 						planName={ PLAN_BUSINESS_2_YEARS }
-						planType={ PLAN_BUSINESS_2_YEARS }
+						planSlug={ PLAN_BUSINESS_2_YEARS }
 					/>
 				);
 
@@ -152,7 +154,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 						{ ...defaultProps }
 						currentSitePlanSlug={ PLAN_BUSINESS_MONTHLY }
 						planName={ PLAN_BUSINESS_3_YEARS }
-						planType={ PLAN_BUSINESS_3_YEARS }
+						planSlug={ PLAN_BUSINESS_3_YEARS }
 					/>
 				);
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -655,7 +655,7 @@ export class PlanFeatures2023Grid extends Component<
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties: PlanProperties ) => {
-				const { planName, isPlaceholder, planConstantObj, current, currencyCode } = properties;
+				const { planName, planConstantObj, current, currencyCode } = properties;
 				const classes = classNames(
 					'plan-features-2023-grid__table-item',
 					'is-top-buttons',

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -60,6 +60,7 @@ import { PlanFeaturesItem } from './components/item';
 import { PlanComparisonGrid } from './components/plan-comparison-grid';
 import { Plans2023Tooltip } from './components/plans-2023-tooltip';
 import PopularBadge from './components/popular-badge';
+import { StickyContainer } from './components/sticky-container';
 import PlansGridContextProvider, { usePlansGridContext } from './grid-context';
 import useHighlightAdjacencyMatrix from './hooks/npm-ready/use-highlight-adjacency-matrix';
 import useIsLargeCurrency from './hooks/use-is-large-currency';
@@ -73,6 +74,7 @@ import './style.scss';
 
 type PlanRowOptions = {
 	isMobile?: boolean;
+	isStuck?: boolean;
 	previousProductNameShort?: string;
 };
 
@@ -353,7 +355,9 @@ export class PlanFeatures2023Grid extends Component<
 					<tr>{ this.renderPlanTagline( planPropertiesObj ) }</tr>
 					<tr>{ this.renderPlanPrice( planPropertiesObj ) }</tr>
 					<tr>{ this.renderBillingTimeframe( planPropertiesObj ) }</tr>
-					<tr>{ this.renderTopButtons( planPropertiesObj ) }</tr>
+					<StickyContainer stickyClass="is-sticky-top-buttons-row" element="tr">
+						{ ( isStuck: boolean ) => this.renderTopButtons( planPropertiesObj, { isStuck } ) }
+					</StickyContainer>
 					<tr>{ this.maybeRenderRefundNotice( planPropertiesObj ) }</tr>
 					<tr>{ this.renderPreviousFeaturesIncludedTitle( planPropertiesObj ) }</tr>
 					<tr>{ this.renderPlanFeaturesList( planPropertiesObj ) }</tr>
@@ -639,12 +643,13 @@ export class PlanFeatures2023Grid extends Component<
 			selectedSiteSlug,
 			translate,
 			planActionOverrides,
+			siteId,
 		} = this.props;
 
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties: PlanProperties ) => {
-				const { planName, planConstantObj, current } = properties;
+				const { planName, isPlaceholder, planConstantObj, current, showMonthlyPrice } = properties;
 				const classes = classNames(
 					'plan-features-2023-grid__table-item',
 					'is-top-buttons',
@@ -680,13 +685,16 @@ export class PlanFeatures2023Grid extends Component<
 							isLaunchPage={ isLaunchPage }
 							onUpgradeClick={ () => this.handleUpgradeClick( properties ) }
 							planName={ planConstantObj.getTitle() }
-							planType={ planName }
+							planSlug={ planName }
 							flowName={ flowName }
 							current={ current ?? false }
 							currentSitePlanSlug={ currentSitePlanSlug }
 							selectedSiteSlug={ selectedSiteSlug }
 							buttonText={ buttonText }
 							planActionOverrides={ planActionOverrides }
+							showMonthlyPrice={ showMonthlyPrice }
+							siteId={ siteId }
+							isStuck={ options?.isStuck || false }
 						/>
 					</Container>
 				);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -654,7 +654,7 @@ export class PlanFeatures2023Grid extends Component<
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties: PlanProperties ) => {
-				const { planName, isPlaceholder, planConstantObj, current } = properties;
+				const { planName, isPlaceholder, planConstantObj, current, currencyCode } = properties;
 				const classes = classNames(
 					'plan-features-2023-grid__table-item',
 					'is-top-buttons',
@@ -700,6 +700,7 @@ export class PlanFeatures2023Grid extends Component<
 							showMonthlyPrice={ true }
 							siteId={ siteId }
 							isStuck={ options?.isStuck || false }
+							currencyCode={ currencyCode || 'USD' }
 						/>
 					</Container>
 				);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -339,7 +339,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderTable( planPropertiesObj: PlanProperties[] ) {
-		const { translate, stickyRowOffset } = this.props;
+		const { translate, stickyRowOffset, isInSignup } = this.props;
 		const tableClasses = classNames(
 			'plan-features-2023-grid__table',
 			`has-${ planPropertiesObj.filter( ( { isVisible } ) => isVisible ).length }-cols`
@@ -357,7 +357,9 @@ export class PlanFeatures2023Grid extends Component<
 					<tr>{ this.renderPlanPrice( planPropertiesObj ) }</tr>
 					<tr>{ this.renderBillingTimeframe( planPropertiesObj ) }</tr>
 					<StickyContainer
-						stickyClass="is-sticky-top-buttons-row"
+						stickyClass={
+							isInSignup ? 'is-sticky-top-buttons-row-signup' : 'is-sticky-top-buttons-row'
+						}
 						element="tr"
 						blockOffset={ stickyRowOffset }
 					>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -114,6 +114,7 @@ export type PlanFeatures2023GridProps = {
 	intent?: PlansIntent;
 	isGlobalStylesOnPersonal?: boolean;
 	showLegacyStorageFeature?: boolean;
+	stickyRowOffset: number;
 };
 
 type PlanFeatures2023GridConnectedProps = {
@@ -338,7 +339,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderTable( planPropertiesObj: PlanProperties[] ) {
-		const { translate } = this.props;
+		const { translate, stickyRowOffset } = this.props;
 		const tableClasses = classNames(
 			'plan-features-2023-grid__table',
 			`has-${ planPropertiesObj.filter( ( { isVisible } ) => isVisible ).length }-cols`
@@ -355,7 +356,11 @@ export class PlanFeatures2023Grid extends Component<
 					<tr>{ this.renderPlanTagline( planPropertiesObj ) }</tr>
 					<tr>{ this.renderPlanPrice( planPropertiesObj ) }</tr>
 					<tr>{ this.renderBillingTimeframe( planPropertiesObj ) }</tr>
-					<StickyContainer stickyClass="is-sticky-top-buttons-row" element="tr">
+					<StickyContainer
+						stickyClass="is-sticky-top-buttons-row"
+						element="tr"
+						blockOffset={ stickyRowOffset }
+					>
 						{ ( isStuck: boolean ) => this.renderTopButtons( planPropertiesObj, { isStuck } ) }
 					</StickyContainer>
 					<tr>{ this.maybeRenderRefundNotice( planPropertiesObj ) }</tr>
@@ -649,7 +654,7 @@ export class PlanFeatures2023Grid extends Component<
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties: PlanProperties ) => {
-				const { planName, isPlaceholder, planConstantObj, current, showMonthlyPrice } = properties;
+				const { planName, isPlaceholder, planConstantObj, current } = properties;
 				const classes = classNames(
 					'plan-features-2023-grid__table-item',
 					'is-top-buttons',
@@ -692,7 +697,7 @@ export class PlanFeatures2023Grid extends Component<
 							selectedSiteSlug={ selectedSiteSlug }
 							buttonText={ buttonText }
 							planActionOverrides={ planActionOverrides }
-							showMonthlyPrice={ showMonthlyPrice }
+							showMonthlyPrice={ true }
 							siteId={ siteId }
 							isStuck={ options?.isStuck || false }
 						/>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -357,11 +357,10 @@ export class PlanFeatures2023Grid extends Component<
 					<tr>{ this.renderPlanPrice( planPropertiesObj ) }</tr>
 					<tr>{ this.renderBillingTimeframe( planPropertiesObj ) }</tr>
 					<StickyContainer
-						stickyClass={
-							isInSignup ? 'is-sticky-top-buttons-row-signup' : 'is-sticky-top-buttons-row'
-						}
+						stickyClass="is-sticky-top-buttons-row"
 						element="tr"
-						blockOffset={ stickyRowOffset }
+						stickyOffset={ stickyRowOffset }
+						topOffset={ stickyRowOffset + ( isInSignup ? 0 : 20 ) }
 					>
 						{ ( isStuck: boolean ) => this.renderTopButtons( planPropertiesObj, { isStuck } ) }
 					</StickyContainer>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -650,6 +650,7 @@ export class PlanFeatures2023Grid extends Component<
 			translate,
 			planActionOverrides,
 			siteId,
+			isLargeCurrency,
 		} = this.props;
 
 		return planPropertiesObj
@@ -701,6 +702,7 @@ export class PlanFeatures2023Grid extends Component<
 							showMonthlyPrice={ true }
 							siteId={ siteId }
 							isStuck={ options?.isStuck || false }
+							isLargeCurrency={ isLargeCurrency }
 							currencyCode={ currencyCode || 'USD' }
 						/>
 					</Container>

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -694,6 +694,33 @@ body.is-section-signup.is-white-signup,
 		}
 	}
 
+	.is-sticky-top-buttons-row {
+		.is-top-buttons.plan-features-2023-grid__table-item {
+			padding-top: 36px;
+			padding-bottom: 36px;
+			border: none;
+			// border-bottom: 1px solid #e0e0e0;
+			background-color: #f9f9f9;
+			box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.04);
+			.plan-features-2023-grid__actions-button {
+				font-size: rem(12px);
+			}
+		}
+		td:first-child {
+			&::before {
+				content: "";
+				background-color: #f9f9f9;
+				box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.04);
+				width: 100vw;
+				height: 112px;
+				position: fixed;
+				top: 0;
+				left: 0;
+				z-index: -1;
+			}
+		}
+	}
+
 	.plan-features-2023-grid__header {
 		background-color: transparent;
 	}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -696,13 +696,25 @@ body.is-section-signup.is-white-signup,
 
 	.is-sticky-top-buttons-row {
 		.is-top-buttons.plan-features-2023-grid__table-item {
-			padding-top: 36px;
+			/**
+			 * padding-top should be 36px as well.
+			 * On certain pages, the `top` property is calculated from the middle of the CTA button
+			 * instead from the top of the CTA button.
+			 * The height of the CTA button is 20px, so the extra 10px is to account for this difference.
+			 */
+			padding-top: 46px;
 			padding-bottom: 36px;
 			border: none;
 			background-color: #f9f9f9;
 			box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.04);
 			.plan-features-2023-grid__actions-button {
 				font-size: rem(12px);
+			}
+		}
+		&-signup {
+			@extend .is-sticky-top-buttons-row;
+			.is-top-buttons.plan-features-2023-grid__table-item {
+				padding-top: 36px;
 			}
 		}
 	}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -398,6 +398,10 @@ $mobile-card-max-width: 440px;
 		&.is-top-buttons {
 			padding: 0 20px;
 			vertical-align: bottom;
+			@include plans-2023-break-small {
+				padding-top: 16px;
+				padding-bottom: 16px;
+			}
 		}
 
 		@include plans-2023-break-small {
@@ -536,7 +540,7 @@ body.is-section-signup.is-white-signup,
 			padding: 0 19px 24px 20px;
 
 			@include plans-2023-break-small {
-				padding-bottom: 16px;
+				padding-bottom: 0;
 			}
 
 			.plan-features-2023-grid__vip-price {
@@ -672,7 +676,7 @@ body.is-section-signup.is-white-signup,
 			margin-bottom: 12px;
 
 			@include plans-2023-break-small {
-				margin-top: 36px;
+				margin-top: 20px;
 				font-size: $font-body-extra-small;
 			}
 
@@ -696,25 +700,11 @@ body.is-section-signup.is-white-signup,
 
 	.is-sticky-top-buttons-row {
 		.is-top-buttons.plan-features-2023-grid__table-item {
-			/**
-			 * padding-top should be 36px as well.
-			 * On certain pages, the `top` property is calculated from the middle of the CTA button
-			 * instead from the top of the CTA button.
-			 * The height of the CTA button is 20px, so the extra 10px is to account for this difference.
-			 */
-			padding-top: 46px;
-			padding-bottom: 36px;
 			border: none;
 			background-color: #f9f9f9;
 			box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.04);
 			.plan-features-2023-grid__actions-button {
 				font-size: rem(12px);
-			}
-		}
-		&-signup {
-			@extend .is-sticky-top-buttons-row;
-			.is-top-buttons.plan-features-2023-grid__table-item {
-				padding-top: 36px;
 			}
 		}
 	}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -699,24 +699,10 @@ body.is-section-signup.is-white-signup,
 			padding-top: 36px;
 			padding-bottom: 36px;
 			border: none;
-			// border-bottom: 1px solid #e0e0e0;
 			background-color: #f9f9f9;
 			box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.04);
 			.plan-features-2023-grid__actions-button {
 				font-size: rem(12px);
-			}
-		}
-		td:first-child {
-			&::before {
-				content: "";
-				background-color: #f9f9f9;
-				box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.04);
-				width: 100vw;
-				height: 112px;
-				position: fixed;
-				top: 0;
-				left: 0;
-				z-index: -1;
 			}
 		}
 	}

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -163,6 +163,10 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 
 	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
 
+	/**
+	 * Calculates the height of the masterbar if it exists, and passes it to the component as an offset
+	 * for the sticky CTA bar.
+	 */
 	useLayoutEffect( () => {
 		const masterbarElement = document.querySelector< HTMLDivElement >( 'header.masterbar' );
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -10,7 +10,7 @@ import {
 import { Button } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useLayoutEffect, useState } from '@wordpress/element';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -161,6 +161,40 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		};
 	}
 
+	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
+
+	useLayoutEffect( () => {
+		const masterbarElement = document.querySelector< HTMLDivElement >( 'header.masterbar' );
+
+		if ( ! masterbarElement ) {
+			return;
+		}
+
+		if ( ! window.ResizeObserver ) {
+			setMasterbarHeight( masterbarElement.offsetHeight );
+			return;
+		}
+
+		let lastHeight = masterbarElement.offsetHeight;
+
+		const observer = new ResizeObserver(
+			( [ masterbar ]: Parameters< ResizeObserverCallback >[ 0 ] ) => {
+				const currentHeight = masterbar.contentRect.height;
+
+				if ( currentHeight !== lastHeight ) {
+					setMasterbarHeight( currentHeight );
+					lastHeight = currentHeight;
+				}
+			}
+		);
+
+		observer.observe( masterbarElement );
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [] );
+
 	const asyncProps: PlanFeatures2023GridProps = {
 		paidDomainName,
 		isInSignup,
@@ -181,6 +215,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		intent,
 		isGlobalStylesOnPersonal: globalStylesInPersonalPlan,
 		showLegacyStorageFeature,
+		stickyRowOffset: masterbarHeight,
 	};
 
 	const asyncPlanFeatures2023Grid = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1392

## Proposed Changes

* Adds sticky behaviour to the CTA bar on the plans grid. This PR currently does not add the sticky behaviour to the plan comparison grid. 
* Figma: xkhhUlDowF13dRoXJqlRDM-fi-997%3A14697

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and scroll up. If the viewport height is less, open the comparison grid so there is space to scroll up, and confirm that the sticky header gets activated.
* Once the plans grid is out of view, the CTA bar should no longer stick.
* Confirm that it matches the design.
* When the CTA buttons are "stuck", they should also display the price of the plan. Confirm that the price matches the one shown in the grid.

https://github.com/Automattic/wp-calypso/assets/5436027/ec2873a9-deff-4afe-a08d-b3557f12f5d3

* Repeat the above steps on `/plans/<site slug>`.
* Additionally, the button text when stuck should be "Upgrade - $X"

https://github.com/Automattic/wp-calypso/assets/5436027/14a09f24-8293-480f-a18b-c3d4e2b4cf62

* Repeat the above steps on `/start/launch-site?siteSlug=<site slug>`.
* Additionally, the button text when stuck should be "Select - $X"

<img width="1904" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/417ccaa3-88be-4807-813c-d2830e695261">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?