### PR TITLE
Don't add post types to patterns

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -162,7 +162,8 @@ class Block_Patterns_From_API {
 
 		$this->update_core_patterns_with_wpcom_categories();
 
-		$this->update_pattern_post_types();
+		// Temporarily removing the call to `update_pattern_post_types` while we investigate
+		// https://github.com/Automattic/wp-calypso/issues/79145.
 
 		return $results;
 	}


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79145

## Proposed Changes

We were adding post types to all registered patterns based upon their block type, however this is causing issues when trying to edit template parts which include those patterns.

This change stops doing that while we investigate the issue.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Apply changes to sandbox
 2. Have a sandboxed site with e.g. TT3 installed
 3. Go to edit the post-meta template part: /wp-admin/site-editor.php?postType=wp_template_part&postId=pub%2Ftwentytwentythree%2F%2Fpost-meta&categoryId=uncategorized&categoryType=wp_template_part&canvas=edit 
 4. The content should show up to be edited and the block list should show spacer and group lists.
 5. If this didn't work then instead you'll see no contents and the block list will show the pattern placeholder block

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
