### PR TITLE
Handle bulk domain availability status checks for already mapped domains

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -74,12 +74,6 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 			loading: false,
 			message: __( 'This domain is unlocked and ready to be transferred.' ),
 		};
-	} else if ( availabilityNotice?.message ) {
-		return {
-			valid: false,
-			loading: false,
-			message: availabilityNotice?.message,
-		};
 	} else if ( validationResult?.auth_code_valid === false ) {
 		// the auth check API has a bug and returns error 400 for incorrect auth codes,
 		// in which case, the `useIsDomainCodeValid` hook returns `false`.
@@ -87,6 +81,12 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 			valid: false,
 			loading: false,
 			message: __( 'This domain is unlocked but the authentication code seems incorrect.' ),
+		};
+	} else if ( availabilityNotice?.message ) {
+		return {
+			valid: false,
+			loading: false,
+			message: availabilityNotice?.message,
 		};
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -68,7 +68,13 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 	const availabilityNotice = getAvailabilityNotice( domain, validationResult?.status, null, true );
 
 	// final success
-	if ( validationResult?.auth_code_valid ) {
+	if ( validationResult?.unlocked === false ) {
+		return {
+			valid: false,
+			loading: false,
+			message: __( 'This domain is locked and can not be transferred.' ),
+		};
+	} else if ( validationResult?.auth_code_valid ) {
 		return {
 			valid: true,
 			loading: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -68,13 +68,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 	const availabilityNotice = getAvailabilityNotice( domain, validationResult?.status, null, true );
 
 	// final success
-	if ( validationResult?.unlocked === false ) {
-		return {
-			valid: false,
-			loading: false,
-			message: __( 'This domain is locked and can not be transferred.' ),
-		};
-	} else if ( validationResult?.auth_code_valid ) {
+	if ( validationResult?.auth_code_valid ) {
 		return {
 			valid: true,
 			loading: false,

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -45,9 +45,7 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 					path: `/domains/${ encodeURIComponent( pair.domain ) }/is-available`,
 				} );
 
-				// The "mapped_*" statuses here are a quick and dirty fix to allow bulk transfer of already connected domains for now.
-				// The "transferrable" status should be the only one that indicates a domain can be transferred because there are some
-				// domains that can be mapped but can't be transferred
+				// A `transferrability` property was added in D115244-code to check whether a mapped domain can be transferred
 				const isUnlocked =
 					[ 'transferrable', 'mapped_to_same_site_transferrable' ].includes(
 						availability.status

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -58,7 +58,6 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 						domain: pair.domain,
 						status: availability.status,
 						unlocked: false,
-						auth_code_valid: false,
 					};
 				}
 

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -30,6 +30,7 @@ type DomainLockResponse = {
 	unlocked: boolean | null | undefined;
 	in_redemption?: boolean;
 	status: string;
+	transferrability?: string;
 };
 
 type DomainCodePair = { domain: string; auth: string };
@@ -47,12 +48,12 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 				// The "mapped_*" statuses here are a quick and dirty fix to allow bulk transfer of already connected domains for now.
 				// The "transferrable" status should be the only one that indicates a domain can be transferred because there are some
 				// domains that can be mapped but can't be transferred
-				const isUnlocked = [
-					'transferrable',
-					'mapped_to_other_site_same_user',
-					'mapped_to_same_site_transferrable',
-					'mapped_domain',
-				].includes( availability.status );
+				const isUnlocked =
+					[ 'transferrable', 'mapped_to_same_site_transferrable' ].includes(
+						availability.status
+					) ||
+					( [ 'mapped_domain', 'mapped_to_other_site_same_user' ].includes( availability.status ) &&
+						'transferrable' === availability?.transferrability );
 
 				if ( ! isUnlocked ) {
 					return {


### PR DESCRIPTION
Update the availability endpoint results to also check the `transferrability` status so that we can handle already mapped domains properly. Currently we can't find out if a domain that's already connected to a site is eligible for transfer or not so we need to add some additional data in the availability endpoint.

Depends on D115244-code

Related to #

## Proposed Changes

* If the status is `mapped_domain` or `mapped_to_other_site_same_user` we check for `transferrable` status in the `transferrability` field.
* Show better error message if the domain is actually locked

## Testing Instructions

* Apply D115244-code and test the bulk transfer page with domains that were previously mapped and are:
  * supported TLDs and locked
  * supported TLDs and unlocked
  * not supported TLDs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?