### PR TITLE
Stats: Hide unsupported components from Overview

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -121,6 +121,11 @@ class StatsNavigation extends Component {
 
 				return config.isEnabled( 'google-my-business' ) && isGoogleMyBusinessLocationConnected;
 
+			case 'subscribers':
+				if ( 'undefined' === typeof siteId ) {
+					return false;
+				}
+
 			default:
 				return true;
 		}
@@ -182,15 +187,17 @@ class StatsNavigation extends Component {
 					<Intervals selected={ interval } pathTemplate={ pathTemplate } standalone />
 				) }
 
-				{ isModuleSettingsSupported && AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] && (
-					<PageModuleToggler
-						availableModules={ AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] }
-						pageModules={ pageModules }
-						onToggleModule={ this.onToggleModule }
-						isTooltipShown={ showSettingsTooltip && ! isPageSettingsTooltipDismissed }
-						onTooltipDismiss={ this.onTooltipDismiss }
-					/>
-				) }
+				{ ! isLegacy &&
+					isModuleSettingsSupported &&
+					AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] && (
+						<PageModuleToggler
+							availableModules={ AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] }
+							pageModules={ pageModules }
+							onToggleModule={ this.onToggleModule }
+							isTooltipShown={ showSettingsTooltip && ! isPageSettingsTooltipDismissed }
+							onTooltipDismiss={ this.onTooltipDismiss }
+						/>
+					) }
 			</div>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #79076.

## Proposed Changes

* Hides unsupported components from the Stats Overview page.

Before|After
-|-
<img width="1061" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/ac86ef79-dca2-4c57-99f2-2bfcea2cac04">|<img width="1073" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/319e8cdb-3a92-4853-b532-13c8fb403a64">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/stats/day` on the live branch for this PR.
* Ensure that the page looks and works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
