### PR TITLE
Create VideoPress TV flow skeleton.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -6,6 +6,7 @@ import {
 	SENSEI_FLOW,
 	VIDEOPRESS_FLOW,
 	isLinkInBioFlow,
+	isVideoPressTVFlow,
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement, useMemo } from '@wordpress/element';
@@ -116,6 +117,27 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 				modal: {
 					buttonText: __( 'Learn more' ),
 					onClick: () => recordTracksEvent( 'calypso_videopress_signup_learn_more_button_clicked' ),
+					content: VideoPressIntroModalContent,
+				},
+			};
+		}
+
+		if ( isVideoPressTVFlow( flowName ) ) {
+			return {
+				title: createInterpolateElement(
+					__( 'An ad-free, home for all your videos.<br />Play. Roll. Share.' ),
+					{ br: <br /> }
+				),
+				secondaryText: sprintf(
+					/* translators: Days of trial displayed on VideoPress intro page. First %s is days of trial. */
+					__( 'Start your %s-day free trial' ),
+					30
+				),
+				buttonText: __( 'Get started' ),
+				modal: {
+					buttonText: __( 'Learn more' ),
+					onClick: () =>
+						recordTracksEvent( 'calypso_videopress_tv_signup_learn_more_button_clicked' ),
 					content: VideoPressIntroModalContent,
 				},
 			};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -159,7 +159,8 @@
 		}
 	}
 
