### PR TITLE
Update the style of the Promote button for the Advertising page

### DIFF
--- a/apps/blaze-dashboard/src/app.scss
+++ b/apps/blaze-dashboard/src/app.scss
@@ -98,10 +98,12 @@
 			border-radius: 4px;
 			font-weight: 600;
 			font-size: 0.75rem;
+			background-color: var(--color-surface);
 
 			&:hover {
 				text-decoration: underline;
 				color: var(--color-accent);
+				background-color: var(--color-surface);
 			}
 		}
 

--- a/client/my-sites/promote-post-i2/components/post-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/post-item/index.tsx
@@ -117,10 +117,11 @@ export default function PostItem( { post }: { post: BlazablePost } ) {
 							{ __( 'View' ) }
 						</a>
 						<Button
-							className="post-item__post-promote-button"
+							isPrimary
 							isBusy={ loading }
 							disabled={ loading }
 							onClick={ onClickPromote }
+							className="post-item__post-promote-button"
 						>
 							{ __( 'Promote' ) }
 						</Button>
@@ -140,10 +141,11 @@ export default function PostItem( { post }: { post: BlazablePost } ) {
 			</td>
 			<td className="post-item__post-promote">
 				<Button
-					className="post-item__post-promote-button"
+					isPrimary
 					isBusy={ loading }
 					disabled={ loading }
 					onClick={ onClickPromote }
+					className="post-item__post-promote-button"
 				>
 					{ __( 'Promote' ) }
 				</Button>

--- a/client/my-sites/promote-post-i2/components/post-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/post-item/style.scss
@@ -112,13 +112,7 @@ body.is-section-promote-post-i2 {
 		}
 
 		&__post-promote-button {
-			color: var(--studio-simplenote-blue-50);
-			text-decoration: none;
-
-			&:hover:not(:disabled) {
-				color: var(--studio-simplenote-blue-50);
-				text-decoration: underline;
-			}
+			border-radius: 4px;
 		}
 	}
 
@@ -222,11 +216,8 @@ body.is-section-promote-post-i2 {
 
 		// Promote link
 		.post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile button.post-item__post-promote-button {
-			@include blazepress-data-row-font-mobile;
-
-			color: #3858ea;
-			height: 16px;
-			padding: 0 12px;
+			height: 26px;
+			margin-left: 5px;
 		}
 	}
 }


### PR DESCRIPTION
Related to SELFSERVE-653

## Proposed Changes

We are updating the style of the Promote button that is located in the Ready to Promote page table on the Advertising page.

The new design will look like this:
![Screenshot 2023-07-05 at 12 46 36](https://github.com/Automattic/wp-calypso/assets/1258162/5b1824f6-31b0-4858-893d-e86d11f898aa)

![Screenshot 2023-07-05 at 12 46 28](https://github.com/Automattic/wp-calypso/assets/1258162/1ad35fed-0280-4e86-95c4-12e743285426)

## Testing Instructions

* Open the live preview and navigate to Tools->Advertising
* Verify that the page shows the new version of the button on the Ready to Promote page
* Shrink your screen to a mobile view, and verify the mobile version of the button.
* Click the button on the Desktop and mobile version of the page, and verify that the Create Campaign widget loads correctly for the selected post.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
