### PR TITLE
Media: Always return an array for allowed file types

### DIFF
--- a/client/lib/media/utils/get-allowed-file-types-for-site.js
+++ b/client/lib/media/utils/get-allowed-file-types-for-site.js
@@ -5,9 +5,5 @@
  * @returns {Array}      Supported file extensions
  */
 export function getAllowedFileTypesForSite( site ) {
-	if ( ! site ) {
-		return [];
-	}
-
-	return site.options.allowed_file_types ?? [];
+	return site?.options.allowed_file_types ?? [];
 }

--- a/client/lib/media/utils/get-allowed-file-types-for-site.js
+++ b/client/lib/media/utils/get-allowed-file-types-for-site.js
@@ -9,5 +9,5 @@ export function getAllowedFileTypesForSite( site ) {
 		return [];
 	}
 
-	return site.options.allowed_file_types;
+	return site.options.allowed_file_types ?? [];
 }


### PR DESCRIPTION
## Proposed Changes

Fixes a bug reported in Sentry when allowed file types are `undefined` for a site.

See p1688521586554459-slack-C04U5A26MJB for more details

## Testing Instructions

* Somewhere in your WP site, use the [`upload_mimes` filter](https://developer.wordpress.org/reference/hooks/upload_mimes/) to return nothing for allowed file types: `add_filter( 'upload_mimes', '__return_null' );`
* Verify `/media/:siteId` still loads correctly.