### PR TITLE
Assembler - Fix hidden navigator headers on breakpoint `< 1080px`

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -17,6 +17,11 @@ $font-family: "SF Pro Text", $sans;
 	height: calc(100vh - 60px);
 	width: 100%;
 
+	.navigator-header {
+		// Force display because by default it shows only for min-width break-xlarge
+		display: block;
+	}
+
 	.pattern-assembler__button {
 		width: 100%;
 		height: 40px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78774

## Proposed Changes

* Show navigator headers for all breakpoints in the assembler
  * because they are hidden when the window width is less than `1080px`

|BEFORE|AFTER|
|--|--|
|<img width="300" alt="Screenshot 2566-07-05 at 12 24 41" src="https://github.com/Automattic/wp-calypso/assets/1881481/c81a6062-5d7e-408b-b47b-c38afcea5f71">|<img width="302" alt="Screenshot 2566-07-05 at 12 24 52" src="https://github.com/Automattic/wp-calypso/assets/1881481/e1f4af86-7aa3-4512-a6c2-8f31aae29a52">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3`
* Reduce the window width to less than `1080px`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
