### PR TITLE
Add site preview to home

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -15,6 +15,7 @@ export const FEATURE_GO_MOBILE = 'home-feature-go-mobile';
 export const FEATURE_QUICK_START = 'home-feature-quick-start';
 export const FEATURE_STATS = 'home-feature-stats';
 export const FEATURE_SUPPORT = 'home-feature-support';
+export const FEATURE_SITE_PREVIEW = 'home-feature-site-preview';
 export const NOTICE_SITE_LAUNCH_SELLER_UPSELL = 'home-site-launch-seller-upsell';
 export const NOTICE_CELEBRATE_SITE_CREATION = 'home-notice-celebrate-site-creation';
 export const NOTICE_CELEBRATE_SITE_LAUNCH = 'home-notice-celebrate-site-launch';

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import { ReactNode } from 'react';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { SiteItemThumbnail } from 'calypso/sites-dashboard/components/sites-site-item-thumbnail';
 import { SiteUrl, Truncated } from 'calypso/sites-dashboard/components/sites-site-url';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -67,19 +66,17 @@ const SitePreview = ( { isFSEActive }: SitePreviewProps ): JSX.Element => {
 		canvas: 'edit',
 	} );
 
+	const iframeSrcKeepHomepage = `//${ selectedSite.domain }/?hide_banners=true&preview_overlay=true`;
+
 	return (
 		<div className="home-site-preview">
 			<ThumbnailWrapper showEditSite={ shouldShowEditSite } editSiteURL={ editSiteURL }>
 				{ shouldShowEditSite && (
 					<div className="home-site-preview__thumbnail-label"> { __( 'Edit site' ) } </div>
 				) }
-				<SiteItemThumbnail
-					displayMode="tile"
-					className="home-site-preview__thumbnail"
-					site={ selectedSite }
-					width={ 312 }
-					height={ 312 }
-				/>
+				<div className="home-site-preview__thumbnail-iframe-wrapper">
+					<iframe scrolling="no" loading="lazy" title="title" src={ iframeSrcKeepHomepage } />
+				</div>
 			</ThumbnailWrapper>
 			<div className="home-site-preview__action-bar">
 				<div className="home-site-preview__site-info">

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -1,24 +1,45 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { SiteItemThumbnail } from 'calypso/sites-dashboard/components/sites-site-item-thumbnail';
+import { SiteUrl, Truncated } from 'calypso/sites-dashboard/components/sites-site-url';
 import { useSelector } from 'calypso/state';
-import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
+import { SitePreviewEllipsisMenu } from './site-preview-ellipsis-menu';
 
 const SitePreview = (): JSX.Element => {
+	const { __ } = useI18n();
 	const selectedSite = useSelector( getSelectedSite );
-	const selectedSiteId = selectedSite?.ID;
-	const domains = useSelector( ( state ) => getWpComDomainBySiteId( state, selectedSiteId ) );
-	const wpComDomain = domains?.domain;
 
-	const iframeSrcKeepHomepage = wpComDomain
-		? `//${ wpComDomain }/?hide_banners=true&preview_overlay=true`
-		: undefined;
+	if ( ! selectedSite ) {
+		return <div></div>;
+	}
+
+	const editSiteSlug = addQueryArgs( `/site-editor/${ selectedSite.slug }`, {
+		canvas: 'edit',
+	} );
+
 	return (
 		<div className="home-site-preview">
-			{ wpComDomain && (
-				<div className="home-site-preview__iframe-wrapper">
-					<iframe scrolling="no" loading="lazy" title="title" src={ iframeSrcKeepHomepage } />
+			<a className="home-site-preview__thumbnail-wrapper" href={ editSiteSlug }>
+				<div className="theme-card__image-label"> { __( 'Edit site' ) } </div>
+				<SiteItemThumbnail
+					displayMode="tile"
+					className="home-site-preview__thumbnail"
+					site={ selectedSite }
+					width={ 235 }
+					height={ 235 }
+				/>
+			</a>
+			<div className="home-site-preview__action-bar">
+				<div className="home-site-preview__site-info">
+					<h2 className="home-site-preview__info-title">{ selectedSite.name }</h2>
+					<SiteUrl href={ selectedSite.URL } title={ selectedSite.URL }>
+						<Truncated>{ selectedSite.URL }</Truncated>
+					</SiteUrl>
 				</div>
-			) }
+				<SitePreviewEllipsisMenu />
+			</div>
 		</div>
 	);
 };

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -35,7 +35,7 @@ const SitePreview = (): JSX.Element => {
 				className="home-site-preview__thumbnail-wrapper"
 				href={ editSiteSlug }
 			>
-				<div className="theme-card__image-label"> { __( 'Edit site' ) } </div>
+				<div className="home-site-preview__thumbnail-label"> { __( 'Edit site' ) } </div>
 				<SiteItemThumbnail
 					displayMode="tile"
 					className="home-site-preview__thumbnail"

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -40,8 +40,8 @@ const SitePreview = (): JSX.Element => {
 					displayMode="tile"
 					className="home-site-preview__thumbnail"
 					site={ selectedSite }
-					width={ 235 }
-					height={ 235 }
+					width={ 312 }
+					height={ 312 }
 				/>
 			</a>
 			<div className="home-site-preview__action-bar">

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -6,7 +6,6 @@ import './style.scss';
 const SitePreview = (): JSX.Element => {
 	const selectedSite = useSelector( getSelectedSite );
 	const selectedSiteId = selectedSite?.ID;
-	// const domains = [ selectedSiteId ];
 	const domains = useSelector( ( state ) => getWpComDomainBySiteId( state, selectedSiteId ) );
 	const wpComDomain = domains?.domain;
 

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -23,27 +23,27 @@ const ThumbnailWrapper = ( { showEditSite, editSiteURL, children }: ThumbnailWra
 		'home-site-preview__remove-pointer': ! showEditSite,
 	} );
 
-	if ( showEditSite ) {
-		return (
-			<a
-				onClick={ ( event ) => {
-					event.preventDefault();
-
-					recordTracksEvent( 'calypso_customer_home_site_preview_clicked', {
-						context: 'customer-home',
-					} );
-
-					window.location.href = event.currentTarget.href;
-				} }
-				className={ classes }
-				href={ editSiteURL }
-			>
-				{ children }
-			</a>
-		);
+	if ( ! showEditSite ) {
+		return <div className={ classes }> { children } </div>;
 	}
 
-	return <div className={ classes }> { children } </div>;
+	return (
+		<a
+			onClick={ ( event ) => {
+				event.preventDefault();
+
+				recordTracksEvent( 'calypso_customer_home_site_preview_clicked', {
+					context: 'customer-home',
+				} );
+
+				window.location.href = event.currentTarget.href;
+			} }
+			className={ classes }
+			href={ editSiteURL }
+		>
+			{ children }
+		</a>
+	);
 };
 
 interface SitePreviewProps {
@@ -79,7 +79,12 @@ const SitePreview = ( { isFSEActive }: SitePreviewProps ): JSX.Element => {
 					</Button>
 				) }
 				<div className="home-site-preview__thumbnail">
-					<iframe scrolling="no" loading="lazy" title="title" src={ iframeSrcKeepHomepage } />
+					<iframe
+						scrolling="no"
+						loading="lazy"
+						title={ __( 'Site Preview' ) }
+						src={ iframeSrcKeepHomepage }
+					/>
 				</div>
 			</ThumbnailWrapper>
 			<div className="home-site-preview__action-bar">

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -1,0 +1,27 @@
+import { useSelector } from 'calypso/state';
+import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import './style.scss';
+
+const SitePreview = (): JSX.Element => {
+	const selectedSite = useSelector( getSelectedSite );
+	const selectedSiteId = selectedSite?.ID;
+	// const domains = [ selectedSiteId ];
+	const domains = useSelector( ( state ) => getWpComDomainBySiteId( state, selectedSiteId ) );
+	const wpComDomain = domains?.domain;
+
+	const iframeSrcKeepHomepage = wpComDomain
+		? `//${ wpComDomain }/?hide_banners=true&preview_overlay=true`
+		: undefined;
+	return (
+		<div className="home-site-preview">
+			{ wpComDomain && (
+				<div className="home-site-preview__iframe-wrapper">
+					<iframe scrolling="no" loading="lazy" title="title" src={ iframeSrcKeepHomepage } />
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default SitePreview;

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -9,6 +9,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { SiteUrl, Truncated } from 'calypso/sites-dashboard/components/sites-site-url';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 import { SitePreviewEllipsisMenu } from './site-preview-ellipsis-menu';
@@ -57,8 +58,9 @@ const SitePreview = ( { isFSEActive }: SitePreviewProps ): JSX.Element => {
 		canCurrentUser( state, selectedSite?.ID ?? 0, 'manage_options' )
 	);
 	const isMobile = useMobileBreakpoint();
+	const wpcomDomain = useSelector( ( state ) => getWpComDomainBySiteId( state, selectedSite?.ID ) );
 
-	if ( isMobile || ! selectedSite ) {
+	if ( isMobile || ! selectedSite || ! wpcomDomain ) {
 		return <></>;
 	}
 
@@ -68,7 +70,7 @@ const SitePreview = ( { isFSEActive }: SitePreviewProps ): JSX.Element => {
 		canvas: 'edit',
 	} );
 
-	const iframeSrcKeepHomepage = `//${ selectedSite.domain }/?hide_banners=true&preview_overlay=true`;
+	const iframeSrcKeepHomepage = `//${ wpcomDomain.domain }/?hide_banners=true&preview_overlay=true`;
 
 	return (
 		<div className="home-site-preview">

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -74,7 +74,7 @@ const SitePreview = ( { isFSEActive }: SitePreviewProps ): JSX.Element => {
 				{ shouldShowEditSite && (
 					<div className="home-site-preview__thumbnail-label"> { __( 'Edit site' ) } </div>
 				) }
-				<div className="home-site-preview__thumbnail-iframe-wrapper">
+				<div className="home-site-preview__thumbnail">
 					<iframe scrolling="no" loading="lazy" title="title" src={ iframeSrcKeepHomepage } />
 				</div>
 			</ThumbnailWrapper>

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -1,5 +1,6 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { SiteItemThumbnail } from 'calypso/sites-dashboard/components/sites-site-item-thumbnail';
 import { SiteUrl, Truncated } from 'calypso/sites-dashboard/components/sites-site-url';
 import { useSelector } from 'calypso/state';
@@ -21,7 +22,19 @@ const SitePreview = (): JSX.Element => {
 
 	return (
 		<div className="home-site-preview">
-			<a className="home-site-preview__thumbnail-wrapper" href={ editSiteSlug }>
+			<a
+				onClick={ ( event ) => {
+					event.preventDefault();
+
+					recordTracksEvent( 'calypso_customer_home_site_preview_clicked', {
+						context: 'customer-home',
+					} );
+
+					window.location.href = event.currentTarget.href;
+				} }
+				className="home-site-preview__thumbnail-wrapper"
+				href={ editSiteSlug }
+			>
 				<div className="theme-card__image-label"> { __( 'Edit site' ) } </div>
 				<SiteItemThumbnail
 					displayMode="tile"

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -1,3 +1,4 @@
+import { isMobile } from '@automattic/viewport';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -12,7 +13,7 @@ const SitePreview = (): JSX.Element => {
 	const { __ } = useI18n();
 	const selectedSite = useSelector( getSelectedSite );
 
-	if ( ! selectedSite ) {
+	if ( isMobile() || ! selectedSite ) {
 		return <div></div>;
 	}
 

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { isMobile } from '@automattic/viewport';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
@@ -56,9 +56,10 @@ const SitePreview = ( { isFSEActive }: SitePreviewProps ): JSX.Element => {
 	const canManageSite = useSelector( ( state ) =>
 		canCurrentUser( state, selectedSite?.ID ?? 0, 'manage_options' )
 	);
+	const isMobile = useMobileBreakpoint();
 
-	if ( isMobile() || ! selectedSite ) {
-		return <div></div>;
+	if ( isMobile || ! selectedSite ) {
+		return <></>;
 	}
 
 	const shouldShowEditSite = isFSEActive && canManageSite;

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import { isMobile } from '@automattic/viewport';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -72,7 +73,9 @@ const SitePreview = ( { isFSEActive }: SitePreviewProps ): JSX.Element => {
 		<div className="home-site-preview">
 			<ThumbnailWrapper showEditSite={ shouldShowEditSite } editSiteURL={ editSiteURL }>
 				{ shouldShowEditSite && (
-					<div className="home-site-preview__thumbnail-label"> { __( 'Edit site' ) } </div>
+					<Button primary className="home-site-preview__thumbnail-label">
+						{ __( 'Edit site' ) }
+					</Button>
 				) }
 				<div className="home-site-preview__thumbnail">
 					<iframe scrolling="no" loading="lazy" title="title" src={ iframeSrcKeepHomepage } />

--- a/client/my-sites/customer-home/cards/features/site-preview/site-preview-ellipsis-menu.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/site-preview-ellipsis-menu.tsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { useRef, useState } from 'react';
@@ -20,7 +21,11 @@ export const SitePreviewEllipsisMenu = () => {
 	return (
 		<span className={ classes }>
 			<button
-				aria-label={ `More options for site ${ selectedSite?.name }` }
+				aria-label={ sprintf(
+					/* translators: %s is the site name */
+					__( 'More options for site %s' ),
+					selectedSite?.name
+				) }
 				ref={ moreButtonRef }
 				onClick={ () => setIsShowingPopover( ! isShowingPopover ) }
 			>

--- a/client/my-sites/customer-home/cards/features/site-preview/site-preview-ellipsis-menu.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/site-preview-ellipsis-menu.tsx
@@ -1,0 +1,45 @@
+import { Gridicon } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
+import { useRef, useState } from 'react';
+import PopoverMenu from 'calypso/components/popover-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+export const SitePreviewEllipsisMenu = () => {
+	const { __ } = useI18n();
+
+	const moreButtonRef = useRef( null );
+	const [ isShowingPopover, setIsShowingPopover ] = useState( false );
+
+	const classes = classNames( 'theme__more-button', { 'is-open': isShowingPopover } );
+	const selectedSite = useSelector( getSelectedSite );
+
+	return (
+		<span className={ classes }>
+			<button
+				aria-label={ `More options for site ${ selectedSite?.name }` }
+				ref={ moreButtonRef }
+				onClick={ () => setIsShowingPopover( ! isShowingPopover ) }
+			>
+				<Gridicon icon="ellipsis" size={ 24 } />
+			</button>
+			{ isShowingPopover && (
+				<PopoverMenu
+					context={ moreButtonRef.current }
+					isVisible
+					onClose={ () => setIsShowingPopover( false ) }
+					position="bottom left"
+				>
+					<PopoverMenuItem key="settings-link" href={ `/settings/general/${ selectedSite?.slug }` }>
+						{ __( 'Settings' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem key="domain-link" href={ `/domains/add/${ selectedSite?.slug }` }>
+						{ __( 'Manage domains' ) }
+					</PopoverMenuItem>
+				</PopoverMenu>
+			) }
+		</span>
+	);
+};

--- a/client/my-sites/customer-home/cards/features/site-preview/site-preview-ellipsis-menu.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/site-preview-ellipsis-menu.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { useRef, useState } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -32,10 +33,28 @@ export const SitePreviewEllipsisMenu = () => {
 					onClose={ () => setIsShowingPopover( false ) }
 					position="bottom left"
 				>
-					<PopoverMenuItem key="settings-link" href={ `/settings/general/${ selectedSite?.slug }` }>
+					<PopoverMenuItem
+						key="settings-link"
+						onClick={ () => {
+							recordTracksEvent( 'calypso_customer_home_site_preview_menu_item_clicked', {
+								context: 'customer-home',
+								item: 'settings',
+							} );
+						} }
+						href={ `/settings/general/${ selectedSite?.slug }` }
+					>
 						{ __( 'Settings' ) }
 					</PopoverMenuItem>
-					<PopoverMenuItem key="domain-link" href={ `/domains/add/${ selectedSite?.slug }` }>
+					<PopoverMenuItem
+						key="domain-link"
+						onClick={ () => {
+							recordTracksEvent( 'calypso_customer_home_site_preview_menu_item_clicked', {
+								context: 'customer-home',
+								item: 'manage-domains',
+							} );
+						} }
+						href={ `/domains/add/${ selectedSite?.slug }` }
+					>
 						{ __( 'Manage domains' ) }
 					</PopoverMenuItem>
 				</PopoverMenu>

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -25,6 +25,19 @@
 			}
 		}
 
+		.home-site-preview__thumbnail-iframe-wrapper {
+			display: block;
+			height: 235px;
+			width: 100%;
+			iframe {
+				height: 357%;
+				width: 357%;
+				max-width: 357%;
+				transform: scale(0.28);
+				transform-origin: top left;
+			}
+		}
+
 		.home-site-preview__thumbnail-label {
 			background: var(--color-accent);
 			border: 1px solid var(--color-accent);

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -30,6 +30,9 @@
 			height: 235px;
 			width: 100%;
 			iframe {
+				// The idea is to zoom-out the iframe to get most of the content
+				// into the thumbnail and then we scale it down so it remains the
+				// size of the parent component (357% * 0.28 ~= 100%)
 				height: 357%;
 				width: 357%;
 				max-width: 357%;

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -46,6 +46,10 @@
 		}
 	}
 
+	.home-site-preview__remove-pointer {
+		cursor: default;
+	}
+
 	.home-site-preview__action-bar {
 		display: flex;
 		flex-direction: row;

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -19,13 +19,13 @@
 				opacity: 0.8;
 			}
 
-			.theme-card__image-label {
+			.home-site-preview__thumbnail-label {
 				opacity: 1;
-				animation: theme-card__image-label 150ms ease-in-out;
+				animation: home-site-preview__thumbnail-label 150ms ease-in-out;
 			}
 		}
 
-		.theme-card__image-label {
+		.home-site-preview__thumbnail-label {
 			background: var(--color-accent);
 			border: 1px solid var(--color-accent);
 			border-radius: 2px;

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -1,0 +1,21 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.home-site-preview {
+	.home-site-preview__iframe-wrapper {
+		flex-grow: 1;
+		overflow: hidden;
+		display: block;
+		height: 235px;
+		max-height: 235px;
+		pointer-events: none;
+
+		iframe {
+			height: 357%;
+			width: 357%;
+			max-width: 357%;
+			transform: scale(0.28);
+			transform-origin: top left;
+		}
+	}
+}

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -2,20 +2,69 @@
 @import "@wordpress/base-styles/mixins";
 
 .home-site-preview {
-	.home-site-preview__iframe-wrapper {
+	.home-site-preview__thumbnail-wrapper {
 		flex-grow: 1;
 		overflow: hidden;
-		display: block;
-		height: 235px;
+		display: flex;
+		justify-content: center;
+		align-items: center;
 		max-height: 235px;
-		pointer-events: none;
+		cursor: pointer;
+		transition: all 200ms ease-in-out;
+		box-shadow: rgba(0, 0, 0, 0.2) 0 7px 30px -10px;
 
-		iframe {
-			height: 357%;
-			width: 357%;
-			max-width: 357%;
-			transform: scale(0.28);
-			transform-origin: top left;
+		&:hover,
+		&:focus {
+			.home-site-preview__thumbnail {
+				opacity: 0.8;
+			}
+
+			.theme-card__image-label {
+				opacity: 1;
+				animation: theme-card__image-label 150ms ease-in-out;
+			}
+		}
+
+		.theme-card__image-label {
+			background: var(--color-accent);
+			border: 1px solid var(--color-accent);
+			border-radius: 2px;
+			color: var(--color-text-inverted);
+			font-size: $font-body-small;
+			opacity: 0;
+			padding: 8px 14px;
+			position: absolute;
+			z-index: 1;
+		}
+
+		.home-site-preview__thumbnail {
+			aspect-ratio: 16 / 11;
+			width: 100%;
+			height: auto;
+			box-sizing: border-box;
+			opacity: 1;
+		}
+	}
+
+	.home-site-preview__action-bar {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		padding: 16px 0 0 0;
+
+		.home-site-preview__site-info {
+			display: flex;
+			flex-direction: column;
+			gap: 4px;
+
+			.home-site-preview__info-title {
+				color: var(--color-neutral-80);
+				flex: 1 1 auto;
+				font-family: inherit;
+				font-size: $font-body;
+				font-weight: 500;
+				line-height: 24px;
+			}
 		}
 	}
 }

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -11,10 +11,10 @@
 		max-height: 235px;
 		cursor: pointer;
 		transition: all 200ms ease-in-out;
-		box-shadow: rgba(0, 0, 0, 0.2) 0 7px 30px -10px;
 
 		&:hover,
 		&:focus {
+			box-shadow: rgba(0, 0, 0, 0.2) 0 7px 30px -10px;
 			.home-site-preview__thumbnail {
 				opacity: 0.8;
 			}

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -59,6 +59,7 @@
 			display: flex;
 			flex-direction: column;
 			gap: 4px;
+			max-width: calc(100% - 24px);
 
 			.home-site-preview__info-title {
 				color: var(--color-neutral-80);

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -39,13 +39,7 @@
 		}
 
 		.home-site-preview__thumbnail-label {
-			background: var(--color-accent);
-			border: 1px solid var(--color-accent);
-			border-radius: 2px;
-			color: var(--color-text-inverted);
-			font-size: $font-body-small;
 			opacity: 0;
-			padding: 8px 14px;
 			position: absolute;
 			z-index: 1;
 		}

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -25,7 +25,7 @@
 			}
 		}
 
-		.home-site-preview__thumbnail-iframe-wrapper {
+		.home-site-preview__thumbnail {
 			display: block;
 			height: 235px;
 			width: 100%;
@@ -48,14 +48,6 @@
 			padding: 8px 14px;
 			position: absolute;
 			z-index: 1;
-		}
-
-		.home-site-preview__thumbnail {
-			aspect-ratio: 16 / 11;
-			width: 100%;
-			height: auto;
-			box-sizing: border-box;
-			opacity: 1;
 		}
 	}
 

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -11,16 +11,19 @@ import {
 	FEATURE_GO_MOBILE,
 	FEATURE_QUICK_START,
 	FEATURE_SUPPORT,
+	FEATURE_SITE_PREVIEW,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import GoMobile from 'calypso/my-sites/customer-home/cards/features/go-mobile';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
 import QuickStart from 'calypso/my-sites/customer-home/cards/features/quick-start';
+import SitePreview from 'calypso/my-sites/customer-home/cards/features/site-preview';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const cardComponents = {
 	[ FEATURE_GO_MOBILE ]: GoMobile,
 	[ FEATURE_SUPPORT ]: HelpSearch,
+	[ FEATURE_SITE_PREVIEW ]: SitePreview,
 	[ ACTION_QUICK_LINKS ]: QuickLinks,
 	[ FEATURE_QUICK_START ]: QuickStart,
 	[ ACTION_WP_FOR_TEAMS_QUICK_LINKS ]: WpForTeamsQuickLinks,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78865

## Proposed Changes

Adds site preview card to `/home`. 
~This should be merged after D115839-code to ensure the correct visibility of the card.~

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /home
* Verify you see the site preview

<img width="1116" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/3fdaebea-a216-4d08-9e74-cd8cb45482b8">

* Verify you don't see the card on mobile. While this was not confirmed by design I think it's a sane default. We can always toggle it with a subsequent PR.
* Verify:
  - Clicking on Site Title does nothing
  - URL opens the site in a new tab
  - 3 dots open an extra menu:
     - Settings `/settings/general`
     - Manage domains `/domains/manage`

### Tracks
Go to your console, run `localStorage.setItem('debug', 'calypso:analytics');` and reload Calypso.

* Verify `calypso_customer_home_site_preview_clicked` is being fired when the site thumbnail is clicked.
* Verify `calypso_customer_home_site_preview_menu_item_clicked` is fired when clicking in the Settings menu item and make sure there's a prop called `item` with `settings` as value.
* Verify `calypso_customer_home_site_preview_menu_item_clicked` is fired when clicking in the Manage domains menu item and make sure there's a prop called `item` with `manage-domains` as value.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?