### PR TITLE
Fix/sending react elements to editor iframe

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -271,7 +271,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		if ( WindowActions.ClassicBlockOpenMediaModel === action ) {
 			if ( data.imageId ) {
 				const { siteId } = this.props;
-				this.props.selectMediaItems( siteId, [ { ID: data.imageId } ] );
+				this.props.selectMediaItems( siteId ?? 0, [ { ID: data.imageId } ] );
 			}
 
 			this.setState( {
@@ -309,7 +309,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 					? value.map( ( item ) => parseInt( item, 10 ) )
 					: [ parseInt( value, 10 ) ];
 				const selectedItems = ids.map( ( id ) => {
-					const media = this.props.getMediaItem( siteId, id );
+					const media = this.props.getMediaItem( siteId ?? 0, id );
 					if ( ! media ) {
 						this.props.fetchMediaItem( siteId, id );
 					}
@@ -319,9 +319,9 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 					};
 				} );
 
-				this.props.selectMediaItems( siteId, selectedItems );
+				this.props.selectMediaItems( siteId ?? 0, selectedItems );
 			} else {
-				this.props.selectMediaItems( siteId, [] );
+				this.props.selectMediaItems( siteId ?? 0, [] );
 			}
 
 			this.setState( { isMediaModalVisible: true, allowedTypes, multiple } );
@@ -353,16 +353,18 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 				this.props.setRoute( `${ currentRoute }/${ postId }` );
 
 				//set postId on state.editor.postId, so components like editor revisions can read from it
-				this.props.startEditingPost( siteId, postId );
+				this.props.startEditingPost( siteId ?? 0, postId );
 
 				//set post type on state.posts.[ id ].type, so components like document head can read from it
-				this.props.editPost( siteId, postId, { type: postType } );
+				this.props.editPost( siteId ?? 0, postId, { type: postType } );
 			}
 		}
 
 		if ( EditorActions.TrashPost === action ) {
 			const { siteId, editedPostId, postTypeTrashUrl } = this.props;
-			this.props.trashPost( siteId, editedPostId );
+			if ( typeof siteId === 'number' && typeof editedPostId === 'number' ) {
+				this.props.trashPost( siteId, editedPostId );
+			}
 			navigate( postTypeTrashUrl );
 		}
 
