### PR TITLE
Checkout: Display feature list for domain transfers product

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -407,7 +407,6 @@ function CheckoutSummaryFeaturesList( props: {
 						<WPCheckoutCheckIcon id="features-list-support-manage" />
 						{ translate( 'Manage everything you need in one place' ) }
 					</CheckoutSummaryFeaturesListItem>
-
 					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="annual-live-chat" />
 						{ translate( 'Live chat support' ) }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -392,20 +392,12 @@ function CheckoutSummaryFeaturesList( props: {
 			{ hasDomainTransferProduct && (
 				<>
 					<CheckoutSummaryFeaturesListItem>
-						<WPCheckoutCheckIcon id="features-list-support-text" />
-						{ translate( 'Extremely fast DNS with SSL' ) }
-					</CheckoutSummaryFeaturesListItem>
-					<CheckoutSummaryFeaturesListItem>
-						<WPCheckoutCheckIcon id="features-list-support-privacy" />
-						{ translate( 'Private domain registration and SSL certificate included for free' ) }
-					</CheckoutSummaryFeaturesListItem>
-					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="features-list-support-another-year" />
 						{ translate( "We'll renew your domain for another year" ) }
 					</CheckoutSummaryFeaturesListItem>
 					<CheckoutSummaryFeaturesListItem>
-						<WPCheckoutCheckIcon id="features-list-support-manage" />
-						{ translate( 'Manage everything you need in one place' ) }
+						<WPCheckoutCheckIcon id="features-list-support-privacy" />
+						{ translate( 'Private domain registration and SSL certificate included for free' ) }
 					</CheckoutSummaryFeaturesListItem>
 					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="annual-live-chat" />

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -387,8 +387,6 @@ function CheckoutSummaryFeaturesList( props: {
 				</CheckoutSummaryFeaturesListItem>
 			) }
 
-			{ ! hasPlanInCart && <CheckoutSummaryChatIfAvailable siteId={ siteId } /> }
-
 			{ hasDomainTransferProduct && (
 				<>
 					<CheckoutSummaryFeaturesListItem>
@@ -399,11 +397,14 @@ function CheckoutSummaryFeaturesList( props: {
 						<WPCheckoutCheckIcon id="features-list-support-privacy" />
 						{ translate( 'Private domain registration and SSL certificate included for free' ) }
 					</CheckoutSummaryFeaturesListItem>
-					<CheckoutSummaryFeaturesListItem>
-						<WPCheckoutCheckIcon id="annual-live-chat" />
-						{ translate( 'Live chat support' ) }
-					</CheckoutSummaryFeaturesListItem>
 				</>
+			) }
+
+			{ ( ! hasPlanInCart || hasDomainTransferProduct ) && (
+				<CheckoutSummaryChatIfAvailable
+					siteId={ siteId }
+					hasDomainTransferInCart={ hasDomainTransferProduct }
+				/>
 			) }
 
 			<CheckoutSummaryRefundWindows cart={ responseCart } />
@@ -576,7 +577,10 @@ function CheckoutSummaryPlanFeatures( props: {
 	);
 }
 
-function CheckoutSummaryChatIfAvailable( props: { siteId: number | undefined } ) {
+function CheckoutSummaryChatIfAvailable( props: {
+	siteId: number | undefined;
+	hasDomainTransferInCart: boolean;
+} ) {
 	const translate = useTranslate();
 
 	const currentPlan = useSelector( ( state ) =>
@@ -586,11 +590,12 @@ function CheckoutSummaryChatIfAvailable( props: { siteId: number | undefined } )
 	const currentPlanSlug = currentPlan?.productSlug;
 
 	const isChatAvailable =
-		currentPlanSlug &&
-		( isWpComPremiumPlan( currentPlanSlug ) ||
-			isWpComBusinessPlan( currentPlanSlug ) ||
-			isWpComEcommercePlan( currentPlanSlug ) ) &&
-		! isMonthly( currentPlanSlug );
+		props.hasDomainTransferInCart ||
+		( currentPlanSlug &&
+			( isWpComPremiumPlan( currentPlanSlug ) ||
+				isWpComBusinessPlan( currentPlanSlug ) ||
+				isWpComEcommercePlan( currentPlanSlug ) ) &&
+			! isMonthly( currentPlanSlug ) );
 
 	if ( ! isChatAvailable ) {
 		return null;

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -354,6 +354,10 @@ function CheckoutSummaryFeaturesList( props: {
 
 	const hasNoAdsAddOn = responseCart.products.some( ( product ) => isNoAds( product ) );
 
+	const hasDomainTransferProduct = responseCart.products.some( ( product ) =>
+		isDomainTransfer( product )
+	);
+
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
 			{ hasDomainsInCart &&
@@ -384,6 +388,32 @@ function CheckoutSummaryFeaturesList( props: {
 			) }
 
 			{ ! hasPlanInCart && <CheckoutSummaryChatIfAvailable siteId={ siteId } /> }
+
+			{ hasDomainTransferProduct && (
+				<>
+					<CheckoutSummaryFeaturesListItem>
+						<WPCheckoutCheckIcon id="features-list-support-text" />
+						{ translate( 'Extremely fast DNS with SSL' ) }
+					</CheckoutSummaryFeaturesListItem>
+					<CheckoutSummaryFeaturesListItem>
+						<WPCheckoutCheckIcon id="features-list-support-privacy" />
+						{ translate( 'Private domain registration and SSL certificate included for free' ) }
+					</CheckoutSummaryFeaturesListItem>
+					<CheckoutSummaryFeaturesListItem>
+						<WPCheckoutCheckIcon id="features-list-support-another-year" />
+						{ translate( "We'll renew your domain for another year" ) }
+					</CheckoutSummaryFeaturesListItem>
+					<CheckoutSummaryFeaturesListItem>
+						<WPCheckoutCheckIcon id="features-list-support-manage" />
+						{ translate( 'Manage everything you need in one place' ) }
+					</CheckoutSummaryFeaturesListItem>
+
+					<CheckoutSummaryFeaturesListItem>
+						<WPCheckoutCheckIcon id="annual-live-chat" />
+						{ translate( 'Live chat support' ) }
+					</CheckoutSummaryFeaturesListItem>
+				</>
+			) }
 
 			<CheckoutSummaryRefundWindows cart={ responseCart } />
 		</CheckoutSummaryFeaturesListWrapper>


### PR DESCRIPTION
## Summary:

On the checkout page, we need to show the list of features customers get when purchasing a domain transfer product.

Related to [#](https://github.com/Automattic/wp-calypso/issues/78855)

## Current situation:

Currently when purchasing a domain transfer product, on the checkout page we see no features listed for the purchase ![z1n0Pt.png](https://github.com/Automattic/wp-calypso/assets/552016/b6bf9d1c-379a-4826-bd5c-4fe37c377d13)
## Proposed Changes

We aim to display some features of the domain transfer product like this:  ![iIjsal.png](https://github.com/Automattic/wp-calypso/assets/552016/363d37af-9844-44cc-950b-ee32f2dabf5d)

## Testing Instructions

1. Apply the patch.
2. Add a Domain transfer product to cart, goto `Upgrades >> Domains >> Add a Domain >> Use a Domain I own` ![AkpNOa.png](https://github.com/Automattic/wp-calypso/assets/552016/41a4fa9d-c6f8-41c3-a3f9-8727e9f10a52)
3. On the `Use a domain I own` page, enter the domain you would like to transfer and click the `continue` button ![4cSUCs.png](https://github.com/Automattic/wp-calypso/assets/552016/26a4643e-b4ff-4d97-9b19-4d997a48d4b0)
4. Ensure that the domain is with another registrar and unlocked besides having the unlock code provided by that registrar when you initiate an out transfer. **If you do not have your own domain then contact me directly via slack and I will give that to you.**
5. Proceed to enter the transfer code and you should now be on the checkout page with the domain transfer product in cart with the features listed on the right side like ![huGkNx.png](https://github.com/Automattic/wp-calypso/assets/552016/7c660235-29ce-43a1-98d4-301c1cf26acc)