### PR TITLE
Plugins: Update SearchBox layout

### DIFF
--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -66,6 +66,9 @@ const SearchBox = ( {
 				delaySearch={ false }
 				recordEvent={ recordSearchEvent }
 				searching={ isSearching }
+				submitOnOpenIconClick
+				openIconSide="right"
+				displayOpenAndCloseIcons
 			/>
 		</div>
 	);

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -85,14 +85,12 @@ const SearchBoxHeader = ( props ) => {
 		searchTerms,
 	} = props;
 
-	// Clear the keyword in search box on PluginsBrowser load if required.
-	// Required when navigating to a new plugins browser location
-	// without using close search ("X") to clear. e.g. When clicking
-	// clear in the search results header.
+	// Update the search box with the value from the url everytime it changes
+	// This allows the component to be refilled with a keyword
+	// when navigating back to a page via breadcrumb,
+	// and get empty when the user accesses a non-search page
 	useEffect( () => {
-		if ( ! searchTerm ) {
-			searchRef?.current?.setKeyword( '' );
-		}
+		searchRef?.current?.setKeyword( searchTerm ?? '' );
 	}, [ searchRef, searchTerm ] );
 
 	const classNames = [ 'search-box-header' ];

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -24,12 +24,13 @@
 				max-width: 400px;
 				margin: 0 auto;
 				border-radius: 4px;
+				padding-right: 10px;
 
 				&.is-expanded-to-container {
 					height: 100%;
 				}
 
-				box-shadow: 0 0 0 1px var(--studio-gray-5);
+				box-shadow: 0 0 0 1px var(--studio-gray-10);
 
 				.search-component__icon-navigation:focus {
 					box-shadow: none;
@@ -37,27 +38,42 @@
 
 				.search-component__open-icon,
 				.search-component__close-icon {
+					color: var(--studio-gray-30);
+
+					&:hover {
+						color: var(--studio-gray-60);
+					}
+				}
+
+				.search-component__icon-navigation {
+					margin-right: 2px;
+				}
+
+				.search-component__icon-navigation-separator {
+					user-select: none;
 					color: var(--studio-gray-5);
+					margin-bottom: 3px;
 				}
 
 				&.is-searching {
 					.components-spinner {
-						margin: 5px 0;
+						margin: 5px -9px 5px 0;
 						width: 50px;
 					}
 				}
 
 				.search-component__input-fade {
-					right: 3px;
+					padding-left: 16px;
 				}
-				.search-component__icon-navigation:first-of-type {
-					margin-left: 3px;
+
+				.search-component__open-icon {
+					height: 28px;
+					margin-right: -9px;
 				}
-				.search-component__icon-navigation:not(:first-of-type) {
-					margin-right: 3px;
-					.search-component__close-icon {
-						color: #757575;
-					}
+
+				.search-component__close-icon {
+					margin-left: -9px;
+					margin-right: -10px;
 				}
 			}
 		}

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -55,6 +55,7 @@ type Props = {
 	dir?: 'ltr' | 'rtl';
 	disableAutocorrect?: boolean;
 	disabled?: boolean;
+	displayOpenAndCloseIcons?: boolean;
 	fitsContainer?: boolean;
 	hideClose?: boolean;
 	isReskinned?: boolean;
@@ -127,6 +128,7 @@ const InnerSearch = (
 		delayTimeout = SEARCH_DEBOUNCE_MS,
 		defaultValue = '',
 		defaultIsOpen = false,
+		displayOpenAndCloseIcons: displayOpenAndClose = false,
 		autoFocus = false,
 		onSearchOpen,
 		recordEvent,
@@ -455,6 +457,30 @@ const InnerSearch = (
 		return null;
 	};
 
+	const renderRightIcons = () => {
+		const closeButton = renderCloseButton();
+
+		if ( displayOpenAndClose ) {
+			return (
+				<>
+					{ renderOpenIcon() }
+					{ closeButton && (
+						<>
+							<div className="search-component__icon-navigation-separator">|</div>
+							{ closeButton }
+						</>
+					) }
+				</>
+			);
+		}
+
+		if ( shouldRenderRightOpenIcon ) {
+			return renderOpenIcon();
+		}
+
+		return closeButton;
+	};
+
 	return (
 		<div dir={ dir } className={ searchClass } role="search">
 			<Spinner />
@@ -488,7 +514,7 @@ const InnerSearch = (
 				{ renderStylingDiv() }
 			</form>
 			{ childrenBeforeCloseButton }
-			{ shouldRenderRightOpenIcon ? renderOpenIcon() : renderCloseButton() }
+			{ renderRightIcons() }
 			{ children }
 		</div>
 	);

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -79,6 +79,7 @@ type Props = {
 	value?: string;
 	searchMode?: 'when-typing' | 'on-enter';
 	searchIcon?: ReactNode;
+	submitOnOpenIconClick?: boolean;
 };
 
 //This is fix for IE11. Does not work on Edge.
@@ -149,6 +150,7 @@ const InnerSearch = (
 		isReskinned = false,
 		searchMode = 'when-typing',
 		searchIcon,
+		submitOnOpenIconClick = false,
 	}: Props,
 	forwardedRef: Ref< ImperativeHandle >
 ) => {
@@ -349,13 +351,13 @@ const InnerSearch = (
 		}
 	};
 
-	const handleSubmit = ( event: FormEvent ) => {
+	const handleSubmit = ( event?: FormEvent ) => {
 		if ( 'on-enter' === searchMode ) {
 			onSearch?.( keyword );
 			onSearchChange?.( keyword );
 		}
-		event.preventDefault();
-		event.stopPropagation();
+		event?.preventDefault();
+		event?.stopPropagation();
 	};
 
 	const searchValue = keyword;
@@ -423,11 +425,23 @@ const InnerSearch = (
 			return renderReskinSearchIcon();
 		}
 
+		const onClick = ( props: React.MouseEvent< HTMLButtonElement > ) => {
+			if ( submitOnOpenIconClick ) {
+				handleSubmit();
+			}
+
+			if ( enableOpenIcon ) {
+				return openSearch( props );
+			}
+
+			return () => searchInput.current?.focus();
+		};
+
 		return (
 			<Button
 				className="search-component__icon-navigation"
 				ref={ openIcon }
-				onClick={ enableOpenIcon ? openSearch : () => searchInput.current?.focus() }
+				onClick={ onClick }
 				tabIndex={ enableOpenIcon ? 0 : undefined }
 				onKeyDown={ enableOpenIcon ? openListener : undefined }
 				aria-controls={ 'search-component-' + instanceId }

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -483,7 +483,7 @@ const InnerSearch = (
 
 	return (
 		<div dir={ dir } className={ searchClass } role="search">
-			<Spinner />
+			{ openIconSide === 'left' && <Spinner /> }
 			{ openIconSide === 'left' && renderOpenIcon() }
 			<form className={ fadeClass } action="." onSubmit={ handleSubmit }>
 				<input
@@ -514,6 +514,7 @@ const InnerSearch = (
 				{ renderStylingDiv() }
 			</form>
 			{ childrenBeforeCloseButton }
+			{ openIconSide === 'right' && <Spinner /> }
 			{ renderRightIcons() }
 			{ children }
 		</div>

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -129,7 +129,7 @@ const InnerSearch = (
 		delayTimeout = SEARCH_DEBOUNCE_MS,
 		defaultValue = '',
 		defaultIsOpen = false,
-		displayOpenAndCloseIcons: displayOpenAndClose = false,
+		displayOpenAndCloseIcons = false,
 		autoFocus = false,
 		onSearchOpen,
 		recordEvent,
@@ -474,7 +474,7 @@ const InnerSearch = (
 	const renderRightIcons = () => {
 		const closeButton = renderCloseButton();
 
-		if ( displayOpenAndClose ) {
+		if ( displayOpenAndCloseIcons ) {
 			return (
 				<>
 					{ renderOpenIcon() }


### PR DESCRIPTION
Fixes  #63451

Project P2: pdh6GB-2Is-p2
Demo P2: p58i-eWf-p2
Demo Video: p1688995364119309-slack-C02JPCHEKDY



## Proposed Changes

Update Plugins SearchBox layout to match f84fqtCG4pCnCh2Hq0But5-fi-6117%3A42880 with all its states.

The following properties were added to the base Search component:
* `submitOnOpenIconClick`
* `displayOpenAndCloseIcons`

And the spinner was moved to be in the same place as the search icon, being it left or right side of the input.

---

Other styling changes were added to the SearchBox component on the Plugins Browser page.


## Testing Instructions

* Go to the `/plugins` page 
* Verify the empty input state only shows the search icon
* Type a search on the input and verify that as soon as you start typing the `X` icon is also displayed
* Verify that both icons have a `hover` effect and that they both work properly.
* Check the loading state displays the spinner in the same place as the search icon

| Before  | After |
| ------------- | ------------- |
|<img width="606" alt="CleanShot 2023-07-07 at 14 05 46@2x" src="https://github.com/Automattic/wp-calypso/assets/5039531/36cbf07f-c6c8-4f74-9cb0-9e82d04bd117">|<img width="569" alt="CleanShot 2023-07-07 at 14 05 25@2x" src="https://github.com/Automattic/wp-calypso/assets/5039531/0b7efdf6-cd88-4e55-acbb-86ad38882dc1">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?