### PR TITLE
Launchpad: Added blog flow component to customer home

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -47,3 +47,4 @@ export const TASK_STAGING = 'home-task-staging';
 export const TASK_FIVERR = 'home-task-fiverr';
 export const TASK_DOMAIN_UPSELL = 'home-task-domain-upsell';
 export const LAUNCHPAD_KEEP_BUILDING = 'home-launchpad-keep-building';
+export const LAUNCHPAD_BLOG_FLOW = 'home-launchpad-blog-flow';

--- a/client/my-sites/customer-home/cards/launchpad/blog-flow.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/blog-flow.tsx
@@ -1,20 +1,18 @@
 import { useLaunchpad } from '@automattic/data-stores';
 import { Task } from '@automattic/launchpad';
-import { isMobile } from '@automattic/viewport';
-import { addQueryArgs } from '@wordpress/url';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CustomerHomeLaunchpad from '.';
 
-const checklistSlug = 'keep-building';
+const checklistSlug = 'TBD';
 
 interface LaunchpadKeepBuildingProps {
 	siteSlug: string | null;
 }
 
-const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.Element => {
+const LaunchpadBlogFlow = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.Element => {
 	const {
 		data: { checklist },
 	} = useLaunchpad( siteSlug, checklistSlug );
@@ -23,6 +21,7 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 	const tasklistCompleted = completedSteps === numberOfSteps;
 
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const recordTaskClickTracksEvent = ( task: Task ) => {
 		recordTracksEvent( 'calypso_launchpad_task_clicked', {
 			checklist_slug: checklistSlug,
@@ -49,49 +48,15 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 
 			let actionDispatch;
 
-			switch ( task.id ) {
-				case 'site_title':
-					actionDispatch = () => {
-						recordTaskClickTracksEvent( task );
-						window.location.assign( `/settings/general/${ siteSlug }` );
-					};
-					break;
-
-				case 'design_edited':
-					actionDispatch = () => {
-						recordTaskClickTracksEvent( task );
-						window.location.assign(
-							addQueryArgs( `/site-editor/${ siteSlug }`, {
-								canvas: 'edit',
-							} )
-						);
-					};
-					break;
-
-				case 'domain_claim':
-				case 'domain_upsell':
-				case 'domain_customize':
-					actionDispatch = () => {
-						recordTaskClickTracksEvent( task );
-						window.location.assign( `/domains/add/${ siteSlug }` );
-					};
-					break;
-				case 'drive_traffic':
-					actionDispatch = () => {
-						recordTaskClickTracksEvent( task );
-						const url = isMobile()
-							? `/marketing/connections/${ siteSlug }`
-							: `/marketing/connections/${ siteSlug }?tour=marketingConnectionsTour`;
-						window.location.assign( url );
-					};
-					break;
-				case 'add_new_page':
-					actionDispatch = () => {
-						recordTaskClickTracksEvent( task );
-						window.location.assign( `/page/${ siteSlug }` );
-					};
-					break;
-			}
+			// Ex:
+			// switch ( task.id ) {
+			// 	case 'my_task_id':
+			// 		actionDispatch = () => {
+			// 			recordTaskClickTracksEvent( task );
+			// 			do_something();
+			// 		};
+			// 		break;
+			// }
 
 			return { ...task, actionDispatch };
 		} );
@@ -105,12 +70,12 @@ const LaunchpadKeepBuilding = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.
 	);
 };
 
-const ConnectedLaunchpadKeepBuilding = connect( ( state ) => {
+const ConnectedLaunchpadBlogFlow = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
 		siteSlug: getSiteSlug( state, siteId ),
 	};
-} )( LaunchpadKeepBuilding );
+} )( LaunchpadBlogFlow );
 
-export default ConnectedLaunchpadKeepBuilding;
+export default ConnectedLaunchpadBlogFlow;

--- a/client/my-sites/customer-home/cards/launchpad/blog-flow.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/blog-flow.tsx
@@ -1,12 +1,14 @@
 import { useLaunchpad } from '@automattic/data-stores';
 import { Task } from '@automattic/launchpad';
+import { isMobile } from '@automattic/viewport';
+import { addQueryArgs } from '@wordpress/url';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CustomerHomeLaunchpad from '.';
 
