### PR TITLE
Harden property lookup in Plugin page parameter handle

### DIFF
--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -161,7 +161,7 @@ export const useESPluginsInfinite = (
 			};
 		},
 		getNextPageParam: ( lastPage ) => {
-			return lastPage?.data?.page_handle || undefined;
+			return lastPage?.data?.page_handle;
 		},
 		enabled,
 		staleTime,

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -161,7 +161,7 @@ export const useESPluginsInfinite = (
 			};
 		},
 		getNextPageParam: ( lastPage ) => {
-			return lastPage.data.page_handle || undefined;
+			return lastPage?.data?.page_handle || undefined;
 		},
 		enabled,
 		staleTime,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This addresses the uncaught Sentry error raised p1688978797733949-slack-C04U5A26MJB where, on the Plugins sections, the `data` property is sometimes empty when `getNextPageParam` is called.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/plugins` while logged in
* check the console for errors
* there shouldn't be any `Cannot read properties of undefined (reading 'page_handle').` error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
