### PR TITLE
Use correct Upgrade plan URL in gs launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,3 +1,4 @@
+import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Gridicon, CircularProgressBar } from '@automattic/components';
 import { OnboardSelect, useLaunchpad } from '@automattic/data-stores';
 import { Launchpad } from '@automattic/launchpad';
@@ -62,7 +63,8 @@ const Sidebar = ( {
 	const clipboardButtonEl = useRef< HTMLButtonElement >( null );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 
-	const { globalStylesInUse, shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
+	const { globalStylesInUse, shouldLimitGlobalStyles, globalStylesInPersonalPlan } =
+		useSiteGlobalStylesStatus( site?.ID );
 
 	const {
 		data: { checklist_statuses: checklistStatuses, checklist: launchpadChecklist },
@@ -97,6 +99,7 @@ const Sidebar = ( {
 			site,
 			submit,
 			globalStylesInUse && shouldLimitGlobalStyles,
+			globalStylesInPersonalPlan ? PLAN_PERSONAL : PLAN_PREMIUM,
 			goToStep,
 			flow,
 			isEmailVerified,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -43,7 +43,7 @@ export function getEnhancedTasks(
 	site: SiteDetails | null,
 	submit: NavigationControls[ 'submit' ],
 	displayGlobalStylesWarning: boolean,
-	globalStylesMinimumPlan: string | null,
+	globalStylesMinimumPlan?: string | null,
 	goToStep?: NavigationControls[ 'goToStep' ],
 	flow: string | null = '',
 	isEmailVerified = false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -1,7 +1,6 @@
 import {
 	FEATURE_VIDEO_UPLOADS,
 	planHasFeature,
-	PLAN_PREMIUM,
 	FEATURE_STYLE_CUSTOMIZATION,
 } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -43,7 +42,7 @@ export function getEnhancedTasks(
 	site: SiteDetails | null,
 	submit: NavigationControls[ 'submit' ],
 	displayGlobalStylesWarning: boolean,
-	globalStylesMinimumPlan?: string | null,
+	globalStylesMinimumPlan: string,
 	goToStep?: NavigationControls[ 'goToStep' ],
 	flow: string | null = '',
 	isEmailVerified = false,
@@ -161,7 +160,7 @@ export function getEnhancedTasks(
 						}
 						const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
 							...( shouldDisplayWarning && {
-								plan: globalStylesMinimumPlan ?? PLAN_PREMIUM,
+								plan: globalStylesMinimumPlan,
 								feature: isVideoPressFlowWithUnsupportedPlan
 									? FEATURE_VIDEO_UPLOADS
 									: FEATURE_STYLE_CUSTOMIZATION,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -43,6 +43,7 @@ export function getEnhancedTasks(
 	site: SiteDetails | null,
 	submit: NavigationControls[ 'submit' ],
 	displayGlobalStylesWarning: boolean,
+	globalStylesMinimumPlan: string | null,
 	goToStep?: NavigationControls[ 'goToStep' ],
 	flow: string | null = '',
 	isEmailVerified = false,
@@ -160,7 +161,7 @@ export function getEnhancedTasks(
 						}
 						const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
 							...( shouldDisplayWarning && {
-								plan: PLAN_PREMIUM,
+								plan: globalStylesMinimumPlan ?? PLAN_PREMIUM,
 								feature: isVideoPressFlowWithUnsupportedPlan
 									? FEATURE_VIDEO_UPLOADS
 									: FEATURE_STYLE_CUSTOMIZATION,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import { getEnhancedTasks } from '../task-helper';
 import { buildTask } from './lib/fixtures';
 
@@ -15,7 +16,7 @@ describe( 'Task Helpers', () => {
 				];
 				expect(
 					// eslint-disable-next-line @typescript-eslint/no-empty-function
-					getEnhancedTasks( fakeTasks, 'fake.wordpress.com', null, () => {}, false )
+					getEnhancedTasks( fakeTasks, 'fake.wordpress.com', null, () => {}, false, PLAN_PREMIUM )
 				).toEqual( fakeTasks );
 			} );
 		} );
@@ -31,7 +32,7 @@ describe( 'Task Helpers', () => {
 						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						() => {},
 						false,
-						null,
+						PLAN_PREMIUM,
 						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						() => {},
 						'newsletter',
@@ -52,7 +53,7 @@ describe( 'Task Helpers', () => {
 						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						() => {},
 						false,
-						null,
+						PLAN_PREMIUM,
 						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						() => {},
 						'start-writing'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -31,6 +31,7 @@ describe( 'Task Helpers', () => {
 						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						() => {},
 						false,
+						null,
 						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						() => {},
 						'newsletter',
@@ -51,6 +52,7 @@ describe( 'Task Helpers', () => {
 						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						() => {},
 						false,
+						null,
 						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						() => {},
 						'start-writing'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78956

## Proposed Changes

If a site doesn't include global styles and the site is using them, then the launchpad reminds them of this including a 'Upgrade plan' badge. This change ensures the badge links to the minimum required plan rather than assuming the premium plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to 21268-explat-experiment and use the bookmarklet to assign yourself to treatment/control
2. Enter the /start process using the live link
3. Choose a free plan
4. Choose a theme with global styles and select those global styles
5. When you reach the launchpad it should include a completed 'Choose a plan' step that nonetheless includes a reminder you have GS and you need to upgrade.
6. Click on 'Upgrade plan', you should go to the Plans page with the appropriate plan suggested
7. Go to 21268-explat-experiment and use the bookmarklet to assign yourself to the opposite side of the experiment
8. Refresh the launchpad page
9. Click on 'Upgrade plan', you should go to the Plans page with the appropriate plan suggested

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
