### PR TITLE
Launchpad: Added blog flow launchpad component

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -48,4 +48,4 @@ export const TASK_STAGING = 'home-task-staging';
 export const TASK_FIVERR = 'home-task-fiverr';
 export const TASK_DOMAIN_UPSELL = 'home-task-domain-upsell';
 export const LAUNCHPAD_KEEP_BUILDING = 'home-launchpad-keep-building';
-export const LAUNCHPAD_BLOG_FLOW = 'home-launchpad-blog-flow';
+export const LAUNCHPAD_INTENT_WRITE = 'home-launchpad-intent-write';

--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -48,3 +48,4 @@ export const TASK_STAGING = 'home-task-staging';
 export const TASK_FIVERR = 'home-task-fiverr';
 export const TASK_DOMAIN_UPSELL = 'home-task-domain-upsell';
 export const LAUNCHPAD_KEEP_BUILDING = 'home-launchpad-keep-building';
+export const LAUNCHPAD_BLOG_FLOW = 'home-launchpad-blog-flow';

--- a/client/my-sites/customer-home/cards/launchpad/blog-flow.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/blog-flow.tsx
@@ -1,12 +1,14 @@
 import { useLaunchpad } from '@automattic/data-stores';
 import { Task } from '@automattic/launchpad';
+import { isMobile } from '@automattic/viewport';
+import { addQueryArgs } from '@wordpress/url';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CustomerHomeLaunchpad from '.';
 
-const checklistSlug = 'TBD';
+const checklistSlug = 'blog-flow';
 
 interface LaunchpadKeepBuildingProps {
 	siteSlug: string | null;
@@ -48,15 +50,44 @@ const LaunchpadBlogFlow = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.Elem
 
 			let actionDispatch;
 
-			// Ex:
-			// switch ( task.id ) {
-			// 	case 'my_task_id':
-			// 		actionDispatch = () => {
-			// 			recordTaskClickTracksEvent( task );
-			// 			do_something();
-			// 		};
-			// 		break;
-			// }
+			switch ( task.id ) {
+				case 'my_task_id':
+				case 'site_title':
+					actionDispatch = () => {
+						recordTaskClickTracksEvent( task );
+						window.location.assign( `/settings/general/${ siteSlug }` );
+					};
+					break;
+
+				case 'design_edited':
+					actionDispatch = () => {
+						recordTaskClickTracksEvent( task );
+						window.location.assign(
+							addQueryArgs( `/site-editor/${ siteSlug }`, {
+								canvas: 'edit',
+							} )
+						);
+					};
+					break;
+
+				case 'domain_claim':
+				case 'domain_upsell':
+				case 'domain_customize':
+					actionDispatch = () => {
+						recordTaskClickTracksEvent( task );
+						window.location.assign( `/domains/add/${ siteSlug }` );
+					};
+					break;
+				case 'drive_traffic':
+					actionDispatch = () => {
+						recordTaskClickTracksEvent( task );
+						const url = isMobile()
+							? `/marketing/connections/${ siteSlug }`
+							: `/marketing/connections/${ siteSlug }?tour=marketingConnectionsTour`;
+						window.location.assign( url );
+					};
+					break;
+			}
 
 			return { ...task, actionDispatch };
 		} );

