### PR TITLE
My Home: Avoid moving to next task in setup if current task is undefined

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -168,7 +168,7 @@ const SiteSetupList = ( {
 		}
 		if ( currentTaskId && currentTask && tasks.length ) {
 			const rawCurrentTask = tasks.find( ( task ) => task.id === currentTaskId );
-			if ( rawCurrentTask.isCompleted && ! currentTask.isCompleted ) {
+			if ( rawCurrentTask?.isCompleted && ! currentTask.isCompleted ) {
 				const nextTaskId = tasks.find( ( task ) => ! task.isCompleted )?.id;
 				setTaskIsManuallySelected( false );
 				setCurrentTaskId( nextTaskId );


### PR DESCRIPTION
## Proposed Changes

Fixes an error flagged by Sentry (p1688651740375919-slack-C04U5A26MJB) where we were trying move to the next site setup task in My Home when the current task is undefined. add a `return` param to a undefined URL in the sidebar.

## Testing Instructions

- Open the Calypso live link below.
- Go to `/start` and create a new site.
- In the Goals screen, select "Sell online" to prevent the Launchpad from appearing.
- Complete the rest of the onboarding until you land in My Home.
- in the site setup list, click on the first task available (e.g. "Give your site a name) and complete it.
- Go back to My Home.
- Make sure the next task available is activated automatically.