### PR TITLE
Add isGlobalStylesOnPersonal to PlanFeatures2023GridProps

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -113,6 +113,7 @@ export type PlanFeatures2023GridProps = {
 	// Value of the `?feature=` query param, so we can highlight a given feature and hide plans without it.
 	selectedFeature?: string;
 	intent?: PlansIntent;
+	isGlobalStylesOnPersonal?: boolean;
 };
 
 type PlanFeatures2023GridConnectedProps = {


### PR DESCRIPTION
## Proposed Changes

This fixes a type error apparently introduced in https://github.com/Automattic/wp-calypso/pull/78634 (although that passed its type checks so...?).

See Slack conversation here: p1689094950434679-slack-C02DQP0FP

## Testing Instructions

None