### PR TITLE
[E2E][GB 16.2.x] Test fixes for Gutenberg (edge/nightly)

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -16,7 +16,7 @@ const selectors = {
 	switchToDraftButton: `${ panel } button.editor-post-switch-to-draft`,
 
 	// Preview
-	previewButton: `${ panel } :text("View"):visible`,
+	previewButton: `${ panel } [aria-label="Preview"]:visible`,
 	desktopPreviewMenuItem: ( target: EditorPreviewOptions ) =>
 		`button[role="menuitem"] span:text("${ target }")`,
 	previewPane: ( target: EditorPreviewOptions ) => `.is-${ target.toLowerCase() }-preview`,


### PR DESCRIPTION
Misc test fixes, preparing for the upcoming 14.6.x release on WPCOM, as part of the nightly/edge testing process.

Issues fixed:
- `specs/editor/editor__post-basic-flow.ts` - https://github.com/Automattic/wp-calypso/issues/78975

#### Testing Instructions

1. Run nightly tests from this branch, tests should pass.
2. Run other builds -- AT edge and simple edge, tests should pass.

Fixes https://github.com/Automattic/wp-calypso/issues/78975.