### PR TITLE
Fixed problem enclosing subscription price in parentheses when it was 'free' in languages other than english

### DIFF
--- a/client/my-sites/subscribers/hooks/use-subscription-plans.ts
+++ b/client/my-sites/subscribers/hooks/use-subscription-plans.ts
@@ -3,8 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useMemo } from 'react';
 import { Subscriber, SubscriptionPlan } from '../types';
 
-const freePlan = 'Free';
-
 type SubscriptionPlanData = {
 	plan: ReactNode;
 	startDate?: string;
@@ -13,6 +11,7 @@ type SubscriptionPlanData = {
 
 const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] => {
 	const translate = useTranslate();
+	const freePlan = translate( 'Free' );
 
 	const getPaymentInterval = ( renew_interval: string ) => {
 		if ( renew_interval === null ) {
@@ -36,7 +35,7 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 	const transformSubscriptionPlans = ( subscriptions?: SubscriptionPlan[] ) => {
 		const defaultSubscription = [
 			{
-				renewalPrice: translate( 'Free' ),
+				renewalPrice: freePlan,
 				when: '',
 				title: undefined,
 				start_date: undefined,


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78899

## Proposed Changes

There was a problem on the Subscribers page, where we showed the renewal price between parentheses when it was 'free' in other languages (like 'Gratis' in Spanish) when it should be without parentheses.

## Testing Instructions

**Note:** To test this properly you should use a site with paid and non-paid subscribers.



1. Apply this PR and run the application.
2. Set the account language to English.
3. Go to `http://calypso.localhost:3000/subscribers/[the domain of your site]`.
4. Check the Subscription Type column. Its format should look like this when 'free' and when there is a price:
<img width="1316" alt="Screenshot 2023-07-05 at 11 26 50" src="https://github.com/Automattic/wp-calypso/assets/3832570/a15ce1a4-7c83-4b89-a3ed-3a1686c8f466">
5. Repeat steps 2 to 4, but change the account language to Spanish. The list should look like this now:
<img width="1315" alt="Screenshot 2023-07-05 at 11 26 20" src="https://github.com/Automattic/wp-calypso/assets/3832570/bc527967-4804-4bd4-a1dc-8eaf1ff2734c">

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
