### PR TITLE
Use correct plan name for newsletter accent colour

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -212,7 +212,7 @@ const AccentColorControl = ( {
 
 		const dropdownOptions = [
 			...freeColors.map( ( freeColor ) => getDropdownOption( freeColor ) ),
-			<SelectDropdown.Label key="dropdown-label"> { planText } </SelectDropdown.Label>,
+			<SelectDropdown.Label key="dropdown-label">{ planText }</SelectDropdown.Label>,
 			...premiumColors.map( ( premiumColor ) => getDropdownOption( premiumColor ) ),
 		];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -60,7 +60,9 @@ const AccentColorControl = ( {
 	const [ colorPickerOpen, setColorPickerOpen ] = useState< boolean >( false );
 	const accentColorRef = useRef< HTMLInputElement >( null );
 	const site = useSite();
-	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
+	const { shouldLimitGlobalStyles, globalStylesInPersonalPlan } = useSiteGlobalStylesStatus(
+		site?.ID
+	);
 
 	const getColorOptions = useCallback(
 		(): ColorOption[] => [
@@ -204,12 +206,13 @@ const AccentColorControl = ( {
 
 		const freeColors = getColorOptions().filter( ( { isPremium } ) => ! isPremium );
 		const premiumColors = getColorOptions().filter( ( { isPremium } ) => isPremium );
+		const planText = globalStylesInPersonalPlan
+			? __( 'Unlock more colors with a Personal plan' )
+			: __( 'Unlock more colors with a Premium plan' );
 
 		const dropdownOptions = [
 			...freeColors.map( ( freeColor ) => getDropdownOption( freeColor ) ),
-			<SelectDropdown.Label key="dropdown-label">
-				{ __( 'Unlock more colors with a Premium plan' ) }
-			</SelectDropdown.Label>,
+			<SelectDropdown.Label key="dropdown-label"> { planText } </SelectDropdown.Label>,
 			...premiumColors.map( ( premiumColor ) => getDropdownOption( premiumColor ) ),
 		];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2863

## Proposed Changes

The newsletter accent colour requires a global styles capable plan. This is currently Premium but we will experiment with making it available on the Personal plan. This change uses the appropriate plan name when explaining to the user what they need.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to 21268-explat-experiment and use the bookmarklet to assign yourself to treatment/control 
2. Use the calypso live link
3. Go to /setup/newsletter
4. Go through the process until you reach the 'It begins with a name' screen
5. Open the accent colour Select, you should see a line that says 'Unlock more colours with a X plan", where X is Personal or Premium depending upon control or treatment.
6. Go to 21268-explat-experiment and use the bookmarklet to assign yourself to the opposite side of the experiment
7. Refresh the newsletter page, check that the Accent colour select now says the opposite plan name

Control | Treatment
-------|------
<img width="553" alt="Screenshot 2023-07-04 at 16 18 40" src="https://github.com/Automattic/wp-calypso/assets/93301/2ec1ed99-ebc8-460c-b3f5-dfa33d96866a"> | <img width="553" alt="Screenshot 2023-07-04 at 16 17 49" src="https://github.com/Automattic/wp-calypso/assets/93301/888bfe3a-98a8-4919-81b9-5135a89f73ce">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?