### PR TITLE
Unify Design Preview: Update the copy and styles of the upsell modal

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -16,6 +16,8 @@ export interface PremiumGlobalStylesUpgradeModalProps {
 	closeModal: () => void;
 	isOpen: boolean;
 	tryStyle: () => void;
+	/** Now we have 3 types of global styles including style variations, color variations, and font variations */
+	numOfSelectedGlobalStyles?: number;
 }
 
 export default function PremiumGlobalStylesUpgradeModal( {
@@ -24,6 +26,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 	closeModal,
 	isOpen,
 	tryStyle,
+	numOfSelectedGlobalStyles = 1,
 }: PremiumGlobalStylesUpgradeModalProps ) {
 	const translate = useTranslate();
 	const premiumPlanProduct = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
@@ -45,11 +48,31 @@ export default function PremiumGlobalStylesUpgradeModal( {
 	];
 	const displayFeatures = globalStylesInPersonalPlan ? personalFeatures : features;
 
+	const featureList = (
+		<div className="upgrade-modal__included">
+			<h2>
+				{ globalStylesInPersonalPlan
+					? translate( 'Included with your Personal plan' )
+					: translate( 'Included with your Premium plan' ) }
+			</h2>
+			<ul>
+				{ displayFeatures.map( ( feature, i ) => (
+					<li key={ i } className="upgrade-modal__included-item">
+						<Gridicon icon="checkmark" size={ 16 } />
+						{ feature }
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+
 	return (
 		<>
 			<QueryProductsList />
 			<Dialog
-				className={ classNames( 'upgrade-modal', { loading: isLoading } ) }
+				className={ classNames( 'upgrade-modal', 'premium-global-styles-upgrade-modal', {
+					loading: isLoading,
+				} ) }
 				isFullScreen
 				isVisible={ isOpen }
 				onClose={ () => closeModal() }
@@ -64,19 +87,26 @@ export default function PremiumGlobalStylesUpgradeModal( {
 									<p>
 										{ globalStylesInPersonalPlan
 											? translate(
-													"You've selected a custom style that will only be visible to visitors after upgrading to the Personal plan or higher."
+													"You've selected a custom style that will only be visible to visitors after upgrading to the Personal plan or higher.",
+													"You've selected custom styles that will only be visible to visitors after upgrading to the Personal plan or higher.",
+													{ count: numOfSelectedGlobalStyles }
 											  )
 											: translate(
-													"You've selected a custom style that will only be visible to visitors after upgrading to the Premium plan or higher."
+													"You've selected a custom style that will only be visible to visitors after upgrading to the Premium plan or higher.",
+													"You've selected custom styles that will only be visible to visitors after upgrading to the Premium plan or higher.",
+													{ count: numOfSelectedGlobalStyles }
 											  ) }
 									</p>
 									<p>
 										{ translate(
-											'Upgrade now to unlock your custom style and get access to tons of other features. Or you can decide later and try it out first.'
+											'Upgrade now to unlock your custom style and get access to tons of other features. Or you can decide later and try it out first.',
+											'Upgrade now to unlock your custom styles and get access to tons of other features. Or you can decide later and try them out first.',
+											{ count: numOfSelectedGlobalStyles }
 										) }
 									</p>
 								</>
 							) }
+							{ featureList }
 							<div className="upgrade-modal__actions bundle">
 								<Button className="upgrade-modal__cancel" onClick={ () => tryStyle() }>
 									{ translate( 'Decide later' ) }
@@ -90,23 +120,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 								</Button>
 							</div>
 						</div>
-						<div className="upgrade-modal__col">
-							<div className="upgrade-modal__included">
-								<h2>
-									{ globalStylesInPersonalPlan
-										? translate( 'Included with your Personal plan' )
-										: translate( 'Included with your Premium plan' ) }
-								</h2>
-								<ul>
-									{ displayFeatures.map( ( feature, i ) => (
-										<li key={ i } className="upgrade-modal__included-item">
-											<Gridicon icon="checkmark" size={ 16 } />
-											{ feature }
-										</li>
-									) ) }
-								</ul>
-							</div>
-						</div>
+						<div className="upgrade-modal__col">{ featureList }</div>
 						<Button className="upgrade-modal__close" borderless onClick={ () => closeModal() }>
 							<Gridicon icon="cross" size={ 12 } />
 							<ScreenReaderText>{ translate( 'Close modal' ) }</ScreenReaderText>

--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -87,13 +87,13 @@ export default function PremiumGlobalStylesUpgradeModal( {
 									<p>
 										{ globalStylesInPersonalPlan
 											? translate(
-													"You've selected a custom style that will only be visible to visitors after upgrading to the Personal plan or higher.",
-													"You've selected custom styles that will only be visible to visitors after upgrading to the Personal plan or higher.",
+													'You’ve selected a custom style that will only be visible to visitors after upgrading to the Personal plan or higher.',
+													'You’ve selected custom styles that will only be visible to visitors after upgrading to the Personal plan or higher.',
 													{ count: numOfSelectedGlobalStyles }
 											  )
 											: translate(
-													"You've selected a custom style that will only be visible to visitors after upgrading to the Premium plan or higher.",
-													"You've selected custom styles that will only be visible to visitors after upgrading to the Premium plan or higher.",
+													'You’ve selected a custom style that will only be visible to visitors after upgrading to the Premium plan or higher.',
+													'You’ve selected custom styles that will only be visible to visitors after upgrading to the Premium plan or higher.',
 													{ count: numOfSelectedGlobalStyles }
 											  ) }
 									</p>

--- a/client/components/premium-global-styles-upgrade-modal/style.scss
+++ b/client/components/premium-global-styles-upgrade-modal/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.upgrade-modal {
+.premium-global-styles-upgrade-modal.upgrade-modal {
 	display: flex;
 	flex-direction: column;
 
@@ -29,10 +29,13 @@
 		}
 	}
 
-	&__col {
+	.upgrade-modal__col {
 		position: relative;
-		padding: 45px;
+		padding: 45px 25px;
+
 		@include break-medium {
+			padding: 45px;
+
 			&:nth-of-type(1) {
 				width: 58%;
 			}
@@ -42,10 +45,26 @@
 			}
 		}
 
+		&:nth-of-type(1) {
+			.upgrade-modal__included {
+				display: block;
+				margin-bottom: 36px;
+
+				@include break-medium {
+					display: none;
+				}
+			}
+		}
+
 		&:nth-of-type(2) {
+			display: none;
 			background-color: var(--studio-gray-0);
 			padding-left: 25px;
 			padding-right: 25px;
+
+			@include break-medium {
+				display: block;
+			}
 		}
 	}
 
@@ -63,7 +82,7 @@
 		margin-bottom: 20px;
 	}
 
-	&__close {
+	.upgrade-modal__close {
 		color: var(--color-text-subtle);
 		position: absolute;
 		top: 0;
@@ -74,10 +93,10 @@
 		}
 	}
 
-	&__actions.bundle {
+	.upgrade-modal__actions.bundle {
 		display: grid;
-		grid-template-columns: 50% 50%;
-		column-gap: 20px;
+		grid-template-columns: repeat(1, 1fr);
+		gap: 20px;
 
 		.button {
 			padding: 9px 25px;
@@ -87,20 +106,16 @@
 			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05) !important;
 
 			&.is-primary {
-				background: var(--color-accent);
-				border-color: var(--color-accent);
 				width: 100%;
-
-				&:hover,
-				&:focus {
-					background: var(--color-accent-60);
-					border-color: var(--color-accent-60);
-				}
 			}
+		}
+
+		@include break-medium {
+			grid-template-columns: repeat(2, 1fr);
 		}
 	}
 
-	&__included {
+	.upgrade-modal__included {
 		ul,
 		li {
 			font-size: $font-body-small;

--- a/client/components/premium-global-styles-upgrade-modal/style.scss
+++ b/client/components/premium-global-styles-upgrade-modal/style.scss
@@ -37,11 +37,11 @@
 			padding: 45px;
 
 			&:nth-of-type(1) {
-				width: 58%;
+				width: 62%;
 			}
 
 			&:nth-of-type(2) {
-				width: 42%;
+				width: 38%;
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
@@ -38,10 +38,11 @@ const useRecipe = (
 		null
 	);
 
-	const hasSelectedGlobalStyles =
-		! isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug ) ||
-		!! selectedColorVariation ||
-		!! selectedFontVariation;
+	const numOfSelectedGlobalStyles = [
+		! isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug ),
+		!! selectedColorVariation,
+		!! selectedFontVariation,
+	].filter( Boolean ).length;
 
 	const [ globalStyles, setGlobalStyles ] = useState< GlobalStylesObject | null >( null );
 
@@ -230,7 +231,7 @@ const useRecipe = (
 		selectedStyleVariation,
 		selectedColorVariation,
 		selectedFontVariation,
-		hasSelectedGlobalStyles,
+		numOfSelectedGlobalStyles,
 		globalStyles,
 		previewDesign,
 		previewDesignVariation,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -174,7 +174,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		selectedStyleVariation,
 		selectedColorVariation,
 		selectedFontVariation,
-		hasSelectedGlobalStyles,
+		numOfSelectedGlobalStyles,
 		globalStyles,
 		setSelectedDesign,
 		previewDesign,
@@ -352,7 +352,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	function unlockPremiumGlobalStyles() {
 		// These conditions should be true at this point, but just in case...
-		if ( selectedDesign && hasSelectedGlobalStyles ) {
+		if ( selectedDesign && numOfSelectedGlobalStyles ) {
 			recordTracksEvent(
 				'calypso_signup_design_global_styles_gating_modal_show',
 				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
@@ -363,7 +363,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	function closePremiumGlobalStylesModal() {
 		// These conditions should be true at this point, but just in case...
-		if ( selectedDesign && hasSelectedGlobalStyles ) {
+		if ( selectedDesign && numOfSelectedGlobalStyles ) {
 			recordTracksEvent(
 				'calypso_signup_design_global_styles_gating_modal_close_button_click',
 				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
@@ -374,7 +374,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	function handleCheckoutForPremiumGlobalStyles() {
 		// These conditions should be true at this point, but just in case...
-		if ( selectedDesign && hasSelectedGlobalStyles && siteSlugOrId ) {
+		if ( selectedDesign && numOfSelectedGlobalStyles && siteSlugOrId ) {
 			recordTracksEvent(
 				'calypso_signup_design_global_styles_gating_modal_checkout_button_click',
 				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
@@ -395,7 +395,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	function tryPremiumGlobalStyles() {
 		// These conditions should be true at this point, but just in case...
-		if ( selectedDesign && hasSelectedGlobalStyles ) {
+		if ( selectedDesign && numOfSelectedGlobalStyles ) {
 			recordTracksEvent(
 				'calypso_signup_design_global_styles_gating_modal_try_button_click',
 				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
@@ -524,7 +524,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		}
 
 		const selectStyle = () => {
-			if ( shouldLimitGlobalStyles && hasSelectedGlobalStyles ) {
+			if ( shouldLimitGlobalStyles && numOfSelectedGlobalStyles ) {
 				unlockPremiumGlobalStyles();
 			} else {
 				pickDesign();
@@ -579,6 +579,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					closeModal={ closePremiumGlobalStylesModal }
 					isOpen={ showPremiumGlobalStylesModal }
 					tryStyle={ tryPremiumGlobalStyles }
+					numOfSelectedGlobalStyles={ numOfSelectedGlobalStyles }
 				/>
 				<AsyncLoad
 					require="@automattic/design-preview"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -32,27 +32,46 @@ $design-button-primary-hover-color: var(--color-primary-60);
 		}
 	}
 
-	&__col {
+	.upgrade-modal__col {
 		position: relative;
-		padding: 45px;
+		padding: 45px 25px;
+
 		@include break-medium {
+			padding: 45px;
+
 			&:nth-of-type(1) {
-				width: 58%;
+				width: 62%;
 			}
 
 			&:nth-of-type(2) {
-				width: 42%;
+				width: 38%;
+			}
+		}
+
+		&:nth-of-type(1) {
+			.upgrade-modal__included {
+				display: block;
+				margin-bottom: 36px;
+
+				@include break-medium {
+					display: none;
+				}
 			}
 		}
 
 		&:nth-of-type(2) {
+			display: none;
 			background-color: var(--studio-gray-0);
 			padding-left: 25px;
 			padding-right: 25px;
+
+			@include break-medium {
+				display: block;
+			}
 		}
 	}
 
-	&__theme-price {
+	.upgrade-modal__theme-price {
 		display: flex;
 		margin-bottom: 5px;
 		align-items: baseline;
@@ -65,7 +84,7 @@ $design-button-primary-hover-color: var(--color-primary-60);
 		}
 	}
 
-	&__subscription-interval {
+	.upgrade-modal__subscription-interval {
 		display: flex;
 		margin-bottom: 15px;
 
@@ -78,7 +97,7 @@ $design-button-primary-hover-color: var(--color-primary-60);
 		}
 	}
 
-	&__plan-nudge {
+	.upgrade-modal__plan-nudge {
 		color: var(--color-text-subtle);
 		font-size: $font-body-small;
 
@@ -88,7 +107,7 @@ $design-button-primary-hover-color: var(--color-primary-60);
 		}
 	}
 
-	&__subscription-savings {
+	.upgrade-modal__subscription-savings {
 		color: var(--studio-green-50);
 		margin-left: 4px;
 	}
@@ -103,7 +122,7 @@ $design-button-primary-hover-color: var(--color-primary-60);
 		}
 	}
 
-	&__woo-logo {
+	.upgrade-modal__woo-logo {
 		width: 70px;
 	}
 
@@ -111,7 +130,7 @@ $design-button-primary-hover-color: var(--color-primary-60);
 		margin-bottom: 20px;
 	}
 
-	&__close {
+	.upgrade-modal__close {
 		color: var(--color-text-subtle);
 		position: absolute;
 		top: 0;
@@ -122,10 +141,10 @@ $design-button-primary-hover-color: var(--color-primary-60);
 		}
 	}
 
-	&__actions.bundle {
+	.upgrade-modal__actions.bundle {
 		display: grid;
-		grid-template-columns: 50% 50%;
-		column-gap: 20px;
+		grid-template-columns: repeat(1, 1fr);
+		gap: 20px;
 
 		.button {
 			padding: 9px 25px;
@@ -146,9 +165,13 @@ $design-button-primary-hover-color: var(--color-primary-60);
 				}
 			}
 		}
+
+		@include break-medium {
+			grid-template-columns: repeat(2, 1fr);
+		}
 	}
 
-	&__included {
+	.upgrade-modal__included {
 		ul,
 		li {
 			font-size: $font-body-small;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -71,7 +71,7 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 			text: (
 				<p>
 					{ translate(
-						"Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It's {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee.",
+						'Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It’s {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
 						{
 							components: {
 								strong: <strong />,
@@ -109,7 +109,7 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 			text: (
 				<p>
 					{ translate(
-						"This theme comes bundled with {{link}}WooCommerce{{/link}} plugin. Upgrade to a Business plan to select this theme and unlock all its features. It's %s per year with a 14-day money-back guarantee.",
+						'This theme comes bundled with {{link}}WooCommerce{{/link}} plugin. Upgrade to a Business plan to select this theme and unlock all its features. It’s %s per year with a 14-day money-back guarantee.',
 						{
 							components: {
 								link: <ExternalLink target="_blank" href="https://woocommerce.com/" />,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -182,6 +182,24 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 				: translate( 'Included with your purchase' );
 	}
 
+	const features = (
+		<div className="upgrade-modal__included">
+			<h2>{ featureListHeader }</h2>
+			<ul>
+				{ featureList.map( ( feature, i ) => (
+					<li key={ i } className="upgrade-modal__included-item">
+						<Tooltip text={ feature.getDescription?.() } position="top left">
+							<div>
+								<Gridicon icon="checkmark" size={ 16 } />
+								{ feature.getTitle() }
+							</div>
+						</Tooltip>
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+
 	return (
 		<Dialog
 			className={ classNames( 'upgrade-modal', { loading: isLoading } ) }
@@ -196,26 +214,10 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 						{ modalData.header }
 						{ modalData.text }
 						{ modalData.price }
+						{ features }
 						{ modalData.action }
 					</div>
-					<div className="upgrade-modal__col">
-						<div className="upgrade-modal__included">
-							<h2>{ featureListHeader }</h2>
-							<ul>
-								{ featureList.map( ( feature, i ) => (
-									<li key={ i } className="upgrade-modal__included-item">
-										<Tooltip text={ feature.getDescription?.() } position="top left">
-											<div>
-												<Gridicon icon="checkmark" size={ 16 } />
-												{ feature.getTitle() }
-											</div>
-										</Tooltip>
-									</li>
-								) ) }
-							</ul>
-						</div>
-					</div>
-
+					<div className="upgrade-modal__col">{ features }</div>
 					<Button className="upgrade-modal__close" borderless onClick={ () => closeModal() }>
 						<Gridicon icon="cross" size={ 12 } />
 						<ScreenReaderText>{ translate( 'Close modal' ) }</ScreenReaderText>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
@@ -34,6 +34,9 @@ const useGlobalStylesUpgradeModal = ( {
 		site?.ID
 	);
 	const { goToCheckout } = useCheckout();
+	const numOfSelectedGlobalStyles = [ hasSelectedColorVariation, hasSelectedFontVariation ].filter(
+		Boolean
+	).length;
 
 	const openModal = () => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_SHOW );
@@ -72,10 +75,10 @@ const useGlobalStylesUpgradeModal = ( {
 	};
 
 	return {
-		shouldUnlockGlobalStyles:
-			( hasSelectedColorVariation || hasSelectedFontVariation ) && shouldLimitGlobalStyles,
+		shouldUnlockGlobalStyles: numOfSelectedGlobalStyles > 0 && shouldLimitGlobalStyles,
 		globalStylesUpgradeModalProps: {
 			isOpen,
+			numOfSelectedGlobalStyles,
 			closeModal,
 			checkout,
 			tryStyle: upgradeLater,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
@@ -1,4 +1,3 @@
-import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { urlToSlug } from 'calypso/lib/url';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
@@ -34,53 +33,7 @@ const useGlobalStylesUpgradeModal = ( {
 	const { shouldLimitGlobalStyles, globalStylesInPersonalPlan } = useSiteGlobalStylesStatus(
 		site?.ID
 	);
-	const translate = useTranslate();
 	const { goToCheckout } = useCheckout();
-
-	let description;
-
-	if ( hasSelectedColorVariation && hasSelectedFontVariation ) {
-		if ( globalStylesInPersonalPlan ) {
-			description = translate(
-				'Your font and color choices will be only visible to visitors after upgrading to the Personal plan or higher.'
-			);
-		} else {
-			description = translate(
-				'Your font and color choices will be only visible to visitors after upgrading to the Premium plan or higher.'
-			);
-		}
-	} else if ( hasSelectedColorVariation ) {
-		if ( globalStylesInPersonalPlan ) {
-			description = translate(
-				'Your color choices will be only visible to visitors after upgrading to the Personal plan or higher.'
-			);
-		} else {
-			description = translate(
-				'Your color choices will be only visible to visitors after upgrading to the Premium plan or higher.'
-			);
-		}
-	} else if ( hasSelectedFontVariation ) {
-		if ( globalStylesInPersonalPlan ) {
-			description = translate(
-				'Your font choices will be only visible to visitors after upgrading to the Personal plan or higher.'
-			);
-		} else {
-			description = translate(
-				'Your font choices will be only visible to visitors after upgrading to the Premium plan or higher.'
-			);
-		}
-	}
-
-	description = (
-		<>
-			<p>{ description }</p>
-			<p>
-				{ translate(
-					'Upgrade now to unlock your current choices and get access to tons of other features. Or you can decide later and try them out first in the editor.'
-				) }
-			</p>
-		</>
-	);
 
 	const openModal = () => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_SHOW );
@@ -123,7 +76,6 @@ const useGlobalStylesUpgradeModal = ( {
 			( hasSelectedColorVariation || hasSelectedFontVariation ) && shouldLimitGlobalStyles,
 		globalStylesUpgradeModalProps: {
 			isOpen,
-			description,
 			closeModal,
 			checkout,
 			tryStyle: upgradeLater,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Related to https://github.com/Automattic/wp-calypso/issues/78419

## Proposed Changes

* Display the feature list on the top of the action buttons on the small screen
* Add plural copy for Colors & Fonts. Now we call them custom styles, so I guess we can simplify the copy to `selected custom styles` instead of `Your font and color choices`

### Screenshots

| | Large Screen | Small Screen |
| - | - | - |
| Premium Theme | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/ee5ca362-9e94-4eee-8c22-b3070ca81880) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/4ad1f8ec-e579-4f0b-a3c2-1056fbfcb39a) |
| Global Styles in Theme Preview | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/be23210a-844c-445f-810a-a915e56f7e8e) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/ac265514-19fa-4d98-85ba-a26eaa323f12) |
| Global Styles in Assembler | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/0ce19fb7-b15a-4643-9997-eb7e9de0dde0) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the URLs below on your free site, especially for the mobile screen
  * /setup?siteSlug=<your_site>: Fonts only
  * /setup?siteSlug=<your_site>&flags=signup/design-picker-preview-colors: Colors & Fonts
* Continue until you land on the Design Picker
* Preview the premium design, and continue. Ensure the upsell modal looks good on both large and small screens.
* Preview the free design, and continue with custom styles. Ensure the upsell modal looks good on both large and small screens as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
