### PR TITLE
Manage All Domains: Fix table alignment for non English locales

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -346,7 +346,7 @@
 	}
 
 	@include break-mobile {
-		flex: 6 6 0;
+		flex: 15 15 0;
 		margin: 0;
 
 		.button.is-borderless {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -303,7 +303,7 @@
 
 .domain-row__auto-renew-cell {
 	display: none;
-	flex: 30 30 0;
+	flex: 40 40 0;
 
 	@include break-mobile {
 		display: flex;
@@ -346,7 +346,7 @@
 	}
 
 	@include break-mobile {
-		flex: 15 15 0;
+		flex: 20 20 0;
 		margin: 0;
 
 		.button.is-borderless {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -337,7 +337,7 @@
 	height: 42px;
 
 	.ellipsis-menu {
-		float: right;
+		margin: 0 auto;
 	}
 
 	.ellipsis-menu__toggle {
@@ -346,12 +346,9 @@
 	}
 
 	@include break-mobile {
+		display: flex;
 		flex: 20 20 0;
 		margin: 0;
-
-		.button.is-borderless {
-			padding: 0 15px 10px 15px;
-		}
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -301,10 +301,10 @@
 	flex: 50 50 0;
 }
 .list__auto-renew-cell {
-	flex: 30 30 0;
+	flex: 40 40 0;
 }
 .list__email-cell {
-	flex: 40 40 0;
+	flex: 30 30 0;
 }
 .list__action-cell {
 	flex: 20 20 0;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -307,6 +307,7 @@
 	flex: 30 30 0;
 }
 .list__action-cell {
+	justify-content: center;
 	flex: 20 20 0;
 }
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -304,10 +304,10 @@
 	flex: 30 30 0;
 }
 .list__email-cell {
-	flex: 30 30 0;
+	flex: 40 40 0;
 }
 .list__action-cell {
-	flex: 15 15 0;
+	flex: 20 20 0;
 }
 
 .domain-only-upsell-carousel {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -307,7 +307,7 @@
 	flex: 30 30 0;
 }
 .list__action-cell {
-	flex: 6 6 0;
+	flex: 15 15 0;
 }
 
 .domain-only-upsell-carousel {


### PR DESCRIPTION
## Changes proposed

**Russian Before**
![image](https://github.com/Automattic/wp-calypso/assets/52076348/43bc6cb9-7797-43de-80a4-d0c5635b51ad)

**Russian After**
![image](https://github.com/Automattic/wp-calypso/assets/52076348/fba63c50-7c22-49d4-95e4-431c2bb704ba)

**Traditional Chinese Before**
![image](https://github.com/Automattic/wp-calypso/assets/52076348/8c9f68b4-f0b9-4c2e-9706-c340a92f7459)

**Traditional Chinese After**
![image](https://github.com/Automattic/wp-calypso/assets/52076348/56a44220-3ff8-4f4c-abee-81402cf71e8e)

**Japanese Before**
![image](https://github.com/Automattic/wp-calypso/assets/52076348/bfecd3fc-9d79-45de-8899-ad92d3609214)

**Japanese After**
![image](https://github.com/Automattic/wp-calypso/assets/52076348/086dccc0-ee56-4a41-af67-518f23d711e9)

## Testing
1. Live Link and visit `/domains/manage`
2. Check the table in various languages

Fixes https://github.com/Automattic/dotcom-forge/issues/2982