### PR TITLE
VideoPress HQ: implement options step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
@@ -113,7 +113,8 @@
 		}
 	}
 
-	.videopress & {
+	.videopress &,
+	.videopress-tv & {
 		max-width: 425px;
 
 		.step-container__header {

--- a/client/landing/stepper/declarative-flow/videopress-tv.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv.ts
@@ -2,6 +2,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, VIDEOPRESS_TV_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
 import './internals/videopress.scss';
 import SiteOptions from './internals/steps-repository/site-options';
@@ -39,16 +40,34 @@ const videopressTv: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
+		const { setSiteDescription, setSiteTitle } = useDispatch( ONBOARD_STORE );
 
 		setStepProgress( flowProgress );
 
-		switch ( _currentStep ) {
-			case 'intro':
-				break;
-			case 'options':
-				// todo: validate user logged in
-				break;
-		}
+		const clearOnboardingSiteOptions = () => {
+			setSiteTitle( '' );
+			setSiteDescription( '' );
+		};
+
+		const stepValidateUserIsLoggedIn = () => {
+			if ( ! userIsLoggedIn ) {
+				navigate( 'intro' );
+				return false;
+			}
+			return true;
+		};
+
+		// needs to be wrapped in a useEffect because validation can call `navigate` which needs to be called in a useEffect
+		useEffect( () => {
+			switch ( _currentStep ) {
+				case 'intro':
+					clearOnboardingSiteOptions();
+					break;
+				case 'options':
+					stepValidateUserIsLoggedIn();
+					break;
+			}
+		} );
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {

--- a/client/landing/stepper/declarative-flow/videopress-tv.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv.ts
@@ -79,6 +79,12 @@ const videopressTv: Flow = {
 					return window.location.replace(
 						`/start/videopress-account/user/${ locale }?variationName=${ name }&flow=${ name }&pageTitle=VideoPress.TV&redirect_to=/setup/videopress-tv/options`
 					);
+				case 'options': {
+					const { siteTitle, tagline } = providedDependencies;
+					setSiteTitle( siteTitle );
+					setSiteDescription( tagline );
+					console.log( 'TODO: site creation with title, description', siteTitle, tagline ); // eslint-disable-line no-console
+				}
 			}
 			return providedDependencies;
 		}

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -92,6 +92,53 @@ export function* createVideoPressSite( {
 	return success;
 }
 
+export function* createVideoPressTvSite( {
+	languageSlug,
+	visibility = Visibility.PublicNotIndexed,
+}: CreateSiteBaseActionParameters ) {
+	const { selectedDesign, selectedFonts, siteTitle, selectedFeatures }: State = yield select(
+		STORE_KEY,
+		'getState'
+	);
+
+	const lang_id = ( getLanguage( languageSlug ) as Language )?.value;
+	const blogTitle = siteTitle.trim() === '' ? __( 'Site Title' ) : siteTitle;
+
+	const params: CreateSiteParams = {
+		blog_name: '', // will be replaced on server with random domain
+		blog_title: blogTitle,
+		public: visibility,
+		options: {
+			site_information: {
+				title: blogTitle,
+			},
+			lang_id: lang_id,
+			site_creation_flow: 'videopress-tv',
+			enable_fse: true,
+			theme: 'pub/videopress-hq',
+			timezone_string: guessTimezone(),
+			...( selectedDesign?.template && { template: selectedDesign.template } ),
+			...( selectedFonts && {
+				font_base: selectedFonts.base,
+				font_headings: selectedFonts.headings,
+			} ),
+			use_patterns: true,
+			selected_features: selectedFeatures,
+			wpcom_public_coming_soon: 1,
+			...( selectedDesign && { is_blank_canvas: isBlankCanvasDesign( selectedDesign ) } ),
+			is_videopress_initial_purchase: true,
+		},
+	};
+
+	const success: NewSiteBlogDetails | undefined = yield dispatch(
+		SITE_STORE,
+		'createSite',
+		params
+	);
+
+	return success;
+}
+
 export function* createSenseiSite( {
 	username = '',
 	languageSlug = '',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/greenhouse/issues/1783

## Proposed Changes

* implement the Options step with all required validations and storage

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn && yarn start` or use a calypso.live link
* visit `/setup/videopress-tv/options` in an incognito browser
* you should be redirected to the `/intro` step
* create a new user (or if you choose `login`, you will need to manually navigate back to the flow using `back` or visiting /options again)
* you should be forwarded to the `/options` page
* refresh the page, you should remain on the `/options` page
* enter a title and description, press `Continue`
   * you should see a TODO message printed in the console with your title and description
* refresh the page, your title and description should be persisted
* return to `/intro` then go through the flow. Your persisted title and description should be removed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
