### PR TITLE
Domains: Show correct message when trying to bulk transfer domains that are mappable but not transferrable (e.g. .uk, .ca, etc)

### DIFF
--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -234,9 +234,21 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 			break;
 
 		case domainAvailability.MAPPABLE:
+			if ( isForTransferOnly ) {
+				message = translate(
+					'This domain cannot be transferred to WordPress.com but it can be connected instead. {{a}}Learn More.{{/a}}',
+					{
+						components: {
+							a: <a rel="noopener noreferrer" href={ localizeUrl( MAP_EXISTING_DOMAIN ) } />,
+						},
+					}
+				);
+			}
+			break;
+
 		case domainAvailability.AVAILABLE:
 			if ( isForTransferOnly ) {
-				message = "This domain isn't registered. Please try again.";
+				message = translate( "This domain isn't registered. Please try again." );
 			}
 			break;
 


### PR DESCRIPTION
## Proposed Changes

This PR updates the message that's shown when trying to bulk transfer domains that are mappable but not transferrable to WPCOM.

- Before:

<img width="677" alt="Screenshot 2023-07-04 at 17 38 09" src="https://github.com/Automattic/wp-calypso/assets/5324818/3bfab45e-24e0-46e6-945d-42e0db21ba7a">

- After:

<img width="756" alt="Screenshot 2023-07-04 at 17 37 44" src="https://github.com/Automattic/wp-calypso/assets/5324818/8d34d511-051e-4f40-8fb0-f5c61b112b49">

Related to #78954

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to the bulk domain transfer page (`/setup/domain-transfer/`)
- Inform a domain with a TLD that's not transferrable to WPCOM (e.g. .uk, .ca, .fr)
- Ensure the error message is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
