### PR TITLE
Plugins: Update how translations are handled in the action modal

### DIFF
--- a/client/my-sites/plugins/hooks/test/use-get-dialog-text.ts
+++ b/client/my-sites/plugins/hooks/test/use-get-dialog-text.ts
@@ -1,0 +1,242 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { PluginActions } from '../types';
+import useGetDialogText from '../use-get-dialog-text';
+import type { Site, Plugin } from '../types';
+jest.mock( 'i18n-calypso', () => ( {
+	translate: jest.fn().mockReturnValue( ( input ) => input ),
+	...jest.requireActual( 'i18n-calypso' ),
+} ) );
+
+const ACTION_HEADING_TEXTS = [
+	{ action: PluginActions.ACTIVATE, text: 'Activate' },
+	{ action: PluginActions.DEACTIVATE, text: 'Deactivate' },
+	{ action: PluginActions.REMOVE, text: 'Deactivate and remove' },
+	{ action: PluginActions.UPDATE, text: 'Update' },
+	{ action: PluginActions.ENABLE_AUTOUPDATES, text: 'Enable auto-updates for' },
+	{ action: PluginActions.DISABLE_AUTOUPDATES, text: 'Disable auto-updates for' },
+	// Check cases in which the action isn't something we recognize
+	{ action: 'unknown/invalid action name', text: 'Affect' },
+	{ action: '', text: 'Affect' },
+];
+
+const ACTION_MESSAGE_TEXTS = ACTION_HEADING_TEXTS.map( ( { action, text } ) => ( {
+	action,
+	text: text.toLocaleLowerCase(),
+} ) );
+
+const runHook = () => renderHook( () => useGetDialogText() ).result.current;
+const createFakePlugin = (
+	slug: string,
+	name?: string,
+	sites: { ID: number }[] = []
+): Plugin => ( {
+	slug,
+	name,
+	sites: sites.reduce( ( acc, next ) => ( { [ next.ID ]: 'value does not matter', ...acc } ), {} ),
+} );
+
+const allSites: Site[] = [
+	{ ID: 1, title: 'Site 1', canUpdateFiles: true },
+	{ ID: 2, title: 'Site 2', canUpdateFiles: true },
+	{ ID: 3, title: 'Site 3', canUpdateFiles: false },
+	{ ID: 4, title: 'Site 4', canUpdateFiles: false },
+	{ ID: 5, title: 'Site 5', canUpdateFiles: false },
+];
+
+describe( 'useGetDialogText', () => {
+	it( 'only counts sites that are able to update files', () => {
+		const getDialogText = runHook();
+
+		// Five sites are available in total
+		const testSites = allSites;
+		expect( testSites.length ).toEqual( 5 );
+
+		const testPlugin = createFakePlugin( 'test', 'Test Plugin', testSites );
+
+		// Only two are able to update files
+		const canUpdateFilesCount = testSites.filter( ( { canUpdateFiles } ) => canUpdateFiles ).length;
+		expect( canUpdateFilesCount ).toEqual( 2 );
+
+		// Therefore, we should see a message appropriate to two sites being affected
+		const { message } = getDialogText( PluginActions.ACTIVATE, [ testPlugin ], testSites );
+		expect( message ).toContain( ` 2 sites` );
+	} );
+
+	it( 'only counts sites on which the given plugin(s) are installed', () => {
+		const getDialogText = runHook();
+
+		// Two sites are available that can update files
+		const testSites = allSites.filter( ( { canUpdateFiles } ) => canUpdateFiles );
+		expect( testSites.length ).toEqual( 2 );
+
+		// Only the first test site has this plugin installed
+		const testPlugin = createFakePlugin( 'test', 'Test Plugin', [ testSites[ 0 ] ] );
+
+		// Since only one site should be affected, we should see a message
+		// appropriate for just one site being affected
+		const { message } = getDialogText( PluginActions.ACTIVATE, [ testPlugin ], testSites );
+		expect( message ).toContain( ` on ${ testSites[ 0 ].title }.` );
+	} );
+
+	it.each( ACTION_HEADING_TEXTS )(
+		'gets the correct `$action` heading text for one plugin with a name',
+		( { action, text } ) => {
+			expect( action ).toBeDefined();
+			expect( text.length ).toBeGreaterThan( 0 );
+
+			const getDialogText = runHook();
+
+			const testSites = [ allSites[ 0 ] ];
+			const testPlugin = createFakePlugin( 'test1', 'Test Plugin', testSites );
+
+			const { heading } = getDialogText( action, [ testPlugin ], testSites );
+			expect( heading ).toEqual( `${ text } ${ testPlugin.name }` );
+		}
+	);
+
+	it.each( ACTION_HEADING_TEXTS )(
+		'gets the correct `$action` heading text for one plugin with a slug but no name',
+		( { action, text } ) => {
+			expect( action.length ).toBeDefined();
+			expect( text.length ).toBeGreaterThan( 0 );
+
+			const getDialogText = runHook();
+
+			const testSites = [ allSites[ 0 ] ];
+			const testPlugin = createFakePlugin( 'test1', undefined, testSites );
+
+			const { heading } = getDialogText( action, [ testPlugin ], testSites );
+			expect( heading ).toEqual( `${ text } ${ testPlugin.slug }` );
+		}
+	);
+
+	it.each( ACTION_HEADING_TEXTS )(
+		'gets the correct `$action` heading text for multiple plugins',
+		( { action, text } ) => {
+			expect( action.length ).toBeDefined();
+			expect( text.length ).toBeGreaterThan( 0 );
+
+			const getDialogText = runHook();
+
+			const testSites = [ allSites[ 0 ] ];
+			const testPlugins = [ 1, 2, 3 ].map( ( i ) =>
+				createFakePlugin( `test${ i }`, `Test Plugin #${ i }`, testSites )
+			);
+
+			const { heading } = getDialogText( action, testPlugins, testSites );
+			expect( heading ).toEqual( `${ text } ${ testPlugins.length } plugins` );
+		}
+	);
+
+	it.each( ACTION_MESSAGE_TEXTS )(
+		'gets the correct `$action` message text for one plugin with a name, and one site',
+		( { action, text } ) => {
+			expect( action.length ).toBeDefined();
+			expect( text.length ).toBeGreaterThan( 0 );
+
+			const getDialogText = runHook();
+
+			const testSite = allSites[ 0 ];
+			const testPlugin = createFakePlugin( 'test1', 'Test Plugin', [ testSite ] );
+
+			const { message } = getDialogText( action, [ testPlugin ], [ testSite ] );
+			expect( message ).toEqual(
+				`You are about to ${ text } the ${ testPlugin.name } plugin installed on ${ testSite.title }.`
+			);
+		}
+	);
+
+	it.each( ACTION_MESSAGE_TEXTS )(
+		'gets the correct `$action` message text for one plugin with a name, and multiple sites',
+		( { action, text } ) => {
+			expect( action.length ).toBeDefined();
+			expect( text.length ).toBeGreaterThan( 0 );
+
+			const getDialogText = runHook();
+
+			const testSites = allSites.slice( 0, 2 );
+			const testPlugin = createFakePlugin( 'test1', 'Test Plugin', testSites );
+
+			const { message } = getDialogText( action, [ testPlugin ], testSites );
+			expect( message ).toEqual(
+				`You are about to ${ text } the ${ testPlugin.name } plugin installed on ${ testSites.length } sites.`
+			);
+		}
+	);
+
+	it.each( ACTION_MESSAGE_TEXTS )(
+		'gets the correct `$action` message text for one plugin with a slug but no name, and one site',
+		( { action, text } ) => {
+			expect( action.length ).toBeDefined();
+			expect( text.length ).toBeGreaterThan( 0 );
+
+			const getDialogText = runHook();
+
+			const testSite = allSites[ 0 ];
+			const testPlugin = createFakePlugin( 'test1', undefined, [ testSite ] );
+
+			const { message } = getDialogText( action, [ testPlugin ], [ testSite ] );
+			expect( message ).toEqual(
+				`You are about to ${ text } the ${ testPlugin.slug } plugin installed on ${ testSite.title }.`
+			);
+		}
+	);
+
+	it.each( ACTION_MESSAGE_TEXTS )(
+		'gets the correct `$action` message text for one plugin with a slug but no name, and multiple sites',
+		( { action, text } ) => {
+			expect( action.length ).toBeDefined();
+			expect( text.length ).toBeGreaterThan( 0 );
+
+			const getDialogText = runHook();
+
+			const testSites = allSites.slice( 0, 2 );
+			const testPlugin = createFakePlugin( 'test1', undefined, testSites );
+
+			const { message } = getDialogText( action, [ testPlugin ], testSites );
+			expect( message ).toEqual(
+				`You are about to ${ text } the ${ testPlugin.slug } plugin installed on ${ testSites.length } sites.`
+			);
+		}
+	);
+
+	it.each( ACTION_MESSAGE_TEXTS )(
+		'gets the correct message text for multiple plugins and one site',
+		( { action, text } ) => {
+			expect( action.length ).toBeDefined();
+			expect( text.length ).toBeGreaterThan( 0 );
+
+			const getDialogText = runHook();
+
+			const testSite = allSites[ 0 ];
+			const testPlugins = [ 1, 2, 3 ].map( ( i ) =>
+				createFakePlugin( `test${ i }`, `Test Plugin #${ i }`, [ testSite ] )
+			);
+
+			const { message } = getDialogText( action, testPlugins, [ testSite ] );
+			expect( message ).toEqual(
+				`You are about to ${ text } ${ testPlugins.length } plugins installed on ${ testSite.title }.`
+			);
+		}
+	);
+
+	it.each( ACTION_MESSAGE_TEXTS )(
+		'gets the correct message text for multiple plugins and multiple sites',
+		( { action, text } ) => {
+			expect( action.length ).toBeDefined();
+			expect( text.length ).toBeGreaterThan( 0 );
+
+			const getDialogText = runHook();
+
+			const testSites = allSites.slice( 0, 2 );
+			const testPlugins = [ 1, 2, 3 ].map( ( i ) =>
+				createFakePlugin( `test${ i }`, `Test Plugin #${ i }`, testSites )
+			);
+
+			const { message } = getDialogText( action, testPlugins, testSites );
+			expect( message ).toEqual(
+				`You are about to ${ text } ${ testPlugins.length } plugins installed on ${ testSites.length } sites.`
+			);
+		}
+	);
+} );