-	&.videopress {
+	&.videopress,
+	&.videopress-tv {
 		padding: 0;
 		color: #fff;
 

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -1,14 +1,18 @@
 @import "./global";
 @import "./videopress-constants.scss";
 
-body.is-videopress-stepper {
+
+body.is-videopress-stepper,
+body.is-videopress-tv-stepper {
 	background-color: #010101;
 	color: $videopress-theme-base-text-color;
 
 	.search-filters__checkbox-label {
 		color: #000;
 	}
-	.videopress {
+
+	.videopress,
+	.videopress-tv {
 		input[type="text"]:focus,
 		textarea:focus {
 			box-shadow: none;

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -8,6 +8,7 @@ import {
 	IMPORT_HOSTED_SITE_FLOW,
 	DOMAIN_TRANSFER,
 	ONBOARDING_PM_FLOW,
+	VIDEOPRESS_TV_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -29,6 +30,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	videopress: () =>
 		import( /* webpackChunkName: "videopress-flow" */ '../declarative-flow/videopress' ),
+
+	[ VIDEOPRESS_TV_FLOW ]: () =>
+		import( /* webpackChunkName: "videopress-tv-flow" */ `../declarative-flow/videopress-tv` ),
 
 	'link-in-bio': () =>
 		import( /* webpackChunkName: "link-in-bio-flow" */ '../declarative-flow/link-in-bio' ),

--- a/client/landing/stepper/declarative-flow/videopress-tv.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv.ts
@@ -34,10 +34,6 @@ const videopressTv: Flow = {
 		setStepProgress( flowProgress );
 
 		const clearOnboardingSiteOptions = () => {
-			setSiteTitle( '' );
-			setSiteDescription( '' );
-			setDomain( undefined );
-			setSelectedDesign( undefined );
 		};
 
 		switch ( _currentStep ) {

--- a/client/landing/stepper/declarative-flow/videopress-tv.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv.ts
@@ -28,7 +28,7 @@ const videopressTv: Flow = {
 		}
 
 		const name = this.name;
-		const { setDomain, setSelectedDesign, setSiteDescription, setSiteTitle, setStepProgress } =
+		const { setStepProgress } =
 			useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
 		setStepProgress( flowProgress );

--- a/client/landing/stepper/declarative-flow/videopress-tv.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv.ts
@@ -1,15 +1,9 @@
-import { SiteSelect } from '@automattic/data-stores';
-import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, VIDEOPRESS_TV_FLOW } from '@automattic/onboarding';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
-import { useState } from 'react';
-import { useNewSiteVisibility } from 'calypso/landing/stepper/hooks/use-selected-plan';
-import { useSiteSlug } from '../hooks/use-site-slug';
-import { SITE_STORE, USER_STORE, ONBOARD_STORE } from '../stores';
+import { ONBOARD_STORE } from '../stores';
 import './internals/videopress.scss';
 import type { Flow, ProvidedDependencies } from './internals/types';
-import type { OnboardSelect, UserSelect } from '@automattic/data-stores';
 
 const videopressTv: Flow = {
 	name: VIDEOPRESS_TV_FLOW,
@@ -22,10 +16,6 @@ const videopressTv: Flow = {
 				slug: 'intro',
 				asyncComponent: () => import( './internals/steps-repository/intro' ),
 			},
-			{
-				slug: 'processing',
-				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
-			},
 		];
 	},
 
@@ -35,17 +25,6 @@ const videopressTv: Flow = {
 			if ( ! document.body.classList.contains( 'is-videopress-tv-stepper' ) ) {
 				document.body.classList.add( 'is-videopress-tv-stepper' );
 			}
-
-			// Also target processing step for background images
-			const processingStepClassName = 'is-processing-step';
-			const hasProcessingStepClass = document.body.classList.contains( processingStepClassName );
-			if ( 'processing' === _currentStep ) {
-				if ( ! hasProcessingStepClass ) {
-					document.body.classList.add( processingStepClassName );
-				}
-			} else if ( hasProcessingStepClass ) {
-				document.body.classList.remove( processingStepClassName );
-			}
 		}
 
 		const name = this.name;
@@ -53,28 +32,6 @@ const videopressTv: Flow = {
 			useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
 		setStepProgress( flowProgress );
-		const _siteSlug = useSiteSlug();
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		);
-		const locale = useLocale();
-
-		const { createVideoPressSite, setSelectedSite, setPendingAction, setProgress } =
-			useDispatch( ONBOARD_STORE );
-		const currentUser = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
-			[]
-		);
-		const siteDescription = useSelect(
-			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteDescription(),
-			[]
-		);
-		const visibility = useNewSiteVisibility();
-		const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
-		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
-
-		const [ isSiteCreationPending, setIsSiteCreationPending ] = useState( false );
 
 		const clearOnboardingSiteOptions = () => {
 			setSiteTitle( '' );
@@ -83,86 +40,26 @@ const videopressTv: Flow = {
 			setSelectedDesign( undefined );
 		};
 
-		const addVideoPressPendingAction = () => {
-			// only allow one call to this action to occur
-			if ( isSiteCreationPending ) {
-				return;
-			}
-
-			setIsSiteCreationPending( true );
-
-			setPendingAction( async () => {
-				setProgress( 0 );
-				try {
-					// Todo: vptv-specific site.
-					await createVideoPressSite( {
-						username: currentUser ? currentUser?.username : '',
-						languageSlug: locale,
-						visibility,
-					} );
-				} catch ( e ) {
-					return;
-				}
-				setProgress( 0.5 );
-
-				const newSite = getNewSite();
-				if ( ! newSite ) {
-					return;
-				}
-
-				setSelectedSite( newSite.blogid );
-				setIntentOnSite( newSite.site_slug, VIDEOPRESS_TV_FLOW );
-				saveSiteSettings( newSite.blogid, {
-					launchpad_screen: 'full',
-					blogdescription: siteDescription,
-				} );
-
-				setProgress( 0.75 );
-			} );
-		};
-
 		switch ( _currentStep ) {
 			case 'intro':
 				clearOnboardingSiteOptions();
 				break;
-			case 'processing':
-				if ( ! _siteSlug ) {
-					addVideoPressPendingAction();
-				}
-				break;
 		}
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
-			recordSubmitStep( providedDependencies, 'anchor-fm', flowName, _currentStep );
 			switch ( _currentStep ) {
 				case 'intro':
 					return navigate( 'processing' );
-
-				case 'processing':
-					if ( userIsLoggedIn ) {
-						return navigate( 'options' );
-					}
-
-					return window.location.replace(
-						`/start/videopress-account/user/${ locale }?variationName=${ name }&flow=${ name }&pageTitle=Video%20Portfolio&redirect_to=/setup/videopress/options`
-					);
 			}
 			return providedDependencies;
 		}
 
 		const goBack = () => {
-			switch ( _currentStep ) {
-				case 'chooseADomain':
-					return navigate( 'options' );
-			}
 			return;
 		};
 
 		const goNext = () => {
 			switch ( _currentStep ) {
-				case 'processing':
-					return window.location.replace( `/view/${ _siteSlug }` );
-
 				default:
 					return navigate( 'intro' );
 			}

--- a/client/landing/stepper/declarative-flow/videopress-tv.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv.ts
@@ -1,0 +1,179 @@
+import { SiteSelect } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
+import { useFlowProgress, VIDEOPRESS_TV_FLOW } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useNewSiteVisibility } from 'calypso/landing/stepper/hooks/use-selected-plan';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { SITE_STORE, USER_STORE, ONBOARD_STORE } from '../stores';
+import './internals/videopress.scss';
+import type { Flow, ProvidedDependencies } from './internals/types';
+import type { OnboardSelect, UserSelect } from '@automattic/data-stores';
+
+const videopressTv: Flow = {
+	name: VIDEOPRESS_TV_FLOW,
+	get title() {
+		return translate( 'VideoPress TV' );
+	},
+	useSteps() {
+		return [
+			{
+				slug: 'intro',
+				asyncComponent: () => import( './internals/steps-repository/intro' ),
+			},
+			{
+				slug: 'processing',
+				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
+			},
+		];
+	},
+
+	useStepNavigation( _currentStep, navigate ) {
+		if ( document.body ) {
+			// Make sure we only target videopress tv stepper for body css
+			if ( ! document.body.classList.contains( 'is-videopress-tv-stepper' ) ) {
+				document.body.classList.add( 'is-videopress-tv-stepper' );
+			}
+
+			// Also target processing step for background images
+			const processingStepClassName = 'is-processing-step';
+			const hasProcessingStepClass = document.body.classList.contains( processingStepClassName );
+			if ( 'processing' === _currentStep ) {
+				if ( ! hasProcessingStepClass ) {
+					document.body.classList.add( processingStepClassName );
+				}
+			} else if ( hasProcessingStepClass ) {
+				document.body.classList.remove( processingStepClassName );
+			}
+		}
+
+		const name = this.name;
+		const { setDomain, setSelectedDesign, setSiteDescription, setSiteTitle, setStepProgress } =
+			useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
+		setStepProgress( flowProgress );
+		const _siteSlug = useSiteSlug();
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+		const locale = useLocale();
+
+		const { createVideoPressSite, setSelectedSite, setPendingAction, setProgress } =
+			useDispatch( ONBOARD_STORE );
+		const currentUser = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+			[]
+		);
+		const siteDescription = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteDescription(),
+			[]
+		);
+		const visibility = useNewSiteVisibility();
+		const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
+		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
+
+		const [ isSiteCreationPending, setIsSiteCreationPending ] = useState( false );
+
+		const clearOnboardingSiteOptions = () => {
+			setSiteTitle( '' );
+			setSiteDescription( '' );
+			setDomain( undefined );
+			setSelectedDesign( undefined );
+		};
+
+		const addVideoPressPendingAction = () => {
+			// only allow one call to this action to occur
+			if ( isSiteCreationPending ) {
+				return;
+			}
+
+			setIsSiteCreationPending( true );
+
+			setPendingAction( async () => {
+				setProgress( 0 );
+				try {
+					// Todo: vptv-specific site.
+					await createVideoPressSite( {
+						username: currentUser ? currentUser?.username : '',
+						languageSlug: locale,
+						visibility,
+					} );
+				} catch ( e ) {
+					return;
+				}
+				setProgress( 0.5 );
+
+				const newSite = getNewSite();
+				if ( ! newSite ) {
+					return;
+				}
+
+				setSelectedSite( newSite.blogid );
+				setIntentOnSite( newSite.site_slug, VIDEOPRESS_TV_FLOW );
+				saveSiteSettings( newSite.blogid, {
+					launchpad_screen: 'full',
+					blogdescription: siteDescription,
+				} );
+
+				setProgress( 0.75 );
+			} );
+		};
+
+		switch ( _currentStep ) {
+			case 'intro':
+				clearOnboardingSiteOptions();
+				break;
+			case 'processing':
+				if ( ! _siteSlug ) {
+					addVideoPressPendingAction();
+				}
+				break;
+		}
+
+		async function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, 'anchor-fm', flowName, _currentStep );
+			switch ( _currentStep ) {
+				case 'intro':
+					return navigate( 'processing' );
+
+				case 'processing':
+					if ( userIsLoggedIn ) {
+						return navigate( 'options' );
+					}
+
+					return window.location.replace(
+						`/start/videopress-account/user/${ locale }?variationName=${ name }&flow=${ name }&pageTitle=Video%20Portfolio&redirect_to=/setup/videopress/options`
+					);
+			}
+			return providedDependencies;
+		}
+
+		const goBack = () => {
+			switch ( _currentStep ) {
+				case 'chooseADomain':
+					return navigate( 'options' );
+			}
+			return;
+		};
+
+		const goNext = () => {
+			switch ( _currentStep ) {
+				case 'processing':
+					return window.location.replace( `/view/${ _siteSlug }` );
+
+				default:
+					return navigate( 'intro' );
+			}
+		};
+
+		const goToStep = ( step: string ) => {
+			return navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};
+
+export default videopressTv;

--- a/client/landing/stepper/declarative-flow/videopress-tv.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv.ts
@@ -28,17 +28,12 @@ const videopressTv: Flow = {
 		}
 
 		const name = this.name;
-		const { setStepProgress } =
-			useDispatch( ONBOARD_STORE );
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
 		setStepProgress( flowProgress );
 
-		const clearOnboardingSiteOptions = () => {
-		};
-
 		switch ( _currentStep ) {
 			case 'intro':
-				clearOnboardingSiteOptions();
 				break;
 		}
 

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -193,6 +193,10 @@ export const isVideoPressFlow = ( flowName ) => {
 	return flowName === 'videopress' || flowName === 'videopress-account';
 };
 
+export const isVideoPressTVFlow = ( flowName ) => {
+	return flowName === 'videopress-tv' || flowName === 'videopress-tv-purchase';
+};
+
 export const isWpccFlow = ( flowName ) => {
 	return flowName === 'wpcc';
 };

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -7,6 +7,7 @@ import {
 	COPY_SITE_FLOW,
 	ONBOARDING_PM_FLOW,
 	DOMAIN_TRANSFER,
+	VIDEOPRESS_TV_FLOW,
 } from '../utils/flows';
 
 /* eslint-disable no-restricted-imports */
@@ -65,6 +66,10 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		chooseADomain: 4,
 		processing: 5,
 		launchpad: 6,
+	},
+	[ VIDEOPRESS_TV_FLOW ]: {
+		intro: 0,
+		processing: 1,
 	},
 	sensei: {
 		senseiSetup: 1,

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -9,6 +9,8 @@ export const LINK_IN_BIO_TLD_FLOW = 'link-in-bio-tld';
 export const LINK_IN_BIO_POST_SETUP_FLOW = 'link-in-bio-post-setup';
 export const CONNECT_DOMAIN_FLOW = 'connect-domain';
 export const VIDEOPRESS_FLOW = 'videopress';
+export const VIDEOPRESS_TV_FLOW = 'videopress-tv';
+export const VIDEOPRESS_TV_PURCHASE_FLOW = 'videopress-tv-purchase';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const IMPORT_HOSTED_SITE_FLOW = 'import-hosted-site';
 export const SENSEI_FLOW = 'sensei';
@@ -157,4 +159,10 @@ export const ecommerceFlowRecurTypes = {
 	MONTHLY: 'monthly',
 	'2Y': '2Y',
 	'3Y': '3Y',
+};
+
+export const isVideoPressTVFlow = ( flowName: string | null | undefined ) => {
+	return Boolean(
+		flowName && [ VIDEOPRESS_TV_FLOW, VIDEOPRESS_TV_PURCHASE_FLOW ].includes( flowName )
+	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

fixes https://github.com/Automattic/greenhouse/issues/1778

Related to https://github.com/Automattic/greenhouse/issues/1778

## Proposed Changes

* Adds a new tailored flow skeleton for VideoPress TV

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply pr and visit `/setup/videopress-tv` on [localhost](http://calypso.localhost:3000/setup/videopress-tv/intro) or Calypso live
* Does not 404. You see the intro screen for the flow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
