### PR TITLE
Overflow PremiumBadge text in compactable mode

### DIFF
--- a/packages/design-picker/src/components/premium-badge/style.scss
+++ b/packages/design-picker/src/components/premium-badge/style.scss
@@ -34,6 +34,7 @@
 		position: relative;
 		padding: 0 10px 0 25px;
 		cursor: default;
+		overflow: hidden;
 
 		&,
 		.premium-badge__logo {
@@ -59,8 +60,13 @@
 
 			.premium-badge__label {
 				width: 0;
-				overflow: hidden;
 			}
+		}
+
+		.premium-badge__label {
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2919

## Proposed Changes

When the design picker PremiumBadge is can display as a compact icon that expands on hover (such as is used in the assembler) then ensure any text inside overflows into ellipses rather than distorting the layout completely.

This isn't an ideal fix, but it is a quick one.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 0. Use calypso live link
 1. Switch language to Spanish
 2. Go through the /start process choosing a free plan
 3. At the design picker scroll to the bottom of the page and use the site assembler
 4. Open the fonts panel and hover over the star.

Before | After
-------|------
![image](https://github.com/Automattic/wp-calypso/assets/93301/49d529d0-b756-40a8-b7e2-ebf3e2b6d215) | <img width="494" alt="Screenshot 2023-07-05 at 19 33 11" src="https://github.com/Automattic/wp-calypso/assets/93301/eea63891-1e5a-4a8a-bc2f-e946257ab3b2">

I believe the "compactable" PremiumBadge is used only in the assembler and the  upcoming fonts & colours in design picker work. But still please feel free to check the badge in other locations such as the design picker grid.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
