### PR TITLE
Checkout: Short-circuit new card processor for failed cards when free

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -3,6 +3,7 @@ import {
 	makeSuccessResponse,
 	makeRedirectResponse,
 	makeErrorResponse,
+	PaymentProcessorResponseType,
 } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
 import { createEbanxToken } from 'calypso/lib/store-transactions';
@@ -294,6 +295,10 @@ export default async function multiPartnerCardProcessor(
 				address: dataForProcessor.contactDetails?.address1?.value,
 			}
 		);
+		if ( newCardResponse.type === PaymentProcessorResponseType.ERROR ) {
+			return newCardResponse;
+		}
+
 		const storedCard = newCardResponse.payload;
 		if ( ! isValidNewCardResponseData( storedCard ) ) {
 			throw new Error( 'New card was not saved' );


### PR DESCRIPTION
## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/79083 added support for using the new card payment method in checkout when the cart total is 0. The way this works is by doing a multi-step process. First it adds a new card without a purchase, just like the "Add payment method" form. Then it completes the purchase with the new card as an existing payment method.

However, if the first part of the process fails (the new card does not get created because eg: it is declined), then we need to stop the process and return early to avoid fatal errors. In this PR we do that.

Before:

<img width="1505" alt="Screenshot 2023-07-10 at 3 53 44 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/420709f2-e941-4efe-aa0d-5d5394c092e3">

After:

<img width="1507" alt="Screenshot 2023-07-10 at 4 08 39 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/08cdf284-bad7-4823-b704-d6a1d76b4707">


## Testing Instructions

- Sandbox the API so you can use test cards.
- Add sufficient credits to your account for the purchase to be free.
- Visit checkout with something in your cart. Make sure that it is free.
- Select "Credit or debit card" as the payment method.
- Enter a [valid test card that will fail](https://stripe.com/docs/testing#declined-payments), eg: `4000000000000002` along with any other info.
- Submit the purchase.
- Verify that you see an error message and checkout does not crash.