### PR TITLE
add query with refetch interval to poll for messages

### DIFF
--- a/client/odysseus/index.tsx
+++ b/client/odysseus/index.tsx
@@ -2,7 +2,7 @@ import { TextControl, Button } from '@wordpress/components';
 import classnames from 'classnames';
 import { useRef, useEffect, useState } from 'react';
 import { useOdysseusAssistantContext } from './context';
-import { useOdysseusGetChatQuery, useOddyseusSendMessage } from './query';
+import { useOdysseusGetChatPollQuery, useOddyseusSendMessage } from './query';
 import WapuuRibbon from './wapuu-ribbon';
 
 import './style.scss';
@@ -14,7 +14,7 @@ const OdysseusAssistant = () => {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ isNudging, setIsNudging ] = useState( false );
 	const { mutateAsync: sendOdysseusMessage } = useOddyseusSendMessage();
-	const { data: chatData } = useOdysseusGetChatQuery( chat.chat_id ?? null );
+	const { data: chatData } = useOdysseusGetChatPollQuery( chat.chat_id ?? null );
 
 	useEffect( () => {
 		if ( isLoadingChat ) {

--- a/client/odysseus/index.tsx
+++ b/client/odysseus/index.tsx
@@ -2,7 +2,7 @@ import { TextControl, Button } from '@wordpress/components';
 import classnames from 'classnames';
 import { useRef, useEffect, useState } from 'react';
 import { useOdysseusAssistantContext } from './context';
-import { useOddyseusSendMessage } from './query';
+import { useOdysseusGetChatQuery, useOddyseusSendMessage } from './query';
 import WapuuRibbon from './wapuu-ribbon';
 
 import './style.scss';
@@ -14,6 +14,7 @@ const OdysseusAssistant = () => {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ isNudging, setIsNudging ] = useState( false );
 	const { mutateAsync: sendOdysseusMessage } = useOddyseusSendMessage();
+	const { data: chatData } = useOdysseusGetChatQuery( chat.chat_id ?? null );
 
 	useEffect( () => {
 		if ( isLoadingChat ) {
@@ -28,6 +29,18 @@ const OdysseusAssistant = () => {
 			setMessages( chat.messages );
 		}
 	}, [ chat, isLoadingChat, setMessages, chat.messages ] );
+
+	useEffect( () => {
+		if ( chatData ) {
+			if ( chat.messages.length !== chatData.messages.length ) {
+				const countNewMessages = chatData.messages.length - chat.messages.length;
+				const newMessages = chatData.messages.slice( -countNewMessages );
+				newMessages.forEach( ( message ) => {
+					addMessage( message );
+				} );
+			}
+		}
+	}, [ chat, chatData, addMessage ] );
 
 	const environmentBadge = document.querySelector( 'body > .environment-badge' );
 
@@ -77,7 +90,7 @@ const OdysseusAssistant = () => {
 			} );
 
 			addMessage( {
-				content: response.message.content,
+				content: response.messages[ 0 ].content,
 				role: 'bot',
 				type: 'message',
 			} );

--- a/client/odysseus/query/index.ts
+++ b/client/odysseus/query/index.ts
@@ -1,7 +1,7 @@
-import { useMutation, UseMutationResult } from '@tanstack/react-query';
+import { useMutation, UseMutationResult, useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useOdysseusAssistantContext } from '../context';
-import type { Message, Context } from '../types';
+import type { Chat, Message, Context } from '../types';
 
 function odysseusSendMessage( messages: Message[], context: Context, chat_id?: string | null ) {
 	const path = `/odysseus/send_message`;
@@ -14,7 +14,7 @@ function odysseusSendMessage( messages: Message[], context: Context, chat_id?: s
 
 // It will post a new message using the current chat_id
 export const useOddyseusSendMessage = (): UseMutationResult<
-	{ chat_id: string; message: Message },
+	{ chat_id: string; messages: Message[] },
 	unknown,
 	{ message: Message }
 > => {
@@ -35,3 +35,21 @@ export const useOddyseusSendMessage = (): UseMutationResult<
 };
 
 // TODO: We will add lately a clear chat to forget the session
+
+const odysseusGetChat = ( chat_id: string | null ) => {
+	const path = `/odysseus/get_chat/${ chat_id }`;
+	return wpcom.req.get( {
+		path,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
+export const useOdysseusGetChatQuery = ( chat_id: string | null ) => {
+	return useQuery< Chat, Error >( {
+		queryKey: [ 'odysseus-get-chat', chat_id ],
+		queryFn: async () => await odysseusGetChat( chat_id ),
+		refetchInterval: 5000,
+		refetchOnWindowFocus: false,
+		enabled: !! chat_id,
+	} );
+};

--- a/client/odysseus/query/index.ts
+++ b/client/odysseus/query/index.ts
@@ -44,7 +44,7 @@ const odysseusGetChat = ( chat_id: string | null ) => {
 	} );
 };
 
-export const useOdysseusGetChatQuery = ( chat_id: string | null ) => {
+export const useOdysseusGetChatPollQuery = ( chat_id: string | null ) => {
 	return useQuery< Chat, Error >( {
 		queryKey: [ 'odysseus-get-chat', chat_id ],
 		queryFn: async () => await odysseusGetChat( chat_id ),


### PR DESCRIPTION
## Proposed Changes

- Add a query to poll for new messages and add them to the current chatbot session. This is mainly for the Slack intervention demo.

## Testing Instructions



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
