### PR TITLE
Provide missing retryImport property function

### DIFF
--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { startImport } from 'calypso/state/imports/actions';
+import { startImport, cancelImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import ErrorPane from './error-pane';
 import ImporterHeader from './importer-header';
@@ -111,6 +111,9 @@ class FileImporter extends PureComponent {
 						description={ errorData.description }
 						siteSlug={ site.slug }
 						code={ errorData.code }
+						retryImport={ () => {
+							this.props.cancelImport( site.ID, importerStatus.importerId );
+						} }
 					/>
 				) }
 				{ includes( importingStates, importerState ) && (
@@ -130,4 +133,4 @@ class FileImporter extends PureComponent {
 	}
 }
 
-export default connect( null, { recordTracksEvent, startImport } )( FileImporter );
+export default connect( null, { recordTracksEvent, startImport, cancelImport } )( FileImporter );


### PR DESCRIPTION
Closes #2089

## Proposed Changes

Provided missing retryImport property to the ErrorPane component. 
The "Try again" link will reset the current import and render the initial list of importers.

<img src="https://user-images.githubusercontent.com/10244734/229062542-a775c54b-0f6d-4c69-8f2b-63f06d4ea28b.png" />

## Testing Instructions

* Go to"/import/{SLUG_NAME}`
* Select an importer; for instance, it could be Blogger
* Run your sandbox env and force importing failure
* Click the "Try again" button
* Check if it shows the importer list screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
