### PR TITLE
GF Signup : Rename prop and change onboarding media variation to tailored

### DIFF
--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -85,7 +85,7 @@ const newsletter: Flow = {
 		} );
 		setStepProgress( flowProgress );
 		const logInUrl = useLoginUrl( {
-			flowName,
+			variationName: flowName,
 			redirectTo: `/setup/${ flowName }/newsletterSetup`,
 			pageTitle: 'Newsletter',
 		} );

--- a/client/landing/stepper/declarative-flow/onboarding-pm.ts
+++ b/client/landing/stepper/declarative-flow/onboarding-pm.ts
@@ -134,7 +134,6 @@ const onboarding: Flow = {
 			[]
 		);
 		const logInUrl = useLoginUrl( {
-			flowName,
 			redirectTo: `/setup/${ flowName }`,
 			pageTitle: 'Onboarding',
 			loginPath: `/start/${ flowName }/`,

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -45,20 +45,22 @@ export function useLangRouteParam() {
 }
 
 export const useLoginUrl = ( {
-	flowName,
+	variationName,
 	redirectTo,
 	pageTitle,
 	loginPath = `/start/account/user/`,
 }: {
-	flowName?: string;
+	variationName?: string | null;
 	redirectTo?: string;
 	pageTitle?: string;
 	loginPath?: string;
 } ): string => {
 	const locale = useLocale();
 	const localizedLoginPath = locale && locale !== 'en' ? `${ loginPath }${ locale }` : loginPath;
+
+	// Empty values are ignored down the call stack, so we don't need to check for them here.
 	return addQueryArgs( localizedLoginPath, {
-		variationName: flowName,
+		variationName,
 		redirect_to: redirectTo,
 		pageTitle,
 		toStepper: true,

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -50,6 +50,9 @@ export const useLoginUrl = ( {
 	pageTitle,
 	loginPath = `/start/account/user/`,
 }: {
+	/**
+	 * Variation name is used to track the relevant login flow in the signup framework as explained in https://github.com/Automattic/wp-calypso/issues/67173
+	 */
 	variationName?: string | null;
 	redirectTo?: string;
 	pageTitle?: string;

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -54,8 +54,8 @@ export const useLoginUrl = ( {
 	 * Variation name is used to track the relevant login flow in the signup framework as explained in https://github.com/Automattic/wp-calypso/issues/67173
 	 */
 	variationName?: string | null;
-	redirectTo?: string;
-	pageTitle?: string;
+	redirectTo?: string | null;
+	pageTitle?: string | null;
 	loginPath?: string;
 } ): string => {
 	const locale = useLocale();


### PR DESCRIPTION
Fixes : Automattic/martech#1931
Related to #67225

## Proposed Changes
The `signup_flow_name` was registering an invalid event called `onboarding-media-onboarding-media`. This is because variationName provided by the login redirect url was similar to the [twin flow name we were using in the signup framework](https://github.com/Automattic/wp-calypso/blob/a808de7b5d1aae20a89f78e19fefabcffbe4e918/client/signup/config/flows-pure.js#L152).

So we will remove the variationName definition from the stepper framework onboarding-media flow so that it is easier for analytics to track this flow without interruptions and the signup_flow_name shows up as `onboarding-media`

## Testing Instructions
* Open incognito window
* Switch to network tab and make sure to preserve log
* Go to `/setup/onboarding-media` and click on CTA
*  In the user step fill form and create a user
* In the resulting API calls make sure `/user/new` has the proper `signup_flow_name` defined as only `onboarding-media`

![image](https://github.com/Automattic/wp-calypso/assets/3422709/4aef0e54-5fe7-4e93-a4f8-044631736e82)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
