### PR TITLE
GF signup: the paid media flow should also show the paid domain + Free plan modal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -8,6 +8,7 @@ import {
 	NEWSLETTER_FLOW,
 	DOMAIN_UPSELL_FLOW,
 	ONBOARDING_PM_FLOW,
+	isOnboardingPMFlow,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -105,7 +106,9 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			} );
 			dispatch( submitDomainStepSelection( suggestion, getAnalyticsSection() ) );
 
-			setHideFreePlan( Boolean( suggestion.product_slug ) || shouldHideFreePlan );
+			if ( ! isOnboardingPMFlow( flow ) ) {
+				setHideFreePlan( Boolean( suggestion.product_slug ) || shouldHideFreePlan );
+			}
 			setDomainCartItem( domainCartItem );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -8,7 +8,6 @@ import {
 	NEWSLETTER_FLOW,
 	DOMAIN_UPSELL_FLOW,
 	ONBOARDING_PM_FLOW,
-	isOnboardingPMFlow,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -106,9 +105,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			} );
 			dispatch( submitDomainStepSelection( suggestion, getAnalyticsSection() ) );
 
-			if ( ! isOnboardingPMFlow( flow ) ) {
-				setHideFreePlan( Boolean( suggestion.product_slug ) || shouldHideFreePlan );
-			}
+			setHideFreePlan( Boolean( suggestion.product_slug ) || shouldHideFreePlan );
 			setDomainCartItem( domainCartItem );
 		}
 

--- a/client/landing/stepper/declarative-flow/onboarding-pm.ts
+++ b/client/landing/stepper/declarative-flow/onboarding-pm.ts
@@ -39,7 +39,7 @@ const onboarding: Flow = {
 	},
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = ONBOARDING_PM_FLOW;
-		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const { setStepProgress, setHideFreePlan } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: currentStep, flowName } );
 		const { domain, provider } = useDomainParams();
 
@@ -77,6 +77,9 @@ const onboarding: Flow = {
 
 			switch ( currentStep ) {
 				case 'domains':
+					// At the moment, this flow is the only one which doesn't hide the Free plan when a paid domain is picked, so it's done here.
+					// Once this behavior is standardized, we will be able to remove this.
+					setHideFreePlan( false );
 					navigate( 'plans' );
 					return;
 				case 'plans':

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
+import { isOnboardingPMFlow } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import classNames from 'classnames';
@@ -273,7 +274,11 @@ const PlansFeaturesMain = ( {
 		// `cartItemForPlan` is empty if Free plan is selected. Show `FreePlanPaidDomainDialog`
 		// in that case and exit. `FreePlanPaidDomainDialog` takes over from there.
 		// - only applicable to main onboarding flow (default `/start`)
-		if ( 'onboarding' === flowName && domainName && ! cartItemForPlan ) {
+		if (
+			( 'onboarding' === flowName || isOnboardingPMFlow( flowName ) ) &&
+			domainName &&
+			! cartItemForPlan
+		) {
 			toggleIsFreePlanPaidDomainDialogOpen();
 			return;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1882

## Proposed Changes

This PR enables the paid domain + Free plan modal for the paid media flow to match the spec. 

## Testing Instructions

* Go `/setup/onboarding-media`
* Pick a paid domain at the domain step
* At the plans step, the Free plan should still present.
* Clicking on "Start with Free", the paid domain + Free plan modal should show.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