-const checklistSlug = 'TBD';
+const checklistSlug = 'blog-flow';
 
 interface LaunchpadKeepBuildingProps {
 	siteSlug: string | null;
@@ -48,15 +50,44 @@ const LaunchpadBlogFlow = ( { siteSlug }: LaunchpadKeepBuildingProps ): JSX.Elem
 
 			let actionDispatch;
 
-			// Ex:
-			// switch ( task.id ) {
-			// 	case 'my_task_id':
-			// 		actionDispatch = () => {
-			// 			recordTaskClickTracksEvent( task );
-			// 			do_something();
-			// 		};
-			// 		break;
-			// }
+			switch ( task.id ) {
+				case 'my_task_id':
+				case 'site_title':
+					actionDispatch = () => {
+						recordTaskClickTracksEvent( task );
+						window.location.assign( `/settings/general/${ siteSlug }` );
+					};
+					break;
+
+				case 'design_edited':
+					actionDispatch = () => {
+						recordTaskClickTracksEvent( task );
+						window.location.assign(
+							addQueryArgs( `/site-editor/${ siteSlug }`, {
+								canvas: 'edit',
+							} )
+						);
+					};
+					break;
+
+				case 'domain_claim':
+				case 'domain_upsell':
+				case 'domain_customize':
+					actionDispatch = () => {
+						recordTaskClickTracksEvent( task );
+						window.location.assign( `/domains/add/${ siteSlug }` );
+					};
+					break;
+				case 'drive_traffic':
+					actionDispatch = () => {
+						recordTaskClickTracksEvent( task );
+						const url = isMobile()
+							? `/marketing/connections/${ siteSlug }`
+							: `/marketing/connections/${ siteSlug }?tour=marketingConnectionsTour`;
+						window.location.assign( url );
+					};
+					break;
+			}
 
 			return { ...task, actionDispatch };
 		} );

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -1,0 +1,69 @@
+import { CircularProgressBar } from '@automattic/components';
+import { useLaunchpad } from '@automattic/data-stores';
+import { Launchpad, Task } from '@automattic/launchpad';
+import { useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+import './style.scss';
+
+interface CustomerHomeLaunchpadProps {
+	siteSlug: string | null;
+	checklistSlug: string;
+	taskFilter: ( tasks: Task[] ) => Task[];
+}
+
+const CustomerHomeLaunchpad = ( {
+	siteSlug,
+	checklistSlug,
+	taskFilter,
+}: CustomerHomeLaunchpadProps ): JSX.Element => {
+	const translate = useTranslate();
+	const {
+		data: { checklist },
+	} = useLaunchpad( siteSlug, checklistSlug );
+
+	const numberOfSteps = checklist?.length || 0;
+	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
+	const tasklistCompleted = completedSteps === numberOfSteps;
+
+	recordTracksEvent( 'calypso_launchpad_tasklist_viewed', {
+		checklist_slug: checklistSlug,
+		tasks: `,${ checklist?.map( ( task: Task ) => task.id ).join( ',' ) },`,
+		is_completed: tasklistCompleted,
+		number_of_steps: numberOfSteps,
+		number_of_completed_steps: completedSteps,
+		context: 'customer-home',
+	} );
+
+	return (
+		<div className="launchpad-keep-building">
+			<div className="launchpad-keep-building__header">
+				<h2 className="launchpad-keep-building__title">
+					{ translate( 'Next steps for your site' ) }
+				</h2>
+				<div className="launchpad-keep-building__progress-bar-container">
+					<CircularProgressBar
+						size={ 40 }
+						enableDesktopScaling
+						numberOfSteps={ numberOfSteps }
+						currentStep={ completedSteps }
+					/>
+				</div>
+			</div>
+			<Launchpad siteSlug={ siteSlug } checklistSlug={ checklistSlug } taskFilter={ taskFilter } />
+		</div>
+	);
+};
+
+const ConnectedCustomerHomeLaunchpad = connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteSlug: getSiteSlug( state, siteId ),
+	};
+} )( CustomerHomeLaunchpad );
+
+export default ConnectedCustomerHomeLaunchpad;

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -7,10 +7,12 @@ import {
 	FEATURE_SUPPORT,
 	SECTION_BLOGGING_PROMPT,
 	LAUNCHPAD_KEEP_BUILDING,
+	LAUNCHPAD_BLOG_FLOW,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import DomainUpsell from 'calypso/my-sites/customer-home/cards/features/domain-upsell';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
 import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
+import LaunchpadBlogFlow from 'calypso/my-sites/customer-home/cards/launchpad/blog-flow';
 import LaunchpadKeepBuilding from 'calypso/my-sites/customer-home/cards/launchpad/keep-building';
 import LearnGrow from './learn-grow';
 
@@ -21,6 +23,7 @@ const cardComponents = {
 	[ SECTION_BLOGGING_PROMPT ]: BloggingPrompt,
 	[ FEATURE_SUPPORT ]: HelpSearch,
 	[ LAUNCHPAD_KEEP_BUILDING ]: LaunchpadKeepBuilding,
+	[ LAUNCHPAD_BLOG_FLOW ]: LaunchpadBlogFlow,
 };
 
 const Secondary = ( { cards, siteId } ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
