### PR TITLE
Edge Cache: Remove Edge Cache feature flag

### DIFF
--- a/client/my-sites/hosting/cache-card/index.js
+++ b/client/my-sites/hosting/cache-card/index.js
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
 import { Button, Card } from '@automattic/components';
 import styled from '@emotion/styled';
 import { ToggleControl } from '@wordpress/components';
@@ -67,14 +66,11 @@ export const CacheCard = ( {
 	siteSlug,
 	translate,
 } ) => {
-	const showEdgeCache = config.isEnabled( 'yolo/edge-cache-i1' );
 	const {
 		isLoading: getEdgeCacheLoading,
 		data: isEdgeCacheActive,
 		isInitialLoading: getEdgeCacheInitialLoading,
-	} = useEdgeCacheQuery( siteId, {
-		enabled: showEdgeCache,
-	} );
+	} = useEdgeCacheQuery( siteId, {} );
 
 	const isEdgeCacheEligible = ! isPrivate && ! isComingSoon;
 
@@ -105,7 +101,7 @@ export const CacheCard = ( {
 	const isClearingCache = isClearingWordpressCache || clearEdgeCacheLoading;
 
 	const clearCache = () => {
-		if ( isEdgeCacheActive && showEdgeCache ) {
+		if ( isEdgeCacheActive ) {
 			clearEdgeCache();
 		}
 		clearAtomicWordPressCache( siteId, 'Manually clearing again.' );
@@ -122,7 +118,8 @@ export const CacheCard = ( {
 						disabled ||
 						isClearingCache ||
 						shouldRateLimitCacheClear ||
-						( showEdgeCache && ( getEdgeCacheLoading || toggleEdgeCacheLoading ) )
+						getEdgeCacheLoading ||
+						toggleEdgeCacheLoading
 					}
 				>
 					<span>{ translate( 'Clear cache' ) }</span>
@@ -167,28 +164,22 @@ export const CacheCard = ( {
 						},
 					} ) }
 				</EdgeCacheDescription>
-				{ showEdgeCache && (
-					<>
-						<ToggleContainer>
-							{ getEdgeCacheInitialLoading ? (
-								<EdgeCacheLoadingPlaceholder />
-							) : (
-								<>
-									<ToggleLabel>{ translate( 'Global edge cache' ) }</ToggleLabel>
-									<ToggleControl
-										disabled={
-											clearEdgeCacheLoading || getEdgeCacheLoading || ! isEdgeCacheEligible
-										}
-										checked={ isEdgeCacheActive }
-										onChange={ toggleEdgeCache }
-										label={ edgeCacheToggleDescription }
-									/>
-									<Hr />
-								</>
-							) }
-						</ToggleContainer>
-					</>
-				) }
+				<ToggleContainer>
+					{ getEdgeCacheInitialLoading ? (
+						<EdgeCacheLoadingPlaceholder />
+					) : (
+						<>
+							<ToggleLabel>{ translate( 'Global edge cache' ) }</ToggleLabel>
+							<ToggleControl
+								disabled={ clearEdgeCacheLoading || getEdgeCacheLoading || ! isEdgeCacheEligible }
+								checked={ isEdgeCacheActive }
+								onChange={ toggleEdgeCache }
+								label={ edgeCacheToggleDescription }
+							/>
+							<Hr />
+						</>
+					) }
+				</ToggleContainer>
 				{ getClearCacheContent() }
 			</CardBody>
 		</Card>

--- a/client/my-sites/hosting/cache-card/test/index.js
+++ b/client/my-sites/hosting/cache-card/test/index.js
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import config from '@automattic/calypso-config';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -9,8 +8,6 @@ import { useClearEdgeCacheMutation } from 'calypso/my-sites/hosting/cache-card/u
 import { useEdgeCacheQuery } from 'calypso/my-sites/hosting/cache-card/use-edge-cache';
 import { useToggleEdgeCacheMutation } from 'calypso/my-sites/hosting/cache-card/use-toggle-edge-cache';
 import { CacheCard } from '..';
-
-const EDGE_CACHE_FEATURE = 'yolo/edge-cache-i1';
 
 const INITIAL_STATE = {
 	sites: {
@@ -155,32 +152,13 @@ describe( 'CacheCard component', () => {
 		expect( useClearEdgeCacheMutation().clearEdgeCache ).toHaveBeenCalledTimes( 1 );
 		expect( defaultProps.clearAtomicWordPressCache ).toHaveBeenCalledTimes( 1 );
 	} );
-	it( 'hides the checkbox button when the feature is disabled', () => {
-		config.enable( EDGE_CACHE_FEATURE );
-		const { rerender } = render(
-			<Provider store={ store }>
-				<CacheCard { ...{ ...defaultProps } } />
-			</Provider>
-		);
-		expect( screen.queryByRole( 'checkbox' ) ).toBeTruthy();
-		config.disable( EDGE_CACHE_FEATURE );
-		rerender(
-			<Provider store={ store }>
-				<CacheCard { ...{ ...defaultProps } } />
-			</Provider>
-		);
-		expect( screen.queryByRole( 'checkbox' ) ).toBeFalsy();
-	} );
-
-	it( 'shows the Clear Cache button regardless of the feature status', () => {
-		// The loading is true in case the feature is disabled
+	it( 'shows the Clear Cache button', () => {
 		useEdgeCacheQuery.mockReturnValue( { data: true, isLoading: true } );
 		useClearEdgeCacheMutation.mockReturnValue( {
 			clearEdgeCache: jest.fn(),
 			isLoading: false,
 		} );
-		config.enable( EDGE_CACHE_FEATURE );
-		const { rerender } = render(
+		render(
 			<Provider store={ store }>
 				<CacheCard { ...{ ...defaultProps } } />
 			</Provider>
@@ -188,15 +166,5 @@ describe( 'CacheCard component', () => {
 		expect( screen.queryByRole( 'button' ) ).toBeTruthy();
 		expect( screen.queryByRole( 'button' ) ).toBeDisabled();
 		fireEvent.click( screen.getByRole( 'button' ) );
-		config.disable( EDGE_CACHE_FEATURE );
-		rerender(
-			<Provider store={ store }>
-				<CacheCard { ...{ ...defaultProps } } />
-			</Provider>
-		);
-		expect( screen.queryByRole( 'button' ) ).toBeTruthy();
-		expect( screen.queryByRole( 'button' ) ).toBeEnabled();
-		fireEvent.click( screen.getByRole( 'button' ) );
-		expect( useClearEdgeCacheMutation().clearEdgeCache ).toHaveBeenCalledTimes( 0 );
 	} );
 } );

--- a/client/my-sites/hosting/cache-card/use-edge-cache.ts
+++ b/client/my-sites/hosting/cache-card/use-edge-cache.ts
@@ -14,7 +14,7 @@ export const useEdgeCacheQuery = (
 				path: `/sites/${ siteId }/hosting/edge-cache/active`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		enabled: !! siteId && ( options?.enabled ?? true ),
+		enabled: !! siteId,
 		select: ( data ) => {
 			return !! data;
 		},

--- a/config/development.json
+++ b/config/development.json
@@ -61,7 +61,6 @@
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
-		"yolo/edge-cache-i1": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,
 		"external-media/openverse": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -32,7 +32,6 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
-		"yolo/edge-cache-i1": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,
 		"external-media/openverse": true,

--- a/config/production.json
+++ b/config/production.json
@@ -41,7 +41,6 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
-		"yolo/edge-cache-i1": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,
 		"external-media/openverse": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,7 +38,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"yolo/edge-cache-i1": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/test.json
+++ b/config/test.json
@@ -40,7 +40,6 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"difm/allow-extra-pages": false,
 		"cookie-banner": false,
-		"yolo/edge-cache-i1": true,
 		"google-my-business": false,
 		"help": true,
 		"importers/substack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,7 +43,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"yolo/edge-cache-i1": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2954

## Proposed Changes

In this diff, I propose to remove code related to the Edge Cache feature flag and a test case we don't need anymore.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test if Global Edge Cache is still available for Atomic sites, toggle cache on, off, and try clearing cache.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
