### PR TITLE
BackupBrowser: Add Tracks event when user downloads a file

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -4,6 +4,8 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import wp from 'calypso/lib/wp';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { FileBrowserItem } from './types';
 import { useBackupPathInfoQuery } from './use-backup-path-info-query';
 import { convertBytes } from './util';
@@ -16,6 +18,7 @@ interface FileInfoCardProps {
 const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( { siteId, item } ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
+	const dispatch = useDispatch();
 
 	const {
 		isSuccess,
@@ -46,8 +49,14 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( { siteId, item } 
 				downloadUrl.searchParams.append( 'disposition', 'attachment' );
 				window.open( downloadUrl, '_blank' );
 				setIsDownloading( false );
+
+				dispatch(
+					recordTracksEvent( 'calypso_jetpack_backup_browser_download', {
+						fileType: item.type,
+					} )
+				);
 			} );
-	}, [ siteId, item ] );
+	}, [ siteId, item, dispatch ] );
 
 	const showActions = item.type !== 'table' && item.type !== 'archive';
 


### PR DESCRIPTION
Related to #78813 

## Proposed Changes

* Add `calypso_jetpack_backup_browser_download` Tracks event when a user downloads a file from the backup browser including the file type (code, audio, video, image, etc.). Here is a [complete list of the possible values](https://github.com/Automattic/wp-calypso/blob/751c0cfef75805287aafd55672f2cd2af7c730d4/client/my-sites/backup/backup-contents-page/file-browser/types.ts#L2).

## Testing Instructions
* Start a Jetpack Cloud or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Browse files and when clicking on one of them you should see the file details and a `Download` button.
* Open Chrome developer console (in network tab).
* Click `Download` in any of those files, and it should show a loading indicator when clicked. After a few, the file should be downloaded.
  * When it completes the download, you should see a `t.gif` call with the event `calypso_jetpack_backup_browser_download`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
