### PR TITLE
Fix clicking "sign in as a different user" redirects to Home for WooCommerce

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -446,22 +446,26 @@ export class JetpackAuthorize extends Component {
 		e.preventDefault();
 
 		const { recordTracksEvent } = this.props;
-		const { from } = this.props.authQuery;
-		if ( 'woocommerce-onboarding' === from ) {
-			recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { different_account: true } );
-		} else if ( from === 'woocommerce-core-profiler' ) {
-			recordTracksEvent( 'calypso_jpc_different_user_click' );
-		}
-
-		try {
-			const { redirect_to: redirectTo } = await this.props.logoutUser( loginURL );
-			disablePersistence();
-			await clearStore();
-			window.location.href = redirectTo || '/';
-		} catch ( error ) {
-			// The logout endpoint might fail if the nonce has expired.
-			// In this case, redirect to wp-login.php?action=logout to get a new nonce generated
-			this.props.redirectToLogout( loginURL );
+		switch ( true ) {
+			case this.isWooOnboarding():
+				recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { use_account: true } );
+				window.location.href = e.target.href;
+				break;
+			case this.isWooCoreProfiler():
+				recordTracksEvent( 'calypso_jpc_different_user_click' );
+				window.location.href = e.target.href;
+				break;
+			default:
+				try {
+					const { redirect_to: redirectTo } = await this.props.logoutUser( loginURL );
+					disablePersistence();
+					await clearStore();
+					window.location.href = redirectTo || '/';
+				} catch ( error ) {
+					// The logout endpoint might fail if the nonce has expired.
+					// In this case, redirect to wp-login.php?action=logout to get a new nonce generated
+					this.props.redirectToLogout( loginURL );
+				}
 		}
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79030

## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/78036 fixed a signin issue for WCCOM Jetpack connection flow. However, it's causing a redirection issue for woocommerce.

This PR:
* Fix clicking "sign in as a different user" redirects to Home for WooCommerce
* Add unit tests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Sign in to wordpress.com.
2. Create a new JN site in the same browser. 
3. Install and activate [WooCommerce 7.9 RC 2](https://github.com/woocommerce/woocommerce/releases/download/7.9.0-rc.2/woocommerce.zip)
4. Start the core profiler and proceed to the plugins page.
5. Make sure to check Jetpack and click Continue.
6. You should be redirected to Jetpack Connect
7. Click `Sign in as a different user`
8. You're redirected to Jetpack login page.
9. (Optional) Follow the instructions in https://github.com/Automattic/wp-calypso/pull/78036 to make sure this fix is still valid

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
