### PR TITLE
Subscribers Page: Check whether the `searchTerm` has any value before displaying it

### DIFF
--- a/client/my-sites/subscribers/components/no-search-results/no-search-results.tsx
+++ b/client/my-sites/subscribers/components/no-search-results/no-search-results.tsx
@@ -17,12 +17,14 @@ const NoSearchResults = ( { searchTerm, setShowAddSubscribersModal }: NoSearchRe
 	return (
 		<div className="no-search-results">
 			<p className="no-search-results__heading">{ translate( '0 subscribers found' ) }</p>
-			<p className="no-search-results__query">
-				{ translate( '“%(searchTerm)s” did not match any current subscribers.', {
-					args: { searchTerm },
-					comment: '%(searchTerm)s is the search term the user entered.',
-				} ) }
-			</p>
+			{ searchTerm && (
+				<p className="no-search-results__query">
+					{ translate( '“%(searchTerm)s” did not match any current subscribers.', {
+						args: { searchTerm },
+						comment: '%(searchTerm)s is the search term the user entered.',
+					} ) }
+				</p>
+			) }
 			{ siteTitle && (
 				<p>
 					{ translate( 'Do you want to invite someone to join %(siteTitle)s?', {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/79117.

## Proposed Changes

* display the `“%(searchTerm)s” did not match any current subscribers.` text only if the `searchTerm` has non-empty value

| Before | After |
|--------|--------|
| ![Markup on 2023-07-10 at 16:30:31](https://github.com/Automattic/wp-calypso/assets/25105483/fb9a1ce8-312f-4c0f-8f9b-0f732efa9c74) | ![Markup on 2023-07-10 at 16:29:55](https://github.com/Automattic/wp-calypso/assets/25105483/16971628-deb1-44d7-a3e9-6c7302cdbb45) | 

## Testing Instructions

Basically, with the proposed changes, the https://github.com/Automattic/wp-calypso/issues/79117 should not be reproducible.

1. Check out the PR branch and build the app.
2. Navigate to _Users → Subscribers_ and on a site that doesn't have either any Email subscribers or WordPress.com subscribers.
3. From the Subscriber type dropdown select the option that doesn't have any subscribers and make sure there's no search term entered.
4. The "no-search-results" message should not include the empty string.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
