### PR TITLE
Subscribers Page: Enable the `subscribers-page-new` feature flag in all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -125,7 +125,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-page-new": false,
+		"subscribers-page-new": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,

--- a/config/production.json
+++ b/config/production.json
@@ -152,7 +152,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-page-new": false,
+		"subscribers-page-new": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -145,7 +145,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-page-new": false,
+		"subscribers-page-new": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -157,7 +157,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-page-new": false,
+		"subscribers-page-new": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,


### PR DESCRIPTION
**⚠️ Please do not merge this PR until we are ready to launch. ⚠️** 

---

Resolves https://github.com/Automattic/wp-calypso/issues/79183.

## Proposed Changes

* enable the `subscribers-page-new` feature flag in all environments

## Testing Instructions

Please review the code changes. There's nothing functional to test.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
