### PR TITLE
Design Preview: Fix the sidebar alignment

### DIFF
--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -77,7 +77,6 @@ $design-preview-sidebar-width: 311px;
 
 .design-preview__sidebar {
 	flex-shrink: 0;
-	align-items: center;
 	background-color: var(--color-body-background);
 	box-sizing: border-box;
 	display: flex;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78419

## Proposed Changes

* The name and description of the theme might be at the center of the sidebar if the description is too short. So, adjust styles to fix the issue

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/215cf8a6-f5fd-4920-b8b2-d883e0e0a4a5) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/987759b4-2b1c-407e-b083-7f94b7108c92) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Continue until you land on the Design Picker
* Preview a theme with a short description, e.g.: Storia
* Ensure the name and description align to the left of the sidebar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
