### PR TITLE
Bulk Transfer Domains: Fix domains form when empty rows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -46,7 +46,9 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 
 	const { __, _n } = useI18n();
 
-	const allGood = Object.values( domainsState ).every( ( { valid } ) => valid );
+	const allGood = Object.values( domainsState )
+		.filter( ( x ) => x.domain && x.auth )
+		.every( ( { valid } ) => valid );
 
 	const hasAnyDomains = Object.values( domainsState ).some(
 		( { domain, auth } ) => domain.trim() || auth.trim()

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -46,9 +46,8 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 
 	const { __, _n } = useI18n();
 
-	const allGood = Object.values( domainsState )
-		.filter( ( x ) => x.domain && x.auth )
-		.every( ( { valid } ) => valid );
+	const filledDomainValues = Object.values( domainsState ).filter( ( x ) => x.domain && x.auth );
+	const allGood = filledDomainValues.every( ( { valid } ) => valid );
 
 	const hasAnyDomains = Object.values( domainsState ).some(
 		( { domain, auth } ) => domain.trim() || auth.trim()
@@ -61,7 +60,7 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 
 	const handleAddTransfer = () => {
 		if ( allGood ) {
-			const cartItems = Object.values( domainsState ).map( ( { domain, auth } ) =>
+			const cartItems = filledDomainValues.map( ( { domain, auth } ) =>
 				domainTransfer( {
 					domain,
 					extra: {


### PR DESCRIPTION
## Bug fixed

https://github.com/Automattic/wp-calypso/assets/52076348/0a1502c0-2b19-40ab-8744-60f34992fb0f
With an empty row, proceeding to the next step was impossible. This PR fixes this.

## Testing
1. Live link
2. Reach `/setup/domain-transfer/domains`
3. Add a valid domain and an empty row. You should be able to proceed.
4. Add a row with only the domain filled. It should be transferring the first row