### PR TITLE
Checkout: add support for using new cards for free purchases

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -6,7 +6,6 @@ import {
 } from '@automattic/composite-checkout';
 import { ManagedContactDetails } from '@automattic/wpcom-checkout';
 import { addQueryArgs } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
 import wp from 'calypso/lib/wp';
 import { getTaxValidationResult } from 'calypso/my-sites/checkout/composite-checkout/lib/contact-validation';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -20,6 +19,7 @@ import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { Stripe, StripeCardNumberElement } from '@stripe/stripe-js';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { CalypsoDispatch } from 'calypso/state/types';
+import type { LocalizeProps } from 'i18n-calypso';
 
 const wpcomAssignPaymentMethod = (
 	subscriptionId: string,
@@ -70,7 +70,7 @@ export async function assignNewCardProcessor(
 		eventSource,
 	}: {
 		purchase: Purchase | undefined;
-		translate: ReturnType< typeof useTranslate >;
+		translate: LocalizeProps[ 'translate' ];
 		stripe: Stripe | null;
 		stripeConfiguration: StripeConfiguration | null;
 		stripeSetupIntentId: StripeSetupIntentId | undefined;

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { StripeHookProvider, StripeSetupIntentIdProvider } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { styled } from '@automattic/wpcom-checkout';
@@ -111,26 +111,28 @@ export default function CheckoutMainWrapper( {
 			>
 				<CalypsoShoppingCartProvider shouldShowPersistentErrors>
 					<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
-						<CheckoutMain
-							siteSlug={ siteSlug }
-							siteId={ selectedSiteId }
-							productAliasFromUrl={ productAliasFromUrl }
-							productSourceFromUrl={ productSourceFromUrl }
-							purchaseId={ purchaseId }
-							couponCode={ couponCode }
-							redirectTo={ redirectTo }
-							feature={ selectedFeature }
-							plan={ plan }
-							isComingFromUpsell={ isComingFromUpsell }
-							infoMessage={ prepurchaseNotices }
-							sitelessCheckoutType={ sitelessCheckoutType }
-							isLoggedOutCart={ isLoggedOutCart }
-							isNoSiteCart={ isNoSiteCart }
-							isGiftPurchase={ isGiftPurchase }
-							jetpackSiteSlug={ jetpackSiteSlug }
-							jetpackPurchaseToken={ jetpackPurchaseToken }
-							isUserComingFromLoginForm={ isUserComingFromLoginForm }
-						/>
+						<StripeSetupIntentIdProvider fetchStipeSetupIntentId={ getStripeConfiguration }>
+							<CheckoutMain
+								siteSlug={ siteSlug }
+								siteId={ selectedSiteId }
+								productAliasFromUrl={ productAliasFromUrl }
+								productSourceFromUrl={ productSourceFromUrl }
+								purchaseId={ purchaseId }
+								couponCode={ couponCode }
+								redirectTo={ redirectTo }
+								feature={ selectedFeature }
+								plan={ plan }
+								isComingFromUpsell={ isComingFromUpsell }
+								infoMessage={ prepurchaseNotices }
+								sitelessCheckoutType={ sitelessCheckoutType }
+								isLoggedOutCart={ isLoggedOutCart }
+								isNoSiteCart={ isNoSiteCart }
+								isGiftPurchase={ isGiftPurchase }
+								jetpackSiteSlug={ jetpackSiteSlug }
+								jetpackPurchaseToken={ jetpackPurchaseToken }
+								isUserComingFromLoginForm={ isUserComingFromLoginForm }
+							/>
+						</StripeSetupIntentIdProvider>
 					</StripeHookProvider>
 				</CalypsoShoppingCartProvider>
 			</CheckoutErrorBoundary>

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -465,9 +465,7 @@ export default function CheckoutMain( {
 				webPayProcessor( 'google-pay', transactionData, dataForProcessor ),
 			'free-purchase': () => freePurchaseProcessor( dataForProcessor ),
 			card: ( transactionData: unknown ) =>
-				multiPartnerCardProcessor( {
-					submitData: transactionData,
-					dataForProcessor,
+				multiPartnerCardProcessor( transactionData, dataForProcessor, {
 					translate,
 					stripeSetupIntentId,
 				} ),

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -1,5 +1,5 @@
 import { JETPACK_SEARCH_PRODUCTS } from '@automattic/calypso-products';
-import { useStripe } from '@automattic/calypso-stripe';
+import { useStripe, useStripeSetupIntentId } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { CheckoutProvider, checkoutTheme } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
@@ -7,7 +7,7 @@ import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useSelect } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, useCallback, useMemo } from 'react';
+import { Fragment, useCallback, useEffect, useMemo } from 'react';
 import QueryContactDetailsCache from 'calypso/components/data/query-contact-details-cache';
 import QueryJetpackSaleCoupon from 'calypso/components/data/query-jetpack-sale-coupon';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -445,6 +445,18 @@ export default function CheckoutMain( {
 		]
 	);
 
+	const {
+		reload: reloadSetupIntentId,
+		setupIntentId: stripeSetupIntentId,
+		error: setupIntentError,
+	} = useStripeSetupIntentId();
+
+	useEffect( () => {
+		if ( setupIntentError ) {
+			reduxDispatch( errorNotice( setupIntentError.message ) );
+		}
+	}, [ setupIntentError, reduxDispatch ] );
+
 	const paymentProcessors = useMemo(
 		() => ( {
 			'apple-pay': ( transactionData: unknown ) =>
@@ -453,7 +465,12 @@ export default function CheckoutMain( {
 				webPayProcessor( 'google-pay', transactionData, dataForProcessor ),
 			'free-purchase': () => freePurchaseProcessor( dataForProcessor ),
 			card: ( transactionData: unknown ) =>
-				multiPartnerCardProcessor( transactionData, dataForProcessor ),
+				multiPartnerCardProcessor( {
+					submitData: transactionData,
+					dataForProcessor,
+					translate,
+					stripeSetupIntentId,
+				} ),
 			alipay: ( transactionData: unknown ) =>
 				genericRedirectProcessor( 'alipay', transactionData, dataForProcessor ),
 			p24: ( transactionData: unknown ) =>
@@ -477,7 +494,7 @@ export default function CheckoutMain( {
 				existingCardProcessor( transactionData, dataForProcessor ),
 			paypal: () => payPalProcessor( dataForProcessor ),
 		} ),
-		[ dataForProcessor ]
+		[ dataForProcessor, translate, stripeSetupIntentId ]
 	);
 
 	const jetpackColors = isJetpackNotAtomic
@@ -670,8 +687,11 @@ export default function CheckoutMain( {
 					error_message: String( transactionError ),
 				} )
 			);
+
+			// We need to regenerate the setup intent if the form was submitted.
+			reloadSetupIntentId();
 		},
-		[ reduxDispatch, translate ]
+		[ reduxDispatch, translate, reloadSetupIntentId ]
 	);
 
 	const handlePaymentRedirect = useCallback( () => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -438,10 +438,10 @@ export default function useCreatePaymentMethods( {
 	// The order is the order of Payment Methods in Checkout.
 	return [
 		...existingCardMethods,
-		freePaymentMethod,
 		applePayMethod,
 		googlePayMethod,
 		stripeMethod,
+		freePaymentMethod,
 		paypalMethod,
 		idealMethod,
 		giropayMethod,

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -235,17 +235,16 @@ async function ebanxCardProcessor(
 		} );
 }
 
-export default async function multiPartnerCardProcessor( {
-	submitData,
-	dataForProcessor,
-	stripeSetupIntentId,
-	translate,
-}: {
-	submitData: unknown;
-	dataForProcessor: PaymentProcessorOptions;
+export interface FreePurchaseData {
 	stripeSetupIntentId: StripeSetupIntentId | undefined;
 	translate: LocalizeProps[ 'translate' ];
-} ): Promise< PaymentProcessorResponse > {
+}
+
+export default async function multiPartnerCardProcessor(
+	submitData: unknown,
+	dataForProcessor: PaymentProcessorOptions,
+	freePurchaseData?: FreePurchaseData
+): Promise< PaymentProcessorResponse > {
 	if ( ! isValidMultiPartnerTransactionData( submitData ) ) {
 		throw new Error( 'Required purchase data is missing' );
 	}
@@ -259,15 +258,18 @@ export default async function multiPartnerCardProcessor( {
 			throw new Error( 'Required purchase data is missing' );
 		}
 		if ( submitData.paymentPartner === 'ebanx' ) {
-			throw new Error( 'Cannot use Ebanx for free purchases.' );
+			throw new Error( 'Cannot use Ebanx for free purchases' );
+		}
+		if ( ! freePurchaseData?.translate ) {
+			throw new Error( 'Required free purchase data is missing' );
 		}
 		const newCardResponse = await assignNewCardProcessor(
 			{
 				purchase: undefined,
-				translate,
+				translate: freePurchaseData.translate,
 				stripe: dataForProcessor.stripe,
 				stripeConfiguration: dataForProcessor.stripeConfiguration,
-				stripeSetupIntentId,
+				stripeSetupIntentId: freePurchaseData?.stripeSetupIntentId,
 				cardNumberElement: submitData.cardNumberElement,
 				reduxDispatch: dataForProcessor.reduxDispatch,
 				eventSource: '/checkout',

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -252,7 +252,9 @@ export default async function multiPartnerCardProcessor(
 	// For free purchases we cannot use the regular processor because it requires
 	// making a charge. Instead, we will create a new card, then use the
 	// existingCardProcessor because it works for free purchases.
-	const isPurchaseFree = dataForProcessor.responseCart.total_cost_integer === 0;
+	const isPurchaseFree =
+		dataForProcessor.responseCart.total_cost_integer === 0 &&
+		dataForProcessor.responseCart.products.length > 0;
 	if ( isPurchaseFree ) {
 		if ( ! isValidStripeCardTransactionData( submitData ) ) {
 			throw new Error( 'Required purchase data is missing' );

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -274,6 +274,14 @@ export default async function multiPartnerCardProcessor( {
 			},
 			{
 				...submitData,
+				// In `PaymentMethodSelector` which is used for adding new cards, the
+				// stripe payment method is passed `shouldShowTaxFields` which causes
+				// it to show required tax location fields in the payment method
+				// itself; that data is then submitted to the `assignNewCardProcessor`
+				// to send to Stripe as part of saving the card. However, in checkout
+				// we do not display those fields since they are already included in
+				// the billing details step. Therefore we must pass in the tax location
+				// data explicitly here so we can use `assignNewCardProcessor`.
 				countryCode: dataForProcessor.contactDetails?.countryCode?.value,
 				postalCode: getPostalCode( dataForProcessor.contactDetails ),
 				state: dataForProcessor.contactDetails?.state?.value,

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker-dropdown.tsx
@@ -1,31 +1,22 @@
 /**
  * @jest-environment jsdom
  */
-import { StripeHookProvider } from '@automattic/calypso-stripe';
-import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
-import { Provider as ReduxProvider } from 'react-redux';
-import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
-import CheckoutMain from '../components/checkout-main';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import useCartKey from '../../use-cart-key';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
 import {
-	siteId,
 	domainProduct,
 	planWithoutDomain,
-	fetchStripeConfiguration,
-	mockSetCartEndpointWith,
-	mockGetCartEndpointWith,
 	getActivePersonalPlanDataForType,
 	getBusinessPlanForInterval,
 	getVariantItemTextForInterval,
 	getPlansItemsState,
-	createTestReduxStore,
 	countryList,
 	mockUserAgent,
 	getPlanSubtitleTextForInterval,
@@ -34,7 +25,9 @@ import {
 	mockGetSupportedCountriesEndpoint,
 	mockGetVatInfoEndpoint,
 	mockMatchMediaOnWindow,
+	getBasicCart,
 } from './util';
+import { MockCheckout } from './util/mock-checkout';
 
 jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
 jest.mock( 'calypso/my-sites/checkout/use-cart-key' );
@@ -55,88 +48,26 @@ jest.setTimeout( 12000 );
 /* eslint-disable jest/no-conditional-expect */
 
 describe( 'CheckoutMain with a variant picker', () => {
-	let MyCheckout;
+	const initialCart = getBasicCart();
+	const mainCartKey = 123456;
 
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
 		jest.clearAllMocks();
-		getPlansBySiteId.mockImplementation( () => ( {
+		( getPlansBySiteId as jest.Mock ).mockImplementation( () => ( {
 			data: getActivePersonalPlanDataForType( 'yearly' ),
 		} ) );
 		hasLoadedSiteDomains.mockImplementation( () => true );
 		getDomainsBySiteId.mockImplementation( () => [] );
 		isMarketplaceProduct.mockImplementation( () => false );
+		( isJetpackSite as jest.Mock ).mockImplementation( () => false );
+		( useCartKey as jest.Mock ).mockImplementation( () => mainCartKey );
 
-		const initialCart = {
-			coupon: '',
-			coupon_savings_total: 0,
-			coupon_savings_total_integer: 0,
-			coupon_savings_total_display: '0',
-			currency: 'BRL',
-			locale: 'br-pt',
-			is_coupon_applied: false,
-			products: [ planWithoutDomain ],
-			tax: {
-				display_taxes: true,
-				location: {},
-			},
-			temporary: false,
-			allowed_payment_methods: [ 'WPCOM_Billing_PayPal_Express' ],
-			total_tax_integer: 700,
-			total_tax_display: 'R$7',
-			total_cost_integer: 15600,
-			total_cost_display: 'R$156',
-			sub_total_integer: 15600,
-			sub_total_display: 'R$156',
-			coupon_discounts_integer: [],
-		};
-
-		const mockSetCartEndpoint = mockSetCartEndpointWith( {
-			currency: initialCart.currency,
-			locale: initialCart.locale,
-		} );
-
-		const store = createTestReduxStore();
-		const queryClient = new QueryClient();
 		mockGetPaymentMethodsEndpoint( [] );
 		mockLogStashEndpoint();
 		mockGetSupportedCountriesEndpoint( countryList );
 		mockGetVatInfoEndpoint( {} );
 		mockMatchMediaOnWindow();
-
-		MyCheckout = ( { cartChanges, additionalProps, additionalCartProps, useUndefinedCartKey } ) => {
-			const managerClient = createShoppingCartManagerClient( {
-				getCart: mockGetCartEndpointWith( { ...initialCart, ...( cartChanges ?? {} ) } ),
-				setCart: mockSetCartEndpoint,
-			} );
-			const mainCartKey = 'foo.com';
-			( useCartKey as jest.Mock ).mockImplementation( () =>
-				useUndefinedCartKey ? undefined : mainCartKey
-			);
-			return (
-				<ReduxProvider store={ store }>
-					<QueryClientProvider client={ queryClient }>
-						<ShoppingCartProvider
-							managerClient={ managerClient }
-							options={ {
-								defaultCartKey: useUndefinedCartKey ? undefined : mainCartKey,
-							} }
-							{ ...additionalCartProps }
-						>
-							<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-								<CheckoutMain
-									siteId={ siteId }
-									siteSlug="foo.com"
-									getStoredCards={ async () => [] }
-									overrideCountryList={ countryList }
-									{ ...additionalProps }
-								/>
-							</StripeHookProvider>
-						</ShoppingCartProvider>
-					</QueryClientProvider>
-				</ReduxProvider>
-			);
-		};
 	} );
 
 	it.each( [
@@ -149,12 +80,12 @@ describe( 'CheckoutMain with a variant picker', () => {
 	] )(
 		'renders the variant picker with a $expectedVariant variant when the cart contains a $cartPlan plan and the current plan is $activePlan',
 		async ( { activePlan, cartPlan, expectedVariant } ) => {
-			getPlansBySiteId.mockImplementation( () => ( {
+			( getPlansBySiteId as jest.Mock ).mockImplementation( () => ( {
 				data: getActivePersonalPlanDataForType( activePlan ),
 			} ) );
 			const user = userEvent.setup();
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
-			render( <MyCheckout cartChanges={ cartChanges } /> );
+			render( <MockCheckout initialCart={ initialCart } cartChanges={ cartChanges } /> );
 
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
 			await user.click( openVariantPicker );
@@ -175,12 +106,12 @@ describe( 'CheckoutMain with a variant picker', () => {
 	] )(
 		'renders the variant picker with a $expectedVariant variant when the cart initially contains $initialPlan and then is changed to $cartPlan',
 		async ( { initialPlan, cartPlan, expectedVariant } ) => {
-			getPlansBySiteId.mockImplementation( () => ( {
+			( getPlansBySiteId as jest.Mock ).mockImplementation( () => ( {
 				data: getActivePersonalPlanDataForType( 'none' ),
 			} ) );
 			const user = userEvent.setup();
 			const cartChanges = { products: [ getBusinessPlanForInterval( initialPlan ) ] };
-			render( <MyCheckout cartChanges={ cartChanges } /> );
+			render( <MockCheckout initialCart={ initialCart } cartChanges={ cartChanges } /> );
 
 			// Open the variant picker
 			let openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
@@ -213,12 +144,12 @@ describe( 'CheckoutMain with a variant picker', () => {
 	] )(
 		'renders the variant picker without a $expectedVariant variant when the cart contains a $cartPlan plan and the current plan is $activePlan',
 		async ( { activePlan, cartPlan, expectedVariant } ) => {
-			getPlansBySiteId.mockImplementation( () => ( {
+			( getPlansBySiteId as jest.Mock ).mockImplementation( () => ( {
 				data: getActivePersonalPlanDataForType( activePlan ),
 			} ) );
 			const user = userEvent.setup();
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
-			render( <MyCheckout cartChanges={ cartChanges } /> );
+			render( <MockCheckout initialCart={ initialCart } cartChanges={ cartChanges } /> );
 
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
 			await user.click( openVariantPicker );
@@ -234,12 +165,12 @@ describe( 'CheckoutMain with a variant picker', () => {
 	it.each( [ { activePlan: 'none', cartPlan: 'yearly', expectedVariant: 'two-year' } ] )(
 		'renders the $expectedVariant variant with a discount percentage for a $cartPlan plan when the current plan is $activePlan',
 		async ( { activePlan, cartPlan, expectedVariant } ) => {
-			getPlansBySiteId.mockImplementation( () => ( {
+			( getPlansBySiteId as jest.Mock ).mockImplementation( () => ( {
 				data: getActivePersonalPlanDataForType( activePlan ),
 			} ) );
 			const user = userEvent.setup();
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
-			render( <MyCheckout cartChanges={ cartChanges } /> );
+			render( <MockCheckout initialCart={ initialCart } cartChanges={ cartChanges } /> );
 
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
 			await user.click( openVariantPicker );
@@ -258,12 +189,12 @@ describe( 'CheckoutMain with a variant picker', () => {
 				( plan ) => plan.product_slug === variantSlug
 			);
 			const finalPrice = variantData.raw_price;
-			const variantInterval = parseInt( variantData.bill_period, 10 );
+			const variantInterval = parseInt( String( variantData.bill_period ), 10 );
 			const currentVariantData = getPlansItemsState().find(
 				( plan ) => plan.product_slug === currentVariantSlug
 			);
 			const currentVariantPrice = currentVariantData.raw_price;
-			const currentVariantInterval = parseInt( currentVariantData.bill_period, 10 );
+			const currentVariantInterval = parseInt( String( currentVariantData.bill_period ), 10 );
 			const intervalsInVariant = Math.round( variantInterval / currentVariantInterval );
 			const priceBeforeDiscount = currentVariantPrice * intervalsInVariant;
 
@@ -276,7 +207,7 @@ describe( 'CheckoutMain with a variant picker', () => {
 
 	it( 'does not render the variant picker if there are no variants', async () => {
 		const cartChanges = { products: [ domainProduct ] };
-		render( <MyCheckout cartChanges={ cartChanges } /> );
+		render( <MockCheckout initialCart={ initialCart } cartChanges={ cartChanges } /> );
 
 		await expect( screen.findByLabelText( 'Pick a product term' ) ).toNeverAppear();
 	} );
@@ -284,19 +215,19 @@ describe( 'CheckoutMain with a variant picker', () => {
 	it( 'does not render the variant picker for a renewal of the current plan', async () => {
 		const currentPlanRenewal = { ...planWithoutDomain, extra: { purchaseType: 'renewal' } };
 		const cartChanges = { products: [ currentPlanRenewal ] };
-		render( <MyCheckout cartChanges={ cartChanges } /> );
+		render( <MockCheckout initialCart={ initialCart } cartChanges={ cartChanges } /> );
 
 		await expect( screen.findByLabelText( 'Pick a product term' ) ).toNeverAppear();
 	} );
 
 	it( 'does not render the variant picker when userAgent is Woo mobile', async () => {
-		getPlansBySiteId.mockImplementation( () => ( {
+		( getPlansBySiteId as jest.Mock ).mockImplementation( () => ( {
 			data: getActivePersonalPlanDataForType( 'none' ),
 		} ) );
 		const cartChanges = { products: [ getBusinessPlanForInterval( 'yearly' ) ] };
 
 		mockUserAgent( 'wc-ios' );
-		render( <MyCheckout cartChanges={ cartChanges } /> );
+		render( <MockCheckout initialCart={ initialCart } cartChanges={ cartChanges } /> );
 
 		await expect(
 			screen.findByLabelText( 'Change the billing term for this product' )

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -1,4 +1,4 @@
-import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import { getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
 import multiPartnerCardProcessor from '../lib/multi-partner-card-processor';
 import {
@@ -14,6 +14,8 @@ import {
 	contactDetailsForDomain,
 	mockCreateAccountSiteCreatedResponse,
 	mockCreateAccountSiteNotCreatedResponse,
+	planWithoutDomain,
+	getBasicCart,
 } from './util';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
@@ -105,13 +107,13 @@ describe( 'multiPartnerCardProcessor', () => {
 		public_key: 'pk_test_1234567890',
 		setup_intent_id: null,
 	};
-	const product = getEmptyResponseCartProduct();
+	const product = planWithoutDomain;
 	const domainProduct = {
 		...getEmptyResponseCartProduct(),
 		meta: 'example.com',
 		is_domain_registration: true,
 	};
-	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const cart = { ...getBasicCart(), products: [ product ] };
 
 	const mockCardNumberElement = () => <div>mock card number</div>;
 

--- a/client/my-sites/checkout/composite-checkout/test/util/mock-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/util/mock-checkout.tsx
@@ -38,12 +38,18 @@ export function MockCheckout( {
 		getCart: mockGetCartEndpointWith( { ...initialCart, ...( cartChanges ?? {} ) } ),
 		setCart: setCart || mockSetCartEndpoint,
 	} );
+
+	const isPurchaseFree = { ...initialCart, ...cartChanges }.total_cost_integer === 0;
+
 	return (
 		<ReduxProvider store={ reduxStore }>
 			<QueryClientProvider client={ queryClient }>
 				<ShoppingCartProvider managerClient={ managerClient }>
 					<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-						<StripeSetupIntentIdProvider fetchStipeSetupIntentId={ fetchStripeConfiguration }>
+						<StripeSetupIntentIdProvider
+							fetchStipeSetupIntentId={ fetchStripeConfiguration }
+							isDisabled={ ! isPurchaseFree }
+						>
 							<CheckoutMain
 								siteId={ useUndefinedSiteId ? undefined : siteId }
 								siteSlug="foo.com"

--- a/client/my-sites/checkout/composite-checkout/test/util/mock-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/util/mock-checkout.tsx
@@ -1,4 +1,4 @@
-import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { StripeHookProvider, StripeSetupIntentIdProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import { PropsOf } from '@emotion/react';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
@@ -43,12 +43,14 @@ export function MockCheckout( {
 			<QueryClientProvider client={ queryClient }>
 				<ShoppingCartProvider managerClient={ managerClient }>
 					<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-						<CheckoutMain
-							siteId={ useUndefinedSiteId ? undefined : siteId }
-							siteSlug="foo.com"
-							overrideCountryList={ countryList }
-							{ ...additionalProps }
-						/>
+						<StripeSetupIntentIdProvider fetchStipeSetupIntentId={ fetchStripeConfiguration }>
+							<CheckoutMain
+								siteId={ useUndefinedSiteId ? undefined : siteId }
+								siteSlug="foo.com"
+								overrideCountryList={ countryList }
+								{ ...additionalProps }
+							/>
+						</StripeSetupIntentIdProvider>
 					</StripeHookProvider>
 				</ShoppingCartProvider>
 			</QueryClientProvider>

--- a/packages/calypso-stripe/README.md
+++ b/packages/calypso-stripe/README.md
@@ -8,7 +8,7 @@ This uses [Stripe elements](https://stripe.com/payments/elements).
 
 You'll need to wrap this context provider around any component that wishes to use `useStripe` or `withStripeProps`. It accepts the following props:
 
-- `children: JSX.Element`
+- `children: React.ReactNode`
 - `fetchStripeConfiguration: GetStripeConfiguration` A function to fetch the stripe configuration from the WP.com HTTP API.
 - `configurationArgs?: null | GetStripeConfigurationArgs` Options to pass to the fetchStripeConfiguration function, specifically `country`.
 - `locale?: string` An optional locale string used to localize error messages for the Stripe elements fields.
@@ -17,8 +17,9 @@ You'll need to wrap this context provider around any component that wishes to us
 
 You'll need to wrap this context provider around any component that wishes to use `useStripeSetupIntentId`. It accepts the following props:
 
-- `children: JSX.Element`
+- `children: React.ReactNode`
 - `fetchStripeConfiguration: GetStripeSetupIntentId` A function to fetch the stripe configuration from the WP.com HTTP API. It will be passed `{needs_intent: true}`.
+- `isDisabled?: boolean` An option to disable the fetching of the setup intent if it is not needed.
 
 ## useStripe
 


### PR DESCRIPTION
## Proposed Changes

We'd like to be able to accept new credit cards in checkout for a recurring product even if the checkout total is 0 (due to credits or a coupon, etc.). Currently it will not work because the way we use it, Stripe does not support adding a new card for a free transaction.

To make this work, this PR modifies the `card` [payment processor function](https://github.com/Automattic/wp-calypso/blob/trunk/packages/composite-checkout/README.md#payment-methods) in checkout so that, if the purchase is free, it will follow a different code path. Instead of submitting its data to the transactions endpoint, it first creates a new unassigned card (as though the user were adding a card via `/me/purchases/add-payment-method`) and then submits that card to the transactions endpoint as an existing payment method.

In order to use the endpoint to create a new unassigned card in this way, we need the backend to create a Stripe Setup Intent. However, there's no need to do this for non-free purchases, so this PR only loads the Setup Intent if the purchase is free.

This will have no effect until D115541-code is merged, but this PR should be merged first.

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/79029 and will require a rebase when that is merged.

Before (without D115541-code or D115364-code):

<img width="653" alt="Screenshot 2023-07-07 at 1 06 01 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/aa14d81b-7be2-4586-b04d-2b9d6ed5eeac">

After (with both D115541-code and D115364-code):

<img width="654" alt="Screenshot 2023-07-07 at 1 12 00 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/cc669006-7149-4004-8354-a14a1676af70">

## Testing Instructions

- Apply D115541-code to your sandbox and sandbox the API.
- Add sufficient credits to your user so that a purchase becomes free.
- Visit checkout with a new (non-renewal) product in your cart.
- Verify that you see "Credit or debit card" as well as "Assign Payment Method Later".
- Select "Credit or debit card" and fill in the credit card info.
- Click "Pay 0 now" to submit the purchase.
- Verify that you see the thank-you page as expected.
- Verify that the card you added is assigned to the purchase.
- Repeat the above steps for a renewal that has a stored card attached (perhaps the product you just purchased).
- Verify that "WordPress.com Credits" is the only payment method available.