### PR TITLE
Move payment features to under the Free plan

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -2203,7 +2203,16 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_PREMIUM_CONTENT_JP ]: {
 		getSlug: () => FEATURE_PREMIUM_CONTENT_JP,
-		getTitle: () => i18n.translate( 'Gated content' ),
+		getTitle: () => {
+			const localeSlug = i18n.getLocaleSlug();
+			const shouldShowNewString =
+				( localeSlug && config< string >( 'english_locales' ).includes( localeSlug ) ) ||
+				i18n.hasTranslation( 'Paid content gating' );
+
+			return shouldShowNewString
+				? i18n.translate( 'Paid content gating' )
+				: i18n.translate( 'Gated content' );
+		},
 		getDescription: () => i18n.translate( 'Sell access to premium content, right from your site.' ),
 	},
 	[ FEATURE_VIDEOPRESS_JP ]: {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -555,8 +555,11 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_MULTI_SITE,
 		FEATURE_SECURITY_MALWARE,
 		FEATURE_SECURITY_DDOS,
+		FEATURE_PREMIUM_CONTENT_JP,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [
+		FEATURE_PAID_SUBSCRIBERS_JP,
+		FEATURE_PREMIUM_CONTENT_JP,
 		FEATURE_DONATIONS_AND_TIPS_JP,
 		FEATURE_STATS_JP,
 		FEATURE_SPAM_JP,
@@ -798,7 +801,6 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SUPPORT_EMAIL,
 		FEATURE_PAYMENT_TRANSACTION_FEES_8,
 	],
-	get2023PricingGridSignupJetpackFeatures: () => [ FEATURE_PREMIUM_CONTENT_JP ],
 	get2023PricingGridSignupStorageOptions: () => [ FEATURE_6GB_STORAGE ],
 	get2023PlanComparisonConditionalFeatures: () => [ FEATURE_SHARES_SOCIAL_MEDIA_JP ],
 	getNewsletterDescription: () =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
## Proposed Changes

Per the request made in pdgrnI-2xq-p2#comment-4128, the following changes are made:

1. Move "Gated content" from under the Personal plan to under the Free plan..
2. The feature "Gated content" is renamed to "Paid content gating" if translation exists.
3. Add "Paid subscribers" under the Free plan.
4. This PR brings parity with the landing page changes done in D115618-code. Verify that the pricing grid UI exactly matches the one seen in `wordpress.com/pricing`.

**Top of the fold:**

<img width="1230" alt="Screenshot 2023-07-11 at 7 29 27 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/868e607a-3f5b-4a03-806f-2116201a4832">

**Below the fold comparison grid**

<img width="1176" alt="Screenshot 2023-07-11 at 7 30 18 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/14c18250-ea06-472e-ac29-1443a3af15cd">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Begin fresh signup at `/start`. At the plans step `/start/plans`, verify that the copy changes mentioned in the description are visible.
* Verify in a non-EN locale that all the translations exist.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
