### PR TITLE
Domains: Allow default sort order override and use at end of bulk transfer

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -86,7 +86,7 @@ const Complete: Step = function Complete( { flow } ) {
 								</a>
 
 								<a
-									href="/domains/manage"
+									href="/domains/manage?filter=owned-by-me&sortKey=registered-until"
 									className="components-button is-primary manage-all-domains"
 									onClick={ () => handleUserClick( '/domains/manage' ) }
 								>

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -409,11 +409,14 @@ class AllDomains extends Component {
 			} );
 		}
 
+		const queryParams = new URLSearchParams( window.location.search );
+
 		return (
 			<>
 				<div className="all-domains__filter">{ this.renderDomainTableFilterButton() }</div>
 				<DomainsTable
 					currentRoute={ currentRoute }
+					defaultSortKey={ queryParams.get( 'sortKey' ) }
 					domains={ domains }
 					handleDomainItemToggle={ this.handleDomainItemToggle }
 					domainsTableColumns={ domainsTableColumns }

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -409,16 +409,11 @@ class AllDomains extends Component {
 			} );
 		}
 
-		const queryParams = new URLSearchParams( window.location.search );
-
 		return (
 			<>
 				<div className="all-domains__filter">{ this.renderDomainTableFilterButton() }</div>
 				<DomainsTable
 					currentRoute={ currentRoute }
-					defaultSortKey={
-						domainsTableColumns?.find( ( c ) => c.name === queryParams.get( 'sortKey' ) )?.name
-					}
 					domains={ domains }
 					handleDomainItemToggle={ this.handleDomainItemToggle }
 					domainsTableColumns={ domainsTableColumns }

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -416,7 +416,9 @@ class AllDomains extends Component {
 				<div className="all-domains__filter">{ this.renderDomainTableFilterButton() }</div>
 				<DomainsTable
 					currentRoute={ currentRoute }
-					defaultSortKey={ queryParams.get( 'sortKey' ) }
+					defaultSortKey={
+						domainsTableColumns?.find( ( c ) => c.name === queryParams.get( 'sortKey' ) )?.name
+					}
 					domains={ domains }
 					handleDomainItemToggle={ this.handleDomainItemToggle }
 					domainsTableColumns={ domainsTableColumns }

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -14,6 +14,8 @@ class DomainsTable extends PureComponent {
 	static propTypes = {
 		currentRoute: PropTypes.string,
 		domains: PropTypes.array,
+		defaultSortKey: PropTypes.string,
+		defaultSortOrder: PropTypes.number,
 		domainsTableColumns: PropTypes.array,
 		goToEditDomainRoot: PropTypes.func,
 		handleUpdatePrimaryDomainOptionClick: PropTypes.func,
@@ -29,13 +31,17 @@ class DomainsTable extends PureComponent {
 		translate: PropTypes.func,
 	};
 
-	state = {
-		sortKey: 'status', // initial column to sort by - should match the header columns
-		sortOrder: -1, // initial sort order where 1 = ascending and -1 = descending
-	};
-
 	renderedQuerySiteDomains = {};
 	renderedQuerySitePurchases = {};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			sortKey: props.defaultSortKey || 'status', // initial column to sort by - should match the header columns
+			sortOrder: props.defaultSortOrder || -1, // initial sort order where 1 = ascending and -1 = descending
+		};
+	}
 
 	changeTableSort = ( selectedColumn, sortOrder = null ) => {
 		const { domainsTableColumns } = this.props;

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -14,8 +14,6 @@ class DomainsTable extends PureComponent {
 	static propTypes = {
 		currentRoute: PropTypes.string,
 		domains: PropTypes.array,
-		defaultSortKey: PropTypes.string,
-		defaultSortOrder: PropTypes.number,
 		domainsTableColumns: PropTypes.array,
 		goToEditDomainRoot: PropTypes.func,
 		handleUpdatePrimaryDomainOptionClick: PropTypes.func,
@@ -43,8 +41,8 @@ class DomainsTable extends PureComponent {
 		)?.name;
 
 		this.state = {
-			sortKey: props.defaultSortKey || queryParamSort || 'status', // initial column to sort by - should match the header columns
-			sortOrder: props.defaultSortOrder || -1, // initial sort order where 1 = ascending and -1 = descending
+			sortKey: queryParamSort || 'status', // initial column to sort by - should match the header columns
+			sortOrder: -1, // initial sort order where 1 = ascending and -1 = descending
 		};
 	}
 

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -37,8 +37,13 @@ class DomainsTable extends PureComponent {
 	constructor( props ) {
 		super( props );
 
+		const queryParams = new URLSearchParams( window.location.search );
+		const queryParamSort = props.domainsTableColumns?.find(
+			( c ) => c.name === queryParams.get( 'sortKey' )
+		)?.name;
+
 		this.state = {
-			sortKey: props.defaultSortKey || 'status', // initial column to sort by - should match the header columns
+			sortKey: props.defaultSortKey || queryParamSort || 'status', // initial column to sort by - should match the header columns
 			sortOrder: props.defaultSortOrder || -1, // initial sort order where 1 = ascending and -1 = descending
 		};
 	}


### PR DESCRIPTION
## Proposed Changes

In a recent domains walkthrough ( p58i-eRk-p2 ), it was suggested that we should default the sort order by registered until, for bulk domains transfers, so that the most recently transferred domains are likely to be at the top. This PR accomplishes that by:

- Allowing the domains table component to have its default sort key overridden via prop
- In the all domains component, allowing the default sort to be overridden by a query param
- In the domain transfer success page, updating the query params to take advantage of the changes.
- Go to domains view for a single site and verify default sort order is by status

## Testing Instructions

* Load `/domains/manage` and verify that the default sort order is status
* Load `/domains/manage?sortKey=registered-until` and ensure default sort order is registered until
* Load `/setup/domain-transfer/complete`, click the manage all domains button, and ensure default sort is by registered until

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?