### PR TITLE
Rename functions used for hosted site onboarding checklists

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites/index.jsx
@@ -18,7 +18,7 @@ import { trackAddDomainAction, trackManageAllDomainsAction } from '../quick-link
 import ActionBox from '../quick-links/action-box';
 import '../quick-links/style.scss';
 
-const QuickLinksForDevs = ( props ) => {
+const QuickLinksForHostedSites = ( props ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
@@ -47,7 +47,7 @@ const QuickLinksForDevs = ( props ) => {
 	] = useDebouncedCallback( updateToggleStatus, 1000 );
 
 	const quickLinks = (
-		<div className="quick-links-for-devs__boxes quick-links__boxes">
+		<div className="quick-links-for-hosted-sites__boxes quick-links__boxes">
 			<ActionBox
 				href={ `/hosting-config/${ siteSlug }#sftp-credentials` }
 				hideLinkIndicator
@@ -135,7 +135,7 @@ const QuickLinksForDevs = ( props ) => {
 
 	return (
 		<FoldableCard
-			className="quick-links-for-devs quick-links"
+			className="quick-links-for-hosted-sites quick-links"
 			header={ translate( 'Quick Links' ) }
 			clickableHeader
 			expanded={ isExpanded }
@@ -175,4 +175,8 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	};
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( QuickLinksForDevs );
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+	mergeProps
+)( QuickLinksForHostedSites );

--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -1,5 +1,6 @@
 export const ACTION_QUICK_LINKS = 'home-action-quick-links';
 export const ACTION_QUICK_LINKS_FOR_DEVS = 'home-action-quick-links-for-devs';
+export const ACTION_QUICK_LINKS_FOR_HOSTED_SITES = 'home-action-quick-links-for-hosted-sites';
 export const ACTION_WP_FOR_TEAMS_QUICK_LINKS = 'home-action-wp-for-teams-quick-links';
 export const EDUCATION_FREE_PHOTO_LIBRARY = 'home-education-free-photo-library';
 export const EDUCATION_EARN = 'home-education-earn';

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -2,11 +2,12 @@ import { createElement, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import QuickLinks from 'calypso/my-sites/customer-home/cards/actions/quick-links';
-import QuickLinksForDevs from 'calypso/my-sites/customer-home/cards/actions/quick-links-for-devs';
+import QuickLinksForHostedSites from 'calypso/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites';
 import WpForTeamsQuickLinks from 'calypso/my-sites/customer-home/cards/actions/wp-for-teams-quick-links';
 import {
 	ACTION_QUICK_LINKS,
 	ACTION_QUICK_LINKS_FOR_DEVS,
+	ACTION_QUICK_LINKS_FOR_HOSTED_SITES,
 	ACTION_WP_FOR_TEAMS_QUICK_LINKS,
 	FEATURE_GO_MOBILE,
 	FEATURE_QUICK_START,
@@ -24,7 +25,8 @@ const cardComponents = {
 	[ ACTION_QUICK_LINKS ]: QuickLinks,
 	[ FEATURE_QUICK_START ]: QuickStart,
 	[ ACTION_WP_FOR_TEAMS_QUICK_LINKS ]: WpForTeamsQuickLinks,
-	[ ACTION_QUICK_LINKS_FOR_DEVS ]: QuickLinksForDevs,
+	[ ACTION_QUICK_LINKS_FOR_DEVS ]: QuickLinksForHostedSites,
+	[ ACTION_QUICK_LINKS_FOR_HOSTED_SITES ]: QuickLinksForHostedSites,
 };
 
 const ManageSite = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2895

## Proposed Changes

* Renames the quicklinks card used for hosted sites
* Temporarily supports both the old and new names

See D115402-code for change which updates the card ID

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?