### PR TITLE
Fix TypeError: Cannot read properties of null (reading 'selectedSite.plan')

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -214,7 +214,7 @@ class CurrentPlan extends Component {
 			isJetpackNotAtomic,
 		} = this.props;
 
-		const currentPlanSlug = selectedSite?.plan?.product_slug;
+		const currentPlanSlug = selectedSite?.plan?.product_slug ?? '';
 		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 		const shouldQuerySiteDomains = selectedSiteId && shouldShowDomainWarnings;
 		const showDomainWarnings = hasDomainsLoaded && shouldShowDomainWarnings;

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -161,7 +161,7 @@ class CurrentPlan extends Component {
 	renderMain() {
 		const { selectedSiteId, selectedSite, showJetpackChecklist, translate } = this.props;
 		const isLoading = this.isLoading();
-		const currentPlanSlug = selectedSite.plan.product_slug;
+		const currentPlanSlug = selectedSite?.plan?.product_slug ?? '';
 		const planTitle = getPlan( currentPlanSlug ).getTitle();
 		const planFeaturesHeader = translate( '{{planName/}} plan features', {
 			components: { planName: <>{ planTitle }</> },
@@ -214,7 +214,7 @@ class CurrentPlan extends Component {
 			isJetpackNotAtomic,
 		} = this.props;
 
-		const currentPlanSlug = selectedSite.plan.product_slug;
+		const currentPlanSlug = selectedSite?.plan?.product_slug;
 		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 		const shouldQuerySiteDomains = selectedSiteId && shouldShowDomainWarnings;
 		const showDomainWarnings = hasDomainsLoaded && shouldShowDomainWarnings;


### PR DESCRIPTION
This PR fixes a TypeError where `selectedSite.plan.product_slug` could be undefined (according to Sentry), when it is expected to be a string.

Sentry Issue: [CALYPSO-18T3](https://a8c.sentry.io/issues/4277107001/?referrer=github_integration)

Asana task: 1201210512993648-as-1205000085153128/f
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Added optional chaining with nullish coalescing operator to fix the issue.

## Implementation Notes:

- Although Sentry indicates that this TypeError could occur, I cannot seem to reproduce `selectedSite` being `null` or `undefined` because when selectedSite is null or undefined, Calypso immediately redirects to site selection, forcing you to select a site.
But still, I'm applying these fixes just to make sure, and to satisfy Sentry. 😉

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this PR & spin up Calypso (`git fetch && git checkout fix/typeerror-selectedsite-plan && yarn start`).
- Go to: http://calypso.localhost:3000/plans/my-plan and select a Jetpack site you have connected. (Or create a Jurassic Ninja site or Ephemeral site and connect it to your account).
- In the url, add a `thank-you` query arg. You url should look like: `http://calypso.localhost:3000/plans/my-plan/:SITE/?thank-you` (Replace :SITE with your site's name).
- Verify everything appears to be working properly and you do not see any errors in the console.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?