### PR TITLE
Bulk Domain Transfer: Improve analytics

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import { Purchase } from 'calypso/lib/purchases/types';
@@ -13,6 +14,12 @@ export const CompleteDomainsTransferred = ( {
 }: Props ) => {
 	const { __ } = useI18n();
 
+	const handleUserClick = ( destination: string ) => {
+		recordTracksEvent( 'calypso_domain_transfer_complete_click', {
+			destination,
+		} );
+	};
+
 	return (
 		<>
 			<div className="domain-complete-summary">
@@ -25,6 +32,9 @@ export const CompleteDomainsTransferred = ( {
 										<a
 											href={ `/domains/manage/all/${ meta }/transfer/in/${ domain }` }
 											className="components-button is-secondary"
+											onClick={ () =>
+												handleUserClick( `/domains/manage/all/${ meta }/transfer/in/${ domain }` )
+											}
 										>
 											{ __( 'Manage domain' ) }
 										</a>
@@ -50,7 +60,12 @@ export const CompleteDomainsTransferred = ( {
 								"Unlock the domain world's secrets. Dive into our comprehensive resource to learn the basics of domains, from registration to management."
 							) }
 						</p>
-						<a href={ localizeUrl( 'https://wordpress.com/support/domains/' ) }>
+						<a
+							href={ localizeUrl( 'https://wordpress.com/support/domains/' ) }
+							onClick={ () =>
+								handleUserClick( localizeUrl( 'https://wordpress.com/support/domains/' ) )
+							}
+						>
 							{ __( 'Master the domain basics' ) }
 						</a>
 					</div>
@@ -61,7 +76,12 @@ export const CompleteDomainsTransferred = ( {
 								'You can find step-by-step guides below that will help you move your site to WordPress.com'
 							) }
 						</p>
-						<a href={ localizeUrl( 'https://wordpress.com/support/moving-a-blog/' ) }>
+						<a
+							href={ localizeUrl( 'https://wordpress.com/support/moving-a-blog/' ) }
+							onClick={ () =>
+								handleUserClick( localizeUrl( 'https://wordpress.com/support/moving-a-blog/' ) )
+							}
+						>
 							{ __( 'Learn more about site transfers' ) }
 						</a>
 					</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -37,11 +37,20 @@ const Complete: Step = function Complete( { flow } ) {
 			Date.now() - new Date( purchase.subscribedDate ).getTime() < oneDay
 	);
 
+	const handleUserClick = ( destination: string ) => {
+		recordTracksEvent( 'calypso_domain_transfer_complete_click', {
+			destination,
+		} );
+	};
+
 	useEffect( () => {
 		dispatch( fetchUserPurchases( userId ) );
 	}, [] );
 
 	const clearDomainsStore = () => {
+		recordTracksEvent( 'calypso_domain_transfer_complete_click', {
+			destination: '/setup/domain-transfer',
+		} );
 		resetOnboardStore();
 	};
 
@@ -79,6 +88,7 @@ const Complete: Step = function Complete( { flow } ) {
 								<a
 									href="/domains/manage"
 									className="components-button is-primary manage-all-domains"
+									onClick={ () => handleUserClick( '/domains/manage' ) }
 								>
 									{ __( 'Manage all domains' ) }
 								</a>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FormInputValidation } from '@automattic/components';
 import { Button, Icon } from '@wordpress/components';
 import { check, trash, closeSmall, update } from '@wordpress/icons';
@@ -59,6 +60,15 @@ export function DomainCodePair( {
 	}, [ domain, id, onChange, auth, valid, loading ] );
 
 	const shouldReportError = hasDuplicates || ( ! loading && domain && auth ? true : false );
+
+	useEffect( () => {
+		if ( shouldReportError ) {
+			recordTracksEvent( 'calypso_domain_transfer_domain_error', {
+				domain,
+				message,
+			} );
+		}
+	}, [ shouldReportError, domain, message ] );
 
 	return (
 		<div className="domains__domain-info-and-validation">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -62,13 +62,13 @@ export function DomainCodePair( {
 	const shouldReportError = hasDuplicates || ( ! loading && domain && auth ? true : false );
 
 	useEffect( () => {
-		if ( shouldReportError ) {
+		if ( shouldReportError && ! valid && message ) {
 			recordTracksEvent( 'calypso_domain_transfer_domain_error', {
 				domain,
-				message,
+				error: message,
 			} );
 		}
-	}, [ shouldReportError, domain, message ] );
+	}, [ shouldReportError, valid, domain, message ] );
 
 	return (
 		<div className="domains__domain-info-and-validation">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -98,6 +98,9 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 	);
 
 	function addDomain() {
+		recordTracksEvent( 'calypso_domain_transfer_add_domain', {
+			resulting_domain_count: domainCount + 1,
+		} );
 		const newDomainsState = { ...domainsState };
 		newDomainsState[ uuid() ] = {
 			domain: '',
@@ -108,6 +111,9 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 	}
 
 	function removeDomain( key: string ) {
+		recordTracksEvent( 'calypso_domain_transfer_remove_domain', {
+			resulting_domain_count: domainCount - 1,
+		} );
 		const newDomainsState = { ...domainsState };
 		delete newDomainsState[ key ];
 		setDomainsTransferData( newDomainsState );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { DomainTransferData } from '@automattic/data-stores';
 import { useDataLossWarning } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
@@ -58,6 +59,11 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 	const changeKey = JSON.stringify( domainsState );
 
 	const handleAddTransfer = () => {
+		recordTracksEvent( 'calypso_domain_transfer_submit_form', {
+			valid: allGood,
+			numberOfValidDomains: numberOfValidDomains,
+		} );
+
 		if ( allGood ) {
 			const cartItems = Object.values( domainsState ).map( ( { domain, auth } ) =>
 				domainTransfer( {


### PR DESCRIPTION
[Context](https://github.com/Automattic/dotcom-forge/issues/2970#issuecomment-1625757857)

## Changes

- Tracked ( `calypso_domain_transfer_complete_click` ) the user destination after landing on the complete page
- Tracked ( `calypso_domain_transfer_submit_form` ) when the user clicks on `Transfer X domains`, with `valid` and `numberOfValidDomains` as parameters
- `calypso_domain_transfer_domain_error` for errors on the domain form

## Testing
1. Use Track Vigilante to see the triggered events
2. Go through the flow starting at `setup/domain-transfer