### PR TITLE
GS on Personal A/B: Display correct plan in welcome modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -66,12 +66,12 @@ const GlobalStylesModal = () => {
 	let description;
 	if ( wpcomGlobalStyles?.globalStylesInPersonalPlan === GLOBAL_STYLES_TREATMENT_GROUP ) {
 		description = __(
-			"Change all of your site's fonts, colors and more. Available on the Premium plan.",
+			"Change all of your site's fonts, colors and more. Available on the Personal plan.",
 			'full-site-editing'
 		);
 	} else {
 		description = __(
-			"Change all of your site's fonts, colors and more. Available on the Personal plan.",
+			"Change all of your site's fonts, colors and more. Available on the Premium plan.",
 			'full-site-editing'
 		);
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -11,6 +11,8 @@ import { useCanvas } from './use-canvas';
 
 import './modal.scss';
 
+const GLOBAL_STYLES_TREATMENT_GROUP = '1';
+
 const GlobalStylesModal = () => {
 	const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ), [] );
 	const { viewCanvasPath } = useCanvas();
@@ -61,6 +63,19 @@ const GlobalStylesModal = () => {
 		return null;
 	}
 
+	let description;
+	if ( wpcomGlobalStyles?.globalStylesInPersonalPlan === GLOBAL_STYLES_TREATMENT_GROUP ) {
+		description = __(
+			"Change all of your site's fonts, colors and more. Available on the Premium plan.",
+			'full-site-editing'
+		);
+	} else {
+		description = __(
+			"Change all of your site's fonts, colors and more. Available on the Personal plan.",
+			'full-site-editing'
+		);
+	}
+
 	return (
 		<Modal
 			className="wpcom-global-styles-modal"
@@ -73,12 +88,7 @@ const GlobalStylesModal = () => {
 					<h1 className="wpcom-global-styles-modal__heading">
 						{ __( 'A powerful new way to style your site', 'full-site-editing' ) }
 					</h1>
-					<p className="wpcom-global-styles-modal__description">
-						{ __(
-							"Change all of your site's fonts, colors and more. Available on the Premium plan.",
-							'full-site-editing'
-						) }
-					</p>
+					<p className="wpcom-global-styles-modal__description">{ description }</p>
 					<div className="wpcom-global-styles-modal__actions">
 						<Button variant="secondary" onClick={ closeModal }>
 							{ __( 'Try it out', 'full-site-editing' ) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2864

## Proposed Changes

For users assigned to treatment group of the GS on Personal A/B test, we upsell now the Personal plan in the welcome modal displayed in the site editor when GS are limited.

<img width="1728" alt="Screenshot 2023-07-06 at 10 15 50" src="https://github.com/Automattic/wp-calypso/assets/1233880/478c663d-6abf-4297-93cf-360f1e0f04f3">



## Testing Instructions

- Apply these changes to your sandbox.
- Go to 21268-explat-experiment and assign yourself to the treatment group.
- Go to `wordpress.com/start` and create a new site.
- Sandbox it.
- Open the site editor and open the Styles section/sidebar.
- Make sure the welcome modal upsells the Personal plan.