### PR TITLE
Plugin update: fix crash on PLUGIN_ALREADY_UP_TO_DATE

### DIFF
--- a/client/my-sites/activity/activity-log-tasklist/index.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/index.jsx
@@ -16,7 +16,10 @@ import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/ac
 import { DEFAULT_NOTICE_DURATION } from 'calypso/state/notices/constants';
 import { updatePlugin } from 'calypso/state/plugins/installed/actions';
 import { getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
-import { PLUGIN_INSTALLATION_COMPLETED } from 'calypso/state/plugins/installed/status/constants';
+import {
+	PLUGIN_INSTALLATION_COMPLETED,
+	PLUGIN_INSTALLATION_UP_TO_DATE,
+} from 'calypso/state/plugins/installed/status/constants';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSite, getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import WithItemsToUpdate from './to-update';
@@ -383,7 +386,11 @@ const updateSingle = ( item, siteId ) => ( dispatch, getState ) => {
 			} );
 		case 'plugin':
 			return dispatch( updatePlugin( siteId, item ) ).then( () => {
-				if ( getStatusForPlugin( getState(), siteId, item.id ) !== PLUGIN_INSTALLATION_COMPLETED ) {
+				const status = getStatusForPlugin( getState(), siteId, item.id );
+				if (
+					status !== PLUGIN_INSTALLATION_COMPLETED &&
+					status !== PLUGIN_INSTALLATION_UP_TO_DATE
+				) {
 					return Promise.reject( 'Plugin update failed' );
 				}
 			} );


### PR DESCRIPTION
I've been pinged by Sentry bot about a crash where the `updatePlugin` dispatch doesn't return a Promise:

<img width="636" alt="Screenshot 2023-07-05 at 9 23 56" src="https://github.com/Automattic/wp-calypso/assets/664258/f1d96b06-be44-43e9-aeb3-88e82ddc3cfc">

It's caused by the non-promise dispatch of `PLUGIN_ALREADY_UP_TO_DATE` added in #67169. I'm fixing this by making the `updatePlugin` thunk an async function, and therefore always returning a Promise.

It also seems that adding a special `PLUGIN_ALREADY_UP_TO_DATE` action in #68624 introduced a bug: this state would lead to a "Plugin update failed" error being thrown, because the new possible state isn't checked for.

**How to test:**
I admit that I didn't test this change, maybe other, more regular contributors (@yashwin, @vitozev) have good testing instructions for this. It's a very straightforward refactor.