### PR TITLE
Bulk Domain Transfer: Redirect from start to stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	LINK_IN_BIO_DOMAIN_FLOW,
 	START_WRITING_FLOW,
@@ -105,14 +104,10 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 		import( /* webpackChunkName: "import-hosted-site-flow" */ './import-hosted-site' ),
 	[ ONBOARDING_PM_FLOW ]: () =>
 		import( /* webpackChunkName: "new-hosted-site-flow" */ './onboarding-pm' ),
+	[ DOMAIN_TRANSFER ]: () =>
+		import( /* webpackChunkName: "domain-transfer" */ './domain-transfer' ),
+	[ 'plugin-bundle' ]: () =>
+		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' ),
 };
-
-availableFlows[ 'plugin-bundle' ] = () =>
-	import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' );
-
-if ( config.isEnabled( 'bulk-domain-transfer-flow' ) ) {
-	availableFlows[ DOMAIN_TRANSFER ] = () =>
-		import( /* webpackChunkName: "domain-transfer" */ './domain-transfer' );
-}
 
 export default availableFlows;

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -102,10 +102,13 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 		),
 	[ IMPORT_HOSTED_SITE_FLOW ]: () =>
 		import( /* webpackChunkName: "import-hosted-site-flow" */ './import-hosted-site' ),
+
 	[ ONBOARDING_PM_FLOW ]: () =>
 		import( /* webpackChunkName: "new-hosted-site-flow" */ './onboarding-pm' ),
+
 	[ DOMAIN_TRANSFER ]: () =>
 		import( /* webpackChunkName: "domain-transfer" */ './domain-transfer' ),
+
 	[ 'plugin-bundle' ]: () =>
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' ),
 };

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -826,6 +826,12 @@ function wpcomPages( app ) {
 		// Otherwise, show them email subscriptions external landing page
 		res.redirect( 'https://wordpress.com/email-subscriptions' );
 	} );
+
+	// Redirects from the /start/domain-transfer flow to the new /setup/domain-transfer.
+	app.get( [ '/start/domain-transfer', '/start/domain-transfer/*' ], function ( req, res ) {
+		const redirectUrl = '/setup/domain-transfer';
+		res.redirect( 301, redirectUrl );
+	} );
 }
 
 export default function pages() {

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1255,6 +1255,13 @@ describe( 'main app', () => {
 		} );
 	} );
 
+	describe( 'Route /start/domain-transfer', () => {
+		it( 'redirects to /setup/domain-transfer', async () => {
+			const { response } = await app.run( { request: { url: '/start/domain-transfer' } } );
+			expect( response.redirect ).toHaveBeenCalledWith( 301, '/setup/domain-transfer' );
+		} );
+	} );
+
 	describe( 'Route /cspreport', () => {
 		let customApp;
 

--- a/config/development.json
+++ b/config/development.json
@@ -32,7 +32,6 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
-		"bulk-domain-transfer-flow": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -13,7 +13,6 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
-		"bulk-domain-transfer-flow": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/production.json
+++ b/config/production.json
@@ -22,7 +22,6 @@
 	"features": {
 		"ad-tracking": true,
 		"akismet/siteless-checkout": true,
-		"bulk-domain-transfer-flow": false,
 		"bilmur-script": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -20,7 +20,6 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
-		"bulk-domain-transfer-flow": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/test.json
+++ b/config/test.json
@@ -25,7 +25,6 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
-		"bulk-domain-transfer-flow": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -20,7 +20,6 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
-		"bulk-domain-transfer-flow": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,


### PR DESCRIPTION
[Context](p1687807044882129-slack-C05CT832K2T)

MERGE ONLY WHEN STEPPER BULK DOMAIN TRANSFER FLOW IS COMPLETED.

- This PR redirects from `/start/domain-transfer` to `/setup/domain-transfer`, hence using the new domain-transfer flow built using Stepper
- Removes the flow flag

## Testing
1. Live  Link
2. Visit `/start/domain-transfer`, you should land in `/setup/domain-transfer`

Fixes https://github.com/Automattic/dotcom-forge/issues/2926