### PR TITLE
Reader: Handle error in thumbnail fetching

### DIFF
--- a/client/state/reader/thumbnails/actions.js
+++ b/client/state/reader/thumbnails/actions.js
@@ -47,10 +47,7 @@ export const requestThumbnail = ( embedUrl ) => ( dispatch ) => {
 
 			try {
 				return globalThis.fetch( posterEndpoint ).then( async ( response ) => {
-					let json;
-					try {
-						json = await response.json();
-					} catch ( error ) {}
+					const json = await response.json();
 
 					const thumbnailUrl = json?.poster ?? '';
 					if ( thumbnailUrl ) {
@@ -65,10 +62,7 @@ export const requestThumbnail = ( embedUrl ) => ( dispatch ) => {
 			const fetchUrl = `https://vimeo.com/api/v2/video/${ id }.json`;
 			try {
 				return globalThis.fetch( fetchUrl ).then( async ( response ) => {
-					let json;
-					try {
-						json = await response.json();
-					} catch ( error ) {}
+					const json = await response.json();
 
 					const thumbnailUrl = get( json, [ 0, 'thumbnail_large' ] );
 					if ( thumbnailUrl ) {

--- a/client/state/reader/thumbnails/actions.js
+++ b/client/state/reader/thumbnails/actions.js
@@ -46,14 +46,15 @@ export const requestThumbnail = ( embedUrl ) => ( dispatch ) => {
 			const posterEndpoint = `https://public-api.wordpress.com/rest/v1.1/videos/${ id }/poster`;
 
 			try {
-				return globalThis.fetch( posterEndpoint ).then( async ( response ) => {
-					const json = await response.json();
-
-					const thumbnailUrl = json?.poster ?? '';
-					if ( thumbnailUrl ) {
-						dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
-					}
-				} );
+				return globalThis
+					.fetch( posterEndpoint )
+					.then( ( response ) => response.json() )
+					.then( ( json ) => {
+						const thumbnailUrl = json?.poster ?? '';
+						if ( thumbnailUrl ) {
+							dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
+						}
+					} );
 			} catch ( error ) {}
 		}
 		case 'vimeo': {
@@ -61,14 +62,15 @@ export const requestThumbnail = ( embedUrl ) => ( dispatch ) => {
 
 			const fetchUrl = `https://vimeo.com/api/v2/video/${ id }.json`;
 			try {
-				return globalThis.fetch( fetchUrl ).then( async ( response ) => {
-					const json = await response.json();
-
-					const thumbnailUrl = get( json, [ 0, 'thumbnail_large' ] );
-					if ( thumbnailUrl ) {
-						dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
-					}
-				} );
+				return globalThis
+					.fetch( fetchUrl )
+					.then( ( response ) => response.json() )
+					.then( ( json ) => {
+						const thumbnailUrl = get( json, [ 0, 'thumbnail_large' ] );
+						if ( thumbnailUrl ) {
+							dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
+						}
+					} );
 			} catch ( error ) {}
 		}
 		default:

--- a/client/state/reader/thumbnails/actions.js
+++ b/client/state/reader/thumbnails/actions.js
@@ -45,33 +45,37 @@ export const requestThumbnail = ( embedUrl ) => ( dispatch ) => {
 		case 'videopress': {
 			const posterEndpoint = `https://public-api.wordpress.com/rest/v1.1/videos/${ id }/poster`;
 
-			return globalThis.fetch( posterEndpoint ).then( async ( response ) => {
-				let json;
-				try {
-					json = await response.json();
-				} catch ( error ) {}
+			try {
+				return globalThis.fetch( posterEndpoint ).then( async ( response ) => {
+					let json;
+					try {
+						json = await response.json();
+					} catch ( error ) {}
 
-				const thumbnailUrl = json?.poster ?? '';
-				if ( thumbnailUrl ) {
-					dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
-				}
-			} );
+					const thumbnailUrl = json?.poster ?? '';
+					if ( thumbnailUrl ) {
+						dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
+					}
+				} );
+			} catch ( error ) {}
 		}
 		case 'vimeo': {
 			debug( `Requesting thumbnail for embed ${ embedUrl }` );
 
 			const fetchUrl = `https://vimeo.com/api/v2/video/${ id }.json`;
-			return globalThis.fetch( fetchUrl ).then( async ( response ) => {
-				let json;
-				try {
-					json = await response.json();
-				} catch ( error ) {}
+			try {
+				return globalThis.fetch( fetchUrl ).then( async ( response ) => {
+					let json;
+					try {
+						json = await response.json();
+					} catch ( error ) {}
 
-				const thumbnailUrl = get( json, [ 0, 'thumbnail_large' ] );
-				if ( thumbnailUrl ) {
-					dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
-				}
-			} );
+					const thumbnailUrl = get( json, [ 0, 'thumbnail_large' ] );
+					if ( thumbnailUrl ) {
+						dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
+					}
+				} );
+			} catch ( error ) {}
 		}
 		default:
 			return Promise.resolve();


### PR DESCRIPTION
## Proposed Changes

This PR resolves an unhandled exception when a thumbnail of a video in the reader fails fetching: `TypeError: Failed to fetch`. 

The solution is very straightforward: wrapping the `fetch` calls in their own `try/catch` block.

Originally reported by Sentry: p1688642363555469-slack-C04U5A26MJB

## Testing Instructions

* Open the Reader and find some videos. 
* Verify their thumbnails in feeds still load correctly.