### PR TITLE
Site Assembler: change 'replaced' notif to 'inserted'

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -228,11 +228,7 @@ const PatternAssembler = ( {
 		setHeader( pattern );
 		updateActivePatternPosition( -1 );
 		if ( pattern ) {
-			if ( header ) {
-				noticeOperations.showPatternReplacedNotice( pattern );
-			} else {
-				noticeOperations.showPatternInsertedNotice( pattern );
-			}
+			noticeOperations.showPatternInsertedNotice( pattern );
 		} else if ( header ) {
 			noticeOperations.showPatternRemovedNotice( header );
 		}
@@ -247,11 +243,7 @@ const PatternAssembler = ( {
 		setFooter( pattern );
 		activateFooterPosition( !! pattern );
 		if ( pattern ) {
-			if ( footer ) {
-				noticeOperations.showPatternReplacedNotice( pattern );
-			} else {
-				noticeOperations.showPatternInsertedNotice( pattern );
-			}
+			noticeOperations.showPatternInsertedNotice( pattern );
 		} else if ( footer ) {
 			noticeOperations.showPatternRemovedNotice( footer );
 		}
@@ -268,7 +260,7 @@ const PatternAssembler = ( {
 				...sections.slice( sectionPosition + 1 ),
 			] );
 			updateActivePatternPosition( sectionPosition );
-			noticeOperations.showPatternReplacedNotice( pattern );
+			noticeOperations.showPatternInsertedNotice( pattern );
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
@@ -1,7 +1,7 @@
 import { NoticeList, SnackbarList } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import i18n from 'i18n-calypso';
-import { ComponentType, ReactNode, ReactChild, useState } from 'react';
+import { ComponentType, ReactNode, ReactElement, useState } from 'react';
 import type { Pattern } from '../types';
 import './notices.scss';
 
@@ -30,7 +30,7 @@ const withNotices = createHigherOrderComponent(
 				setNoticeList( ( current ) => current.filter( ( notice ) => notice.id !== id ) );
 			};
 
-			const createNotice = ( id: string, content: ReactChild ) => {
+			const createNotice = ( id: string, content: ReactElement | string | number ) => {
 				const existingNoticeWithSameId = noticeList.find( ( notice ) => notice.id === id );
 				if ( existingNoticeWithSameId?.timer ) {
 					clearTimeout( existingNoticeWithSameId.timer );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
@@ -13,7 +13,6 @@ type Notice = NoticeList.Notice & {
 
 interface NoticeOperationsProps {
 	showPatternInsertedNotice: ( pattern: Pattern ) => void;
-	showPatternReplacedNotice: ( pattern: Pattern ) => void;
 	showPatternRemovedNotice: ( pattern: Pattern ) => void;
 }
 
@@ -57,14 +56,6 @@ const withNotices = createHigherOrderComponent(
 					createNotice(
 						'pattern-inserted',
 						i18n.translate( 'Block pattern "%(patternName)s" inserted.', {
-							args: { patternName: pattern.title },
-						} )
-					);
-				},
-				showPatternReplacedNotice: ( pattern: Pattern ) => {
-					createNotice(
-						'pattern-replaced',
-						i18n.translate( 'Block pattern "%(patternName)s" replaced.', {
 							args: { patternName: pattern.title },
 						} )
 					);


### PR DESCRIPTION
## Proposed Changes

When we set a header/footer pattern, the "replaced" notification in Site Assembler is misleading as the said pattern is replacing (a replaced pattern), not replaced.

This PR simply treat this as "pattern inserted" case for more clarity.

|Before|After|
|-|-|
|<img width="242" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/8364c3e5-042d-44f8-b85b-750999859ac1">| <img width="261" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/6d814a28-3f70-445e-b1c2-512e36960a96">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Site Assembler flow
2. Add header or footer pattern.
3. Verify that the notification says "inserted" not "replaced".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
