### PR TITLE
Hosting onboarding: Sites created in the hosted flow fall back to the default WP theme

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -85,6 +85,9 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		theme = DEFAULT_WOOEXPRESS_FLOW;
 	} else if ( isStartWritingFlow( flow ) ) {
 		theme = DEFAULT_START_WRITING_THEME;
+	} else if ( isNewHostedSiteCreationFlow( flow ) ) {
+		// Causes no theme to be set, so WordPress's default theme gets used.
+		theme = '';
 	} else {
 		theme = isLinkInBioFlow( flow ) ? DEFAULT_LINK_IN_BIO_THEME : DEFAULT_NEWSLETTER_THEME;
 	}
@@ -124,7 +127,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 	const urlQueryParams = useQuery();
 	const sourceSiteSlug = urlQueryParams.get( 'from' ) || '';
 	const { data: sourceMigrationStatus } = useSourceMigrationStatusQuery( sourceSiteSlug );
-	const useThemeHeadstart = ! isStartWritingFlow( flow );
+	const useThemeHeadstart = ! isStartWritingFlow( flow ) && ! isNewHostedSiteCreationFlow( flow );
 
 	async function createSite() {
 		if ( isManageSiteFlow ) {

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -32,7 +32,7 @@ type NewSiteParams = {
 	find_available_url: boolean;
 	options: {
 		designType: string;
-		theme: string;
+		theme?: string;
 		use_theme_annotation: boolean;
 		default_annotation_as_primary_fallback: boolean;
 		site_segment: undefined;
@@ -75,7 +75,6 @@ export const getNewSiteParams = ( {
 		public: siteVisibility,
 		options: {
 			designType: '',
-			theme: themeSlugWithRepo,
 			use_theme_annotation: useThemeHeadstart,
 			default_annotation_as_primary_fallback: true,
 			site_segment: undefined,
@@ -87,6 +86,7 @@ export const getNewSiteParams = ( {
 			wpcom_public_coming_soon: siteVisibility === 0 ? 1 : 0,
 			...( sourceSlug && { site_source_slug: sourceSlug } ),
 			...( siteAccentColor && { site_accent_color: siteAccentColor } ),
+			...( themeSlugWithRepo && { theme: themeSlugWithRepo } ),
 		},
 		validate: false,
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2948

## Proposed Changes

If the site was created by `/setup/new-hosted-site` then we don't specify a theme, and it will instead use the standard `WP_DEFAULT_THEME` constant.


| WordPress.com default content | Core default content (via `instawp.io`) |
|-----|------|
| ![com default](https://github.com/Automattic/wp-calypso/assets/1500769/96a723fe-1af9-476e-a074-838074a30619) | ![wp default](https://github.com/Automattic/wp-calypso/assets/1500769/c6eea07d-878e-4277-b80b-373b99680fcf) |


Note that the default content isn't exactly the same. The hello world post text is different, and the "about" page instead of the "sample" page in the menu. I tried to bypass `headstart` to see whether that fixed it, but that wasn't enough. Turns out we're overloading the `wp_install_defaults` function in a MU plugin, so we won't get default WordPress core behaviour. I think it's probably close enough though.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try create a new site with `/setup/new-hosted-site` and your new site should be using the TT3 theme
* Try creating a new site with `/setup/new-hosted-site?hosting-flow=true`, and you'll get the same behaviour
* Create a site via `/start` or `/setup/link-in-bio` and you don't get TT3, the behaviour shouldn't be any different from production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
