### PR TITLE
VideoPress Onboarding: Fix flow blocking bugs

### DIFF
--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -3,7 +3,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, VIDEOPRESS_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
 import { useNewSiteVisibility } from 'calypso/landing/stepper/hooks/use-selected-plan';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
@@ -216,22 +216,24 @@ const videopress: Flow = {
 			} );
 		};
 
-		switch ( _currentStep ) {
-			case 'intro':
-				clearOnboardingSiteOptions();
-				break;
-			case 'options':
-				stepValidateUserIsLoggedIn();
-				break;
-			case 'chooseADomain':
-				stepValidateSiteTitle();
-				break;
-			case 'processing':
-				if ( ! _siteSlug ) {
-					addVideoPressPendingAction();
-				}
-				break;
-		}
+		useEffect( () => {
+			switch ( _currentStep ) {
+				case 'intro':
+					clearOnboardingSiteOptions();
+					break;
+				case 'options':
+					stepValidateUserIsLoggedIn();
+					break;
+				case 'chooseADomain':
+					stepValidateSiteTitle();
+					break;
+				case 'processing':
+					if ( ! _siteSlug ) {
+						addVideoPressPendingAction();
+					}
+					break;
+			}
+		} );
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -216,6 +216,7 @@ const videopress: Flow = {
 			} );
 		};
 
+		// needs to be wrapped in a useEffect because validation can call `navigate` which needs to be called in a useEffect
 		useEffect( () => {
 			switch ( _currentStep ) {
 				case 'intro':

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -62,7 +62,10 @@ function getRedirectToAfterLoginUrl( {
 	) {
 		return initialContext.query.oauth2_redirect;
 	}
-	if ( initialContext?.canonicalPath?.startsWith( '/start/account' ) ) {
+	if (
+		initialContext?.canonicalPath?.startsWith( '/start/account' ) ||
+		initialContext?.canonicalPath?.startsWith( '/start/videopress-account' )
+	) {
 		return initialContext.query.redirect_to;
 	}
 
@@ -217,7 +220,13 @@ export class UserStep extends Component {
 					'By creating an account via any of the options below, {{br/}}you agree to our {{a}}Terms of Service{{/a}}.',
 					{
 						components: {
-							a: <a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer" />,
+							a: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
 							br: <br />,
 						},
 					}


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* wrap nested call to `navigate` on step load in `useEffect` which appears to be a new requirement
* add an early return for `/start/videopress-account` account creation flow where the existing `/start/account` page early returns
* Also had to make an unrelated `localizeUrl` change to the Crowdsignal oauth flow because the linter was complaining.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn && yarn start` or use a calypso.live link
* open `/setup/videopress/options` in an incognito browser
* You should be redirected to the `/intro` step (1st bug fix)
* go through the flow, at Account Creation choose the `login` link
* login with an existing account
* upon login, you should be redirected back to the onboarding flow to the `/options` step (2nd bug fix)
* TEST THE Crowdsignal oauth TOS link by:
   * visit crowdsignal.com in an incognito browser
   * click "Login"
   * change the url from `https://wordpress.com` to your test url (ex calypso.live url or `http://calypso.localhost`
   * click "Create a new account" link at the bottom of the form below all the sign in options
   * check the "Terms of Service" link at the top of the new page, it should be a valid link

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
