### PR TITLE
Help Center: disable the posting button when submitting

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -515,7 +515,7 @@ export const HelpCenterContactForm = () => {
 				<section className="contact-form-submit">
 					<Button
 						isBusy={ isFetchingGPTResponse }
-						disabled={ isFetchingGPTResponse }
+						disabled={ isFetchingGPTResponse || isCTADisabled() }
 						onClick={ handleCTA }
 						isPrimary={ ! showingGPTResponse || isGPTError }
 						isSecondary={ showingGPTResponse && ! isGPTError }

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -418,21 +418,6 @@ export const HelpCenterContactForm = () => {
 
 	const shouldShowHelpLanguagePrompt = getSupportedLanguages( mode, locale );
 
-	const isCTADisabled = () => {
-		if ( isSubmitting || ! message || ownershipStatusLoading ) {
-			return true;
-		}
-
-		switch ( mode ) {
-			case 'CHAT':
-				return ! supportSite;
-			case 'EMAIL':
-				return ! supportSite || ! subject;
-			case 'FORUM':
-				return ! subject;
-		}
-	};
-
 	const getHEsTraySection = () => {
 		return (
 			<section>
@@ -464,6 +449,27 @@ export const HelpCenterContactForm = () => {
 		stopAt: 'response',
 		enabled: enableGPTResponse,
 	} );
+
+	const isCTADisabled = () => {
+		if ( isSubmitting || ! message || ownershipStatusLoading ) {
+			return true;
+		}
+
+		// We're prefetching the GPT response,
+		// so only disabling the button while fetching if we're on the response screen
+		if ( isFetchingGPTResponse && ! showingGPTResponse ) {
+			return true;
+		}
+
+		switch ( mode ) {
+			case 'CHAT':
+				return ! supportSite;
+			case 'EMAIL':
+				return ! supportSite || ! subject;
+			case 'FORUM':
+				return ! subject;
+		}
+	};
 
 	const getCTALabel = () => {
 		const showingHelpOrGPTResults = showingSearchResults || showingGPTResponse;
@@ -515,7 +521,7 @@ export const HelpCenterContactForm = () => {
 				<section className="contact-form-submit">
 					<Button
 						isBusy={ isFetchingGPTResponse }
-						disabled={ isFetchingGPTResponse || isCTADisabled() }
+						disabled={ isCTADisabled() }
 						onClick={ handleCTA }
 						isPrimary={ ! showingGPTResponse || isGPTError }
 						isSecondary={ showingGPTResponse && ! isGPTError }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #79180

## Proposed Changes

* When AI answers are enabled (current default), the CTA button needs to be disabled while submitting the request, otherwise we can end up with multiple submissions.
* This also prevents the button from being disabled after the request is typed (and the debounce time has past), if we're still on the form page.

## Testing Instructions

* See #79180 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
