### PR TITLE
Disable Assembler survey

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
@@ -2,23 +2,34 @@ import Banner from 'calypso/components/banner';
 import './survey.scss';
 
 interface Props {
+	eventName?: string;
+	eventUrl?: string;
+	title?: string | React.ReactNode;
 	setSurveyDismissed: ( dismissed: boolean ) => void;
 }
 
-const Survey = ( { setSurveyDismissed }: Props ) => {
+const Survey = ( { eventName, eventUrl, title, setSurveyDismissed }: Props ) => {
+	if ( ! eventUrl ) {
+		return null;
+	}
+
 	return (
 		<Banner
 			className="pattern-assembler__survey"
-			// Translation to other locales is not required
 			title={
-				<>
-					<a href="https://lucasmdo.survey.fm/assembler-survey-modal" target="blank">
-						Fill out this quick survey
-					</a>{ ' ' }
-					and help us to improve our product.
-				</>
+				title ? (
+					title
+				) : (
+					// Translation to other locales is not required
+					<>
+						<a href={ eventUrl } target="blank">
+							Fill out this quick survey
+						</a>{ ' ' }
+						and help us to improve our product.
+					</>
+				)
 			}
-			event="assembler-june-2023"
+			event={ eventName }
 			onDismiss={ ( e: Event ) => {
 				e.stopPropagation();
 				setSurveyDismissed( true );


### PR DESCRIPTION
## Proposed Changes

Now that the survey has surpassed the targeted number of responses, this PR removes the Assembler survey banner by not passing the prop `eventUrl`, which is required for the banner to be rendered. This proposal leaves the `<Survey>` component in code, in case we want to conduct future surveys.

Might be worth considering moving the `<Survey>` component to either `/client/components` or `/packages/components` so that it can be reused.

| Before | After |
| --- | --- |
| ![Screenshot 2023-07-05 at 5 55 28 PM](https://github.com/Automattic/wp-calypso/assets/797888/dcb5b35a-db4c-4fd7-af29-dee3c2544ce9) | ![Screenshot 2023-07-05 at 5 54 56 PM](https://github.com/Automattic/wp-calypso/assets/797888/35efbb01-9524-4461-a0cf-9a651a65e712) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler `/setup/with-theme-assembler?theme=blank-canvas-3&siteSlug=${site_slug}`.
* Ensure that the survey CTA is no longer showing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
