### PR TITLE
Subscription Management: Create add sites modal feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -190,6 +190,7 @@
 		"subscriber-importer": true,
 		"subscribers-page-new": true,
 		"subscription-gifting": true,
+		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -127,6 +127,7 @@
 		"subscriber-importer": true,
 		"subscribers-page-new": false,
 		"subscription-gifting": true,
+		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,

--- a/config/production.json
+++ b/config/production.json
@@ -154,6 +154,7 @@
 		"subscriber-importer": true,
 		"subscribers-page-new": false,
 		"subscription-gifting": true,
+		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -147,6 +147,7 @@
 		"subscriber-importer": true,
 		"subscribers-page-new": false,
 		"subscription-gifting": true,
+		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -159,6 +159,7 @@
 		"subscriber-importer": true,
 		"subscribers-page-new": false,
 		"subscription-gifting": true,
+		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,


### PR DESCRIPTION
Close [#79225](https://github.com/Automattic/wp-calypso/issues/79225)

## Proposed Changes

- Create new feature flag subscription-management-add-sites-modal

## Testing Instructions

No testing is needed 🎇

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
