### PR TITLE
GS on Personal A/B: Display correct plan in welcome modal

### DIFF
--- a/packages/global-styles/src/strings.ts
+++ b/packages/global-styles/src/strings.ts
@@ -1,0 +1,11 @@
+import { useTranslate } from 'i18n-calypso';
+
+const GlobalStylesTemporaryStrings = () => {
+	const translate = useTranslate();
+	translate( "Change all of your site's fonts, colors and more. Available on the Personal plan." );
+	translate( "Change all of your site's fonts, colors and more. Available on the Premium plan." );
+};
+
+if ( window.DummyVariable ) {
+	window.DummyVariable.strings = GlobalStylesTemporaryStrings;
+}


### PR DESCRIPTION

## Proposed Changes

* Don't merge. Used for translations.

<img width="1728" alt="251388562-478c663d-6abf-4297-93cf-360f1e0f04f3" src="https://github.com/Automattic/wp-calypso/assets/7847633/94ec168c-16de-496f-a920-58b0d46f9d74">
