### PR TITLE
Domains: Fix `undefined` or `null` state variables within components

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/non-owner-card.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/non-owner-card.jsx
@@ -6,6 +6,11 @@ import { getSelectedDomain } from 'calypso/lib/domains';
 const NonOwnerCard = ( { domains, redesigned = false, selectedDomainName } ) => {
 	const translate = useTranslate();
 	const domain = getSelectedDomain( { domains, selectedDomainName } );
+
+	if ( ! domains || ! domain ) {
+		return null;
+	}
+
 	const text = translate(
 		'These settings can be changed by the user {{strong}}%(owner)s{{/strong}}.',
 		{

--- a/client/my-sites/domains/domain-management/settings/cards/site-redirect-card.jsx
+++ b/client/my-sites/domains/domain-management/settings/cards/site-redirect-card.jsx
@@ -47,7 +47,9 @@ class SiteRedirectCard extends Component {
 	};
 
 	componentDidMount() {
-		this.props.fetchSiteRedirect( this.props.selectedSite.domain );
+		if ( this.props.selectedSite ) {
+			this.props.fetchSiteRedirect( this.props.selectedSite.domain );
+		}
 	}
 
 	componentWillUnmount() {
@@ -55,7 +57,9 @@ class SiteRedirectCard extends Component {
 	}
 
 	closeRedirectNotice = () => {
-		this.props.closeSiteRedirectNotice( this.props.selectedSite.domain );
+		if ( this.props.selectedSite ) {
+			this.props.closeSiteRedirectNotice( this.props.selectedSite.domain );
+		}
 	};
 
 	handleChange = ( event ) => {
@@ -65,35 +69,37 @@ class SiteRedirectCard extends Component {
 	};
 
 	handleClick = () => {
-		this.props
-			.updateSiteRedirect( this.props.selectedSite.domain, this.state.redirectUrl )
-			.then( ( success ) => {
-				this.props.recordUpdateSiteRedirectClick(
-					this.props.selectedDomainName,
-					this.state.redirectUrl,
-					success
-				);
-
-				if ( success ) {
-					this.props.fetchSiteDomains( this.props.selectedSite.ID );
-					this.props.fetchSiteRedirect( this.state.redirectUrl.replace( /\/+$/, '' ).trim() );
-
-					page(
-						domainManagementSiteRedirect(
-							this.props.selectedSite.slug,
-							this.state.redirectUrl.replace( /\/+$/, '' ).trim(),
-							this.props.currentRoute
-						)
+		if ( this.props.selectedSite ) {
+			this.props
+				.updateSiteRedirect( this.props.selectedSite.domain, this.state.redirectUrl )
+				.then( ( success ) => {
+					this.props.recordUpdateSiteRedirectClick(
+						this.props.selectedDomainName,
+						this.state.redirectUrl,
+						success
 					);
 
-					this.props.successNotice(
-						this.props.translate( 'Site redirect updated successfully.' ),
-						noticeOptions
-					);
-				} else {
-					this.props.errorNotice( this.props.location.notice.text );
-				}
-			} );
+					if ( success ) {
+						this.props.fetchSiteDomains( this.props.selectedSite.ID );
+						this.props.fetchSiteRedirect( this.state.redirectUrl.replace( /\/+$/, '' ).trim() );
+
+						page(
+							domainManagementSiteRedirect(
+								this.props.selectedSite.slug,
+								this.state.redirectUrl.replace( /\/+$/, '' ).trim(),
+								this.props.currentRoute
+							)
+						);
+
+						this.props.successNotice(
+							this.props.translate( 'Site redirect updated successfully.' ),
+							noticeOptions
+						);
+					} else {
+						this.props.errorNotice( this.props.location.notice.text );
+					}
+				} );
+		}
 	};
 
 	handleFocus = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes
Some components don't handle `null` or `undefined` values for the `domain` or `selectedSite` state variables. This PR fixes it.

## Testing Instructions
Analyze the code statically, ensure the unit tests pass, and ensure the fixed components are still working properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
