### PR TITLE
VideoPress HQ: add login/user creation to flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -74,7 +74,8 @@
 
 }
 
-.is-videopress-stepper.is-processing-step {
+.is-videopress-stepper.is-processing-step,
+.is-videopress-tv-stepper.is-processing-step {
 	padding: 0;
 	color: #fff;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -1,4 +1,8 @@
-import { VIDEOPRESS_FLOW, isNewHostedSiteCreationFlow } from '@automattic/onboarding';
+import {
+	VIDEOPRESS_FLOW,
+	VIDEOPRESS_TV_FLOW,
+	isNewHostedSiteCreationFlow,
+} from '@automattic/onboarding';
 import { NewHostedSiteOptions } from './new-hosted-site-options';
 import { SiteOptions } from './site-options';
 import { VideoPressSiteOptions } from './videopress-site-options';
@@ -10,7 +14,7 @@ const SiteOptionsStepRouter: Step = function SiteOptionsStepRouter( { navigation
 		return <NewHostedSiteOptions navigation={ navigation } />;
 	}
 
-	if ( flow === VIDEOPRESS_FLOW ) {
+	if ( flow === VIDEOPRESS_FLOW || flow === VIDEOPRESS_TV_FLOW ) {
 		return <VideoPressSiteOptions navigation={ navigation } />;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
@@ -113,7 +113,8 @@
 		}
 	}
 
-	.videopress & {
+	.videopress &,
+	.videopress-tv & {
 		max-width: 425px;
 
 		.step-container__header {

--- a/client/landing/stepper/declarative-flow/videopress-tv.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv.ts
@@ -1,9 +1,14 @@
+import { SiteSelect } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, VIDEOPRESS_TV_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
-import { ONBOARD_STORE, USER_STORE } from '../stores';
+import { useEffect, useState } from 'react';
+import { useNewSiteVisibility } from 'calypso/landing/stepper/hooks/use-selected-plan';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
 import './internals/videopress.scss';
+import ProcessingStep from './internals/steps-repository/processing-step';
 import SiteOptions from './internals/steps-repository/site-options';
 import type { Flow, ProvidedDependencies } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';
@@ -20,6 +25,7 @@ const videopressTv: Flow = {
 				asyncComponent: () => import( './internals/steps-repository/intro' ),
 			},
 			{ slug: 'options', component: SiteOptions },
+			{ slug: 'processing', component: ProcessingStep },
 		];
 	},
 
@@ -32,23 +38,83 @@ const videopressTv: Flow = {
 		}
 
 		const name = this.name;
-		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const { createVideoPressTvSite, setPendingAction, setProgress, setStepProgress } =
+			useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
 		const locale = useLocale();
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
+		const { setSiteDescription, setSiteTitle } = useDispatch( ONBOARD_STORE );
+		const _siteSlug = useSiteSlug();
+		const [ isSiteCreationPending, setIsSiteCreationPending ] = useState( false );
+		const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
+		const visibility = useNewSiteVisibility();
 
 		setStepProgress( flowProgress );
 
-		switch ( _currentStep ) {
-			case 'intro':
-				break;
-			case 'options':
-				// todo: validate user logged in
-				break;
-		}
+		const clearOnboardingSiteOptions = () => {
+			setSiteTitle( '' );
+			setSiteDescription( '' );
+		};
+
+		const stepValidateUserIsLoggedIn = () => {
+			if ( ! userIsLoggedIn ) {
+				navigate( 'intro' );
+				return false;
+			}
+			return true;
+		};
+
+		const addVideoPressPendingAction = () => {
+			// only allow one call to this action to occur
+			if ( isSiteCreationPending ) {
+				return;
+			}
+
+			setIsSiteCreationPending( true );
+
+			setPendingAction( async () => {
+				setProgress( 0 );
+				try {
+					await createVideoPressTvSite( {
+						languageSlug: locale,
+						visibility,
+					} );
+				} catch ( e ) {
+					return;
+				}
+				setProgress( 0.5 );
+
+				const newSite = getNewSite();
+				if ( ! newSite || ! newSite.site_slug ) {
+					return;
+				}
+
+				setProgress( 1 );
+
+				// go to the new site, and let the "empty state" act as the remaining of onboarding.
+				window.location.href = `https://${ newSite.site_slug }`;
+			} );
+		};
+
+		// needs to be wrapped in a useEffect because validation can call `navigate` which needs to be called in a useEffect
+		useEffect( () => {
+			switch ( _currentStep ) {
+				case 'intro':
+					clearOnboardingSiteOptions();
+					break;
+				case 'options':
+					stepValidateUserIsLoggedIn();
+					break;
+				case 'processing':
+					if ( ! _siteSlug ) {
+						addVideoPressPendingAction();
+					}
+					break;
+			}
+		} );
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {
@@ -60,6 +126,12 @@ const videopressTv: Flow = {
 					return window.location.replace(
 						`/start/videopress-account/user/${ locale }?variationName=${ name }&flow=${ name }&pageTitle=VideoPress.TV&redirect_to=/setup/videopress-tv/options`
 					);
+				case 'options': {
+					const { siteTitle, tagline } = providedDependencies;
+					setSiteTitle( siteTitle );
+					setSiteDescription( tagline );
+					return navigate( 'processing' );
+				}
 			}
 			return providedDependencies;
 		}

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -92,6 +92,53 @@ export function* createVideoPressSite( {
 	return success;
 }
 
+export function* createVideoPressTvSite( {
+	languageSlug,
+	visibility = Visibility.PublicNotIndexed,
+}: CreateSiteBaseActionParameters ) {
+	const { selectedDesign, selectedFonts, siteTitle, selectedFeatures }: State = yield select(
+		STORE_KEY,
+		'getState'
+	);
+
+	const lang_id = ( getLanguage( languageSlug ) as Language )?.value;
+	const blogTitle = siteTitle.trim() === '' ? __( 'Site Title' ) : siteTitle;
+
+	const params: CreateSiteParams = {
+		blog_name: '', // will be replaced on server with random domain
+		blog_title: blogTitle,
+		public: visibility,
+		options: {
+			site_information: {
+				title: blogTitle,
+			},
+			lang_id: lang_id,
+			site_creation_flow: 'videopress-tv',
+			enable_fse: true,
+			theme: 'pub/videopress-hq',
+			timezone_string: guessTimezone(),
+			...( selectedDesign?.template && { template: selectedDesign.template } ),
+			...( selectedFonts && {
+				font_base: selectedFonts.base,
+				font_headings: selectedFonts.headings,
+			} ),
+			use_patterns: true,
+			selected_features: selectedFeatures,
+			wpcom_public_coming_soon: 1,
+			...( selectedDesign && { is_blank_canvas: isBlankCanvasDesign( selectedDesign ) } ),
+			is_videopress_initial_purchase: true,
+		},
+	};
+
+	const success: NewSiteBlogDetails | undefined = yield dispatch(
+		SITE_STORE,
+		'createSite',
+		params
+	);
+
+	return success;
+}
+
 export function* createSenseiSite( {
 	username = '',
 	languageSlug = '',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/greenhouse/issues/1782

## Proposed Changes

* add a login / user creation step to the flow
* add a temporary "Options" flow so there is somewhere to redirect to after login (this will be updated in a future PR)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn && yarn start` or use a calypso.live link
* open the `/setup/videopress-tv` page in an incognito browser
* proceed through the  flow
* when prompted to, create a new account
* upon account creation you should be redirected to the settings page
* return to the `/setup/videopress-tv/intro` step (**don't** start a new browser session)
* proceed through the flow
* you should not be prompted for an account and be sent straight to the Options step, since you are already logged in.

NOTE: the `log in` link at account creation time is broken because there are duplicate `redirect_to` query params, and the first one is set incorrectly. I will fix this in a separate PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
