### PR TITLE
Move isDefaultGlobalStylesVariationSlug to @automattic/global-styles

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -2,7 +2,7 @@ import { Card, Button, Gridicon } from '@automattic/components';
 import {
 	DesignPreviewImage,
 	ThemeCard,
-	isDefaultGlobalStylesVariationSlug,
+	asyncIsDefaultGlobalStylesVariationSlug,
 } from '@automattic/design-picker';
 import { localize } from 'i18n-calypso';
 import { isEmpty, isEqual } from 'lodash';
@@ -160,7 +160,7 @@ export class Theme extends Component {
 		// With that in mind, we only use mShots for non-default style variations to ensure
 		// that there is no flash of image transition from static image to mShots on page load.
 		if (
-			! isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug ) &&
+			! asyncIsDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug ) &&
 			! isExternallyManagedTheme
 		) {
 			const { id: themeId, stylesheet } = theme;
@@ -286,7 +286,7 @@ export class Theme extends Component {
 	renderBadge = () => {
 		const isLockedStyleVariation =
 			this.props.shouldLimitGlobalStyles &&
-			! isDefaultGlobalStylesVariationSlug( this.props.selectedStyleVariation?.slug );
+			! asyncIsDefaultGlobalStylesVariationSlug( this.props.selectedStyleVariation?.slug );
 		return (
 			<ThemeTypeBadge
 				siteId={ this.props.siteId }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
@@ -1,5 +1,9 @@
-import { isDefaultGlobalStylesVariationSlug, isAssemblerDesign } from '@automattic/design-picker';
-import { useColorPaletteVariations, useFontPairingVariations } from '@automattic/global-styles';
+import { isAssemblerDesign } from '@automattic/design-picker';
+import {
+	isDefaultGlobalStylesVariationSlug,
+	useColorPaletteVariations,
+	useFontPairingVariations,
+} from '@automattic/global-styles';
 import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect, useMemo } from 'react';
@@ -61,6 +65,7 @@ const useRecipe = (
 			preselectedColorVariationTitle: searchParams.get( 'color_variation_title' ),
 			preselectedFontVariationTitle: searchParams.get( 'font_variation_title' ),
 		} ),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[]
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -8,13 +8,13 @@ import {
 	useStarterDesignsQuery,
 } from '@automattic/data-stores';
 import {
-	isDefaultGlobalStylesVariationSlug,
 	UnifiedDesignPicker,
 	useCategorizationFromApi,
 	getDesignPreviewUrl,
 	isBlankCanvasDesign,
 	isAssemblerDesign,
 } from '@automattic/design-picker';
+import { isDefaultGlobalStylesVariationSlug } from '@automattic/global-styles';
 import { useLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon, Button } from '@automattic/components';
-import { DesignPreviewImage, isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
+import { DesignPreviewImage } from '@automattic/design-picker';
+import { isDefaultGlobalStylesVariationSlug } from '@automattic/global-styles';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -105,6 +106,7 @@ const ThemeNameSectionWrapper = styled.div`
 	flex-wrap: wrap;
 `;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -10,10 +10,10 @@ import {
 } from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
 import {
-	DEFAULT_GLOBAL_STYLES_VARIATION_SLUG,
 	ThemePreview as ThemeWebPreview,
+	asyncGetDefaultGlobalStylesVariationSlug,
+	asyncIsDefaultGlobalStylesVariationSlug,
 	getDesignPreviewUrl,
-	isDefaultGlobalStylesVariationSlug,
 } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -392,7 +392,7 @@ class ThemeSheet extends Component {
 	shouldRenderUnlockStyleButton() {
 		const { defaultOption, selectedStyleVariationSlug, shouldLimitGlobalStyles, styleVariations } =
 			this.props;
-		const isNonDefaultStyleVariation = ! isDefaultGlobalStylesVariationSlug(
+		const isNonDefaultStyleVariation = ! asyncIsDefaultGlobalStylesVariationSlug(
 			selectedStyleVariationSlug
 		);
 
@@ -503,7 +503,7 @@ class ThemeSheet extends Component {
 	renderWebPreview = () => {
 		const { locale, siteSlug, stylesheet, styleVariations, themeId } = this.props;
 		const baseStyleVariation = styleVariations.find( ( style ) =>
-			isDefaultGlobalStylesVariationSlug( style.slug )
+			asyncIsDefaultGlobalStylesVariationSlug( style.slug )
 		);
 		const baseStyleVariationInlineCss = baseStyleVariation?.inline_css || '';
 		const selectedStyleVariationInlineCss = this.getSelectedStyleVariation()?.inline_css || '';
@@ -1120,7 +1120,7 @@ class ThemeSheet extends Component {
 		const { selectedStyleVariationSlug, themeId } = this.props;
 		return {
 			theme_name: themeId,
-			style_variation: selectedStyleVariationSlug ?? DEFAULT_GLOBAL_STYLES_VARIATION_SLUG,
+			style_variation: selectedStyleVariationSlug ?? asyncGetDefaultGlobalStylesVariationSlug(),
 		};
 	};
 

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -32,6 +32,7 @@
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
+		"@automattic/global-styles": "workspace:^",
 		"@automattic/js-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/typography": "workspace:^",

--- a/packages/design-picker/src/components/style-variation-badges/index.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/index.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
-import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '../../constants';
-import { isDefaultGlobalStylesVariationSlug } from '../../utils';
+import {
+	asyncGetDefaultGlobalStylesVariationSlug,
+	asyncIsDefaultGlobalStylesVariationSlug,
+} from '../../utils';
 import Badge from './badge';
 import type { StyleVariation } from '../../types';
 import './style.scss';
@@ -22,7 +24,9 @@ const Badges: React.FC< BadgesProps > = ( {
 	onClick,
 	selectedVariation,
 } ) => {
-	const isSelectedVariationDefault = isDefaultGlobalStylesVariationSlug( selectedVariation?.slug );
+	const isSelectedVariationDefault = asyncIsDefaultGlobalStylesVariationSlug(
+		selectedVariation?.slug
+	);
 	const variationsToShow = useMemo( () => {
 		return variations.slice( 0, maxVariationsToShow );
 	}, [ variations, maxVariationsToShow ] );
@@ -36,7 +40,7 @@ const Badges: React.FC< BadgesProps > = ( {
 					onClick={ onClick }
 					isSelected={
 						( isSelectedVariationDefault &&
-							variation.slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG ) ||
+							variation.slug === asyncGetDefaultGlobalStylesVariationSlug() ) ||
 						variation.slug === selectedVariation?.slug
 					}
 				/>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
+import { isDefaultGlobalStylesVariationSlug } from '@automattic/global-styles';
 import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
@@ -10,7 +11,6 @@ import {
 	getDesignPreviewUrl,
 	getMShotOptions,
 	isBlankCanvasDesign,
-	isDefaultGlobalStylesVariationSlug,
 	filterDesignsByCategory,
 } from '../utils';
 import { UnifiedDesignPickerCategoryFilter } from './design-picker-category-filter/unified-design-picker-category-filter';

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
-import { isDefaultGlobalStylesVariationSlug } from '@automattic/global-styles';
 import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
@@ -8,6 +7,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { SHOW_ALL_SLUG, DEFAULT_ASSEMBLER_DESIGN } from '../constants';
 import {
+	asyncIsDefaultGlobalStylesVariationSlug,
 	getDesignPreviewUrl,
 	getMShotOptions,
 	isBlankCanvasDesign,
@@ -154,7 +154,9 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 
 	const { style_variations = [] } = design;
 	const trackingDivRef = useTrackDesignView( { category, design, isPremiumThemeAvailable } );
-	const isDefaultVariation = isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug );
+	const isDefaultVariation = asyncIsDefaultGlobalStylesVariationSlug(
+		selectedStyleVariation?.slug
+	);
 
 	const isLockedStyleVariation =
 		( ! design.is_premium && shouldLimitGlobalStyles && ! isDefaultVariation ) ?? false;

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -4,7 +4,6 @@ export const FONT_TITLES: Partial< Record< Font, string > > = {
 	'Playfair Display': 'Playfair',
 };
 
-export const DEFAULT_GLOBAL_STYLES_VARIATION_SLUG = 'default';
 export const SHOW_ALL_SLUG = 'CLIENT_ONLY_SHOW_ALL_SLUG';
 
 /**

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -13,6 +13,8 @@ export {
 	usePatternAssemblerCtaData,
 } from './components/pattern-assembler-cta';
 export {
+	asyncGetDefaultGlobalStylesVariationSlug,
+	asyncIsDefaultGlobalStylesVariationSlug,
 	availableDesignsConfig,
 	getAvailableDesigns,
 	getFontTitle,
@@ -20,14 +22,12 @@ export {
 	getDesignPreviewUrl,
 	isAssemblerDesign,
 	isBlankCanvasDesign,
-	isDefaultGlobalStylesVariationSlug,
 	getMShotOptions,
 	shouldGoToAssembler,
 } from './utils';
 export {
 	FONT_PAIRINGS,
 	ANCHORFM_FONT_PAIRINGS,
-	DEFAULT_GLOBAL_STYLES_VARIATION_SLUG,
 	DEFAULT_VIEWPORT_WIDTH,
 	DEFAULT_VIEWPORT_HEIGHT,
 	MOBILE_VIEWPORT_WIDTH,

--- a/packages/design-picker/src/utils/global-styles.ts
+++ b/packages/design-picker/src/utils/global-styles.ts
@@ -1,5 +1,15 @@
-import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '../constants';
+let DEFAULT_GLOBAL_STYLES_VARIATION_SLUG = '';
+let isDefaultGlobalStylesVariationSlug = () => false;
 
-export function isDefaultGlobalStylesVariationSlug( slug?: string ): boolean {
-	return ! slug || slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG;
+if ( typeof window !== 'undefined' ) {
+	import( '@automattic/global-styles' )
+		.then( ( module ) => {
+			DEFAULT_GLOBAL_STYLES_VARIATION_SLUG = module.DEFAULT_GLOBAL_STYLES_VARIATION_SLUG;
+			isDefaultGlobalStylesVariationSlug = module.isDefaultGlobalStylesVariationSlug;
+		} )
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		.catch( () => {} );
 }
+
+export const asyncGetDefaultGlobalStylesVariationSlug = () => DEFAULT_GLOBAL_STYLES_VARIATION_SLUG;
+export const asyncIsDefaultGlobalStylesVariationSlug = isDefaultGlobalStylesVariationSlug;

--- a/packages/design-picker/tsconfig.json
+++ b/packages/design-picker/tsconfig.json
@@ -11,6 +11,7 @@
 	"references": [
 		{ "path": "../calypso-config" },
 		{ "path": "../data-stores" },
+		{ "path": "../global-styles" },
 		{ "path": "../js-utils" },
 		{ "path": "../onboarding" },
 		{ "path": "../viewport" }

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -1,9 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
 import {
 	GlobalStylesVariations,
 	ColorPaletteVariations,
 	FontPairingVariations,
+	isDefaultGlobalStylesVariationSlug,
 } from '@automattic/global-styles';
 import { color, styles, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -144,6 +144,7 @@ const useScreens = ( {
 						onSubmit: onScreenSubmit,
 					},
 			].filter( Boolean ) as NavigatorScreenObject[],
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[
 			variations,
 			siteId,

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -3,13 +3,13 @@ import { ENTER } from '@wordpress/keycodes';
 import classnames from 'classnames';
 import { translate, TranslateResult } from 'i18n-calypso';
 import { useMemo, useContext } from 'react';
-import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '../../constants';
 import {
 	GlobalStylesContext,
 	mergeBaseAndUserConfigs,
 	withExperimentalBlockEditorProvider,
 } from '../../gutenberg-bridge';
 import { useRegisterCoreBlocks } from '../../hooks';
+import { isDefaultGlobalStylesVariationSlug } from '../../utils';
 import GlobalStylesVariationPreview from './preview';
 import type { GlobalStylesObject } from '../../types';
 import './style.scss';
@@ -32,9 +32,6 @@ interface GlobalStylesVariationsProps {
 	onSelect: ( globalStylesVariation: GlobalStylesObject ) => void;
 	globalStylesInPersonalPlan: boolean;
 }
-
-const isDefaultGlobalStyleVariationSlug = ( globalStylesVariation: GlobalStylesObject ) =>
-	globalStylesVariation.slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG;
 
 const GlobalStylesVariation = ( {
 	globalStylesVariation,
@@ -121,14 +118,15 @@ const GlobalStylesVariations = ( {
 	const baseGlobalStyles = useMemo(
 		() =>
 			globalStylesVariations.find( ( globalStylesVariation ) =>
-				isDefaultGlobalStyleVariationSlug( globalStylesVariation )
+				isDefaultGlobalStylesVariationSlug( globalStylesVariation.slug )
 			) ?? ( {} as GlobalStylesObject ),
 		[ globalStylesVariations ]
 	);
 	const globalStylesVariationsWithoutDefault = useMemo(
 		() =>
 			globalStylesVariations.filter(
-				( globalStylesVariation ) => ! isDefaultGlobalStyleVariationSlug( globalStylesVariation )
+				( globalStylesVariation ) =>
+					! isDefaultGlobalStylesVariationSlug( globalStylesVariation.slug )
 			),
 		[ globalStylesVariations ]
 	);
@@ -182,7 +180,7 @@ const GlobalStylesVariations = ( {
 							globalStylesVariation={ baseGlobalStyles }
 							isActive={
 								! selectedGlobalStylesVariation ||
-								isDefaultGlobalStyleVariationSlug( selectedGlobalStylesVariation )
+								isDefaultGlobalStylesVariationSlug( selectedGlobalStylesVariation?.slug )
 							}
 							showOnlyHoverView={ showOnlyHoverViewDefaultVariation }
 							onSelect={ () => onSelect( baseGlobalStyles ) }

--- a/packages/global-styles/src/utils.ts
+++ b/packages/global-styles/src/utils.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_GLOBAL_STYLES_VARIATION_TITLE } from './constants';
+import {
+	DEFAULT_GLOBAL_STYLES_VARIATION_SLUG,
+	DEFAULT_GLOBAL_STYLES_VARIATION_TITLE,
+} from './constants';
 import { GlobalStylesObject, GlobalStylesVariationType } from './types';
 
 export const getVariationTitle = ( variation: GlobalStylesObject | null ) =>
@@ -10,3 +13,6 @@ export const getVariationType = (
 	variation && variation.title !== DEFAULT_GLOBAL_STYLES_VARIATION_TITLE
 		? GlobalStylesVariationType.Premium
 		: GlobalStylesVariationType.Free;
+
+export const isDefaultGlobalStylesVariationSlug = ( slug?: string ) =>
+	! slug || slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG;

--- a/packages/global-styles/tsconfig.json
+++ b/packages/global-styles/tsconfig.json
@@ -8,5 +8,5 @@
 	},
 	"include": [ "src", "src/*.json" ],
 	"exclude": [ "**/__tests__/*", "**/__mocks__/*" ],
-	"references": [ { "path": "../design-picker" } ]
+	"references": [ { "path": "../components" } ]
 }

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -28,6 +28,7 @@
 		"test": "yarn jest"
 	},
 	"dependencies": {
+		"@automattic/calypso-config": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/languages": "workspace:^",
 		"@wordpress/compose": "^6.15.0",

--- a/packages/i18n-utils/tsconfig.json
+++ b/packages/i18n-utils/tsconfig.json
@@ -7,5 +7,9 @@
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ],
-	"references": [ { "path": "../languages" }, { "path": "../calypso-url" } ]
+	"references": [
+		{ "path": "../calypso-config" },
+		{ "path": "../languages" },
+		{ "path": "../calypso-url" }
+	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -657,6 +657,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
+    "@automattic/global-styles": "workspace:^"
     "@automattic/js-utils": "workspace:^"
     "@automattic/onboarding": "workspace:^"
     "@automattic/typography": "workspace:^"
@@ -904,6 +905,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/i18n-utils@workspace:packages/i18n-utils"
   dependencies:
+    "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
     "@automattic/languages": "workspace:^"


### PR DESCRIPTION
## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
