### PR TITLE
E2E Framework: do not load warm cookies for Pre-Release Tests.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -103,7 +103,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 				checked = "true",
 				unchecked = "false"
 			)
-			param("env.AUTHENTICATE_ACCOUNTS", "gutenbergSimpleSiteEdgeUser,gutenbergSimpleSiteUser,coBlocksSimpleSiteEdgeUser,simpleSitePersonalPlanUser")
+			param("env.AUTHENTICATE_ACCOUNTS", "gutenbergSimpleSiteEdgeUser,gutenbergSimpleSiteUser,coBlocksSimpleSiteEdgeUser,simpleSitePersonalPlanUser,gutenbergAtomicSiteUser,gutenbergAtomicSiteEdgeUser,gutenbergAtomicSiteEdgeNightliesUser")
 			param("env.VIEWPORT_NAME", "$targetDevice")
 			if (atomic) {
 				param("env.TEST_ON_ATOMIC", "true")

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -730,7 +730,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 		""".trimIndent(),
 		testGroup = "calypso-pr",
 		buildParams = {
-			param("env.AUTHENTICATE_ACCOUNTS", "simpleSitePersonalPlanUser,defaultUser,atomicUser")
+			param("env.AUTHENTICATE_ACCOUNTS", "simpleSitePersonalPlanUser,gutenbergSimpleSiteUser,defaultUser")
 			param("env.LIVEBRANCHES", "true")
 			param("env.VIEWPORT_NAME", "$targetDevice")
 		},

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -784,7 +784,7 @@ object PreReleaseE2ETests : BuildType({
 	}
 
 	params {
-		param("env.NODE_CONFIG_ENV", "test")
+		param("env.NODE_CONFIG_ENV", "pre-release")
 		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
 		param("env.TEAMCITY_VERSION", "2021")
 		param("env.HEADLESS", "true")

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -784,7 +784,7 @@ object PreReleaseE2ETests : BuildType({
 	}
 
 	params {
-		param("env.NODE_CONFIG_ENV", "pre-release")
+		param("env.NODE_CONFIG_ENV", "test")
 		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
 		param("env.TEAMCITY_VERSION", "2021")
 		param("env.HEADLESS", "true")

--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -19,7 +19,7 @@ const defaultEnvVariables: SupportedEnvVariables = {
 	GUTENBERG_EDGE: false,
 	GUTENBERG_NIGHTLY: false,
 	COBLOCKS_EDGE: false,
-	AUTHENTICATE_ACCOUNTS: [ 'simpleSitePersonalPlanUser', 'atomicUser', 'defaultUser' ],
+	AUTHENTICATE_ACCOUNTS: [],
 	COOKIES_PATH: path.join( process.cwd(), 'cookies' ),
 	ARTIFACTS_PATH: path.join( process.cwd(), 'results' ),
 	TEST_ON_ATOMIC: false,

--- a/packages/calypso-e2e/src/jest-playwright-config/global-setup.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/global-setup.ts
@@ -15,7 +15,7 @@ export default async (): Promise< void > => {
 
 	// If the list of accounts for which to pre-authenticate and save cookies
 	// for is empty, then don't run.
-	if ( AUTHENTICATE_ACCOUNTS.length <= 0 ) {
+	if ( AUTHENTICATE_ACCOUNTS.length === 0 ) {
 		return;
 	}
 

--- a/packages/calypso-e2e/src/jest-playwright-config/global-setup.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/global-setup.ts
@@ -7,6 +7,12 @@ import pwConfig from './playwright-config';
 export default async (): Promise< void > => {
 	const { AUTHENTICATE_ACCOUNTS } = envVariables;
 
+	// If running in the Pre-Release Tests environment in CI,
+	// don't execute the cookie refresh.
+	if ( process.env.NODE_CONFIG_ENV === 'pre-release' ) {
+		return;
+	}
+
 	// If PWDEBUG mode is enabled (stepping through each step)
 	// don't execute the cookie refresh.
 	if ( process.env.PWDEBUG ) {

--- a/packages/calypso-e2e/src/jest-playwright-config/global-setup.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/global-setup.ts
@@ -7,41 +7,39 @@ import pwConfig from './playwright-config';
 export default async (): Promise< void > => {
 	const { AUTHENTICATE_ACCOUNTS } = envVariables;
 
-	// If running in the Pre-Release Tests environment in CI,
-	// don't execute the cookie refresh.
-	if ( process.env.NODE_CONFIG_ENV === 'pre-release' ) {
-		return;
-	}
-
 	// If PWDEBUG mode is enabled (stepping through each step)
 	// don't execute the cookie refresh.
 	if ( process.env.PWDEBUG ) {
 		return;
 	}
 
-	if ( AUTHENTICATE_ACCOUNTS.length > 0 ) {
-		const browser = await chromium.launch( {
-			...pwConfig.launchOptions,
-			headless: true,
-		} );
-
-		await Promise.all(
-			AUTHENTICATE_ACCOUNTS.map( async ( accountName ) => {
-				const testAccount = new TestAccount( accountName );
-				if ( await testAccount.hasFreshAuthCookies() ) {
-					return;
-				}
-
-				const page = await browser.newPage( pwConfig.contextOptions );
-				page.setDefaultTimeout( envVariables.TIMEOUT );
-
-				await testAccount.logInViaLoginPage( page );
-				await testAccount.saveAuthCookies( page.context() );
-
-				await page.close();
-			} )
-		);
-
-		await browser.close();
+	// If the list of accounts for which to pre-authenticate and save cookies
+	// for is empty, then don't run.
+	if ( AUTHENTICATE_ACCOUNTS.length <= 0 ) {
+		return;
 	}
+
+	const browser = await chromium.launch( {
+		...pwConfig.launchOptions,
+		headless: true,
+	} );
+
+	await Promise.all(
+		AUTHENTICATE_ACCOUNTS.map( async ( accountName ) => {
+			const testAccount = new TestAccount( accountName );
+			if ( await testAccount.hasFreshAuthCookies() ) {
+				return;
+			}
+
+			const page = await browser.newPage( pwConfig.contextOptions );
+			page.setDefaultTimeout( envVariables.TIMEOUT );
+
+			await testAccount.logInViaLoginPage( page );
+			await testAccount.saveAuthCookies( page.context() );
+
+			await page.close();
+		} )
+	);
+
+	await browser.close();
 };


### PR DESCRIPTION
## Proposed Changes

This PR changes the behavior of the cookie preloading in the framework.

Because the Pre-Release Tests don't benefit much (if at all) from preloading warm cookies, this PR makes changes to disable the process. 

Key changes:
- change `NODE_CONFIG_ENV` to 'pre-release' for Pre-Release Tests.
- add a clause to short-circuit if the `NODE_CONFIG_ENV` matches "pre-release".

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
