### PR TITLE
Domains: Fix unknown DNS record addition

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -119,9 +119,10 @@ class DnsAddNew extends React.Component {
 	}
 
 	getFieldsForType( type ) {
-		const dnsRecord = find( this.dnsRecords, ( record ) => {
-			return includes( record.types, type );
-		} );
+		const dnsRecord =
+			find( this.dnsRecords, ( record ) => {
+				return includes( record.types, type );
+			} ) ?? this.dnsRecords[ 0 ];
 
 		return {
 			...dnsRecord.initialFields,


### PR DESCRIPTION
## Proposed Changes

This PR fixes an edge case reported by Sentry, caused by this code:

https://github.com/Automattic/wp-calypso/blob/cdb4ce0228ae61abd51ab122e3dc2b043264249e/client/my-sites/domains/domain-management/dns/dns-add-new.jsx#L122C1-L127

where `dnsRecord` ends up `undefined` for some reason, and `...dnsRecord.initialFields` crashes. 

Since the default record type is `A`, we're defaulting to the first one in that scenario.

## Testing Instructions

* Head to `/domains/manage/{ SITE_ID }/dns/{ DOMAIN_NAME }`
* Add a few different DNS records and verify the addition interface still works.