### PR TITLE
Subscribers Page: Update Add Subscribers modal style

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -1,7 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
+import { useLocale } from '@automattic/i18n-utils';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { Modal } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n/';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { LoadingBar } from 'calypso/components/loading-bar';
@@ -23,10 +25,16 @@ const AddSubscribersModal = ( {
 	onAddFinished,
 }: AddSubscribersModalProps ) => {
 	const translate = useTranslate();
-	const modalTitle = translate( 'Add subscribers to %s', {
-		args: [ siteTitle ],
-		comment: "%s is the site's title",
-	} );
+	const locale = useLocale();
+	const { hasTranslation } = useI18n();
+
+	const modalTitle =
+		locale.startsWith( 'en' ) || hasTranslation( 'Add subscribers to %s' )
+			? translate( 'Add subscribers to %s', {
+					args: [ siteTitle ],
+					comment: "%s is the site's title",
+			  } )
+			: translate( 'Add subscribers' );
 
 	const [ isUploading, setIsUploading ] = useState( false );
 	const onImportStarted = ( hasFile: boolean ) => setIsUploading( hasFile );
@@ -49,7 +57,8 @@ const AddSubscribersModal = ( {
 				<>
 					<LoadingBar progress={ 0.5 } />
 					<span className="add-subscribers-modal__loading-text">
-						{ translate( 'Uploading CSV file' ) }...
+						{ ( locale.startsWith( 'en' ) || hasTranslation( 'Uploading CSV file…' ) ) &&
+							translate( 'Uploading CSV file…' ) }
 					</span>
 				</>
 			) }

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -3,9 +3,13 @@ import { isEnabled } from '@automattic/calypso-config';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { LoadingBar } from 'calypso/components/loading-bar';
+import './style.scss';
 
 type AddSubscribersModalProps = {
 	siteId: number;
+	siteTitle: string;
 	showModal: boolean;
 	onClose: () => void;
 	onAddFinished: () => void;
@@ -13,29 +17,55 @@ type AddSubscribersModalProps = {
 
 const AddSubscribersModal = ( {
 	siteId,
+	siteTitle,
 	showModal,
 	onClose,
 	onAddFinished,
 }: AddSubscribersModalProps ) => {
 	const translate = useTranslate();
-	const title = translate( 'Add subscribers' );
+	const modalTitle = translate( 'Add subscribers to %s', {
+		args: [ siteTitle ],
+		comment: "%s is the site's title",
+	} );
+
+	const [ isUploading, setIsUploading ] = useState( false );
+	const onImportStarted = ( hasFile: boolean ) => setIsUploading( hasFile );
+	const onImportFinished = () => {
+		setIsUploading( false );
+		onAddFinished();
+	};
+
+	if ( ! showModal ) {
+		return null;
+	}
 
 	return (
-		<>
-			{ showModal && (
-				<Modal title={ title } onRequestClose={ onClose }>
-					<AddSubscriberForm
-						siteId={ siteId }
-						submitBtnAlwaysEnable={ true }
-						onImportFinished={ onAddFinished }
-						showTitle={ false }
-						showSubtitle={ false }
-						showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
-						recordTracksEvent={ recordTracksEvent }
-					/>
-				</Modal>
+		<Modal title={ modalTitle } onRequestClose={ onClose } overlayClassName="add-subscribers-modal">
+			{ isUploading && (
+				<>
+					<LoadingBar progress={ 0.5 } />
+					<span className="add-subscribers-modal__loading-text">
+						{ translate( 'Uploading CSV file' ) }...
+					</span>
+				</>
 			) }
-		</>
+
+			{ ! isUploading && (
+				<label className="add-subscribers-modal__label">{ translate( 'Email or username' ) }</label>
+			) }
+
+			<AddSubscriberForm
+				siteId={ siteId }
+				submitBtnAlwaysEnable={ true }
+				onImportStarted={ onImportStarted }
+				onImportFinished={ onImportFinished }
+				showTitle={ false }
+				showSubtitle={ false }
+				showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
+				recordTracksEvent={ recordTracksEvent }
+				hidden={ isUploading }
+			/>
+		</Modal>
 	);
 };
 

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -40,7 +40,11 @@ const AddSubscribersModal = ( {
 	}
 
 	return (
-		<Modal title={ modalTitle } onRequestClose={ onClose } overlayClassName="add-subscribers-modal">
+		<Modal
+			title={ modalTitle as string }
+			onRequestClose={ onClose }
+			overlayClassName="add-subscribers-modal"
+		>
 			{ isUploading && (
 				<>
 					<LoadingBar progress={ 0.5 } />

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -55,7 +55,7 @@ const AddSubscribersModal = ( {
 			) }
 
 			{ ! isUploading && (
-				<label className="add-subscribers-modal__label">{ translate( 'Email or username' ) }</label>
+				<label className="add-subscribers-modal__label">{ translate( 'Email' ) }</label>
 			) }
 
 			<AddSubscriberForm

--- a/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
@@ -1,0 +1,94 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
+.add-subscribers-modal {
+	.components-modal__frame {
+		width: 560px;
+
+		.components-modal__header {
+			padding: 0 24px;
+		}
+
+		.components-modal__content {
+			padding: 0 24px 24px;
+		}
+
+		@media ( max-width: $break-small ) {
+			width: auto;
+		}
+	}
+
+	.add-subscriber__form--container {
+		.add-subscriber__form--disclaimer {
+			margin-top: 16px !important;
+			margin-bottom: 24px !important;
+		}
+
+		.components-base-control__help {
+			top: 7px !important;
+			margin-top: 0;
+		}
+
+		.form-input-validation {
+			padding-left: 0 !important;
+
+			svg {
+				position: static !important;
+				margin-left: 0 !important;
+				margin-right: 5px;
+			}
+		}
+
+		.is-error .components-base-control__field {
+			margin-bottom: 6px !important;
+		}
+
+		.components-base-control__field {
+			margin-top: 0 !important;
+			margin-bottom: 8px !important;
+		}
+
+		.components-text-control__input {
+			border-radius: 2px;
+			padding: 10px 16px !important;
+		}
+	}
+
+	.add-subscribers-modal__label {
+		display: block;
+		margin-bottom: 6px;
+		font-size: $font-body-small;
+		font-weight: 500;
+		line-height: rem(20px);
+	}
+
+	.add-subscriber__form-submit-btn {
+		float: right;
+		min-width: auto;
+	}
+
+	.add-subscribers-modal__form--hidden {
+		// display: none;
+		opacity: 0;
+		height: 0;
+		overflow: hidden;
+	}
+
+	.loading-bar {
+		height: 4px;
+		margin-bottom: 24px;
+		margin-top: 0;
+
+		&::before {
+			background-color: $studio-gray-70;
+		}
+	}
+
+	.add-subscribers-modal__loading-text {
+		color: $studio-gray-50;
+		font-size: $font-body;
+		font-weight: 400;
+		line-height: rem(20px);
+	}
+}

--- a/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
@@ -69,7 +69,6 @@
 	}
 
 	.add-subscribers-modal__form--hidden {
-		// display: none;
 		opacity: 0;
 		height: 0;
 		overflow: hidden;

--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -11,7 +11,7 @@ import { useRecordExport } from '../../tracks';
 import '../shared/popover-style.scss';
 
 type SubscribersHeaderPopoverProps = {
-	siteId: number | null;
+	siteId: number | undefined;
 };
 
 const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) => {

--- a/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
@@ -6,7 +6,7 @@ import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subs
 import { SubscribersHeaderPopover } from '../subscribers-header-popover';
 
 type SubscribersHeaderProps = {
-	selectedSiteId: number | null;
+	selectedSiteId: number | undefined;
 	navigationItems: Item[];
 	setShowAddSubscribersModal: React.Dispatch< React.SetStateAction< boolean > >;
 };

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -6,7 +6,7 @@ import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
 import { useSubscribersQuery } from '../../queries';
 
 type SubscribersPageProviderProps = {
-	siteId: number | null;
+	siteId: number | undefined;
 	page: number;
 	pageChanged: ( page: number ) => void;
 	children: React.ReactNode;

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -33,7 +33,7 @@ const getSubscribersCacheKey = (
 };
 
 const getSubscriberDetailsUrl = (
-	siteSlug: string | null,
+	siteSlug: string | undefined,
 	subscriptionId: number | undefined,
 	userId: number | undefined,
 	pageNumber = 1

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -6,7 +6,7 @@ const getEarnPaymentsPageUrl = ( siteSlug: string | null ) =>
 	`${ URL_PREFIX }/earn/payments/${ siteSlug ?? '' }`;
 
 const getSubscribersCacheKey = (
-	siteId: number | null,
+	siteId: number | undefined | null,
 	currentPage?: number,
 	perPage?: number,
 	search?: string,

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -33,7 +33,7 @@ const getSubscribersCacheKey = (
 };
 
 const getSubscriberDetailsUrl = (
-	siteSlug: string | undefined,
+	siteSlug: string | undefined | null,
 	subscriptionId: number | undefined,
 	userId: number | undefined,
 	pageNumber = 1
@@ -46,7 +46,7 @@ const getSubscriberDetailsUrl = (
 };
 
 const getSubscriberDetailsCacheKey = (
-	siteId: number | null,
+	siteId: number | undefined | null,
 	subscriptionId: number | undefined,
 	userId: number | undefined,
 	type: string

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -8,7 +8,7 @@ import { useRecordRemoveModal } from '../tracks';
 import { Subscriber } from '../types';
 
 const useUnsubscribeModal = (
-	siteId: number | null,
+	siteId: number | undefined,
 	pageNumber = 1,
 	detailsView = false,
 	onSuccess?: () => void

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -8,7 +8,7 @@ import { useRecordRemoveModal } from '../tracks';
 import { Subscriber } from '../types';
 
 const useUnsubscribeModal = (
-	siteId: number | undefined,
+	siteId: number | undefined | null,
 	pageNumber = 1,
 	detailsView = false,
 	onSuccess?: () => void

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -9,7 +9,7 @@ import Main from 'calypso/components/main';
 import { SubscriberListContainer } from 'calypso/my-sites/subscribers/components/subscriber-list-container';
 import { SubscribersPageProvider } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { successNotice } from 'calypso/state/notices/actions';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { AddSubscribersModal } from './components/add-subscribers-modal';
 import { SubscribersHeader } from './components/subscribers-header';
 import { UnsubscribeModal } from './components/unsubscribe-modal';
@@ -24,12 +24,13 @@ type SubscribersProps = {
 };
 
 const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const selectedSite = useSelector( getSelectedSite );
 	const { currentSubscriber, onClickUnsubscribe, onConfirmModal, resetSubscriber } =
-		useUnsubscribeModal( selectedSiteId, pageNumber );
+		useUnsubscribeModal( selectedSite?.ID, pageNumber );
 	const onClickView = ( { subscription_id, user_id }: Subscriber ) => {
-		page.show( getSubscriberDetailsUrl( selectedSiteSlug, subscription_id, user_id, pageNumber ) );
+		page.show(
+			getSubscriberDetailsUrl( selectedSite?.slug, subscription_id, user_id, pageNumber )
+		);
 	};
 	const [ showAddSubscribersModal, setShowAddSubscribersModal ] = useState( false );
 	const dispatch = useDispatch();
@@ -52,7 +53,7 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 	const navigationItems: Item[] = [
 		{
 			label: translate( 'Subscribers' ),
-			href: `/subscribers/${ selectedSiteSlug }`,
+			href: `/subscribers/${ selectedSite?.slug }`,
 			helpBubble: (
 				<span>
 					{ translate(
@@ -77,7 +78,7 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 
 	return (
 		<SubscribersPageProvider
-			siteId={ selectedSiteId }
+			siteId={ selectedSite?.ID }
 			page={ pageNumber }
 			pageChanged={ pageChanged }
 		>
@@ -86,7 +87,7 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 
 				<SubscribersHeader
 					navigationItems={ navigationItems }
-					selectedSiteId={ selectedSiteId }
+					selectedSiteId={ selectedSite?.ID }
 					setShowAddSubscribersModal={ setShowAddSubscribersModal }
 				/>
 
@@ -101,9 +102,10 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 					onCancel={ resetSubscriber }
 					onConfirm={ onConfirmModal }
 				/>
-				{ selectedSiteId && (
+				{ selectedSite && (
 					<AddSubscribersModal
-						siteId={ selectedSiteId }
+						siteId={ selectedSite.ID }
+						siteTitle={ selectedSite.title }
 						showModal={ showAddSubscribersModal }
 						onClose={ () => setShowAddSubscribersModal( false ) }
 						onAddFinished={ () => addSubscribersCallback() }

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -9,7 +9,7 @@ import { useRecordSubscriberRemoved } from '../tracks';
 import type { SubscriberEndpointResponse, Subscriber } from '../types';
 
 const useSubscriberRemoveMutation = (
-	siteId: number | null,
+	siteId: number | undefined | null,
 	currentPage: number,
 	invalidateDetailsCache = false
 ) => {

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -5,7 +5,7 @@ import { getSubscribersCacheKey } from '../helpers';
 import type { SubscriberEndpointResponse } from '../types';
 
 type SubscriberQueryParams = {
-	siteId: number | null;
+	siteId: number | undefined | null;
 	page?: number;
 	perPage?: number;
 	search?: string;

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -39,11 +39,13 @@ interface Props {
 	manualListEmailInviting?: boolean;
 	recordTracksEvent?: RecordTrackEvents;
 	onSkipBtnClick?: () => void;
+	onImportStarted?: ( hasFile: boolean ) => void;
 	onImportFinished?: () => void;
 	onChangeIsImportValid?: ( isValid: boolean ) => void;
 	titleText?: string;
 	subtitleText?: string;
 	showSkipLink?: boolean;
+	hidden?: boolean;
 }
 
 export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
@@ -65,12 +67,14 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		allowEmptyFormSubmit,
 		manualListEmailInviting,
 		recordTracksEvent,
+		onImportStarted,
 		onImportFinished,
 		onChangeIsImportValid,
 		onSkipBtnClick,
 		titleText,
 		subtitleText,
 		showSkipLink,
+		hidden = false,
 	} = props;
 
 	const {
@@ -162,6 +166,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	function onFormSubmit( e: FormEvent ) {
 		e.preventDefault();
 		setSubmitAttemptCount( submitAttemptCount + 1 );
+		onImportStarted?.( !! selectedFile );
 
 		const validEmails = getValidEmails();
 
@@ -443,6 +448,10 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 				</label>
 			)
 		);
+	}
+
+	if ( hidden ) {
+		return null;
 	}
 
 	return (

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -1,5 +1,3 @@
-@import "@wordpress/base-styles/breakpoints";
-
 // On-boarding flow
 .step-container.subscribers {
 	padding: 0 1.5rem;
@@ -46,16 +44,6 @@
 
 	.add-subscriber__form-submit-btn {
 		margin-top: 0.5rem;
-	}
-}
-
-.is-section-subscribers {
-	.add-subscriber__form--container {
-		width: 420px;
-
-		@media ( max-width: $break-small ) {
-			width: auto;
-		}
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78800

## Proposed Changes

* Updates Add Subscribers modal style to match design changes on Figma h8tMpJlCqNFemEerU9owHI-fi-2890%3A102545

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/subscribers/{site-slug}
* Click on "Add Subscribers"
* Try to add subscribers by email and csv
* You should see the loading state when adding by email
* And you should see a progress bar when importing a csv
 
<img width="573" alt="Screenshot 2023-07-04 at 18 11 09" src="https://github.com/Automattic/wp-calypso/assets/3113712/4e69ea53-bf3e-41de-97e8-7cce2bf72514">

<img width="580" alt="Screenshot 2023-07-04 at 18 11 15" src="https://github.com/Automattic/wp-calypso/assets/3113712/6ee26692-cbbe-4545-9e1a-0f7f0afe43b2">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?