### PR TITLE
explat-client: Fix LocalStorage polyfill

### DIFF
--- a/packages/explat-client/CHANGELOG.md
+++ b/packages/explat-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.4
+
+- Fix case where checking for localstorage throws an error.
+
 ## 0.0.3
 
 - Shortened timeout

--- a/packages/explat-client/package.json
+++ b/packages/explat-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/explat-client",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"description": "Standalone ExPlat Client.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/explat-client/src/internal/local-storage.ts
+++ b/packages/explat-client/src/internal/local-storage.ts
@@ -1,10 +1,9 @@
 /**
  * LocalStorage polyfill from https://gist.github.com/juliocesar/926500
  * length and key methods were added to allow for implementing removeExpiredExperimentAssignments
- * Altered to match window.localStorage signature exactly
  * Exported only for testing purposes
  */
-export const polyfilledLocalStorage: typeof window.localStorage = {
+export const polyfilledLocalStorage: Storage = {
 	_data: {} as Record< string, string >,
 	setItem: function ( id: string, val: string ): void {
 		this._data[ id ] = val;
@@ -33,10 +32,9 @@ export const polyfilledLocalStorage: typeof window.localStorage = {
  */
 let localStorage = polyfilledLocalStorage;
 try {
-	localStorage =
-		typeof window !== 'undefined' && window.localStorage
-			? window.localStorage
-			: polyfilledLocalStorage;
+	if ( window.localStorage ) {
+		localStorage = window.localStorage;
+	}
 } catch ( e ) {}
 
 export default localStorage;

--- a/packages/explat-client/src/internal/local-storage.ts
+++ b/packages/explat-client/src/internal/local-storage.ts
@@ -1,15 +1,16 @@
 /**
  * LocalStorage polyfill from https://gist.github.com/juliocesar/926500
  * length and key methods were added to allow for implementing removeExpiredExperimentAssignments
+ * Altered to match window.localStorage signature exactly
  * Exported only for testing purposes
  */
-export const polyfilledLocalStorage = {
+export const polyfilledLocalStorage: typeof window.localStorage = {
 	_data: {} as Record< string, string >,
 	setItem: function ( id: string, val: string ): void {
 		this._data[ id ] = val;
 	},
-	getItem: function ( id: string ): string | undefined {
-		return this._data.hasOwnProperty( id ) ? this._data[ id ] : undefined;
+	getItem: function ( id: string ): string | null {
+		return this._data.hasOwnProperty( id ) ? this._data[ id ] : null;
 	},
 	removeItem: function ( id: string ): void {
 		delete this._data[ id ];
@@ -20,8 +21,9 @@ export const polyfilledLocalStorage = {
 	get length(): number {
 		return Object.keys( this._data ).length;
 	},
-	key: function ( index: number ): string | undefined {
-		return Object.keys( this._data )[ index ];
+	key: function ( index: number ): string | null {
+		const keys = Object.keys( this._data );
+		return index in keys ? keys[ index ] : null;
 	},
 };
 
@@ -29,9 +31,12 @@ export const polyfilledLocalStorage = {
  * A polyfilled LocalStorage.
  * The polyfill is required at least for testing.
  */
-const localStorage =
-	typeof window !== 'undefined' && window.localStorage
-		? window.localStorage
-		: polyfilledLocalStorage;
+let localStorage = polyfilledLocalStorage;
+try {
+	localStorage =
+		typeof window !== 'undefined' && window.localStorage
+			? window.localStorage
+			: polyfilledLocalStorage;
+} catch ( e ) {}
 
 export default localStorage;

--- a/packages/explat-client/src/internal/test/local-storage.ts
+++ b/packages/explat-client/src/internal/test/local-storage.ts
@@ -39,11 +39,11 @@ describe( 'length', () => {
 } );
 
 describe( 'key', () => {
-	it( 'should return undefined for any index if localStorage is empty', () => {
-		expect( localStorage.key( 0 ) ).toBe( undefined );
-		expect( localStorage.key( 5 ) ).toBe( undefined );
-		expect( localStorage.key( 200 ) ).toBe( undefined );
-		expect( localStorage.key( -1 ) ).toBe( undefined );
+	it( 'should return null for any index if localStorage is empty', () => {
+		expect( localStorage.key( 0 ) ).toBe( null );
+		expect( localStorage.key( 5 ) ).toBe( null );
+		expect( localStorage.key( 200 ) ).toBe( null );
+		expect( localStorage.key( -1 ) ).toBe( null );
 	} );
 
 	it( 'should return the key at the given index if there are elements in localStorage', () => {
@@ -53,10 +53,10 @@ describe( 'key', () => {
 		expect( localStorage.key( 1 ) ).toBe( 'key2' );
 	} );
 
-	it( 'should return undefined if there are elements in localStorage and the index is out of bounds', () => {
+	it( 'should return null if there are elements in localStorage and the index is out of bounds', () => {
 		localStorage.setItem( 'key1', 'value1' );
 		localStorage.setItem( 'key2', 'value2' );
-		expect( localStorage.key( 2 ) ).toBe( undefined );
-		expect( localStorage.key( -1 ) ).toBe( undefined );
+		expect( localStorage.key( 2 ) ).toBe( null );
+		expect( localStorage.key( -1 ) ).toBe( null );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Accessing `localStorage` can sometimes throw an exception, this PR adds a try-catch block to our polyfill system.

From p1688855464153629-slack-C04U5A26MJB

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Existing tests use the polyfill system

