### PR TITLE
Fix/campaign details skeleton

### DIFF
--- a/client/my-sites/promote-post-i2/components/ad-preview/style.scss
+++ b/client/my-sites/promote-post-i2/components/ad-preview/style.scss
@@ -1,14 +1,15 @@
 
 .promote-post-ad-preview__loading {
-	width: 300px;
-	height: 250px;
+	animation: skeleton-loading 1s linear infinite alternate;
 	background-color: hsl(200, 20%, 90%);
 	border-radius: 4px;
 	display: inline-block;
-	position: relative;
+	height: 250px;
 	overflow: hidden;
+	position: relative;
 	min-height: 16px;
-	animation: skeleton-loading 1s linear infinite alternate;
+	width: 300px;
+
 	@keyframes skeleton-loading {
 		0% {
 			background-color: hsl(200, 20%, 80%);

--- a/client/my-sites/promote-post-i2/components/ad-preview/style.scss
+++ b/client/my-sites/promote-post-i2/components/ad-preview/style.scss
@@ -1,7 +1,7 @@
+@import "../../style.scss";
+
 
 .promote-post-ad-preview__loading {
-	animation: skeleton-loading 1s linear infinite alternate;
-	background-color: hsl(200, 20%, 90%);
 	border-radius: 4px;
 	display: inline-block;
 	height: 250px;
@@ -10,13 +10,5 @@
 	min-height: 16px;
 	width: 300px;
 
-	@keyframes skeleton-loading {
-		0% {
-			background-color: hsl(200, 20%, 80%);
-		}
-		100% {
-			background-color: hsl(200, 20%, 95%);
-		}
-	}
-
+	@include blazepress-animated-skeleton;
 }

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -523,15 +523,15 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 	}
 
 	.campaign-item-details__flexible-skeleton {
-		display: inline-block;
-		position: relative;
-		overflow: hidden;
-		min-height: 16px;
-		width: 100%;
-		height: 100%;
-		max-width: 250px;
 		animation: skeleton-loading 1s linear infinite alternate;
 		border-radius: 4px;
+		display: inline-block;
+		height: 100%;
+		overflow: hidden;
+		position: relative;
+		max-width: 250px;
+		min-height: 16px;
+		width: 100%;
 
 		@keyframes skeleton-loading {
 			0% {

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -1,5 +1,6 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@wordpress/base-styles/breakpoints";
+@import "../../style.scss";
 
 body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 	margin: 0 64px;
@@ -523,24 +524,15 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 	}
 
 	.campaign-item-details__flexible-skeleton {
-		animation: skeleton-loading 1s linear infinite alternate;
 		border-radius: 4px;
 		display: inline-block;
-		height: 100%;
 		overflow: hidden;
 		position: relative;
 		max-width: 250px;
-		min-height: 16px;
+		height: 16px;
 		width: 100%;
 
-		@keyframes skeleton-loading {
-			0% {
-				background-color: hsl(200, 20%, 80%);
-			}
-			100% {
-				background-color: hsl(200, 20%, 95%);
-			}
-		}
+		@include blazepress-animated-skeleton;
 	}
 }
 

--- a/client/my-sites/promote-post-i2/components/campaigns-table/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 	isFetchingPageResults: boolean;
 }
 
-export const CampaignItemLoading = ( { totalRows = 7 }: { totalRows?: number } ) => {
+export const SingleItemLoading = ( { totalRows = 8 }: { totalRows?: number } ) => {
 	return (
 		<tr>
 			<td>
@@ -26,6 +26,17 @@ export const CampaignItemLoading = ( { totalRows = 7 }: { totalRows?: number } )
 				<td key={ i }></td>
 			) ) }
 		</tr>
+	);
+};
+
+export const ItemsLoading = ( { totalRows = 8 }: { totalRows?: number } ) => {
+	const rowsNumber = 5;
+	return (
+		<>
+			{ new Array( rowsNumber ).fill( 0, 0, rowsNumber ).map( () => (
+				<SingleItemLoading totalRows={ totalRows } />
+			) ) }
+		</>
 	);
 };
 
