### PR TITLE
reader: redirect invalid languages to /read/search

### DIFF
--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -1,4 +1,8 @@
-import { getLanguageRouteParam, removeLocaleFromPathLocaleInFront } from '@automattic/i18n-utils';
+import {
+	getLanguage,
+	getLanguageRouteParam,
+	removeLocaleFromPathLocaleInFront,
+} from '@automattic/i18n-utils';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { setLocaleMiddleware } from 'calypso/controller/shared';
@@ -23,10 +27,26 @@ const redirectLoggedInUrl = ( context, next ) => {
 	}
 	next();
 };
+
+const redirectInvalidLanguage = ( context, next ) => {
+	const langParam = context.params.lang;
+	const language = getLanguage( langParam );
+	if ( langParam && ! language ) {
+		// redirect unsupported language to the default language
+		return page.redirect( context.path.replace( `/${ langParam }`, '' ) );
+	} else if ( langParam && language.langSlug !== langParam ) {
+		// redirect unsupported child language to the parent language
+		return page.redirect( context.path.replace( `/${ langParam }`, `/${ language.langSlug }` ) );
+	}
+	next();
+};
+
 export default function () {
 	const langParam = getLanguageRouteParam();
 	// Old recommendations page
 	page( '/recommendations', '/read/search' );
+	// Invalid language
+	page( `/:lang([a-z]{2,3}|[a-z]{2}-[a-z]{2})/read/search/`, redirectInvalidLanguage );
 
 	page(
 		[ '/read/search', `/${ langParam }/read/search` ],


### PR DESCRIPTION
Address comment pMz3w-hSu-p2#comment-110373.

Currently if a language passed into `/$lang/read/search` is non-existent, the user would see a WSOD. This change means that the user will be redirected to the default /read/search page.

Note that I couldn't use the same filters as the themes page because those filters only work on the server side, but this filter has to work on the client side

### Testing instructions.
Test invalid language e.g. /aaaaaaa/read/search -> You should see 404 page
Test non-existing language e.g. `/aa-aa/read/search` -> You should be redirected to `/read/search`
Test invalid child language e.g. `/es-zz/read/search` -> you should be redirected to parent language page `/es/read/search`