### PR TITLE
Subscribers Page: Move `showAddSubscribersModal` state and `adSubscribersCallback` into `SubscribersPageProvider`

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -5,6 +5,7 @@ import { AddSubscriberForm } from '@automattic/subscriber';
 import { Modal } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n/';
 import { useTranslate } from 'i18n-calypso';
+import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { useState } from 'react';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import './style.scss';
@@ -12,21 +13,16 @@ import './style.scss';
 type AddSubscribersModalProps = {
 	siteId: number;
 	siteTitle: string;
-	showModal: boolean;
-	onClose: () => void;
-	onAddFinished: () => void;
 };
 
 const AddSubscribersModal = ( {
 	siteId,
 	siteTitle,
-	showModal,
-	onClose,
-	onAddFinished,
 }: AddSubscribersModalProps ) => {
 	const translate = useTranslate();
 	const locale = useLocale();
 	const { hasTranslation } = useI18n();
+	const { showAddSubscribersModal, setShowAddSubscribersModal, addSubscribersCallback } = useSubscribersPage();
 
 	const modalTitle =
 		locale.startsWith( 'en' ) || hasTranslation( 'Add subscribers to %s' )
@@ -40,17 +36,17 @@ const AddSubscribersModal = ( {
 	const onImportStarted = ( hasFile: boolean ) => setIsUploading( hasFile );
 	const onImportFinished = () => {
 		setIsUploading( false );
-		onAddFinished();
+		addSubscribersCallback();
 	};
 
-	if ( ! showModal ) {
+	if ( ! showAddSubscribersModal ) {
 		return null;
 	}
 
 	return (
 		<Modal
 			title={ modalTitle as string }
-			onRequestClose={ onClose }
+			onRequestClose={ () => setShowAddSubscribersModal( false ) }
 			overlayClassName="add-subscribers-modal"
 		>
 			{ isUploading && (

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -5,9 +5,9 @@ import { AddSubscriberForm } from '@automattic/subscriber';
 import { Modal } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n/';
 import { useTranslate } from 'i18n-calypso';
-import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { useState } from 'react';
 import { LoadingBar } from 'calypso/components/loading-bar';
+import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import './style.scss';
 
 type AddSubscribersModalProps = {
@@ -15,14 +15,12 @@ type AddSubscribersModalProps = {
 	siteTitle: string;
 };
 
-const AddSubscribersModal = ( {
-	siteId,
-	siteTitle,
-}: AddSubscribersModalProps ) => {
+const AddSubscribersModal = ( { siteId, siteTitle }: AddSubscribersModalProps ) => {
 	const translate = useTranslate();
 	const locale = useLocale();
 	const { hasTranslation } = useI18n();
-	const { showAddSubscribersModal, setShowAddSubscribersModal, addSubscribersCallback } = useSubscribersPage();
+	const { showAddSubscribersModal, setShowAddSubscribersModal, addSubscribersCallback } =
+		useSubscribersPage();
 
 	const modalTitle =
 		locale.startsWith( 'en' ) || hasTranslation( 'Add subscribers to %s' )

--- a/client/my-sites/subscribers/components/no-search-results/no-search-results.tsx
+++ b/client/my-sites/subscribers/components/no-search-results/no-search-results.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
+import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { useSelector } from 'calypso/state';
 import { getSiteTitle } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -7,12 +8,12 @@ import './style.scss';
 
 type NoSearchResultsProps = {
 	searchTerm: string;
-	setShowAddSubscribersModal: React.Dispatch< React.SetStateAction< boolean > >;
 };
 
-const NoSearchResults = ( { searchTerm, setShowAddSubscribersModal }: NoSearchResultsProps ) => {
+const NoSearchResults = ( { searchTerm }: NoSearchResultsProps ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const siteTitle = useSelector( ( state ) => getSiteTitle( state, selectedSiteId ) );
+	const { setShowAddSubscribersModal } = useSubscribersPage();
 
 	return (
 		<div className="no-search-results">

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -13,13 +13,11 @@ import './style.scss';
 type SubscriberListContainerProps = {
 	onClickView: ( subscriber: Subscriber ) => void;
 	onClickUnsubscribe: ( subscriber: Subscriber ) => void;
-	setShowAddSubscribersModal: React.Dispatch< React.SetStateAction< boolean > >;
 };
 
 const SubscriberListContainer = ( {
 	onClickView,
 	onClickUnsubscribe,
-	setShowAddSubscribersModal,
 }: SubscriberListContainerProps ) => {
 	const { grandTotal, total, perPage, page, pageChangeCallback, searchTerm } = useSubscribersPage();
 	useRecordSearch();
@@ -37,10 +35,7 @@ const SubscriberListContainer = ( {
 					{ total ? (
 						<SubscriberList onView={ onClickView } onUnsubscribe={ onClickUnsubscribe } />
 					) : (
-						<NoSearchResults
-							searchTerm={ searchTerm }
-							setShowAddSubscribersModal={ setShowAddSubscribersModal }
-						/>
+						<NoSearchResults searchTerm={ searchTerm } />
 					) }
 
 					<Pagination

--- a/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
@@ -8,15 +8,10 @@ import { SubscribersHeaderPopover } from '../subscribers-header-popover';
 type SubscribersHeaderProps = {
 	selectedSiteId: number | undefined;
 	navigationItems: Item[];
-	setShowAddSubscribersModal: React.Dispatch< React.SetStateAction< boolean > >;
 };
 
-const SubscribersHeader = ( {
-	navigationItems,
-	selectedSiteId,
-	setShowAddSubscribersModal,
-}: SubscribersHeaderProps ) => {
-	const { grandTotal } = useSubscribersPage();
+const SubscribersHeader = ( { navigationItems, selectedSiteId }: SubscribersHeaderProps ) => {
+	const { grandTotal, setShowAddSubscribersModal } = useSubscribersPage();
 
 	return (
 		<FixedNavigationHeader navigationItems={ navigationItems }>

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -1,7 +1,10 @@
+import { translate } from 'i18n-calypso';
 import React, { createContext, useState, useContext, useEffect, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 import { useDebounce } from 'use-debounce';
 import { usePagination } from 'calypso/my-sites/subscribers/hooks';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
+import { successNotice } from 'calypso/state/notices/actions';
 import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
 import { useSubscribersQuery } from '../../queries';
 
@@ -32,6 +35,9 @@ type SubscribersPageContextProps = {
 	setSortTerm: ( term: SubscribersSortBy ) => void;
 	filterOption: SubscribersFilterBy;
 	setFilterOption: ( option: SubscribersFilterBy ) => void;
+	showAddSubscribersModal: boolean;
+	setShowAddSubscribersModal: ( show: boolean ) => void;
+	addSubscribersCallback: () => void;
 };
 
 const SubscribersPageContext = createContext< SubscribersPageContextProps | undefined >(
@@ -53,11 +59,14 @@ export const SubscribersPageProvider = ( {
 	sortTermChanged,
 }: SubscribersPageProviderProps ) => {
 	const [ perPage, setPerPage ] = useState( DEFAULT_PER_PAGE );
+	const [ showAddSubscribersModal, setShowAddSubscribersModal ] = useState( false );
 
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 300 );
 
 	const grandTotalQueryResult = useSubscribersQuery( { siteId } );
 	const grandTotal = grandTotalQueryResult.data?.total || 0;
+
+	const dispatch = useDispatch();
 
 	const subscribersQueryResult = useSubscribersQuery( {
 		page: pageNumber,
@@ -73,6 +82,20 @@ export const SubscribersPageProvider = ( {
 		pageChanged,
 		subscribersQueryResult.isFetching
 	);
+
+	const addSubscribersCallback = () => {
+		setShowAddSubscribersModal( false );
+		dispatch(
+			successNotice(
+				translate(
+					"Your subscriber list is being processed. We'll send you an email when it's finished importing."
+				),
+				{
+					duration: 5000,
+				}
+			)
+		);
+	};
 
 	const handleSearch = useCallback( ( term: string ) => {
 		searchTermChanged( term );
@@ -108,6 +131,9 @@ export const SubscribersPageProvider = ( {
 				setSortTerm: sortTermChanged,
 				filterOption,
 				setFilterOption: filterOptionChanged,
+				showAddSubscribersModal,
+				setShowAddSubscribersModal,
+				addSubscribersCallback,
 			} }
 		>
 			{ children }

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -112,10 +112,7 @@ const SubscribersPage = ( {
 					onConfirm={ onConfirmModal }
 				/>
 				{ selectedSite && (
-					<AddSubscribersModal
-						siteId={ selectedSite.ID }
-						siteTitle={ selectedSite.title }
-					/>
+					<AddSubscribersModal siteId={ selectedSite.ID } siteTitle={ selectedSite.title } />
 				) }
 			</Main>
 		</SubscribersPageProvider>

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,14 +1,12 @@
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import page from 'page';
-import { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { Item } from 'calypso/components/breadcrumb';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import { SubscriberListContainer } from 'calypso/my-sites/subscribers/components/subscriber-list-container';
 import { SubscribersPageProvider } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
-import { successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { AddSubscribersModal } from './components/add-subscribers-modal';
 import { SubscribersHeader } from './components/subscribers-header';
@@ -55,23 +53,7 @@ const SubscribersPage = ( {
 		page.show( getSubscriberDetailsUrl( selectedSite?.slug, subscription_id, user_id, pageArgs ) );
 	};
 
-	const [ showAddSubscribersModal, setShowAddSubscribersModal ] = useState( false );
-	const dispatch = useDispatch();
 	const localizeUrl = useLocalizeUrl();
-
-	const addSubscribersCallback = () => {
-		setShowAddSubscribersModal( false );
-		dispatch(
-			successNotice(
-				translate(
-					"Your subscriber list is being processed. We'll send you an email when it's finished importing."
-				),
-				{
-					duration: 5000,
-				}
-			)
-		);
-	};
 
 	const navigationItems: Item[] = [
 		{
@@ -117,13 +99,11 @@ const SubscribersPage = ( {
 				<SubscribersHeader
 					navigationItems={ navigationItems }
 					selectedSiteId={ selectedSite?.ID }
-					setShowAddSubscribersModal={ setShowAddSubscribersModal }
 				/>
 
 				<SubscriberListContainer
 					onClickView={ onClickView }
 					onClickUnsubscribe={ onClickUnsubscribe }
-					setShowAddSubscribersModal={ setShowAddSubscribersModal }
 				/>
 
 				<UnsubscribeModal
@@ -135,9 +115,6 @@ const SubscribersPage = ( {
 					<AddSubscribersModal
 						siteId={ selectedSite.ID }
 						siteTitle={ selectedSite.title }
-						showModal={ showAddSubscribersModal }
-						onClose={ () => setShowAddSubscribersModal( false ) }
-						onAddFinished={ () => addSubscribersCallback() }
 					/>
 				) }
 			</Main>


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/79186.

## Proposed Changes

This is a refactor PR that does not introduce any functional / feature updates.

The proposed changes move the following to the `SubscribersPageContext`:
* `showAddSubscribersModal` state variable and `setShowAddSubscribersModal` state update function
* `addSubscribersCallback` callback

## Testing Instructions

1. Check out the PR branch and build the app.
2. The app should works exactly as before.
3. Focus mostly to the functionality of the "Add subscribers" / import modal.
4. There should be no regressions, errors, nor warnings.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
