### PR TITLE
Add tablet Launchpad preview for blog onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -7,6 +7,7 @@ import {
 	WRITE_FLOW,
 	START_WRITING_FLOW,
 	DESIGN_FIRST_FLOW,
+	isBlogOnboardingFlow,
 } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -29,7 +30,9 @@ const LaunchpadSitePreview = ( {
 	const isInVideoPressFlow = isVideoPressFlow( flow );
 
 	let previewUrl = siteSlug ? 'https://' + siteSlug : null;
-	const devicesToShow: Device[] = [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.PHONE ];
+	const devicesToShow: Device[] = isBlogOnboardingFlow( flow )
+		? [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.TABLET, DEVICE_TYPES.PHONE ]
+		: [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.PHONE ];
 	let defaultDevice = getSitePreviewDefaultDevice( flow );
 	let loadingMessage = translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
 		components: { strong: <strong /> },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -7,7 +7,6 @@ import {
 	WRITE_FLOW,
 	START_WRITING_FLOW,
 	DESIGN_FIRST_FLOW,
-	isBlogOnboardingFlow,
 } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -30,9 +29,11 @@ const LaunchpadSitePreview = ( {
 	const isInVideoPressFlow = isVideoPressFlow( flow );
 
 	let previewUrl = siteSlug ? 'https://' + siteSlug : null;
-	const devicesToShow: Device[] = isBlogOnboardingFlow( flow )
-		? [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.TABLET, DEVICE_TYPES.PHONE ]
-		: [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.PHONE ];
+	const devicesToShow: Device[] = [
+		DEVICE_TYPES.COMPUTER,
+		DEVICE_TYPES.TABLET,
+		DEVICE_TYPES.PHONE,
+	];
 	let defaultDevice = getSitePreviewDefaultDevice( flow );
 	let loadingMessage = translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
 		components: { strong: <strong /> },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -342,6 +342,12 @@
 		}
 	}
 
+	.is-tablet .web-preview__placeholder {
+		@include break-large {
+			max-width: 783px;
+		}
+	}
+
 	.web-preview__placeholder {
 		overflow-y: visible;
 		max-width: 100%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2590

## Proposed Changes

* This PR adds a tablet preview to the blog onboarding Launchpad.

![tablet-view](https://github.com/Automattic/wp-calypso/assets/140841/19926c2e-35b1-4495-80c9-3cc2411c55f5)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Go to http://calypso.localhost:3000/setup/design-first/ or http://calypso.localhost:3000/setup/start-writing/
* Progress through the flow until you reach the Launchpad.
* The tablet preview should be available and functional at the top of the Launchpad preview.
* The tablet preview should only be visible for blog onboarding. Try another onboarding flow like http://calypso.localhost:3000/setup/link-in-bio/ to confirm the tablet preview is not visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
