### PR TITLE
Assembler - UX - New Colors and Fonts navigation to open on a side panel

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -17,3 +17,11 @@ export const NAVIGATOR_PATHS = {
 };
 
 export const STYLES_PATHS = [ NAVIGATOR_PATHS.COLOR_PALETTES, NAVIGATOR_PATHS.FONT_PAIRINGS ];
+
+export const MAIN_ITEMS = {
+	HEADER: 'header',
+	SECTION: 'section',
+	FOOTER: 'footer',
+	COLOR_PALETTES: 'color-palettes',
+	FONT_PAIRINGS: 'font-pairings',
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -380,6 +380,11 @@ const PatternAssembler = ( {
 		goBack?.();
 	};
 
+	const closePanel = () => {
+		setIsPanelOpen( false );
+		setSelectedMainItem( null );
+	};
+
 	const onSubmit = () => {
 		const design = getDesign();
 		const stylesheet = design.recipe?.stylesheet ?? '';
@@ -388,6 +393,8 @@ const PatternAssembler = ( {
 		if ( ! siteSlugOrId || ! site?.ID || ! themeId ) {
 			return;
 		}
+
+		closePanel();
 
 		if ( isEnabled( 'pattern-assembler/logged-in-showcase' ) ) {
 			setPendingAction( () =>
@@ -486,16 +493,9 @@ const PatternAssembler = ( {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.MAIN_ITEM_SELECT, { name } );
 
 		// The screen section is not using the panel
-		if ( name === MAIN_ITEMS.SECTION ) {
-			setIsPanelOpen( false );
-			setSelectedMainItem( null );
-			return;
-		}
-
-		if ( name === selectedMainItem ) {
+		if ( name === MAIN_ITEMS.SECTION || name === selectedMainItem ) {
 			// Toggle panel
-			setIsPanelOpen( false );
-			setSelectedMainItem( null );
+			closePanel();
 			return;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -27,7 +27,7 @@ import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { recordSelectedDesign, getAssemblerSource } from '../../analytics/record-design';
-import { SITE_TAGLINE, NAVIGATOR_PATHS, CATEGORY_ALL_SLUG } from './constants';
+import { SITE_TAGLINE, NAVIGATOR_PATHS, CATEGORY_ALL_SLUG, MAIN_ITEMS } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import useCategoryAll from './hooks/use-category-all';
 import useDotcomPatterns from './hooks/use-dotcom-patterns';
@@ -41,8 +41,6 @@ import PatternAssemblerContainer from './pattern-assembler-container';
 import PatternLargePreview from './pattern-large-preview';
 import ScreenActivation from './screen-activation';
 import ScreenCategoryList from './screen-category-list';
-import ScreenColorPalettes from './screen-color-palettes';
-import ScreenFontPairings from './screen-font-pairings';
 import ScreenMain from './screen-main';
 import ScreenSection from './screen-section';
 import { encodePatternId } from './utils';
@@ -318,7 +316,7 @@ const PatternAssembler = ( {
 		updateActivePatternPosition( position - 1 );
 	};
 
-	const onSelect = (
+	const onPatternSelect = (
 		type: string,
 		selectedPattern: Pattern | null,
 		selectedCategory?: string | null
@@ -484,10 +482,11 @@ const PatternAssembler = ( {
 		onSubmit();
 	};
 
-	const onMainItemSelect = ( { name, isPanel = false }: { name: string; isPanel?: boolean } ) => {
+	const onMainItemSelect = ( name: string ) => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.MAIN_ITEM_SELECT, { name } );
 
-		if ( ! isPanel ) {
+		// The screen section is not using the panel
+		if ( name === MAIN_ITEMS.SECTION ) {
 			setIsPanelOpen( false );
 			setSelectedMainItem( null );
 			return;
@@ -526,9 +525,9 @@ const PatternAssembler = ( {
 		moveDownSection( position );
 	};
 
-	const onDeleteHeader = () => onSelect( 'header', null );
+	const onDeleteHeader = () => onPatternSelect( 'header', null );
 
-	const onDeleteFooter = () => onSelect( 'footer', null );
+	const onDeleteFooter = () => onPatternSelect( 'footer', null );
 
 	const onScreenColorsSelect = ( variation: GlobalStylesObject | null ) => {
 		setColorVariation( variation );
@@ -538,28 +537,12 @@ const PatternAssembler = ( {
 		} );
 	};
 
-	const onScreenColorsBack = () => {
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_COLORS_BACK_CLICK );
-	};
-
-	const onScreenColorsDone = () => {
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_COLORS_DONE_CLICK );
-	};
-
 	const onScreenFontsSelect = ( variation: GlobalStylesObject | null ) => {
 		setFontVariation( variation );
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_FONTS_PREVIEW_CLICK, {
 			font_variation_title: getVariationTitle( variation ),
 			font_variation_type: getVariationType( variation ),
 		} );
-	};
-
-	const onScreenFontsBack = () => {
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_FONTS_BACK_CLICK );
-	};
-
-	const onScreenFontsDone = () => {
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_FONTS_DONE_CLICK );
 	};
 
 	if ( ! site?.ID || ! selectedDesign ) {
@@ -579,7 +562,8 @@ const PatternAssembler = ( {
 				<NavigatorScreen path={ NAVIGATOR_PATHS.MAIN }>
 					<ScreenMain
 						onMainItemSelect={ onMainItemSelect }
-						onSelect={ onSelect }
+						onPatternSelect={ onPatternSelect }
+						onScreenColorsSelect={ onScreenColorsSelect }
 						onContinueClick={ onContinueClick }
 						recordTracksEvent={ recordTracksEvent }
 						surveyDismissed={ surveyDismissed }
@@ -602,9 +586,13 @@ const PatternAssembler = ( {
 								return activateFooterPosition( !! footer );
 							}
 						} }
+						siteId={ site?.ID }
+						stylesheet={ stylesheet }
+						selectedColorPaletteVariation={ colorVariation }
+						selectedFontPairingVariation={ fontVariation }
+						onScreenFontsSelect={ onScreenFontsSelect }
 					/>
 				</NavigatorScreen>
-
 				<NavigatorScreen path={ NAVIGATOR_PATHS.SECTION }>
 					<ScreenSection
 						patterns={ sections }
@@ -623,36 +611,13 @@ const PatternAssembler = ( {
 						onDoneClick={ () => onDoneClick( 'section' ) }
 						replacePatternMode={ sectionPosition !== null }
 						selectedPattern={ sectionPosition !== null ? sections[ sectionPosition ] : null }
-						onSelect={ onSelect }
+						onSelect={ onPatternSelect }
 						recordTracksEvent={ recordTracksEvent }
 						onTogglePatternPanelList={ setIsPanelOpen }
 						selectedPatterns={ sections }
 						onBack={ onPatternSelectorBack }
 					/>
 				</NavigatorScreen>
-
-				<NavigatorScreen path={ NAVIGATOR_PATHS.COLOR_PALETTES }>
-					<ScreenColorPalettes
-						siteId={ site?.ID }
-						stylesheet={ stylesheet }
-						selectedColorPaletteVariation={ colorVariation }
-						onSelect={ onScreenColorsSelect }
-						onBack={ onScreenColorsBack }
-						onDoneClick={ onScreenColorsDone }
-					/>
-				</NavigatorScreen>
-
-				<NavigatorScreen path={ NAVIGATOR_PATHS.FONT_PAIRINGS }>
-					<ScreenFontPairings
-						siteId={ site?.ID }
-						stylesheet={ stylesheet }
-						selectedFontPairingVariation={ fontVariation }
-						onSelect={ onScreenFontsSelect }
-						onBack={ onScreenFontsBack }
-						onDoneClick={ onScreenFontsDone }
-					/>
-				</NavigatorScreen>
-
 				<NavigatorScreen path={ NAVIGATOR_PATHS.ACTIVATION } className="screen-activation">
 					<ScreenActivation onActivate={ onActivate } />
 				</NavigatorScreen>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -394,8 +394,6 @@ const PatternAssembler = ( {
 			return;
 		}
 
-		closePanel();
-
 		if ( isEnabled( 'pattern-assembler/logged-in-showcase' ) ) {
 			setPendingAction( () =>
 				Promise.resolve()
@@ -436,6 +434,7 @@ const PatternAssembler = ( {
 	};
 
 	const handleContinue = () => {
+		closePanel();
 		if ( isNewSite ) {
 			onSubmit();
 		} else {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -17,19 +17,13 @@ import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { NAVIGATOR_PATHS } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import NavigatorTitle from './navigator-title';
-import PatternListPanel from './pattern-list-panel';
+import SidebarPanel, { SidebarPanelProps } from './sidebar-panel/sidebar-panel';
 import Survey from './survey';
-import { Pattern, Category } from './types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { MouseEvent } from 'react';
 
-interface Props {
-	onSelect: (
-		type: string,
-		selectedPattern: Pattern | null,
-		selectedCategory: string | null
-	) => void;
-	onMainItemSelect: ( { name, isPanel }: { name: string; isPanel?: boolean } ) => void;
+type Props = {
+	onMainItemSelect: ( name: string ) => void;
 	onContinueClick: ( callback?: () => void ) => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 	surveyDismissed: boolean;
@@ -40,32 +34,24 @@ interface Props {
 	hasColor: boolean;
 	hasFont: boolean;
 	selectedMainItem: string | null;
-	selectedHeader: Pattern | null;
-	selectedFooter: Pattern | null;
 	updateActivePatternPosition: () => void;
-	categories: Category[];
-	patternsMapByCategory: { [ key: string ]: Pattern[] };
-}
+} & SidebarPanelProps;
 
-const ScreenMain = ( {
-	onSelect,
-	onMainItemSelect,
-	onContinueClick,
-	recordTracksEvent,
-	surveyDismissed,
-	setSurveyDismissed,
-	hasSections,
-	hasHeader,
-	hasFooter,
-	hasColor,
-	hasFont,
-	selectedMainItem,
-	selectedHeader,
-	selectedFooter,
-	updateActivePatternPosition,
-	categories,
-	patternsMapByCategory,
-}: Props ) => {
+const ScreenMain = ( props: Props ) => {
+	const {
+		onMainItemSelect,
+		onContinueClick,
+		recordTracksEvent,
+		surveyDismissed,
+		setSurveyDismissed,
+		hasSections,
+		hasHeader,
+		hasFooter,
+		hasColor,
+		hasFont,
+		selectedMainItem,
+		updateActivePatternPosition,
+	} = props;
 	const translate = useTranslate();
 	const [ disabled, setDisabled ] = useState( true );
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
@@ -91,38 +77,6 @@ const ScreenMain = ( {
 	const handleClick = () => {
 		if ( ! disabled ) {
 			onContinueClick();
-		}
-	};
-
-	const getSelectedPattern = () => {
-		if ( 'header' === selectedMainItem ) {
-			return selectedHeader;
-		}
-		if ( 'footer' === selectedMainItem ) {
-			return selectedFooter;
-		}
-		return null;
-	};
-
-	const getLabel = () => {
-		if ( 'header' === selectedMainItem ) {
-			return translate( 'Header' );
-		}
-		if ( 'footer' === selectedMainItem ) {
-			return translate( 'Footer' );
-		}
-	};
-
-	const getDescription = () => {
-		if ( 'header' === selectedMainItem ) {
-			return translate(
-				'The header appears at the top of every page, with a site name and navigation.'
-			);
-		}
-		if ( 'footer' === selectedMainItem ) {
-			return translate(
-				'The footer appears at the bottom of a site and shows useful links and contact information.'
-			);
 		}
 	};
 
@@ -172,7 +126,7 @@ const ScreenMain = ( {
 							path={ NAVIGATOR_PATHS.MAIN }
 							icon={ header }
 							aria-label={ translate( 'Header' ) }
-							onClick={ () => onMainItemSelect( { name: 'header', isPanel: true } ) }
+							onClick={ () => onMainItemSelect( 'header' ) }
 							active={ getIsActiveButton( 'header' ) }
 						>
 							{ translate( 'Header' ) }
@@ -182,7 +136,7 @@ const ScreenMain = ( {
 							path={ hasSections ? NAVIGATOR_PATHS.SECTION : NAVIGATOR_PATHS.SECTION_PATTERNS }
 							icon={ layout }
 							aria-label={ translate( 'Homepage' ) }
-							onClick={ () => onMainItemSelect( { name: 'section' } ) }
+							onClick={ () => onMainItemSelect( 'section' ) }
 						>
 							{ translate( 'Homepage' ) }
 						</NavigationButtonAsItem>
@@ -191,7 +145,7 @@ const ScreenMain = ( {
 							path={ NAVIGATOR_PATHS.MAIN }
 							icon={ footer }
 							aria-label={ translate( 'Footer' ) }
-							onClick={ () => onMainItemSelect( { name: 'footer', isPanel: true } ) }
+							onClick={ () => onMainItemSelect( 'footer' ) }
 							active={ getIsActiveButton( 'footer' ) }
 						>
 							{ translate( 'Footer' ) }
@@ -201,19 +155,21 @@ const ScreenMain = ( {
 						<>
 							<NavigationButtonAsItem
 								checked={ hasColor }
-								path={ NAVIGATOR_PATHS.COLOR_PALETTES }
+								path={ NAVIGATOR_PATHS.MAIN }
 								icon={ color }
 								aria-label={ translate( 'Colors' ) }
-								onClick={ () => onMainItemSelect( { name: 'color-palettes' } ) }
+								onClick={ () => onMainItemSelect( 'color-palettes' ) }
+								active={ getIsActiveButton( 'color-palettes' ) }
 							>
 								{ translate( 'Colors' ) }
 							</NavigationButtonAsItem>
 							<NavigationButtonAsItem
 								checked={ hasFont }
-								path={ NAVIGATOR_PATHS.FONT_PAIRINGS }
+								path={ NAVIGATOR_PATHS.MAIN }
 								icon={ typography }
 								aria-label={ translate( 'Fonts' ) }
-								onClick={ () => onMainItemSelect( { name: 'font-pairings' } ) }
+								onClick={ () => onMainItemSelect( 'font-pairings' ) }
+								active={ getIsActiveButton( 'font-pairings' ) }
 							>
 								{ translate( 'Fonts' ) }
 							</NavigationButtonAsItem>
@@ -236,19 +192,7 @@ const ScreenMain = ( {
 					{ translate( 'Continue' ) }
 				</Button>
 			</div>
-			{ selectedMainItem && (
-				<PatternListPanel
-					onSelect={ ( selectedPattern: Pattern | null ) =>
-						onSelect( selectedMainItem, selectedPattern, selectedMainItem )
-					}
-					selectedPattern={ getSelectedPattern() }
-					label={ getLabel() }
-					description={ getDescription() }
-					selectedCategory={ selectedMainItem }
-					categories={ categories }
-					patternsMapByCategory={ patternsMapByCategory }
-				/>
-			) }
+			<SidebarPanel { ...props } />
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/sidebar-panel/panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/sidebar-panel/panel.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+const Panel = ( {
+	label,
+	description,
+	children,
+}: {
+	children: ReactNode;
+	label?: string;
+	description?: string;
+} ) => {
+	return (
+		<div key="panel" className="pattern-list-panel__wrapper">
+			<div className="pattern-list-panel__title">{ label }</div>
+			<div className="pattern-list-panel__description">{ description }</div>
+			{ children }
+		</div>
+	);
+};
+
+export default Panel;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/sidebar-panel/sidebar-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/sidebar-panel/sidebar-panel.tsx
@@ -1,0 +1,149 @@
+import { ColorPaletteVariations, FontPairingVariations } from '@automattic/global-styles';
+import { useTranslate } from 'i18n-calypso';
+import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
+import { MAIN_ITEMS } from '../constants';
+import PatternListPanel from '../pattern-list-panel';
+import { Pattern, Category } from '../types';
+import Panel from './panel';
+import type { GlobalStylesObject } from '@automattic/global-styles';
+
+export type SidebarPanelProps = {
+	siteId: number | string;
+	stylesheet: string;
+	categories: Category[];
+	patternsMapByCategory: { [ key: string ]: Pattern[] };
+	selectedMainItem: string | null;
+	selectedHeader: Pattern | null;
+	selectedFooter: Pattern | null;
+	selectedColorPaletteVariation: GlobalStylesObject | null;
+	selectedFontPairingVariation: GlobalStylesObject | null;
+	onPatternSelect: (
+		type: string,
+		selectedPattern: Pattern | null,
+		selectedCategory: string | null
+	) => void;
+	onScreenColorsSelect: ( colorPaletteVariation: GlobalStylesObject | null ) => void;
+	onScreenFontsSelect: ( fontPairingVariation: GlobalStylesObject | null ) => void;
+};
+
+const SidebarPanel = ( {
+	siteId,
+	stylesheet,
+	categories,
+	patternsMapByCategory,
+	selectedMainItem,
+	selectedHeader,
+	selectedFooter,
+	selectedColorPaletteVariation,
+	selectedFontPairingVariation,
+	onPatternSelect,
+	onScreenColorsSelect,
+	onScreenFontsSelect,
+}: SidebarPanelProps ) => {
+	const translate = useTranslate();
+	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId );
+
+	// Get props for selected main item
+	const getSelectedPattern = () => {
+		if ( MAIN_ITEMS.HEADER === selectedMainItem ) {
+			return selectedHeader;
+		}
+		if ( MAIN_ITEMS.FOOTER === selectedMainItem ) {
+			return selectedFooter;
+		}
+		return null;
+	};
+
+	const getLabel = () => {
+		if ( MAIN_ITEMS.HEADER === selectedMainItem ) {
+			return translate( 'Header' );
+		}
+		if ( MAIN_ITEMS.FOOTER === selectedMainItem ) {
+			return translate( 'Footer' );
+		}
+		if ( MAIN_ITEMS.COLOR_PALETTES === selectedMainItem ) {
+			return translate( 'Colors' );
+		}
+		if ( MAIN_ITEMS.FONT_PAIRINGS === selectedMainItem ) {
+			return translate( 'Fonts' );
+		}
+	};
+
+	const getDescription = () => {
+		if ( MAIN_ITEMS.HEADER === selectedMainItem ) {
+			return translate(
+				'The header appears at the top of every page, with a site name and navigation.'
+			);
+		}
+		if ( MAIN_ITEMS.FOOTER === selectedMainItem ) {
+			return translate(
+				'The footer appears at the bottom of a site and shows useful links and contact information.'
+			);
+		}
+		if ( MAIN_ITEMS.COLOR_PALETTES === selectedMainItem ) {
+			return translate(
+				'Choose from our curated color palettes when you upgrade to the Premium plan or above.'
+			);
+		}
+		if ( MAIN_ITEMS.FONT_PAIRINGS === selectedMainItem ) {
+			return translate(
+				'Choose from our curated font pairings when you upgrade to the Premium plan or above.'
+			);
+		}
+	};
+
+	// Render
+	if ( ! selectedMainItem ) {
+		return null;
+	}
+
+	// Patterns
+	if ( [ MAIN_ITEMS.HEADER, MAIN_ITEMS.FOOTER ].includes( selectedMainItem ) ) {
+		return (
+			<PatternListPanel
+				label={ getLabel() }
+				description={ getDescription() }
+				onSelect={ ( selectedPattern: Pattern | null ) =>
+					onPatternSelect( selectedMainItem, selectedPattern, selectedMainItem )
+				}
+				categories={ categories }
+				selectedPattern={ getSelectedPattern() }
+				selectedCategory={ selectedMainItem }
+				patternsMapByCategory={ patternsMapByCategory }
+			/>
+		);
+	}
+
+	// Styles
+	if ( MAIN_ITEMS.COLOR_PALETTES === selectedMainItem ) {
+		return (
+			<Panel label={ getLabel() } description={ getDescription() }>
+				<ColorPaletteVariations
+					siteId={ siteId }
+					stylesheet={ stylesheet }
+					selectedColorPaletteVariation={ selectedColorPaletteVariation }
+					onSelect={ onScreenColorsSelect }
+					limitGlobalStyles={ shouldLimitGlobalStyles }
+				/>
+			</Panel>
+		);
+	}
+
+	if ( MAIN_ITEMS.FONT_PAIRINGS === selectedMainItem ) {
+		return (
+			<Panel label={ getLabel() } description={ getDescription() }>
+				<FontPairingVariations
+					siteId={ siteId }
+					stylesheet={ stylesheet }
+					selectedFontPairingVariation={ selectedFontPairingVariation }
+					onSelect={ onScreenFontsSelect }
+					limitGlobalStyles={ shouldLimitGlobalStyles }
+				/>
+			</Panel>
+		);
+	}
+
+	return null;
+};
+
+export default SidebarPanel;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -353,7 +353,7 @@ $font-family: "SF Pro Text", $sans;
 		display: block;
 	}
 
-	.navigator-button--is-active {
+	.navigator-button.navigator-button--is-active {
 		background-color: var(--studio-blue-0);
 		color: var(--studio-blue-50);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78987

## Proposed Changes

This PR uses #78987 as a base so we can test the new header and footer navigation

* Show colors and fonts in a panel


https://github.com/Automattic/wp-calypso/assets/1881481/558ab2e7-684c-4140-8c4f-79272dcc6a0d


### Pending tasks

- Move the focus automatically to the first font/color on the list when the panel opens
- Any style updates on the panel? We are using the same title and description styles as in the patterns panel. cc: @lucasmendes-design 
- Others?


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }&theme=blank-canvas-3`
* Click on "Header", "Footer", or "Homepage" to add patterns
* Click on "Colors" and "Fonts" to choose a color/font from the panel
* Verify the active state of the colors/fonts button
* Verify the hover, focus, and checked states of the colors/fonts button on the main screen look as before
* Verify that tracks events are not affected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
