### PR TITLE
GF Signup: show 1y/2y toggle on the paid media flow.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -73,6 +73,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			 ).getHidePlansFeatureComparison(),
 		};
 	}, [] );
+	const { flowName, hostingFlow } = props;
 
 	const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
 
@@ -85,8 +86,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const customerType = 'personal';
 	const isInVerticalScrollingPlansExperiment = true;
 	const headerText = __( 'Choose a plan' );
-	const isInSignup = props?.flowName === DOMAIN_UPSELL_FLOW ? false : true;
-	const plansIntent = getPlansIntent( props?.flowName, props.hostingFlow );
+	const isInSignup = flowName === DOMAIN_UPSELL_FLOW ? false : true;
+	const plansIntent = getPlansIntent( flowName, hostingFlow );
 	const hideFreePlan = plansIntent
 		? reduxHideFreePlan && 'plans-blog-onboarding' === plansIntent
 		: reduxHideFreePlan;
@@ -126,8 +127,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	};
 
 	const plansFeaturesList = () => {
-		const { flowName } = props;
-
 		if ( ! props.plansLoaded ) {
 			return renderLoading();
 		}
@@ -137,6 +136,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 				<PlansFeaturesMain
 					isPlansInsideStepper={ true }
 					siteId={ site?.ID }
+					showBiennialToggle={ isOnboardingPMFlow( flowName ) }
 					hideFreePlan={ hideFreePlan }
 					isInSignup={ isInSignup }
 					isStepperUpgradeFlow={ true }
@@ -155,7 +155,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	};
 
 	const getHeaderText = () => {
-		const { flowName } = props;
 		if (
 			flowName === DOMAIN_UPSELL_FLOW ||
 			isNewHostedSiteCreationFlow( flowName ) ||
@@ -180,8 +179,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	};
 
 	const getSubHeaderText = () => {
-		const { flowName } = props;
-
 		const freePlanButton = (
 			<Button onClick={ handleFreePlanButtonClick } className="is-borderless" />
 		);
@@ -211,8 +208,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	};
 
 	const plansFeaturesSelection = () => {
-		const { flowName } = props;
-
 		const headerText = getHeaderText();
 		const fallbackHeaderText = headerText;
 		const subHeaderText = getSubHeaderText();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -1,6 +1,4 @@
-// import { subscribeIsDesktop } from '@automattic/viewport';
 import { getPlan, PLAN_FREE } from '@automattic/calypso-products';
-import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
 import {
 	DOMAIN_UPSELL_FLOW,
@@ -30,6 +28,7 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { startedInHostingFlow } from 'calypso/landing/stepper/utils/hosting-flow';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { getIntervalType } from 'calypso/signup/steps/plans/util';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPlanSlug } from 'calypso/state/plans/selectors';
 import { ONBOARD_STORE } from '../../../../stores';
@@ -37,7 +36,6 @@ import type { OnboardSelect } from '@automattic/data-stores';
 import type { PlansIntent } from 'calypso/my-sites/plans-features-main/hooks/use-plan-types-with-intent';
 import './style.scss';
 
-type IntervalType = 'yearly' | 'monthly';
 interface Props {
 	flowName: string | null;
 	onSubmit: ( pickedPlan: MinimalRequestCartProduct | null ) => void;
@@ -125,18 +123,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 				<LoadingEllipsis className="active" />
 			</div>
 		);
-	};
-
-	const getIntervalType: () => IntervalType = () => {
-		const urlParts = getUrlParts( typeof window !== 'undefined' ? window.location?.href : '' );
-		const intervalType = urlParts?.searchParams.get( 'intervalType' );
-		switch ( intervalType ) {
-			case 'monthly':
-			case 'yearly':
-				return intervalType as IntervalType;
-			default:
-				return 'yearly';
-		}
 	};
 
 	const plansFeaturesList = () => {

--- a/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
@@ -40,7 +40,7 @@ export type PlanTypeSelectorProps = {
 	siteSlug?: string | null;
 	selectedPlan?: string;
 	selectedFeature?: string;
-	showBiannualToggle?: boolean;
+	showBiennialToggle?: boolean;
 	isInSignup: boolean;
 	plans: string[];
 	eligibleForWpcomMonthlyPlans?: boolean;
@@ -131,7 +131,7 @@ export type IntervalTypeProps = Pick<
 	| 'isPlansInsideStepper'
 	| 'hideDiscountLabel'
 	| 'redirectTo'
-	| 'showBiannualToggle'
+	| 'showBiennialToggle'
 	| 'selectedPlan'
 	| 'selectedFeature'
 >;
@@ -143,7 +143,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		isInSignup,
 		eligibleForWpcomMonthlyPlans,
 		hideDiscountLabel,
-		showBiannualToggle,
+		showBiennialToggle,
 	} = props;
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 	const segmentClasses = classNames( 'plan-features__interval-type', 'price-toggle', {
@@ -156,14 +156,14 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		return currentSitePlanSlug ? getPlanBillPeriod( state, currentSitePlanSlug ) : null;
 	} );
 
-	if ( showBiannualToggle ) {
+	if ( showBiennialToggle ) {
 		// skip showing toggle if current plan's term is higher than 1 year
 		if ( currentPlanBillingPeriod && PLAN_ANNUAL_PERIOD < currentPlanBillingPeriod ) {
 			return null;
 		}
 	}
 
-	if ( ! showBiannualToggle ) {
+	if ( ! showBiennialToggle ) {
 		if ( ! eligibleForWpcomMonthlyPlans ) {
 			return null;
 		}
@@ -183,7 +183,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 
 	const isJetpackAppFlow = new URLSearchParams( window.location.search ).get( 'jetpackAppPlans' );
 
-	const intervalTabs = showBiannualToggle ? [ 'yearly', '2yearly' ] : [ 'monthly', 'yearly' ];
+	const intervalTabs = showBiennialToggle ? [ 'yearly', '2yearly' ] : [ 'monthly', 'yearly' ];
 
 	return (
 		<IntervalTypeToggleWrapper
@@ -210,11 +210,11 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 							}
 						>
 							{ interval === 'monthly' ? translate( 'Pay monthly' ) : null }
-							{ interval === 'yearly' && ! showBiannualToggle ? translate( 'Pay annually' ) : null }
-							{ interval === 'yearly' && showBiannualToggle ? translate( 'Pay 1 year' ) : null }
+							{ interval === 'yearly' && ! showBiennialToggle ? translate( 'Pay annually' ) : null }
+							{ interval === 'yearly' && showBiennialToggle ? translate( 'Pay 1 year' ) : null }
 							{ interval === '2yearly' ? translate( 'Pay 2 years' ) : null }
 						</span>
-						{ ! showBiannualToggle && hideDiscountLabel ? null : (
+						{ ! showBiennialToggle && hideDiscountLabel ? null : (
 							<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
 								{ translate(
 									'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -77,6 +77,7 @@ interface PlansFeaturesMainProps {
 	isLaunchPage?: boolean | null;
 	isReskinned?: boolean;
 	isPlansInsideStepper?: boolean;
+	showBiennialToggle?: boolean;
 }
 
 type OnboardingPricingGrid2023Props = PlansFeaturesMainProps & {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -233,6 +233,7 @@ const PlansFeaturesMain = ( {
 	hideEnterprisePlan,
 	intent: intentFromProps, // do not set a default value for this prop here
 	isReskinned,
+	showBiennialToggle,
 	customerType = 'personal',
 	planTypeSelector = 'interval',
 	intervalType = 'yearly',
@@ -370,6 +371,7 @@ const PlansFeaturesMain = ( {
 		siteSlug,
 		selectedPlan,
 		selectedFeature,
+		showBiennialToggle,
 		kind: planTypeSelector,
 		plans: visiblePlans,
 	};

--- a/client/signup/steps/plans-pm/plans-features-main-pm.jsx
+++ b/client/signup/steps/plans-pm/plans-features-main-pm.jsx
@@ -164,7 +164,7 @@ export class PlansFeaturesMainPM extends Component {
 			eligibleForWpcomMonthlyPlans: true,
 			isInSignup: this.props.isInSignup,
 			intervalType: this.props.intervalType,
-			showBiannualToggle: this.props.showBiannualToggle,
+			showBiennialToggle: this.props.showBiennialToggle,
 		};
 		const plans = this.getPlans();
 
@@ -195,7 +195,7 @@ PlansFeaturesMainPM.propTypes = {
 	plansWithScroll: PropTypes.bool,
 	planTypeSelector: PropTypes.string,
 	redirectToAddDomainFlow: PropTypes.bool,
-	showBiannualToggle: PropTypes.bool,
+	showBiennialToggle: PropTypes.bool,
 	shouldShowPlansFeatureComparison: PropTypes.bool,
 };
 
@@ -207,7 +207,7 @@ PlansFeaturesMainPM.defaultProps = {
 	isReskinned: true,
 	plansWithScroll: false,
 	planTypeSelector: 'interval',
-	showBiannualToggle: true,
+	showBiennialToggle: true,
 	shouldShowPlansFeatureComparison: true,
 };
 

--- a/client/signup/steps/plans/util.ts
+++ b/client/signup/steps/plans/util.ts
@@ -7,7 +7,6 @@ type DomainItem = {
 	product_slug?: string;
 };
 
-// TODO: this can be so much simpler once all the call sites of this functions are TS
 export const getIntervalType = ( path?: string ): IntervalType => {
 	const url = path ?? window?.location?.href ?? '';
 	const intervalType = getUrlParts( url ).searchParams.get( 'intervalType' ) || 'yearly';

--- a/client/signup/steps/plans/util.ts
+++ b/client/signup/steps/plans/util.ts
@@ -1,4 +1,5 @@
 import { getUrlParts } from '@automattic/calypso-url';
+import type { IntervalType } from 'calypso/my-sites/plans-features-main/types';
 
 type DomainItem = {
 	is_domain_registration?: boolean;
@@ -6,10 +7,13 @@ type DomainItem = {
 	product_slug?: string;
 };
 
-export const getIntervalType = ( path?: string ): string => {
+// TODO: this can be so much simpler once all the call sites of this functions are TS
+export const getIntervalType = ( path?: string ): IntervalType => {
 	const url = path ?? window?.location?.href ?? '';
 	const intervalType = getUrlParts( url ).searchParams.get( 'intervalType' ) || 'yearly';
-	return [ 'yearly', '2yearly', 'monthly' ].includes( intervalType ) ? intervalType : 'yearly';
+	return (
+		[ 'yearly', '2yearly', 'monthly' ].includes( intervalType ) ? intervalType : 'yearly'
+	) as IntervalType;
 };
 
 export const getDomainName = ( domainItem: DomainItem ): string | undefined => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1882

## Proposed Changes

This PR updates the term toggle as the 1y/2y to match the spec. There is some accompanied maintenance done along the way:

* Rename "biannual" as "biennial" since the former actually means twice a year.
* Remove duplicated code, particular the interval-related code that can be just reused.

<img width="1263" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/a2923879-7550-4a6c-83a4-72b13d5000d2">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through `/setup/onboarding-meida` and make sure 1y/2y toggle is presented on the plans page.
* Cherry-pick one another tailored flows, e.g. `/setup/newsletter`, and make sure it's unaffected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
