### PR TITLE
Plugins: Scroll to search results only when the search is non-empty

### DIFF
--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -28,16 +28,16 @@ const SearchBox = ( {
 	const searchTermSuggestion = useTermsSuggestions( searchTerms ) || 'ecommerce';
 
 	const pageToSearch = useCallback(
-		( s ) => {
+		( search ) => {
 			const isCategoryPage = window.location.href.includes( '/plugins/browse/' );
 			if ( isCategoryPage ) {
 				dispatch( resetBreadcrumbs() );
 			}
 
 			page.show( localizePath( `/plugins/${ selectedSite?.slug || '' }` ) ); // Ensures location.href is on the main Plugins page before setQueryArgs uses it to construct the redirect.
-			setQueryArgs( '' !== s ? { s } : {} );
+			setQueryArgs( '' !== search ? { s: search } : {} );
 
-			if ( s ) {
+			if ( search ) {
 				searchBoxRef.current.blur();
 				scrollTo( {
 					x: 0,

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -36,14 +36,17 @@ const SearchBox = ( {
 
 			page.show( localizePath( `/plugins/${ selectedSite?.slug || '' }` ) ); // Ensures location.href is on the main Plugins page before setQueryArgs uses it to construct the redirect.
 			setQueryArgs( '' !== s ? { s } : {} );
-			searchBoxRef.current.blur();
-			scrollTo( {
-				x: 0,
-				y:
-					categoriesRef.current?.getBoundingClientRect().y - // Get to the top of categories
-					categoriesRef.current?.getBoundingClientRect().height, // But don't show the categories
-				duration: 300,
-			} );
+
+			if ( s ) {
+				searchBoxRef.current.blur();
+				scrollTo( {
+					x: 0,
+					y:
+						categoriesRef.current?.getBoundingClientRect().y - // Get to the top of categories
+						categoriesRef.current?.getBoundingClientRect().height, // But don't show the categories
+					duration: 300,
+				} );
+			}
 		},
 		[ searchBoxRef, categoriesRef, dispatch, selectedSite, localizePath ]
 	);


### PR DESCRIPTION
Related to #79140

## Proposed Changes

Scroll to search results only when the search is non-empty.
This will make the `X` click on the search button to always scroll to the top of the page.

## Testing Instructions
* On this branch
* Go to the `/plugins` page
* Scroll down the page and type something on the search input
* Click on the `X` button
* It should be scrolled back to the top of the page
* Search a term (ex: `booking`) and press `Enter`
* You should be scrolled down to the results area
* Click on the `X` button again
* It should be scrolled back to the top of the page

![CleanShot 2023-07-10 at 14 03 14](https://github.com/Automattic/wp-calypso/assets/5039531/1b8b945a-4baf-4c72-a145-dce7b6a05f04)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
