### PR TITLE
Checkout: Validate active step number when total steps change

### DIFF
--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -119,6 +119,12 @@ function createCheckoutStepGroupActions(
 		onStateChange();
 	};
 
+	const validateActiveStepNumber = () => {
+		if ( state.activeStepNumber > state.totalSteps ) {
+			state.activeStepNumber = state.totalSteps;
+		}
+	};
+
 	const setTotalSteps = ( stepCount: number ) => {
 		if ( stepCount < 0 ) {
 			throw new Error( `Cannot set total steps to '${ stepCount }' because it is too low` );
@@ -127,6 +133,7 @@ function createCheckoutStepGroupActions(
 			return;
 		}
 		state.totalSteps = stepCount;
+		validateActiveStepNumber();
 		onStateChange();
 	};
 


### PR DESCRIPTION
## Proposed Changes

Checkout is made up of a series of steps, only one of which can be active. However, there are cases where the number of steps changes after they have been rendered. When that happens, it's possible for the currently active step number to be invalid. For example, if there are 2 steps and the active step is 2, then we remove a step, the active step will still be 2 even though no such step now exists.

In this PR we add code to reset the active step to a valid step after the step total has been changed.

Fixes https://github.com/Automattic/wp-calypso/issues/79185

## Screenshots

Before:

<img width="1268" alt="last-step-inactive" src="https://github.com/Automattic/wp-calypso/assets/2036909/1eb9206d-b3d7-40ba-85a9-130703f47b7e">

After:

<img width="1271" alt="last-step-active" src="https://github.com/Automattic/wp-calypso/assets/2036909/80ad6332-d1ab-4b30-80fc-32c668375472">


## Testing Instructions

- Visit checkout with a product in the cart that costs money.
- Make sure the billing details step is active.
- Add a 100% discount coupon.
- Verify that the payment methods step becomes active.