### PR TITLE
Launchpad: Fix issue with duplicate skip links on Newsletter flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -6,14 +6,12 @@ import { useSelect } from '@wordpress/data';
 import { useRef, useState } from '@wordpress/element';
 import { Icon, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import Badge from 'calypso/components/badge';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Tooltip from 'calypso/components/tooltip';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { useSelector } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
@@ -29,7 +27,6 @@ type SidebarProps = {
 	goNext: NavigationControls[ 'goNext' ];
 	goToStep?: NavigationControls[ 'goToStep' ];
 	flow: string | null;
-	hideNavigation: boolean | null;
 };
 
 function getUrlInfo( url: string ) {
@@ -43,15 +40,7 @@ function getUrlInfo( url: string ) {
 	return [ siteName, topLevelDomain ];
 }
 
-const Sidebar = ( {
-	sidebarDomain,
-	siteSlug,
-	submit,
-	goNext,
-	goToStep,
-	flow,
-	hideNavigation,
-}: SidebarProps ) => {
+const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarProps ) => {
 	let siteName = '';
 	let topLevelDomain = '';
 	let showClipboardButton = false;
@@ -227,19 +216,6 @@ const Sidebar = ( {
 					makeLastTaskPrimaryAction={ true }
 				/>
 			</div>
-			{ ! hideNavigation && (
-				<div className="launchpad__sidebar-admin-link">
-					<StepNavigationLink
-						direction="forward"
-						handleClick={ () => {
-							recordTracksEvent( 'calypso_launchpad_go_to_admin_clicked', { flow: flow } );
-							goNext?.();
-						} }
-						label={ translate( 'Skip to dashboard' ) }
-						borderless={ true }
-					/>
-				</div>
-			) }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -64,7 +64,6 @@ const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentP
 					goNext={ goNext }
 					goToStep={ goToStep }
 					flow={ flow }
-					hideNavigation={ flow !== 'newsletter' }
 				/>
 				<LaunchpadSitePreview flow={ flow } siteSlug={ iFrameURL } />
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -29,6 +29,8 @@
 	}
 
 	.step-container__content {
+		margin-bottom: 50px;
+
 		@include break-large {
 			height: 100vh;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -153,13 +153,6 @@ describe( 'Sidebar', () => {
 		props.sidebarDomain = sidebarDomain;
 	} );
 
-	it( 'displays an escape hatch from Launchpad that will take the user to Calypso my Home', () => {
-		renderSidebar( props );
-
-		const escapeHatchButton = screen.getByRole( 'button', { name: /Skip to dashboard/i } );
-		expect( escapeHatchButton ).toBeVisible();
-	} );
-
 	it( 'displays the current site url', () => {
 		renderSidebar( props );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -232,12 +232,6 @@ describe( 'StepContent', () => {
 			expect( firstPostListItem ).toHaveClass( 'completed' );
 		} );
 
-		it( 'renders skip to dashboard link', () => {
-			renderStepContent( false, NEWSLETTER_FLOW );
-
-			expect( screen.getByRole( 'button', { name: 'Skip to dashboard' } ) ).toBeInTheDocument();
-		} );
-
 		it( 'renders web preview section', () => {
 			renderStepContent( false, NEWSLETTER_FLOW );
 


### PR DESCRIPTION
The Newsletter flow was showing both 'Skip to dashboard' and 'Skip for now'. This fixes it so we just show 'Skip for now'

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76965

## Proposed Changes

The newsletter flow was showing both the 'Skip to dashboard' _and_ 'Skip for now' links. This removes the 'Skip to dashboard' link.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch or use the calypso.live link.
* Go to `/setup/newsletter` and work through the flow.
* When you reach the Launchpad, verify only the 'Skip for now' link is there.

![image](https://github.com/Automattic/wp-calypso/assets/917632/8e81788e-0e7f-4d19-88cb-a0cf7ef7e207)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
