### PR TITLE
Domains: Include checkbox to import DNS records for incoming transfers

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -24,7 +24,7 @@ export interface Props {
 }
 
 const defaultState: DomainTransferForm = {
-	shouldImportDnsRecords: false,
+	shouldImportDnsRecords: true,
 	domains: {
 		[ uuid() ]: {
 			domain: '',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -102,6 +102,7 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 					extra: {
 						auth_code: auth,
 						signup: false,
+						import_dns_records: storedDomainsState.shouldImportDnsRecords,
 					},
 				} )
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -7,7 +7,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -362,7 +362,7 @@
 			border-bottom: 1px solid rgba(220, 220, 222, 0.64);
 			font-weight: 500;
 			padding: 20px 0;
-			margin-bottom: 42px;
+			margin-bottom: 20px;
 
 			div:nth-of-type(1) {
 				flex: 9;
@@ -377,11 +377,9 @@
 				}
 			}
 		}
-		
+
 		.bulk-domain-transfer__import-dns-records {
 			margin-bottom: 42px;
-			padding-top: 20px;
-			border-top: 1px solid #d9d9d9;
 		}
 
 		.bulk-domain-transfer__cta-container {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -377,6 +377,10 @@
 				}
 			}
 		}
+		
+		.bulk-domain-transfer__import-dns-records {
+			margin-bottom: 20px;
+		}
 
 		.bulk-domain-transfer__cta-container {
 			display: flex;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -379,7 +379,9 @@
 		}
 		
 		.bulk-domain-transfer__import-dns-records {
-			margin-bottom: 20px;
+			margin-bottom: 42px;
+			padding-top: 20px;
+			border-top: 1px solid #d9d9d9;
 		}
 
 		.bulk-domain-transfer__cta-container {

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -456,6 +456,13 @@ export const setDomainsTransferData = ( bulkDomainsData: DomainTransferData | un
 	bulkDomainsData,
 } );
 
+export const setShouldImportDomainTransferDnsRecords = (
+	shouldImportDomainTransferDnsRecords: boolean
+) => ( {
+	type: 'SET_SHOULD_IMPORT_DOMAIN_TRANSFER_DNS_RECORDS' as const,
+	shouldImportDomainTransferDnsRecords,
+} );
+
 export const setHideFreePlan = ( hideFreePlan: boolean ) => ( {
 	type: 'SET_HIDE_FREE_PLAN' as const,
 	hideFreePlan,
@@ -494,6 +501,7 @@ export type OnboardAction = ReturnType<
 	| typeof resetOnboardStoreWithSkipFlags
 	| typeof setStoreType
 	| typeof setDomainsTransferData
+	| typeof setShouldImportDomainTransferDnsRecords
 	| typeof setDomain
 	| typeof setDomainCategory
 	| typeof setDomainSearch

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -36,6 +36,7 @@ export function register(): typeof STORE_KEY {
 			'anchorEpisodeId',
 			'anchorSpotifyUrl',
 			'domainTransferNames',
+			'shouldImportDomainTransferDnsRecords',
 			'domain',
 			'domainSearch',
 			'domainForm',

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -578,14 +578,14 @@ export const domainTransferAuthCodes: Reducer<
 };
 
 export const shouldImportDomainTransferDnsRecords: Reducer< boolean, OnboardAction > = (
-	state = false,
+	state = true,
 	action
 ) => {
 	if ( action.type === 'SET_SHOULD_IMPORT_DOMAIN_TRANSFER_DNS_RECORDS' ) {
 		return action.shouldImportDomainTransferDnsRecords;
 	}
 	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return false;
+		return true;
 	}
 	return state;
 };

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -577,6 +577,19 @@ export const domainTransferAuthCodes: Reducer<
 	return state;
 };
 
+export const shouldImportDomainTransferDnsRecords: Reducer< boolean, OnboardAction > = (
+	state = false,
+	action
+) => {
+	if ( action.type === 'SET_SHOULD_IMPORT_DOMAIN_TRANSFER_DNS_RECORDS' ) {
+		return action.shouldImportDomainTransferDnsRecords;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return false;
+	}
+	return state;
+};
+
 const paidSubscribers: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
 	if ( action.type === 'SET_PAID_SUBSCRIBERS' ) {
 		return action.paidSubscribers;
@@ -602,6 +615,7 @@ const reducer = combineReducers( {
 	selectedFeatures,
 	domainTransferNames,
 	domainTransferAuthCodes,
+	shouldImportDomainTransferDnsRecords,
 	storeType,
 	selectedFonts,
 	selectedDesign,

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -27,6 +27,8 @@ export const getBulkDomainsData = ( state: State ) => {
 	}
 	return domainTransferData;
 };
+export const getBulkDomainsImportDnsRecords = ( state: State ) =>
+	state.shouldImportDomainTransferDnsRecords;
 export const getIsRedirecting = ( state: State ) => state.isRedirecting;
 export const getPlanProductId = ( state: State ) => state.planProductId;
 export const getPlanCartItem = ( state: State ) => state.planCartItem;

--- a/packages/data-stores/src/onboard/types.ts
+++ b/packages/data-stores/src/onboard/types.ts
@@ -36,3 +36,8 @@ export type DomainTransferData = Record<
 		currencyCode?: string;
 	}
 >;
+
+export type DomainTransferForm = {
+	shouldImportDnsRecords: boolean;
+	domains: DomainTransferData;
+};

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -603,6 +603,7 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	selected_page_titles?: string[];
 	site_title?: string;
 	signup_flow?: string;
+	import_dns_records?: boolean;
 	signup?: boolean;
 	headstart_theme?: string;
 }


### PR DESCRIPTION
## Proposed Changes
Adds a checkbox to let the user decide whether they want to import their DNS records from their current NS. 

## Preview

![image](https://github.com/Automattic/wp-calypso/assets/18705930/3e997ea5-0a4f-4493-9883-6c87bf7bd862)



## Testing Instructions

- Build this branch locally or access the live link;
- Go to `/setup/domain-transfer/domains`;
- Ensure you can see the toggle and that its state persists through page reloads.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
