### PR TITLE
Update the nav used on the Jepack pricing page to match the nav on jetpack.com

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -101,6 +101,16 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 						href: `${ JETPACK_COM_BASE_URL }/features/growth/`,
 						items: [
 							{
+								label: translate( 'AI Assistant', { context: 'Jetpack product name' } ),
+								tagline: translate( 'Write smarter, not harder' ),
+								href: `${ JETPACK_COM_BASE_URL }/ai/`,
+							},
+							{
+								label: translate( 'Stats', { context: 'Jetpack product name' } ),
+								tagline: translate( 'Simple, yet powerful analytics' ),
+								href: `${ JETPACK_COM_BASE_URL }/stats/`,
+							},
+							{
 								label: translate( 'Social', { context: 'Jetpack product name' } ),
 								tagline: translate( 'Write once, post everywhere' ),
 								href: `${ JETPACK_COM_BASE_URL }/social/`,
@@ -124,8 +134,8 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 				href: `${ JETPACK_COM_BASE_URL }/pricing/`,
 			},
 			{
-				label: translate( 'Agencies' ),
-				href: `${ JETPACK_COM_BASE_URL }/for/agencies/`,
+				label: translate( 'Partners' ),
+				href: `${ JETPACK_COM_BASE_URL }/jetpack-partners/`,
 			},
 			{
 				label: translate( 'Support' ),

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -568,7 +568,7 @@
 		backdrop-filter: blur(8px);
 		animation-name: submenu-backdrop;
 		animation-duration: 0.3s;
-		animation-delay: calc(0.35s / 1.5);
+		animation-delay: calc(0.1s / 1.5);
 	}
 	@media ( max-width: 900px ) {
 		.header__submenu::before {
@@ -596,7 +596,7 @@
 		background-color: var(--studio-white);
 		transform-origin: 0 0;
 		animation-name: submenu-content;
-		animation-duration: 0.35s;
+		animation-duration: 0.1s;
 		animation-timing-function: ease-out;
 	}
 	@media ( prefers-reduced-motion ) {
@@ -609,7 +609,7 @@
 			z-index: 3;
 			padding-top: 2rem;
 			background-image: none;
-			animation-duration: 0.35s;
+			animation-duration: 0.1s;
 			animation-name: submenu-content-mobile;
 		}
 	}
@@ -697,49 +697,57 @@
 		}
 	}
 	.header__submenu-categories-list > li:nth-of-type(1) {
-		animation-delay: calc(calc(0.085s * 1) + calc(0.35s / 1.5));
+		animation-delay: calc(calc(0.055s * 1) + calc(0.1s / 1.5));
 	}
 	.header__submenu-categories-list > li:nth-of-type(1)
 	.header__submenu-links-list > li:nth-of-type(1) > a {
-		animation-delay: calc(calc(0.085s * 3) + calc(0.35s / 1.5));
+		animation-delay: calc(calc(0.055s * 3) + calc(0.1s / 1.5));
 	}
 	.header__submenu-categories-list > li:nth-of-type(1)
 	.header__submenu-links-list > li:nth-of-type(2) > a {
-		animation-delay: calc(calc(0.085s * 4) + calc(0.35s / 1.5));
+		animation-delay: calc(calc(0.055s * 4) + calc(0.1s / 1.5));
 	}
 	.header__submenu-categories-list > li:nth-of-type(1)
 	.header__submenu-links-list > li:nth-of-type(3) > a {
-		animation-delay: calc(calc(0.085s * 5) + calc(0.35s / 1.5));
+		animation-delay: calc(calc(0.055s * 5) + calc(0.1s / 1.5));
 	}
 	.header__submenu-categories-list > li:nth-of-type(2) {
-		animation-delay: calc(calc(0.085s * 2) + calc(0.35s / 1.5));
+		animation-delay: calc(calc(0.055s * 2) + calc(0.1s / 1.5));
 	}
 	.header__submenu-categories-list > li:nth-of-type(2)
 	.header__submenu-links-list > li:nth-of-type(1) > a {
-		animation-delay: calc(calc(0.085s * 4) + calc(0.35s / 1.5));
+		animation-delay: calc(calc(0.055s * 4) + calc(0.1s / 1.5));
 	}
 	.header__submenu-categories-list > li:nth-of-type(2)
 	.header__submenu-links-list > li:nth-of-type(2) > a {
-		animation-delay: calc(calc(0.085s * 5) + calc(0.35s / 1.5));
+		animation-delay: calc(calc(0.055s * 5) + calc(0.1s / 1.5));
 	}
 	.header__submenu-categories-list > li:nth-of-type(2)
 	.header__submenu-links-list > li:nth-of-type(3) > a {
-		animation-delay: calc(calc(0.085s * 6) + calc(0.35s / 1.5));
+		animation-delay: calc(calc(0.055s * 6) + calc(0.1s / 1.5));
 	}
 	.header__submenu-categories-list > li:nth-of-type(3) {
-		animation-delay: calc(calc(0.085s * 3) + calc(0.35s / 1.5));
+		animation-delay: calc(calc(0.055s * 3) + calc(0.1s / 1.5));
 	}
 	.header__submenu-categories-list > li:nth-of-type(3)
 	.header__submenu-links-list > li:nth-of-type(1) > a {
-		animation-delay: calc(calc(0.085s * 5) + calc(0.35s / 1.5));
+		animation-delay: calc(calc(0.055s * 5) + calc(0.1s / 1.5));
 	}
 	.header__submenu-categories-list > li:nth-of-type(3)
 	.header__submenu-links-list > li:nth-of-type(2) > a {
-		animation-delay: calc(calc(0.085s * 6) + calc(0.35s / 1.5));
+		animation-delay: calc(calc(0.055s * 6) + calc(0.1s / 1.5));
 	}
 	.header__submenu-categories-list > li:nth-of-type(3)
 	.header__submenu-links-list > li:nth-of-type(3) > a {
-		animation-delay: calc(calc(0.085s * 7) + calc(0.35s / 1.5));
+		animation-delay: calc(calc(0.055s * 7) + calc(0.1s / 1.5));
+	}
+	.header__submenu-categories-list > li:nth-of-type(3)
+	.header__submenu-links-list > li:nth-of-type(4) > a {
+		animation-delay: calc(calc(0.055s * 8) + calc(0.1s / 1.5));
+	}
+	.header__submenu-categories-list > li:nth-of-type(3)
+	.header__submenu-links-list > li:nth-of-type(5) > a {
+		animation-delay: calc(calc(0.055s * 9) + calc(0.1s / 1.5));
 	}
 
 	.header__submenu-bottom-section {
@@ -757,7 +765,7 @@
 		flex: 1;
 
 		.header__submenu-link {
-			animation-delay: calc(calc(0.085s * 9) + calc(0.35s / 1.5));
+			animation-delay: calc(calc(0.055s * 9) + calc(0.1s / 1.5));
 		}
 	}
 