--- a/client/my-sites/plugins/hooks/test/use-show-plugin-action-dialog.jsx
+++ b/client/my-sites/plugins/hooks/test/use-show-plugin-action-dialog.jsx
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { PluginActions } from '../types';
+import useShowPluginActionDialog from '../use-show-plugin-action-dialog';
+
+const HEADING_TEXT = 'Heading';
+const MESSAGE_TEXT = 'Message';
+jest.mock( '../use-get-dialog-text', () =>
+	jest.fn().mockReturnValue( () => ( { heading: HEADING_TEXT, message: MESSAGE_TEXT } ) )
+);
+
+const runHook = () => renderHook( () => useShowPluginActionDialog() ).result.current;
+
+describe( 'useShowPluginActionDialog', () => {
+	// A new dialog is created every time we call showPluginActionDialog, and
+	// JSDOM doesn't clear the page before each test; so, we have to clear the
+	// document ourselves.
+	beforeEach( () => {
+		document.documentElement.innerHTML = '<head></head><body></body>';
+	} );
+
+	it( 'renders a dialog modal', () => {
+		const showPluginActionDialog = runHook();
+
+		const callback = () => {
+			/* Purposely do nothing */
+		};
+		const result = render( showPluginActionDialog( '', [], [], callback ) );
+		expect( result.queryByRole( 'dialog' ) ).toBeInTheDocument();
+	} );
+
+	it( 'displays the correct heading and message text', () => {
+		const showPluginActionDialog = runHook();
+
+		const callback = () => {
+			/* Purposely do nothing */
+		};
+		const result = render( showPluginActionDialog( '', [], [], callback ) );
+
+		// NOTE: Selecting these elements by class is less than ideal,
+		// but currently there's no other way to reliably identify them
+		const heading = result.getByText( HEADING_TEXT, { selector: 'div' } );
+		expect( heading ).toBeInTheDocument();
+
+		const message = result.getByText( MESSAGE_TEXT, { selector: 'span' } );
+		expect( message ).toBeInTheDocument();
+	} );
+
+	it( 'applies the `is-scary` class to the accept button if the given action is "remove"', () => {
+		const showPluginActionDialog = runHook();
+
+		const callback = () => {
+			/* Purposely do nothing */
+		};
+		const result = render( showPluginActionDialog( PluginActions.REMOVE, [], [], callback ) );
+		const button = result.getByRole( 'button', { name: HEADING_TEXT } );
+		expect( button.classList ).toContain( 'is-scary' );
+	} );
+
+	it( 'calls the given callback with "true" parameter value when the accept button is clicked', () => {
+		const showPluginActionDialog = runHook();
+
+		const callback = jest.fn();
+
+		const result = render( showPluginActionDialog( PluginActions.REMOVE, [], [], callback ) );
+		const acceptButton = result.getByRole( 'button', { name: HEADING_TEXT } );
+		acceptButton.click();
+
+		expect( callback ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'calls the given callback with "false" parameter value when the cancel button is clicked', () => {
+		const showPluginActionDialog = runHook();
+
+		const callback = jest.fn();
+
+		const result = render( showPluginActionDialog( PluginActions.REMOVE, [], [], callback ) );
+		const cancelButton = result.getByRole( 'button', { name: 'Cancel' } );
+		cancelButton.click();
+
+		expect( callback ).toHaveBeenCalledWith( false );
+	} );
+} );

--- a/client/my-sites/plugins/hooks/types.ts
+++ b/client/my-sites/plugins/hooks/types.ts
@@ -1,0 +1,25 @@
+// NOTE: This is a crude version of an enum,
+// since TypeScript enums behave strangely
+// with regular JavaScript after transpilation
+export const PluginActions = {
+	ACTIVATE: 'activate',
+	DEACTIVATE: 'deactivate',
+	REMOVE: 'remove',
+	UPDATE: 'update',
+	ENABLE_AUTOUPDATES: 'enableAutoUpdates',
+	DISABLE_AUTOUPDATES: 'disableAutoUpdates',
+} as const;
+
+export type PluginActionName = ( typeof PluginActions )[ keyof typeof PluginActions ];
+
+export type Site = {
+	ID: number;
+	title: string;
+	canUpdateFiles?: boolean;
+};
+
+export type Plugin = {
+	slug: string;
+	sites: Record< string, unknown >;
+	name?: string;
+};

--- a/client/my-sites/plugins/hooks/use-get-dialog-text.ts
+++ b/client/my-sites/plugins/hooks/use-get-dialog-text.ts
@@ -1,0 +1,405 @@
+import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { Site, Plugin, PluginActionName } from './types';
+
+/****************************
+ * NOTE BEFORE READING:
+ *
+ * Yes, a lot of the code structure in this file is repeated. This is regrettable
+ * but purposeful, for a few reasons:
+ *
+ * 1. Because GlotPress, the translation engine we use, recognizes the work it
+ *    needs to by detecting calls to translate and parsing their arguments. To
+ *    do its job properly, it needs to see literal (i.e., non-concatenated,
+ *    unaffected by variable values) strings. Passing string variables into
+ *    `translate` as the first parameter, splitting strings up into segments, or
+ *    adding variables in between will confuse both the engine and our (very
+ *    human) translators.
+ * 2. We're handling four unique, non-overlapping cases and several pre-defined
+ *    supported actions/verbs. Each verb needs to have translations written for
+ *    each case, and because of reason 1, we can't reuse text among them.
+ *
+ * For more information, consult the i18n-calypso package's documentation
+ * regarding `translate`.
+ ****************************/
+
+type DialogText = {
+	heading: TranslateResult;
+	message: TranslateResult;
+};
+
+type DialogTextGetter = (
+	translate: ReturnType< typeof useTranslate >,
+	plugins: Plugin[],
+	sites: Site[]
+) => DialogText;
+
+/************************/
+/**** ACTIONS: BEGIN ****/
+/************************/
+
+// Fallback dialog text, in case we're given an action we haven't written
+// translations for yet
+const unspecifiedAction: DialogTextGetter = ( translate, plugins, sites ) => {
+	const heading = translate( 'Affect %(plugin)s', 'Affect %(pluginCount)d plugins', {
+		count: plugins.length,
+		args: { plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug, pluginCount: plugins.length },
+	} );
+
+	// More than one plugin
+	if ( plugins.length > 1 ) {
+		return {
+			heading,
+			message: translate(
+				'You are about to affect %(pluginCount)d plugins installed on %(site)s.',
+				'You are about to affect %(pluginCount)d plugins installed on %(siteCount)d sites.',
+				{
+					count: sites.length,
+					args: {
+						pluginCount: plugins.length,
+						site: sites[ 0 ].title,
+						siteCount: sites.length,
+					},
+				}
+			),
+		};
+	}
+
+	// Only one plugin
+	return {
+		heading,
+		message: translate(
+			'You are about to affect the %(plugin)s plugin installed on %(site)s.',
+			'You are about to affect the %(plugin)s plugin installed on %(siteCount)d sites.',
+			{
+				count: sites.length,
+				args: {
+					plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug,
+					site: sites[ 0 ].title,
+					siteCount: sites.length,
+				},
+			}
+		),
+	};
+};
+
+const activate: DialogTextGetter = ( translate, plugins, sites ) => {
+	const heading = translate( 'Activate %(plugin)s', 'Activate %(pluginCount)d plugins', {
+		count: plugins.length,
+		args: { plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug, pluginCount: plugins.length },
+	} );
+
+	// More than one plugin
+	if ( plugins.length > 1 ) {
+		return {
+			heading,
+			message: translate(
+				'You are about to activate %(pluginCount)d plugins installed on %(site)s.',
+				'You are about to activate %(pluginCount)d plugins installed on %(siteCount)d sites.',
+				{
+					count: sites.length,
+					args: {
+						pluginCount: plugins.length,
+						site: sites[ 0 ].title,
+						siteCount: sites.length,
+					},
+				}
+			),
+		};
+	}
+
+	// Only one plugin
+	return {
+		heading,
+		message: translate(
+			'You are about to activate the %(plugin)s plugin installed on %(site)s.',
+			'You are about to activate the %(plugin)s plugin installed on %(siteCount)d sites.',
+			{
+				count: sites.length,
+				args: {
+					plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug,
+					site: sites[ 0 ].title,
+					siteCount: sites.length,
+				},
+			}
+		),
+	};
+};
+
+const deactivate: DialogTextGetter = ( translate, plugins, sites ) => {
+	const heading = translate( 'Deactivate %(plugin)s', 'Deactivate %(pluginCount)d plugins', {
+		count: plugins.length,
+		args: { plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug, pluginCount: plugins.length },
+	} );
+
+	// More than one plugin
+	if ( plugins.length > 1 ) {
+		return {
+			heading,
+			message: translate(
+				'You are about to deactivate %(pluginCount)d plugins installed on %(site)s.',
+				'You are about to deactivate %(pluginCount)d plugins installed on %(siteCount)d sites.',
+				{
+					count: sites.length,
+					args: {
+						pluginCount: plugins.length,
+						site: sites[ 0 ].title,
+						siteCount: sites.length,
+					},
+				}
+			),
+		};
+	}
+
+	// Only one plugin
+	return {
+		heading,
+		message: translate(
+			'You are about to deactivate the %(plugin)s plugin installed on %(site)s.',
+			'You are about to deactivate the %(plugin)s plugin installed on %(siteCount)d sites.',
+			{
+				count: sites.length,
+				args: {
+					plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug,
+					site: sites[ 0 ].title,
+					siteCount: sites.length,
+				},
+			}
+		),
+	};
+};
+
+const remove: DialogTextGetter = ( translate, plugins, sites ) => {
+	const heading = translate(
+		'Deactivate and remove %(plugin)s',
+		'Deactivate and remove %(pluginCount)d plugins',
+		{
+			count: plugins.length,
+			args: { plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug, pluginCount: plugins.length },
+		}
+	);
+
+	// More than one plugin
+	if ( plugins.length > 1 ) {
+		return {
+			heading,
+			message: translate(
+				'You are about to deactivate and remove %(pluginCount)d plugins installed on %(site)s.',
+				'You are about to deactivate and remove %(pluginCount)d plugins installed on %(siteCount)d sites.',
+				{
+					count: sites.length,
+					args: {
+						pluginCount: plugins.length,
+						site: sites[ 0 ].title,
+						siteCount: sites.length,
+					},
+				}
+			),
+		};
+	}
+
+	// Only one plugin
+	return {
+		heading,
+		message: translate(
+			'You are about to deactivate and remove the %(plugin)s plugin installed on %(site)s.',
+			'You are about to deactivate and remove the %(plugin)s plugin installed on %(siteCount)d sites.',
+			{
+				count: sites.length,
+				args: {
+					plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug,
+					site: sites[ 0 ].title,
+					siteCount: sites.length,
+				},
+			}
+		),
+	};
+};
+
+const update: DialogTextGetter = ( translate, plugins, sites ) => {
+	const heading = translate( 'Update %(plugin)s', 'Update %(pluginCount)d plugins', {
+		count: plugins.length,
+		args: { plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug, pluginCount: plugins.length },
+	} );
+
+	// More than one plugin
+	if ( plugins.length > 1 ) {
+		return {
+			heading,
+			message: translate(
+				'You are about to update %(pluginCount)d plugins installed on %(site)s.',
+				'You are about to update %(pluginCount)d plugins installed on %(siteCount)d sites.',
+				{
+					count: sites.length,
+					args: {
+						pluginCount: plugins.length,
+						site: sites[ 0 ].title,
+						siteCount: sites.length,
+					},
+				}
+			),
+		};
+	}
+
+	// Only one plugin
+	return {
+		heading,
+		message: translate(
+			'You are about to update the %(plugin)s plugin installed on %(site)s.',
+			'You are about to update the %(plugin)s plugin installed on %(siteCount)d sites.',
+			{
+				count: sites.length,
+				args: {
+					plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug,
+					site: sites[ 0 ].title,
+					siteCount: sites.length,
+				},
+			}
+		),
+	};
+};
+
+const enableAutoUpdates: DialogTextGetter = ( translate, plugins, sites ) => {
+	const heading = translate(
+		'Enable auto-updates for %(plugin)s',
+		'Enable auto-updates for %(pluginCount)d plugins',
+		{
+			count: plugins.length,
+			args: { plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug, pluginCount: plugins.length },
+		}
+	);
+
+	// More than one plugin
+	if ( plugins.length > 1 ) {
+		return {
+			heading,
+			message: translate(
+				'You are about to enable auto-updates for %(pluginCount)d plugins installed on %(site)s.',
+				'You are about to enable auto-updates for %(pluginCount)d plugins installed on %(siteCount)d sites.',
+				{
+					count: sites.length,
+					args: {
+						pluginCount: plugins.length,
+						site: sites[ 0 ].title,
+						siteCount: sites.length,
+					},
+				}
+			),
+		};
+	}
+
+	// Only one plugin
+	return {
+		heading,
+		message: translate(
+			'You are about to enable auto-updates for the %(plugin)s plugin installed on %(site)s.',
+			'You are about to enable auto-updates for the %(plugin)s plugin installed on %(siteCount)d sites.',
+			{
+				count: sites.length,
+				args: {
+					plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug,
+					site: sites[ 0 ].title,
+					siteCount: sites.length,
+				},
+			}
+		),
+	};
+};
+
+const disableAutoUpdates: DialogTextGetter = ( translate, plugins, sites ) => {
+	const heading = translate(
+		'Disable auto-updates for %(plugin)s',
+		'Disable auto-updates for %(pluginCount)d plugins',
+		{
+			count: plugins.length,
+			args: { plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug, pluginCount: plugins.length },
+		}
+	);
+
+	// More than one plugin
+	if ( plugins.length > 1 ) {
+		return {
+			heading,
+			message: translate(
+				'You are about to disable auto-updates for %(pluginCount)d plugins installed on %(site)s.',
+				'You are about to disable auto-updates for %(pluginCount)d plugins installed on %(siteCount)d sites.',
+				{
+					count: sites.length,
+					args: {
+						pluginCount: plugins.length,
+						site: sites[ 0 ].title,
+						siteCount: sites.length,
+					},
+				}
+			),
+		};
+	}
+
+	// Only one plugin
+	return {
+		heading,
+		message: translate(
+			'You are about to disable auto-updates for the %(plugin)s plugin installed on %(site)s.',
+			'You are about to disable auto-updates for the %(plugin)s plugin installed on %(siteCount)d sites.',
+			{
+				count: sites.length,
+				args: {
+					plugin: plugins[ 0 ].name ?? plugins[ 0 ].slug,
+					site: sites[ 0 ].title,
+					siteCount: sites.length,
+				},
+			}
+		),
+	};
+};
+
+const ALL_ACTIONS: Record< PluginActionName, DialogTextGetter > = {
+	activate,
+	deactivate,
+	remove,
+	update,
+	enableAutoUpdates,
+	disableAutoUpdates,
+};
+const get = ( action: string ) =>
+	( ALL_ACTIONS as Record< string, DialogTextGetter > )[ action ] ?? unspecifiedAction;
+
+/************************/
+/***** ACTIONS: END *****/
+/************************/
+
+const getAffectedSites = ( plugins: Plugin[], sites: Site[] ) => {
+	// NOTE: We expect the `sites` parameter not to have any duplicate IDs;
+	// if duplicate IDs are present, the returned list of sites will include all
+	// duplicates.
+
+	const pluginsInstalledOnSiteIds = new Set(
+		plugins
+			.map( ( p ) => Object.keys( p.sites ) )
+			.flat()
+			.map( ( id ) => parseInt( id ) )
+	);
+
+	return (
+		sites
+			// We can't affect any sites that don't allow updating files
+			.filter( ( { canUpdateFiles } ) => canUpdateFiles )
+			.filter( ( s ) => pluginsInstalledOnSiteIds.has( s.ID ) )
+	);
+};
+
+const useGetDialogText = () => {
+	const translate = useTranslate();
+
+	return useCallback(
+		( action: string, plugins: Plugin[], sites: Site[] ) => {
+			const getDialogText = get( action );
+			const affectedSites = getAffectedSites( plugins, sites );
+
+			return getDialogText( translate, plugins, affectedSites );
+		},
+		[ translate ]
+	);
+};
+
+export default useGetDialogText;

--- a/client/my-sites/plugins/hooks/use-show-plugin-action-dialog.tsx
+++ b/client/my-sites/plugins/hooks/use-show-plugin-action-dialog.tsx
@@ -41,9 +41,13 @@ const useShowPluginActionDialog = () => {
 };
 
 // For use in situations where hooks aren't supported :-(
-export const withShowPluginActionDialog = ( Component: React.Component ) => ( props ) => {
-	const showPluginActionDialog = useShowPluginActionDialog();
-	return <Component showPluginActionDialog={ showPluginActionDialog } { ...props } />;
-};
+export function withShowPluginActionDialog< ComponentProps >(
+	Component: React.ComponentType< ComponentProps >
+) {
+	return ( props: ComponentProps ) => {
+		const showPluginActionDialog = useShowPluginActionDialog();
+		return <Component showPluginActionDialog={ showPluginActionDialog } { ...props } />;
+	};
+}
 
 export default useShowPluginActionDialog;

--- a/client/my-sites/plugins/hooks/use-show-plugin-action-dialog.tsx
+++ b/client/my-sites/plugins/hooks/use-show-plugin-action-dialog.tsx
@@ -1,0 +1,49 @@
+import React, { useCallback } from 'react';
+import acceptDialog from 'calypso/lib/accept';
+import { PluginActions } from './types';
+import useGetDialogText from './use-get-dialog-text';
+import type { Site, Plugin } from './types';
+import type { TranslateResult } from 'i18n-calypso';
+
+type DialogMessageProps = {
+	heading: TranslateResult;
+	message: TranslateResult;
+};
+const DialogMessage: React.FC< DialogMessageProps > = ( { heading, message } ) => (
+	<div>
+		<div className="plugins__confirmation-modal-heading">{ heading }</div>
+		<span className="plugins__confirmation-modal-desc">{ message }</span>
+	</div>
+);
+
+type DialogCallback = ( accepted: boolean ) => void;
+const useShowPluginActionDialog = () => {
+	const getDialogText = useGetDialogText();
+
+	return useCallback(
+		( action: string, plugins: Plugin[], sites: Site[], callback: DialogCallback ) => {
+			const dialogOptions = {
+				additionalClassNames: 'plugins__confirmation-modal',
+				...( action === PluginActions.REMOVE && { isScary: true } ),
+			};
+
+			const { heading, message } = getDialogText( action, plugins, sites );
+			acceptDialog(
+				<DialogMessage heading={ heading } message={ message } />,
+				callback,
+				heading,
+				null,
+				dialogOptions
+			);
+		},
+		[ getDialogText ]
+	);
+};
+
+// For use in situations where hooks aren't supported :-(
+export const withShowPluginActionDialog = ( Component: React.Component ) => ( props ) => {
+	const showPluginActionDialog = useShowPluginActionDialog();
+	return <Component showPluginActionDialog={ showPluginActionDialog } { ...props } />;
+};
+
+export default useShowPluginActionDialog;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -299,25 +299,28 @@ export class PluginsMain extends Component {
 	}
 
 	getEmptyContentData() {
-		const { translate } = this.props;
-		let emptyContentData = {
-			illustration: '/calypso/images/illustrations/illustration-empty-results.svg',
-		};
-
-		switch ( this.props.filter ) {
-			case 'active':
-				emptyContentData.title = translate( 'No plugins are active.', { textOnly: true } );
-				break;
-			case 'inactive':
-				emptyContentData.title = translate( 'No plugins are inactive.', { textOnly: true } );
-				break;
-			case 'updates':
-				emptyContentData = this.getEmptyContentUpdateData();
-				break;
-			default:
-				return null;
+		const { filter } = this.props;
+		if ( filter === 'update' ) {
+			return this.getEmptyContentUpdateData();
 		}
-		return emptyContentData;
+
+		const { translate } = this.props;
+		const illustration = '/calypso/images/illustrations/illustration-empty-results.svg';
+		if ( filter === 'active' ) {
+			return {
+				title: translate( 'No plugins are active.', { textOnly: true } ),
+				illustration,
+			};
+		}
+
+		if ( filter === 'inactive' ) {
+			return {
+				title: translate( 'No plugins are inactive.', { textOnly: true } ),
+				illustration,
+			};
+		}
+
+		return null;
 	}
 
 	getUpdatesTabVisibility() {

--- a/client/my-sites/plugins/plugin-management-v2/test/remove-plugin.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/remove-plugin.test.tsx
@@ -94,7 +94,7 @@ describe( '<RemovePlugin>', () => {
 		// Test to check if modal is open and has `Remove Button`
 		const [ removeButtonOnModal ] = document.getElementsByClassName( 'button is-primary' );
 		expect( removeButtonOnModal ).toBeInTheDocument();
-		expect( removeButtonOnModal.textContent ).toEqual( `Remove ${ plugin.name }` );
+		expect( removeButtonOnModal.textContent ).toEqual( `Deactivate and remove ${ plugin.name }` );
 		// Simulate click which triggers API call to remove plugin
 		await userEvent.click( removeButtonOnModal );
 		// Test to check if modal is closed after the API is triggered

--- a/client/my-sites/plugins/plugin-management-v2/test/remove-plugin.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/remove-plugin.test.tsx
@@ -11,13 +11,9 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { ACTIVATE_PLUGIN } from 'calypso/lib/plugins/constants';
+import { getSite } from 'calypso/state/sites/selectors';
 import RemovePlugin from '../remove-plugin';
 import { site, plugin } from './utils/constants';
-
-const props = {
-	site,
-	plugin,
-};
 
 const initialState = {
 	sites: { items: { [ site.ID ]: site } },
@@ -75,9 +71,14 @@ describe( '<RemovePlugin>', () => {
 	} );
 
 	test( 'should render correctly and return null', async () => {
+		// The site object passed around Calypso is more than just the raw
+		// state.site.items object; pass in a version from the getSite selector
+		// so that we get other important properties like `canUpdateFiles`.
+		const testSite = getSite( store.getState(), site.ID );
+
 		const { container } = render(
 			<Provider store={ store }>
-				<RemovePlugin { ...props } />
+				<RemovePlugin site={ testSite } plugin={ plugin } />
 			</Provider>
 		);
 

--- a/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
@@ -41,7 +41,11 @@ export default function UpdatePlugins( { plugins, isWpCom }: Props ): ReactEleme
 			'updates'
 		)
 	);
-	const allSites = useSelector( getSites );
+
+	// We don't want null or undefined "sites"
+	const allSites = useSelector( ( state ) =>
+		getSites( state ).filter( ( s ): s is SiteDetails => Boolean( s ) )
+	);
 
 	const pluginsOnSites = useSelector( ( state ) => getPluginsOnSites( state, plugins ) );
 	const selectedSite = useSelector( getSelectedSite );

--- a/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
@@ -1,8 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
+import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import ButtonGroup from 'calypso/components/button-group';
-import acceptDialog from 'calypso/lib/accept';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { updatePlugin } from 'calypso/state/plugins/installed/actions';
@@ -11,11 +11,9 @@ import { removePluginStatuses } from 'calypso/state/plugins/installed/status/act
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import getSites from 'calypso/state/selectors/get-sites';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import {
-	getPluginActionDailogMessage,
-	handleUpdatePlugins,
-	siteObjectsToSiteIds,
-} from '../../utils';
+import { PluginActions } from '../../hooks/types';
+import useShowPluginActionDialog from '../../hooks/use-show-plugin-action-dialog';
+import { handleUpdatePlugins, siteObjectsToSiteIds } from '../../utils';
 import type { PluginComponentProps } from '../types';
 import type { ReactElement } from 'react';
 
@@ -71,26 +69,14 @@ export default function UpdatePlugins( { plugins, isWpCom }: Props ): ReactEleme
 		}
 	}
 
+	const showPluginActionDialog = useShowPluginActionDialog();
+
 	function updateAllPluginsNotice() {
-		let heading = translate( 'Update %(pluginUpdateCount)d plugins', {
-			args: { pluginUpdateCount },
-		} );
-
-		if ( pluginUpdateCount === 1 ) {
-			const [ { name, slug } ] = pluginsWithUpdates;
-			heading = translate( 'Update %(pluginName)s', { args: { pluginName: name || slug } } );
-		}
-
-		const dialogOptions = {
-			additionalClassNames: 'plugins__confirmation-modal',
-		};
-
-		acceptDialog(
-			getPluginActionDailogMessage( allSites, pluginsWithUpdates, heading, 'update' ),
-			( accepted: boolean ) => updateAllPlugins( accepted ),
-			heading,
-			null,
-			dialogOptions
+		showPluginActionDialog(
+			PluginActions.UPDATE,
+			pluginsWithUpdates,
+			allSites,
+			( accepted: boolean ) => updateAllPlugins( accepted )
 		);
 	}
 

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -10,7 +10,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import accept from 'calypso/lib/accept';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { REMOVE_PLUGIN } from 'calypso/lib/plugins/constants';
@@ -19,7 +18,7 @@ import PluginAction from 'calypso/my-sites/plugins/plugin-action/plugin-action';
 import { removePlugin } from 'calypso/state/plugins/installed/actions';
 import { isPluginActionInProgress } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
-import { getPluginActionDailogMessage } from '../utils';
+import { withShowPluginActionDialog } from '../hooks/use-show-plugin-action-dialog';
 
 import './style.scss';
 
@@ -27,23 +26,8 @@ class PluginRemoveButton extends Component {
 	static displayName = 'PluginRemoveButton';
 
 	removeAction = () => {
-		const { translate, plugin, site } = this.props;
-		const dialogOptions = {
-			additionalClassNames: 'plugins__confirmation-modal',
-			isScary: true,
-		};
-		const heading = translate( 'Remove %(pluginName)s', {
-			args: {
-				pluginName: plugin.name,
-			},
-		} );
-		accept(
-			getPluginActionDailogMessage( [ site ], [ plugin ], heading, 'deactivate and delete' ),
-			this.processRemovalConfirmation,
-			heading,
-			null,
-			dialogOptions
-		);
+		const { plugin, site, showPluginActionDialog } = this.props;
+		showPluginActionDialog( 'remove', [ plugin ], [ site ], this.processRemovalConfirmation );
 	};
 
 	processRemovalConfirmation = ( accepted ) => {
@@ -229,4 +213,4 @@ export default connect(
 		inProgress: isPluginActionInProgress( state, site.ID, plugin.id, REMOVE_PLUGIN ),
 	} ),
 	{ removePlugin, removePluginStatuses }
-)( localize( PluginRemoveButton ) );
+)( withShowPluginActionDialog( localize( PluginRemoveButton ) ) );

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -354,60 +354,21 @@ export class PluginsList extends Component {
 		const selectedPlugins = selectedPlugin ? [ selectedPlugin ] : plugins.filter( this.isSelected );
 		const isJetpackIncluded = selectedPlugins.some( ( { slug } ) => slug === 'jetpack' );
 
-		switch ( actionName ) {
-			case PluginActions.ACTIVATE: {
-				showPluginActionDialog( PluginActions.ACTIVATE, selectedPlugins, allSites, ( accepted ) =>
-					this.activateSelected( accepted )
-				);
-				break;
-			}
-			case PluginActions.DEACTIVATE: {
-				showPluginActionDialog(
-					PluginActions.DEACTIVATE,
-					selectedPlugins,
-					allSites,
-					isJetpackIncluded
-						? ( accepted ) => this.deactiveAndDisconnectSelected( accepted )
-						: ( accepted ) => this.deactivateSelected( accepted )
-				);
-				break;
-			}
-			case PluginActions.ENABLE_AUTOUPDATES: {
-				showPluginActionDialog(
-					PluginActions.ENABLE_AUTOUPDATES,
-					selectedPlugins,
-					allSites,
-					( accepted ) => this.setAutoupdateSelected( accepted )
-				);
-				break;
-			}
-			case PluginActions.DISABLE_AUTOUPDATES: {
-				showPluginActionDialog(
-					PluginActions.DISABLE_AUTOUPDATES,
-					selectedPlugins,
-					allSites,
-					( accepted ) => this.unsetAutoupdateSelected( accepted )
-				);
-				break;
-			}
-			case PluginActions.UPDATE: {
-				showPluginActionDialog( PluginActions.UPDATE, selectedPlugins, allSites, ( accepted ) =>
-					this.updateSelected( accepted )
-				);
-				break;
-			}
-			case PluginActions.REMOVE: {
-				showPluginActionDialog(
-					PluginActions.REMOVE,
-					selectedPlugins,
-					allSites,
-					isJetpackIncluded
-						? ( accepted ) => this.removeSelectedWithJetpack( accepted, selectedPlugins )
-						: ( accepted ) => this.removeSelected( accepted, selectedPlugins )
-				);
-				break;
-			}
-		}
+		const ALL_ACTION_CALLBACKS = {
+			[ PluginActions.ACTIVATE ]: this.activateSelected,
+			[ PluginActions.DEACTIVATE ]: isJetpackIncluded
+				? this.deactiveAndDisconnectSelected
+				: this.deactivateSelected,
+			[ PluginActions.REMOVE ]: isJetpackIncluded
+				? ( accepted ) => this.removeSelectedWithJetpack( accepted, selectedPlugins )
+				: ( accepted ) => this.removeSelected( accepted, selectedPlugins ),
+			[ PluginActions.UPDATE ]: this.updateSelected,
+			[ PluginActions.ENABLE_AUTOUPDATES ]: this.setAutoupdateSelected,
+			[ PluginActions.DISABLE_AUTOUPDATES ]: this.unsetAutoupdateSelected,
+		};
+
+		const selectedActionCallback = ALL_ACTION_CALLBACKS[ actionName ];
+		showPluginActionDialog( actionName, selectedPlugins, allSites, selectedActionCallback );
 	};
 
 	removePluginDialog = ( selectedPlugin ) => {

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -286,7 +286,7 @@ export class PluginsList extends Component {
 		const ALL_ACTION_CALLBACKS = {
 			[ PluginActions.ACTIVATE ]: this.activateSelected,
 			[ PluginActions.DEACTIVATE ]: isJetpackIncluded
-				? this.deactiveAndDisconnectSelected
+				? this.deactivateAndDisconnectSelected
 				: this.deactivateSelected,
 			[ PluginActions.REMOVE ]: isJetpackIncluded
 				? ( accepted ) => this.removeSelectedWithJetpack( accepted, selectedPlugins )
@@ -311,7 +311,7 @@ export class PluginsList extends Component {
 		this.doActionOverSelected( 'activating', this.props.activatePlugin );
 	};
 
-	deactiveAndDisconnectSelected = ( accepted ) => {
+	deactivateAndDisconnectSelected = ( accepted ) => {
 		if ( ! accepted ) {
 			return;
 		}
@@ -482,7 +482,7 @@ export class PluginsList extends Component {
 					selected={ this.getSelected() }
 					toggleBulkManagement={ this.toggleBulkManagement }
 					updateSelected={ this.updateSelected }
-					deactiveAndDisconnectSelected={ this.deactiveAndDisconnectSelected }
+					deactiveAndDisconnectSelected={ this.deactivateAndDisconnectSelected }
 					setAutoupdateSelected={ this.setAutoupdateSelected }
 					unsetAutoupdateSelected={ this.unsetAutoupdateSelected }
 					removePluginNotice={ () => this.removePluginDialog() }

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -235,10 +235,10 @@ export class PluginsList extends Component {
 		if ( ! selectedPlugins ) {
 			selectedPlugins = this.props.plugins.filter( this.isSelected );
 		}
+
 		const isDeactivatingOrRemovingAndJetpackSelected = ( { slug } ) =>
 			[ 'deactivating', 'activating', 'removing' ].includes( actionName ) && 'jetpack' === slug;
 
-		const flattenArrays = ( full, partial ) => [ ...full, ...partial ];
 		this.removePluginStatuses();
 		const pluginAndSiteObjects = selectedPlugins
 			.filter( ( plugin ) => ! isDeactivatingOrRemovingAndJetpackSelected( plugin ) ) // ignore sites that are deactivating, activating or removing jetpack
@@ -251,7 +251,7 @@ export class PluginsList extends Component {
 					};
 				} );
 			} ) // list of plugins -> list of plugin+site objects
-			.reduce( flattenArrays, [] ); // flatten the list into one big list of plugin+site objects
+			.flat(); // flatten the list into one big list of plugin+site objects
 
 		pluginAndSiteObjects.forEach( ( { plugin, site } ) => action( site.ID, plugin ) );
 

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -278,34 +278,46 @@ export class PluginsList extends Component {
 	};
 
 	updateSelected = ( accepted ) => {
-		if ( accepted ) {
-			this.doActionOverSelected( 'updating', this.props.updatePlugin );
-			this.recordEvent( 'Clicked Update Plugin(s)', true );
+		if ( ! accepted ) {
+			return;
 		}
+
+		this.recordEvent( 'Clicked Update Plugin(s)', true );
+		this.doActionOverSelected( 'updating', this.props.updatePlugin );
 	};
 
 	updatePlugin = ( selectedPlugin ) => {
+		this.recordEvent( 'Clicked Update Plugin(s)', true );
+
 		handleUpdatePlugins( [ selectedPlugin ], this.props.updatePlugin, this.props.pluginsOnSites );
 		this.removePluginStatuses();
-		this.recordEvent( 'Clicked Update Plugin(s)', true );
 	};
 
 	activateSelected = ( accepted ) => {
-		if ( accepted ) {
-			this.doActionOverSelected( 'activating', this.props.activatePlugin );
-			this.recordEvent( 'Clicked Activate Plugin(s)', true );
+		if ( ! accepted ) {
+			return;
 		}
+
+		this.recordEvent( 'Clicked Activate Plugin(s)', true );
+		this.doActionOverSelected( 'activating', this.props.activatePlugin );
 	};
 
 	deactivateSelected = ( accepted ) => {
-		if ( accepted ) {
-			this.doActionOverSelected( 'deactivating', this.props.deactivatePlugin );
-			this.recordEvent( 'Clicked Deactivate Plugin(s)', true );
+		if ( ! accepted ) {
+			return;
 		}
+
+		this.recordEvent( 'Clicked Deactivate Plugin(s)', true );
+		this.doActionOverSelected( 'deactivating', this.props.deactivatePlugin );
 	};
 
 	deactiveAndDisconnectSelected = ( accepted ) => {
-		if ( accepted ) {
+		if ( ! accepted ) {
+			return;
+		}
+
+		this.recordEvent( 'Clicked Deactivate Plugin(s) and Disconnect Jetpack', true );
+
 			let waitForDeactivate = false;
 
 			this.doActionOverSelected( 'deactivating', ( site, plugin ) => {
@@ -316,23 +328,24 @@ export class PluginsList extends Component {
 			if ( waitForDeactivate && this.props.selectedSite ) {
 				this.setState( { disconnectJetpackNotice: true } );
 			}
-
-			this.recordEvent( 'Clicked Deactivate Plugin(s) and Disconnect Jetpack', true );
-		}
 	};
 
 	setAutoupdateSelected = ( accepted ) => {
-		if ( accepted ) {
-			this.doActionOverSelected( 'enablingAutoupdates', this.props.enableAutoupdatePlugin );
-			this.recordEvent( 'Clicked Enable Autoupdate Plugin(s)', true );
+		if ( ! accepted ) {
+			return;
 		}
+
+		this.recordEvent( 'Clicked Enable Autoupdate Plugin(s)', true );
+		this.doActionOverSelected( 'enablingAutoupdates', this.props.enableAutoupdatePlugin );
 	};
 
 	unsetAutoupdateSelected = ( accepted ) => {
-		if ( accepted ) {
-			this.doActionOverSelected( 'disablingAutoupdates', this.props.disableAutoupdatePlugin );
-			this.recordEvent( 'Clicked Disable Autoupdate Plugin(s)', true );
+		if ( ! accepted ) {
+			return;
 		}
+
+		this.recordEvent( 'Clicked Disable Autoupdate Plugin(s)', true );
+		this.doActionOverSelected( 'disablingAutoupdates', this.props.disableAutoupdatePlugin );
 	};
 
 	bulkActionDialog = ( actionName, selectedPlugin ) => {
@@ -469,18 +482,26 @@ export class PluginsList extends Component {
 	};
 
 	removeSelected = ( accepted, selectedPlugins ) => {
-		if ( accepted ) {
-			this.doActionOverSelected( 'removing', this.props.removePlugin, selectedPlugins );
-			this.recordEvent( 'Clicked Remove Plugin(s)', true );
+		if ( ! accepted ) {
+			return;
 		}
+
+		this.recordEvent( 'Clicked Remove Plugin(s)', true );
+		this.doActionOverSelected( 'removing', this.props.removePlugin, selectedPlugins );
 	};
 
 	removeSelectedWithJetpack = ( accepted, selectedPlugins ) => {
-		if ( accepted ) {
+		if ( ! accepted ) {
+			return;
+		}
+
+		this.recordEvent( 'Clicked Remove Plugin(s) and Remove Jetpack', true );
+
 			if ( selectedPlugins.length === 1 ) {
 				this.setState( { removeJetpackNotice: true } );
-				this.recordEvent( 'Clicked Remove Plugin(s) and Remove Jetpack', true );
-			} else {
+			return;
+		}
+
 				let waitForRemove = false;
 				this.doActionOverSelected( 'removing', ( site, plugin ) => {
 					waitForRemove = true;
@@ -489,20 +510,23 @@ export class PluginsList extends Component {
 
 				if ( waitForRemove && this.props.selectedSite ) {
 					this.setState( { removeJetpackNotice: true } );
-					this.recordEvent( 'Clicked Remove Plugin(s) and Remove Jetpack', true );
-				}
-			}
 		}
 	};
 
 	maybeShowDisconnectNotice() {
-		const { translate } = this.props;
+		if ( ! this.state.disconnectJetpackNotice ) {
+			return;
+		}
 
-		if ( this.state.disconnectJetpackNotice && ! this.props.inProgressStatuses.length ) {
+		if ( this.props.inProgressStatuses.length > 0 ) {
+			return;
+		}
+
 			this.setState( {
 				disconnectJetpackNotice: false,
 			} );
 
+		const { translate } = this.props;
 			this.props.warningNotice(
 				translate(
 					'Jetpack cannot be deactivated from WordPress.com. {{link}}Manage connection{{/link}}',
@@ -514,19 +538,23 @@ export class PluginsList extends Component {
 				)
 			);
 		}
-	}
 
 	maybeShowRemoveNotice() {
-		const { translate } = this.props;
+		if ( ! this.state.removeJetpackNotice ) {
+			return;
+		}
 
-		if ( this.state.removeJetpackNotice && ! this.props.inProgressStatuses.length ) {
+		if ( this.props.inProgressStatuses.length > 0 ) {
+			return;
+		}
+
 			this.setState( {
 				removeJetpackNotice: false,
 			} );
 
+		const { translate } = this.props;
 			this.props.warningNotice( translate( 'Jetpack must be removed via wp-admin.' ) );
 		}
-	}
 
 	getPluginsSites() {
 		const { plugins } = this.props;

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -30,7 +30,7 @@ import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors
 import { PluginActions } from '../hooks/types';
 import { withShowPluginActionDialog } from '../hooks/use-show-plugin-action-dialog';
 import PluginManagementV2 from '../plugin-management-v2';
-import { getSitePlugin, handleUpdatePlugins } from '../utils';
+import { handleUpdatePlugins } from '../utils';
 
 import './style.scss';
 
@@ -160,46 +160,8 @@ export class PluginsList extends Component {
 		} );
 	};
 
-	filterSelection = {
-		active( plugin ) {
-			if ( this.isSelected( plugin ) ) {
-				return Object.keys( plugin.sites ).some( ( siteId ) => {
-					const sitePlugin = getSitePlugin( plugin, siteId, this.props.pluginsOnSites );
-					return sitePlugin?.active;
-				} );
-			}
-			return false;
-		},
-		inactive( plugin ) {
-			if ( this.isSelected( plugin ) && plugin.slug !== 'jetpack' ) {
-				return Object.keys( plugin.sites ).some( ( siteId ) => {
-					const sitePlugin = getSitePlugin( plugin, siteId, this.props.pluginsOnSites );
-					return ! sitePlugin?.active;
-				} );
-			}
-			return false;
-		},
-		updates( plugin ) {
-			if ( this.isSelected( plugin ) ) {
-				return Object.keys( plugin.sites ).some( ( siteId ) => {
-					const sitePlugin = getSitePlugin( plugin, siteId, this.props.pluginsOnSites );
-					const site = this.props.allSites.find( ( s ) => s.ID === parseInt( siteId ) );
-					return sitePlugin?.update?.new_version && site.canUpdateFiles;
-				} );
-			}
-			return false;
-		},
-		selected( plugin ) {
-			return this.isSelected( plugin );
-		},
-	};
-
 	getSelected() {
-		return this.props.plugins.filter( this.filterSelection.selected.bind( this ) );
-	}
-
-	siteSuffix() {
-		return this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '';
+		return this.props.plugins.filter( this.isSelected.bind( this ) );
 	}
 
 	recordEvent( eventAction, includeSelectedPlugins ) {
@@ -269,14 +231,6 @@ export class PluginsList extends Component {
 			sites: siteIds,
 		} );
 	}
-
-	pluginHasUpdate = ( plugin ) => {
-		return Object.keys( plugin.sites ).some( ( siteId ) => {
-			const sitePlugin = getSitePlugin( plugin, siteId, this.props.pluginsOnSites );
-			const site = this.props.allSites.find( ( s ) => s.ID === parseInt( siteId ) );
-			return sitePlugin?.update && site?.canUpdateFiles;
-		} );
-	};
 
 	bulkActionDialog = ( actionName, selectedPlugin ) => {
 		const { plugins, allSites, showPluginActionDialog } = this.props;
@@ -452,20 +406,6 @@ export class PluginsList extends Component {
 
 		const { translate } = this.props;
 		this.props.warningNotice( translate( 'Jetpack must be removed via wp-admin.' ) );
-	}
-
-	getPluginsSites() {
-		const { plugins } = this.props;
-		return plugins.reduce( ( sites, plugin ) => {
-			Object.keys( plugin.sites ).map( ( pluginSiteId ) => {
-				if ( ! sites.find( ( site ) => site.ID === pluginSiteId ) ) {
-					const pluginSite = this.props.allSites.find( ( s ) => s.ID === parseInt( pluginSiteId ) );
-					sites.push( pluginSite );
-				}
-			} );
-
-			return sites;
-		}, [] );
 	}
 
 	render() {

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -278,77 +278,6 @@ export class PluginsList extends Component {
 		} );
 	};
 
-	updateSelected = ( accepted ) => {
-		if ( ! accepted ) {
-			return;
-		}
-
-		this.recordEvent( 'Clicked Update Plugin(s)', true );
-		this.doActionOverSelected( 'updating', this.props.updatePlugin );
-	};
-
-	updatePlugin = ( selectedPlugin ) => {
-		this.recordEvent( 'Clicked Update Plugin(s)', true );
-
-		handleUpdatePlugins( [ selectedPlugin ], this.props.updatePlugin, this.props.pluginsOnSites );
-		this.removePluginStatuses();
-	};
-
-	activateSelected = ( accepted ) => {
-		if ( ! accepted ) {
-			return;
-		}
-
-		this.recordEvent( 'Clicked Activate Plugin(s)', true );
-		this.doActionOverSelected( 'activating', this.props.activatePlugin );
-	};
-
-	deactivateSelected = ( accepted ) => {
-		if ( ! accepted ) {
-			return;
-		}
-
-		this.recordEvent( 'Clicked Deactivate Plugin(s)', true );
-		this.doActionOverSelected( 'deactivating', this.props.deactivatePlugin );
-	};
-
-	deactiveAndDisconnectSelected = ( accepted ) => {
-		if ( ! accepted ) {
-			return;
-		}
-
-		this.recordEvent( 'Clicked Deactivate Plugin(s) and Disconnect Jetpack', true );
-
-		let waitForDeactivate = false;
-
-		this.doActionOverSelected( 'deactivating', ( site, plugin ) => {
-			waitForDeactivate = true;
-			this.props.deactivatePlugin( site, plugin );
-		} );
-
-		if ( waitForDeactivate && this.props.selectedSite ) {
-			this.setState( { disconnectJetpackNotice: true } );
-		}
-	};
-
-	setAutoupdateSelected = ( accepted ) => {
-		if ( ! accepted ) {
-			return;
-		}
-
-		this.recordEvent( 'Clicked Enable Autoupdate Plugin(s)', true );
-		this.doActionOverSelected( 'enablingAutoupdates', this.props.enableAutoupdatePlugin );
-	};
-
-	unsetAutoupdateSelected = ( accepted ) => {
-		if ( ! accepted ) {
-			return;
-		}
-
-		this.recordEvent( 'Clicked Disable Autoupdate Plugin(s)', true );
-		this.doActionOverSelected( 'disablingAutoupdates', this.props.disableAutoupdatePlugin );
-	};
-
 	bulkActionDialog = ( actionName, selectedPlugin ) => {
 		const { plugins, allSites, showPluginActionDialog } = this.props;
 		const selectedPlugins = selectedPlugin ? [ selectedPlugin ] : plugins.filter( this.isSelected );
@@ -371,17 +300,43 @@ export class PluginsList extends Component {
 		showPluginActionDialog( actionName, selectedPlugins, allSites, selectedActionCallback );
 	};
 
-	removePluginDialog = ( selectedPlugin ) => {
-		this.bulkActionDialog( PluginActions.REMOVE, selectedPlugin );
-	};
+	/** BEGIN BULK ACTION DIALOG CALLBACKS */
 
-	removeSelected = ( accepted, selectedPlugins ) => {
+	activateSelected = ( accepted ) => {
 		if ( ! accepted ) {
 			return;
 		}
 
-		this.recordEvent( 'Clicked Remove Plugin(s)', true );
-		this.doActionOverSelected( 'removing', this.props.removePlugin, selectedPlugins );
+		this.recordEvent( 'Clicked Activate Plugin(s)', true );
+		this.doActionOverSelected( 'activating', this.props.activatePlugin );
+	};
+
+	deactiveAndDisconnectSelected = ( accepted ) => {
+		if ( ! accepted ) {
+			return;
+		}
+
+		this.recordEvent( 'Clicked Deactivate Plugin(s) and Disconnect Jetpack', true );
+
+		let waitForDeactivate = false;
+
+		this.doActionOverSelected( 'deactivating', ( site, plugin ) => {
+			waitForDeactivate = true;
+			this.props.deactivatePlugin( site, plugin );
+		} );
+
+		if ( waitForDeactivate && this.props.selectedSite ) {
+			this.setState( { disconnectJetpackNotice: true } );
+		}
+	};
+
+	deactivateSelected = ( accepted ) => {
+		if ( ! accepted ) {
+			return;
+		}
+
+		this.recordEvent( 'Clicked Deactivate Plugin(s)', true );
+		this.doActionOverSelected( 'deactivating', this.props.deactivatePlugin );
 	};
 
 	removeSelectedWithJetpack = ( accepted, selectedPlugins ) => {
@@ -405,6 +360,55 @@ export class PluginsList extends Component {
 		if ( waitForRemove && this.props.selectedSite ) {
 			this.setState( { removeJetpackNotice: true } );
 		}
+	};
+
+	removeSelected = ( accepted, selectedPlugins ) => {
+		if ( ! accepted ) {
+			return;
+		}
+
+		this.recordEvent( 'Clicked Remove Plugin(s)', true );
+		this.doActionOverSelected( 'removing', this.props.removePlugin, selectedPlugins );
+	};
+
+	updateSelected = ( accepted ) => {
+		if ( ! accepted ) {
+			return;
+		}
+
+		this.recordEvent( 'Clicked Update Plugin(s)', true );
+		this.doActionOverSelected( 'updating', this.props.updatePlugin );
+	};
+
+	setAutoupdateSelected = ( accepted ) => {
+		if ( ! accepted ) {
+			return;
+		}
+
+		this.recordEvent( 'Clicked Enable Autoupdate Plugin(s)', true );
+		this.doActionOverSelected( 'enablingAutoupdates', this.props.enableAutoupdatePlugin );
+	};
+
+	unsetAutoupdateSelected = ( accepted ) => {
+		if ( ! accepted ) {
+			return;
+		}
+
+		this.recordEvent( 'Clicked Disable Autoupdate Plugin(s)', true );
+		this.doActionOverSelected( 'disablingAutoupdates', this.props.disableAutoupdatePlugin );
+	};
+
+	/** END BULK ACTION DIALOG CALLBACKS */
+
+	updatePlugin = ( selectedPlugin ) => {
+		this.recordEvent( 'Clicked Update Plugin(s)', true );
+
+		handleUpdatePlugins( [ selectedPlugin ], this.props.updatePlugin, this.props.pluginsOnSites );
+		this.removePluginStatuses();
+	};
+
+	removePluginDialog = ( selectedPlugin ) => {
+		this.bulkActionDialog( PluginActions.REMOVE, selectedPlugin );
 	};
 
 	maybeShowDisconnectNotice() {

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isMagnificentLocale } from '@automattic/i18n-utils';
-import { useTranslate, translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -30,93 +30,6 @@ export function useLocalizedPlugins() {
 
 	return { localizePath };
 }
-
-// Returns translated text based on different combination of plugins and sites
-const getConfirmationText = ( sites, selectedPlugins, actionText ) => {
-	const pluginsList = {};
-	const sitesList = {};
-	let pluginName;
-	let siteName;
-
-	selectedPlugins.forEach( ( plugin ) => {
-		pluginsList[ plugin.slug ] = true;
-		pluginName = plugin.name || plugin.slug;
-
-		Object.keys( plugin.sites ).forEach( ( siteId ) => {
-			const site = sites.find( ( s ) => s.ID === parseInt( siteId ) );
-			if ( site && site.canUpdateFiles ) {
-				sitesList[ site.ID ] = true;
-				siteName = site.title;
-			}
-		} );
-	} );
-
-	const pluginsListSize = Object.keys( pluginsList ).length;
-	const siteListSize = Object.keys( sitesList ).length;
-	const combination =
-		( siteListSize > 1 ? 'n sites' : '1 site' ) +
-		' ' +
-		( pluginsListSize > 1 ? 'n plugins' : '1 plugin' );
-
-	switch ( combination ) {
-		case '1 site 1 plugin':
-			return translate( 'You are about to %(actionText)s %(plugin)s installed on %(site)s.', {
-				args: {
-					actionText: actionText,
-					plugin: pluginName,
-					site: siteName,
-				},
-			} );
-
-		case '1 site n plugins':
-			return translate(
-				'You are about to %(actionText)s %(numberOfPlugins)d plugins installed on %(site)s.',
-				{
-					args: {
-						actionText: actionText,
-						numberOfPlugins: pluginsListSize,
-						site: siteName,
-					},
-				}
-			);
-
-		case 'n sites 1 plugin':
-			return translate(
-				'You are about to %(actionText)s %(plugin)s installed across %(numberOfSites)d sites.',
-				{
-					args: {
-						actionText: actionText,
-						plugin: pluginName,
-						numberOfSites: siteListSize,
-					},
-				}
-			);
-
-		case 'n sites n plugins':
-			return translate(
-				'You are about to %(actionText)s %(numberOfPlugins)d plugins installed across %(numberOfSites)d sites.',
-				{
-					args: {
-						actionText: actionText,
-						numberOfPlugins: pluginsListSize,
-						numberOfSites: siteListSize,
-					},
-				}
-			);
-	}
-};
-
-// Returns plugin action dailog message for different action types
-export const getPluginActionDailogMessage = ( sites, selectedPlugins, heading, actionText ) => {
-	return (
-		<div>
-			<div className="plugins__confirmation-modal-heading">{ heading }</div>
-			<span className="plugins__confirmation-modal-desc">
-				{ getConfirmationText( sites, selectedPlugins, actionText ) }
-			</span>
-		</div>
-	);
-};
 
 export function getSitePlugin( plugin, siteId, pluginsOnSites ) {
 	return {

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -31,7 +31,7 @@ export function useLocalizedPlugins() {
 	return { localizePath };
 }
 
-export function getSitePlugin( plugin, siteId, pluginsOnSites ) {
+function getSitePlugin( plugin, siteId, pluginsOnSites ) {
 	return {
 		...plugin,
 		...pluginsOnSites[ plugin.slug ]?.sites[ siteId ],


### PR DESCRIPTION
This PR replaces the `getPluginActionDailog` method with a new hook that responds to changes in the user's locale via `useTranslate`. It also rewrites some plugin management-related code to reduce complexity and improve readability. All existing functionality should be preserved.

Resolves `1202619025189113-as-1202978931490015`.
Relates to #67799.

## Proposed Changes

* Create a new `useShowPluginActionDialog` hook (with supporting hook `useGetDialogText`).
* Create a higher-order component `withShowPluginActionDialog`, for a couple areas dependent on this functionality that don't (yet) support hooks.
* Add unit test coverage for both new hooks.
* Remove unused/unreferenced methods in the `PluginsList` component, and re-order/refactor some methods to reduce nesting, improve readability, and take advantage of new JavaScript features (e.g., `Array.flat`).
* Replace all references to the `getPluginActionDailog` method with usages of `useShowPluginActionDialog` or the HOC equivalent.
* Remove the old (and now, unused) `getPluginActionDailog` method.

## Testing Instructions

***TL;DR:** Regression testing for all plugin management functions.*

* In the Jetpack Cloud dashboard for agencies/partners, experiment with the various available plugin management actions:
  * Try affecting just one plugin, just one site, multiples of either, or multiples of both.
  * Try accepting the confirmation modal, and try canceling it.
  * Pay special attention to the modal's verbiage to check that the action name, site title and/or plugin name (if applicable), and spelling are all correct.
* In Calypso Blue, do much the same testing on the `/plugins/{pluginSlug}` and `/plugins/{pluginSlug}/{siteSlug}` pages. (NOTE: You'll likely need access to a WPCOM Business or eCommerce site for this step.) Confirm that all functionality works as expected.

### Reference screenshots

<img width="597" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/d3cdacb9-24a5-4e9d-b4b4-9faf7f21a1ca">

<img width="918" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/40484051-ee7a-4615-8db4-e5b04b1256cc">

<img width="1202" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/7d6f9da7-942e-4ad4-acf1-120579a43ee0">

<img width="1318" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/69f9bf94-36fa-4fe3-a386-810267c6119f">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202978931490015