### PR TITLE
Unify Design Preview: Display animations when navigating to Colors & Fonts

### DIFF
--- a/packages/components/src/device-switcher/device-switcher.scss
+++ b/packages/components/src/device-switcher/device-switcher.scss
@@ -32,7 +32,7 @@
 	flex: 1;
 	width: 100%;
 	overflow: hidden;
-	transition: max-width 0.2s ease-out, max-height 0.2s ease-out;
+	transition: all 0.2s ease-out;
 	max-width: 100%;
 	max-height: 100%;
 	box-sizing: border-box;
@@ -92,6 +92,8 @@
 	.device-switcher__container--is-fullscreen & {
 		max-height: 100vh;
 		max-width: 100vw;
+		border-width: 0;
+		border-radius: 0;
 	}
 
 	.device-switcher__container--frame-fixed-viewport & {

--- a/packages/design-preview/src/components/animated-fullscreen.tsx
+++ b/packages/design-preview/src/components/animated-fullscreen.tsx
@@ -1,0 +1,48 @@
+import { useLayoutEffect, useState, useRef } from 'react';
+
+interface Props {
+	className?: string;
+	children: JSX.Element;
+	isFullscreen?: boolean;
+	enabled?: boolean;
+}
+
+const AnimatedFullscreen = ( { className, children, isFullscreen, enabled }: Props ) => {
+	const positionerRef = useRef< HTMLDivElement | null >( null );
+	const targetRef = useRef< HTMLDivElement | null >( null );
+	const [ style, setStyle ] = useState( {} );
+
+	useLayoutEffect( () => {
+		if ( ! enabled || ! positionerRef.current || ! targetRef.current ) {
+			return;
+		}
+
+		const { width, height, left, top } = positionerRef.current.getBoundingClientRect();
+
+		setStyle( {
+			position: 'absolute',
+			left: 0,
+			top: 0,
+			width,
+			height,
+			transform: `translate(${ left }px, ${ top }px)`,
+			transformOrigin: 'center center',
+			transition: 'transform 0.15s linear',
+		} );
+	}, [ isFullscreen, enabled ] );
+
+	if ( ! enabled ) {
+		return <div className={ className }>{ children }</div>;
+	}
+
+	return (
+		<>
+			<div className={ className } ref={ positionerRef } />
+			<div className={ className } ref={ targetRef } style={ style }>
+				{ children }
+			</div>
+		</>
+	);
+};
+
+export default AnimatedFullscreen;

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -117,6 +117,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 				url={ previewUrl }
 				inlineCss={ inlineCss }
 				isFullscreen={ isFullscreen }
+				animated={ ! isDesktop }
 				recordDeviceClick={ recordDeviceClick }
 			/>
 		</div>

--- a/packages/design-preview/src/components/site-preview.tsx
+++ b/packages/design-preview/src/components/site-preview.tsx
@@ -1,9 +1,12 @@
 import { ThemePreview } from '@automattic/design-picker';
+import classnames from 'classnames';
+import AnimatedFullscreen from './animated-fullscreen';
 
 interface SitePreviewProps {
 	url: string;
 	inlineCss?: string;
 	isFullscreen?: boolean;
+	animated?: boolean;
 	recordDeviceClick: ( device: string ) => void;
 }
 
@@ -11,19 +14,26 @@ const SitePreview: React.FC< SitePreviewProps > = ( {
 	url,
 	inlineCss = '',
 	isFullscreen,
+	animated,
 	recordDeviceClick,
 } ) => {
 	return (
-		<div className="design-preview__site-preview">
+		<AnimatedFullscreen
+			className={ classnames( 'design-preview__site-preview', {
+				'design-preview__site-preview--animated': animated,
+			} ) }
+			isFullscreen={ isFullscreen }
+			enabled={ animated }
+		>
 			<ThemePreview
 				url={ url }
 				inlineCss={ inlineCss }
-				isShowFrameBorder={ ! isFullscreen }
+				isShowFrameBorder
 				isShowDeviceSwitcher
 				isFullscreen={ isFullscreen }
 				recordDeviceClick={ recordDeviceClick }
 			/>
-		</div>
+		</AnimatedFullscreen>
 	);
 };
 

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -52,6 +52,7 @@ $design-preview-sidebar-width: 311px;
 			border-bottom: 1px solid rgb(0 0 0 / 5%);
 			box-shadow: -4px 0 8px rgb(0 0 0 / 7%);
 			overflow: auto;
+			z-index: 1;
 		}
 
 		.design-preview__site-preview {
@@ -359,6 +360,12 @@ $design-preview-sidebar-width: 311px;
 
 		@include break-large {
 			display: block;
+		}
+	}
+
+	&.design-preview__site-preview--animated {
+		.device-switcher__frame {
+			transition: none;
 		}
 	}
 }

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -53,6 +53,8 @@ $design-preview-sidebar-width: 311px;
 			box-shadow: -4px 0 8px rgb(0 0 0 / 7%);
 			overflow: auto;
 			z-index: 1;
