### PR TITLE
Google Auth: Warn the user if it wasn't possible to initialize Google Identity Services

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -70,11 +70,9 @@ class GoogleSocialButton extends Component {
 		const googleSignIn = await this.loadGoogleIdentityServicesAPI();
 
 		if ( ! googleSignIn ) {
-			this.props.showErrorNotice(
-				this.props.translate(
-					'Something went wrong when trying to load Google sign-in. Please refresh the page.'
-				)
-			);
+			this.setState( {
+				error: this.props.translate( 'Something went wrong while trying to load Google sign-in.' ),
+			} );
 
 			return;
 		}

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -69,6 +69,16 @@ class GoogleSocialButton extends Component {
 	async initializeGoogleSignIn() {
 		const googleSignIn = await this.loadGoogleIdentityServicesAPI();
 
+		if ( ! googleSignIn ) {
+			this.props.showErrorNotice(
+				this.props.translate(
+					'Something went wrong when trying to load Google sign-in. Please refresh the page.'
+				)
+			);
+
+			return;
+		}
+
 		this.client = googleSignIn.initCodeClient( {
 			client_id: this.props.clientId,
 			scope: this.props.scope,
@@ -94,7 +104,11 @@ class GoogleSocialButton extends Component {
 
 	async loadGoogleIdentityServicesAPI() {
 		if ( ! window.google?.accounts?.oauth2 ) {
-			await loadScript( 'https://accounts.google.com/gsi/client' );
+			try {
+				await loadScript( 'https://accounts.google.com/gsi/client' );
+			} catch {
+				return null;
+			}
 		}
 
 		return window.google.accounts.oauth2;

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -107,6 +107,7 @@ class GoogleSocialButton extends Component {
 			try {
 				await loadScript( 'https://accounts.google.com/gsi/client' );
 			} catch {
+				// It's safe to ignore loading errors because if Google is blocked in some way the the button will be disabled.
 				return null;
 			}
 		}


### PR DESCRIPTION
Related to p1688520343833659-slack-C04U5A26MJB

## Proposed Changes

Let's wrap the GSI client loading in a try-catch block and warn the user whenever the script fails to load.

| Origin | Screenshot |
| ------ | ----------- |
|`trunk`| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/a27eb512-3105-4567-aa89-b4caca0d548e) |
| This&nbsp;PR | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/b457eea1-5f55-4ca2-ac79-c7e7433e3f19) |

## Testing Instructions

Browse `/start/user` or any other flow that includes social sign-up.

Assuming you're using a Chromium-based browser, open the DevTools, go to Network and filter by `gsi/client`. Wait for it to load then right-click and select "Block request URL":

![image](https://github.com/Automattic/wp-calypso/assets/26530524/479234de-96c6-476c-9bb4-548cf3f9036c)

Refresh the page and should be able to see:
- the disabled Google sign in button;
- zero Uncaught Errors in the console;
- a popover when hovering the button saying that the browser couldn't load GSI.