### PR TITLE
Domains: Fix second-level domains in some domain availability error notices

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -13,7 +13,6 @@ import FeaturedDomainSuggestions from 'calypso/components/domains/featured-domai
 import MaterialIcon from 'calypso/components/material-icon';
 import Notice from 'calypso/components/notice';
 import { isDomainMappingFree, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
-import { getTld } from 'calypso/lib/domains';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import { DESIGN_TYPE_STORE } from 'calypso/signup/constants';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
@@ -65,6 +64,7 @@ class DomainSearchResults extends Component {
 			lastDomainIsTransferrable,
 			lastDomainStatus,
 			lastDomainSearched,
+			lastDomainTld,
 			selectedSite,
 			translate,
 			isDomainOnly,
@@ -138,7 +138,7 @@ class DomainSearchResults extends Component {
 				? translate(
 						'{{strong}}.%(tld)s{{/strong}} domains are not available for registration on WordPress.com.',
 						{
-							args: { tld: getTld( domain ) },
+							args: { tld: lastDomainTld },
 							components: {
 								strong: <strong />,
 							},
@@ -179,7 +179,7 @@ class DomainSearchResults extends Component {
 					'{{strong}}.%(tld)s{{/strong}} domains are temporarily not offered on WordPress.com. ' +
 						'Please try again later or choose a different extension.',
 					{
-						args: { tld: getTld( domain ) },
+						args: { tld: lastDomainTld },
 						components: { strong: <strong /> },
 					}
 				);

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -213,6 +213,7 @@ class RegisterDomainStep extends Component {
 			availabilityError: null,
 			availabilityErrorData: null,
 			availabilityErrorDomain: null,
+			availabilityErrorDomainTld: null,
 			availableTlds: [],
 			bloggerFilterAdded: false,
 			clickedExampleSuggestion: false,
@@ -398,6 +399,7 @@ class RegisterDomainStep extends Component {
 			availabilityError,
 			availabilityErrorData,
 			availabilityErrorDomain,
+			availabilityErrorDomainTld,
 			showAvailabilityNotice,
 			showSuggestionNotice,
 			suggestionError,
@@ -415,7 +417,7 @@ class RegisterDomainStep extends Component {
 			? getAvailabilityNotice( suggestionErrorDomain, suggestionError, suggestionErrorData )
 			: {};
 		const { message: availabilityMessage, severity: availabilitySeverity } = showAvailabilityNotice
-			? getAvailabilityNotice( availabilityErrorDomain, availabilityError, availabilityErrorData )
+			? getAvailabilityNotice( availabilityErrorDomain, availabilityError, availabilityErrorData, null, availabilityErrorDomainTld )
 			: {};
 
 		const containerDivClassName = classNames( 'register-domain-step', {
@@ -749,6 +751,7 @@ class RegisterDomainStep extends Component {
 			availabilityError: null,
 			availabilityErrorData: null,
 			availabilityErrorDomain: null,
+			availabilityErrorDomainTld: null,
 			exactMatchDomain: null,
 			lastDomainSearched: null,
 			lastFilters: this.state.filters,
@@ -856,6 +859,7 @@ class RegisterDomainStep extends Component {
 				availabilityError: null,
 				availabilityErrorData: null,
 				availabilityErrorDomain: null,
+				availabilityErrorDomainTld: null,
 				exactMatchDomain: null,
 				lastDomainSearched: null,
 				isQueryInvalid: false,
@@ -989,6 +993,7 @@ class RegisterDomainStep extends Component {
 
 					this.setState( {
 						exactMatchDomain: domainChecked,
+						lastDomainTld: result.tld,
 						lastDomainStatus: availabilityStatus,
 						lastDomainIsTransferrable: isDomainTransferrable,
 					} );
@@ -1011,6 +1016,7 @@ class RegisterDomainStep extends Component {
 						this.showAvailabilityErrorMessage( domain, availabilityStatus, {
 							site,
 							maintenanceEndTime: get( result, 'maintenance_end_time', null ),
+							tld: result.tld,
 						} );
 					}
 
@@ -1390,6 +1396,7 @@ class RegisterDomainStep extends Component {
 			lastDomainIsTransferrable,
 			lastDomainSearched,
 			lastDomainStatus,
+			lastDomainTld,
 			premiumDomains,
 		} = this.state;
 
@@ -1426,6 +1433,7 @@ class RegisterDomainStep extends Component {
 				isDomainOnly={ this.props.isDomainOnly }
 				lastDomainSearched={ lastDomainSearched }
 				lastDomainStatus={ lastDomainStatus }
+				lastDomainTld={ lastDomainTld }
 				lastDomainIsTransferrable={ lastDomainIsTransferrable }
 				onAddMapping={ onAddMapping }
 				onClickResult={ this.onAddDomain }
@@ -1579,6 +1587,7 @@ class RegisterDomainStep extends Component {
 			availabilityError: error,
 			availabilityErrorData: errorData,
 			availabilityErrorDomain: domain,
+			availabilityErrorDomainTld: errorData?.tld,
 		} );
 	}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -417,7 +417,14 @@ class RegisterDomainStep extends Component {
 			? getAvailabilityNotice( suggestionErrorDomain, suggestionError, suggestionErrorData )
 			: {};
 		const { message: availabilityMessage, severity: availabilitySeverity } = showAvailabilityNotice
-			? getAvailabilityNotice( availabilityErrorDomain, availabilityError, availabilityErrorData, null, availabilityErrorDomainTld )
+			? getAvailabilityNotice(
+					availabilityErrorDomain,
+					availabilityError,
+					availabilityErrorData,
+					null,
+					null,
+					availabilityErrorDomainTld
+			  )
 			: {};
 
 		const containerDivClassName = classNames( 'register-domain-step', {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -213,7 +213,6 @@ class RegisterDomainStep extends Component {
 			availabilityError: null,
 			availabilityErrorData: null,
 			availabilityErrorDomain: null,
-			availabilityErrorDomainTld: null,
 			availableTlds: [],
 			bloggerFilterAdded: false,
 			clickedExampleSuggestion: false,
@@ -399,7 +398,6 @@ class RegisterDomainStep extends Component {
 			availabilityError,
 			availabilityErrorData,
 			availabilityErrorDomain,
-			availabilityErrorDomainTld,
 			showAvailabilityNotice,
 			showSuggestionNotice,
 			suggestionError,
@@ -417,14 +415,7 @@ class RegisterDomainStep extends Component {
 			? getAvailabilityNotice( suggestionErrorDomain, suggestionError, suggestionErrorData )
 			: {};
 		const { message: availabilityMessage, severity: availabilitySeverity } = showAvailabilityNotice
-			? getAvailabilityNotice(
-					availabilityErrorDomain,
-					availabilityError,
-					availabilityErrorData,
-					null,
-					null,
-					availabilityErrorDomainTld
-			  )
+			? getAvailabilityNotice( availabilityErrorDomain, availabilityError, availabilityErrorData )
 			: {};
 
 		const containerDivClassName = classNames( 'register-domain-step', {
@@ -758,7 +749,6 @@ class RegisterDomainStep extends Component {
 			availabilityError: null,
 			availabilityErrorData: null,
 			availabilityErrorDomain: null,
-			availabilityErrorDomainTld: null,
 			exactMatchDomain: null,
 			lastDomainSearched: null,
 			lastFilters: this.state.filters,
@@ -866,7 +856,6 @@ class RegisterDomainStep extends Component {
 				availabilityError: null,
 				availabilityErrorData: null,
 				availabilityErrorDomain: null,
-				availabilityErrorDomainTld: null,
 				exactMatchDomain: null,
 				lastDomainSearched: null,
 				isQueryInvalid: false,
@@ -1023,7 +1012,6 @@ class RegisterDomainStep extends Component {
 						this.showAvailabilityErrorMessage( domain, availabilityStatus, {
 							site,
 							maintenanceEndTime: get( result, 'maintenance_end_time', null ),
-							tld: result.tld,
 						} );
 					}
 
@@ -1594,7 +1582,6 @@ class RegisterDomainStep extends Component {
 			availabilityError: error,
 			availabilityErrorData: errorData,
 			availabilityErrorDomain: domain,
-			availabilityErrorDomainTld: errorData?.tld,
 		} );
 	}
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -529,6 +529,7 @@ class TransferDomainStep extends Component {
 				{ domainName: domain, blogId: get( this.props, 'selectedSite.ID', null ) },
 				( error, result ) => {
 					const status = get( result, 'status', error );
+					const tld = result.tld || getTld( domain );
 					switch ( status ) {
 						case domainAvailability.AVAILABLE:
 							this.setState( { suggestion: result } );
@@ -542,8 +543,6 @@ class TransferDomainStep extends Component {
 							} );
 							break;
 						case domainAvailability.TLD_NOT_SUPPORTED: {
-							const tld = getTld( domain );
-
 							this.setState( {
 								notice: this.props.translate(
 									'This domain appears to be available for registration, however we do not offer registrations or accept transfers for domains ending in {{strong}}.%(tld)s{{/strong}}. ' +
@@ -563,8 +562,6 @@ class TransferDomainStep extends Component {
 						case domainAvailability.MAPPABLE:
 						case domainAvailability.TLD_NOT_SUPPORTED_TEMPORARILY:
 						case domainAvailability.TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE: {
-							const tld = getTld( domain );
-
 							this.setState( {
 								notice: this.props.translate(
 									"We don't support transfers for domains ending with {{strong}}.%(tld)s{{/strong}}, " +

--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -109,7 +109,7 @@ export function getOptionInfo( {
 						__(
 							"We don't support transfers for domains ending with <strong>.%s</strong>, but you can connect it instead."
 						),
-						getTld( domain )
+						availability.tld || getTld( domain )
 					),
 					{ strong: createElement( 'strong' ) }
 				),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -70,7 +70,8 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		validationResult?.status,
 		null,
 		true,
-		'_blank'
+		'_blank',
+		validationResult?.tld
 	);
 
 	// final success

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -34,6 +34,7 @@ type DomainLockResponse = {
 	raw_price?: number;
 	sale_cost?: number;
 	currency_code?: string;
+	tld?: string;
 };
 
 type DomainCodePair = { domain: string; auth: string };
@@ -59,6 +60,7 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 				if ( ! isUnlocked ) {
 					return {
 						domain: pair.domain,
+						tld: availability.tld,
 						status: availability.status,
 						unlocked: false,
 					};

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -23,9 +23,10 @@ function getAvailabilityNotice(
 	error,
 	errorData,
 	isForTransferOnly = false,
-	linksTarget = '_self'
+	linksTarget = '_self',
+	domainTld = ''
 ) {
-	const tld = domain ? getTld( domain ) : null;
+	const tld = domainTld || ( domain ? getTld( domain ) : null );
 	const { site, maintenanceEndTime, availabilityPreCheck } = errorData || {};
 
 	// The message is set only when there is a valid error


### PR DESCRIPTION
## Proposed Changes

In some pages, when we search for a domain with an unsupported second-level domain like `.co.jp`, we show an availability error notice with the incorrect TLD, e.g. we show a message like `.jp domains are unsupported` (but it is) instead of `.co.jp domains are unsupported`. 

This PR updates these notices to use the correct TLD or SLD returned from the domain availability endpoint.

This depends on D116140-code

### Screenshots without this PR

These are some of the pages that show incorrect messages:

- `/setup/domain-transfer` page

> <img width="794" alt="Screenshot 2023-07-14 at 19 59 20" src="https://github.com/Automattic/wp-calypso/assets/5324818/1f0d6a89-1dc4-4877-b933-dc46dc5c2930">

- `/domains/` domain search

> <img width="964" alt="Screenshot 2023-07-14 at 21 10 00" src="https://github.com/Automattic/wp-calypso/assets/5324818/b2275c94-9c19-4f1a-9e0d-b093ec0febed">

- Site domain search page

> <img width="1078" alt="Screenshot 2023-07-14 at 19 34 30" src="https://github.com/Automattic/wp-calypso/assets/5324818/f065a2fc-6805-4e53-8eba-df33dc6d0848">

- Domain connect or transfer page

> <img width="1065" alt="Screenshot 2023-07-14 at 19 43 58" src="https://github.com/Automattic/wp-calypso/assets/5324818/3e42fb77-6ac3-42dd-8c45-171fffacd3de">

### Screenshots with the PR

These are the same pages above with this PR applied:

- `/setup/domain-transfer` page

> <img width="790" alt="Screenshot 2023-07-14 at 19 59 14" src="https://github.com/Automattic/wp-calypso/assets/5324818/e54e51c0-f375-4fc3-a98e-82c5ad407dcd">

- `/domains/` domain search

> <img width="968" alt="Screenshot 2023-07-14 at 21 10 13" src="https://github.com/Automattic/wp-calypso/assets/5324818/6320f950-1806-403f-b042-a1d00f67a92f">

- Site domain search page

> <img width="1066" alt="Screenshot 2023-07-14 at 19 34 36" src="https://github.com/Automattic/wp-calypso/assets/5324818/4d15dc64-59e0-45d1-a77e-69711e93a896">

- Domain connect or transfer page

> <img width="1071" alt="Screenshot 2023-07-14 at 19 44 23" src="https://github.com/Automattic/wp-calypso/assets/5324818/507cf9e5-fd48-43ec-94c3-b2aa5104772b">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the live Calypso link or build this branch locally
- You need to have D116140-code applied in your backend
- Visit the following pages and search for a domain with an unsupported SLD, e.g. `.co.jp`
  - `/setup/domain-transfer`
  - `/domains/`
  - Site domain search page
  - Domain connect or transfer page
- Ensure the correct TLD is shown in the domain availability error message

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?