### PR TITLE
App Banner: Fix sessionStorage possibly null

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -66,7 +66,7 @@ export class AppBanner extends Component {
 
 		if (
 			typeof window !== 'undefined' &&
-			window.sessionStorage.getItem( 'wpcom_signup_complete_show_draft_post_modal' )
+			window.sessionStorage?.getItem( 'wpcom_signup_complete_show_draft_post_modal' )
 		) {
 			this.state = { isDraftPostModalShown: true };
 		} else {
@@ -203,6 +203,7 @@ export class AppBanner extends Component {
 }
 
 export function getiOSDeepLink( currentRoute, currentSection ) {
+	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 	const baseURI = 'https://apps.wordpress.com/get?campaign=calypso-open-in-app';
 	const fragment = buildDeepLinkFragment( currentRoute, currentSection );
 


### PR DESCRIPTION
[Context](p1688836438623089-slack-C04U5A26MJB)

## Proposed Change

`window.sessionStorage` could possibly be null in some circumstances, such as when user has disabled the web storage in their browser settings. This PR adds a check on sessionStorage before calling `getItem()`
