### PR TITLE
Support Global Content Footer: Fix upgrade link

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -43,7 +43,7 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 			<?php esc_html_e( 'Unlock tools, expert help, and community for your brand\'s growth and success.', 'happy-blocks' ); ?>
 			</p>
 			<div class="resource-link">
-				<a href="<?php echo esc_url( 'https://wordpress.com//pricing' ); ?>">
+				<a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com//pricing' ) ); ?>">
 					<?php esc_html_e( 'Upgrade your plan', 'happy-blocks' ); ?>
 				</a>
 			</div>

--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -43,7 +43,7 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 			<?php esc_html_e( 'Unlock tools, expert help, and community for your brand\'s growth and success.', 'happy-blocks' ); ?>
 			</p>
 			<div class="resource-link">
-				<a href="https://www.youtube.com/wordpressdotcom">
+				<a href="<?php echo esc_url( 'https://wordpress.com//pricing' ); ?>">
 					<?php esc_html_e( 'Upgrade your plan', 'happy-blocks' ); ?>
 				</a>
 			</div>


### PR DESCRIPTION
## Changes proposed

![image](https://github.com/Automattic/wp-calypso/assets/52076348/85abc328-645d-4f7d-bd47-612edb7e6556)

`Upgrade your plan`  link was sending users to youtube. This PR fixes that sending them to `wordpress.com/pricing`.

## Testing
1. Checkout branch
2. `cd apps/happy-blocks` and then `yarn dev --sync`
3. Sandbox Support website and visit any page. 
4. Check that the link is correct