### PR TITLE
Stats: only show upsell when user has no paid stats

### DIFF
--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -10,6 +10,7 @@ import {
 import { JetpackUpsellCard } from '@automattic/components';
 import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useSelector } from 'calypso/state';
+import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import usePurchasedProducts from './use-purchased-products';
 
@@ -25,13 +26,14 @@ const QUERY_VALUES = {
 
 export default function JetpackUpsellSection() {
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+	const hasPaidStats = useSelector( hasSiteProductJetpackStatsPaid );
 
 	// NOTE: This will only work within Odyssey Stats.
-	const { purchasedProducts, error, isLoading } = usePurchasedProducts();
+	const { purchasedProducts } = usePurchasedProducts();
 
 	// Exit early if we don't have and can't get the site purchase data.
 	// Also exit early if we're not in the Odyssey Stats environment.
-	if ( isLoading || error || ! isOdysseyStats ) {
+	if ( ! isOdysseyStats && ! hasPaidStats ) {
 		return null;
 	}
 

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -33,7 +33,7 @@ export default function JetpackUpsellSection() {
 
 	// Exit early if we don't have and can't get the site purchase data.
 	// Also exit early if we're not in the Odyssey Stats environment.
-	if ( ! isOdysseyStats && ! hasPaidStats ) {
+	if ( ! isOdysseyStats && hasPaidStats ) {
 		return null;
 	}
 

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -33,7 +33,7 @@ export default function JetpackUpsellSection() {
 
 	// Exit early if we don't have and can't get the site purchase data.
 	// Also exit early if we're not in the Odyssey Stats environment.
-	if ( ! isOdysseyStats && hasPaidStats ) {
+	if ( ! isOdysseyStats || hasPaidStats ) {
 		return null;
 	}
 

--- a/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
@@ -27,7 +27,7 @@ const KEY_SLUG_MAP = new Map( [
 	[ 'video', JETPACK_VIDEOPRESS_PRODUCTS as readonly string[] ],
 ] );
 
-function formatResponse( siteProducts?: SiteProduct[] | null ) {
+function getSupportedProductSlugs( siteProducts?: SiteProduct[] | null ) {
 	const products = [] as string[];
 	// Find active purchase product slugs.
 	const purchasedProductSlugs =
@@ -47,6 +47,6 @@ export default function usePurchasedProducts() {
 	);
 
 	return {
-		purchasedProducts: formatResponse( purchasedProducts ),
+		purchasedProducts: getSupportedProductSlugs( purchasedProducts ),
 	};
 }

--- a/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
@@ -6,8 +6,12 @@ import {
 	JETPACK_SOCIAL_PRODUCTS,
 	JETPACK_VIDEOPRESS_PRODUCTS,
 } from '@automattic/calypso-products';
-import { useEffect, useState } from 'react';
-import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import {
+	default as getSiteProducts,
+	SiteProduct,
+} from 'calypso/state/sites/selectors/get-site-products';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 //
 // WARNING: This hook will only work within Odyssey Stats!
@@ -23,11 +27,11 @@ const KEY_SLUG_MAP = new Map( [
 	[ 'video', JETPACK_VIDEOPRESS_PRODUCTS as readonly string[] ],
 ] );
 
-function formatResponse( responseData?: Record< string, string >[] ) {
+function formatResponse( siteProducts?: SiteProduct[] | null ) {
 	const products = [] as string[];
 	// Find active purchase product slugs.
 	const purchasedProductSlugs =
-		responseData?.filter( ( p ) => p.active === '1' )?.map( ( p ) => p.product_slug ) ?? [];
+		siteProducts?.filter( ( p ) => ! p.expired )?.map( ( p ) => p.productSlug ) ?? [];
 	// Append active product slugs to the products array.
 	KEY_SLUG_MAP.forEach( ( value, key ) => {
 		if ( purchasedProductSlugs.some( ( slug ) => value.includes( slug ) ) ) {
@@ -38,24 +42,11 @@ function formatResponse( responseData?: Record< string, string >[] ) {
 }
 
 export default function usePurchasedProducts() {
-	const [ purchasedProducts, setPurchasedProducts ] = useState( [] as string[] );
-	const [ isLoading, setIsLoading ] = useState( true );
-	const [ error, setError ] = useState< Error | null >( null );
-
-	useEffect( () => {
-		wpcom.req
-			.get( { path: '/site/purchases', apiNamespace: 'jetpack/v4' } )
-			.then( ( res: { data: string } ) => JSON.parse( res.data ) )
-			.then( ( purchases: Record< string, string >[] ) => {
-				setIsLoading( false );
-				setPurchasedProducts( formatResponse( purchases ) );
-			} )
-			.catch( ( error: Error ) => setError( error ) );
-	}, [] );
+	const purchasedProducts = useSelector( ( state ) =>
+		getSiteProducts( state, getSelectedSiteId( state ) )
+	);
 
 	return {
-		purchasedProducts,
-		error,
-		isLoading,
+		purchasedProducts: formatResponse( purchasedProducts ),
 	};
 }

--- a/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
@@ -17,7 +17,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 // WARNING: This hook will only work within Odyssey Stats!
 // It also requires the existence of ${api_root}/jetpack/v4/site/purchases!
 //
-
+// TODO: check whether the site plan supports these products.
 const KEY_SLUG_MAP = new Map( [
 	[ 'backup', [ ...JETPACK_BACKUP_PRODUCTS, ...JETPACK_SECURITY_PLANS ] as readonly string[] ],
 	[ 'boost', JETPACK_BOOST_PRODUCTS as readonly string[] ],


### PR DESCRIPTION
Related to #79040 

## Proposed Changes

- Use newly added `products` from initial state instead
- Only show Jetpack upsell section when site doesn't have paid Stats

## Testing Instructions

* Build the branch for Odyssey
  * `STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Build Jetpack if necessary
  * `jetpack build plugins/jetpack`
* Open `/wp-admin/admin.php?page=stats`
* Ensure Jetpack Upsell Section is shown if site doesn't have a paid Stats product (Free or no Stats product)
* Ensure Jetpack Upsell Section is hidden if site has a paid Stats product
* Ensure individual upsells are shown/hidden correctly, for example if site has Search product, then the Search upsell line is hidden

Know issue: the visibility of individual product upsell doesn't test site plan to see whether supported. The fix is out of the scope of the PR. We'll tackle that in follow up PRs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
