### PR TITLE
Add pluralized subheader text

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -56,8 +56,10 @@ const Complete: Step = function Complete( { flow } ) {
 							'Congrats on your domain transfers',
 							newlyTransferredDomains?.length || storedDomainsAmount
 						) }
-						subHeaderText={ __(
-							'Hold tight as we complete the set up of your newly transferred domain.'
+						subHeaderText={ _n(
+							'Hold tight as we complete the set up of your newly transferred domain.',
+							'Hold tight as we complete the set up of your newly transferred domains.',
+							newlyTransferredDomains?.length || storedDomainsAmount
 						) }
 						align="center"
 						children={


### PR DESCRIPTION

## Proposed Changes

Simple text fixes on the subheader title when transferring more than one domain

If one domain -> `Hold tight as we complete the set up of your newly transferred domain.`
Many -> `Hold tight as we complete the set up of your newly transferred domains.`

## Testing Instructions
Pull and run this branch or use calypso live link
Navigate to setup/domain-transfer/complete
Go to setup/domain-transfer/domains
Add one domain, no need to submit.
Go to setup/domain-transfer/complete
You should see “Hold tight as we complete the set up of your newly transferred domain.” (singular).
Go to setup/domain-transfer/domains
Add 2
Go to setup/domain-transfer/complete
“Hold tight as we complete the set up of your newly transferred domains” (plural domainS)
