### PR TITLE
Add more timeouts to teamcity builds

### DIFF
--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -53,6 +53,10 @@ open class WPComPluginBuild(
 		artifactRules = "$pluginSlug.zip"
 		buildNumberPattern = "%build.prefix%.%build.counter%"
 
+		failureConditions {
+			executionTimeoutMin = 6
+		}
+
 		triggers {
 			vcs {
 				branchFilter = """

--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -153,6 +153,10 @@ object E2ETests : BuildType({
 		}
 	}
 
+	failureConditions {
+		executionTimeoutMin = 5
+	}
+
 	triggers {
 		vcs {
 			branchFilter = """

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -446,7 +446,7 @@ object RunAllUnitTests : BuildType({
 	}
 
 	failureConditions {
-		executionTimeoutMin = 10
+		executionTimeoutMin = 8
 	}
 	features {
 		feature {


### PR DESCRIPTION
@worldomonation noticed the plugin build taking a long time. I added several execution timeouts to TeamCity builds which didn't have them. Unfortunately, I couldn't find a way to apply it globally :/

i think there is a global setting (https://www.jetbrains.com/help/teamcity/teamcity-configuration-and-maintenance.html#Build+Settings), but I don't think we have access to that. It doesn't seem like you can override it per-project or anything like that.