### PR TITLE
Pass user locale to theme-setup API endpoint.

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -444,7 +444,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		}
 
 		const response: { blog: string } = yield wpcomRequest( {
-			path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup`,
+			path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup/?_locale=user`,
 			apiNamespace: 'wpcom/v2',
 			body: themeSetupOptions,
 			method: 'POST',

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -448,7 +448,7 @@ describe( 'Site Actions', () => {
 		const createMockedThemeSetupApiRequest = ( payload ) => ( {
 			type: 'WPCOM_REQUEST',
 			request: {
-				path: `/sites/${ siteSlug }/theme-setup`,
+				path: `/sites/${ siteSlug }/theme-setup/?_locale=user`,
 				apiNamespace: 'wpcom/v2',
 				body: payload,
 				method: 'POST',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #79091
Related to #78951

Lots of discussion: p1688567445665619-slack-C0Q664T29

## Proposed Changes

This fixes an issue where headstarted content on a new site was always in English, rather than the locale used by the user's WordPress.com account.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Testing Setup

1. Change your WordPress.com [account](https://wordpress.com/me/account) to use a language other than English. 
2. Unproxy and verify that all WordPress.com UIs are displaying the language you selected.
3. Apply D115686-code on your sandbox and sandbox the public-api.

### Verify the _incorrect_ behavior

1. Go to https://wordpress.com/start and create a new Free site.
2. Select the "Zoologist" theme.
4. After completing setup and launching the site, go to `/pages` in the admin.
5. The headstart-created 'About' page should be in English rather than the locale you selected.

### Regular flow

1. Apply this branch or use the calypso.live link.
2. Go to `/start` and create a new Free site.
3. Select the "Zoologist" theme and then launch the site.
4. Go to `/pages` for the site and verify that the 'About' page is in the language you have selected for your WordPress.com account.

![image](https://github.com/Automattic/wp-calypso/assets/917632/3be4dff3-1d91-4017-a347-ff2990880786)


### Plugin bundle flow

1. Apply this branch or use the calypso.live link.
2. Go to `/start` and create a new site with the Business plan.
3. Select the "Sell" intent.
4. Select any theme with WooCommerce bundled (like Tsubaki).
6. Finish setting up the site.
7. Go to `/pages` for the site and verify that all of the default pages are in the language you have selected for your WordPress.com account.

![image](https://github.com/Automattic/wp-calypso/assets/917632/61ac014a-e94f-499b-85c0-9d9681fb1a4f)


### Site data-store tests
Tests should still pass.
```
yarn run test-packages ./packages/data-stores/src/site/test
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?