### PR TITLE
Subscribers Page: Add URL param support for search, sorting and filtering

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -18,7 +18,7 @@ const getSortOptions = ( translate: ReturnType< typeof useTranslate > ) => [
 
 const ListActionsBar = () => {
 	const translate = useTranslate();
-	const { handleSearch, sortTerm, setSortTerm, filterOption, setFilterOption } =
+	const { handleSearch, searchTerm, sortTerm, setSortTerm, filterOption, setFilterOption } =
 		useSubscribersPage();
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
 	const recordSort = useRecordSort();
@@ -30,6 +30,8 @@ const ListActionsBar = () => {
 				placeholder={ translate( 'Search by name, username or email…' ) }
 				searchIcon={ <SearchIcon size={ 18 } /> }
 				onSearch={ handleSearch }
+				onSearchClose={ () => handleSearch( '' ) }
+				defaultValue={ searchTerm }
 			/>
 
 			<SelectDropdown
@@ -41,6 +43,7 @@ const ListActionsBar = () => {
 				selectedText={ translate( 'Subscriber type: %s', {
 					args: getOptionLabel( filterOptions, filterOption ) || '',
 				} ) }
+				initialSelected={ filterOption }
 			/>
 
 			<SortControls

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -18,8 +18,15 @@ const getSortOptions = ( translate: ReturnType< typeof useTranslate > ) => [
 
 const ListActionsBar = () => {
 	const translate = useTranslate();
-	const { handleSearch, searchTerm, sortTerm, setSortTerm, filterOption, setFilterOption } =
-		useSubscribersPage();
+	const {
+		handleSearch,
+		searchTerm,
+		pageChangeCallback,
+		sortTerm,
+		setSortTerm,
+		filterOption,
+		setFilterOption,
+	} = useSubscribersPage();
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
 	const recordSort = useRecordSort();
 	const filterOptions = useSubscribersFilterOptions();
@@ -37,9 +44,10 @@ const ListActionsBar = () => {
 			<SelectDropdown
 				className="subscribers__filter-control"
 				options={ filterOptions }
-				onSelect={ ( selectedOption: Option< SubscribersFilterBy > ) =>
-					setFilterOption( selectedOption.value )
-				}
+				onSelect={ ( selectedOption: Option< SubscribersFilterBy > ) => {
+					setFilterOption( selectedOption.value );
+					pageChangeCallback( 1 );
+				} }
 				selectedText={ translate( 'Subscriber type: %s', {
 					args: getOptionLabel( filterOptions, filterOption ) || '',
 				} ) }

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -21,7 +21,7 @@ const SubscriberListContainer = ( {
 	onClickUnsubscribe,
 	setShowAddSubscribersModal,
 }: SubscriberListContainerProps ) => {
-	const { grandTotal, total, perPage, page, pageClickCallback, searchTerm } = useSubscribersPage();
+	const { grandTotal, total, perPage, page, pageChangeCallback, searchTerm } = useSubscribersPage();
 	useRecordSearch();
 
 	return (
@@ -48,7 +48,7 @@ const SubscriberListContainer = ( {
 						page={ page }
 						perPage={ perPage }
 						total={ total }
-						pageClick={ pageClickCallback }
+						pageClick={ pageChangeCallback }
 					/>
 
 					<GrowYourAudience />

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -54,6 +54,15 @@ export const SubscribersPageProvider = ( {
 }: SubscribersPageProviderProps ) => {
 	const [ perPage, setPerPage ] = useState( DEFAULT_PER_PAGE );
 
+<<<<<<< HEAD
+=======
+	const handleSearch = useCallback( ( term: string ) => {
+		searchTermChanged( term );
+		pageChanged( 1 );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+>>>>>>> 54f64001c4 (Reset page when searching)
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 300 );
 
 	const grandTotalQueryResult = useSubscribersQuery( { siteId } );

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -54,15 +54,6 @@ export const SubscribersPageProvider = ( {
 }: SubscribersPageProviderProps ) => {
 	const [ perPage, setPerPage ] = useState( DEFAULT_PER_PAGE );
 
-<<<<<<< HEAD
-=======
-	const handleSearch = useCallback( ( term: string ) => {
-		searchTermChanged( term );
-		pageChanged( 1 );
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
-
->>>>>>> 54f64001c4 (Reset page when searching)
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 300 );
 
 	const grandTotalQueryResult = useSubscribersQuery( { siteId } );

--- a/client/my-sites/subscribers/constants.ts
+++ b/client/my-sites/subscribers/constants.ts
@@ -8,3 +8,5 @@ export enum SubscribersFilterBy {
 	Email = 'email',
 	WPCOM = 'wpcom',
 }
+
+export const DEFAULT_PER_PAGE = 10;

--- a/client/my-sites/subscribers/controller.js
+++ b/client/my-sites/subscribers/controller.js
@@ -1,22 +1,44 @@
+import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import page from 'page';
-import { addQueryArgs } from 'calypso/lib/route';
 import { sanitizeInt } from './helpers';
 import SubscribersPage from './main';
 import SubscriberDetailsPage from './subscriber-details-page';
 
-const pageChanged = ( path ) => ( pageNumber ) => {
-	if ( window ) {
-		window.scrollTo( 0, 0 );
+const scrollToTop = () => window?.scrollTo( 0, 0 );
+
+const FILTER_KEY = 'f';
+const PAGE_KEY = 'page';
+const SEARCH_KEY = 's';
+const SORT_KEY = 'sort';
+
+const queryStringChanged = ( path, key ) => ( value ) => {
+	scrollToTop();
+
+	if ( ! value ) {
+		return page.show( removeQueryArgs( path, key ) );
 	}
-	return page( addQueryArgs( { page: pageNumber }, path ) );
+
+	return page.show( addQueryArgs( path, { [ key ]: value } ) );
 };
 
 export function subscribers( context, next ) {
 	const { path, query } = context;
-	const pageNumber = sanitizeInt( query.page ) ?? 1;
+	const filterOption = query[ FILTER_KEY ];
+	const pageNumber = sanitizeInt( query[ PAGE_KEY ] ) ?? 1;
+	const searchTerm = query[ SEARCH_KEY ];
+	const sortTerm = query[ SORT_KEY ];
 
 	context.primary = (
-		<SubscribersPage pageNumber={ pageNumber } pageChanged={ pageChanged( path ) } />
+		<SubscribersPage
+			filterOption={ filterOption }
+			pageNumber={ pageNumber }
+			searchTerm={ searchTerm }
+			sortTerm={ sortTerm }
+			filterOptionChanged={ queryStringChanged( path, FILTER_KEY ) }
+			pageChanged={ queryStringChanged( path, PAGE_KEY ) }
+			searchTermChanged={ queryStringChanged( path, SEARCH_KEY ) }
+			sortTermChanged={ queryStringChanged( path, SORT_KEY ) }
+		/>
 	);
 
 	next();
@@ -25,9 +47,20 @@ export function subscribers( context, next ) {
 export function subscriberDetails( context, next ) {
 	const { path, query } = context;
 	const userId = path.split( '/' ).pop();
-	const pageNumber = sanitizeInt( query.page ) ?? 1;
+	const filterOption = query[ FILTER_KEY ];
+	const pageNumber = sanitizeInt( query[ PAGE_KEY ] ) ?? 1;
+	const searchTerm = query[ SEARCH_KEY ];
+	const sortTerm = query[ SORT_KEY ];
 
-	context.primary = <SubscriberDetailsPage userId={ userId } pageNumber={ pageNumber } />;
+	context.primary = (
+		<SubscriberDetailsPage
+			userId={ userId }
+			filterOption={ filterOption }
+			pageNumber={ pageNumber }
+			searchTerm={ searchTerm }
+			sortTerm={ sortTerm }
+		/>
+	);
 
 	next();
 }
@@ -35,10 +68,19 @@ export function subscriberDetails( context, next ) {
 export function externalSubscriberDetails( context, next ) {
 	const { path, query } = context;
 	const subscriberId = path.split( '/' ).pop();
-	const pageNumber = sanitizeInt( query.page ) ?? 1;
+	const filterOption = query[ FILTER_KEY ];
+	const pageNumber = sanitizeInt( query[ PAGE_KEY ] ) ?? 1;
+	const searchTerm = query[ SEARCH_KEY ];
+	const sortTerm = query[ SORT_KEY ];
 
 	context.primary = (
-		<SubscriberDetailsPage subscriptionId={ subscriberId } pageNumber={ pageNumber } />
+		<SubscriberDetailsPage
+			subscriptionId={ subscriberId }
+			filterOption={ filterOption }
+			pageNumber={ pageNumber }
+			searchTerm={ searchTerm }
+			sortTerm={ sortTerm }
+		/>
 	);
 
 	next();

--- a/client/my-sites/subscribers/controller.js
+++ b/client/my-sites/subscribers/controller.js
@@ -11,7 +11,9 @@ const PAGE_KEY = 'page';
 const SEARCH_KEY = 's';
 const SORT_KEY = 'sort';
 
-const queryStringChanged = ( path, key ) => ( value ) => {
+const queryStringChanged = ( key ) => ( value ) => {
+	const path = window.location.pathname + window.location.search;
+
 	scrollToTop();
 
 	if ( ! value ) {
@@ -22,7 +24,7 @@ const queryStringChanged = ( path, key ) => ( value ) => {
 };
 
 export function subscribers( context, next ) {
-	const { path, query } = context;
+	const { query } = context;
 	const filterOption = query[ FILTER_KEY ];
 	const pageNumber = sanitizeInt( query[ PAGE_KEY ] ) ?? 1;
 	const searchTerm = query[ SEARCH_KEY ];
@@ -34,10 +36,10 @@ export function subscribers( context, next ) {
 			pageNumber={ pageNumber }
 			searchTerm={ searchTerm }
 			sortTerm={ sortTerm }
-			filterOptionChanged={ queryStringChanged( path, FILTER_KEY ) }
-			pageChanged={ queryStringChanged( path, PAGE_KEY ) }
-			searchTermChanged={ queryStringChanged( path, SEARCH_KEY ) }
-			sortTermChanged={ queryStringChanged( path, SORT_KEY ) }
+			filterOptionChanged={ queryStringChanged( FILTER_KEY ) }
+			pageChanged={ queryStringChanged( PAGE_KEY ) }
+			searchTermChanged={ queryStringChanged( SEARCH_KEY ) }
+			sortTermChanged={ queryStringChanged( SORT_KEY ) }
 		/>
 	);
 

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -1,3 +1,5 @@
+import { SubscriberListArgs } from '../types';
+
 const URL_PREFIX = 'https://wordpress.com';
 
 const getEarnPageUrl = ( siteSlug: string | null ) => `${ URL_PREFIX }/earn/${ siteSlug ?? '' }`;
@@ -32,17 +34,45 @@ const getSubscribersCacheKey = (
 	return cacheKey;
 };
 
+const getSubscribersQueryString = (
+	pageNumber: number,
+	search?: string,
+	sortTerm?: string,
+	filterOption?: string
+): string => {
+	const queryParams = [
+		search ? `s=${ search }` : '',
+		sortTerm ? `sort=${ sortTerm }` : '',
+		filterOption ? `f=${ filterOption }` : '',
+	];
+
+	let queryString = queryParams.filter( ( param ) => !! param ).join( '&' );
+	queryString = queryString ? `&${ queryString }` : '';
+
+	return `page=${ pageNumber }${ queryString }`;
+};
+
+const getSubscribersUrl = ( siteSlug: string | undefined | null, args: SubscriberListArgs ): string => {
+	const { currentPage, searchTerm, sortTerm, filterOption } = args;
+	const queryString = getSubscribersQueryString( currentPage, searchTerm, sortTerm, filterOption );
+
+	return `/subscribers/${ siteSlug }?${ queryString }`;
+};
+
 const getSubscriberDetailsUrl = (
 	siteSlug: string | undefined | null,
 	subscriptionId: number | undefined,
 	userId: number | undefined,
-	pageNumber = 1
-) => {
+	args: SubscriberListArgs
+): string => {
+	const { currentPage, searchTerm, sortTerm, filterOption } = args;
+	const queryString = getSubscribersQueryString( currentPage, searchTerm, sortTerm, filterOption );
+
 	if ( userId ) {
-		return `/subscribers/${ siteSlug }/${ userId }?page=${ pageNumber }`;
+		return `/subscribers/${ siteSlug }/${ userId }?${ queryString }`;
 	}
 
-	return `/subscribers/external/${ siteSlug }/${ subscriptionId }?page=${ pageNumber }`;
+	return `/subscribers/external/${ siteSlug }/${ subscriptionId }?${ queryString }`;
 };
 
 const getSubscriberDetailsCacheKey = (
@@ -66,5 +96,6 @@ export {
 	getSubscriberDetailsUrl,
 	getSubscriberDetailsType,
 	getSubscribersCacheKey,
+	getSubscribersUrl,
 	sanitizeInt,
 };

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -52,7 +52,10 @@ const getSubscribersQueryString = (
 	return `page=${ pageNumber }${ queryString }`;
 };
 
-const getSubscribersUrl = ( siteSlug: string | undefined | null, args: SubscriberListArgs ): string => {
+const getSubscribersUrl = (
+	siteSlug: string | undefined | null,
+	args: SubscriberListArgs
+): string => {
 	const { currentPage, searchTerm, sortTerm, filterOption } = args;
 	const queryString = getSubscribersQueryString( currentPage, searchTerm, sortTerm, filterOption );
 

--- a/client/my-sites/subscribers/hooks/use-pagination.ts
+++ b/client/my-sites/subscribers/hooks/use-pagination.ts
@@ -8,7 +8,7 @@ const usePagination = (
 ) => {
 	const [ currentPage, setCurrentPage ] = useState( page );
 	const recordPaged = useRecordPaged();
-	const pageClickCallback = ( page: number ) => {
+	const pageChangeCallback = ( page: number ) => {
 		recordPaged( { page } );
 		setCurrentPage( page );
 	};
@@ -19,7 +19,7 @@ const usePagination = (
 		}
 	}, [ currentPage, isFetching, page, pageChanged ] );
 
-	return { pageClickCallback };
+	return { pageChangeCallback };
 };
 
 export default usePagination;

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -5,18 +5,18 @@ import { UnsubscribeActionType } from '../components/unsubscribe-modal';
 import { getEarnPaymentsPageUrl } from '../helpers';
 import { useSubscriberRemoveMutation } from '../mutations';
 import { useRecordRemoveModal } from '../tracks';
-import { Subscriber } from '../types';
+import { Subscriber, SubscriberListArgs } from '../types';
 
 const useUnsubscribeModal = (
 	siteId: number | undefined | null,
-	pageNumber = 1,
+	args: SubscriberListArgs,
 	detailsView = false,
 	onSuccess?: () => void
 ) => {
 	const [ currentSubscriber, setCurrentSubscriber ] = useState< Subscriber >();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const recordRemoveModal = useRecordRemoveModal();
-	const { mutate } = useSubscriberRemoveMutation( siteId, pageNumber, detailsView );
+	const { mutate } = useSubscriberRemoveMutation( siteId, args, detailsView );
 
 	const onClickUnsubscribe = ( subscriber: Subscriber ) => {
 		setCurrentSubscriber( subscriber );

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -30,7 +30,16 @@ type SubscribersProps = {
 	sortTermChanged: ( term: SubscribersSortBy ) => void;
 };
 
-const SubscribersPage = ( { filterOption, pageNumber, searchTerm, sortTerm, filterOptionChanged, pageChanged, searchTermChanged, sortTermChanged }: SubscribersProps ) => {
+const SubscribersPage = ( {
+	filterOption,
+	pageNumber,
+	searchTerm,
+	sortTerm,
+	filterOptionChanged,
+	pageChanged,
+	searchTermChanged,
+	sortTermChanged,
+}: SubscribersProps ) => {
 	const selectedSite = useSelector( getSelectedSite );
 
 	const pageArgs = {
@@ -43,9 +52,7 @@ const SubscribersPage = ( { filterOption, pageNumber, searchTerm, sortTerm, filt
 	const { currentSubscriber, onClickUnsubscribe, onConfirmModal, resetSubscriber } =
 		useUnsubscribeModal( selectedSite?.ID, pageArgs );
 	const onClickView = ( { subscription_id, user_id }: Subscriber ) => {
-		page.show(
-			getSubscriberDetailsUrl( selectedSite?.slug, subscription_id, user_id, pageArgs )
-		);
+		page.show( getSubscriberDetailsUrl( selectedSite?.slug, subscription_id, user_id, pageArgs ) );
 	};
 
 	const [ showAddSubscribersModal, setShowAddSubscribersModal ] = useState( false );

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -13,25 +13,41 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { AddSubscribersModal } from './components/add-subscribers-modal';
 import { SubscribersHeader } from './components/subscribers-header';
 import { UnsubscribeModal } from './components/unsubscribe-modal';
-import { getSubscriberDetailsUrl } from './helpers';
+import { SubscribersFilterBy, SubscribersSortBy } from './constants';
+import { getSubscriberDetailsUrl, getSubscribersUrl } from './helpers';
 import { useUnsubscribeModal } from './hooks';
 import { Subscriber } from './types';
 import './style.scss';
 
 type SubscribersProps = {
+	filterOption: SubscribersFilterBy;
 	pageNumber: number;
+	searchTerm: string;
+	sortTerm: SubscribersSortBy;
+	filterOptionChanged: ( option: SubscribersFilterBy ) => void;
 	pageChanged: ( page: number ) => void;
+	searchTermChanged: ( term: string ) => void;
+	sortTermChanged: ( term: SubscribersSortBy ) => void;
 };
 
-const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
+const SubscribersPage = ( { filterOption, pageNumber, searchTerm, sortTerm, filterOptionChanged, pageChanged, searchTermChanged, sortTermChanged }: SubscribersProps ) => {
 	const selectedSite = useSelector( getSelectedSite );
+
+	const pageArgs = {
+		currentPage: pageNumber,
+		filterOption,
+		searchTerm,
+		sortTerm,
+	};
+
 	const { currentSubscriber, onClickUnsubscribe, onConfirmModal, resetSubscriber } =
-		useUnsubscribeModal( selectedSite?.ID, pageNumber );
+		useUnsubscribeModal( selectedSite?.ID, pageArgs );
 	const onClickView = ( { subscription_id, user_id }: Subscriber ) => {
 		page.show(
-			getSubscriberDetailsUrl( selectedSite?.slug, subscription_id, user_id, pageNumber )
+			getSubscriberDetailsUrl( selectedSite?.slug, subscription_id, user_id, pageArgs )
 		);
 	};
+
 	const [ showAddSubscribersModal, setShowAddSubscribersModal ] = useState( false );
 	const dispatch = useDispatch();
 	const localizeUrl = useLocalizeUrl();
@@ -53,7 +69,7 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 	const navigationItems: Item[] = [
 		{
 			label: translate( 'Subscribers' ),
-			href: `/subscribers/${ selectedSite?.slug }`,
+			href: getSubscribersUrl( selectedSite?.slug, pageArgs ),
 			helpBubble: (
 				<span>
 					{ translate(
@@ -79,8 +95,14 @@ const SubscribersPage = ( { pageNumber, pageChanged }: SubscribersProps ) => {
 	return (
 		<SubscribersPageProvider
 			siteId={ selectedSite?.ID }
-			page={ pageNumber }
+			filterOption={ filterOption }
+			pageNumber={ pageNumber }
+			searchTerm={ searchTerm }
+			sortTerm={ sortTerm }
+			filterOptionChanged={ filterOptionChanged }
 			pageChanged={ pageChanged }
+			searchTermChanged={ searchTermChanged }
+			sortTermChanged={ sortTermChanged }
 		>
 			<Main wideLayout className="subscribers">
 				<DocumentHead title={ translate( 'Subscribers' ) } />

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -1,20 +1,30 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import { DEFAULT_PER_PAGE } from '../constants';
 import {
 	getSubscriberDetailsCacheKey,
 	getSubscriberDetailsType,
 	getSubscribersCacheKey,
 } from '../helpers';
 import { useRecordSubscriberRemoved } from '../tracks';
-import type { SubscriberEndpointResponse, Subscriber } from '../types';
+import type { SubscriberEndpointResponse, Subscriber, SubscriberListArgs } from '../types';
 
 const useSubscriberRemoveMutation = (
 	siteId: number | undefined | null,
-	currentPage: number,
+	args: SubscriberListArgs,
 	invalidateDetailsCache = false
 ) => {
+	const { currentPage, perPage = DEFAULT_PER_PAGE, filterOption, searchTerm, sortTerm } = args;
 	const queryClient = useQueryClient();
 	const recordSubscriberRemoved = useRecordSubscriberRemoved();
+	const subscribersCacheKey = getSubscribersCacheKey(
+		siteId,
+		currentPage,
+		perPage,
+		filterOption,
+		searchTerm,
+		sortTerm
+	);
 
 	return useMutation( {
 		mutationFn: async ( subscriber: Subscriber ) => {
@@ -50,21 +60,19 @@ const useSubscriberRemoveMutation = (
 			return true;
 		},
 		onMutate: async ( subscriber ) => {
-			await queryClient.cancelQueries( getSubscribersCacheKey( siteId ) );
+			await queryClient.cancelQueries( subscribersCacheKey );
 			let page = currentPage;
 
-			const previousData = queryClient.getQueryData< SubscriberEndpointResponse >(
-				getSubscribersCacheKey( siteId, currentPage )
-			);
+			const previousData =
+				queryClient.getQueryData< SubscriberEndpointResponse >( subscribersCacheKey );
 			const previousPages = [];
 
 			if ( previousData ) {
 				// This is some complicated logic to remove the subscriber from the list and shift the next page's first item into this page and so on
 				// This is done to avoid a flash of the next page's first item when the query is refetched
 				while ( page <= previousData?.pages ) {
-					const previousSubscribers = queryClient.getQueryData< SubscriberEndpointResponse >(
-						getSubscribersCacheKey( siteId, page )
-					);
+					const previousSubscribers =
+						queryClient.getQueryData< SubscriberEndpointResponse >( subscribersCacheKey );
 
 					if ( previousSubscribers ) {
 						// Save previous page data for when query fails and we have to restore
@@ -82,13 +90,20 @@ const useSubscriberRemoveMutation = (
 						// Take the first subscriber of the next page (if we have it cached) and append it to this list.
 						// The next page will briefly show this item
 						const nextPageQueryData = queryClient.getQueryData< SubscriberEndpointResponse >(
-							getSubscribersCacheKey( siteId, page + 1 )
+							getSubscribersCacheKey(
+								siteId,
+								page + 1,
+								perPage,
+								filterOption,
+								searchTerm,
+								sortTerm
+							)
 						);
 						if ( nextPageQueryData && nextPageQueryData.subscribers.length ) {
 							subscribers.push( nextPageQueryData.subscribers[ 0 ] );
 						}
 
-						queryClient.setQueryData( getSubscribersCacheKey( siteId, page ), {
+						queryClient.setQueryData( subscribersCacheKey, {
 							...previousSubscribers,
 							subscribers,
 							total,
@@ -123,19 +138,22 @@ const useSubscriberRemoveMutation = (
 		onError: ( error, variables, context ) => {
 			if ( context?.previousPages ) {
 				context.previousPages?.forEach( ( previousSubscribers, page ) => {
-					queryClient.setQueryData( getSubscribersCacheKey( siteId, page ), previousSubscribers );
+					queryClient.setQueryData(
+						getSubscribersCacheKey( siteId, page, perPage, filterOption, searchTerm, sortTerm ),
+						previousSubscribers
+					);
 				} );
 			}
 
 			if ( context?.previousDetailsData ) {
-				const cacheKey = getSubscriberDetailsCacheKey(
+				const detailsCacheKey = getSubscriberDetailsCacheKey(
 					siteId,
 					context.previousDetailsData.subscription_id,
 					context.previousDetailsData.user_id,
 					getSubscriberDetailsType( context.previousDetailsData.user_id )
 				);
 
-				queryClient.setQueryData( cacheKey, context.previousDetailsData );
+				queryClient.setQueryData( detailsCacheKey, context.previousDetailsData );
 			}
 		},
 		onSuccess: ( data, subscriber ) => {
@@ -146,17 +164,17 @@ const useSubscriberRemoveMutation = (
 			} );
 		},
 		onSettled: ( data, error, subscriber ) => {
-			queryClient.invalidateQueries( getSubscribersCacheKey( siteId ) );
+			queryClient.invalidateQueries( subscribersCacheKey );
 
 			if ( invalidateDetailsCache ) {
-				const cacheKey = getSubscriberDetailsCacheKey(
+				const detailsCacheKey = getSubscriberDetailsCacheKey(
 					siteId,
 					subscriber.subscription_id,
 					subscriber.user_id,
 					getSubscriberDetailsType( subscriber.user_id )
 				);
 
-				queryClient.invalidateQueries( cacheKey );
+				queryClient.invalidateQueries( detailsCacheKey );
 			}
 		},
 	} );

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import { SubscribersFilterBy, SubscribersSortBy } from '../constants';
+import { DEFAULT_PER_PAGE, SubscribersFilterBy, SubscribersSortBy } from '../constants';
 import { getSubscribersCacheKey } from '../helpers';
 import type { SubscriberEndpointResponse } from '../types';
 
@@ -16,7 +16,7 @@ type SubscriberQueryParams = {
 const useSubscribersQuery = ( {
 	siteId,
 	page = 1,
-	perPage = 10,
+	perPage = DEFAULT_PER_PAGE,
 	search,
 	sortTerm = SubscribersSortBy.DateSubscribed,
 	filterOption = SubscribersFilterBy.All,

--- a/client/my-sites/subscribers/subscriber-details-page.tsx
+++ b/client/my-sites/subscribers/subscriber-details-page.tsx
@@ -89,7 +89,11 @@ const SubscriberDetailsPage = ( {
 				onCancel={ resetSubscriber }
 				onConfirm={ onConfirmModal }
 			/>
-			{ isLoading && <Spinner /> }
+			{ isLoading && (
+				<div className="subscriber-details-page__loading">
+					<Spinner />
+				</div>
+			) }
 		</Main>
 	);
 };

--- a/client/my-sites/subscribers/subscriber-details-page.tsx
+++ b/client/my-sites/subscribers/subscriber-details-page.tsx
@@ -11,7 +11,8 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import { SubscriberDetails } from './components/subscriber-details';
 import { SubscriberPopover } from './components/subscriber-popover';
 import { UnsubscribeModal } from './components/unsubscribe-modal';
-import { getSubscriberDetailsUrl } from './helpers';
+import { SubscribersFilterBy, SubscribersSortBy } from './constants';
+import { getSubscriberDetailsUrl, getSubscribersUrl } from './helpers';
 import { useUnsubscribeModal } from './hooks';
 import useSubscriberDetailsQuery from './queries/use-subscriber-details-query';
 import './subscriber-details-style.scss';
@@ -19,13 +20,19 @@ import './subscriber-details-style.scss';
 type SubscriberDetailsPageProps = {
 	subscriptionId?: number;
 	userId?: number;
+	filterOption?: SubscribersFilterBy;
 	pageNumber?: number;
+	searchTerm?: string;
+	sortTerm?: SubscribersSortBy;
 };
 
 const SubscriberDetailsPage = ( {
 	subscriptionId,
 	userId,
+	filterOption,
 	pageNumber = 1,
+	searchTerm,
+	sortTerm,
 }: SubscriberDetailsPageProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -38,8 +45,17 @@ const SubscriberDetailsPage = ( {
 		userId
 	);
 
+	const pageArgs = {
+		currentPage: pageNumber,
+		filterOption,
+		searchTerm,
+		sortTerm,
+	};
+
+	const subscribersUrl = getSubscribersUrl( selectedSiteSlug, pageArgs );
+
 	const removeSubscriberSuccess = () => {
-		page.show( `/subscribers/${ selectedSiteSlug }?page=${ pageNumber }` );
+		page.show( subscribersUrl );
 
 		dispatch(
 			successNotice(
@@ -59,7 +75,7 @@ const SubscriberDetailsPage = ( {
 		onClickUnsubscribe,
 		onConfirmModal,
 		resetSubscriber,
-	} = useUnsubscribeModal( selectedSiteId, pageNumber, true, removeSubscriberSuccess );
+	} = useUnsubscribeModal( selectedSiteId, pageArgs, true, removeSubscriberSuccess );
 
 	const unsubscribeClickHandler = () => {
 		if ( subscriber ) {
@@ -70,11 +86,11 @@ const SubscriberDetailsPage = ( {
 	const navigationItems: Item[] = [
 		{
 			label: translate( 'Subscribers' ),
-			href: `/subscribers/${ selectedSiteSlug }`,
+			href: subscribersUrl,
 		},
 		{
 			label: translate( 'Details' ),
-			href: getSubscriberDetailsUrl( selectedSiteSlug, subscriptionId, userId, pageNumber ),
+			href: getSubscriberDetailsUrl( selectedSiteSlug, subscriptionId, userId, pageArgs ),
 		},
 	];
 

--- a/client/my-sites/subscribers/subscriber-details-style.scss
+++ b/client/my-sites/subscribers/subscriber-details-style.scss
@@ -4,6 +4,13 @@
 	padding: 0 32px;
 }
 
+.subscriber-details-page__loading {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	margin-top: 48px;
+}
+
 @media ( max-width: $break-medium ) {
 	.is-section-subscribers .subscriber-details {
 		margin-top: 108px;

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -1,3 +1,5 @@
+import { SubscribersFilterBy, SubscribersSortBy } from '../constants';
+
 export type SubscriberEndpointResponse = {
 	per_page: number;
 	total: number;
@@ -33,4 +35,12 @@ export type Subscriber = {
 		name: string;
 	};
 	url?: string;
+};
+
+export type SubscriberListArgs = {
+	currentPage: number;
+	perPage?: number;
+	filterOption?: SubscribersFilterBy;
+	searchTerm?: string;
+	sortTerm?: SubscribersSortBy;
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78780

## Proposed Changes

* Adds URL param support for search, sorting and filtering
* Fixes loading style (centralize)
* Fixes the redirection between details and list page on unsubscribe

## Testing Instructions

* Apply this PR to your local env
* Go to http://calypso.localhost:3000/subscribers/{site-slug}
* Execute multiple tests by searching, sorting, filtering, and paging
* Combine different scenarios and verify if the URL represents what you see on the UI
* Refresh the page and see if the results are the same
* Click on View to see details from a subscriber, the URL params should stay there
  * When clicking on the breadcrumb, you should be redirect back to the list with the previous state
  * When clicking on unsubscribe, you should also be redirect back to the list with the previous state
* Test for regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
