### PR TITLE
Mailing Lists: add new category for Jetpack agency onboarding notifications

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -114,6 +114,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Jetpack Newsletter' );
 		} else if ( 'jetpack_reports' === category ) {
 			return this.props.translate( 'Jetpack Reports' );
+		} else if ( 'jetpack_agencies_pro_onboarding' === category ) {
+			return this.props.translate( 'Jetpack Agencies Pro Onboarding' );
 		} else if ( 'akismet_marketing' === category ) {
 			return this.props.translate( 'Akismet Marketing' );
 		} else if ( 'woopay_marketing' === category ) {
@@ -159,6 +161,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Jetpack news, announcements, and product spotlights.' );
 		} else if ( 'jetpack_reports' === category ) {
 			return this.props.translate( 'Jetpack security and performance reports.' );
+		} else if ( 'jetpack_agencies_pro_onboarding' === category ) {
+			return this.props.translate( 'Jetpack Agency & Pro program setup and onboarding.' );
 		} else if ( 'akismet_marketing' === category ) {
 			return this.props.translate(
 				'Relevant tips and new features to get the most out of Akismet'

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -41,7 +41,6 @@ const options = {
 	jetpack_promotion: 'jetpack_promotion',
 	jetpack_news: 'jetpack_news',
 	jetpack_reports: 'jetpack_reports',
-	jetpack_agencies_pro_onboarding: 'jetpack_agencies_pro_onboarding',
 };
 
 class WPCOMNotifications extends Component {
@@ -175,13 +174,6 @@ class WPCOMNotifications extends Component {
 							isEnabled={ get( settings, options.jetpack_reports ) }
 							title={ translate( 'Reports' ) }
 							description={ translate( 'Jetpack security and performance reports.' ) }
-						/>
-
-						<EmailCategory
-							name={ options.jetpack_agencies_pro_onboarding }
-							isEnabled={ get( settings, options.jetpack_agencies_pro_onboarding ) }
-							title={ translate( 'Jetpack Agencies Pro Onboarding' ) }
-							description={ translate( 'Jetpack Agency & Pro program setup and onboarding.' ) }
 						/>
 					</>
 				) : (

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -41,6 +41,7 @@ const options = {
 	jetpack_promotion: 'jetpack_promotion',
 	jetpack_news: 'jetpack_news',
 	jetpack_reports: 'jetpack_reports',
+	jetpack_agencies_pro_onboarding: 'jetpack_agencies_pro_onboarding',
 };
 
 class WPCOMNotifications extends Component {
@@ -174,6 +175,13 @@ class WPCOMNotifications extends Component {
 							isEnabled={ get( settings, options.jetpack_reports ) }
 							title={ translate( 'Reports' ) }
 							description={ translate( 'Jetpack security and performance reports.' ) }
+						/>
+
+						<EmailCategory
+							name={ options.jetpack_agencies_pro_onboarding }
+							isEnabled={ get( settings, options.jetpack_agencies_pro_onboarding ) }
+							title={ translate( 'Jetpack Agencies Pro Onboarding' ) }
+							description={ translate( 'Jetpack Agency & Pro program setup and onboarding.' ) }
 						/>
 					</>
 				) : (


### PR DESCRIPTION
This change adds proper Calypso (UI) support for a new mailing list category used for Jetpack agency onboarding notifications.

## Testing Instructions

The backend work on adding the new mailing list category for Jetpack Agency Pro Onboarding was completed via D114748.

* Visit [this unsubscribe URL](http://calypso.localhost:3000/mailing-lists/unsubscribe?category=jetpack_agencies_pro_onboarding&email=codefourcomics%40gmail.com&hmac=8cea5d900cca656411b3b9d2615e2530). Confirm that the subscribe and resubscribe actions work, and that the title and description of the message is correctly displayed. 

<img width="1149" alt="CleanShot 2023-07-06 at 15 04 50@2x" src="https://github.com/Automattic/wp-calypso/assets/135139690/31c354ef-57fd-402d-9cdd-7150e8a65cb3">
