### PR TITLE
[Odysseus] Refactor of Odysseus to nest Context inside Chat

### DIFF
--- a/client/odysseus/context/index.tsx
+++ b/client/odysseus/context/index.tsx
@@ -4,6 +4,12 @@ import type { ReactNode } from 'react';
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
+export type Context = {
+	section_name?: string;
+	session_id?: string;
+	// etc
+};
+
 export type Nudge = {
 	nudge: string;
 	initialMessage: string;
@@ -18,12 +24,13 @@ export type Message = {
 	content: string;
 	role: MessageRole;
 	type: MessageType;
-	chatId?: string | null;
+	chat_id?: string | null;
 };
 
 export type Chat = {
-	chatId?: string | null;
+	chat_id?: string | null;
 	messages: Message[];
+	context: Context;
 };
 
 interface OdysseusAssistantContextInterface {
@@ -31,25 +38,23 @@ interface OdysseusAssistantContextInterface {
 	chat: Chat;
 	isLoadingChat: boolean;
 	lastNudge: Nudge | null;
-	messages: Message[];
-	sectionName: string;
 	sendNudge: ( nudge: Nudge ) => void;
 	setChat: ( chat: Chat ) => void;
 	setIsLoadingChat: ( isLoadingChat: boolean ) => void;
 	setMessages: ( messages: Message[] ) => void;
+	setContext: ( context: Context ) => void;
 }
 
 const defaultContextInterfaceValues = {
 	addMessage: noop,
-	chat: { messages: [] },
+	chat: { context: { section_name: '' }, messages: [] },
 	isLoadingChat: false,
 	lastNudge: null,
-	messages: [],
-	sectionName: '',
 	sendNudge: noop,
 	setChat: noop,
 	setIsLoadingChat: noop,
 	setMessages: noop,
+	setContext: noop,
 };
 
 // Create a default new context
@@ -70,14 +75,18 @@ const OdysseusAssistantProvider = ( {
 } ) => {
 	const [ lastNudge, setLastNudge ] = useState< Nudge | null >( null );
 	const [ messages, setMessages ] = useState< Message[] >( [] );
-	const [ chat, setChat ] = useState< Chat >( { messages: [] } );
+	const [ chat, setChat ] = useState< Chat >( {
+		context: { section_name: sectionName },
+		messages,
+	} );
 
 	const addMessage = ( message: Message ) => {
 		setMessages( ( prevMessages ) => {
 			const newMessages = [ ...prevMessages, message ];
 			setChat( ( prevChat ) => ( {
-				chatId: message.chatId ?? prevChat.chatId,
+				chat_id: message.chat_id ?? prevChat.chat_id,
 				messages: newMessages,
+				context: prevChat.context,
 			} ) );
 			return newMessages;
 		} );
@@ -90,12 +99,11 @@ const OdysseusAssistantProvider = ( {
 				chat,
 				isLoadingChat: false,
 				lastNudge,
-				messages,
-				sectionName,
 				sendNudge: setLastNudge,
 				setChat,
 				setIsLoadingChat: noop,
 				setMessages,
+				setContext: noop,
 			} }
 		>
 			{ children }

--- a/client/odysseus/context/index.tsx
+++ b/client/odysseus/context/index.tsx
@@ -1,37 +1,11 @@
 import { createContext, useContext, useState } from 'react';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { Chat, Context, Message, Nudge } from '../types';
 import type { ReactNode } from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
-
-export type Context = {
-	section_name?: string;
-	session_id?: string;
-	// etc
-};
-
-export type Nudge = {
-	nudge: string;
-	initialMessage: string;
-	context?: Record< string, unknown >;
-};
-
-export type MessageRole = 'user' | 'bot';
-
-export type MessageType = 'message' | 'action' | 'meta' | 'error';
-
-export type Message = {
-	content: string;
-	role: MessageRole;
-	type: MessageType;
-	chat_id?: string | null;
-};
-
-export type Chat = {
-	chat_id?: string | null;
-	messages: Message[];
-	context: Context;
-};
 
 interface OdysseusAssistantContextInterface {
 	addMessage: ( message: Message ) => void;
@@ -47,7 +21,7 @@ interface OdysseusAssistantContextInterface {
 
 const defaultContextInterfaceValues = {
 	addMessage: noop,
-	chat: { context: { section_name: '' }, messages: [] },
+	chat: { context: { section_name: '', site_id: null }, messages: [] },
 	isLoadingChat: false,
 	lastNudge: null,
 	sendNudge: noop,
@@ -73,10 +47,14 @@ const OdysseusAssistantProvider = ( {
 	sectionName: string;
 	children: ReactNode;
 } ) => {
+	const siteId = useSelector( getSelectedSiteId );
+
 	const [ lastNudge, setLastNudge ] = useState< Nudge | null >( null );
-	const [ messages, setMessages ] = useState< Message[] >( [] );
+	const [ messages, setMessages ] = useState< Message[] >( [
+		{ content: 'Hello, I am Wapuu! Your personal assistant.', role: 'bot', type: 'message' },
+	] );
 	const [ chat, setChat ] = useState< Chat >( {
-		context: { section_name: sectionName },
+		context: { section_name: sectionName, site_id: siteId },
 		messages,
 	} );
 
@@ -84,9 +62,8 @@ const OdysseusAssistantProvider = ( {
 		setMessages( ( prevMessages ) => {
 			const newMessages = [ ...prevMessages, message ];
 			setChat( ( prevChat ) => ( {
-				chat_id: message.chat_id ?? prevChat.chat_id,
+				...prevChat,
 				messages: newMessages,
-				context: prevChat.context,
 			} ) );
 			return newMessages;
 		} );

--- a/client/odysseus/index.tsx
+++ b/client/odysseus/index.tsx
@@ -93,7 +93,7 @@ const OdysseusAssistant = () => {
 				content: response.message.content,
 				role: 'bot',
 				type: 'message',
-				chatId: response.chatId,
+				chat_id: response.chat_id,
 			} );
 		} catch ( e ) {
 			addMessage( {

--- a/client/odysseus/index.tsx
+++ b/client/odysseus/index.tsx
@@ -1,8 +1,6 @@
 import { TextControl, Button } from '@wordpress/components';
 import classnames from 'classnames';
 import { useRef, useEffect, useState } from 'react';
-import { useSelector } from 'calypso/state';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useOdysseusAssistantContext } from './context';
 import { useOddyseusSendMessage } from './query';
 import WapuuRibbon from './wapuu-ribbon';
@@ -10,14 +8,12 @@ import WapuuRibbon from './wapuu-ribbon';
 import './style.scss';
 
 const OdysseusAssistant = () => {
-	const siteId = useSelector( getSelectedSiteId );
-	const { lastNudge, chat, isLoadingChat, addMessage, messages, setMessages } =
-		useOdysseusAssistantContext();
+	const { lastNudge, chat, isLoadingChat, addMessage, setMessages } = useOdysseusAssistantContext();
 	const [ input, setInput ] = useState( '' );
 	const [ isVisible, setIsVisible ] = useState( false );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ isNudging, setIsNudging ] = useState( false );
-	const { mutateAsync: sendOdysseusMessage } = useOddyseusSendMessage( siteId );
+	const { mutateAsync: sendOdysseusMessage } = useOddyseusSendMessage();
 
 	useEffect( () => {
 		if ( isLoadingChat ) {
@@ -31,7 +27,7 @@ const OdysseusAssistant = () => {
 		} else if ( chat ) {
 			setMessages( chat.messages );
 		}
-	}, [ chat, isLoadingChat, setMessages ] );
+	}, [ chat, isLoadingChat, setMessages, chat.messages ] );
 
 	const environmentBadge = document.querySelector( 'body > .environment-badge' );
 
@@ -39,7 +35,7 @@ const OdysseusAssistant = () => {
 
 	useEffect( () => {
 		messagesEndRef.current?.scrollIntoView( { behavior: 'smooth' } );
-	}, [ messages ] );
+	}, [ chat.messages ] );
 
 	useEffect( () => {
 		if ( lastNudge ) {
@@ -60,10 +56,6 @@ const OdysseusAssistant = () => {
 				clearTimeout( timeoutId );
 			};
 		}
-
-		setMessages( [
-			{ content: 'Hello, I am Wapuu! Your personal assistant.', role: 'bot', type: 'message' },
-		] );
 	}, [ lastNudge, setMessages ] );
 
 	const handleMessageChange = ( text: string ) => {
@@ -82,18 +74,12 @@ const OdysseusAssistant = () => {
 			setInput( '' );
 			const response = await sendOdysseusMessage( {
 				message: { content: input, role: 'user', type: 'message' },
-				context: lastNudge ?? {
-					nudge: 'none',
-					context: {},
-					initialMessage: 'Hello, I am Wapuu, your personal WordPress assistant',
-				},
 			} );
 
 			addMessage( {
 				content: response.message.content,
 				role: 'bot',
 				type: 'message',
-				chat_id: response.chat_id,
 			} );
 		} catch ( e ) {
 			addMessage( {
@@ -146,9 +132,9 @@ const OdysseusAssistant = () => {
 			<div className="chatbox-header">Wapuu Assistant</div>
 			<div className="chat-box-message-container">
 				<div className="chatbox-messages">
-					{ messages.map( ( message, index ) => (
+					{ chat.messages.map( ( message, index ) => (
 						<div
-							ref={ index === messages.length - 1 ? messagesEndRef : null }
+							ref={ index === chat.messages.length - 1 ? messagesEndRef : null }
 							className={ `chatbox-message ${ message.role === 'user' ? 'user' : 'wapuu' }` }
 							key={ index }
 						>

--- a/client/odysseus/query/index.ts
+++ b/client/odysseus/query/index.ts
@@ -1,20 +1,19 @@
 import { useMutation, UseMutationResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import { Nudge, useOdysseusAssistantContext } from '../context';
+import { Context, useOdysseusAssistantContext } from '../context';
 import type { Message } from '../context';
 
 function odysseusSendMessage(
 	siteId: number | null,
 	messages: Message[],
-	context: Nudge,
-	sectionName: string,
-	chatId?: string | null
+	context: Context,
+	chat_id?: string | null
 ) {
 	const path = `/odysseus/send_message`;
 	return wpcom.req.post( {
 		path,
 		apiNamespace: 'wpcom/v2',
-		body: { messages, context, sectionName, siteId, chatId },
+		body: { messages, context, siteId, chat_id: chat_id },
 	} );
 }
 
@@ -22,22 +21,22 @@ function odysseusSendMessage(
 export const useOddyseusSendMessage = (
 	siteId: number | null
 ): UseMutationResult<
-	{ chatId: string; message: Message },
+	{ chat_id: string; message: Message },
 	unknown,
-	{ message: Message; context: Nudge }
+	{ message: Message; context: Context }
 > => {
-	const { sectionName, chat, messages, setChat } = useOdysseusAssistantContext();
+	const { chat, setChat } = useOdysseusAssistantContext();
 
 	return useMutation( {
-		mutationFn: ( { message, context }: { message: Message; context: Nudge } ) => {
+		mutationFn: ( { message, context }: { message: Message; context: Context } ) => {
 			// If chatId is defined, we only send the message to the current chat
 			// Otherwise we send previous messages and the new one appended to the end to the server
-			const messagesToSend = chat?.chatId ? [ message ] : [ ...messages, message ];
+			const messagesToSend = chat?.chat_id ? [ message ] : [ ...chat.messages, message ];
 
-			return odysseusSendMessage( siteId, messagesToSend, context, sectionName, chat.chatId );
+			return odysseusSendMessage( siteId, messagesToSend, context, chat.chat_id );
 		},
 		onSuccess: ( data ) => {
-			setChat( { ...chat, chatId: data.chatId } );
+			setChat( { ...chat, chat_id: data.chat_id } );
 		},
 	} );
 };

--- a/client/odysseus/query/index.ts
+++ b/client/odysseus/query/index.ts
@@ -1,39 +1,32 @@
 import { useMutation, UseMutationResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import { Context, useOdysseusAssistantContext } from '../context';
-import type { Message } from '../context';
+import { useOdysseusAssistantContext } from '../context';
+import type { Message, Context } from '../types';
 
-function odysseusSendMessage(
-	siteId: number | null,
-	messages: Message[],
-	context: Context,
-	chat_id?: string | null
-) {
+function odysseusSendMessage( messages: Message[], context: Context, chat_id?: string | null ) {
 	const path = `/odysseus/send_message`;
 	return wpcom.req.post( {
 		path,
 		apiNamespace: 'wpcom/v2',
-		body: { messages, context, siteId, chat_id: chat_id },
+		body: { messages, context, chat_id: chat_id },
 	} );
 }
 
-// It will post a new message using the current chatId
-export const useOddyseusSendMessage = (
-	siteId: number | null
-): UseMutationResult<
+// It will post a new message using the current chat_id
+export const useOddyseusSendMessage = (): UseMutationResult<
 	{ chat_id: string; message: Message },
 	unknown,
-	{ message: Message; context: Context }
+	{ message: Message }
 > => {
 	const { chat, setChat } = useOdysseusAssistantContext();
 
 	return useMutation( {
-		mutationFn: ( { message, context }: { message: Message; context: Context } ) => {
-			// If chatId is defined, we only send the message to the current chat
+		mutationFn: ( { message }: { message: Message } ) => {
+			// If chat_id is defined, we only send the message to the current chat
 			// Otherwise we send previous messages and the new one appended to the end to the server
 			const messagesToSend = chat?.chat_id ? [ message ] : [ ...chat.messages, message ];
 
-			return odysseusSendMessage( siteId, messagesToSend, context, chat.chat_id );
+			return odysseusSendMessage( messagesToSend, chat.context, chat.chat_id );
 		},
 		onSuccess: ( data ) => {
 			setChat( { ...chat, chat_id: data.chat_id } );

--- a/client/odysseus/types/index.ts
+++ b/client/odysseus/types/index.ts
@@ -1,0 +1,29 @@
+export type Context = {
+	nudge_id?: string | undefined;
+	section_name?: string;
+	session_id?: string;
+	site_id: number | null;
+	// etc
+};
+
+export type Nudge = {
+	nudge: string;
+	initialMessage: string;
+	context?: Record< string, unknown >;
+};
+
+export type MessageRole = 'user' | 'bot';
+
+export type MessageType = 'message' | 'action' | 'meta' | 'error';
+
+export type Message = {
+	content: string;
+	role: MessageRole;
+	type: MessageType;
+};
+
+export type Chat = {
+	chat_id?: string | null;
+	messages: Message[];
+	context: Context;
+};


### PR DESCRIPTION
Related to
- 73-gh-Automattic/ai-services
- 83-gh-Automattic/ai-services 

## Proposed Changes

We can deal with nudges later - they prrrrobably should live on the server, with just a "nudge opportunity" in the client, and the server can choose to take the opportunity or not.

* Change `chatId` to `chat_id` everywhere, same as recent API changes (so everything's named the same everywhere)
* Refactor client to just have context, messages and chat_id at the top level of a chat request.
* Also as part of these changes I've moved types away from the context.

## Testing Instructions

1. Apply patch D115510
2. Ask Wapuu something
3. Assert that the format sent to the backend is as follows:

```json
{
	"messages": [{
		"content": "string"
		"role": "string"
		"type": "string"
	}],
	"context": {
		"section_name": "string",
		"site_id": "number"
	},
	"chat_id": "string"
}
```

For the first request, `chat_id` won't be there, you need to perform another question so `chat_id` has been "server-side" init'd

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