--- a/client/my-sites/customer-home/cards/launchpad/blog-flow.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/blog-flow.tsx
@@ -1,0 +1,81 @@
+import { useLaunchpad } from '@automattic/data-stores';
+import { Task } from '@automattic/launchpad';
+import { connect } from 'react-redux';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import CustomerHomeLaunchpad from '.';
+
+const checklistSlug = 'TBD';
+
+interface LaunchpadKeepBuildingProps {
+	siteSlug: string | null;
+}
+
+const LaunchpadBlogFlow = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.Element => {
+	const {
+		data: { checklist },
+	} = useLaunchpad( siteSlug, checklistSlug );
+
+	const numberOfSteps = checklist?.length || 0;
+	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
+	const tasklistCompleted = completedSteps === numberOfSteps;
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const recordTaskClickTracksEvent = ( task: Task ) => {
+		recordTracksEvent( 'calypso_launchpad_task_clicked', {
+			checklist_slug: checklistSlug,
+			checklist_completed: tasklistCompleted,
+			task_id: task.id,
+			is_completed: task.completed,
+			context: 'customer-home',
+		} );
+	};
+
+	const sortedTasksWithActions = ( tasks: Task[] ) => {
+		const completedTasks = tasks.filter( ( task: Task ) => task.completed );
+		const incompleteTasks = tasks.filter( ( task: Task ) => ! task.completed );
+
+		const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
+
+		return sortedTasks.map( ( task: Task ) => {
+			recordTracksEvent( 'calypso_launchpad_task_view', {
+				checklist_slug: checklistSlug,
+				task_id: task.id,
+				is_completed: task.completed,
+				context: 'customer-home',
+			} );
+
+			let actionDispatch;
+
+			// Ex:
+			// switch ( task.id ) {
+			// 	case 'my_task_id':
+			// 		actionDispatch = () => {
+			// 			recordTaskClickTracksEvent( task );
+			// 			do_something();
+			// 		};
+			// 		break;
+			// }
+
+			return { ...task, actionDispatch };
+		} );
+	};
+
+	return (
+		<CustomerHomeLaunchpad
+			checklistSlug={ checklistSlug }
+			taskFilter={ sortedTasksWithActions }
+		></CustomerHomeLaunchpad>
+	);
+};
+
+const ConnectedLaunchpadBlogFlow = connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteSlug: getSiteSlug( state, siteId ),
+	};
+} )( LaunchpadBlogFlow );
+
+export default ConnectedLaunchpadBlogFlow;

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -1,0 +1,69 @@
+import { CircularProgressBar } from '@automattic/components';
+import { useLaunchpad } from '@automattic/data-stores';
+import { Launchpad, Task } from '@automattic/launchpad';
+import { useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+import './style.scss';
+
+interface CustomerHomeLaunchpadProps {
+	siteSlug: string | null;
+	checklistSlug: string;
+	taskFilter: ( tasks: Task[] ) => Task[];
+}
+
+const CustomerHomeLaunchpad = ( {
+	siteSlug,
+	checklistSlug,
+	taskFilter,
+}: CustomerHomeLaunchpadProps ): JSX.Element => {
+	const translate = useTranslate();
+	const {
+		data: { checklist },
+	} = useLaunchpad( siteSlug, checklistSlug );
+
+	const numberOfSteps = checklist?.length || 0;
+	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
+	const tasklistCompleted = completedSteps === numberOfSteps;
+
+	recordTracksEvent( 'calypso_launchpad_tasklist_viewed', {
+		checklist_slug: checklistSlug,
+		tasks: `,${ checklist?.map( ( task: Task ) => task.id ).join( ',' ) },`,
+		is_completed: tasklistCompleted,
+		number_of_steps: numberOfSteps,
+		number_of_completed_steps: completedSteps,
+		context: 'customer-home',
+	} );
+
+	return (
+		<div className="launchpad-keep-building">
+			<div className="launchpad-keep-building__header">
+				<h2 className="launchpad-keep-building__title">
+					{ translate( 'Next steps for your site' ) }
+				</h2>
+				<div className="launchpad-keep-building__progress-bar-container">
+					<CircularProgressBar
+						size={ 40 }
+						enableDesktopScaling
+						numberOfSteps={ numberOfSteps }
+						currentStep={ completedSteps }
+					/>
+				</div>
+			</div>
+			<Launchpad siteSlug={ siteSlug } checklistSlug={ checklistSlug } taskFilter={ taskFilter } />
+		</div>
+	);
+};
+
+const ConnectedCustomerHomeLaunchpad = connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteSlug: getSiteSlug( state, siteId ),
+	};
+} )( CustomerHomeLaunchpad );
+
+export default ConnectedCustomerHomeLaunchpad;

--- a/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
@@ -2,26 +2,26 @@ import { useLaunchpad } from '@automattic/data-stores';
 import { Task } from '@automattic/launchpad';
 import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
-import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSelector } from 'calypso/state';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CustomerHomeLaunchpad from '.';
+import type { AppState } from 'calypso/types';
 
-const checklistSlug = 'blog-flow';
+const checklistSlug = 'intent-write';
 
