### PR TITLE
Ensure makeImageURLSafe works with both object and string urls

### DIFF
--- a/client/lib/post-normalizer/test/utils.js
+++ b/client/lib/post-normalizer/test/utils.js
@@ -1,4 +1,4 @@
-import { isFeaturedImageInContent } from '../utils';
+import { isFeaturedImageInContent, makeImageURLSafe } from '../utils';
 
 describe( 'isFeaturedImageInContent', () => {
 	test( 'should detect identical urls', () => {
@@ -49,5 +49,63 @@ describe( 'isFeaturedImageInContent', () => {
 			images: [ { src: 'http://example.com/image.jpg' }, { src: 'http://example.com/image.jpg' } ],
 		};
 		expect( isFeaturedImageInContent( post ) ).toEqual( 1 );
+	} );
+} );
+
+describe( 'makeImageURLSafe', () => {
+	describe( 'with a relative path resource', () => {
+		test( 'works when `baseUrl` is not specified', () => {
+			const obj = { src: '/foo/bar.jpg' };
+			makeImageURLSafe( obj, 'src' );
+			expect( obj.src ).toEqual( '/foo/bar.jpg' );
+		} );
+
+		test( 'works when `baseUrl` is specified as a URL object', () => {
+			const obj = { src: '/foo/bar.jpg' };
+			makeImageURLSafe( obj, 'src', null, new URL( 'http://example.com/' ) );
+			expect( obj.src ).toEqual( 'https://i0.wp.com/example.com/foo/bar.jpg' );
+		} );
+
+		test( 'works when `baseUrl` is specified as a URL string', () => {
+			const obj = { src: '/foo/bar.jpg' };
+			makeImageURLSafe( obj, 'src', null, 'http://example.com/' );
+			expect( obj.src ).toEqual( 'https://i0.wp.com/example.com/foo/bar.jpg' );
+		} );
+
+		test( 'correctly limits the image size when `maxWidth` is specified', () => {
+			const obj = { src: '/foo/bar.jpg' };
+			makeImageURLSafe( obj, 'src', 100, 'http://example.com/' );
+			expect( obj.src ).toEqual(
+				'https://i0.wp.com/example.com/foo/bar.jpg?quality=80&strip=info&w=100'
+			);
+		} );
+	} );
+
+	describe( 'with an absolute path resource', () => {
+		test( 'works when `baseUrl` is not specified', () => {
+			const obj = { src: 'http://example.org/foo/bar.jpg' };
+			makeImageURLSafe( obj, 'src' );
+			expect( obj.src ).toEqual( 'https://i0.wp.com/example.org/foo/bar.jpg' );
+		} );
+
+		test( 'works when `baseUrl` is specified as a URL object', () => {
+			const obj = { src: 'http://example.org/foo/bar.jpg' };
+			makeImageURLSafe( obj, 'src', null, new URL( 'http://example.com/' ) );
+			expect( obj.src ).toEqual( 'https://i0.wp.com/example.org/foo/bar.jpg' );
+		} );
+
+		test( 'works when `baseUrl` is specified as a URL string', () => {
+			const obj = { src: 'http://example.org/foo/bar.jpg' };
+			makeImageURLSafe( obj, 'src', null, 'http://example.com/' );
+			expect( obj.src ).toEqual( 'https://i0.wp.com/example.org/foo/bar.jpg' );
+		} );
+
+		test( 'correctly limits the image size when `maxWidth` is specified', () => {
+			const obj = { src: 'http://example.org/foo/bar.jpg' };
+			makeImageURLSafe( obj, 'src', 100, 'http://example.com/' );
+			expect( obj.src ).toEqual(
+				'https://i0.wp.com/example.org/foo/bar.jpg?quality=80&strip=info&w=100'
+			);
+		} );
 	} );
 } );

--- a/client/lib/post-normalizer/utils/make-image-url-safe.js
+++ b/client/lib/post-normalizer/utils/make-image-url-safe.js
@@ -6,12 +6,16 @@ export function makeImageURLSafe( object, propName, maxWidth, baseURL ) {
 	if ( object && object[ propName ] ) {
 		const urlParts = getUrlParts( object[ propName ] );
 		if ( baseURL && ! urlParts.hostname ) {
-			const { pathname: basePath } = getUrlParts( baseURL );
+			const {
+				pathname: basePath,
+				protocol: baseProtocol,
+				hostname: baseHostname,
+			} = getUrlParts( baseURL );
 			const resolvedPath = resolveRelativePath( basePath, object[ propName ] );
 			object[ propName ] = getUrlFromParts( {
 				...urlParts,
-				protocol: baseURL.protocol,
-				hostname: baseURL.hostname,
+				protocol: baseProtocol,
+				hostname: baseHostname,
 				pathname: resolvedPath,
 			} ).href;
 		}


### PR DESCRIPTION
`makeImageURLSafe` currently only works correctly with a `baseUrl` specified as a URL object, and not a string.

This PR ensures that it works with both.

## Proposed Changes

* Ensure `makeImageURLSafe` works with both `baseURL` objects and strings

## Testing Instructions

- Ensure that the existing unit tests still pass
- Ensure that the new unit tests also pass
- Smoke-test the reader and ensure that nothing breaks

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you checked for TypeScript, React or other console errors?
