### PR TITLE
Staging Sites: remove etk domain upsell callout for staging sites

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/class-wpcom-domain-upsell-callout.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/class-wpcom-domain-upsell-callout.php
@@ -83,7 +83,7 @@ class WPCOM_Domain_Upsell_Callout {
 	private function should_not_show_callout() {
 		$blog_id = defined( 'IS_WPCOM' ) && IS_WPCOM ? get_current_blog_id() : \Jetpack_Options::get_option( 'id' );
 
-		return $this->has_unlaunched_launchpad() || $this->blog_has_custom_domain( $blog_id ) || $this->user_has_email_unverified() || $this->blog_is_p2( $blog_id );
+		return $this->has_unlaunched_launchpad() || $this->blog_has_custom_domain( $blog_id ) || $this->user_has_email_unverified() || $this->blog_is_p2( $blog_id ) || $this->blog_is_wpcom_staging();
 	}
 
 	/**
@@ -167,6 +167,21 @@ class WPCOM_Domain_Upsell_Callout {
 	 */
 	private function blog_is_p2( $blog_id ) {
 		return defined( 'IS_ATOMIC' ) && IS_ATOMIC ? false : \WPForTeams\is_wpforteams_site( $blog_id );
+	}
+
+	/**
+	 * Check if the blog is a wpcom staging.
+	 *
+	 * @return boolean
+	 */
+	private function blog_is_wpcom_staging() {
+		if ( ! defined( 'IS_ATOMIC' ) || ! IS_ATOMIC ) {
+			return false;
+		}
+
+		$site_url = $this->get_domain_from_site_url();
+		// Only staging sites can be prefixed with 'staging-'.
+		return 'staging-' === substr( $site_url, 0, 8 );
 	}
 
 	/**


### PR DESCRIPTION
- Fixes https://github.com/Automattic/wp-calypso/issues/78603

## Proposed Changes

* Hide ETK domain upsell callout for staging sites on new post/page editor

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create an atomic dev blog. Please don't assign any domain.
* Download the built ETK plugin from team city.
* Install it on your dev blog. Alternatively, build ETK on your local machine and use rsync to upload the changes to your dev blog.
* Go to `/wp-admin/post-new.php?post_type=page&calypsoify=1&block-editor=1` on your dev blog.
* Observe the domain upsell on the top.
* Go to `https://wordpres.com/hosting-config/${your-dev-site-url}` and create a staging site.
   * TIL. A staging site from a dev blog is also a "dev" blog.
* Go to `/wp-admin/post-new.php?post_type=page&calypsoify=1&block-editor=1` on your new dev blog staging site.
* Observe that the domain upsell on the top is not present.


## Screenshots

| **Before** | **After** |
|---|---|
| <img width="1266" alt="Screenshot 2023-07-05 at 14 26 17" src="https://github.com/Automattic/wp-calypso/assets/779993/777a702c-75e9-46c1-9df3-46ac3c8d9516"> | <img width="1256" alt="Screenshot 2023-07-05 at 14 26 46" src="https://github.com/Automattic/wp-calypso/assets/779993/54eac86a-9a27-4047-96a0-1a6d6bd6cc5c"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
