### PR TITLE
Blog Onboarding: Fix localization for Firefox on redirect

### DIFF
--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -1,4 +1,5 @@
 import { useLocale } from '@automattic/i18n-utils';
+import { getQueryArg } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
 import {
@@ -30,7 +31,8 @@ const Blog: Flow = {
 	useAssertConditions(): AssertConditionResult {
 		const flowName = this.name;
 		const isLoggedIn = useSelector( isUserLoggedIn );
-		const locale = useLocale();
+		const defaultLocale = useLocale();
+		const locale = getQueryArg( window.location.search, 'locale' ) ?? defaultLocale;
 
 		const logInUrl =
 			locale && locale !== 'en'

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -3,7 +3,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { addQueryArgs } from '@wordpress/url';
+import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { useSelector } from 'react-redux';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
@@ -195,7 +195,8 @@ const designFirst: Flow = {
 		const flowName = this.name;
 		const isLoggedIn = useSelector( isUserLoggedIn );
 		const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
-		const locale = useLocale();
+		const defaultLocale = useLocale();
+		const locale = getQueryArg( window.location.search, 'locale' ) ?? defaultLocale;
 		const currentPath = window.location.pathname;
 		const isSiteCreationStep =
 			currentPath.endsWith( 'setup/design-first/' ) ||

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -3,6 +3,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import { getQueryArg } from '@wordpress/url';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
 import {
@@ -186,7 +187,8 @@ const startWriting: Flow = {
 		const flowName = this.name;
 		const isLoggedIn = useSelector( isUserLoggedIn );
 		const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
-		const locale = useLocale();
+		const defaultLocale = useLocale();
+		const locale = getQueryArg( window.location.search, 'locale' ) ?? defaultLocale;
 		const currentPath = window.location.pathname;
 		const isSiteCreationStep =
 			currentPath.endsWith( 'setup/start-writing/' ) ||


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2913

## Proposed Changes

To ensure that the user is directed to the appropriate signup/login page based on their selected locale, we manually added the `queryParam` after checking that it was not taken at first by `locale`.

This fix is for the following flows:
- Blog binary selection: `/setup/blog`
- Start writing flow: `/setup/start-writing`
- Design first flow: `/setup/design-first`

## Testing Instructions

* You have to be logged out.
* Go to one of the flows URL adding the selected query param, like `/setup/blog?locale=es`
* Make sure you are redirected to login/signup page in the selected locale.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
