### PR TITLE
Payment Checkout: implement redirect modal in the checkout page for Agency/Pro users from Jetpack Pricing or My Jetpack page

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -27,6 +27,7 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
+import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -57,6 +58,7 @@ import webPayProcessor from '../lib/web-pay-processor';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
 import { CheckoutLoadingPlaceholder } from './checkout-loading-placeholder';
 import { OnChangeItemVariant } from './item-variation-picker';
+import JetpackProRedirectModal from './jetpack-pro-redirect-modal';
 import WPCheckout from './wp-checkout';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
@@ -128,6 +130,10 @@ export default function CheckoutMain( {
 	customizedPreviousPath?: string;
 } ) {
 	const translate = useTranslate();
+
+	// Show a banner to redirect agency users to the partner portal dashboard
+	const showProDashboardRedirectBanner = useSelector( isAgencyUser );
+
 	const isJetpackNotAtomic =
 		useSelector( ( state ) => {
 			return siteId && isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
@@ -722,26 +728,34 @@ export default function CheckoutMain( {
 				theme={ theme }
 				selectFirstAvailablePaymentMethod
 			>
-				<WPCheckout
-					loadingContent={
-						<CheckoutLoadingPlaceholder checkoutLoadingConditions={ checkoutLoadingConditions } />
-					}
-					customizedPreviousPath={ customizedPreviousPath }
-					isRemovingProductFromCart={ isRemovingProductFromCart }
-					areThereErrors={ areThereErrors }
-					isInitialCartLoading={ isInitialCartLoading }
-					addItemToCart={ addItemAndLog }
-					changePlanLength={ changePlanLength }
-					countriesList={ countriesList }
-					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-					infoMessage={ infoMessage }
-					isLoggedOutCart={ !! isLoggedOutCart }
-					onPageLoadError={ onPageLoadError }
-					removeProductFromCart={ removeProductFromCartAndMaybeRedirect }
-					showErrorMessageBriefly={ showErrorMessageBriefly }
-					siteId={ updatedSiteId }
-					siteUrl={ updatedSiteSlug }
-				/>
+				<>
+					<WPCheckout
+						loadingContent={
+							<CheckoutLoadingPlaceholder checkoutLoadingConditions={ checkoutLoadingConditions } />
+						}
+						customizedPreviousPath={ customizedPreviousPath }
+						isRemovingProductFromCart={ isRemovingProductFromCart }
+						areThereErrors={ areThereErrors }
+						isInitialCartLoading={ isInitialCartLoading }
+						addItemToCart={ addItemAndLog }
+						changePlanLength={ changePlanLength }
+						countriesList={ countriesList }
+						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
+						infoMessage={ infoMessage }
+						isLoggedOutCart={ !! isLoggedOutCart }
+						onPageLoadError={ onPageLoadError }
+						removeProductFromCart={ removeProductFromCartAndMaybeRedirect }
+						showErrorMessageBriefly={ showErrorMessageBriefly }
+						siteId={ updatedSiteId }
+						siteUrl={ updatedSiteSlug }
+					/>
+					{ showProDashboardRedirectBanner && (
+						<JetpackProRedirectModal
+							redirectTo={ redirectTo }
+							productSourceFromUrl={ productSourceFromUrl }
+						/>
+					) }
+				</>
 			</CheckoutProvider>
 		</Fragment>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -728,34 +728,32 @@ export default function CheckoutMain( {
 				theme={ theme }
 				selectFirstAvailablePaymentMethod
 			>
-				<>
-					<WPCheckout
-						loadingContent={
-							<CheckoutLoadingPlaceholder checkoutLoadingConditions={ checkoutLoadingConditions } />
-						}
-						customizedPreviousPath={ customizedPreviousPath }
-						isRemovingProductFromCart={ isRemovingProductFromCart }
-						areThereErrors={ areThereErrors }
-						isInitialCartLoading={ isInitialCartLoading }
-						addItemToCart={ addItemAndLog }
-						changePlanLength={ changePlanLength }
-						countriesList={ countriesList }
-						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-						infoMessage={ infoMessage }
-						isLoggedOutCart={ !! isLoggedOutCart }
-						onPageLoadError={ onPageLoadError }
-						removeProductFromCart={ removeProductFromCartAndMaybeRedirect }
-						showErrorMessageBriefly={ showErrorMessageBriefly }
-						siteId={ updatedSiteId }
-						siteUrl={ updatedSiteSlug }
+				<WPCheckout
+					loadingContent={
+						<CheckoutLoadingPlaceholder checkoutLoadingConditions={ checkoutLoadingConditions } />
+					}
+					customizedPreviousPath={ customizedPreviousPath }
+					isRemovingProductFromCart={ isRemovingProductFromCart }
+					areThereErrors={ areThereErrors }
+					isInitialCartLoading={ isInitialCartLoading }
+					addItemToCart={ addItemAndLog }
+					changePlanLength={ changePlanLength }
+					countriesList={ countriesList }
+					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
+					infoMessage={ infoMessage }
+					isLoggedOutCart={ !! isLoggedOutCart }
+					onPageLoadError={ onPageLoadError }
+					removeProductFromCart={ removeProductFromCartAndMaybeRedirect }
+					showErrorMessageBriefly={ showErrorMessageBriefly }
+					siteId={ updatedSiteId }
+					siteUrl={ updatedSiteSlug }
+				/>
+				{ showProDashboardRedirectBanner && (
+					<JetpackProRedirectModal
+						redirectTo={ redirectTo }
+						productSourceFromUrl={ productSourceFromUrl }
 					/>
-					{ showProDashboardRedirectBanner && (
-						<JetpackProRedirectModal
-							redirectTo={ redirectTo }
-							productSourceFromUrl={ productSourceFromUrl }
-						/>
-					) }
-				</>
+				) }
 			</CheckoutProvider>
 		</Fragment>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -27,7 +27,6 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
-import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -130,9 +129,6 @@ export default function CheckoutMain( {
 	customizedPreviousPath?: string;
 } ) {
 	const translate = useTranslate();
-
-	// Show a banner to redirect agency users to the partner portal dashboard
-	const showProDashboardRedirectBanner = useSelector( isAgencyUser );
 
 	const isJetpackNotAtomic =
 		useSelector( ( state ) => {
@@ -748,12 +744,13 @@ export default function CheckoutMain( {
 					siteId={ updatedSiteId }
 					siteUrl={ updatedSiteSlug }
 				/>
-				{ showProDashboardRedirectBanner && (
+				{
+					// Redirect modal is displayed mainly to all the agency partners who are purchasing Jetpack plans
 					<JetpackProRedirectModal
 						redirectTo={ redirectTo }
 						productSourceFromUrl={ productSourceFromUrl }
 					/>
-				) }
+				}
 			</CheckoutProvider>
 		</Fragment>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
+import { CheckoutCheckIcon } from '@automattic/composite-checkout';
 import { Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { CheckIcon } from 'calypso/../packages/composite-checkout/src/components/shared-icons';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -81,12 +81,15 @@ export default function JetpackProRedirectModal( { redirectTo, productSourceFrom
 							) }
 						</p>
 						<ul className="jetpack-pro-redirect-modal__list">
-							{ features.map( ( feature, index ) => (
-								<li key={ index }>
-									<CheckIcon id={ index.toString() } />
-									{ feature }
-								</li>
-							) ) }
+							{ features.map( ( feature ) => {
+								const id = feature.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase();
+								return (
+									<li key={ id }>
+										<CheckoutCheckIcon id={ id } />
+										{ feature }
+									</li>
+								);
+							} ) }
 						</ul>
 					</div>
 					<div className="jetpack-pro-redirect-modal__footer">

--- a/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
@@ -1,0 +1,111 @@
+import { Button } from '@automattic/components';
+import { Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { CheckIcon } from 'calypso/../packages/composite-checkout/src/components/shared-icons';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import {
+	JETPACK_DASHBOARD_CHECKOUT_REDIRECT_MODAL_DISMISSED as preferenceName,
+	getJetpackDashboardPreference as getPreference,
+} from 'calypso/state/jetpack-agency-dashboard/selectors';
+import { setPreference } from 'calypso/state/preferences/actions';
+import getPageValueFromUrl from './utils/get-page-value-from-url';
+
+import './style.scss';
+
+interface Props {
+	redirectTo?: string;
+	productSourceFromUrl?: string;
+}
+
+export default function JetpackProRedirectModal( { redirectTo, productSourceFromUrl }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const isDismissed = useSelector( ( state ) => getPreference( state, preferenceName ) );
+
+	// Function to set the preference to dismiss the modal and record the event.
+	const dismissAndRecordEvent = () => {
+		dispatch( setPreference( preferenceName, true ) );
+		dispatch( recordTracksEvent( 'jetpack_dashboard_agency_checkout_redirect_modal_dismiss' ) );
+	};
+
+	// Function to record the event when the user clicks on the redirect button.
+	const recordRedirectEvent = () => {
+		dispatch( recordTracksEvent( 'jetpack_dashboard_agency_checkout_redirect_modal_redirect' ) );
+	};
+
+	// Features list of Agency/Pro Dashboard.
+	const features = [
+		translate( 'Up to 60% off our products and bundles.' ),
+		translate( 'A recurring discount (not just for the first year).' ),
+		translate( 'More flexible billing (only pay per day of use, billed monthly).' ),
+		translate( 'Access to our Pro Dashboard – manage all of your sites in one place.' ),
+	];
+
+	const redirectURLPage = getPageValueFromUrl( redirectTo ) ?? '';
+
+	// Show the banner only if the user has not dismissed the banner and
+	// is coming from the Jetpack Plans page or Jetpack page in WP.com
+	if (
+		isDismissed ||
+		! (
+			productSourceFromUrl === 'jetpack-plans' ||
+			[ 'my-jetpack', 'jetpack' ].includes( redirectURLPage )
+		)
+	) {
+		return null;
+	}
+
+	return (
+		<>
+			<Modal
+				open={ true }
+				onRequestClose={ dismissAndRecordEvent }
+				title=""
+				className="jetpack-pro-redirect-modal"
+			>
+				<div className="jetpack-pro-redirect-modal__container">
+					<div className="jetpack-pro-redirect-modal__top-header">
+						<JetpackLogo size={ 22 } className="jetpack-pro-redirect-modal__logo" />
+						{ translate( 'For Agencies & Pros' ) }
+					</div>
+					<div className="jetpack-pro-redirect-modal__content">
+						<div className="jetpack-pro-redirect-modal__heading">
+							{ translate( 'Get a recurring discount and more flexible billing' ) }
+						</div>
+						<p>
+							{ translate(
+								'As a Jetpack partner, by purchasing products through our Agency & Pro tools, you get:'
+							) }
+						</p>
+						<ul className="jetpack-pro-redirect-modal__list">
+							{ features.map( ( feature, index ) => (
+								<li key={ index }>
+									<CheckIcon id={ index.toString() } />
+									{ feature }
+								</li>
+							) ) }
+						</ul>
+					</div>
+					<div className="jetpack-pro-redirect-modal__footer">
+						<div className="jetpack-pro-redirect-modal__footer-buttons">
+							<Button
+								type="submit"
+								primary
+								href="https://cloud.jetpack.com/partner-portal/issue-license"
+								onClick={ recordRedirectEvent }
+							>
+								{ translate( 'Unlock savings now' ) }
+							</Button>
+							<Button borderless onClick={ dismissAndRecordEvent }>
+								{ translate( 'Continue with purchase here' ) }
+							</Button>
+						</div>
+					</div>
+				</div>
+			</Modal>
+		</>
+	);
+}

--- a/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
@@ -9,6 +9,7 @@ import {
 	JETPACK_DASHBOARD_CHECKOUT_REDIRECT_MODAL_DISMISSED as preferenceName,
 	getJetpackDashboardPreference as getPreference,
 } from 'calypso/state/jetpack-agency-dashboard/selectors';
+import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import { setPreference } from 'calypso/state/preferences/actions';
 import getPageValueFromUrl from './utils/get-page-value-from-url';
 
@@ -46,9 +47,12 @@ export default function JetpackProRedirectModal( { redirectTo, productSourceFrom
 
 	const redirectURLPage = getPageValueFromUrl( redirectTo ) ?? '';
 
-	// Show the banner only if the user has not dismissed the banner and
+	const isAgencyPartner = useSelector( isAgencyUser );
+
+	// Show the banner only if the user is agency partner, has not dismissed the banner and
 	// is coming from the Jetpack Plans page or Jetpack page in WP.com
 	if (
+		! isAgencyPartner ||
 		isDismissed ||
 		! (
 			productSourceFromUrl === 'jetpack-plans' ||
@@ -59,56 +63,54 @@ export default function JetpackProRedirectModal( { redirectTo, productSourceFrom
 	}
 
 	return (
-		<>
-			<Modal
-				open={ true }
-				onRequestClose={ dismissAndRecordEvent }
-				title=""
-				className="jetpack-pro-redirect-modal"
-			>
-				<div className="jetpack-pro-redirect-modal__container">
-					<div className="jetpack-pro-redirect-modal__top-header">
-						<JetpackLogo size={ 22 } className="jetpack-pro-redirect-modal__logo" />
-						{ translate( 'For Agencies & Pros' ) }
+		<Modal
+			open={ true }
+			onRequestClose={ dismissAndRecordEvent }
+			title=""
+			className="jetpack-pro-redirect-modal"
+		>
+			<div className="jetpack-pro-redirect-modal__container">
+				<div className="jetpack-pro-redirect-modal__top-header">
+					<JetpackLogo size={ 22 } className="jetpack-pro-redirect-modal__logo" />
+					{ translate( 'For Agencies & Pros' ) }
+				</div>
+				<div className="jetpack-pro-redirect-modal__content">
+					<div className="jetpack-pro-redirect-modal__heading">
+						{ translate( 'Get a recurring discount and more flexible billing' ) }
 					</div>
-					<div className="jetpack-pro-redirect-modal__content">
-						<div className="jetpack-pro-redirect-modal__heading">
-							{ translate( 'Get a recurring discount and more flexible billing' ) }
-						</div>
-						<p>
-							{ translate(
-								'As a Jetpack partner, by purchasing products through our Agency & Pro tools, you get:'
-							) }
-						</p>
-						<ul className="jetpack-pro-redirect-modal__list">
-							{ features.map( ( feature ) => {
-								const id = feature.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase();
-								return (
-									<li key={ id }>
-										<CheckoutCheckIcon id={ id } />
-										{ feature }
-									</li>
-								);
-							} ) }
-						</ul>
-					</div>
-					<div className="jetpack-pro-redirect-modal__footer">
-						<div className="jetpack-pro-redirect-modal__footer-buttons">
-							<Button
-								type="submit"
-								primary
-								href="https://cloud.jetpack.com/partner-portal/issue-license"
-								onClick={ recordRedirectEvent }
-							>
-								{ translate( 'Unlock savings now' ) }
-							</Button>
-							<Button borderless onClick={ dismissAndRecordEvent }>
-								{ translate( 'Continue with purchase here' ) }
-							</Button>
-						</div>
+					<p>
+						{ translate(
+							'As a Jetpack partner, by purchasing products through our Agency & Pro tools, you get:'
+						) }
+					</p>
+					<ul className="jetpack-pro-redirect-modal__list">
+						{ features.map( ( feature ) => {
+							const id = feature.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase();
+							return (
+								<li key={ id }>
+									<CheckoutCheckIcon id={ id } />
+									{ feature }
+								</li>
+							);
+						} ) }
+					</ul>
+				</div>
+				<div className="jetpack-pro-redirect-modal__footer">
+					<div className="jetpack-pro-redirect-modal__footer-buttons">
+						<Button
+							type="submit"
+							primary
+							href="https://cloud.jetpack.com/partner-portal/issue-license"
+							onClick={ recordRedirectEvent }
+						>
+							{ translate( 'Unlock savings now' ) }
+						</Button>
+						<Button borderless onClick={ dismissAndRecordEvent }>
+							{ translate( 'Continue with purchase here' ) }
+						</Button>
 					</div>
 				</div>
-			</Modal>
-		</>
+			</div>
+		</Modal>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/style.scss
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/style.scss
@@ -1,0 +1,124 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
+
+.jetpack-pro-redirect-modal {
+	position: relative;
+
+	.banner__close-icon {
+		width: 20px;
+		height: 20px;
+	}
+
+	.components-modal__header .components-button {
+		top: -40px;
+	}
+
+	.components-modal__header {
+		padding: 0 16px;
+		height: 120px;
+		background-image: url(calypso/assets/images/jetpack/jetpack-jitm-background.png);
+		background-position: top right;
+		background-repeat: no-repeat;
+	}
+
+	.components-modal__content {
+		margin-top: 120px;
+	}
+
+	.jetpack-pro-redirect-modal__container {
+		margin-block-start: 32px;
+		padding-block-end: 100px;
+
+		@include break-small {
+			padding-block-end: 0;
+		}
+
+		.jetpack-pro-redirect-modal__top-header {
+			position: absolute;
+			inset-block-start: 48px;
+			z-index: 99;
+			inset-inline-start: 50%;
+			transform: translateX(-50%);
+			font-size: 1rem;
+			font-weight: 700;
+			white-space: nowrap;
+		}
+
+		p {
+			margin-bottom: 16px;
+		}
+	}
+
+	.jetpack-pro-redirect-modal__heading {
+		color: var(--studio-gray-100);
+		font-weight: 700;
+		font-size: 1.5rem;
+		margin-block-end: 16px;
+	}
+
+	.jetpack-pro-redirect-modal__list {
+		margin: 16px 0;
+		list-style: none;
+
+		li {
+			letter-spacing: -0.16px;
+
+			svg {
+				fill: var(--studio-green-40);
+				position: relative;
+				top: 5px;
+				right: 5px;
+			}
+		}
+	}
+
+	.jetpack-pro-redirect-modal__logo {
+		position: relative;
+		top: 5px;
+		right: 10px;
+	}
+
+	.jetpack-pro-redirect-modal__footer {
+		width: calc(100% - 64px); // reducing the left and right padding
+		display: flex;
+		justify-content: flex-start;
+		flex-direction: column;
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		padding: 16px 32px;
+		background: var(--studio-white);
+
+		.jetpack-pro-redirect-modal__footer-buttons {
+			display: flex;
+			flex-direction: column;
+		}
+
+		@include break-mobile {
+			position: static;
+			justify-content: right;
+			flex-direction: initial;
+			margin-block-start: 32px;
+			width: auto;
+			padding: 0;
+
+			.jetpack-pro-redirect-modal__footer-buttons {
+				width: 100%;
+				flex-direction: initial;
+			}
+		}
+
+		.button {
+			&.is-borderless {
+				margin-inline-start: 24px;
+				text-decoration: underline;
+			}
+
+			&.is-primary {
+				background-color: var(--studio-green-50);
+				border: 1px solid var(--studio-green-50);
+				color: #fff;
+			}
+		}
+	}
+}

--- a/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/utils/get-page-value-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/utils/get-page-value-from-url.ts
@@ -1,0 +1,10 @@
+const getPageValueFromUrl = ( url?: string ) => {
+	if ( ! url ) {
+		return '';
+	}
+	const newURL = new URL( url );
+	const redirectURLParams = new URLSearchParams( newURL.search );
+	return redirectURLParams.get( 'page' );
+};
+
+export default getPageValueFromUrl;

--- a/client/state/jetpack-agency-dashboard/selectors.ts
+++ b/client/state/jetpack-agency-dashboard/selectors.ts
@@ -16,6 +16,9 @@ export const JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE_HOME_PAGE =
 export const JETPACK_DASHBOARD_SURVEY_BANNER_PREFERENCE =
 	'jetpack-dashboard-agency-program-survey-banner-preference';
 
+export const JETPACK_DASHBOARD_CHECKOUT_REDIRECT_MODAL_DISMISSED =
+	'jetpack-dashboard-checkout-redirect-modal-dismissed';
+
 /**
  * Returns preference associated with the key provided.
  */

--- a/client/state/jetpack-agency-dashboard/selectors.ts
+++ b/client/state/jetpack-agency-dashboard/selectors.ts
@@ -17,7 +17,7 @@ export const JETPACK_DASHBOARD_SURVEY_BANNER_PREFERENCE =
 	'jetpack-dashboard-agency-program-survey-banner-preference';
 
 export const JETPACK_DASHBOARD_CHECKOUT_REDIRECT_MODAL_DISMISSED =
-	'jetpack-dashboard-checkout-redirect-modal-dismissed';
+	'agency-program-checkout-redirect-modal-dismissed';
 
 /**
  * Returns preference associated with the key provided.


### PR DESCRIPTION
Related to 1202619025189113-as-1204953498074085

## Proposed Changes

This PR implements a modal in the payment checkout page that shows the Agency/Pro users the benefits of buying the products from the Jetpack Licensing Portal. 

We show this page only if 

- The user is an agency partner.
- If the user is coming from Jetpack Pricing or My Jetpack page.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/show-redirect-modal-in-checkout` and `yarn start` or open the Calypso live link. 
2. Open http://calypso.localhost:3000/ or the Calypso live link.
3. Visit https://cloud.jetpack.com/pricing and click on the `Get` button on any product -> You'll be redirected to the payment checkout page -> Replace `https://wordpress.com/` with `http://calypso.localhost:3000/ ` or the live link URL.
4. Verify that you can see the modal as shown below

![mobile (23)](https://github.com/Automattic/wp-calypso/assets/10586875/a79f2eb2-036b-4aa9-898b-00ea0ddacfca)

5. Go to WP.com -> Select any Jetpack site -> Visit WP Admin page -> Click on Jetpack - My Jetpack -> Click on `Start for free` on the Search card -> Click the `Get Jetpack Search` button -> Replace `https://wordpress.com/` with `http://calypso.localhost:3000/ ` or the live link URL and verify you can now see the same modal.

6. Go to WP.com -> Select any Jetpack site -> Visit WP Admin page -> Click on Jetpack - My Jetpack -> Click on `Purchase` on any product(Backup or Scan) -> Click the get product button -> Replace `https://wordpress.com/` with `http://calypso.localhost:3000/ ` or the live link URL and verify you can now see the same modal.
7. Verify the modal looks good on different screen sizes

**Tablet**

![mobile (24)](https://github.com/Automattic/wp-calypso/assets/10586875/4a90923b-4ff0-4ef6-b06b-801afe4cb120)

**Mobile**

![mobile (25)](https://github.com/Automattic/wp-calypso/assets/10586875/e7e8a569-743b-482f-bd25-4939382f81ac)

8. Go to WP.com and add any WP.com plans(Personal or Business) by clicking the Upgrade button and verify that the modal is not shown now.

<img width="1266" alt="Screenshot 2023-07-05 at 10 11 14 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e18c81b6-03f6-4b4c-b1c0-7dd2c725a7d6">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?