### PR TITLE
Domain transfer: Fix mobile titles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -65,7 +65,15 @@ export function DomainCodePair( {
 			<div className="domains__domain-info">
 				<div className="domains__domain-domain">
 					<FormFieldset>
-						{ showLabels && <FormLabel htmlFor={ id }>{ __( 'Domain name' ) }</FormLabel> }
+						<FormLabel
+							className={ classnames( {
+								'is-first-label-title': showLabels,
+							} ) }
+							htmlFor={ id }
+						>
+							{ __( 'Domain name' ) }
+						</FormLabel>
+
 						<FormInput
 							disabled={ valid }
 							id={ id }
@@ -79,9 +87,15 @@ export function DomainCodePair( {
 				</div>
 				<div className="domains__domain-key">
 					<FormFieldset>
-						{ showLabels && (
-							<FormLabel htmlFor={ id + '-auth' }>{ __( 'Authorization code' ) }</FormLabel>
-						) }
+						<FormLabel
+							className={ classnames( {
+								'is-first-label-title': showLabels,
+							} ) }
+							htmlFor={ id + '-auth' }
+						>
+							{ __( 'Authorization code' ) }
+						</FormLabel>
+
 						<FormInput
 							id={ id + '-auth' }
 							disabled={ valid || hasDuplicates }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -112,6 +112,16 @@
 	.domains__domain-domain,
 	.domains__domain-key {
 
+		// Show the titles on mobile and hide on desktop (except for the first one)
+		.form-label {
+			display: none;
+			@media ( max-width: $break-medium ) {
+				display: block;
+			}
+			&.is-first-label-title {
+				display: block;
+			}
+		}
 
 		.form-fieldset {
 			position: relative;


### PR DESCRIPTION
## Proposed Changes

On mobile, the titles were not being displayed, this PR fixes it.

Before:

<img width="462" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/d8486fdd-251f-4e4e-a7e6-0e39a3688753">

After:

<img width="408" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/d070abdc-9b46-4441-95fd-8cdbf4fbd10f">


## Testing Instructions

- Pull and run this branch or use calypso live links
- Navigate to setup/domain-transfer/domains
- Add more rows on the domains table
- Check the mobile version if the titles are visually there
- On desktop, the titles are only displayed on the first row
