### PR TITLE
Design Picker: Remove hard-coded list of theme slugs

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/constants.ts
@@ -1,19 +1,1 @@
 export const STEP_NAME = 'design-setup';
-
-/**
- * Designs that are to be retired soon.
- * Designs can be removed from this list when the corresponding themes have actually been retired.
- */
-export const RETIRING_DESIGN_SLUGS = [
-	'ames',
-	'antonia',
-	'appleton',
-	'barnett',
-	'calvin',
-	'dorna',
-	'farrow',
-	'hari',
-	'heiwa',
-	'meraki',
-	'quadrat',
-];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -49,7 +49,7 @@ import {
 } from '../../analytics/record-design';
 import StepperLoader from '../../components/stepper-loader';
 import { getCategorizationOptions } from './categories';
-import { RETIRING_DESIGN_SLUGS, STEP_NAME } from './constants';
+import { STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
 import useRecipe from './hooks/use-recipe';
 import UpgradeModal from './upgrade-modal';
@@ -113,10 +113,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	// ********** Logic for fetching designs
 	const selectStarterDesigns = ( allDesigns: StarterDesigns ) => {
-		allDesigns.designs = allDesigns.designs.filter(
-			( design ) => RETIRING_DESIGN_SLUGS.indexOf( design.slug ) === -1
-		);
-
 		const blankCanvasDesignOffset = allDesigns.designs.findIndex( isBlankCanvasDesign );
 		if ( blankCanvasDesignOffset !== -1 ) {
 			// Extract the blank canvas design first and then insert it into the last one for the build and write intents


### PR DESCRIPTION
## Proposed Changes

This PR removes the hard-coded list of theme slug, since it's no longer necessary as they have been delisted in the backend. See pekYwv-2d9-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Onboarding Design Picker step `/setup/site-setup/designSetup?siteSlug=${site_slug}`
* Ensure that the list of themes is still not available in the Design Picker.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?