### PR TITLE
Conditionally redirect user after getting the correct locale

### DIFF
--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -1,4 +1,5 @@
 import { useLocale } from '@automattic/i18n-utils';
+import { getWpI18nLocaleSlug } from '@automattic/i18n-utils/src/locale-context';
 import { getQueryArg } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
@@ -42,7 +43,9 @@ const Blog: Flow = {
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 
 		if ( ! isLoggedIn ) {
-			redirect( logInUrl );
+			if ( getWpI18nLocaleSlug() ) {
+				redirect( logInUrl );
+			}
 			result = {
 				state: AssertConditionState.CHECKING,
 				message: `${ flowName } requires a logged in user`,

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -39,7 +39,7 @@ function mapWpI18nLangToLocaleSlug( locale: Locale = '' ): Locale {
 /**
  * Get the current locale slug from the @wordpress/i18n locale data
  */
-function getWpI18nLocaleSlug(): string | undefined {
+export function getWpI18nLocaleSlug(): string | undefined {
 	const language = i18n.getLocaleData ? i18n.getLocaleData()?.[ '' ]?.language : '';
 
 	return mapWpI18nLangToLocaleSlug( language );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
