### PR TITLE
Domain transfer: fix filter duration

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -29,7 +29,7 @@ const Complete: Step = function Complete( { flow } ) {
 
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const userPurchases = useSelector( ( state ) => getUserPurchases( state ) );
-	const oneDay = 999999 * 60 * 60 * 1000; // Number of milliseconds in a day
+	const oneDay = 24 * 60 * 60 * 1000; // Number of milliseconds in a day
 
 	const newlyTransferredDomains = userPurchases?.filter(
 		( purchase ) =>


### PR DESCRIPTION
Follow up for https://github.com/Automattic/wp-calypso/pull/79177/files.

That PR shows purchases from 99999 hours on the Congrats page of domain transfer, a leftover from testing.

This reverts back to 1 day.