### PR TITLE
Launchpad: Handler for update_about_page task

### DIFF
--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -67,6 +67,11 @@ export const setUpActionsForTasks = ( {
 					setShareSiteModalIsOpen?.( true );
 				};
 				break;
+			case 'update_about_page':
+				action = () => {
+					window.location.assign( `/page/${ siteSlug }/${ task?.extra_data?.about_page_id }` );
+				};
+				break;
 		}
 
 		const actionDispatch = () => {

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -1,3 +1,6 @@
+export interface TaskExtraData {
+	about_page_id?: number;
+}
 export interface Task {
 	id: string;
 	completed: boolean;
@@ -7,7 +10,7 @@ export interface Task {
 	badge_text?: string;
 	actionDispatch?: () => void;
 	isLaunchTask?: boolean;
-	extra_data?: any;
+	extra_data?: TaskExtraData;
 }
 
 export type LaunchpadChecklist = Task[];

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -7,6 +7,7 @@ export interface Task {
 	badge_text?: string;
 	actionDispatch?: () => void;
 	isLaunchTask?: boolean;
+	extra_data?: any;
 }
 
 export type LaunchpadChecklist = Task[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78951

## Proposed Changes

This adds the handler for the `update_about_page` task. Clicking the task takes the user to the edit view for the 'About' page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See [Jetpack PR 31966](https://github.com/Automattic/jetpack/pull/31966) for testing instructions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
