### PR TITLE
Stats Widget: Adjust styles to avoid displaying hidden notices in WP-Admin

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -16,6 +16,12 @@
 	font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	margin-bottom: 2px;
 
+	// Avoid overriding hidden notices.
+	&[aria-hidden="true"],
+	&.hidden {
+		display: none;
+	}
+
 	h2,
 	h3 {
 		color: var(--studio-gray-90);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/76196#issuecomment-1522506320, https://github.com/Automattic/jetpack/issues/31375#issuecomment-1622903661.

## Proposed Changes

* Fix the increased CSS specificity introduced from [another fix](https://github.com/Automattic/wp-calypso/pull/78221).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build the branch for Odyssey Stats.
  * `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Navigate to the Dashboard page: `/wp-admin/index.php`.
* Ensure the hidden error messages of event location search and comment reply blocks are not showing.

### Event Location Search
|Before|After|
|-|-|
|<img width="602" alt="截圖 2023-07-06 下午2 09 19" src="https://github.com/Automattic/wp-calypso/assets/6869813/9726b12f-287f-4aac-a4f6-a3bea01563ed">|<img width="599" alt="截圖 2023-07-06 下午2 07 40" src="https://github.com/Automattic/wp-calypso/assets/6869813/6785d551-8aaf-43d6-91f9-e1288078857d">|

### Comment Reply
|Before|After|
|-|-|
|<img width="603" alt="截圖 2023-07-06 下午2 09 27" src="https://github.com/Automattic/wp-calypso/assets/6869813/8059851e-a4f2-4d68-9f99-f0af69b4eda3">|<img width="604" alt="截圖 2023-07-06 下午2 08 47" src="https://github.com/Automattic/wp-calypso/assets/6869813/bf7660bc-1af6-4b44-be0b-a49cc3878ec9">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
