### PR TITLE
Domains: Update domain only transfer to use connect language instead of transfer

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
@@ -32,7 +32,7 @@ const DomainOnlyConnectCard = ( props: DomainOnlyConnectCardProps ) => {
 						currentRoute
 					) }
 				>
-					{ translate( 'Transfer to an existing site' ) }
+					{ translate( 'Map to an existing site' ) }
 				</Button>
 			</div>
 		</div>

--- a/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
@@ -32,7 +32,7 @@ const DomainOnlyConnectCard = ( props: DomainOnlyConnectCardProps ) => {
 						currentRoute
 					) }
 				>
-					{ translate( 'Map to an existing site' ) }
+					{ translate( 'Connect to an existing site' ) }
 				</Button>
 			</div>
 		</div>

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -41,7 +41,7 @@ class TransferConfirmationDialog extends PureComponent {
 		}
 
 		return translate(
-			'Do you want to map {{strong}}%(domainName)s{{/strong}} ' +
+			'Do you want to connect {{strong}}%(domainName)s{{/strong}} ' +
 				'to site {{strong}}%(targetSiteTitle)s{{/strong}}?',
 			{
 				args: { domainName: domain.name, targetSiteTitle },
@@ -97,7 +97,7 @@ class TransferConfirmationDialog extends PureComponent {
 	render() {
 		const { domain, isMapping, translate } = this.props;
 		const actionLabel = ! isMapping
-			? translate( 'Confirm Mapping' )
+			? translate( 'Confirm Connection' )
 			: translate( 'Confirm Domain Connection Transfer' );
 		const buttons = [
 			{
@@ -118,7 +118,7 @@ class TransferConfirmationDialog extends PureComponent {
 
 		return (
 			<Dialog isVisible={ this.props.isVisible } buttons={ buttons } onClose={ this.props.onClose }>
-				<h1>{ translate( 'Confirm Mapping' ) }</h1>
+				<h1>{ translate( 'Confirm Connection' ) }</h1>
 				<p>{ this.getMessage() }</p>
 				{ hasEmailWithUs && this.renderEmailSubscriptionInformation() }
 				{ ! this.props.isTargetSiteOnPaidPlan && this.renderTargetSiteOnFreePlanWarnings() }

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -41,7 +41,7 @@ class TransferConfirmationDialog extends PureComponent {
 		}
 
 		return translate(
-			'Do you want to transfer {{strong}}%(domainName)s{{/strong}} ' +
+			'Do you want to map {{strong}}%(domainName)s{{/strong}} ' +
 				'to site {{strong}}%(targetSiteTitle)s{{/strong}}?',
 			{
 				args: { domainName: domain.name, targetSiteTitle },
@@ -97,7 +97,7 @@ class TransferConfirmationDialog extends PureComponent {
 	render() {
 		const { domain, isMapping, translate } = this.props;
 		const actionLabel = ! isMapping
-			? translate( 'Confirm Transfer' )
+			? translate( 'Confirm Mapping' )
 			: translate( 'Confirm Domain Connection Transfer' );
 		const buttons = [
 			{
@@ -118,7 +118,7 @@ class TransferConfirmationDialog extends PureComponent {
 
 		return (
 			<Dialog isVisible={ this.props.isVisible } buttons={ buttons } onClose={ this.props.onClose }>
-				<h1>{ translate( 'Confirm Transfer' ) }</h1>
+				<h1>{ translate( 'Confirm Mapping' ) }</h1>
 				<p>{ this.getMessage() }</p>
 				{ hasEmailWithUs && this.renderEmailSubscriptionInformation() }
 				{ ! this.props.isTargetSiteOnPaidPlan && this.renderTargetSiteOnFreePlanWarnings() }

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -121,7 +121,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		const { selectedDomainName: domainName, translate } = this.props;
 		const translateArgs = { args: { domainName }, components: { strong: <strong /> } };
 		return translate(
-			"Map {{strong}}%(domainName)s{{/strong}} to a site you're an administrator of:",
+			"Connect {{strong}}%(domainName)s{{/strong}} to a site you're an administrator of:",
 			translateArgs
 		);
 	}
@@ -150,7 +150,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 				<FormattedHeader
 					hasScreenOptions={ false }
 					brandFont
-					headerText={ translate( 'Map to another WordPress.com site' ) }
+					headerText={ translate( 'Connect to another WordPress.com site' ) }
 					align="left"
 				/>
 				<div className={ `${ componentClassName }__container` }>
@@ -179,7 +179,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 				href: domainManagementEdit( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{
-				label: translate( 'Map' ),
+				label: translate( 'Connect' ),
 				href: domainManagementTransfer( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{ label: translate( 'To another WordPress.com site' ) },

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -121,7 +121,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		const { selectedDomainName: domainName, translate } = this.props;
 		const translateArgs = { args: { domainName }, components: { strong: <strong /> } };
 		return translate(
-			"Transfer {{strong}}%(domainName)s{{/strong}} to a site you're an administrator of:",
+			"Map {{strong}}%(domainName)s{{/strong}} to a site you're an administrator of:",
 			translateArgs
 		);
 	}
@@ -150,7 +150,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 				<FormattedHeader
 					hasScreenOptions={ false }
 					brandFont
-					headerText={ translate( 'Transfer to another WordPress.com site' ) }
+					headerText={ translate( 'Map to another WordPress.com site' ) }
 					align="left"
 				/>
 				<div className={ `${ componentClassName }__container` }>
@@ -179,7 +179,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 				href: domainManagementEdit( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{
-				label: translate( 'Transfer' ),
+				label: translate( 'Map' ),
 				href: domainManagementTransfer( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{ label: translate( 'To another WordPress.com site' ) },


### PR DESCRIPTION
See p58i-eRk-p2

## Proposed Changes

As part of the recent domains walkthrough, it was pointed out that using the transfer language for users that have recently transferred their domains to us is not ideal. It was suggested that we use something more like "mapping" so that there was a distinction between transferring and mapping.
<img width="1366" alt="Screenshot 2023-07-06 at 5 57 28 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/26b8db14-29ab-429a-a5b2-2828a1eee6d9">
<img width="1492" alt="Screenshot 2023-07-06 at 5 57 33 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/7a86039d-6f7b-4715-8e81-cd9e6464d105">
<img width="1492" alt="Screenshot 2023-07-06 at 5 57 35 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/5c321b8c-6714-428a-8815-b2ccea8cf2cb">

This change specifically does NOT address transferring a domain that is already connected to a site. This seems like it could use a bit more thinking and I'd like to optimize for getting translations in here. This is what that page looks like though:

<img width="1483" alt="Screenshot 2023-07-06 at 6 01 49 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/d209bfeb-b292-4c70-b467-2915f2e4d846">


## Testing Instructions

- Start on the domain detail page for a domain that is not connected to a site. Either purchase a domain from the `/domains` landing page or transfer in a domain if you don't already have one.
- Verify that you see the section to create a site or connect your domain to an existing site
- Click to connect to an existing site
- Ensure that you see language about connections instead of transfers

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?