### PR TITLE
Update Payments Modal Improvements

### DIFF
--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -330,7 +330,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					<ToggleControl
 						onChange={ handleMarkAsDonation }
 						checked={ 'donation' === editedMarkAsDonation }
-						label={ translate( 'Tips and donation' ) }
+						label={ translate( 'Mark this plan as a donation' ) }
 					/>
 					<ToggleControl
 						onChange={ ( newValue ) => setEditedPostsEmail( newValue ) }

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -253,7 +253,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				},
 			] }
 		>
-			<FormSectionHeading>{ product && product.ID ? editPlan : addPlan }</FormSectionHeading>
+			<FormSectionHeading>{ editing ? editPlan : addPlan }</FormSectionHeading>
 			<div className="memberships__dialog-sections">
 				<FormFieldset>
 					<FormLabel htmlFor="title">{ translate( 'Describe the offer' ) }</FormLabel>

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -11,8 +11,8 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormSelect from 'calypso/components/forms/form-select';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
 import {
 	requestAddProduct,
@@ -228,17 +228,13 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	};
 
 	const addPlan = editedPostsEmail
-		? translate( 'Add a newsletter payment plan' )
-		: translate( 'Add a payment plan' );
+		? translate( 'Create a paid newsletter subscription plan' )
+		: translate( 'Create a payment plan' );
 
 	const editPlan = editedPostsEmail
-		? translate( 'Edit newsletter payment plan' )
+		? translate( 'Edit a paid newsletter subscription plan' )
 		: translate( 'Edit a payment plan' );
 