+			position: relative;
+			animation: sidebarFadeIn 0.3s ease-out;
 		}
 
 		.design-preview__site-preview {
@@ -257,7 +259,6 @@ $design-preview-sidebar-width: 311px;
 	display: block;
 	padding: 16px 24px 8px 32px;
 	margin: 0 -16px;
-	animation: fadeIn 0.3s ease-out;
 
 	> p {
 		color: var(--studio-gray-100);
@@ -364,12 +365,6 @@ $design-preview-sidebar-width: 311px;
 			display: block;
 		}
 	}
-
-	&.design-preview__site-preview--animated {
-		.device-switcher__frame {
-			transition: none;
-		}
-	}
 }
 
 .design-picker__premium-badge {
@@ -418,11 +413,12 @@ $design-preview-sidebar-width: 311px;
 	}
 }
 
-@keyframes fadeIn {
+// We cannot use translate here as the sidebar might container element with fixed position
+@keyframes sidebarFadeIn {
 	from {
-		transform: translateY(-100%);
+		top: -100%;
 	}
 	to {
-		transform: translateY(0%);
+		top: 0;
 	}
 }

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -257,6 +257,7 @@ $design-preview-sidebar-width: 311px;
 	display: block;
 	padding: 16px 24px 8px 32px;
 	margin: 0 -16px;
+	animation: fadeIn 0.3s ease-out;
 
 	> p {
 		color: var(--studio-gray-100);
@@ -301,6 +302,7 @@ $design-preview-sidebar-width: 311px;
 	@include break-large {
 		padding: 8px 16px 0;
 		overflow-y: auto;
+		animation: none;
 
 		> p {
 			display: block;
@@ -413,5 +415,14 @@ $design-preview-sidebar-width: 311px;
 		color: var(--color-neutral-0);
 		padding: 8px;
 		-webkit-font-smoothing: antialiased;
+	}
+}
+
+@keyframes fadeIn {
+	from {
+		transform: translateY(-100%);
+	}
+	to {
+		transform: translateY(0%);
 	}
 }

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -48,12 +48,11 @@ $design-preview-sidebar-width: 311px;
 		z-index: 1;
 
 		.design-preview__sidebar {
+			position: relative;
 			padding: 0;
 			border-bottom: 1px solid rgb(0 0 0 / 5%);
 			box-shadow: -4px 0 8px rgb(0 0 0 / 7%);
-			overflow: auto;
 			z-index: 1;
-			position: relative;
 			animation: sidebarFadeIn 0.3s ease-out;
 		}
 

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -256,9 +256,11 @@ $design-preview-sidebar-width: 311px;
 }
 
 .design-preview__sidebar-variations {
-	display: block;
-	padding: 16px 24px 8px 32px;
-	margin: 0 -16px;
+	display: flex;
+	width: 100%;
+	padding: 16px 20px 8px;
+	box-sizing: border-box;
+	overflow: auto;
 
 	> p {
 		color: var(--studio-gray-100);
@@ -302,7 +304,8 @@ $design-preview-sidebar-width: 311px;
 
 	@include break-large {
 		padding: 8px 16px 0;
-		overflow-y: auto;
+		margin: 0 -16px;
+		box-sizing: content-box;
 		animation: none;
 
 		> p {

--- a/packages/global-styles/package.json
+++ b/packages/global-styles/package.json
@@ -42,6 +42,7 @@
 		"i18n-calypso": "workspace:^",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
+		"react-intersection-observer": "^9.4.3",
 		"tslib": "^2.3.0",
 		"wpcom-proxy-request": "workspace:^"
 	},

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -9,6 +9,7 @@ import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/compo
 import classnames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useMemo, useContext } from 'react';
+import { InView, IntersectionObserverProps } from 'react-intersection-observer';
 import { useColorPaletteVariations } from '../../hooks';
 import ColorPaletteVariationPreview from './preview';
 import type { GlobalStylesObject } from '../../types';
@@ -61,11 +62,19 @@ const ColorPaletteVariation = ( {
 				} ) as string
 			}
 		>
-			<div className="global-styles-variation__item-preview">
-				<GlobalStylesContext.Provider value={ context }>
-					<ColorPaletteVariationPreview title={ colorPaletteVariation.title } />
-				</GlobalStylesContext.Provider>
-			</div>
+			<InView triggerOnce>
+				{
+					( ( { inView, ref } ) => (
+						<div className="global-styles-variation__item-preview" ref={ ref }>
+							{ ( isActive || inView ) && (
+								<GlobalStylesContext.Provider value={ context }>
+									<ColorPaletteVariationPreview title={ colorPaletteVariation.title } />
+								</GlobalStylesContext.Provider>
+							) }
+						</div>
+					) ) as IntersectionObserverProps[ 'children' ]
+				}
+			</InView>
 		</CompositeItem>
 	);
 };

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -9,6 +9,7 @@ import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/compo
 import classnames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useMemo, useContext } from 'react';