@@ -85,11 +96,7 @@ export default function CampaignsTable( props: Props ) {
 				</thead>
 				<tbody>
 					{ isLoading && ! isFetchingPageResults ? (
-						<>
-							{ columns.map( ( item, key ) => (
-								<CampaignItemLoading key={ key } />
-							) ) }
-						</>
+						<ItemsLoading />
 					) : (
 						<>
 							{ campaigns.map( ( campaign ) => {
@@ -100,7 +107,7 @@ export default function CampaignsTable( props: Props ) {
 									/>
 								);
 							} ) }
-							{ isFetchingPageResults && <CampaignItemLoading /> }
+							{ isFetchingPageResults && <SingleItemLoading /> }
 						</>
 					) }
 				</tbody>

--- a/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
@@ -93,6 +93,8 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 
 		&__header-image-skeleton {
 			margin-right: 16px;
+
+			@include blazepress-animated-skeleton;
 		}
 
 		font-family: $font-sf-pro-text;
@@ -133,14 +135,15 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 
 		.campaign-item__skeleton-text {
 			width: 142px;
-			height: 12px;
-			background-color: #f5f5f5;
+			height: 16px;
 			border-radius: 4px;
 			margin-top: 8px;
 			&.campaign-item__skeleton-text2 {
 				width: 97px;
 				margin-top: 12px;
 			}
+
+			@include blazepress-animated-skeleton;
 		}
 	}
 

--- a/client/my-sites/promote-post-i2/components/posts-table/index.tsx
+++ b/client/my-sites/promote-post-i2/components/posts-table/index.tsx
@@ -2,7 +2,7 @@ import '../campaigns-table/style.scss';
 
 import { BlazablePost } from 'calypso/data/promote-post/types';
 import PostItem from 'calypso/my-sites/promote-post-i2/components/post-item';
-import { CampaignItemLoading } from '../campaigns-table';
+import { ItemsLoading, SingleItemLoading } from '../campaigns-table';
 import PostsListHeader from '../posts-list/header';
 
 interface Props {
@@ -20,19 +20,13 @@ export default function PostsTable( props: Props ) {
 
 			<tbody>
 				{ isLoading && ! isFetchingPageResults ? (
-					<>
-						<CampaignItemLoading totalRows={ 8 } />
-						<CampaignItemLoading totalRows={ 8 } />
-						<CampaignItemLoading totalRows={ 8 } />
-						<CampaignItemLoading totalRows={ 8 } />
-						<CampaignItemLoading totalRows={ 8 } />
-					</>
+					<ItemsLoading />
 				) : (
 					<>
 						{ posts.map( ( post: BlazablePost ) => {
 							return <PostItem key={ `post-id${ post.ID }` } post={ post } />;
 						} ) }
-						{ isFetchingPageResults && <CampaignItemLoading /> }
+						{ isFetchingPageResults && <SingleItemLoading /> }
 					</>
 				) }
 			</tbody>

--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -69,6 +69,20 @@
 	}
 }
 
+@mixin blazepress-animated-skeleton {
+	background-color: hsl(200, 20%, 90%);
+	animation: skeleton-loading 1s linear infinite alternate;
+
+	@keyframes skeleton-loading {
+		0% {
+			background-color: hsl(200, 20%, 80%);
+		}
+		100% {
+			background-color: hsl(200, 20%, 95%);
+		}
+	}
+}
+
 .notouch .promote-post-i2 .section-nav-tab__link:hover {
 	background-color: transparent;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to SELFSERVE-616

## Proposed Changes

* We want to make sure that skeleton styles (how we show elements while loading the data) are consistent amongst posts, campaigns, and campaign details

![blazepress-skeleton-animation](https://github.com/Automattic/wp-calypso/assets/115007291/b1ce757e-2f0c-4054-933b-a95bae863778)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch in your local environment
* Apply the following [patch](https://github.com/Automattic/wp-calypso/files/11951514/always-loading-skeleton.patch) to enforce Post/Campaigns/Campaign Details to show `isLoading` state infinitely
* Check that styling is consistent across Posts, Camaigns, and Campaign Details.
 
https://github.com/Automattic/wp-calypso/assets/115007291/47620847-2da8-4593-be9d-92ac33739890

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
