### PR TITLE
Don't show refund policy and international fee notice in Jetpack cart 

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms.tsx
@@ -4,6 +4,10 @@ import { Fragment } from 'react';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { hasRenewableSubscription } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
+import { useSelector } from 'calypso/state';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AdditionalTermsOfServiceInCart from './additional-terms-of-service-in-cart';
 import BundledDomainNotice from './bundled-domain-notice';
 import DomainRegistrationAgreement from './domain-registration-agreement';
@@ -21,8 +25,14 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 	const isGiftPurchase = cart.is_gift_purchase;
 	const translate = useTranslate();
-	const shouldShowRefundPolicy = ! isJetpackCheckout() && ! isAkismetCheckout();
-	const shouldShowInternationalFeeNotice = ! isJetpackCheckout() && ! isAkismetCheckout();
+	const siteId = useSelector( getSelectedSiteId );
+	const isJetpackNotAtomic = useSelector( ( state ) => {
+		return siteId && isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
+	} );
+	const shouldShowRefundPolicy =
+		! isJetpackCheckout() && ! isJetpackNotAtomic && ! isAkismetCheckout();
+	const shouldShowInternationalFeeNotice =
+		! isJetpackCheckout() && ! isJetpackNotAtomic && ! isAkismetCheckout();
 
 	// Domain transfer is a one-time purchase, but it creates a renewable
 	// subscription behind the scenes so we need to show the full TOS including

--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms.tsx
@@ -1,7 +1,9 @@
 import { isDomainTransfer } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { hasRenewableSubscription } from 'calypso/lib/cart-values/cart-items';
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import AdditionalTermsOfServiceInCart from './additional-terms-of-service-in-cart';
 import BundledDomainNotice from './bundled-domain-notice';
 import DomainRegistrationAgreement from './domain-registration-agreement';
@@ -19,6 +21,8 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 	const isGiftPurchase = cart.is_gift_purchase;
 	const translate = useTranslate();
+	const shouldShowRefundPolicy = ! isJetpackCheckout() && ! isAkismetCheckout();
+	const shouldShowInternationalFeeNotice = ! isJetpackCheckout() && ! isAkismetCheckout();
 
 	// Domain transfer is a one-time purchase, but it creates a renewable
 	// subscription behind the scenes so we need to show the full TOS including
@@ -43,12 +47,12 @@ export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 			{ ! isGiftPurchase && <DomainRegistrationAgreement cart={ cart } /> }
 			{ ! isGiftPurchase && <DomainRegistrationHsts cart={ cart } /> }
 			{ ! isGiftPurchase && <DomainRegistrationDotGay cart={ cart } /> }
-			<RefundPolicies cart={ cart } />
+			{ shouldShowRefundPolicy && <RefundPolicies cart={ cart } /> }
 			{ ! isGiftPurchase && <BundledDomainNotice cart={ cart } /> }
 			{ ! isGiftPurchase && <TitanTermsOfService cart={ cart } /> }
 			{ ! isGiftPurchase && <ThirdPartyPluginsTermsOfService cart={ cart } /> }
 			<EbanxTermsOfService />
-			<InternationalFeeNotice />
+			{ shouldShowInternationalFeeNotice && <InternationalFeeNotice /> }
 			{ ! isGiftPurchase && <AdditionalTermsOfServiceInCart /> }
 			<JetpackSocialAdvancedPricingDisclaimer />
 		</Fragment>


### PR DESCRIPTION
## Proposed Changes

* This diff removes the refund policy notice and international fee notice from the Jetpack and Akismet carts since these can be communicated more effectively elsewhere. 

## Testing Instructions

* With this PR applied, test the following checkouts
* http://calypso.localhost:3000/checkout/jetpack/jetpack_backup_t1_yearly
* http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_1
* Confirm that you no longer see the refund notice or the international fee included in the cart terms

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
