### PR TITLE
Design Preview: Disable Colors for themes that don't play well with them

### DIFF
--- a/packages/design-preview/src/constants.ts
+++ b/packages/design-preview/src/constants.ts
@@ -1,4 +1,4 @@
-export const COLOR_VARIATIONS_BLACK_LIST = [
+export const COLOR_VARIATIONS_BLOCK_LIST = [
 	'pub/aldente',
 	'pub/calyx',
 	'pub/jinjang',

--- a/packages/design-preview/src/constants.ts
+++ b/packages/design-preview/src/constants.ts
@@ -1,0 +1,8 @@
+export const COLOR_VARIATIONS_BLACK_LIST = [
+	'pub/aldente',
+	'pub/calyx',
+	'pub/jinjang',
+	'pub/loudness',
+	'pub/tenaz',
+	'premium/skivers',
+];

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -8,6 +8,7 @@ import {
 import { color, styles, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { COLOR_VARIATIONS_BLACK_LIST } from '../constants';
 import type { StyleVariation } from '@automattic/design-picker/src/types';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 import type { NavigatorScreenObject } from '@automattic/onboarding';
@@ -75,6 +76,7 @@ const useScreens = ( {
 					variations.length === 0 &&
 					// Disable Colors for themes that don't play well with them. See pbxlJb-4cl-p2 for more context.
 					! isVirtual &&
+					! COLOR_VARIATIONS_BLACK_LIST.includes( stylesheet ) &&
 					isEnabled( 'signup/design-picker-preview-colors' ) && {
 						checked: !! selectedColorVariation,
 						icon: color,

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -8,7 +8,7 @@ import {
 import { color, styles, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { COLOR_VARIATIONS_BLACK_LIST } from '../constants';
+import { COLOR_VARIATIONS_BLOCK_LIST } from '../constants';
 import type { StyleVariation } from '@automattic/design-picker/src/types';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 import type { NavigatorScreenObject } from '@automattic/onboarding';
@@ -76,7 +76,7 @@ const useScreens = ( {
 					variations.length === 0 &&
 					// Disable Colors for themes that don't play well with them. See pbxlJb-4cl-p2 for more context.
 					! isVirtual &&
-					! COLOR_VARIATIONS_BLACK_LIST.includes( stylesheet ) &&
+					! COLOR_VARIATIONS_BLOCK_LIST.includes( stylesheet ) &&
 					isEnabled( 'signup/design-picker-preview-colors' ) && {
 						checked: !! selectedColorVariation,
 						icon: color,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbxlJb-4cl-p2

## Proposed Changes

* Introduce a black list for themes that don't play well with the Colors

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=your_site&flags=signup/design-picker-preview-colors
* Continue until you land on the Design Picker
* Select following themes and ensure you won't see the Colors
  * AI Dente
  * Calyx
  * Jinjang
  * Loudness
  * Tenaz
  * Skivers

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?