### PR TITLE
Stats: Adjust Jetpack Stats purchase banner styling

### DIFF
--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -67,7 +67,7 @@ const DoYouLoveJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 				onClose={ dismissNotice }
 			>
 				{ translate(
-					"{{p}}Now that you've gotten familiar with the new Jetpack Stats, we'd love to hear about your experience so we can continue to shape Jetpack to meet your needs.{{/p}}{{p}}{{jetpackStatsProductLink}}I want to support Jetpack Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}",
+					'{{p}}Upgrade Jetpack Stats to unlock upcoming features, priority support, and an ad-free experience.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}',
 					{
 						components: {
 							p: <p />,

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -84,7 +84,7 @@ const DoYouLoveJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 									href={ JETPACK_STATS_PRODUCT_LANDING_PAGE_URL }
 								/>
 							),
-							externalIcon: <Icon className="stats-icon" icon={ external } size={ 18 } />,
+							externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
 						},
 					}
 				) }

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -67,7 +67,7 @@ const DoYouLoveJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 				onClose={ dismissNotice }
 			>
 				{ translate(
-					"{{p}}Now that you've gotten familiar with the new Jetpack Stats, we'd love to hear about your experience so we can continue to shape Jetpack to meet your needs.{{/p}}{{p}}{{jetpackStatsProductLink}}I want to support Jetpack Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}Learn more{{/learnMoreLink}}{{externalIcon /}}{{/p}}",
+					"{{p}}Now that you've gotten familiar with the new Jetpack Stats, we'd love to hear about your experience so we can continue to shape Jetpack to meet your needs.{{/p}}{{p}}{{jetpackStatsProductLink}}I want to support Jetpack Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}",
 					{
 						components: {
 							p: <p />,
@@ -82,8 +82,11 @@ const DoYouLoveJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 								<a
 									className="notice-banner__action-link"
 									href={ JETPACK_STATS_PRODUCT_LANDING_PAGE_URL }
+									target="_blank"
+									rel="noreferrer"
 								/>
 							),
+							learnMoreLinkText: <span />,
 							externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
 						},
 					}

--- a/client/my-sites/stats/stats-notices/style.scss
+++ b/client/my-sites/stats/stats-notices/style.scss
@@ -5,10 +5,6 @@
 		margin-bottom: 0;
 	}
 
-	.notice-banner__action-link {
-		margin-right: 4px;
-	}
-
 	.stats-icon {
 		vertical-align: middle;
 		display: inline-block;

--- a/packages/components/src/notice-banner/index.tsx
+++ b/packages/components/src/notice-banner/index.tsx
@@ -1,4 +1,4 @@
-import { Icon, warning, info, check, close } from '@wordpress/icons';
+import { Icon, warning, info, check, closeSmall } from '@wordpress/icons';
 import classNames from 'classnames';
 import React from 'react';
 import './style.scss';
@@ -81,7 +81,7 @@ const NoticeBanner: React.FC< NoticeBannerProps > = ( {
 
 			{ ! hideCloseButton && (
 				<button aria-label="close" className="notice-banner__close-button" onClick={ onClose }>
-					<Icon icon={ close } />
+					<Icon icon={ closeSmall } />
 				</button>
 			) }
 		</div>

--- a/packages/components/src/notice-banner/style.scss
+++ b/packages/components/src/notice-banner/style.scss
@@ -132,11 +132,18 @@
 		color: var(--jp-black);
 		font-weight: 600;
 		margin-left: 24px;
-		// Underline styling
-		border-bottom: 1.5px solid var(--jp-black);
 
-		&:not(:last-child) {
-			margin-right: 4px;
+		&:focus {
+			outline: none;
+			box-shadow: none;
+		}
+
+		& > span {
+			border-bottom: 1.5px solid var(--jp-black);
+		}
+
+		& > svg {
+			margin-left: 4px;
 		}
 	}
 

--- a/packages/components/src/notice-banner/style.scss
+++ b/packages/components/src/notice-banner/style.scss
@@ -1,4 +1,7 @@
+@import "@automattic/components/src/styles/typography";
+
 :root {
+	--font-title-small: 20px;
 	--font-body: 16px;
 	--jp-black: #000;
 	--jp-gray-5: #dcdcde;
@@ -20,7 +23,7 @@
 	border-color: var(--jp-gray-5);
 	border-left-width: 6px;
 
-	padding: 24px 31px 27px 18px;
+	padding: 24px;
 }
 
 .notice-banner__icon-wrapper {
@@ -61,11 +64,15 @@
 }
 
 .notice-banner__main-content {
+	font-family: $font-sf-pro-text;
 	flex-grow: 1;
 }
 
 .notice-banner__title {
-	font-weight: 600;
+	font-family: $font-sf-pro-display;
+	font-weight: 500;
+	font-size: var(--font-title-small);
+	line-height: 30px;
 	margin-bottom: 8px;
 }
 
@@ -113,24 +120,31 @@
 
 	.notice-banner__action-button,
 	.notice-banner__action-link {
+		font-family: inherit;
+		font-size: var(--font-body);
+		font-weight: 600;
+		line-height: 24px;
 		cursor: pointer;
-
-		margin-top: 16px;
-		margin-right: 8px;
-	}
-
-	.notice-banner__action-button {
-		background-color: var(--jp-black);
-		border-radius: 4px;
-		color: var(--studio-white);
-		padding: 8px;
+		margin-top: 20px;
 	}
 
 	.notice-banner__action-link {
 		color: var(--jp-black);
-		text-decoration: underline;
 		font-weight: 600;
-		margin-left: 16px;
+		margin-left: 24px;
+		// Underline styling
+		border-bottom: 1.5px solid var(--jp-black);
+
+		&:not(:last-child) {
+			margin-right: 4px;
+		}
+	}
+
+	.notice-banner__action-button {
+		background-color: var(--jp-black);
+		color: var(--studio-white);
+		border-radius: 4px;
+		padding: 8px 24px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78452 

## Proposed Changes

* Adjust the purchase notice styling in line with the design.
* Change notice copy with general messages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Jetpack Odyssey Stats
* Build the branch for Odyssey.
  * `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Build Jetpack if necessary.
  * `jetpack build plugins/jetpack`
* Navigate to `/wp-admin/admin.php?page=stats&flags=stats/paid-stats`.
* Ensure the notice is in line with the design.
* Ensure the `Learn more` link directs to the Stats landing page with a new tab.

<img width="1300" alt="截圖 2023-07-06 下午1 33 33" src="https://github.com/Automattic/wp-calypso/assets/6869813/e0009191-8d02-44f5-bd44-9a21313fc07d">

### Calypso Stats
* Launch the branch on the local Calypso site.
* Navigate to Stats > `Traffic` page with the query string `?flags=stats/paid-stats`.
* Ensure the notice is in line with the design.
* Ensure the `Learn more` link directs to the Stats landing page with a new tab.

<img width="1311" alt="截圖 2023-07-06 下午1 32 38" src="https://github.com/Automattic/wp-calypso/assets/6869813/ece8591b-2f65-4b09-8727-ef5963267c95">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
