### PR TITLE
Revert "Checkout: add support for using new cards for free purchases"

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -6,6 +6,7 @@ import {
 } from '@automattic/composite-checkout';
 import { ManagedContactDetails } from '@automattic/wpcom-checkout';
 import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
 import wp from 'calypso/lib/wp';
 import { getTaxValidationResult } from 'calypso/my-sites/checkout/composite-checkout/lib/contact-validation';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -19,7 +20,6 @@ import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { Stripe, StripeCardNumberElement } from '@stripe/stripe-js';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { CalypsoDispatch } from 'calypso/state/types';
-import type { LocalizeProps } from 'i18n-calypso';
 
 const wpcomAssignPaymentMethod = (
 	subscriptionId: string,
@@ -70,7 +70,7 @@ export async function assignNewCardProcessor(
 		eventSource,
 	}: {
 		purchase: Purchase | undefined;
-		translate: LocalizeProps[ 'translate' ];
+		translate: ReturnType< typeof useTranslate >;
 		stripe: Stripe | null;
 		stripeConfiguration: StripeConfiguration | null;
 		stripeSetupIntentId: StripeSetupIntentId | undefined;

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -1,8 +1,7 @@
 import config from '@automattic/calypso-config';
-import { StripeHookProvider, StripeSetupIntentIdProvider } from '@automattic/calypso-stripe';
+import { StripeHookProvider } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
-import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -17,9 +16,7 @@ import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutMain from './composite-checkout/components/checkout-main';
 import PrePurchaseNotices from './composite-checkout/components/prepurchase-notices';
 import { convertErrorToString } from './composite-checkout/lib/analytics';
-import useCartKey from './use-cart-key';
 import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
-import type { ReactNode } from 'react';
 
 const logCheckoutError = ( error: Error ) => {
 	logToLogstash( {
@@ -114,46 +111,30 @@ export default function CheckoutMainWrapper( {
 			>
 				<CalypsoShoppingCartProvider shouldShowPersistentErrors>
 					<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
-						<InnerCheckoutMainWrapper>
-							<CheckoutMain
-								siteSlug={ siteSlug }
-								siteId={ selectedSiteId }
-								productAliasFromUrl={ productAliasFromUrl }
-								productSourceFromUrl={ productSourceFromUrl }
-								purchaseId={ purchaseId }
-								couponCode={ couponCode }
-								redirectTo={ redirectTo }
-								feature={ selectedFeature }
-								plan={ plan }
-								isComingFromUpsell={ isComingFromUpsell }
-								infoMessage={ prepurchaseNotices }
-								sitelessCheckoutType={ sitelessCheckoutType }
-								isLoggedOutCart={ isLoggedOutCart }
-								isNoSiteCart={ isNoSiteCart }
-								isGiftPurchase={ isGiftPurchase }
-								jetpackSiteSlug={ jetpackSiteSlug }
-								jetpackPurchaseToken={ jetpackPurchaseToken }
-								isUserComingFromLoginForm={ isUserComingFromLoginForm }
-							/>
-						</InnerCheckoutMainWrapper>
+						<CheckoutMain
+							siteSlug={ siteSlug }
+							siteId={ selectedSiteId }
+							productAliasFromUrl={ productAliasFromUrl }
+							productSourceFromUrl={ productSourceFromUrl }
+							purchaseId={ purchaseId }
+							couponCode={ couponCode }
+							redirectTo={ redirectTo }
+							feature={ selectedFeature }
+							plan={ plan }
+							isComingFromUpsell={ isComingFromUpsell }
+							infoMessage={ prepurchaseNotices }
+							sitelessCheckoutType={ sitelessCheckoutType }
+							isLoggedOutCart={ isLoggedOutCart }
+							isNoSiteCart={ isNoSiteCart }
+							isGiftPurchase={ isGiftPurchase }
+							jetpackSiteSlug={ jetpackSiteSlug }
+							jetpackPurchaseToken={ jetpackPurchaseToken }
+							isUserComingFromLoginForm={ isUserComingFromLoginForm }
+						/>
 					</StripeHookProvider>
 				</CalypsoShoppingCartProvider>
 			</CheckoutErrorBoundary>
 			{ isLoggedOutCart && <Recaptcha badgePosition="bottomright" /> }
 		</CheckoutMainWrapperStyles>
-	);
-}
-
-function InnerCheckoutMainWrapper( { children }: { children: ReactNode } ) {
-	const cartKey = useCartKey();
-	const { responseCart, isLoading, isPendingUpdate } = useShoppingCart( cartKey );
-	const isPurchaseFree = responseCart.total_cost_integer === 0;
-	return (
-		<StripeSetupIntentIdProvider
-			fetchStipeSetupIntentId={ getStripeConfiguration }
-			isDisabled={ ! isPurchaseFree || isLoading || isPendingUpdate }
-		>
-			{ children }
-		</StripeSetupIntentIdProvider>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -1,5 +1,5 @@
 import { JETPACK_SEARCH_PRODUCTS } from '@automattic/calypso-products';
-import { useStripe, useStripeSetupIntentId } from '@automattic/calypso-stripe';
+import { useStripe } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { CheckoutProvider, checkoutTheme } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
@@ -7,7 +7,7 @@ import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useSelect } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, useCallback, useEffect, useMemo } from 'react';
+import { Fragment, useCallback, useMemo } from 'react';
 import QueryContactDetailsCache from 'calypso/components/data/query-contact-details-cache';
 import QueryJetpackSaleCoupon from 'calypso/components/data/query-jetpack-sale-coupon';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -445,18 +445,6 @@ export default function CheckoutMain( {
 		]
 	);
 
-	const {
-		reload: reloadSetupIntentId,
-		setupIntentId: stripeSetupIntentId,
-		error: setupIntentError,
-	} = useStripeSetupIntentId();
-
-	useEffect( () => {
-		if ( setupIntentError ) {
-			reduxDispatch( errorNotice( setupIntentError.message ) );
-		}
-	}, [ setupIntentError, reduxDispatch ] );
-
 	const paymentProcessors = useMemo(
 		() => ( {
 			'apple-pay': ( transactionData: unknown ) =>
@@ -465,10 +453,7 @@ export default function CheckoutMain( {
 				webPayProcessor( 'google-pay', transactionData, dataForProcessor ),
 			'free-purchase': () => freePurchaseProcessor( dataForProcessor ),
 			card: ( transactionData: unknown ) =>
-				multiPartnerCardProcessor( transactionData, dataForProcessor, {
-					translate,
-					stripeSetupIntentId,
-				} ),
+				multiPartnerCardProcessor( transactionData, dataForProcessor ),
 			alipay: ( transactionData: unknown ) =>
 				genericRedirectProcessor( 'alipay', transactionData, dataForProcessor ),
 			p24: ( transactionData: unknown ) =>
@@ -492,7 +477,7 @@ export default function CheckoutMain( {
 				existingCardProcessor( transactionData, dataForProcessor ),
 			paypal: () => payPalProcessor( dataForProcessor ),
 		} ),
-		[ dataForProcessor, translate, stripeSetupIntentId ]
+		[ dataForProcessor ]
 	);
 
 	const jetpackColors = isJetpackNotAtomic
@@ -685,11 +670,8 @@ export default function CheckoutMain( {
 					error_message: String( transactionError ),
 				} )
 			);
-
-			// We need to regenerate the setup intent if the form was submitted.
-			reloadSetupIntentId();
 		},
-		[ reduxDispatch, translate, reloadSetupIntentId ]
+		[ reduxDispatch, translate ]
 	);
 
 	const handlePaymentRedirect = useCallback( () => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -438,10 +438,10 @@ export default function useCreatePaymentMethods( {
 	// The order is the order of Payment Methods in Checkout.
 	return [
 		...existingCardMethods,
+		freePaymentMethod,
 		applePayMethod,
 		googlePayMethod,
 		stripeMethod,
-		freePaymentMethod,
 		paypalMethod,
 		idealMethod,
 		giropayMethod,

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -6,10 +6,8 @@ import {
 } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
-import { assignNewCardProcessor } from 'calypso/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
-import existingCardProcessor from './existing-card-processor';
 import getDomainDetails from './get-domain-details';
 import getPostalCode from './get-postal-code';
 import submitWpcomTransaction from './submit-wpcom-transaction';
@@ -18,10 +16,9 @@ import {
 	createTransactionEndpointCartFromResponseCart,
 } from './translate-cart';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
-import type { StripeSetupIntentId, StripeConfiguration } from '@automattic/calypso-stripe';
+import type { StripeConfiguration } from '@automattic/calypso-stripe';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { Stripe, StripeCardNumberElement } from '@stripe/stripe-js';
-import type { LocalizeProps } from 'i18n-calypso';
 
 const debug = debugFactory( 'calypso:composite-checkout:multi-partner-card-processor' );
 
@@ -235,80 +232,13 @@ async function ebanxCardProcessor(
 		} );
 }
 
-export interface FreePurchaseData {
-	stripeSetupIntentId: StripeSetupIntentId | undefined;
-	translate: LocalizeProps[ 'translate' ];
-}
-
 export default async function multiPartnerCardProcessor(
 	submitData: unknown,
-	dataForProcessor: PaymentProcessorOptions,
-	freePurchaseData?: FreePurchaseData
+	dataForProcessor: PaymentProcessorOptions
 ): Promise< PaymentProcessorResponse > {
 	if ( ! isValidMultiPartnerTransactionData( submitData ) ) {
 		throw new Error( 'Required purchase data is missing' );
 	}
-
-	// For free purchases we cannot use the regular processor because it requires
-	// making a charge. Instead, we will create a new card, then use the
-	// existingCardProcessor because it works for free purchases.
-	const isPurchaseFree =
-		dataForProcessor.responseCart.total_cost_integer === 0 &&
-		dataForProcessor.responseCart.products.length > 0;
-	if ( isPurchaseFree ) {
-		if ( ! isValidStripeCardTransactionData( submitData ) ) {
-			throw new Error( 'Required purchase data is missing' );
-		}
-		if ( submitData.paymentPartner === 'ebanx' ) {
-			throw new Error( 'Cannot use Ebanx for free purchases' );
-		}
-		if ( ! freePurchaseData?.translate ) {
-			throw new Error( 'Required free purchase data is missing' );
-		}
-		const newCardResponse = await assignNewCardProcessor(
-			{
-				purchase: undefined,
-				translate: freePurchaseData.translate,
-				stripe: dataForProcessor.stripe,
-				stripeConfiguration: dataForProcessor.stripeConfiguration,
-				stripeSetupIntentId: freePurchaseData?.stripeSetupIntentId,
-				cardNumberElement: submitData.cardNumberElement,
-				reduxDispatch: dataForProcessor.reduxDispatch,
-				eventSource: '/checkout',
-			},
-			{
-				...submitData,
-				// In `PaymentMethodSelector` which is used for adding new cards, the
-				// stripe payment method is passed `shouldShowTaxFields` which causes
-				// it to show required tax location fields in the payment method
-				// itself; that data is then submitted to the `assignNewCardProcessor`
-				// to send to Stripe as part of saving the card. However, in checkout
-				// we do not display those fields since they are already included in
-				// the billing details step. Therefore we must pass in the tax location
-				// data explicitly here so we can use `assignNewCardProcessor`.
-				countryCode: dataForProcessor.contactDetails?.countryCode?.value,
-				postalCode: getPostalCode( dataForProcessor.contactDetails ),
-				state: dataForProcessor.contactDetails?.state?.value,
-				city: dataForProcessor.contactDetails?.city?.value,
-				organization: dataForProcessor.contactDetails?.organization?.value,
-				address: dataForProcessor.contactDetails?.address1?.value,
-			}
-		);
-		const storedCard = newCardResponse.payload;
-		if ( ! isValidNewCardResponseData( storedCard ) ) {
-			throw new Error( 'New card was not saved' );
-		}
-		return existingCardProcessor(
-			{
-				...submitData,
-				storedDetailsId: storedCard.stored_details_id,
-				paymentMethodToken: storedCard.mp_ref,
-				paymentPartnerProcessorId: storedCard.payment_partner,
-			},
-			dataForProcessor
-		);
-	}
-
 	const paymentPartner = submitData.paymentPartner;
 	if ( paymentPartner === 'stripe' ) {
 		return stripeCardProcessor( submitData, dataForProcessor );
@@ -351,20 +281,6 @@ function isValidEbanxCardTransactionData(
 	const data = submitData as EbanxCardTransactionRequest;
 	if ( ! data ) {
 		throw new Error( 'Transaction requires data and none was provided' );
-	}
-	return true;
-}
-
-interface NewCardResponseData {
-	stored_details_id: string;
-	mp_ref: string;
-	payment_partner: string;
-}
-
-function isValidNewCardResponseData( submitData: unknown ): submitData is NewCardResponseData {
-	const data = submitData as NewCardResponseData;
-	if ( ! data || ! data.stored_details_id || ! data.mp_ref || ! data.payment_partner ) {
-		throw new Error( 'New card was not saved' );
 	}
 	return true;
 }

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -1,4 +1,4 @@
-import { getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
 import multiPartnerCardProcessor from '../lib/multi-partner-card-processor';
 import {
@@ -14,8 +14,6 @@ import {
 	contactDetailsForDomain,
 	mockCreateAccountSiteCreatedResponse,
 	mockCreateAccountSiteNotCreatedResponse,
-	planWithoutDomain,
-	getBasicCart,
 } from './util';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
@@ -107,13 +105,13 @@ describe( 'multiPartnerCardProcessor', () => {
 		public_key: 'pk_test_1234567890',
 		setup_intent_id: null,
 	};
-	const product = planWithoutDomain;
+	const product = getEmptyResponseCartProduct();
 	const domainProduct = {
 		...getEmptyResponseCartProduct(),
 		meta: 'example.com',
 		is_domain_registration: true,
 	};
-	const cart = { ...getBasicCart(), products: [ product ] };
+	const cart = { ...getEmptyResponseCart(), products: [ product ] };
 
 	const mockCardNumberElement = () => <div>mock card number</div>;
 

--- a/client/my-sites/checkout/composite-checkout/test/util/mock-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/util/mock-checkout.tsx
@@ -1,4 +1,4 @@
-import { StripeHookProvider, StripeSetupIntentIdProvider } from '@automattic/calypso-stripe';
+import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import { PropsOf } from '@emotion/react';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
@@ -38,25 +38,17 @@ export function MockCheckout( {
 		getCart: mockGetCartEndpointWith( { ...initialCart, ...( cartChanges ?? {} ) } ),
 		setCart: setCart || mockSetCartEndpoint,
 	} );
-
-	const isPurchaseFree = { ...initialCart, ...cartChanges }.total_cost_integer === 0;
-
 	return (
 		<ReduxProvider store={ reduxStore }>
 			<QueryClientProvider client={ queryClient }>
 				<ShoppingCartProvider managerClient={ managerClient }>
 					<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-						<StripeSetupIntentIdProvider
-							fetchStipeSetupIntentId={ fetchStripeConfiguration }
-							isDisabled={ ! isPurchaseFree }
-						>
-							<CheckoutMain
-								siteId={ useUndefinedSiteId ? undefined : siteId }
-								siteSlug="foo.com"
-								overrideCountryList={ countryList }
-								{ ...additionalProps }
-							/>
-						</StripeSetupIntentIdProvider>
+						<CheckoutMain
+							siteId={ useUndefinedSiteId ? undefined : siteId }
+							siteSlug="foo.com"
+							overrideCountryList={ countryList }
+							{ ...additionalProps }
+						/>
 					</StripeHookProvider>
 				</ShoppingCartProvider>
 			</QueryClientProvider>

--- a/packages/calypso-stripe/README.md
+++ b/packages/calypso-stripe/README.md
@@ -8,7 +8,7 @@ This uses [Stripe elements](https://stripe.com/payments/elements).
 
 You'll need to wrap this context provider around any component that wishes to use `useStripe` or `withStripeProps`. It accepts the following props:
 
-- `children: React.ReactNode`
+- `children: JSX.Element`
 - `fetchStripeConfiguration: GetStripeConfiguration` A function to fetch the stripe configuration from the WP.com HTTP API.
 - `configurationArgs?: null | GetStripeConfigurationArgs` Options to pass to the fetchStripeConfiguration function, specifically `country`.
 - `locale?: string` An optional locale string used to localize error messages for the Stripe elements fields.
@@ -17,9 +17,8 @@ You'll need to wrap this context provider around any component that wishes to us
 
 You'll need to wrap this context provider around any component that wishes to use `useStripeSetupIntentId`. It accepts the following props:
 
-- `children: React.ReactNode`
+- `children: JSX.Element`
 - `fetchStripeConfiguration: GetStripeSetupIntentId` A function to fetch the stripe configuration from the WP.com HTTP API. It will be passed `{needs_intent: true}`.
-- `isDisabled?: boolean` An option to disable the fetching of the setup intent if it is not needed.
 
 ## useStripe
 

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -435,10 +435,7 @@ const setupIntentRequestArgs = { needs_intent: true };
  * since a Setup Intent may need to be recreated. You can force the
  * configuration to reload by calling `reload()`.
  */
-function useFetchSetupIntentId(
-	fetchStripeConfiguration: GetStripeSetupIntentId,
-	{ isDisabled }: { isDisabled?: boolean }
-): {
+function useFetchSetupIntentId( fetchStripeConfiguration: GetStripeSetupIntentId ): {
 	setupIntentId: StripeSetupIntentId | undefined;
 	error: undefined | Error;
 	reload: ReloadSetupIntentId;
@@ -449,14 +446,8 @@ function useFetchSetupIntentId(
 	const reload = useCallback( () => setReloadCount( ( count ) => count + 1 ), [] );
 
 	useEffect( () => {
-		let isSubscribed = true;
-		if ( isDisabled ) {
-			debug( 'not loading stripe setup intent id because it is disabled' );
-			return () => {
-				isSubscribed = false;
-			};
-		}
 		debug( 'loading stripe setup intent id' );
+		let isSubscribed = true;
 		fetchStripeConfiguration( setupIntentRequestArgs )
 			.then( ( configuration ) => {
 				if ( ! isSubscribed ) {
@@ -477,7 +468,7 @@ function useFetchSetupIntentId(
 		return () => {
 			isSubscribed = false;
 		};
-	}, [ stripeReloadCount, fetchStripeConfiguration, isDisabled ] );
+	}, [ stripeReloadCount, fetchStripeConfiguration ] );
 	return { setupIntentId, error, reload };
 }
 
@@ -494,12 +485,10 @@ function areRequestArgsEqual(
 export function StripeSetupIntentIdProvider( {
 	children,
 	fetchStipeSetupIntentId,
-	isDisabled,
 }: PropsWithChildren< {
 	fetchStipeSetupIntentId: GetStripeSetupIntentId;
-	isDisabled?: boolean;
 } > ) {
-	const setupIntentData = useFetchSetupIntentId( fetchStipeSetupIntentId, { isDisabled } );
+	const setupIntentData = useFetchSetupIntentId( fetchStipeSetupIntentId );
 
 	return (
 		<StripeSetupIntentContext.Provider value={ setupIntentData }>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#79083 Just in case... we've seen some fatal errors in Slack p1689009291268809-slack-C04U5A26MJB