### PR TITLE
Allow payment methods to be added/ edited on subscriptions even if there are no sites

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -212,12 +212,6 @@ export function addNewPaymentMethod( context, next ) {
 }
 
 export function changePaymentMethod( context, next ) {
-	const state = context.store.getState();
-
-	if ( userHasNoSites( state ) ) {
-		return noSites( context, '/me/purchases/:site/:purchaseId/payment-method/change/:cardId' );
-	}
-
 	const ChangePaymentMethodWrapper = () => {
 		const translate = useTranslate();
 		const logPurchasesError = useLogPurchasesError(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR allows payment methods to be added/ edited on existing subscriptions even if the account has no sites
* With the addition of Akismet purchases (which are siteless) the payment method routes no longer require sites. This updates the controller method to remove a check for sites on the account - which is no longer required.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new test WordPress.com user
* Navigate to https://wordpress.com/checkout/akismet/ak_plus_yearly_1 and purchase an Akismet subscription for this user
* From the Calypso dashboard, delete the site that was created during setup
* Now, navigate to `/me/purchases`
* Select the Akismet purchase, from the purchase management screen, click "Edit Payment Method" (or "Add Payment Method" if you used credits)
* Without this PR, clicking this action will just show a screen that indicates that you do not have any WordPress.com sites
* With this PR, confirm that the payment method add/ change screen shows and that you can successfully add and edit payment methods

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
