### PR TITLE
Edge Cache: Update edge cache label and launch it

### DIFF
--- a/client/my-sites/hosting/cache-card/index.js
+++ b/client/my-sites/hosting/cache-card/index.js
@@ -142,9 +142,9 @@ export const CacheCard = ( {
 	};
 
 	const edgeCacheToggleDescription = isEdgeCacheEligible
-		? translate( 'Enable edge caching for faster content delivery.' )
+		? translate( 'Enable global edge caching for faster content delivery.' )
 		: translate(
-				'Edge cache can only be enabled for public sites. {{a}}Review privacy settings.{{/a}}',
+				'Global edge cache can only be enabled for public sites. {{a}}Review privacy settings.{{/a}}',
 				{
 					components: {
 						a: <a href={ '/settings/general/' + siteSlug + '#site-privacy-settings' } />,
@@ -174,7 +174,7 @@ export const CacheCard = ( {
 								<EdgeCacheLoadingPlaceholder />
 							) : (
 								<>
-									<ToggleLabel>{ translate( 'Edge cache' ) }</ToggleLabel>
+									<ToggleLabel>{ translate( 'Global edge cache' ) }</ToggleLabel>
 									<ToggleControl
 										disabled={
 											clearEdgeCacheLoading || getEdgeCacheLoading || ! isEdgeCacheEligible

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -32,6 +32,7 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
+		"yolo/edge-cache-i1": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,
 		"external-media/openverse": true,

--- a/config/production.json
+++ b/config/production.json
@@ -41,6 +41,7 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
+		"yolo/edge-cache-i1": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,
 		"external-media/openverse": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,7 +38,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"yolo/edge-cache-i1": false,
+		"yolo/edge-cache-i1": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2912

## Proposed Changes

In this diff, I propose to rename 'edge cache' to 'global edge cache' and launch the feature.

<img width="761" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/cfaa8053-58b1-4379-a1cc-21a688563dda">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to the site's Hosting Configuration
2. Confirm labels say 'global edge cache'

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
