### PR TITLE
Don't show sharing modal for private or password protected posts

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -20,7 +20,12 @@ import useSharingModalDismissed from './use-sharing-modal-dismissed';
 import './style.scss';
 
 type CoreEditorPlaceholder = {
-	getCurrentPost: ( ...args: unknown[] ) => { link: string; title: string };
+	getCurrentPost: ( ...args: unknown[] ) => {
+		link: string;
+		title: string;
+		status: string;
+		password: string;
+	};
 	getCurrentPostType: ( ...args: unknown[] ) => string;
 	isCurrentPostPublished: ( ...args: unknown[] ) => boolean;
 };
@@ -33,7 +38,12 @@ const SharingModal: React.FC = () => {
 	const { __ } = useI18n();
 	const isPrivateBlog = window?.wpcomGutenberg?.blogPublic === '-1';
 
-	const { link, title } = useSelect(
+	const {
+		link,
+		title,
+		status: postStatus,
+		password: postPassword,
+	} = useSelect(
 		( select ) => ( select( 'core/editor' ) as CoreEditorPlaceholder ).getCurrentPost(),
 		[]
 	);
@@ -65,6 +75,9 @@ const SharingModal: React.FC = () => {
 			launchpadScreenOption !== 'full' &&
 			! previousIsCurrentPostPublished.current &&
 			isCurrentPostPublished &&
+			// Ensure post is published publicly and not private or password protected.
+			postStatus === 'publish' &&
+			! postPassword &&
 			postType === 'post'
 		) {
 			previousIsCurrentPostPublished.current = isCurrentPostPublished;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/78462

Checks the posts status and whether it has a password set before showing the post publish sharing modal.

### Testing instructions.

Sandbox a test site.
```
cd apps/editing-toolkit
yarn dev --sync
```

Create a new post.
Set the visibility to "private"
publish the post.
You should not see the sharing modal