@@ -500,7 +502,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 
 	setFrontPage = () => {
 		const { editedPostId, siteId } = this.props;
-		this.props.updateSiteFrontPage( siteId, {
+		this.props.updateSiteFrontPage( siteId ?? 0, {
 			show_on_front: 'page',
 			page_on_front: editedPostId,
 		} );
@@ -579,9 +581,13 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		this.setState( { isCheckoutModalVisible: false } );
 	};
 
-	/* eslint-disable @typescript-eslint/ban-types */
+	/* eslint-disable-next-line @typescript-eslint/ban-types */
 	openCustomizer = ( autofocus: object, unsavedChanges: boolean ) => {
 		let { customizerUrl } = this.props;
+		if ( ! customizerUrl ) {
+			return;
+		}
+
 		if ( autofocus ) {
 			const [ key, value ] = Object.entries( autofocus )[ 0 ];
 			customizerUrl = addQueryArgs(

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -407,10 +407,15 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 
 		if ( EditorActions.GetCloseButtonUrl === action ) {
 			const { closeUrl, closeLabel } = this.props;
-			ports[ 0 ].postMessage( {
-				closeUrl: `${ window.location.origin }${ closeUrl }`,
-				label: closeLabel,
-			} );
+
+			// If the closeLabel isn't a string, it's a React component and we can't serialize it over a message.
+			// Don't send the message and allow the editor to use it's default close URL and label.
+			if ( typeof closeLabel === 'string' ) {
+				ports[ 0 ].postMessage( {
+					closeUrl: `${ window.location.origin }${ closeUrl }`,
+					label: closeLabel,
+				} );
+			}
 		}
 
 		if ( EditorActions.GetGutenboardingStatus === action ) {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-/* eslint-disable no-restricted-imports */
 import config from '@automattic/calypso-config';
 import { getQueryArg } from '@wordpress/url';
 import { localize, LocalizeProps } from 'i18n-calypso';
@@ -16,12 +13,7 @@ import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { navigate } from 'calypso/lib/navigate';
-import {
-	withStopPerformanceTrackingProp,
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore - PerformanceTrackProps is defined calypso/lib/performance-tracking/index.web.js
-	PerformanceTrackProps,
-} from 'calypso/lib/performance-tracking';
+import { withStopPerformanceTrackingProp } from 'calypso/lib/performance-tracking';
 import { protectForm, ProtectedFormProps } from 'calypso/lib/protect-form';
 import { addQueryArgs } from 'calypso/lib/route';
 import wpcom from 'calypso/lib/wp';
@@ -59,16 +51,16 @@ import Iframe from './iframe';
 import { getEnabledFilters, getDisabledDataSources, mediaCalypsoToGutenberg } from './media-utils';
 import { Placeholder } from './placeholder';
 import type { RequestCart } from '@automattic/shopping-cart';
+import type { PerformanceTrackProps } from 'calypso/lib/performance-tracking/index.web';
 import './style.scss';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 interface Props {
 	duplicatePostId: T.PostId;
 	creatingNewHomepage?: boolean;
 	postId: T.PostId;
 	postType: T.PostType;
 	editorType: 'site' | 'post'; // Note: a page or other CPT is a type of post.
-	pressThisData: any;
+	pressThisData: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 	anchorFmData: {
 		anchor_podcast: string | undefined;
 		anchor_episode: string | undefined;
@@ -87,17 +79,16 @@ interface CheckoutModalOptions extends RequestCart {
 }
 
 interface State {
-	allowedTypes?: any;
-	classicBlockEditorId?: any;
+	allowedTypes?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+	classicBlockEditorId?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 	isIframeLoaded: boolean;
 	currentIFrameUrl: string;
 	isMediaModalVisible: boolean;
 	isCheckoutModalVisible: boolean;
-	multiple?: any;
+	multiple?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 	postUrl?: T.URL;
 	checkoutModalOptions?: CheckoutModalOptions;
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 enum WindowActions {
 	Loaded = 'loaded',
@@ -301,8 +292,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		// see: https://github.com/Automattic/wp-calypso/pull/45436
 		const ports = data.ports ?? backCompatPorts;
 
-		/* eslint-disable @typescript-eslint/no-explicit-any */
-		const { action, payload }: { action: EditorActions; payload: any } = data;
+		const { action, payload }: { action: EditorActions; payload: any } = data; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 		if ( EditorActions.OpenMediaModal === action && ports && ports[ 0 ] ) {
 			const { siteId } = this.props;

--- a/client/state/editor/actions.js
+++ b/client/state/editor/actions.js
@@ -67,6 +67,10 @@ export function setEditorMediaModalView( view ) {
 	return action;
 }
 
+/**
+ * @param {boolean} isIframeLoaded
+ * @param {MessagePort | null} iframePort
+ */
 export const setEditorIframeLoaded = ( isIframeLoaded = true, iframePort = null ) => ( {
 	type: EDITOR_IFRAME_LOADED,
 	isIframeLoaded,

--- a/client/state/selectors/get-editor-close-config.js
+++ b/client/state/selectors/get-editor-close-config.js
@@ -9,9 +9,9 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
  * @param {Object} state  Global state tree
  * @param {number|string|undefined|null} siteId Site ID
  * @param {string} postType The type of the current post being edited
- * @returns {{url: string; label: string}} The URL that should be used when the block editor close button is clicked
+ * @returns {{url: string; label: import('i18n-calypso').TranslateResult}} The URL that should be used when the block editor close button is clicked
  * @property {string} url The URL that should be used when the block editor close button is clicked
- * @property {string} label The label that should be used for the block editor back button
+ * @property {import('i18n-calypso').TranslateResult} label The label that should be used for the block editor back button
  */
 
 export default function getEditorCloseConfig( state, siteId, postType ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Reported by Sentry p1688693946971599-slack-C04U5A26MJB

## Proposed Changes

Calypso customises the editor close button by sending a custom URL and label using `postMessage()`. The arguments sent in the message need to be serialisable. That's fine because usually the URL and label are plain strings. However Sentry has told us that sometimes the close label is a React node.

I can't reproduce this, but I can see how it's technically possible. The value returned by `translate()` can be a React node. Maybe it happens for only some languages? Maybe it happens if translations haven't completed loading?

I've
- Updated `getEditorCloseConfig` types to make it clear it might return a non-string
- Improved `<CalypsoifyIframe>` typings so the fixed close label types flow through the component correctly
- Fixed the error by not customising the close button if the close label isn't serialisable.

We could have also customised the URL but not the label. I don't think this is a good idea because we could end up in a weird situation where the URL is pointing to the theme explorer but the label is saying "Dashboard".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Close repo and test Calypso locally
* Open the post, page, or site editor and test the close editor button (which is in the sidebar accessed by the (W) button)
* Edit the back label so it includes a React node
   * https://github.com/Automattic/wp-calypso/blob/3ed8c7a856d67e555ac13aa8c723c53e27f49bb6/client/state/selectors/get-editor-close-config.js#L59
   * Change it to something like `translate( 'View {{b}}Posts{{/b}}', { components: { b: <strong /> } } );`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?