-interface LaunchpadKeepBuildingProps {
-	siteSlug: string | null;
-}
+const LaunchpadIntentWrite = (): JSX.Element => {
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
 
-const LaunchpadBlogFlow = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.Element => {
 	const {
 		data: { checklist },
 	} = useLaunchpad( siteSlug, checklistSlug );
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
-	const tasklistCompleted = completedSteps === numberOfSteps;
+	const tasklistCompleted = numberOfSteps > 0 && completedSteps === numberOfSteps;
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const recordTaskClickTracksEvent = ( task: Task ) => {
@@ -51,7 +51,6 @@ const LaunchpadBlogFlow = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.Elem
 			let actionDispatch;
 
 			switch ( task.id ) {
-				case 'my_task_id':
 				case 'site_title':
 					actionDispatch = () => {
 						recordTaskClickTracksEvent( task );
@@ -101,12 +100,4 @@ const LaunchpadBlogFlow = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.Elem
 	);
 };
 
-const ConnectedLaunchpadBlogFlow = connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-
-	return {
-		siteSlug: getSiteSlug( state, siteId ),
-	};
-} )( LaunchpadBlogFlow );
-
-export default ConnectedLaunchpadBlogFlow;
+export default LaunchpadIntentWrite;

--- a/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
@@ -1,5 +1,4 @@
 import { useLaunchpad } from '@automattic/data-stores';
-import { Task } from '@automattic/launchpad';
 import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -7,6 +6,7 @@ import { useSelector } from 'calypso/state';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CustomerHomeLaunchpad from '.';
+import type { Task } from '@automattic/launchpad';
 import type { AppState } from 'calypso/types';
 
 const checklistSlug = 'intent-write';
@@ -23,7 +23,6 @@ const LaunchpadIntentWrite = (): JSX.Element => {
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 	const tasklistCompleted = numberOfSteps > 0 && completedSteps === numberOfSteps;
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const recordTaskClickTracksEvent = ( task: Task ) => {
 		recordTracksEvent( 'calypso_launchpad_task_clicked', {
 			checklist_slug: checklistSlug,

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -1,5 +1,4 @@
 import { useLaunchpad } from '@automattic/data-stores';
-import { Task } from '@automattic/launchpad';
 import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
@@ -10,6 +9,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ShareSiteModal from '../../components/share-site-modal';
 import CustomerHomeLaunchpad from '.';
 import type { SiteDetails } from '@automattic/data-stores';
+import type { Task } from '@automattic/launchpad';
 
 import './style.scss';
 

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -1,15 +1,14 @@
-import { CircularProgressBar } from '@automattic/components';
 import { useLaunchpad } from '@automattic/data-stores';
-import { Launchpad, Task } from '@automattic/launchpad';
+import { Task } from '@automattic/launchpad';
 import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ShareSiteModal from '../../components/share-site-modal';
+import CustomerHomeLaunchpad from '.';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
@@ -21,7 +20,6 @@ interface LaunchpadKeepBuildingProps {
 }
 
 const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Element => {
-	const translate = useTranslate();
 	const siteSlug = site?.slug || null;
 
 	const {
@@ -41,24 +39,6 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 			context: 'customer-home',
 		} );
 	};
-
-	recordTracksEvent( 'calypso_launchpad_tasklist_viewed', {
-		checklist_slug: checklistSlug,
-		tasks: `,${ checklist?.map( ( task: Task ) => task.id ).join( ',' ) },`,
-		is_completed: tasklistCompleted,
-		number_of_steps: numberOfSteps,
-		number_of_completed_steps: completedSteps,
-		context: 'customer-home',
-	} );
-
-	recordTracksEvent( 'calypso_launchpad_tasklist_viewed', {
-		checklist_slug: checklistSlug,
-		tasks: `,${ checklist?.map( ( task: Task ) => task.id ).join( ',' ) },`,
-		is_completed: completedSteps === numberOfSteps,
-		number_of_steps: numberOfSteps,
-		number_of_completed_steps: completedSteps,
-		context: 'customer-home',
-	} );
 
 	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
 
@@ -141,26 +121,10 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 
 	return (
 		<>
-			<div className="launchpad-keep-building">
-				<div className="launchpad-keep-building__header">
-					<h2 className="launchpad-keep-building__title">
-						{ translate( 'Next steps for your site' ) }
-					</h2>
-					<div className="launchpad-keep-building__progress-bar-container">
-						<CircularProgressBar
-							size={ 40 }
-							enableDesktopScaling
-							numberOfSteps={ numberOfSteps }
-							currentStep={ completedSteps }
-						/>
-					</div>
-				</div>
-				<Launchpad
-					siteSlug={ siteSlug }
-					checklistSlug={ checklistSlug }
-					taskFilter={ sortedTasksWithActions }
-				/>
-			</div>
+			<CustomerHomeLaunchpad
+				checklistSlug={ checklistSlug }
+				taskFilter={ sortedTasksWithActions }
+			></CustomerHomeLaunchpad>
 			{ shareSiteModalIsOpen && (
 				<ShareSiteModal setModalIsOpen={ setShareSiteModalIsOpen } site={ site } />
 			) }

--- a/client/my-sites/customer-home/cards/launchpad/style.scss
+++ b/client/my-sites/customer-home/cards/launchpad/style.scss
@@ -2,20 +2,20 @@
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
 
-.launchpad-keep-building {
+.customer-home-launchpad {
 	padding: 24px;
 	border-radius: 3px; /* stylelint-disable-line scales/radii */
 	box-shadow: 0 0 0 1px var(--color-border-subtle);
 	margin-bottom: 16px;
 
-	.launchpad-keep-building__header {
+	.customer-home-launchpad__header {
 		display: flex;
 
-		.launchpad-keep-building__progress-bar-container {
+		.customer-home-launchpad__progress-bar-container {
 			margin: 5px;
 		}
 
-		.launchpad-keep-building__title {
+		.customer-home-launchpad__title {
 			flex: 1;
 			font-size: $font-title-small;
 			font-weight: 500;

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -7,7 +7,7 @@ import {
 	FEATURE_SUPPORT,
 	SECTION_BLOGGING_PROMPT,
 	LAUNCHPAD_KEEP_BUILDING,
-	LAUNCHPAD_BLOG_FLOW,
+	LAUNCHPAD_INTENT_WRITE,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import DomainUpsell from 'calypso/my-sites/customer-home/cards/features/domain-upsell';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
@@ -23,7 +23,7 @@ const cardComponents = {
 	[ SECTION_BLOGGING_PROMPT ]: BloggingPrompt,
 	[ FEATURE_SUPPORT ]: HelpSearch,
 	[ LAUNCHPAD_KEEP_BUILDING ]: LaunchpadKeepBuilding,
-	[ LAUNCHPAD_BLOG_FLOW ]: LaunchpadBlogFlow,
+	[ LAUNCHPAD_INTENT_WRITE ]: LaunchpadBlogFlow,
 };
 
 const Secondary = ( { cards, siteId } ) => {

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -7,10 +7,12 @@ import {
 	FEATURE_SUPPORT,
 	SECTION_BLOGGING_PROMPT,
 	LAUNCHPAD_KEEP_BUILDING,
+	LAUNCHPAD_BLOG_FLOW,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import DomainUpsell from 'calypso/my-sites/customer-home/cards/features/domain-upsell';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
 import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
+import LaunchpadBlogFlow from 'calypso/my-sites/customer-home/cards/launchpad/blog-flow';
 import LaunchpadKeepBuilding from 'calypso/my-sites/customer-home/cards/launchpad/keep-building';
 import LearnGrow from './learn-grow';
 
@@ -21,6 +23,7 @@ const cardComponents = {
 	[ SECTION_BLOGGING_PROMPT ]: BloggingPrompt,
 	[ FEATURE_SUPPORT ]: HelpSearch,
 	[ LAUNCHPAD_KEEP_BUILDING ]: LaunchpadKeepBuilding,
+	[ LAUNCHPAD_BLOG_FLOW ]: LaunchpadBlogFlow,
 };
 
 const Secondary = ( { cards, siteId } ) => {

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -12,7 +12,7 @@ import {
 import DomainUpsell from 'calypso/my-sites/customer-home/cards/features/domain-upsell';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
 import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
-import LaunchpadBlogFlow from 'calypso/my-sites/customer-home/cards/launchpad/blog-flow';
+import LaunchpadIntentWrite from 'calypso/my-sites/customer-home/cards/launchpad/intent-write';
 import LaunchpadKeepBuilding from 'calypso/my-sites/customer-home/cards/launchpad/keep-building';
 import LearnGrow from './learn-grow';
 
@@ -23,7 +23,7 @@ const cardComponents = {
 	[ SECTION_BLOGGING_PROMPT ]: BloggingPrompt,
 	[ FEATURE_SUPPORT ]: HelpSearch,
 	[ LAUNCHPAD_KEEP_BUILDING ]: LaunchpadKeepBuilding,
-	[ LAUNCHPAD_INTENT_WRITE ]: LaunchpadBlogFlow,
+	[ LAUNCHPAD_INTENT_WRITE ]: LaunchpadIntentWrite,
 };
 
 const Secondary = ( { cards, siteId } ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/31707 (backend part)

## Proposed Changes

* Added a Blog flow launchpad checklist component
* Refactored the existing KeepBuilding component so the HTML is reused

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Apply diff D115457-code to your sandbox and use it :) 
* ~~Apply https://github.com/Automattic/jetpack/pull/31707~~ 
* Create a new site with `build` intent 
* Launch the site
* Verify that the launchpad still works correctly in the customer home after the refactor
* Create a new site with the blog flow
* Launch the site
* Verify that the launchpad works correctly in the customer home
![image](https://github.com/Automattic/wp-calypso/assets/3801502/bccf2c23-6771-4ced-9c11-f6e7ac4fa3c7)


Without the backend changes, users shouldn't notice any changes from this PR.