### PR TITLE
Domains: Hide domain-only site sections for domain-only transfers

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -391,9 +391,16 @@ class DomainRow extends PureComponent {
 							? translate( 'View transfer' )
 							: translate( 'View settings' ) }
 					</PopoverMenuItem>
-					<PopoverMenuItem icon="info-outline" onClick={ this.goToDNSManagement }>
-						{ translate( 'Manage DNS' ) }
-					</PopoverMenuItem>
+					{ ! (
+						domain.type === domainTypes.SITE_REDIRECT ||
+						domain.transferStatus === transferStatus.PENDING_ASYNC
+					) &&
+						domain.canManageDnsRecords &&
+						domain.transferStatus !== transferStatus.PENDING_ASYNC && (
+							<PopoverMenuItem icon="info-outline" onClick={ this.goToDNSManagement }>
+								{ translate( 'Manage DNS' ) }
+							</PopoverMenuItem>
+						) }
 
 					{ domain.type === domainTypes.REGISTERED &&
 						( isDomainUpdateable( domain ) || isDomainInGracePeriod( domain ) ) && (

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -19,7 +19,11 @@ import {
 	isDomainUpdateable,
 	resolveDomainStatus,
 } from 'calypso/lib/domains';
-import { type as domainTypes, domainInfoContext } from 'calypso/lib/domains/constants';
+import {
+	type as domainTypes,
+	domainInfoContext,
+	transferStatus,
+} from 'calypso/lib/domains/constants';
 import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { canSetAsPrimary } from 'calypso/lib/domains/utils/can-set-as-primary';
 import { isRecentlyRegisteredAndDoesNotPointToWpcom } from 'calypso/lib/domains/utils/is-recently-registered-and-does-not-point-to-wpcom';
@@ -416,7 +420,7 @@ class DomainRow extends PureComponent {
 							{ translate( 'Transfer to WordPress.com' ) }
 						</PopoverMenuItem>
 					) }
-					{ site.options?.is_domain_only && (
+					{ site.options?.is_domain_only && domain.type !== domainTypes.TRANSFER && (
 						<PopoverMenuItem href={ createSiteFromDomainOnly( site.slug, site.siteId ) }>
 							<Icon icon={ plus } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
 							{ translate( 'Create site' ) }

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -395,8 +395,7 @@ class DomainRow extends PureComponent {
 						domain.type === domainTypes.SITE_REDIRECT ||
 						domain.transferStatus === transferStatus.PENDING_ASYNC
 					) &&
-						domain.canManageDnsRecords &&
-						domain.transferStatus !== transferStatus.PENDING_ASYNC && (
+						domain.canManageDnsRecords && (
 							<PopoverMenuItem icon="info-outline" onClick={ this.goToDNSManagement }>
 								{ translate( 'Manage DNS' ) }
 							</PopoverMenuItem>

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -112,6 +112,7 @@ const Settings = ( {
 		}
 		if (
 			domain.type === domainTypes.SITE_REDIRECT ||
+			domain.type === domainTypes.TRANSFER ||
 			domain.transferStatus === transferStatus.PENDING_ASYNC
 		) {
 			return null;

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -276,7 +276,8 @@ const Settings = ( {
 		if (
 			! domain ||
 			domain.type === domainTypes.SITE_REDIRECT ||
-			domain.transferStatus === transferStatus.PENDING_ASYNC
+			domain.transferStatus === transferStatus.PENDING_ASYNC ||
+			! domain.canManageDnsRecords
 		) {
 			return null;
 		}

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -128,7 +128,10 @@ const Settings = ( {
 	};
 
 	const renderStatusSection = () => {
-		if ( ! ( domain && selectedSite?.options?.is_domain_only ) ) {
+		if (
+			! ( domain && selectedSite?.options?.is_domain_only ) ||
+			domain.type === domainTypes.TRANSFER
+		) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -110,6 +110,12 @@ const Settings = ( {
 		if ( ! isSecuredWithUs( domain ) ) {
 			return null;
 		}
+		if (
+			domain.type === domainTypes.SITE_REDIRECT ||
+			domain.transferStatus === transferStatus.PENDING_ASYNC
+		) {
+			return null;
+		}
 
 		return (
 			<Accordion


### PR DESCRIPTION
## Proposed Changes
#78712 enabled the management of any domain in a domain-only site, but there are a few items that shouldn't be displayed for a few particular cases, such as this one: the "Create site" section shouldn't be displayed for domain-only transfers. 
This PR enables it. 

It also fixes the items in the ellipsis menu for the `DomainRow` component:
- "Manage DNS" isn't displayed anymore - the management section was already hidden in #78826;
- "Create site" shouldn't also be displayed.

## Testing Instructions
To test this, you need a domain-only site with a domain transfer.

- Go to "All domains";
- After finding the domain in the list, ensure that:
  - Clicking the ellipsis menu won't display the "Manage DNS" and "Create site" buttons - you should only see the "View transfer" button;
  - There's no "Connect a WordPress.com site" section on the management page;

## Preview
### Ellipsis menu
#### Before
![image](https://github.com/Automattic/wp-calypso/assets/18705930/9d6419d8-19e6-43fa-8b94-30fe86e47108)


#### After
![image](https://github.com/Automattic/wp-calypso/assets/18705930/ea77a149-a6b9-4797-9782-6165c9988408)


### Management

#### Before
![image](https://github.com/Automattic/wp-calypso/assets/18705930/5d802d76-6cb0-4abc-a2c7-dfc4284eade8)

#### After
![image](https://github.com/Automattic/wp-calypso/assets/18705930/7f94da14-2a8b-4368-a62f-ae7657eafceb)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
