### PR TITLE
Cleanup: Remove unused `newsletter/stats` flag.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -129,7 +129,6 @@
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
-		"newsletter/stats": true,
 		"oauth": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -81,6 +81,7 @@
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"newsletter/stats": true,
+		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redesign": true,
 		"p2/p2-plus": true,
 		"plans/migration-trial": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -80,8 +80,6 @@
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
-		"newsletter/stats": true,
-		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redesign": true,
 		"p2/p2-plus": true,
 		"plans/migration-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -97,7 +97,6 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
-		"newsletter/stats": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -174,9 +174,7 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"newsletter/stats": false,
-		"yolo/hosting-metrics-i1": true,
-		"yolo/site-transfers-i1": true
+		"yolo/hosting-metrics-i1": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -175,7 +175,8 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"newsletter/stats": false,
-		"yolo/hosting-metrics-i1": true
+		"yolo/hosting-metrics-i1": true,
+		"yolo/site-transfers-i1": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -102,7 +102,6 @@
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
-		"newsletter/stats": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,


### PR DESCRIPTION
## Proposed Changes

* Remove unused `newsletter/stats` flag.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just a clean-up. You can do a search in the Calypso codebase and you should see the flag is no longer used.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