+import { InView, IntersectionObserverProps } from 'react-intersection-observer';
 import { useFontPairingVariations } from '../../hooks';
 import FontPairingVariationPreview from './preview';
 import type { GlobalStylesObject } from '../../types';
@@ -62,11 +63,19 @@ const FontPairingVariation = ( {
 				} ) as string
 			}
 		>
-			<div className="global-styles-variation__item-preview">
-				<GlobalStylesContext.Provider value={ context }>
-					<FontPairingVariationPreview />
-				</GlobalStylesContext.Provider>
-			</div>
+			<InView triggerOnce>
+				{
+					( ( { inView, ref } ) => (
+						<div className="global-styles-variation__item-preview" ref={ ref }>
+							{ ( isActive || inView ) && (
+								<GlobalStylesContext.Provider value={ context }>
+									<FontPairingVariationPreview />
+								</GlobalStylesContext.Provider>
+							) }
+						</div>
+					) ) as IntersectionObserverProps[ 'children' ]
+				}
+			</InView>
 		</CompositeItem>
 	);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -814,6 +814,7 @@ __metadata:
     i18n-calypso: "workspace:^"
     react: ^18.2.0
     react-dom: ^18.2.0
+    react-intersection-observer: ^9.4.3
     tslib: ^2.3.0
     typescript: ^4.7.4
     wpcom-proxy-request: "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78419

## Proposed Changes

* Add the animations when people select Colors & Fonts

| Before | After | Latest |
| - | - | - |
| <video src="https://github.com/Automattic/wp-calypso/assets/13596067/6964d02a-5bc0-4c81-8ee4-2f7e5878a169" /> | <video src="https://github.com/Automattic/wp-calypso/assets/13596067/f72dcb47-4ada-48b1-ada5-b3c4e820dc7e" /> | <video src="https://github.com/Automattic/wp-calypso/assets/13596067/3a270d62-4a88-49a3-80f7-060fab35d27d" /> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the URLs below, especially for the mobile screen
  * /setup?siteSlug=<your_site>&flags=signup/design-picker-preview-colors
* Continue until you land on the Design Picker
* Preview the design without the style variation
* Navigate to Colors & Fonts, and check the animation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
