### PR TITLE
Bulk Domain Transfer: Fix event name

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -61,7 +61,7 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 	const handleAddTransfer = () => {
 		recordTracksEvent( 'calypso_domain_transfer_submit_form', {
 			valid: allGood,
-			numberOfValidDomains: numberOfValidDomains,
+			number_of_valid_domains: numberOfValidDomains,
 		} );
 
 		if ( allGood ) {


### PR DESCRIPTION
We [recently added](https://github.com/Automattic/wp-calypso/pull/79184) new events.

One parameter passed is `numberOfValidDomains`, which causes problems.

```
Tracks: Event `calypso_domain_transfer_submit_form` will be rejected because property name `numberOfValidDomains` does not match /^[a-z_][a-z0-9_]*$/. Please use a compliant property name.
```

This PR fixes this