### PR TITLE
Gravatar toggle: Remove CSS fix which is no longed needed

### DIFF
--- a/client/me/profile/style.scss
+++ b/client/me/profile/style.scss
@@ -8,10 +8,6 @@
 	}
 }
 
-.profile__settings .components-form-toggle {
-	min-width: auto;
-}
-
 @media ( min-width: 961px ) {
 	.me-profile-settings .edit-gravatar {
 		margin-bottom: 0;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2160

## Proposed Changes

In this diff, I propose to remove the CSS code added in https://github.com/Automattic/wp-calypso/pull/75385 to fix Gravatar toggle overflow.

The fix is no longer needed as `@wordpress/components` package was upgraded to `v23.x` and the issue was fixed in `22.1.0`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/me`
2. Check that the "Hide my photo and Gravatar profile" toggle does not overlap the text

<img width="760" alt="Screenshot 2023-07-06 at 17 31 20" src="https://github.com/Automattic/wp-calypso/assets/727413/49d53e2a-a8eb-43cf-b098-0fa9e5a228c8">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