@@ -810,7 +818,7 @@
 			animation-name: submenu-item;
 			animation-duration: 0.25s;
 			animation-timing-function: ease-in-out;
-			animation-delay: calc(calc(0.085s * 8) + calc(0.35s / 1.5));
+			animation-delay: calc(calc(0.055s * 8) + calc(0.1s / 1.5));
 
 			@media ( prefers-reduced-motion ) {
 				animation-duration: 0;
@@ -869,6 +877,7 @@
 
 	.header__submenu-label {
 		position: relative;
+		line-height: 1.25;
 	}
 
 	.header__submenu-tagline {
@@ -878,6 +887,7 @@
 		color: #646970;
 		font-size: 0.875rem;
 		font-weight: 400;
+		line-height: 1.25;
 	}
 	.header__submenu-tagline::after {
 		content: "";


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This diff updates the nav used on cloud.jetpack.com/pricing to match the nav on jetpack.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the local Jetpack cloud environment with this diff applied `yarn start-jetpack-cloud-p`
* Navigate to: http://jetpack.cloud.localhost:3001/pricing
* Confirm that the navigation matches the navigation on Jetpack.com. Specifically, the "AI" and "Stats" items have been added in the "Growth" section of the products menu. The "Agencies" nav item is now "Partners"

![Screenshot 2023-07-07 at 9 23 41 AM](https://github.com/Automattic/wp-calypso/assets/18016357/8f4c7254-86e5-459b-a162-1a02fb3adef9)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
