### PR TITLE
Fix localization of redirect url to /start/account/user from /setup/blog

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -10,7 +10,7 @@ import { loadUserUndeployedTranslations } from 'calypso/lib/i18n-utils/switch-lo
 import { LOCALE_SET } from 'calypso/state/action-types';
 import { setLocale } from 'calypso/state/ui/language/actions';
 
-function getLocaleFromPathname() {
+export function getLocaleFromPathname() {
 	const pathname = window.location.pathname.replace( /\/$/, '' );
 	const lastPathSegment = pathname.substr( pathname.lastIndexOf( '/' ) + 1 );
 	const pathLocaleSlug =
@@ -20,7 +20,7 @@ function getLocaleFromPathname() {
 	return pathLocaleSlug;
 }
 
-function getLocaleFromQueryParam() {
+export function getLocaleFromQueryParam() {
 	const query = new URLSearchParams( window.location.search );
 	return query.get( 'locale' );
 }

--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -1,6 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
-import { getQueryArg } from '@wordpress/url';
+import { useEffect } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
 import {
 	AssertConditionResult,
@@ -31,18 +32,36 @@ const Blog: Flow = {
 	useAssertConditions(): AssertConditionResult {
 		const flowName = this.name;
 		const isLoggedIn = useSelector( isUserLoggedIn );
-		const defaultLocale = useLocale();
-		const locale = getQueryArg( window.location.search, 'locale' ) ?? defaultLocale;
+
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		// We also need to support both query param and path suffix localized urls
+		// depending on where the user is coming from.
+		const useLocaleSlug = useLocale();
+		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+		const queryLocaleSlug = getLocaleFromQueryParam();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
 
 		const logInUrl =
 			locale && locale !== 'en'
 				? `/start/account/user/${ locale }?redirect_to=/setup/blog&variationName=blogger-intent`
 				: `/start/account/user?redirect_to=/setup/blog&variationName=blogger-intent`;
 
+		// Despite sending a CHECKING state, this function gets called again with the
+		// /setup/blog/blogger-intent route which has no locale in the path so we need to
+		// redirect off of the first render.
+		// This effects both /setup/blog/<locale> starting points and /setup/blog/blogger-intent/<locale> urls.
+		// The double call also hapens on urls without locale.
+		useEffect( () => {
+			if ( ! isLoggedIn ) {
+				redirect( logInUrl );
+			}
+		}, [] );
+
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 
 		if ( ! isLoggedIn ) {
-			redirect( logInUrl );
 			result = {
 				state: AssertConditionState.CHECKING,
 				message: `${ flowName } requires a logged in user`,

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -3,8 +3,9 @@ import { useLocale } from '@automattic/i18n-utils';
 import { DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import { addQueryArgs } from '@wordpress/url';
 import { useSelector } from 'react-redux';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
 import {
@@ -195,32 +196,50 @@ const designFirst: Flow = {
 		const flowName = this.name;
 		const isLoggedIn = useSelector( isUserLoggedIn );
 		const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
-		const defaultLocale = useLocale();
-		const locale = getQueryArg( window.location.search, 'locale' ) ?? defaultLocale;
 		const currentPath = window.location.pathname;
 		const isSiteCreationStep =
 			currentPath.endsWith( 'setup/design-first/' ) ||
 			currentPath.includes( 'setup/design-first/site-creation-step' );
 		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
 
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		// We also need to support both query param and path suffix localized urls
+		// depending on where the user is coming from.
+		const useLocaleSlug = useLocale();
+		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+		const queryLocaleSlug = getLocaleFromQueryParam();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
+
 		const logInUrl =
 			locale && locale !== 'en'
 				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Pick%20a%20design&redirect_to=/setup/${ flowName }`
 				: `/start/account/user?variationName=${ flowName }&pageTitle=Pick%20a%20design&redirect_to=/setup/${ flowName }`;
 
+		// Despite sending a CHECKING state, this function gets called again with the
+		// /setup/blog/blogger-intent route which has no locale in the path so we need to
+		// redirect off of the first render.
+		// This effects both /setup/blog/<locale> starting points and /setup/blog/blogger-intent/<locale> urls.
+		// The double call also hapens on urls without locale.
+		useEffect( () => {
+			if ( ! isLoggedIn ) {
+				redirect( logInUrl );
+			} else if ( userAlreadyHasSites && isSiteCreationStep ) {
+				// Redirect users with existing sites out of the flow as we create a new site as the first step in this flow.
+				// This prevents a bunch of sites being created accidentally.
+				redirect( `/themes` );
+			}
+		}, [] );
+
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 
 		if ( ! isLoggedIn ) {
-			redirect( logInUrl );
 			result = {
 				state: AssertConditionState.CHECKING,
 				message: `${ flowName } requires a logged in user`,
 			};
 		} else if ( userAlreadyHasSites && isSiteCreationStep ) {
-			// Redirect users with existing sites out of the flow as we create a new site as the first step in this flow.
-			// This prevents a bunch of sites being created accidentally.
-			redirect( `/themes` );
-
 			result = {
 				state: AssertConditionState.CHECKING,
 				message: `${ flowName } requires no preexisting sites`,

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -218,9 +218,9 @@ const designFirst: Flow = {
 				: `/start/account/user?variationName=${ flowName }&pageTitle=Pick%20a%20design&redirect_to=/setup/${ flowName }`;
 
 		// Despite sending a CHECKING state, this function gets called again with the
-		// /setup/blog/blogger-intent route which has no locale in the path so we need to
+		// /setup/design-first/site-creation-step route which has no locale in the path so we need to
 		// redirect off of the first render.
-		// This effects both /setup/blog/<locale> starting points and /setup/blog/blogger-intent/<locale> urls.
+		// This effects both /setup/design-first/<locale> starting points and /setup/design-first/site-creation-step/<locale> urls.
 		// The double call also hapens on urls without locale.
 		useEffect( () => {
 			if ( ! isLoggedIn ) {

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -4,6 +4,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import wpcom from 'calypso/lib/wp';
 import {
 	setSignupCompleteSlug,
@@ -151,7 +152,17 @@ const free: Flow = {
 
 		const queryParams = new URLSearchParams( window.location.search );
 		const flowName = this.name;
-		const locale = useLocale();
+
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		// We also need to support both query param and path suffix localized urls
+		// depending on where the user is coming from.
+		const useLocaleSlug = useLocale();
+		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+		const queryLocaleSlug = getLocaleFromQueryParam();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
+
 		const flags = queryParams.get( 'flags' );
 		const siteSlug = queryParams.get( 'siteSlug' );
 
@@ -180,6 +191,18 @@ const free: Flow = {
 
 			return url + ( flags ? `&flags=${ flags }` : '' );
 		};
+
+		// Despite sending a CHECKING state, this function gets called again with the
+		// /setup/blog/blogger-intent route which has no locale in the path so we need to
+		// redirect off of the first render.
+		// This effects both /setup/blog/<locale> starting points and /setup/blog/blogger-intent/<locale> urls.
+		// The double call also hapens on urls without locale.
+		useEffect( () => {
+			if ( ! userIsLoggedIn ) {
+				const logInUrl = getStartUrl();
+				window.location.assign( logInUrl );
+			}
+		}, [] );
 
 		if ( ! userIsLoggedIn ) {
 			const logInUrl = getStartUrl();

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -209,9 +209,9 @@ const startWriting: Flow = {
 				: `/start/account/user?variationName=${ flowName }&pageTitle=Start%20writing&redirect_to=/setup/${ flowName }`;
 
 		// Despite sending a CHECKING state, this function gets called again with the
-		// /setup/blog/blogger-intent route which has no locale in the path so we need to
+		// /setup/start-writing/site-creation-step route which has no locale in the path so we need to
 		// redirect off of the first render.
-		// This effects both /setup/blog/<locale> starting points and /setup/blog/blogger-intent/<locale> urls.
+		// This effects both /setup/start-writing/<locale> starting points and /setup/start-writing/site-creation-step/<locale> urls.
 		// The double call also hapens on urls without locale.
 		useEffect( () => {
 			if ( ! isLoggedIn ) {

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -8,6 +8,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, ECOMMERCE_FLOW, ecommerceFlowRecurTypes } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	setSignupCompleteSlug,
@@ -83,7 +84,16 @@ const ecommerceFlow: Flow = {
 
 		const flags = new URLSearchParams( window.location.search ).get( 'flags' );
 		const flowName = this.name;
-		const locale = useLocale();
+
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		// We also need to support both query param and path suffix localized urls
+		// depending on where the user is coming from.
+		const useLocaleSlug = useLocale();
+		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+		const queryLocaleSlug = getLocaleFromQueryParam();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
 
 		const { recurType } = useSelect(
 			( select ) => ( {
@@ -116,9 +126,19 @@ const ecommerceFlow: Flow = {
 			return url + ( flags ? `&flags=${ flags }` : '' );
 		};
 
+		// Despite sending a CHECKING state, this function gets called again with the
+		// /setup/blog/blogger-intent route which has no locale in the path so we need to
+		// redirect off of the first render.
+		// This effects both /setup/blog/<locale> starting points and /setup/blog/blogger-intent/<locale> urls.
+		// The double call also hapens on urls without locale.
+		useEffect( () => {
+			if ( ! userIsLoggedIn ) {
+				const logInUrl = getStartUrl();
+				window.location.assign( logInUrl );
+			}
+		}, [] );
+
 		if ( ! userIsLoggedIn ) {
-			const logInUrl = getStartUrl();
-			window.location.assign( logInUrl );
 			result = {
 				state: AssertConditionState.FAILURE,
 				message: 'store-setup requires a logged in user',

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -1,5 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import recordGTMDatalayerEvent from 'calypso/lib/analytics/ad-tracking/woo/record-gtm-datalayer-event';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
@@ -39,7 +41,16 @@ const wooexpress: Flow = {
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 
 		const flowName = this.name;
-		const locale = useLocale();
+
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		// We also need to support both query param and path suffix localized urls
+		// depending on where the user is coming from.
+		const useLocaleSlug = useLocale();
+		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+		const queryLocaleSlug = getLocaleFromQueryParam();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
 
 		const queryParams = new URLSearchParams( window.location.search );
 		const profilerData = queryParams.get( 'profilerdata' );
@@ -75,9 +86,19 @@ const wooexpress: Flow = {
 			return `/start/account/user?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
 		};
 
+		// Despite sending a CHECKING state, this function gets called again with the
+		// /setup/wooexpress/siteCreationStep route which has no locale in the path so we need to
+		// redirect off of the first render.
+		// This effects both /setup/wooexpress/<locale> starting points and /setup/wooexpress/siteCreationStep/<locale> urls.
+		// The double call also hapens on urls without locale.
+		useEffect( () => {
+			if ( ! userIsLoggedIn ) {
+				const logInUrl = getStartUrl();
+				window.location.assign( logInUrl );
+			}
+		}, [] );
+
 		if ( ! userIsLoggedIn ) {
-			const logInUrl = getStartUrl();
-			window.location.assign( logInUrl );
 			result = {
 				state: AssertConditionState.FAILURE,
 				message: 'wooexpress-trial requires a logged in user',

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -3,6 +3,8 @@ import { useFlowProgress, WRITE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import wpcom from 'calypso/lib/wp';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
@@ -91,7 +93,17 @@ const write: Flow = {
 
 		const queryParams = new URLSearchParams( window.location.search );
 		const flowName = this.name;
-		const locale = useLocale();
+
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		// We also need to support both query param and path suffix localized urls
+		// depending on where the user is coming from.
+		const useLocaleSlug = useLocale();
+		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+		const queryLocaleSlug = getLocaleFromQueryParam();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
+
 		const flags = queryParams.get( 'flags' );
 		const siteSlug = queryParams.get( 'siteSlug' );
 
@@ -121,9 +133,19 @@ const write: Flow = {
 			return url + ( flags ? `&flags=${ flags }` : '' );
 		};
 
+		// Despite sending a CHECKING state, this function gets called again with the
+		// /setup/write/launchpad route which has no locale in the path so we need to
+		// redirect off of the first render.
+		// This effects both /setup/write/<locale> starting points and /setup/write/launchpad/<locale> urls.
+		// The double call also hapens on urls without locale.
+		useEffect( () => {
+			if ( ! userIsLoggedIn ) {
+				const logInUrl = getStartUrl();
+				window.location.assign( logInUrl );
+			}
+		}, [] );
+
 		if ( ! userIsLoggedIn ) {
-			const logInUrl = getStartUrl();
-			window.location.assign( logInUrl );
 			result = {
 				state: AssertConditionState.FAILURE,
 				message: 'write-flow requires a logged in user',


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2960 / https://github.com/Automattic/dotcom-forge/issues/2961

Fixes: https://github.com/Automattic/dotcom-forge/issues/2921

## Proposed Changes

* Fixes the localization of redirect url to /start/account/user from /setup/blog.
* Handles a race condition in [AppBoot](https://github.com/Automattic/wp-calypso/blob/9fe3994f721e3e4c4e6a2b531b21108bdb4d885d/client/landing/stepper/index.tsx#L114) where a non en locale is detected but the app is being rendered before the locale update is dispatched.
* Handles an issue in the stepper framework where useAssertConditions is being called twice, likely due to a redirect/navigate call but I haven't found the cause yet.
* I'd like to properly fix both of these problems but I think we should ship this workaround in the meantime.

Todo: 
- [x] Repeat for start writing and design flows.
- [x] Add fix for `connect-domain` flow (`/setup/connect-domain/fr?domain=thisisatestdomain.com`)
- [x] Add fix for `free` flow (`/setup/free/fr`)
- [x] Add fix for `ecommerce` flow (`/setup/ecommerce/fr`)
- [x] Add fix for `wooexpress` flow (`/setup/wooexpress/fr`)
- [x] Add fix for `write ` flow (`/setup/write/fr`)
- [ ] Check for other flows that need the fix

## Testing Instructions

While logged out.

Both:
- http://calypso.localhost:3000/setup/blog/fr and 
- http://calypso.localhost:3000/setup/blog/blogger-intent/fr

Should redirect to:
* http://calypso.localhost:3000/start/account/user/fr?redirect_to=/setup/blog&variationName=blogger-intent