### PR TITLE
Convert PartnerPortalSidebar to functional component

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
@@ -1,7 +1,7 @@
-import config from '@automattic/calypso-config';
-import { localize, translate as TranslateType } from 'i18n-calypso';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { isEnabled } from '@automattic/calypso-config';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import Sidebar from 'calypso/layout/sidebar';
 import SidebarItem from 'calypso/layout/sidebar/item';
@@ -11,105 +11,100 @@ import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import 'calypso/components/jetpack/sidebar/style.scss';
 
-interface Props {
+type Props = {
 	path: string;
-	dispatchRecordTracksEvent: typeof recordTracksEvent;
-	translate: typeof TranslateType;
-}
-class PartnerPortalSidebar extends Component< Props > {
-	onNavigate = ( menuItem: string ) => () => {
-		this.props.dispatchRecordTracksEvent( 'calypso_jetpack_sidebar_menu_click', {
-			menu_item: menuItem,
-		} );
+};
 
-		window.scrollTo( 0, 0 );
-	};
+const PartnerPortalSidebar: React.FC< Props > = ( { path } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
 
-	render() {
-		const { translate, path } = this.props;
+	const onNavigate = useCallback(
+		( menuItem: string ) => () => {
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_sidebar_menu_click', {
+					menu_item: menuItem,
+				} )
+			);
+		},
+		[ dispatch ]
+	);
 
