### PR TITLE
Plugins: Update the searchbox with the keyword from URL

### DIFF
--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -85,14 +85,12 @@ const SearchBoxHeader = ( props ) => {
 		searchTerms,
 	} = props;
 
-	// Clear the keyword in search box on PluginsBrowser load if required.
-	// Required when navigating to a new plugins browser location
-	// without using close search ("X") to clear. e.g. When clicking
-	// clear in the search results header.
+	// Update the search box with the value from the url everytime it changes
+	// This allows the component to be refilled with a keyword
+	// when navigating back to a page via breadcrumb,
+	// and get empty when the user accesses a non-search page
 	useEffect( () => {
-		if ( ! searchTerm ) {
-			searchRef?.current?.setKeyword( '' );
-		}
+		searchRef?.current?.setKeyword( searchTerm ?? '' );
 	}, [ searchRef, searchTerm ] );
 
 	const classNames = [ 'search-box-header' ];


### PR DESCRIPTION
Fixes #79017
Related to #66883 (I would love a review from @DustyReagan or @lsl in case of any regressions)

## Proposed Changes

Update the search box with the value from the URL every time it changes,  allowing the component to be refilled with a keyword when navigating back to a page via breadcrumb, and get empty when the user accesses a non-search page.

On the current version, it is only updating for empty keywords.

![CleanShot 2023-07-07 at 13 46 14](https://github.com/Automattic/wp-calypso/assets/5039531/694cc218-5854-46f9-8f3a-1638f276f8df)


## Testing Instructions

* Load the plugins page with a search. Ex: `/plugins?s=bookings`
* The search box MUST CONTAIN the search item (`bookings` in this case)
* Go to a category page
* The search box MUST BE EMPTY
* Click on the `Search Results` breadcrumb
*  The search box MUST CONTAIN the search item 


* The production behavior can be verified at #79017


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
