### PR TITLE
Apply stricter validation to launchpad redirect URLs

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
@@ -34,7 +34,7 @@ export const leaveCheckout = ( {
 
 	const signupFlowName = getSignupCompleteFlowName();
 	const redirectToParam = getQueryArg( window.location.href, 'redirect_to' );
-	const launchpadURLRegex = /setup\/(.*)\/launchpad\b/g;
+	const launchpadURLRegex = /^\/setup\/[a-z][a-z\-_]*[a-z]\/launchpad\b/g;
 	const launchpadURLRegexMatch = redirectToParam?.toString().match( launchpadURLRegex );
 
 	if ( isTailoredSignupFlow( signupFlowName ) ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* As reported internally in the following thread, p7H4VZ-4sH-p2#comment-11309, we were not validating the redirect for launchpad URLs correctly. This PR ensures we apply stricter validation that only allows URL targets that start with `/setup/{flowOrIntent}/launchpad`, where `flowOrIntent` may only include lowercase letters, `-`, and `_`, with at least one starting and trailing lowercase letter (implying a string length of 2 or more characters).
  - More discussion on the specific validation in this thread: p1688998678701239-slack-C0Q664T29

## Testing Instructions

* For now, I am not going to document the testing instructions as they are effectively instructions to exploit the issue. I'll revisit this once I chat with folks internally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?