### PR TITLE
Domain Transfer: Add placeholders 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
@@ -2,8 +2,6 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import { Purchase } from 'calypso/lib/purchases/types';
 
-import './styles.scss';
-
 type Props = {
 	newlyTransferredDomains: Purchase[] | undefined;
 	placeHolderCount: number;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
@@ -17,9 +17,8 @@ export const CompleteDomainsTransferred = ( {
 		<>
 			<div className="domain-complete-summary">
 				<ul className="domain-complete-list">
-					{ newlyTransferredDomains ? (
-						<ul className="domain-complete-list">
-							{ newlyTransferredDomains.map( ( { meta }, key ) => {
+					{ newlyTransferredDomains
+						? newlyTransferredDomains.map( ( { meta }, key ) => {
 								return (
 									<li className="domain-complete-list-item" key={ key }>
 										<h2>{ meta }</h2>
@@ -31,20 +30,15 @@ export const CompleteDomainsTransferred = ( {
 										</a>
 									</li>
 								);
-							} ) }
-						</ul>
-					) : (
-						<ul className="domain-complete-list">
-							{ [ ...Array( placeHolderCount ) ].map( ( data, key ) => {
+						  } )
+						: [ ...Array( placeHolderCount ) ].map( ( data, key ) => {
 								return (
 									<li className="domain-complete-list-item" key={ key }>
 										<p className="loading-placeholder"></p>
 										<button className="components-button loading-placeholder"></button>
 									</li>
 								);
-							} ) }
-						</ul>
-					) }
+						  } ) }
 				</ul>
 			</div>
 			<div className="domain-complete-tips">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
@@ -1,9 +1,19 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import { Purchase } from 'calypso/lib/purchases/types';
+import './styles.scss';
 
 type Props = {
-	newlyTransferredDomains: Purchase[];
+	newlyTransferredDomains: Purchase[] | undefined;
+};
+
+const PlaceHolderLisItem = () => {
+	return (
+		<li className="domain-complete-list-item">
+			<p className="loading-placeholder"></p>
+			<button className="components-button loading-placeholder"></button>
+		</li>
+	);
 };
 
 export const CompleteDomainsTransferred = ( { newlyTransferredDomains }: Props ) => {
@@ -13,16 +23,23 @@ export const CompleteDomainsTransferred = ( { newlyTransferredDomains }: Props )
 		<>
 			<div className="domain-complete-summary">
 				<ul className="domain-complete-list">
-					{ newlyTransferredDomains.map( ( { meta }, key ) => {
-						return (
-							<li className="domain-complete-list-item" key={ key }>
-								<h2>{ meta }</h2>
-								<a href={ `/domains/manage/${ meta }` } className="components-button is-secondary">
-									{ __( 'Manage domain' ) }
-								</a>
-							</li>
-						);
-					} ) }
+					{ newlyTransferredDomains ? (
+						newlyTransferredDomains.map( ( { meta }, key ) => {
+							return (
+								<li className="domain-complete-list-item" key={ key }>
+									<h2>{ meta }</h2>
+									<a
+										href={ `/domains/manage/${ meta }` }
+										className="components-button is-secondary"
+									>
+										{ __( 'Manage domain' ) }
+									</a>
+								</li>
+							);
+						} )
+					) : (
+						<PlaceHolderLisItem />
+					) }
 				</ul>
 			</div>
 			<div className="domain-complete-tips">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
@@ -1,22 +1,18 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import { Purchase } from 'calypso/lib/purchases/types';
+
 import './styles.scss';
 
 type Props = {
 	newlyTransferredDomains: Purchase[] | undefined;
+	placeHolderCount: number;
 };
 
-const PlaceHolderLisItem = () => {
-	return (
-		<li className="domain-complete-list-item">
-			<p className="loading-placeholder"></p>
-			<button className="components-button loading-placeholder"></button>
-		</li>
-	);
-};
-
-export const CompleteDomainsTransferred = ( { newlyTransferredDomains }: Props ) => {
+export const CompleteDomainsTransferred = ( {
+	newlyTransferredDomains,
+	placeHolderCount,
+}: Props ) => {
 	const { __ } = useI18n();
 
 	return (
@@ -24,21 +20,32 @@ export const CompleteDomainsTransferred = ( { newlyTransferredDomains }: Props )
 			<div className="domain-complete-summary">
 				<ul className="domain-complete-list">
 					{ newlyTransferredDomains ? (
-						newlyTransferredDomains.map( ( { meta }, key ) => {
-							return (
-								<li className="domain-complete-list-item" key={ key }>
-									<h2>{ meta }</h2>
-									<a
-										href={ `/domains/manage/${ meta }` }
-										className="components-button is-secondary"
-									>
-										{ __( 'Manage domain' ) }
-									</a>
-								</li>
-							);
-						} )
+						<ul className="domain-complete-list">
+							{ newlyTransferredDomains.map( ( { meta }, key ) => {
+								return (
+									<li className="domain-complete-list-item" key={ key }>
+										<h2>{ meta }</h2>
+										<a
+											href={ `/domains/manage/${ meta }` }
+											className="components-button is-secondary"
+										>
+											{ __( 'Manage domain' ) }
+										</a>
+									</li>
+								);
+							} ) }
+						</ul>
 					) : (
-						<PlaceHolderLisItem />
+						<ul className="domain-complete-list">
+							{ [ ...Array( placeHolderCount ) ].map( ( data, key ) => {
+								return (
+									<li className="domain-complete-list-item" key={ key }>
+										<p className="loading-placeholder"></p>
+										<button className="components-button loading-placeholder"></button>
+									</li>
+								);
+							} ) }
+						</ul>
 					) }
 				</ul>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -11,6 +11,16 @@ import { CompleteDomainsTransferred } from './complete-domains-transferred';
 import type { Step } from '../../types';
 import './styles.scss';
 
+const PlaceHolderHeader = () => {
+	return (
+		<div className="placeholder-main-title">
+			<p className="loading-placeholder"></p>
+			<p className="loading-placeholder"></p>
+			<button className="loading-placeholder"></button>
+		</div>
+	);
+};
+
 const Complete: Step = function Complete( { flow } ) {
 	const { __, _n } = useI18n();
 	const dispatch = useDispatch();
@@ -31,13 +41,13 @@ const Complete: Step = function Complete( { flow } ) {
 
 	return (
 		<>
-			{ newlyTransferredDomains && (
-				<StepContainer
-					flowName={ flow }
-					stepName="complete"
-					isHorizontalLayout={ false }
-					isLargeSkipLayout={ false }
-					formattedHeader={
+			<StepContainer
+				flowName={ flow }
+				stepName="complete"
+				isHorizontalLayout={ false }
+				isLargeSkipLayout={ false }
+				formattedHeader={
+					newlyTransferredDomains ? (
 						<FormattedHeader
 							id="domains-header"
 							headerText={ _n(
@@ -58,18 +68,20 @@ const Complete: Step = function Complete( { flow } ) {
 								</a>
 							}
 						/>
-					}
-					stepContent={
-						<CompleteDomainsTransferred newlyTransferredDomains={ newlyTransferredDomains } />
-					}
-					recordTracksEvent={ recordTracksEvent }
-					showHeaderJetpackPowered={ false }
-					showHeaderWooCommercePowered={ false }
-					showVideoPressPowered={ false }
-					showJetpackPowered={ false }
-					hideBack={ true }
-				/>
-			) }
+					) : (
+						<PlaceHolderHeader />
+					)
+				}
+				stepContent={
+					<CompleteDomainsTransferred newlyTransferredDomains={ newlyTransferredDomains } />
+				}
+				recordTracksEvent={ recordTracksEvent }
+				showHeaderJetpackPowered={ false }
+				showHeaderWooCommercePowered={ false }
+				showVideoPressPowered={ false }
+				showJetpackPowered={ false }
+				hideBack={ true }
+			/>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -23,6 +23,8 @@ const Complete: Step = function Complete( { flow } ) {
 		[]
 	);
 
+	const storedDomainsAmount = Object.keys( { ...storedDomainsState } ).length;
+
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const userPurchases = useSelector( ( state ) => getUserPurchases( state ) );
 	const oneDay = 24 * 60 * 60 * 1000; // Number of milliseconds in a day
@@ -50,7 +52,7 @@ const Complete: Step = function Complete( { flow } ) {
 						headerText={ _n(
 							'Congrats on your domain transfer',
 							'Congrats on your domain transfers',
-							newlyTransferredDomains?.length || Object.keys( { ...storedDomainsState } ).length
+							newlyTransferredDomains?.length || storedDomainsAmount
 						) }
 						subHeaderText={ __(
 							'Hold tight as we complete the set up of your newly transferred domain.'
@@ -65,7 +67,7 @@ const Complete: Step = function Complete( { flow } ) {
 				}
 				stepContent={
 					<CompleteDomainsTransferred
-						placeHolderCount={ Object.keys( { ...storedDomainsState } ).length }
+						placeHolderCount={ storedDomainsAmount }
 						newlyTransferredDomains={ newlyTransferredDomains }
 					/>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -18,6 +18,8 @@ const Complete: Step = function Complete( { flow } ) {
 	const { __, _n } = useI18n();
 	const dispatch = useDispatch();
 
+	// Use the stored domains as a clue for the number of domains that were transferred to render placeholders.
+	// This number is used as a rough guess, and shouldn't be used to render anything.
 	const storedDomainsState = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getBulkDomainsData(),
 		[]

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -259,4 +259,55 @@
 			}
 		}
 	}
+
+	.placeholder-main-title {
+		display: flex;
+		flex-direction: column;
+		flex-wrap: wrap;
+		align-items: center;
+
+		p:first-child {
+			font-size: 3rem;
+			width: 750px;
+			height: 54px;
+			margin-bottom: 10px;
+			@media ( max-width: $break-medium ) {
+				width: 88vw;
+			}
+		}
+		button {
+			margin-top: 20px;
+			width: 170px;
+			height: 50px;
+		}
+	}
+
+	// Placeholder Gradient
+	.loading-placeholder {
+		background-image: linear-gradient(90deg, #e4e4e4 0%, #f1f1f1 40%, #ededed 60%, #e4e4e4 100%);
+		background-position: 0 0;
+		background-repeat: repeat;
+	}
+
+	p.loading-placeholder {
+		animation: animatedBackground 10s linear infinite;
+		width: 300px;
+		height: 20px;
+
+	}
+	button.loading-placeholder {
+		animation: animatedBackground 20s linear infinite;
+		width: 150px;
+		pointer-events: none;
+	}
+	// Animation
+	@keyframes animatedBackground {
+		from {
+			background-position: 0 0;
+		}
+		to {
+			background-position: 1500px 0;
+		}
+	}
+
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -267,7 +267,6 @@
 		align-items: center;
 
 		p:first-child {
-			font-size: 3rem;
 			width: 750px;
 			height: 54px;
 			margin-bottom: 10px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -260,53 +260,12 @@
 		}
 	}
 
-	.placeholder-main-title {
-		display: flex;
-		flex-direction: column;
-		flex-wrap: wrap;
-		align-items: center;
-
-		p:first-child {
-			width: 750px;
-			height: 54px;
-			margin-bottom: 10px;
-			@media ( max-width: $break-medium ) {
-				width: 88vw;
-			}
-		}
-		button {
-			margin-top: 20px;
-			width: 170px;
-			height: 50px;
-		}
-	}
-
-	// Placeholder Gradient
-	.loading-placeholder {
-		background-image: linear-gradient(90deg, #e4e4e4 0%, #f1f1f1 40%, #ededed 60%, #e4e4e4 100%);
-		background-position: 0 0;
-		background-repeat: repeat;
-	}
-
 	p.loading-placeholder {
-		animation: animatedBackground 10s linear infinite;
 		width: 300px;
-		height: 20px;
-
+		@include placeholder();
 	}
 	button.loading-placeholder {
-		animation: animatedBackground 20s linear infinite;
 		width: 150px;
-		pointer-events: none;
+		@include placeholder();
 	}
-	// Animation
-	@keyframes animatedBackground {
-		from {
-			background-position: 0 0;
-		}
-		to {
-			background-position: 1500px 0;
-		}
-	}
-
 }


### PR DESCRIPTION
## Proposed Changes

Add placeholders to improve UX.
In the `complete` step of the domain transfer flow, the request to fetch user's purchases takes some seconds, meanwhile we show a placeholder.


<img width="1000" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/afb87f28-0492-4a25-be08-63baf45439bf">


## Testing Instructions

- Pull and run this branch or use calypso live links
- Go to /setup/domain-transfer/complete
- Check if the placeholder is present while loading data.
