### PR TITLE
Sidebar: Set `return` param only is URL is defined

### DIFF
--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -25,7 +25,7 @@ const sanitizeUrl = ( url, wpAdminUrl ) => {
 	);
 
 	// Gives WP Admin Customizer a chance to return to where we started from.
-	if ( isSafeWpAdminUrl && url.includes( 'wp-admin/customize.php' ) ) {
+	if ( isSafeWpAdminUrl && url?.includes( 'wp-admin/customize.php' ) ) {
 		url = addQueryArgs(
 			{
 				return: document.location.href,


### PR DESCRIPTION
## Proposed Changes

Fixes an error flagged by Sentry (p1688561883490759-slack-C04U5A26MJB) where we were mistakenly trying to add a `return` param to a undefined URL in the sidebar.

## Testing Instructions

- Open the Calypso live link below.
- Make sure that "Appearance > Customizer" link still contains a return param.