### PR TITLE
Domain transfer: Fix redirect domain url

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
@@ -18,12 +18,12 @@ export const CompleteDomainsTransferred = ( {
 			<div className="domain-complete-summary">
 				<ul className="domain-complete-list">
 					{ newlyTransferredDomains
-						? newlyTransferredDomains.map( ( { meta }, key ) => {
+						? newlyTransferredDomains.map( ( { meta, domain }, key ) => {
 								return (
 									<li className="domain-complete-list-item" key={ key }>
 										<h2>{ meta }</h2>
 										<a
-											href={ `/domains/manage/${ meta }` }
+											href={ `/domains/manage/all/${ meta }/transfer/in/${ domain }` }
 											className="components-button is-secondary"
 										>
 											{ __( 'Manage domain' ) }


### PR DESCRIPTION

## Proposed Changes

Fix the redirect URL domain

## Testing Instructions

- Pull and run this branch or use calypso live link
- Navigate to setup/domain-transfer/complete
- Check if by clicking on `manage domain `button, you will be redirected to `/domains/manage/all/"yourdomain.com"/transfer/in/"yourdomain` 

