### PR TITLE
wpcom-proxy-request: Remove progress-event dependency

### DIFF
--- a/packages/wpcom-proxy-request/History.md
+++ b/packages/wpcom-proxy-request/History.md
@@ -4,6 +4,10 @@
 
 - Don't modify a falsy boolean JSON response body by defaulting it.
 
+## 7.0.4 / 2023-07-11
+
+- Remove dependendy `progress-event`. This polyfill is no longer needed due to ProgressEvent being widely supported now.
+
 ## 6.0.0 / 2021-03-19
 
 - Add "support" for streamed responses and `onStreamRecord`. Doesn't implement, just tolerates the callback.

--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wpcom-proxy-request",
-	"version": "7.0.3",
+	"version": "7.0.4",
 	"description": "Proxied cookie-authenticated REST API requests to WordPress.com.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
@@ -40,7 +40,6 @@
 	},
 	"dependencies": {
 		"debug": "^4.3.3",
-		"progress-event": "^1.0.0",
 		"uuid": "^8.3.2",
 		"wp-error": "^1.3.0"
 	},

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -1,5 +1,4 @@
 import debugFactory from 'debug';
-import ProgressEvent from 'progress-event';
 import { v4 as uuidv4 } from 'uuid';
 import WPError from 'wp-error';
 
@@ -472,7 +471,7 @@ function onprogress( data ) {
 	debug( 'got "progress" event: %o', data );
 	const xhr = requests[ data.callbackId ];
 	if ( xhr ) {
-		const prog = new ProgressEvent( 'progress', data );
+		const prog = new window.ProgressEvent( 'progress', data );
 		const target = data.upload ? xhr.upload : xhr;
 		target.dispatchEvent( prog );
 	}
@@ -486,7 +485,7 @@ function onprogress( data ) {
  */
 
 function resolve( xhr, body, headers ) {
-	const e = new ProgressEvent( 'load' );
+	const e = new window.ProgressEvent( 'load' );
 	e.data = e.body = e.response = body;
 	e.headers = headers;
 	xhr.dispatchEvent( e );
@@ -500,7 +499,7 @@ function resolve( xhr, body, headers ) {
  */
 
 function reject( xhr, err, headers ) {
-	const e = new ProgressEvent( 'error' );
+	const e = new window.ProgressEvent( 'error' );
 	e.error = e.err = err;
 	e.headers = headers;
 	xhr.dispatchEvent( e );

--- a/yarn.lock
+++ b/yarn.lock
@@ -23565,13 +23565,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"progress-event@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "progress-event@npm:1.0.0"
-  checksum: cb24e71d83ec2d78b87b4600965a97bca1bbbc852b05f39041f285188de11d3327e47f856661989d519d63444acf7dee943d4babdda6bb011e4a0aa92e741c8b
-  languageName: node
-  linkType: hard
-
 "progress@npm:^2.0.0, progress@npm:^2.0.1, progress@npm:^2.0.3":
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
@@ -30132,7 +30125,6 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     debug: ^4.3.3
     postcss: ^8.4.5
-    progress-event: ^1.0.0
     uuid: ^8.3.2
     webpack: ^5.68.0
     wp-error: ^1.3.0


### PR DESCRIPTION
## Proposed Changes

This PR removes the dependency `progress-event`, which is a polyfill for the browser API ProgressEvent. The reasoning for removing this dependency is:

- The dependency is quite [outdated](https://github.com/webmodules/progress-event).
- The API ProgressEvent is now [widely supported](https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent#browser_compatibility).

One motivation behind this change is that the polyfill doesn't work in SSR, due to the following [line](https://github.com/webmodules/progress-event/blob/master/index.js#L26):
```javascript
'function' === typeof document.createEvent ? function ProgressEvent (type, props) { <--- HERE
  var e = document.createEvent('Event');
  e.initEvent(type, false, false);
  if (props) {
    e.lengthComputable = Boolean(props.lengthComputable);
    e.loaded = Number(props.loaded) || 0;
    e.total = Number(props.total) || 0;
  } else {
    e.lengthComputable = false;
    e.loaded = e.total = 0;
  }
  return e;
} :
```

As a result, SSR pages such as `/themes` cannot import any package (such as `@automattic/components`) that has `wpcom-proxy-request` as its [dependency](https://github.com/Automattic/wp-calypso/blob/trunk/packages/components/package.json#L48). Unfortunately, currently, it's not obvious which packages are "SSR-friendly". 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Not sure how to test this.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
