### PR TITLE
media: fix JS error when attempting to upload an invalid item

### DIFF
--- a/client/data/media/use-upload-media-mutation.js
+++ b/client/data/media/use-upload-media-mutation.js
@@ -43,9 +43,10 @@ export const useUploadMediaMutation = ( queryOptions = {} ) => {
 			}
 
 			const uploadedItems = [];
-
-			const uploads = dispatch( createTransientMediaItems( files, site ) );
+			const transientItems = dispatch( createTransientMediaItems( files, site ) );
 			const { ID: siteId } = site;
+
+			const uploads = files.map( ( _, i ) => [ files[ i ], transientItems[ i ] ] );
 
 			for await ( const [ file, transientMedia ] of uploads ) {
 				if ( ! transientMedia ) {

--- a/client/state/media/thunks/create-transient-media-items.js
+++ b/client/state/media/thunks/create-transient-media-items.js
@@ -34,7 +34,7 @@ export function createTransientMediaItems( files, site ) {
 			const errors = validateMediaItem( site, transientMedia );
 			if ( errors?.length ) {
 				dispatch( setMediaItemErrors( siteId, transientMedia.ID, errors ) );
-				return;
+				return [ file ];
 			}
 
 			dispatch( createMediaItem( site, transientMedia ) );

--- a/client/state/media/thunks/create-transient-media-items.js
+++ b/client/state/media/thunks/create-transient-media-items.js
@@ -34,12 +34,12 @@ export function createTransientMediaItems( files, site ) {
 			const errors = validateMediaItem( site, transientMedia );
 			if ( errors?.length ) {
 				dispatch( setMediaItemErrors( siteId, transientMedia.ID, errors ) );
-				return [ file ];
+				return;
 			}
 
 			dispatch( createMediaItem( site, transientMedia ) );
 
-			return [ file, transientMedia ];
+			return transientMedia;
 		} );
 	};
 }

--- a/client/state/media/thunks/test/create-transient-media-items.js
+++ b/client/state/media/thunks/test/create-transient-media-items.js
@@ -29,19 +29,16 @@ describe( 'media - thunks - createTransientMediaItems', () => {
 		createTransientMedia.mockImplementation( ( x ) => x );
 	} );
 
-	it( 'should return a list of tuples which hold media files and transient items', () => {
+	it( 'should return the list of transient items', () => {
 		jest.spyOn( dateUtils, 'getTransientDate' ).mockReturnValue( transientDate );
 		createTransientMedia.mockReturnValueOnce( { transient: true } );
 		const result = createTransientMediaItems( [ file ], site );
 		expect( result ).toEqual( [
-			[
-				file,
-				{
-					date: transientDate,
-					ID: transientId,
-					transient: true,
-				},
-			],
+			{
+				date: transientDate,
+				ID: transientId,
+				transient: true,
+			},
 		] );
 	} );
 


### PR DESCRIPTION
Related to p1688519778526199-slack-C04U5A26M

## Proposed Changes

If there's an error by attempting to upload a file with an unsupported file type we abort the process of creating a transient item and show an error. Previously we'd return a tuple if nothing goes wrong but `undefined` if an error occurs which provoked the error in `useUploadMediaMutation` (see also the relevant Sentry thread; this was a rework I did in in [#59298](https://github.com/Automattic/wp-calypso/pull/59298/files#diff-a36f2d8a3f5499bc9b01fc2fd1c9eb1c3bf28b9493e1c51a78f7817448f25af6R42)). We now undo this to make sure the logic in `uploadMediaAsync` works as expected (the lack of `transientMedia` is an indicator for `uploadMediaAsync` that there's been an error and [it won't process it further](https://github.com/Automattic/wp-calypso/blob/27e3bbb6b891c7f437eb769479d5ee5fab3bca1d/client/data/media/use-upload-media-mutation.js#L51-L53)).

## Testing Instructions

Attempt to upload media files by either by using the drop zone or the _Add new_ button on `/media`.:

- A single file with an unsupported file type, verify there's no errors in the console (an error notice should be shown)
- Two (or more) files where one of them is a file with an unsupported file type. Verify an error is shown, there are no errors in the console and all other items are being processed as expected