### PR TITLE
Checkout: improve free purchase labels to exist alongside stored cards

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -161,10 +161,6 @@ export function hasRenewalItem( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isRenewal );
 }
 
-export function hasRenewalItemAndWillAutoRenew( cart: ObjectWithProducts ): boolean {
-	return getAllCartItems( cart ).some( ( product ) => product.is_renewal_and_will_auto_renew );
-}
-
 export function hasTransferProduct( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isDomainTransfer );
 }

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -161,6 +161,10 @@ export function hasRenewalItem( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isRenewal );
 }
 
+export function hasRenewalItemAndWillAutoRenew( cart: ObjectWithProducts ): boolean {
+	return getAllCartItems( cart ).some( ( product ) => product.is_renewal_and_will_auto_renew );
+}
+
 export function hasTransferProduct( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isDomainTransfer );
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -435,9 +435,10 @@ export default function useCreatePaymentMethods( {
 		storedCards,
 	} );
 
+	// The order mirrors the order of Payment Methods in Checkout.
 	return [
-		freePaymentMethod,
 		...existingCardMethods,
+		freePaymentMethod,
 		applePayMethod,
 		googlePayMethod,
 		stripeMethod,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -435,7 +435,7 @@ export default function useCreatePaymentMethods( {
 		storedCards,
 	} );
 
-	// The order mirrors the order of Payment Methods in Checkout.
+	// The order is the order of Payment Methods in Checkout.
 	return [
 		...existingCardMethods,
 		freePaymentMethod,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
@@ -107,7 +107,7 @@ function WordPressFreePurchaseLabel() {
 		);
 	}
 
-	if ( isCartAllOneTimePurchases && doesPurchaseHaveFullCredits( responseCart ) ) {
+	if ( doesPurchaseHaveFullCredits( responseCart ) ) {
 		return (
 			<>
 				<div>
@@ -121,15 +121,6 @@ function WordPressFreePurchaseLabel() {
 						} )
 					}
 				</div>
-				<WordPressLogo />
-			</>
-		);
-	}
-
-	if ( doesCartHaveRenewalWithPaymentMethod ) {
-		return (
-			<>
-				<div>{ __( 'Renew Without Changing Saved Payment Method' ) }</div>
 				<WordPressLogo />
 			</>
 		);

--- a/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
@@ -10,7 +10,10 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { doesPurchaseHaveFullCredits } from '@automattic/wpcom-checkout';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { hasRenewableSubscription } from 'calypso/lib/cart-values/cart-items';
+import {
+	hasRenewableSubscription,
+	hasRenewalItemAndWillAutoRenew,
+} from 'calypso/lib/cart-values/cart-items';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import WordPressLogo from '../components/wordpress-logo';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
@@ -107,8 +110,9 @@ function WordPressFreePurchaseLabel() {
 	// If the cart has any renewable purchases and there are more
 	// than one payment method options, change the label.
 	const isRenewableCart = hasRenewableSubscription( responseCart ) || hasDomainTransfer;
+	const hasRenewableItemThatWillAutoRenew = hasRenewalItemAndWillAutoRenew( responseCart );
 	const freePurchaseLabel =
-		isRenewableCart && availablePaymentMethodIds.length > 1
+		isRenewableCart && availablePaymentMethodIds.length > 1 && ! hasRenewableItemThatWillAutoRenew
 			? __( 'Assign a Payment Method Later' )
 			: __( 'Free Purchase' );
 

--- a/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
@@ -1,4 +1,9 @@
-import { Button, useFormStatus, FormStatus } from '@automattic/composite-checkout';
+import {
+	Button,
+	useFormStatus,
+	FormStatus,
+	useAvailablePaymentMethodIds,
+} from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { doesPurchaseHaveFullCredits } from '@automattic/wpcom-checkout';
@@ -91,6 +96,7 @@ function WordPressFreePurchaseLabel() {
 	const { __ } = useI18n();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
+	const availablePaymentMethodIds = useAvailablePaymentMethodIds();
 
 	if ( doesPurchaseHaveFullCredits( responseCart ) ) {
 		return (
@@ -113,7 +119,11 @@ function WordPressFreePurchaseLabel() {
 
 	return (
 		<Fragment>
-			<div>{ __( 'Free Purchase' ) }</div>
+			<div>
+				{ availablePaymentMethodIds.length > 1
+					? __( 'Assign Payment Method Later' )
+					: __( 'Free Purchase' ) }
+			</div>
 			<WordPressLogo />
 		</Fragment>
 	);

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.tsx
@@ -72,7 +72,7 @@ describe( 'Checkout contact step', () => {
 	it( 'renders the step after the contact step as active if the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
-		expect( await screen.findByText( 'Free Purchase' ) ).toBeVisible();
+		expect( await screen.findByText( 'Assign a Payment Method Later' ) ).toBeVisible();
 	} );
 
 	it( 'renders the contact step when the purchase is not free', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
@@ -118,7 +118,7 @@ describe( 'Checkout payment methods list', () => {
 			/>
 		);
 		await waitFor( () => {
-			expect( screen.getByText( /WordPress.com Credits:/ ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Assign a Payment Method Later' ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -145,6 +145,7 @@ describe( 'Checkout payment methods list', () => {
 		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			expect( screen.queryByText( 'Free Purchase' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Assign a Payment Method Later' ) ).not.toBeInTheDocument();
 		} );
 	} );
 
@@ -195,7 +196,7 @@ describe( 'Checkout payment methods list', () => {
 			/>
 		);
 		await waitFor( () => {
-			expect( screen.getByText( 'Free Purchase' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Assign a Payment Method Later' ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
@@ -197,9 +197,7 @@ describe( 'Checkout payment methods list', () => {
 			/>
 		);
 		await waitFor( () => {
-			expect(
-				screen.getByText( 'Renew Without Changing Saved Payment Method' )
-			).toBeInTheDocument();
+			expect( screen.getByText( /WordPress.com Credits/ ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
@@ -122,6 +122,85 @@ describe( 'Checkout payment methods list', () => {
 		} );
 	} );
 
+	it( 'renders the full credits payment method option when full credits are available for a one-time purchase', async () => {
+		const cartChanges = {
+			sub_total_integer: 0,
+			sub_total_display: '0',
+			credits_integer: 15600,
+			credits_display: 'R$156',
+			products: [
+				{
+					...initialCart.products[ 0 ],
+					is_one_time_purchase: true,
+				},
+			],
+		};
+		render(
+			<MockCheckout
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
+		await waitFor( () => {
+			expect( screen.getByText( /WordPress.com Credits/ ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders the full credits payment method option when full credits are available for a renewal with a saved payment method', async () => {
+		const cartChanges = {
+			sub_total_integer: 0,
+			sub_total_display: '0',
+			credits_integer: 15600,
+			credits_display: 'R$156',
+			products: [
+				{
+					...initialCart.products[ 0 ],
+					is_renewal: true,
+					is_renewal_and_will_auto_renew: true,
+				},
+			],
+		};
+		render(
+			<MockCheckout
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
+		await waitFor( () => {
+			expect(
+				screen.getByText( 'Renew Without Changing Saved Payment Method' )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders the full credits payment method option when full credits are available for a renewal without a saved payment method', async () => {
+		const cartChanges = {
+			sub_total_integer: 0,
+			sub_total_display: '0',
+			credits_integer: 15600,
+			credits_display: 'R$156',
+			products: [
+				{
+					...initialCart.products[ 0 ],
+					is_renewal: true,
+					is_renewal_and_will_auto_renew: false,
+				},
+			],
+		};
+		render(
+			<MockCheckout
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
+		await waitFor( () => {
+			expect( screen.getByText( 'Assign a Payment Method Later' ) ).toBeInTheDocument();
+		} );
+	} );
+
 	it( 'does not render the other payment method options when full credits are available', async () => {
 		const cartChanges = {
 			sub_total_integer: 0,

--- a/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
@@ -105,10 +105,10 @@ describe( 'Checkout payment methods list', () => {
 
 	it( 'renders the full credits payment method option when full credits are available', async () => {
 		const cartChanges = {
-			sub_total_integer: 0,
-			sub_total_display: '0',
 			credits_integer: 15600,
 			credits_display: 'R$156',
+			total_tax_integer: 0,
+			total_cost_integer: 0,
 		};
 		render(
 			<MockCheckout
@@ -122,12 +122,40 @@ describe( 'Checkout payment methods list', () => {
 		} );
 	} );
 
-	it( 'renders the full credits payment method option when full credits are available for a one-time purchase', async () => {
+	it( 'renders the full credits payment method option when a coupon has made the purchase free for a one-time purchase', async () => {
 		const cartChanges = {
+			coupon: 'FREE',
 			sub_total_integer: 0,
 			sub_total_display: '0',
+			credits_integer: 0,
+			credits_display: '0',
+			total_tax_integer: 0,
+			total_cost_integer: 0,
+			products: [
+				{
+					...initialCart.products[ 0 ],
+					is_one_time_purchase: true,
+				},
+			],
+		};
+		render(
+			<MockCheckout
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
+		await waitFor( () => {
+			expect( screen.getByText( 'Free Purchase' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders the full credits payment method option when full credits are available for a one-time purchase', async () => {
+		const cartChanges = {
 			credits_integer: 15600,
 			credits_display: 'R$156',
+			total_tax_integer: 0,
+			total_cost_integer: 0,
 			products: [
 				{
 					...initialCart.products[ 0 ],
@@ -149,10 +177,10 @@ describe( 'Checkout payment methods list', () => {
 
 	it( 'renders the full credits payment method option when full credits are available for a renewal with a saved payment method', async () => {
 		const cartChanges = {
-			sub_total_integer: 0,
-			sub_total_display: '0',
 			credits_integer: 15600,
 			credits_display: 'R$156',
+			total_tax_integer: 0,
+			total_cost_integer: 0,
 			products: [
 				{
 					...initialCart.products[ 0 ],
@@ -177,10 +205,10 @@ describe( 'Checkout payment methods list', () => {
 
 	it( 'renders the full credits payment method option when full credits are available for a renewal without a saved payment method', async () => {
 		const cartChanges = {
-			sub_total_integer: 0,
-			sub_total_display: '0',
 			credits_integer: 15600,
 			credits_display: 'R$156',
+			total_tax_integer: 0,
+			total_cost_integer: 0,
 			products: [
 				{
 					...initialCart.products[ 0 ],
@@ -203,10 +231,10 @@ describe( 'Checkout payment methods list', () => {
 
 	it( 'does not render the other payment method options when full credits are available', async () => {
 		const cartChanges = {
-			sub_total_integer: 0,
-			sub_total_display: '0',
 			credits_integer: 15600,
 			credits_display: 'R$156',
+			total_tax_integer: 0,
+			total_cost_integer: 0,
 		};
 		render(
 			<MockCheckout
@@ -244,8 +272,6 @@ describe( 'Checkout payment methods list', () => {
 
 	it( 'does not render the full credits payment method option when full credits are available but the purchase is free', async () => {
 		const cartChanges = {
-			sub_total_integer: 0,
-			sub_total_display: '0',
 			total_tax_integer: 0,
 			total_tax_display: 'R$0',
 			total_cost_integer: 0,

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -46,6 +46,7 @@ import {
 	usePaymentMethod,
 	usePaymentMethodId,
 	useAllPaymentMethods,
+	useAvailablePaymentMethodIds,
 	useTogglePaymentMethod,
 } from './lib/payment-methods';
 import PaymentLogo from './lib/payment-methods/payment-logo';
@@ -103,6 +104,7 @@ export {
 	makeRedirectResponse,
 	makeSuccessResponse,
 	useAllPaymentMethods,
+	useAvailablePaymentMethodIds,
 	useFormStatus,
 	useIsStepActive,
 	useIsStepComplete,

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -496,6 +496,11 @@ export interface ResponseCartProduct {
 	 */
 	is_renewal_and_will_auto_renew?: boolean;
 
+	/**
+	 * True if the product will not renew.
+	 */
+	is_one_time_purchase?: boolean;
+
 	subscription_id?: string;
 	introductory_offer_terms?: IntroductoryOfferTerms;
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -488,6 +488,14 @@ export interface ResponseCartProduct {
 	 */
 	is_renewal?: boolean;
 
+	/**
+	 * True if the product is a renewal and the subscription will auto-renew.
+	 *
+	 * A subscription will auto-renew if it both can auto-renew (it's a recurring subscription,
+	 * has a payment method, isn't blocked, etc.) and the user has auto-renew enabled.
+	 */
+	is_renewal_and_will_auto_renew: boolean;
+
 	subscription_id?: string;
 	introductory_offer_terms?: IntroductoryOfferTerms;
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -494,7 +494,7 @@ export interface ResponseCartProduct {
 	 * A subscription will auto-renew if it both can auto-renew (it's a recurring subscription,
 	 * has a payment method, isn't blocked, etc.) and the user has auto-renew enabled.
 	 */
-	is_renewal_and_will_auto_renew: boolean;
+	is_renewal_and_will_auto_renew?: boolean;
 
 	subscription_id?: string;
 	introductory_offer_terms?: IntroductoryOfferTerms;


### PR DESCRIPTION
This PR updates the "Free Purchase" label to "Assign a Payment Method Later" when the cart is not entirely one-time purchases. 

If the cart is free because of full credits, the label will read "WordPress.com Credits: X available".

If the cart contains entirely one-time purchases and is free because of a coupon or other reason, the label will read "Free Purchase".

(This logic uses new cart properties introduced in D115488-code.)

Once D115364-code is merged, stored cards will be available in checkout for free purchases and the changes here will improve the UX of that flow, although that diff is not required for this to be merged.

See: https://github.com/Automattic/payments-shilling/issues/1802

| Before | After |
| ----------- | ----------- |
| <img width="1531" alt="Screenshot 2023-07-05 at 3 16 38 PM" src="https://github.com/Automattic/wp-calypso/assets/942359/35119b1e-3756-47bd-a4e1-aa2871f38a8b"> | <img width="1531" alt="Screenshot 2023-07-05 at 3 14 39 PM" src="https://github.com/Automattic/wp-calypso/assets/942359/06d3f533-2088-4894-bfc1-2a2ea37d645a"> |

**To test:**
- apply D115364-code, sandbox `public-api.wordpress.com`, and sandbox Store
- for a user without any existing stored details:
  - visit checkout and apply the coupon `cainsfree`
  - verify that only the "Free Purchase" payment method is available
- for a user with existing stored details: 
  - visit checkout with a recurring purchase (e.g. `/checkout/{site}/premium`) and apply the coupon `cainsfree`
  - verify that the existing stored details are displayed first in Checkout
  - verify that the free payment method is shown with an "Assign payment method later" label
  - verify that the promotional pricing ToS block is shown at that the information included is accurate
- for a user with existing stored details: 
  - visit checkout with a one-time purchase (e.g. `/checkout/{site}/wp_difm_extra_page`) and apply the coupon `cainsfree`
  - verify that the existing stored details are not displayed first in Checkout
  - verify that the free payment method is shown with an "Free Purchase" label
- for a user with existing stored details: 
  - visit checkout with a both a one-time purchase (e.g. `/checkout/{site}/video,wp_difm_extra_page`) and apply the coupon `cainsfree`
  - verify that the free payment method is shown with an "Assign payment method later" label
  - verify that the promotional pricing ToS block is shown at that the information included is accurate
- for a user with full credits:
  - update your test user to add enough credits to fully cover a purchase.
  - visit checkout and remove any applied coupons.
  - verify that the free payment method is shown with a "Assign a payment method later" label.
- Repeat the above steps for a renewal with full credits that has a payment method assigned.
  - verify that the free payment method is shown with a "WordPress.com Credits" label.
- Repeat the above steps for a renewal with full credits that does not have payment method assigned.
  - verify that the free payment method is shown with a "Assign a payment method later" label.