### PR TITLE
Stats: allow purchase notice for all site types with exclusions

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -4,6 +4,7 @@ import version_compare from 'calypso/lib/version-compare';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
+import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
@@ -24,9 +25,14 @@ const TEAM51_OWNER_ID = 70055110;
  */
 const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => {
 	const hasPaidStats = useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) );
-	const isSiteVip = useSelector( ( state ) => isVipSite( state as object, siteId as number ) );
+	// `is_vip` is not correctly placed in Odyssey, so we need to check `options.is_vip` as well.
+	const isVip = useSelector(
+		( state ) =>
+			isVipSite( state as object, siteId as number ) || getSiteOption( state, siteId, 'is_vip' )
+	);
+
 	const isP2 = useSelector( ( state ) => !! isSiteWPForTeams( state as object, siteId as number ) );
-	const isTeam51Site = useSelector(
+	const isOwnedByTeam51 = useSelector(
 		( state ) => getSelectedSite( state )?.site_owner === TEAM51_OWNER_ID
 	);
 
@@ -35,9 +41,9 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => 
 
 	const showPaidStatsNotice =
 		config.isEnabled( 'stats/paid-stats' ) &&
-		! isSiteVip &&
+		! isVip &&
 		! isP2 &&
-		! isTeam51Site &&
+		! isOwnedByTeam51 &&
 		! hasPaidStats &&
 		hasLoadedPurchases;
 

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -1,9 +1,10 @@
 import config from '@automattic/calypso-config';
 import { useSelector } from 'react-redux';
 import version_compare from 'calypso/lib/version-compare';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isVipSite from 'calypso/state/selectors/is-vip-site';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
 import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
-import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
 import FeedbackNotice from './feedback-notice';
 import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
@@ -20,16 +21,16 @@ import './style.scss';
  */
 const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => {
 	const hasPaidStats = useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) );
-	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
-		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
-	);
+	const isSiteVip = useSelector( ( state ) => isVipSite( state as object, siteId as number ) );
+	const isP2 = useSelector( ( state ) => !! isSiteWPForTeams( state as object, siteId as number ) );
 
 	// TODO: Display error messages on the notice.
 	const { hasLoadedPurchases } = usePurchasesToUpdateSiteProducts( isOdysseyStats, siteId );
 
 	const showPaidStatsNotice =
 		config.isEnabled( 'stats/paid-stats' ) &&
-		isSiteJetpackNotAtomic &&
+		! isSiteVip &&
+		! isP2 &&
 		! hasPaidStats &&
 		hasLoadedPurchases;
 

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -5,6 +5,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
 import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
+import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
 import FeedbackNotice from './feedback-notice';
 import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
@@ -15,6 +16,8 @@ import { NewStatsNoticesProps, StatsNoticesProps, PurchaseNoticesProps } from '.
 import usePurchasesToUpdateSiteProducts from './use-purchases-to-update-site-products';
 import './style.scss';
 
+const TEAM51_OWNER_ID = 70055110;
+
 /**
  * New notices aim to support Calypso and Odyssey stats.
  * New notices are based on async API call and hence is faster than the old notices.
@@ -23,6 +26,9 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => 
 	const hasPaidStats = useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) );
 	const isSiteVip = useSelector( ( state ) => isVipSite( state as object, siteId as number ) );
 	const isP2 = useSelector( ( state ) => !! isSiteWPForTeams( state as object, siteId as number ) );
+	const isTeam51Site = useSelector(
+		( state ) => getSelectedSite( state )?.site_owner === TEAM51_OWNER_ID
+	);
 
 	// TODO: Display error messages on the notice.
 	const { hasLoadedPurchases } = usePurchasesToUpdateSiteProducts( isOdysseyStats, siteId );
@@ -31,6 +37,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => 
 		config.isEnabled( 'stats/paid-stats' ) &&
 		! isSiteVip &&
 		! isP2 &&
+		! isTeam51Site &&
 		! hasPaidStats &&
 		hasLoadedPurchases;
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/79050#issuecomment-1624405320

## Proposed Changes

- Allow Stats upsell banner for all site types
- Exclude VIP sites
- Exclude P2 sites
- Exclude sites for special project team
- <strike>Exclude Newspack sites (?)</strike>

## Testing Instructions

### Calypso

* Open Calypso Live Branch
* Open a site without Stats paid products `/stats/day/${siteSlug}?flags=stats/paid-stats`
* Ensure you see the 'Do you love Jetpack Stats' banner
* Open a P2 `/stats/day/${siteSlug}?flags=stats/paid-stats`
* Ensure you do not see the upsell banner

<img width="814" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/e7b013e8-6605-4714-a3b8-ca1e83fdb2ec">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