-	const editProduct = translate( 'Edit your existing payment plan.' );
-	const noProduct = translate(
-		'Each amount you add will create a separate payment plan. You can create many of them.'
-	);
 	const editing = product && product.ID;
 	return (
 		<Dialog
@@ -259,48 +255,48 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		>
 			<FormSectionHeading>{ product && product.ID ? editPlan : addPlan }</FormSectionHeading>
 			<div className="memberships__dialog-sections">
-				<p>{ editing ? editProduct : noProduct }</p>
 				<FormFieldset>
-					<FormLabel htmlFor="title">
-						{ translate( 'Please describe your payment plan' ) }
-					</FormLabel>
+					<FormLabel htmlFor="title">{ translate( 'Describe the payment plan' ) }</FormLabel>
 					<FormTextInput
 						id="title"
 						value={ editedProductName }
 						onChange={ onNameChange }
 						onBlur={ () => setFocusedName( true ) }
 					/>
+					<FormSettingExplanation>
+						{ translate( 'Use this to tell your users what they’ll get.' ) }
+					</FormSettingExplanation>
 					{ ! isFormValid( 'name' ) && focusedName && (
 						<FormInputValidation isError text={ translate( 'Please input a name.' ) } />
 					) }
 				</FormFieldset>
-				<FormFieldset className="memberships__dialog-sections-price">
-					{ ! isFormValid( 'price' ) && (
-						<FormInputValidation
-							isError
-							text={ translate( 'Please enter a price higher than %s', {
-								args: [
-									formatCurrency(
-										minimumCurrencyTransactionAmount(
-											currentCurrency,
-											connectedAccountDefaultCurrency
-										),
-										currentCurrency
+				{ editing && (
+					<Notice
+						text={ translate(
+							'Updating the price will not affect existing subscribers, who will pay what they were originally charged on renewal.'
+						) }
+						showDismiss={ false }
+					/>
+				) }
+				{ ! isFormValid( 'price' ) && (
+					<FormInputValidation
+						isError
+						text={ translate( 'Please enter a price higher than %s', {
+							args: [
+								formatCurrency(
+									minimumCurrencyTransactionAmount(
+										currentCurrency,
+										connectedAccountDefaultCurrency
 									),
-								],
-							} ) }
-						/>
-					) }
+									currentCurrency
+								),
+							],
+						} ) }
+					/>
+				) }
+				<FormFieldset className="memberships__dialog-sections-price">
 					<div className="memberships__dialog-sections-price-field-container">
 						<FormLabel htmlFor="currency">{ translate( 'Select price' ) }</FormLabel>
-						{ editing && (
-							<Notice
-								text={ translate(
-									'Updating the price will not affect existing subscribers, who will pay what they were originally charged on renewal.'
-								) }
-								showDismiss={ false }
-							/>
-						) }
 						<FormCurrencyInput
 							name="currency"
 							id="currency"
@@ -328,38 +324,32 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					</div>
 				</FormFieldset>
 				<FormFieldset>
-					<p>
-						{ translate(
-							'Allow members of this payment plan to opt into receiving new posts via email.'
-						) }{ ' ' }
-						<InlineSupportLink supportContext="paid-newsletters" showIcon={ false }>
-							{ translate( 'Learn more.' ) }
-						</InlineSupportLink>
-					</p>
 					<ToggleControl
 						onChange={ ( newValue ) => setEditedPostsEmail( newValue ) }
 						checked={ editedPostsEmail }
 						label={ translate( 'Email newly published posts to your customers.' ) }
 					/>
 				</FormFieldset>
-				<FoldableCard header={ translate( 'Advanced Options' ) } hideSummary>
-					<FormFieldset>
-						<h6 className="memberships__dialog-form-header">
-							{ translate( 'Custom confirmation message' ) }
-						</h6>
-						<p>
-							{ translate(
-								'Add a custom message to the confirmation email that is sent after purchase. For example, you can thank your customers.'
-							) }
-						</p>
-						<CountedTextArea
-							value={ editedCustomConfirmationMessage }
-							onChange={ ( event ) => setEditedCustomConfirmationMessage( event.target.value ) }
-							acceptableLength={ MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE }
-							showRemainingCharacters={ true }
-							placeholder={ translate( 'Thank you for subscribing!' ) }
-						/>
-					</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="renewal_schedule">
+						{ translate( 'Personalized confirmation message' ) }
+					</FormLabel>
+					<CountedTextArea
+						value={ editedCustomConfirmationMessage }
+						onChange={ ( event ) => setEditedCustomConfirmationMessage( event.target.value ) }
+						acceptableLength={ MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE }
+						showRemainingCharacters={ true }
+						placeholder={ translate( 'Thank you for subscribing!' ) }
+					/>
+					<FormSettingExplanation>
+						{ translate( 'Your new customers will receive this message' ) }
+					</FormSettingExplanation>
+				</FormFieldset>
+				<FoldableCard
+					header={ translate( 'Advanced Options' ) }
+					hideSummary
+					className="memberships__dialog-advanced-options"
+				>
 					<FormFieldset>
 						<ToggleControl
 							onChange={ handlePayWhatYouWant }

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -318,6 +318,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 							onCurrencyChange={ handleCurrencyChange }
 							currencyList={ currencyList }
 							placeholder="0.00"
+							noWrap
 						/>
 					</div>
 				</FormFieldset>

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -323,10 +323,6 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					</div>
 				</FormFieldset>
 				<FormFieldset>
-					{ /*<ToggleControl*/ }
-					{ /*	label={ translate( 'Product, service, or download' ) }*/ }
-					{ /*	onChange={ () => {} }*/ }
-					{ /*/>*/ }
 					<ToggleControl
 						onChange={ handleMarkAsDonation }
 						checked={ 'donation' === editedMarkAsDonation }

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -264,7 +264,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						onBlur={ () => setFocusedName( true ) }
 					/>
 					<FormSettingExplanation>
-						{ translate( "Let your subscriber know what they'll get when they subscribe." ) }
+						{ translate( "Let your audience know what they'll get when they subscribe." ) }
 					</FormSettingExplanation>
 					{ ! isFormValid( 'name' ) && focusedName && (
 						<FormInputValidation isError text={ translate( 'Please input a name.' ) } />

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -296,7 +296,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				) }
 				<FormFieldset className="memberships__dialog-sections-price">
 					<div className="memberships__dialog-sections-price-field-container">
-						<FormLabel htmlFor="currency">{ translate( 'Select price' ) }</FormLabel>
+						<FormLabel htmlFor="currency">{ translate( 'Amount' ) }</FormLabel>
 						<FormCurrencyInput
 							name="currency"
 							id="currency"
@@ -309,9 +309,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						/>
 					</div>
 					<div className="memberships__dialog-sections-price-field-container">
-						<FormLabel htmlFor="renewal_schedule">
-							{ translate( 'Select renewal frequency' ) }
-						</FormLabel>
+						<FormLabel htmlFor="renewal_schedule">{ translate( 'Renewal frequency' ) }</FormLabel>
 						<FormSelect
 							id="renewal_schedule"
 							value={ editedSchedule }

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -228,12 +228,12 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	};
 
 	const addPlan = editedPostsEmail
-		? translate( 'Create a paid newsletter subscription plan' )
-		: translate( 'Create a payment plan' );
+		? translate( 'Set up newsletter payment options' )
+		: translate( 'Set up payment options' );
 
 	const editPlan = editedPostsEmail
-		? translate( 'Edit a paid newsletter subscription plan' )
-		: translate( 'Edit a payment plan' );
+		? translate( 'Edit newsletter payment options' )
+		: translate( 'Edit payment options' );
 
 	const editing = product && product.ID;
 	return (
@@ -256,7 +256,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 			<FormSectionHeading>{ product && product.ID ? editPlan : addPlan }</FormSectionHeading>
 			<div className="memberships__dialog-sections">
 				<FormFieldset>
-					<FormLabel htmlFor="title">{ translate( 'Describe the payment plan' ) }</FormLabel>
+					<FormLabel htmlFor="title">{ translate( 'Describe the offer' ) }</FormLabel>
 					<FormTextInput
 						id="title"
 						value={ editedProductName }
@@ -264,7 +264,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						onBlur={ () => setFocusedName( true ) }
 					/>
 					<FormSettingExplanation>
-						{ translate( 'Use this to tell your users what they’ll get.' ) }
+						{ translate( "Let your subscriber know what they'll get when they subscribe." ) }
 					</FormSettingExplanation>
 					{ ! isFormValid( 'name' ) && focusedName && (
 						<FormInputValidation isError text={ translate( 'Please input a name.' ) } />
@@ -296,6 +296,18 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				) }
 				<FormFieldset className="memberships__dialog-sections-price">
 					<div className="memberships__dialog-sections-price-field-container">
+						<FormLabel htmlFor="renewal_schedule">{ translate( 'Renewal frequency' ) }</FormLabel>
+						<FormSelect
+							id="renewal_schedule"
+							value={ editedSchedule }
+							onChange={ onSelectSchedule }
+						>
+							<option value="1 month">{ translate( 'Monthly' ) }</option>
+							<option value="1 year">{ translate( 'Yearly' ) }</option>
+							<option value="one-time">{ translate( 'One time sale' ) }</option>
+						</FormSelect>
+					</div>
+					<div className="memberships__dialog-sections-price-field-container">
 						<FormLabel htmlFor="currency">{ translate( 'Amount' ) }</FormLabel>
 						<FormCurrencyInput
 							name="currency"
@@ -308,30 +320,25 @@ const RecurringPaymentsPlanAddEditModal = ( {
 							placeholder="0.00"
 						/>
 					</div>
-					<div className="memberships__dialog-sections-price-field-container">
-						<FormLabel htmlFor="renewal_schedule">{ translate( 'Renewal frequency' ) }</FormLabel>
-						<FormSelect
-							id="renewal_schedule"
-							value={ editedSchedule }
-							onChange={ onSelectSchedule }
-						>
-							<option value="1 month">{ translate( 'Monthly' ) }</option>
-							<option value="1 year">{ translate( 'Yearly' ) }</option>
-							<option value="one-time">{ translate( 'One time sale' ) }</option>
-						</FormSelect>
-					</div>
 				</FormFieldset>
 				<FormFieldset>
+					{ /*<ToggleControl*/ }
+					{ /*	label={ translate( 'Product, service, or download' ) }*/ }
+					{ /*	onChange={ () => {} }*/ }
+					{ /*/>*/ }
+					<ToggleControl
+						onChange={ handleMarkAsDonation }
+						checked={ 'donation' === editedMarkAsDonation }
+						label={ translate( 'Tips and donation' ) }
+					/>
 					<ToggleControl
 						onChange={ ( newValue ) => setEditedPostsEmail( newValue ) }
 						checked={ editedPostsEmail }
-						label={ translate( 'Email newly published posts to your subscribers' ) }
+						label={ translate( 'Paid newsletter subscription' ) }
 					/>
 				</FormFieldset>
 				<FormFieldset>
-					<FormLabel htmlFor="renewal_schedule">
-						{ translate( 'Personalized confirmation message' ) }
-					</FormLabel>
+					<FormLabel htmlFor="renewal_schedule">{ translate( 'Welcome message' ) }</FormLabel>
 					<CountedTextArea
 						value={ editedCustomConfirmationMessage }
 						onChange={ ( event ) => setEditedCustomConfirmationMessage( event.target.value ) }
@@ -340,7 +347,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						placeholder={ translate( 'Thank you for subscribing!' ) }
 					/>
 					<FormSettingExplanation>
-						{ translate( 'Your new customers will receive this message' ) }
+						{ translate( 'The welcome message sent when your subscriber completes their order.' ) }
 					</FormSettingExplanation>
 				</FormFieldset>
 				<FoldableCard
@@ -353,25 +360,13 @@ const RecurringPaymentsPlanAddEditModal = ( {
 							onChange={ handlePayWhatYouWant }
 							checked={ editedPayWhatYouWant }
 							label={ translate(
-								'Enable customers to pick their own amount ("Pay what you want").'
+								'Enable customers to pick their own amount (“Pay what you want”)'
 							) }
 						/>
-					</FormFieldset>
-					<FormFieldset>
 						<ToggleControl
 							onChange={ handleMultiplePerUser }
 							checked={ editedMultiplePerUser }
-							label={ translate(
-								'Allow the same customer to purchase or sign up to this plan multiple times.'
-							) }
-						/>
-					</FormFieldset>
-					<FormFieldset>
-						<ToggleControl
-							onChange={ handleMarkAsDonation }
-							checked={ 'donation' === editedMarkAsDonation }
-							label={ translate( 'Mark this plan as a donation.' ) }
-							disabled={ !! product && product.ID }
+							label={ translate( 'Enable customers to make the same purchase multiple times' ) }
 						/>
 					</FormFieldset>
 				</FoldableCard>

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -4,6 +4,7 @@ import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
+import FoldableCard from 'calypso/components/foldable-card';
 import CountedTextArea from 'calypso/components/forms/counted-textarea';
 import FormCurrencyInput from 'calypso/components/forms/form-currency-input';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -341,49 +342,51 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						label={ translate( 'Email newly published posts to your customers.' ) }
 					/>
 				</FormFieldset>
-				<FormFieldset>
-					<h6 className="memberships__dialog-form-header">
-						{ translate( 'Custom confirmation message' ) }
-					</h6>
-					<p>
-						{ translate(
-							'Add a custom message to the confirmation email that is sent after purchase. For example, you can thank your customers.'
-						) }
-					</p>
-					<CountedTextArea
-						value={ editedCustomConfirmationMessage }
-						onChange={ ( event ) => setEditedCustomConfirmationMessage( event.target.value ) }
-						acceptableLength={ MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE }
-						showRemainingCharacters={ true }
-						placeholder={ translate( 'Thank you for subscribing!' ) }
-					/>
-				</FormFieldset>
-				<FormFieldset>
-					<ToggleControl
-						onChange={ handlePayWhatYouWant }
-						checked={ editedPayWhatYouWant }
-						label={ translate(
-							'Enable customers to pick their own amount ("Pay what you want").'
-						) }
-					/>
-				</FormFieldset>
-				<FormFieldset>
-					<ToggleControl
-						onChange={ handleMultiplePerUser }
-						checked={ editedMultiplePerUser }
-						label={ translate(
-							'Allow the same customer to purchase or sign up to this plan multiple times.'
-						) }
-					/>
-				</FormFieldset>
-				<FormFieldset>
-					<ToggleControl
-						onChange={ handleMarkAsDonation }
-						checked={ 'donation' === editedMarkAsDonation }
-						label={ translate( 'Mark this plan as a donation.' ) }
-						disabled={ !! product && product.ID }
-					/>
-				</FormFieldset>
+				<FoldableCard header={ translate( 'Advanced Options' ) } hideSummary>
+					<FormFieldset>
+						<h6 className="memberships__dialog-form-header">
+							{ translate( 'Custom confirmation message' ) }
+						</h6>
+						<p>
+							{ translate(
+								'Add a custom message to the confirmation email that is sent after purchase. For example, you can thank your customers.'
+							) }
+						</p>
+						<CountedTextArea
+							value={ editedCustomConfirmationMessage }
+							onChange={ ( event ) => setEditedCustomConfirmationMessage( event.target.value ) }
+							acceptableLength={ MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE }
+							showRemainingCharacters={ true }
+							placeholder={ translate( 'Thank you for subscribing!' ) }
+						/>
+					</FormFieldset>
+					<FormFieldset>
+						<ToggleControl
+							onChange={ handlePayWhatYouWant }
+							checked={ editedPayWhatYouWant }
+							label={ translate(
+								'Enable customers to pick their own amount ("Pay what you want").'
+							) }
+						/>
+					</FormFieldset>
+					<FormFieldset>
+						<ToggleControl
+							onChange={ handleMultiplePerUser }
+							checked={ editedMultiplePerUser }
+							label={ translate(
+								'Allow the same customer to purchase or sign up to this plan multiple times.'
+							) }
+						/>
+					</FormFieldset>
+					<FormFieldset>
+						<ToggleControl
+							onChange={ handleMarkAsDonation }
+							checked={ 'donation' === editedMarkAsDonation }
+							label={ translate( 'Mark this plan as a donation.' ) }
+							disabled={ !! product && product.ID }
+						/>
+					</FormFieldset>
+				</FoldableCard>
 			</div>
 		</Dialog>
 	);

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -315,8 +315,8 @@ const RecurringPaymentsPlanAddEditModal = ( {
 							value={ editedSchedule }
 							onChange={ onSelectSchedule }
 						>
-							<option value="1 month">{ translate( 'Renew monthly' ) }</option>
-							<option value="1 year">{ translate( 'Renew yearly' ) }</option>
+							<option value="1 month">{ translate( 'Monthly' ) }</option>
+							<option value="1 year">{ translate( 'Yearly' ) }</option>
 							<option value="one-time">{ translate( 'One time sale' ) }</option>
 						</FormSelect>
 					</div>

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -325,7 +325,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					<ToggleControl
 						onChange={ ( newValue ) => setEditedPostsEmail( newValue ) }
 						checked={ editedPostsEmail }
-						label={ translate( 'Email newly published posts to your customers.' ) }
+						label={ translate( 'Email newly published posts to your subscribers' ) }
 					/>
 				</FormFieldset>
 				<FormFieldset>

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -316,6 +316,38 @@
 	display: grid;
 	grid-template: "item" 1fr / 1fr;
 	width: 580px;
+	& * {
+		font-size: $font-body;
+		font-weight: normal;
+	}
+	.form-label {
+		font-size: $font-body;
+		font-weight: normal;
+	}
+	.form-setting-explanation {
+		font-style: normal;
+		font-size: $font-body-small;
+	}
+	.memberships__dialog-advanced-options {
+		width: 100%;
+		box-shadow: none;
+		.foldable-card__header {
+			padding: 0;
+		}
+		&.foldable-card.is-expanded {
+			margin: 0;
+			.foldable-card__content {
+				border-top: none;
+				padding: 0;
+			}
+		}
+		.foldable-card__main {
+			display: block;
+			.foldable-card__action {
+				right: unset;
+			}
+		}
+	}
 }
 
 .memberships__dialog-section {
@@ -343,28 +375,6 @@
 	flex-direction: column;
 	&:first-child {
 		margin-right: 35px;
-	}
-}
-
-.memberships__dialog-advanced-options {
-	width: 100%;
-	box-shadow: none;
-	.foldable-card__header {
-		padding: 0;
-	}
-	.foldable-card__content {
-		padding: 0;
-	}
-	&.foldable-card.is-expanded {
-		.foldable-card__content {
-			border-top: none;
-		}
-	}
-	.foldable-card__main {
-		display: block;
-		.foldable-card__action {
-			right: unset;
-		}
 	}
 }
 

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -315,6 +315,7 @@
 .memberships__dialog-sections {
 	display: grid;
 	grid-template: "item" 1fr / 1fr;
+	width: 580px;
 }
 
 .memberships__dialog-section {
@@ -341,8 +342,12 @@
 	display: flex;
 	flex-direction: column;
 	&:first-child {
-		margin-right: 30px;
+		margin-right: 35px;
 	}
+}
+
+.memberships__dialog-advanced-options {
+	width: 100%;
 }
 
 /**

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -315,17 +315,10 @@
 .memberships__dialog-sections {
 	display: grid;
 	grid-template: "item" 1fr / 1fr;
-	width: 580px;
-	& * {
-		font-size: $font-body;
-		font-weight: normal;
-	}
-	.form-label {
-		font-size: $font-body;
-		font-weight: normal;
+	@include breakpoint-deprecated( "<600px" ) {
+		min-width: 580px;
 	}
 	.form-setting-explanation {
-		font-style: normal;
 		font-size: $font-body-small;
 	}
 	.memberships__dialog-advanced-options {
@@ -343,6 +336,8 @@
 		}
 		.foldable-card__main {
 			display: block;
+			font-weight: 600;
+			font-size: 0.875rem;
 			.foldable-card__action {
 				right: unset;
 			}
@@ -373,6 +368,7 @@
 .memberships__dialog-sections-price-field-container {
 	display: flex;
 	flex-direction: column;
+	max-width: 200px;
 	&:first-child {
 		margin-right: 35px;
 	}

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -348,6 +348,24 @@
 
 .memberships__dialog-advanced-options {
 	width: 100%;
+	box-shadow: none;
+	.foldable-card__header {
+		padding: 0;
+	}
+	.foldable-card__content {
+		padding: 0;
+	}
+	&.foldable-card.is-expanded {
+		.foldable-card__content {
+			border-top: none;
+		}
+	}
+	.foldable-card__main {
+		display: block;
+		.foldable-card__action {
+			right: unset;
+		}
+	}
 }
 
 /**

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -315,7 +315,7 @@
 .memberships__dialog-sections {
 	display: grid;
 	grid-template: "item" 1fr / 1fr;
-	@include breakpoint-deprecated( ">600px" ) {
+	@include break-medium {
 		min-width: 580px;
 	}
 	.form-setting-explanation {
@@ -337,7 +337,7 @@
 		.foldable-card__main {
 			display: block;
 			font-weight: 600;
-			font-size: 0.875rem;
+			font-size: $font-body-small;
 			.foldable-card__action {
 				right: unset;
 			}

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -332,6 +332,19 @@
 	margin-bottom: 1.5em;
 }
 
+.memberships__dialog-sections-price {
+	display: flex;
+	justify-content: flex-start;
+}
+
+.memberships__dialog-sections-price-field-container {
+	display: flex;
+	flex-direction: column;
+	&:first-child {
+		margin-right: 30px;
+	}
+}
+
 /**
  * Delete Site Options
  */

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -315,7 +315,7 @@
 .memberships__dialog-sections {
 	display: grid;
 	grid-template: "item" 1fr / 1fr;
-	@include breakpoint-deprecated( "<600px" ) {
+	@include breakpoint-deprecated( ">600px" ) {
 		min-width: 580px;
 	}
 	.form-setting-explanation {
@@ -368,7 +368,7 @@
 .memberships__dialog-sections-price-field-container {
 	display: flex;
 	flex-direction: column;
-	max-width: 200px;
+	width: 200px;
 	&:first-child {
 		margin-right: 35px;
 	}

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -363,14 +363,22 @@
 .memberships__dialog-sections-price {
 	display: flex;
 	justify-content: flex-start;
+	flex-direction: column;
+
+	@include break-medium {
+		flex-direction: row;
+	}
 }
 
 .memberships__dialog-sections-price-field-container {
 	display: flex;
 	flex-direction: column;
-	width: 200px;
-	&:first-child {
+	margin-bottom: 25px;
+
+	@include break-medium {
+		margin-bottom: 0;
 		margin-right: 35px;
+		max-width: 200px;
 	}
 }
 


### PR DESCRIPTION
Related to #77258

## Proposed Changes

#### Before
<img width="980" alt="Screenshot 2023-07-05 at 14 29 37" src="https://github.com/Automattic/wp-calypso/assets/104869/ab69b853-c700-4d9c-91a6-c0a5514a3884">


#### After
<img width="765" alt="Screenshot 2023-07-11 at 09 23 27" src="https://github.com/Automattic/wp-calypso/assets/104869/da7e2343-5753-4ab7-8041-ae136798e3d7">


## Testing Instructions

* Go to `/earn/payments-plans/example.com` in [calypso live link](https://github.com/Automattic/wp-calypso/pull/78959#issuecomment-1620638679) 
* Add and edit plans.
* Pick different options.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
