### PR TITLE
Update info on the Social pricing modal

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -880,7 +880,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Post to multiple channels at once' ),
 		translate( 'Manage all of your channels from a single hub' ),
 		translate( 'Scheduled posts' ),
-		translate( 'Share to Facebook, LinkedIn, and Tumblr' ),
+		translate( 'Share to Facebook, Instagram, LinkedIn, Mastodon & Tumblr' ),
 		translate( 'Recycle content' ),
 	];
 	const socialAdvancedIncludesInfo = [
@@ -888,7 +888,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Post to multiple channels at once' ),
 		translate( 'Manage all of your channels from a single hub' ),
 		translate( 'Scheduled posts' ),
-		translate( 'Share to Facebook, LinkedIn, and Tumblr' ),
+		translate( 'Share to Facebook, Instagram, LinkedIn, Mastodon & Tumblr' ),
 		translate( 'Engagement Optimizer' ),
 		translate( 'Recycle content' ),
 		translate( 'Image generator' ),
@@ -936,11 +936,7 @@ export const getJetpackProductsWhatIsIncludedComingSoon = (): Record<
 	string,
 	Array< TranslateResult >
 > => {
-	const socialAdvancedIncludesInfo = [
-		translate( 'Auto-sharing to Instagram & Mastodon' ),
-		translate( 'Multi-image sharing' ),
-		translate( 'Video sharing' ),
-	];
+	const socialAdvancedIncludesInfo = [ translate( 'Multi-image sharing' ) ];
 
 	return {
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: socialAdvancedIncludesInfo,
@@ -1009,6 +1005,8 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 		translate( 'Easy-to-use interface' ),
 		translate( 'No developer required' ),
 		translate( 'Enhance social media engagement with personalized posts' ),
+		translate( 'Upload & automatically share images and videos to social media' ),
+		translate( 'Automatically create custom images, saving you hours of tedious work' ),
 		translate( 'Repurpose, reuse or republish already published content' ),
 	];
 
@@ -1054,11 +1052,7 @@ export const getJetpackProductsBenefitsComingSoon = (): Record<
 	string,
 	Array< TranslateResult >
 > => {
-	const socialAdvancedBenefits = [
-		translate( 'Share multiple images to social media' ),
-		translate( 'Upload & automatically share videos to social media' ),
-		translate( 'Automatically create custom images, saving you hours of tedious work' ),
-	];
+	const socialAdvancedBenefits = [ translate( 'Share multiple images to social media' ) ];
 
 	return {
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: socialAdvancedBenefits,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

We had some outdated information on the Social modal in calypso and in jetpack.com pricing page. This PR updates that

## Proposed Changes

* Moved Social Image generator stuff from coming soon to benefits.
* Moved videos from coming soon to already implemented
* Updated available platforms

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR, then start JP cloud with `npm run start-jetpack-cloud` - or just use Calypso live below and be fancy
* Check out the pricing page on `/pricing`, and open the Social modal.

| Before | After |
| ------------- | ------------- |
|  <img width="975" alt="CleanShot 2023-07-10 at 11 06 03 png" src="https://github.com/Automattic/wp-calypso/assets/36671565/ff8b0726-7f12-46c1-8677-875c4acc1833"> |  <img width="977" alt="CleanShot 2023-07-10 at 11 05 39 png" src="https://github.com/Automattic/wp-calypso/assets/36671565/0a6da70b-5700-4331-b476-2cca131eeaab"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
