### PR TITLE
Design Preview: Disable Colors & Fonts for the VTs

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -590,7 +590,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 						! isPluginBundleEligible
 					}
 					title={ headerDesignTitle }
-					description={ ! selectedDesign.is_virtual && selectedDesign.description }
+					description={ selectedDesign.description }
 					variations={
 						selectedDesignHasStyleVariations ? selectedDesignDetails?.style_variations : []
 					}
@@ -601,6 +601,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					limitGlobalStyles={ shouldLimitGlobalStyles }
 					siteId={ site.ID }
 					stylesheet={ selectedDesign.recipe?.stylesheet }
+					isVirtual={ selectedDesign.is_virtual }
 					selectedColorVariation={ selectedColorVariation }
 					onSelectColorVariation={ setSelectedColorVariation }
 					selectedFontVariation={ selectedFontVariation }

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -26,6 +26,7 @@ interface DesignPreviewProps {
 	recordDeviceClick: ( device: string ) => void;
 	siteId: number;
 	stylesheet: string;
+	isVirtual?: boolean;
 	selectedColorVariation: GlobalStylesObject | null;
 	onSelectColorVariation: ( variation: GlobalStylesObject | null ) => void;
 	selectedFontVariation: GlobalStylesObject | null;
@@ -53,6 +54,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	recordDeviceClick,
 	siteId,
 	stylesheet,
+	isVirtual,
 	selectedColorVariation,
 	onSelectColorVariation,
 	selectedFontVariation,
@@ -74,6 +76,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	const screens = useScreens( {
 		siteId,
 		stylesheet,
+		isVirtual,
 		limitGlobalStyles,
 		variations,
 		splitPremiumVariations,

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -15,6 +15,7 @@ import type { NavigatorScreenObject } from '@automattic/onboarding';
 interface Props {
 	siteId: number;
 	stylesheet: string;
+	isVirtual?: boolean;
 	limitGlobalStyles?: boolean;
 	variations?: StyleVariation[];
 	splitPremiumVariations: boolean;
@@ -29,6 +30,7 @@ interface Props {
 const useScreens = ( {
 	siteId,
 	stylesheet,
+	isVirtual,
 	limitGlobalStyles,
 	variations,
 	splitPremiumVariations,
@@ -71,6 +73,7 @@ const useScreens = ( {
 					},
 				variations &&
 					variations.length === 0 &&
+					! isVirtual &&
 					isEnabled( 'signup/design-picker-preview-colors' ) && {
 						checked: !! selectedColorVariation,
 						icon: color,
@@ -96,6 +99,7 @@ const useScreens = ( {
 					},
 				variations &&
 					variations.length === 0 &&
+					! isVirtual &&
 					isEnabled( 'signup/design-picker-preview-fonts' ) && {
 						checked: !! selectedFontVariation,
 						icon: typography,

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -73,6 +73,7 @@ const useScreens = ( {
 					},
 				variations &&
 					variations.length === 0 &&
+					// Disable Colors for themes that don't play well with them. See pbxlJb-4cl-p2 for more context.
 					! isVirtual &&
 					isEnabled( 'signup/design-picker-preview-colors' ) && {
 						checked: !! selectedColorVariation,
@@ -99,7 +100,6 @@ const useScreens = ( {
 					},
 				variations &&
 					variations.length === 0 &&
-					! isVirtual &&
 					isEnabled( 'signup/design-picker-preview-fonts' ) && {
 						checked: !! selectedFontVariation,
 						icon: typography,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbxlJb-4cl-p2

## Proposed Changes

* Based on pbxlJb-4cl-p2, the Colors & Fonts don't play well with the virtual themes. Let's disable them!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D115594-code to your sandbox
* Go to /setup?siteSlug=your_site&flags=signup/design-picker-preview-colors
* Continue until you land on the Design Picker
* Select any virtual theme
* Ensure the Colors & Fonts won't show
* Ensure the virtual theme has the description

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?