### PR TITLE
Assembler - Reset content of newly created sites only if users add blog posts patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -387,6 +387,9 @@ const PatternAssembler = ( {
 		const design = getDesign();
 		const stylesheet = design.recipe?.stylesheet ?? '';
 		const themeId = getThemeIdFromStylesheet( stylesheet );
+		const hasBlogPatterns = !! sections.find(
+			( { categories } ) => categories[ 'posts' ] || categories[ 'blog' ]
+		);
 
 		if ( ! siteSlugOrId || ! site?.ID || ! themeId ) {
 			return;
@@ -412,8 +415,9 @@ const PatternAssembler = ( {
 							headerHtml: header?.html,
 							footerHtml: footer?.html,
 							globalStyles: syncedGlobalStylesUserConfig,
-							// Newly created sites should reset the starter content created from the default Headstart annotation
-							shouldResetContent: isNewSite,
+							// Newly created sites with blog patterns reset the starter content created from the default Headstart annotation
+							// TODO: Ask users whether they want all their pages and posts to be replaced with the content from theme demo site
+							shouldResetContent: isNewSite && hasBlogPatterns,
 							// All sites using the assembler set the option wpcom_site_setup
 							siteSetupOption: design.is_virtual ? 'assembler-virtual-theme' : 'assembler',
 						} )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77489 https://github.com/Automattic/dotcom-forge/issues/2758
The Pattern Assembler without the headstart: pbxlJb-3Xv-p2

## Proposed Changes

* Reset content of **newly created sites** only if users add blog posts patterns

https://github.com/Automattic/wp-calypso/assets/1881481/601f8fdc-6ffb-42be-8b16-829b4de6fd09

### **Notes**

- The goal of this PR is to reduce the long processing time caused by resetting the content for all newly created sites. See https://github.com/Automattic/dotcom-forge/issues/2758
- Users that click on "Continue" without adding `Blog posts` will get faster processing because we won't reset their site content.
- We check for the existence of `Blog posts` patterns by looking into the categories of the patterns added to the canvas. To make it simpler, for now, we don't check if patterns use a query block or not. We will improve this in future iterations.

### **Background**

What a content reset means? 
 - First trash all pages and posts on the user's site
 - Then copy all the pages/posts from the theme demo site into the user's site

Resetting all pages/posts on the endpoint `/site-assembler` will only make sense when:
  1. **Users expect to see on the editor the same posts they see on the assembler previews.**
     - This is the use case on this PR because the previews of blog patterns on the assembler use the posts from the BC3 theme demo site. 
     - But there is no need to reset pages
  2. **Users expect to choose the theme to assemble their site and make it look like the theme demo site but with the Homepage they create on the assembler.**
     - But the assembler uses BC3/Creatio for now, users cannot choose another theme. Why should we reset the content for newly created sites? I think we don't need it for now. cc: @arthur791004 
     - We plan to allow users to choose any block theme to assemble their site. In that case, users might want to use the pages/posts from the theme demo site on the assembler previews to achieve the specific look that is characteristic of the theme. Anyways, IMO, we should ask users if they want to reset the content or not from the activation screen on the assembler. cc: @taipeicoder 
       - The navigation blocks in the headers/footers from Dotcom patterns won't show the pages list. See #76169
  4. Others?
 
@Automattic/lego WDYT about resetting the user's site content on the assembler endpoint? I think we have to rethink it.

### Follow-up PRs to improve performance
- Only copy posts from the theme demo site when users add patterns with a query block.
  - We have to add the pattern meta `block_type_core/query` to the `Blog posts` patterns that include a query block so it's included in the PTK API response. See #78478
- Add features on the endpoint `/site-assembler` for a more granular content reset
   - `reset_posts` to only trash/copy posts because the assembler only needs this on specific cases
   - `reset_pages` to only trash/copy pages because the assembler doesn't need this for now  

### New features for the assembler with any theme
UI enhancements to ask users to give them what they want from the assembler:
  - Preview patterns with the user's site content or the theme demo site content?
  - Replace your post/pages with the theme demo site content?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link
* Create a new site from the admin or head to `/start` - **Won't work if you use an existing site**
* Pick a domain and a plan and then continue until the design picker and scroll down
* Click on "Start designing" from the CTA "Create your own"
* Click "Homepage" to add patterns from the "Blog posts" category
* Click "Continue"
* Verify that you land on the editor and you see the same posts that you saw on the assembler preview
* Verify that the `/site-assembler` processing time takes around `~20s` when the param `should_reset_content: true`
* Create another new site 
* This time when you are on the assembler don't add any patterns or add them from other categories. Note that `Blog posts` patterns are included in the `All` category so don't choose any pattern that looks like a blog post.  
* Verify that the `/site-assembler` processing time takes around `~3s` when the param `should_reset_content: false`


https://github.com/Automattic/wp-calypso/assets/1881481/c175b334-b250-4ecb-bb6d-29b694f26090




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?