### PR TITLE
Flaky E2E: tweaks to the SupportComponent and Help Centre test expectations.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -92,7 +92,11 @@ export class SupportComponent {
 			.getByRole( 'listitem' )
 			.nth( index );
 
+		await locator.waitFor();
 		await locator.click();
+
+		// Somteimes, the network call for the help doc can be slow.
+		await this.page.waitForResponse( /\/help\/article/, { timeout: 15 * 1000 } );
 	}
 
 	/**
@@ -101,7 +105,7 @@ export class SupportComponent {
 	 * @returns {string} Title of the article.
 	 */
 	async getOpenArticleTitle(): Promise< string > {
-		const locator = this.anchor.getByRole( 'article' ).getByRole( 'heading' ).nth( 0 );
+		const locator = this.anchor.getByRole( 'article' ).getByRole( 'heading' ).first();
 
 		await locator.waitFor();
 		return await locator.innerText();
@@ -112,6 +116,7 @@ export class SupportComponent {
 	 */
 	async goBack(): Promise< void > {
 		const locator = this.anchor.getByRole( 'button', { name: 'Back', exact: true } );
+
 		await locator.waitFor();
 		await locator.click();
 	}

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -95,8 +95,10 @@ export class SupportComponent {
 		await locator.waitFor();
 		await locator.click();
 
-		// Somteimes, the network call for the help doc can be slow.
-		await this.page.waitForResponse( /\/help\/article/, { timeout: 15 * 1000 } );
+		if ( category === 'Docs' ) {
+			// Sometimes, the network call for the help doc can be slow.
+			await this.page.waitForResponse( /\/help\/article/, { timeout: 15 * 1000 } );
+		}
 	}
 
 	/**

--- a/test/e2e/specs/help-center/help-center__general-interaction.ts
+++ b/test/e2e/specs/help-center/help-center__general-interaction.ts
@@ -45,6 +45,8 @@ describe( 'Help Center: Interact with Results', function () {
 	} );
 
 	describe( 'Navigate to Calypso Link', function () {
+		let popupPage: Page;
+
 		it( 'Close article and return to search results', async function () {
 			await supportComponent.goBack();
 		} );
@@ -58,11 +60,13 @@ describe( 'Help Center: Interact with Results', function () {
 		} );
 
 		it( 'Click on the first Calypso Link result', async function () {
+			const popupEvent = page.waitForEvent( 'popup' );
 			await supportComponent.clickResultByIndex( 'Calypso Link', 0 );
+			popupPage = await popupEvent;
 		} );
 
 		it( 'Calypso Link opens in a new page', async function () {
-			await page.waitForEvent( 'popup' );
+			expect( popupPage.url() ).not.toBe( page.url() );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/78968.

## Proposed Changes

This PR makes two tweaks to the Help Centre spec:
- add a `waitForResponse` when accessing a help doc.
- generate the promise prior to the popup, then resolve the promise in the same test step.

## Testing Instructions
Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)

It would appear the changes are stable, but we'll see how it behaves in production.
![image](https://github.com/Automattic/wp-calypso/assets/6549265/51f48ef5-723f-42b7-a592-28b8de85d794)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
