### PR TITLE
Added ability to download subscribers emails, regardless of them being wpcom users or not

### DIFF
--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -20,7 +20,7 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 	const onToggle = useCallback( () => setIsVisible( ( visible ) => ! visible ), [] );
 	const buttonRef = useRef< HTMLButtonElement >( null );
 	const downloadCsvLink = addQueryArgs(
-		{ page: 'subscribers', blog: siteId, blog_subscribers: 'csv', type: 'email' },
+		{ page: 'subscribers', blog: siteId, blog_subscribers: 'csv', type: 'all' },
 		'https://dashboard.wordpress.com/wp-admin/index.php'
 	);
 	const recordExport = useRecordExport();
@@ -56,7 +56,7 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 				focusOnShow={ false }
 			>
 				<PopoverMenuItem href={ downloadCsvLink } onClick={ onDownloadCsvClick }>
-					{ translate( 'Download email subscribers as CSV' ) }
+					{ translate( 'Download subscribers as CSV' ) }
 				</PopoverMenuItem>
 			</PopoverMenu>
 		</div>

--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -1,4 +1,6 @@
 import { Gridicon } from '@automattic/components';
+import { useLocale } from '@automattic/i18n-utils';
+import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
@@ -24,6 +26,8 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 		'https://dashboard.wordpress.com/wp-admin/index.php'
 	);
 	const recordExport = useRecordExport();
+	const locale = useLocale();
+	const { hasTranslation } = useI18n();
 
 	const onDownloadCsvClick = () => {
 		dispatch(
@@ -56,7 +60,11 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 				focusOnShow={ false }
 			>
 				<PopoverMenuItem href={ downloadCsvLink } onClick={ onDownloadCsvClick }>
-					{ translate( 'Download subscribers as CSV' ) }
+					{ ( locale.startsWith( 'en' ) || hasTranslation( 'Download subscribers as CSV' ) ) &&
+						translate( 'Download subscribers as CSV' ) }
+					{ ! locale.startsWith( 'en' ) &&
+						! hasTranslation( 'Download subscribers as CSV' ) &&
+						translate( 'Download email subscribers as CSV' ) }
 				</PopoverMenuItem>
 			</PopoverMenu>
 		</div>


### PR DESCRIPTION
☢️☢️☢️ Attention! Don't merge this PR until this patch is in production: D115660-code ☢️☢️☢️

Fixes https://github.com/Automattic/wp-calypso/issues/78888

## Proposed Changes

This PR changes the "Download subscribers as CSV" param from 'email' to 'all'. The backend is ready to interpret that value as "download the emails of all the users, whether email users or WPCOM users".

## Testing Instructions

1. Apply this PR and this patch in your sandbox (if it's not already in production): D115660-code
2. Go to `http://calypso.localhost:3000/subscribers/[domain of your site]`.
3. Click on the ellipsis menu in the top right corner of the screen and then on the "Download subscribers as CSV" link:
<img width="913" alt="Screenshot 2023-07-10 at 20 33 10" src="https://github.com/Automattic/wp-calypso/assets/3832570/2d14b7bf-5199-4078-ab00-f11aa63f9646">
4. You should have downloaded a CSV file with the emails from both the email and WPCOM users.

## Pre-merge Checklist
- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?