-		return (
-			<Sidebar className="sidebar__jetpack-cloud">
-				<SidebarRegion>
-					<SidebarMenu>
+	const arePaymentsEnabled = isEnabled( 'jetpack/partner-portal-payment' );
+
+	return (
+		<Sidebar className="sidebar__jetpack-cloud">
+			<SidebarRegion>
+				<SidebarMenu>
+					<SidebarItem
+						customIcon={ <JetpackIcons icon="licenses" /> }
+						label={ translate( 'Licenses', {
+							comment: 'Jetpack sidebar navigation item',
+						} ) }
+						link="/partner-portal/licenses"
+						onNavigate={ onNavigate( 'Jetpack Cloud / Partner Portal / Licenses' ) }
+						selected={ itemLinkMatches( '/partner-portal/licenses', path ) }
+					/>
+
+					<SidebarItem
+						customIcon={ <JetpackIcons icon={ arePaymentsEnabled ? 'money' : 'credit-card' } /> }
+						label={ translate( 'Billing', {
+							comment: 'Jetpack sidebar navigation item',
+						} ) }
+						link="/partner-portal/billing"
+						onNavigate={ onNavigate( 'Jetpack Cloud / Partner Portal' ) }
+						selected={ path === '/partner-portal/billing' }
+					/>
+
+					{ arePaymentsEnabled && (
 						<SidebarItem
-							customIcon={ <JetpackIcons icon="licenses" /> }
-							label={ translate( 'Licenses', {
-								comment: 'Jetpack sidebar navigation item',
+							customIcon={ <JetpackIcons icon="credit-card" /> }
+							label={ translate( 'Payment Methods', {
+								comment: 'Jeptack sidebar navigation item',
 							} ) }
-							link="/partner-portal/licenses"
-							onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Licenses' ) }
-							selected={ itemLinkMatches( '/partner-portal/licenses', path ) }
+							link="/partner-portal/payment-methods"
+							onNavigate={ onNavigate( 'Jetpack Cloud / Partner Portal / Payment Methods' ) }
+							selected={ itemLinkMatches( '/partner-portal/payment-methods', path ) }
 						/>
+					) }
 
+					{ arePaymentsEnabled && (
 						<SidebarItem
-							customIcon={
-								<JetpackIcons
-									icon={
-										config.isEnabled( 'jetpack/partner-portal-payment' ) ? 'money' : 'credit-card'
-									}
-								/>
-							}
-							label={ translate( 'Billing', {
-								comment: 'Jetpack sidebar navigation item',
+							customIcon={ <JetpackIcons icon="page" /> }
+							label={ translate( 'Invoices', {
+								comment: 'Jeptack sidebar navigation item',
 							} ) }
-							link="/partner-portal/billing"
-							onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal' ) }
-							selected={ path === '/partner-portal/billing' }
+							link="/partner-portal/invoices"
+							onNavigate={ onNavigate( 'Jetpack Cloud / Partner Portal / Invoices' ) }
+							selected={ itemLinkMatches( '/partner-portal/invoices', path ) }
 						/>
+					) }
 
-						{ config.isEnabled( 'jetpack/partner-portal-payment' ) && (
-							<SidebarItem
-								customIcon={ <JetpackIcons icon="credit-card" /> }
-								label={ translate( 'Payment Methods', {
-									comment: 'Jeptack sidebar navigation item',
-								} ) }
-								link="/partner-portal/payment-methods"
-								onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Payment Methods' ) }
-								selected={ itemLinkMatches( '/partner-portal/payment-methods', path ) }
-							/>
-						) }
+					<SidebarItem
+						customIcon={ <JetpackIcons icon="prices" /> }
+						label={ translate( 'Prices', {
+							comment: 'Jetpack sidebar navigation item',
+						} ) }
+						link="/partner-portal/prices"
+						onNavigate={ onNavigate( 'Jetpack Cloud / Partner Portal / Prices' ) }
+						selected={ itemLinkMatches( '/partner-portal/prices', path ) }
+					/>
 
-						{ config.isEnabled( 'jetpack/partner-portal-payment' ) && (
-							<SidebarItem
-								customIcon={ <JetpackIcons icon="page" /> }
-								label={ translate( 'Invoices', {
-									comment: 'Jeptack sidebar navigation item',
-								} ) }
-								link="/partner-portal/invoices"
-								onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Invoices' ) }
-								selected={ itemLinkMatches( '/partner-portal/invoices', path ) }
-							/>
-						) }
-
+					{ arePaymentsEnabled && (
 						<SidebarItem
-							customIcon={ <JetpackIcons icon="prices" /> }
-							label={ translate( 'Prices', {
-								comment: 'Jetpack sidebar navigation item',
+							customIcon={ <JetpackIcons icon="settings" /> }
+							label={ translate( 'Company Details', {
+								comment: 'Jeptack sidebar navigation item',
 							} ) }
-							link="/partner-portal/prices"
-							onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Prices' ) }
-							selected={ itemLinkMatches( '/partner-portal/prices', path ) }
+							link="/partner-portal/company-details"
+							onNavigate={ onNavigate( 'Jetpack Cloud / Partner Portal / Company Details' ) }
+							selected={ itemLinkMatches( '/partner-portal/company-details', path ) }
 						/>
+					) }
+				</SidebarMenu>
+			</SidebarRegion>
+		</Sidebar>
+	);
+};
 
-						{ config.isEnabled( 'jetpack/partner-portal-payment' ) && (
-							<SidebarItem
-								customIcon={ <JetpackIcons icon="settings" /> }
-								label={ translate( 'Company Details', {
-									comment: 'Jeptack sidebar navigation item',
-								} ) }
-								link="/partner-portal/company-details"
-								onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Company Details' ) }
-								selected={ itemLinkMatches( '/partner-portal/company-details', path ) }
-							/>
-						) }
-					</SidebarMenu>
-				</SidebarRegion>
-			</Sidebar>
-		);
-	}
-}
-
-export default connect( null, {
-	dispatchRecordTracksEvent: recordTracksEvent,
-} )( localize( PartnerPortalSidebar ) );
+export default PartnerPortalSidebar;


### PR DESCRIPTION
This PR isn't attached to any ongoing task; I just noticed we had a class-based component that could be pretty quickly refactored into a functional one, to match most of the rest of Calypso.

## Proposed Changes

* Convert `PartnerPortalSidebar` from a class-based component to a function-based one.
* Convert `onNavigate` from a class method to a memoized callback.
* Convert `Props` from an interface to a type (for uniformity with most of the rest of Calypso, with no real loss of functionality).
* Extract the feature flag check for `jetpack/partner-portal-payment` into its own variable.

## Testing Instructions

* Click through every link in the Partner Portal sidebar, verifying that you're taken to the appropriate page. Be sure to also check that the correct Tracks events are fired with the correct arguments.

<img width="262" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/ea21841c-8cbc-4f3f-80f1-48c329f207af">