### PR TITLE
Checkout: Update CheckoutMain default export to include setup intent provider

### DIFF
--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -1,8 +1,7 @@
 import config from '@automattic/calypso-config';
-import { StripeHookProvider, StripeSetupIntentIdProvider } from '@automattic/calypso-stripe';
+import { StripeHookProvider } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
-import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -17,9 +16,7 @@ import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutMain from './composite-checkout/components/checkout-main';
 import PrePurchaseNotices from './composite-checkout/components/prepurchase-notices';
 import { convertErrorToString } from './composite-checkout/lib/analytics';
-import useCartKey from './use-cart-key';
 import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
-import type { ReactNode } from 'react';
 
 const logCheckoutError = ( error: Error ) => {
 	logToLogstash( {
@@ -114,46 +111,30 @@ export default function CheckoutMainWrapper( {
 			>
 				<CalypsoShoppingCartProvider shouldShowPersistentErrors>
 					<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
-						<InnerCheckoutMainWrapper>
-							<CheckoutMain
-								siteSlug={ siteSlug }
-								siteId={ selectedSiteId }
-								productAliasFromUrl={ productAliasFromUrl }
-								productSourceFromUrl={ productSourceFromUrl }
-								purchaseId={ purchaseId }
-								couponCode={ couponCode }
-								redirectTo={ redirectTo }
-								feature={ selectedFeature }
-								plan={ plan }
-								isComingFromUpsell={ isComingFromUpsell }
-								infoMessage={ prepurchaseNotices }
-								sitelessCheckoutType={ sitelessCheckoutType }
-								isLoggedOutCart={ isLoggedOutCart }
-								isNoSiteCart={ isNoSiteCart }
-								isGiftPurchase={ isGiftPurchase }
-								jetpackSiteSlug={ jetpackSiteSlug }
-								jetpackPurchaseToken={ jetpackPurchaseToken }
-								isUserComingFromLoginForm={ isUserComingFromLoginForm }
-							/>
-						</InnerCheckoutMainWrapper>
+						<CheckoutMain
+							siteSlug={ siteSlug }
+							siteId={ selectedSiteId }
+							productAliasFromUrl={ productAliasFromUrl }
+							productSourceFromUrl={ productSourceFromUrl }
+							purchaseId={ purchaseId }
+							couponCode={ couponCode }
+							redirectTo={ redirectTo }
+							feature={ selectedFeature }
+							plan={ plan }
+							isComingFromUpsell={ isComingFromUpsell }
+							infoMessage={ prepurchaseNotices }
+							sitelessCheckoutType={ sitelessCheckoutType }
+							isLoggedOutCart={ isLoggedOutCart }
+							isNoSiteCart={ isNoSiteCart }
+							isGiftPurchase={ isGiftPurchase }
+							jetpackSiteSlug={ jetpackSiteSlug }
+							jetpackPurchaseToken={ jetpackPurchaseToken }
+							isUserComingFromLoginForm={ isUserComingFromLoginForm }
+						/>
 					</StripeHookProvider>
 				</CalypsoShoppingCartProvider>
 			</CheckoutErrorBoundary>
 			{ isLoggedOutCart && <Recaptcha badgePosition="bottomright" /> }
 		</CheckoutMainWrapperStyles>
-	);
-}
-
-function InnerCheckoutMainWrapper( { children }: { children: ReactNode } ) {
-	const cartKey = useCartKey();
-	const { responseCart, isLoading, isPendingUpdate } = useShoppingCart( cartKey );
-	const isPurchaseFree = responseCart.total_cost_integer === 0;
-	return (
-		<StripeSetupIntentIdProvider
-			fetchStipeSetupIntentId={ getStripeConfiguration }
-			isDisabled={ ! isPurchaseFree || isLoading || isPendingUpdate }
-		>
-			{ children }
-		</StripeSetupIntentIdProvider>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/test/util/mock-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/util/mock-checkout.tsx
@@ -1,4 +1,4 @@
-import { StripeHookProvider, StripeSetupIntentIdProvider } from '@automattic/calypso-stripe';
+import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import { PropsOf } from '@emotion/react';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
@@ -39,24 +39,17 @@ export function MockCheckout( {
 		setCart: setCart || mockSetCartEndpoint,
 	} );
 
-	const isPurchaseFree = { ...initialCart, ...cartChanges }.total_cost_integer === 0;
-
 	return (
 		<ReduxProvider store={ reduxStore }>
 			<QueryClientProvider client={ queryClient }>
 				<ShoppingCartProvider managerClient={ managerClient }>
 					<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-						<StripeSetupIntentIdProvider
-							fetchStipeSetupIntentId={ fetchStripeConfiguration }
-							isDisabled={ ! isPurchaseFree }
-						>
-							<CheckoutMain
-								siteId={ useUndefinedSiteId ? undefined : siteId }
-								siteSlug="foo.com"
-								overrideCountryList={ countryList }
-								{ ...additionalProps }
-							/>
-						</StripeSetupIntentIdProvider>
+						<CheckoutMain
+							siteId={ useUndefinedSiteId ? undefined : siteId }
+							siteSlug="foo.com"
+							overrideCountryList={ countryList }
+							{ ...additionalProps }
+						/>
 					</StripeHookProvider>
 				</ShoppingCartProvider>
 			</QueryClientProvider>


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/79083 we modified `CheckoutMain` to call `useStripeSetupIntentId()`. That requires that `CheckoutMain` be wrapped in a `StripeSetupIntentIdProvider`. To do that, we added a `StripeSetupIntentIdProvider` to `CheckoutMainWrapper`... but there are places in calypso that use `CheckoutMain` without that wrapper (eg: [here](https://github.com/Automattic/wp-calypso/blob/91a2bd56e374a613d7719dcb3f3326c1e3a0a1e9/client/blocks/editor-checkout-modal/index.tsx#L74) and [here](https://github.com/Automattic/wp-calypso/blob/91a2bd56e374a613d7719dcb3f3326c1e3a0a1e9/client/my-sites/checkout/modal/index.tsx#L116)). That will cause those places to throw a fatal error `useStripeSetupIntentId can only be used inside a StripeSetupIntentIdProvider`.

In this PR we modify `CheckoutMain` so that its default export includes `StripeSetupIntentIdProvider` itself.

Before:

<img width="1279" alt="Screenshot 2023-07-10 at 1 52 02 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/5af8bc9a-3f60-4de0-b472-d70addc064dc">

After:

<img width="1274" alt="Screenshot 2023-07-10 at 1 51 53 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/2d19ea68-b7bf-4704-bd14-ede5c5b9c17d">


## Testing Instructions

- You'll need a Simple wordpress.com site without any plans purchased.
- Visit https://wordpress.com/setup/site-setup/designSetup?siteSlug=YOUR_SIMPLE_SITE
- Select "Tazza" as the theme.
- Click to continue until you end up on a checkout page.
- Verify that the page loads without fatal errors.