### PR TITLE
Preserve search when changing theme showcase tier

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -132,7 +132,7 @@ class ThemeShowcase extends Component {
 	}
 
 	componentWillUnmount() {
-		this.props.setBackPath( this.constructUrl( { searchString: this.props.search } ) );
+		this.props.setBackPath( this.constructUrl() );
 	}
 
 	isStaticFilter = ( tabFilter ) => {
@@ -253,7 +253,7 @@ class ThemeShowcase extends Component {
 		const url = this.constructUrl( {
 			filter: filterString,
 			// Strip filters and excess whitespace
-			searchString: searchBoxContent.replace( filterRegex, '' ).replace( /\s+/g, ' ' ).trim(),
+			search: searchBoxContent.replace( filterRegex, '' ).replace( /\s+/g, ' ' ).trim(),
 		} );
 
 		this.setState( { tabFilter: this.getTabFilterFromUrl( filterString ) } );
@@ -269,15 +269,14 @@ class ThemeShowcase extends Component {
 	 * @param {string} sections.tier override tier prop
 	 * @param {string} sections.filter override filter prop
 	 * @param {string} sections.siteSlug override siteSlug prop
-	 * @param {string} sections.searchString override searchString prop
+	 * @param {string} sections.search override search prop
 	 * @returns {string} Theme showcase url
 	 */
 	constructUrl = ( sections ) => {
-		const { vertical, tier, filter, siteSlug, searchString, locale, isLoggedIn } = {
+		const { vertical, tier, filter, siteSlug, search, locale, isLoggedIn } = {
 			...this.props,
 			...sections,
 		};
-
 		const siteIdSection = siteSlug ? `/${ siteSlug }` : '';
 		const verticalSection = vertical ? `/${ vertical }` : '';
 		const tierSection = tier && tier !== 'all' ? `/${ tier }` : '';
@@ -289,7 +288,7 @@ class ThemeShowcase extends Component {
 			locale,
 			! isLoggedIn
 		);
-		return buildRelativeSearchUrl( url, searchString );
+		return buildRelativeSearchUrl( url, search );
 	};
 
 	onTierSelect = ( { value: tier } ) => {
@@ -330,7 +329,7 @@ class ThemeShowcase extends Component {
 			};
 		}
 
-		const { filter = '', search, filterToTermTable } = this.props;
+		const { filter = '', filterToTermTable } = this.props;
 		const subjectTerm = filterToTermTable[ `subject:${ tabFilter.key }` ];
 		const subjectFilters = Object.values( this.subjectTermTable );
 		const filterWithoutSubjects = filter
@@ -342,7 +341,7 @@ class ThemeShowcase extends Component {
 			? [ filterWithoutSubjects, subjectTerm ].join( '+' )
 			: filterWithoutSubjects;
 
-		page( this.constructUrl( { filter: newFilter, searchString: search } ) );
+		page( this.constructUrl( { filter: newFilter } ) );
 
 		this.setState( { tabFilter }, callback );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78413

## Proposed Changes

After searching in the theme showcase if the user changes the tier (Free, Premium, Paid) then the search terms were lost (as opposed to subject which is preserved) . This change preserves the search terms until the user explicitly clears them.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


 1. Use calypso live link
 2. Go to /themes and choose a simple site
 3. Type a search query into the search bar and hit enter
 4. See that the themes in the list below change
 5. Change from 'All' to 'Free'
 6. See that the search query is still in the search bar
 7. See that the themes in the list below change - the same Free themes as before are included but the Premium and Paid ones are not.

Switch to Atomic and it should work exactly the same way, note that there is a 'My Themes' section here which purposefully does not preserve the tier, it will preserve the search though.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

## Implementation note

This ThemeShowcase component expects a `search` prop but as of 71a28655945 the `constructUrl` method replaced `updateUrl` and rather than `searchString` defaulting to the `search` prop it defaulted to the `searchString` prop, which isn't actually a prop. I suspect this was an accident. Over the years people have started updating the component to get the `search` prop and pass it to `constructUrl` as `searchString`. I've reversed this so `constructUrl` uses the search prop and you need to pass `search` to override it.