### PR TITLE
Automattic Components: Add select dropdown to package

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -60,6 +60,7 @@
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@storybook/addon-actions": "^7.0.18",
 		"@storybook/react": "^7.0.18",
+		"@testing-library/dom": "^9.0.0",
 		"@testing-library/jest-dom": "^5.17.0",
 		"@testing-library/react": "^14.0.0",
 		"@testing-library/react-hooks": "7.0.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -45,7 +45,9 @@
 		"prop-types": "^15.7.2",
 		"react-modal": "^3.16.1",
 		"react-slider": "^2.0.5",
-		"utility-types": "^3.10.0"
+		"utility-types": "^3.10.0",
+		"uuid": "^8.3.2",
+		"wpcom-proxy-request": "workspace:^"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^9.8.0",
@@ -61,6 +63,7 @@
 		"@testing-library/jest-dom": "^5.17.0",
 		"@testing-library/react": "^14.0.0",
 		"@testing-library/react-hooks": "7.0.2",
+		"@testing-library/user-event": "^14.4.3",
 		"@types/canvas-confetti": "^1.6.0",
 		"@types/react-slider": "^1.3.1",
 		"qrcode.react": "^3.1.0",

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -18,6 +18,7 @@ export { default as Ribbon } from './ribbon';
 export { default as RootChild } from './root-child';
 export { default as ScreenReaderText } from './screen-reader-text';
 export { useScrollToTop } from './scroll-to-top/use-scroll-to-top';
+export { default as SelectDropdown } from './select-dropdown';
 export { SiteThumbnail, DEFAULT_THUMBNAIL_SIZE } from './site-thumbnail';
 export { default as Suggestions } from './suggestions';
 export { default as PaginationControl } from './pagination-control';

--- a/packages/components/src/select-dropdown/README.md
+++ b/packages/components/src/select-dropdown/README.md
@@ -1,0 +1,236 @@
+# Select Dropdown
+
+React component used to display a dropdown selector.
+
+It can be utilized via two different techniques: children components or an options array. These techniques are available because certain use cases prefer the "selection" logic to be built into `SelectDropdown`, while others prefer to explicitly define that logic elsewhere.
+
+---
+
+## Using Children
+
+The children technique is appropriate when you'd like to define the "selection" logic at the same point where `<SelectDropdown>` is implemented.
+
+A good example for this case is navigation. Sometimes the option that is selected is defined by the route, other times it's a state value, external prop, etc.
+
+```jsx
+import SelectDropdown from 'calypso/components/select-dropdown';
+
+export default function MyComponent() {
+	return (
+		<SelectDropdown selectedText="Published">
+			<SelectDropdown.Item selected path="/published">
+				Published
+			</SelectDropdown.Item>
+			<SelectDropdown.Item path="/scheduled">Scheduled</SelectDropdown.Item>
+			<SelectDropdown.Item path="/drafts">Drafts</SelectDropdown.Item>
+			<SelectDropdown.Item path="/trashed">Trashed</SelectDropdown.Item>
+		</SelectDropdown>
+	);
+}
+```
+
+The key here is that it's up to the parent component to explicitly define things like: which item is selected, what the selected text is (used in the dropdown header), and potentially `onClick` callbacks, etc.
+
+### Props
+
+#### Select Dropdown
+
+`selectedText`
+
+Used for displaying the text on the dropdown header.
+
+![selectedText example screenshot](https://cldup.com/Da_dTXN4mF.png)
+
+`selectedCount`
+
+Used for displaying the count on the dropdown header.
+
+`selectedIcon`
+
+Used for displaying an icon on the dropdown header.
+
+`className`
+
+Optional extra class(es) to be applied to the `.select-dropdown`.
+
+`tabIndex`
+
+Optional tabIndex setting to override tab order via keyboard navigation. By default this is set to `0` which simply puts the element in the tabbing flow according to the component's placement in the document.
+
+`disabled`
+
+Used to determine whether the select dropdown is in a disabled state. When disabled it will not respond to interaction and will render to appear disabled.
+
+`ariaLabel`
+
+Optional dropdown header label that can be used to improve the accessibility for screen readers.
+
+#### Dropdown Item
+
+`selected`
+
+Boolean representing the selected visual state. `selected={ true }` creates a blue background on the selected item.
+
+`count`
+
+Optional number to show a Count next to the item text.
+
+![selected example screenshot](https://cldup.com/BOZktaoqTT.png)
+
+`icon`
+
+Optional icon to show before the item text.
+
+`path`
+
+Optional URL to navigate to when option is clicked.
+
+`disabled`
+
+Optional bool to disable dropdown item.
+
+`onClick`
+
+Optional callback that will be applied when a `SelectDropdown.Item` has been clicked. This could be used for updating a parent's state, tracking analytics, etc.
+
+`ariaLabel`
+
+Optional dropdown item label that can be used to improve the accessibility for screen readers.
+
+### Label
+
+An item "label" can be added like as a sibling to `SelectDropdown.Item`. The purpose
+of this `SelectDropdown.Label` component is used to display a static item, for example, to group
+items.
+
+### Separator
+
+As a sibling to `SelectDropdown.Item`, an item "separator" or horizontal line can be used to visually separate items.
+
+![separator example screenshot](https://cldup.com/CWEH2K9PUf.png)
+
+```js
+import SelectDropdown from 'calypso/components/select-dropdown';
+
+export default class extends React.Component {
+	// ...
+
+	render() {
+		return (
+			<SelectDropdown selectedText="Published">
+				<SelectDropdown.Label>
+					<em>Post status</em>
+				</SelectDropdown.Label>
+				<SelectDropdown.Item selected path="/published">
+					Published
+				</SelectDropdown.Item>
+				<SelectDropdown.Item path="/scheduled">Scheduled</SelectDropdown.Item>
+				<SelectDropdown.Item path="/drafts">Drafts</SelectDropdown.Item>
+				<SelectDropdown.Separator />
+				<SelectDropdown.Item path="/trashed">Trashed</SelectDropdown.Item>
+			</SelectDropdown>
+		);
+	}
+}
+```
+
+---
+
+## Using options array
+
+`SelectDropdown` can also be used by passing in an `options` array as a prop. This technique is great for situations where you don't want to explicitly define things like what happens when an item is clicked or which item is currently selected, etc.
+
+A good example for this case is a form element. You don't want to have to write the logic for updating the component when a new selection is made, but you might want to hook into certain events like: when a new selection is made, what was the option?
+
+> **NOTE** - there is still more work here in order to be fully functional as a form element, not recommended use case... yet.
+
+```js
+import SelectDropdown from 'calypso/components/select-dropdown';
+
+const options = [
+	{ label: 'Post status', isLabel: true },
+	{ value: 'published', label: 'Published' },
+	{ value: 'scheduled', label: 'Scheduled' },
+	{ value: 'drafts', label: 'Drafts' },
+	{ value: 'trashed', label: 'Trashed' },
+];
+
+export default class extends React.Component {
+	// ...
+
+	handleOnSelect = ( option ) => {
+		console.log( 'selected option:', option ); // full object of selected option
+	};
+
+	render() {
+		return <SelectDropdown options={ options } onSelect={ this.handleOnSelect } />;
+	}
+}
+```
+
+Note that all the "selection" logic will be applied in `SelectDropdown` itself using a simple `selected` value comparison in state. It will update itself when an option has been clicked.
+
+### Props
+
+`options`
+
+The main data set for rendering out the various options.
+
+```js
+const options = [
+	{
+		value: 'the value', // *required* - (string) tracked by component
+		label: 'the label', // *required* - (string) displayed to user
+		isLabel: true, // optional - (boolean) set this item like a static label
+		path: '/', // optional - (string) URL to navigate when clicked
+	},
+	// ...
+];
+```
+
+`initialSelected`
+
+Optional string representing the initial selected option's `value`. Default will be the first option's `value`.
+
+`compact`
+
+Optional boolean indicating the dropdown will be rendered in compact mode
+
+`onSelect`
+
+Optional callback that will be run whenever a new selection has been clicked.
+
+`onToggle`
+
+Optional callback that will be run after the dropdown is opened or closed. An event object is passed, including a `target` property equal to the `SelectDropdown` React element instance, and `open` equal to the current toggle state of the dropdown.
+
+### Label
+
+Adding `isLabel` key set to `true` into the item object will create a `SelectDropdown.Label` component.
+
+```js
+const options = [
+	{ label: 'Post status', isLabel: true },
+	{ value: 'published', label: 'Published' },
+	{ value: 'scheduled', label: 'Scheduled' },
+	{ value: 'drafts', label: 'Drafts' },
+	null,
+	{ value: 'trashed', label: 'Trashed' },
+];
+```
+
+### Separator
+
+Using a `null` or `false` item in the `options` will render an item "separator" or horizontal line can be used to visually separate items.
+
+![separator example screenshot](https://cldup.com/CWEH2K9PUf.png)
+
+```js
+const options = [
+	{ value: 'published', label: 'Published' },
+	{ value: 'scheduled', label: 'Scheduled' },
+	{ value: 'drafts', label: 'Drafts' },
+	null,
+	{ value: 'trashed', label: 'Trashed' },
+];
+```

--- a/packages/components/src/select-dropdown/docs/example.jsx
+++ b/packages/components/src/select-dropdown/docs/example.jsx
@@ -1,0 +1,238 @@
+import { PureComponent } from 'react';
+import SelectDropdown from 'calypso/components/select-dropdown';
+import Gridicon from '../gridicon';
+
+class SelectDropdownExample extends PureComponent {
+	static displayName = 'SelectDropdownExample';
+
+	static defaultProps = {
+		options: [
+			{ value: 'status-options', label: 'Statuses', isLabel: true },
+			{ value: 'published', label: 'Published', count: 12 },
+			{ value: 'scheduled', label: 'Scheduled' },
+			{ value: 'drafts', label: 'Drafts' },
+			null,
+			{ value: 'trashed', label: 'Trashed' },
+		],
+	};
+
+	state = {
+		childSelected: 'Published',
+		selectedCount: 10,
+		compactButtons: false,
+		selectedIcon: <Gridicon icon="align-image-left" size={ 18 } />,
+	};
+
+	toggleButtons = () => {
+		this.setState( { compactButtons: ! this.state.compactButtons } );
+	};
+
+	render() {
+		const toggleButtonsText = this.state.compactButtons ? 'Normal Buttons' : 'Compact Buttons';
+
+		return (
+			<div className="docs__select-dropdown-container">
+				<button className="docs__design-toggle button" onClick={ this.toggleButtons }>
+					{ toggleButtonsText }
+				</button>
+
+				<h3>Items passed as options prop</h3>
+				<SelectDropdown
+					compact={ this.state.compactButtons }
+					options={ this.props.options }
+					onSelect={ this.onDropdownSelect }
+				/>
+
+				<h3 style={ { marginTop: 20 } }>Items passed as children</h3>
+				<SelectDropdown
+					compact={ this.state.compactButtons }
+					onSelect={ this.onDropdownSelect }
+					selectedText={ this.state.childSelected }
+					selectedCount={ this.state.selectedCount }
+				>
+					<SelectDropdown.Label>
+						<strong>Statuses</strong>
+					</SelectDropdown.Label>
+
+					<SelectDropdown.Item
+						count={ 10 }
+						selected={ this.state.childSelected === 'Published' }
+						onClick={ this.getSelectItemHandler( 'Published', 10 ) }
+					>
+						Published
+					</SelectDropdown.Item>
+
+					<SelectDropdown.Item
+						count={ 4 }
+						selected={ this.state.childSelected === 'Scheduled' }
+						onClick={ this.getSelectItemHandler( 'Scheduled', 4 ) }
+					>
+						Scheduled
+					</SelectDropdown.Item>
+
+					<SelectDropdown.Item
+						count={ 3343 }
+						selected={ this.state.childSelected === 'Drafts' }
+						onClick={ this.getSelectItemHandler( 'Drafts', 3343 ) }
+					>
+						Drafts
+					</SelectDropdown.Item>
+
+					<SelectDropdown.Separator />
+
+					<SelectDropdown.Item
+						count={ 3 }
+						selected={ this.state.childSelected === 'Trashed' }
+						onClick={ this.getSelectItemHandler( 'Trashed', 3 ) }
+					>
+						Trashed
+					</SelectDropdown.Item>
+				</SelectDropdown>
+
+				<h3 style={ { marginTop: 20 } }>With Icons in Items Passed as Options</h3>
+				<SelectDropdown
+					compact={ this.state.compactButtons }
+					onSelect={ this.onDropdownSelect }
+					options={ [
+						{
+							value: 'published',
+							label: 'Published',
+							icon: <Gridicon icon="align-image-left" size={ 18 } />,
+						},
+						{
+							value: 'scheduled',
+							label: 'Scheduled',
+							icon: <Gridicon icon="calendar" size={ 18 } />,
+						},
+						{
+							value: 'drafts',
+							label: 'Drafts',
+							icon: <Gridicon icon="create" size={ 18 } />,
+						},
+						{
+							value: 'trashed',
+							label: 'Trashed',
+							icon: <Gridicon icon="trash" size={ 18 } />,
+						},
+					] }
+				/>
+
+				<h3 style={ { marginTop: 20 } }>With Icons in Items Passed as Children</h3>
+				<SelectDropdown
+					compact={ this.state.compactButtons }
+					onSelect={ this.onDropdownSelect }
+					selectedText={ this.state.childSelected }
+					selectedIcon={ this.state.selectedIcon }
+				>
+					<SelectDropdown.Label>
+						<strong>Statuses</strong>
+					</SelectDropdown.Label>
+
+					<SelectDropdown.Item
+						selected={ this.state.childSelected === 'Published' }
+						icon={ <Gridicon icon="align-image-left" size={ 18 } /> }
+						onClick={ this.getSelectItemHandler(
+							'Published',
+							10,
+							<Gridicon icon="align-image-left" size={ 18 } />
+						) }
+					>
+						Published
+					</SelectDropdown.Item>
+
+					<SelectDropdown.Item
+						selected={ this.state.childSelected === 'Scheduled' }
+						icon={ <Gridicon icon="calendar" size={ 18 } /> }
+						onClick={ this.getSelectItemHandler(
+							'Scheduled',
+							4,
+							<Gridicon icon="calendar" size={ 18 } />
+						) }
+					>
+						Scheduled
+					</SelectDropdown.Item>
+
+					<SelectDropdown.Item
+						selected={ this.state.childSelected === 'Drafts' }
+						icon={ <Gridicon icon="create" size={ 18 } /> }
+						onClick={ this.getSelectItemHandler(
+							'Drafts',
+							3343,
+							<Gridicon icon="create" size={ 18 } />
+						) }
+					>
+						Drafts
+					</SelectDropdown.Item>
+
+					<SelectDropdown.Separator />
+
+					<SelectDropdown.Item
+						selected={ this.state.childSelected === 'Trashed' }
+						icon={ <Gridicon icon="trash" size={ 18 } /> }
+						onClick={ this.getSelectItemHandler(
+							'Trashed',
+							3,
+							<Gridicon icon="trash" size={ 18 } />
+						) }
+					>
+						Trashed
+					</SelectDropdown.Item>
+				</SelectDropdown>
+
+				<h3 style={ { marginTop: 20 } }>max-width: 220px;</h3>
+				<SelectDropdown
+					className="select-dropdown-example__fixed-width"
+					compact={ this.state.compactButtons }
+					onSelect={ this.onDropdownSelect }
+					selectedText="Published publish publish publish"
+					selectedCount={ 10 }
+				>
+					<SelectDropdown.Label>
+						<strong>Statuses</strong>
+					</SelectDropdown.Label>
+					<SelectDropdown.Item count={ 10 } selected={ true }>
+						Published publish publish publish
+					</SelectDropdown.Item>
+					<SelectDropdown.Item count={ 4 }> Scheduled scheduled</SelectDropdown.Item>
+					<SelectDropdown.Item count={ 3343 }>Drafts</SelectDropdown.Item>
+					<SelectDropdown.Item disabled={ true }>Disabled Item</SelectDropdown.Item>
+					<SelectDropdown.Separator />
+					<SelectDropdown.Item count={ 3 }>Trashed</SelectDropdown.Item>
+				</SelectDropdown>
+
+				<h3 style={ { marginTop: 20 } }>Disabled State</h3>
+				<SelectDropdown
+					compact={ this.state.compactButtons }
+					options={ this.props.options }
+					onSelect={ this.onDropdownSelect }
+					disabled={ true }
+				/>
+			</div>
+		);
+	}
+
+	getSelectItemHandler = ( name, count, icon ) => {
+		return ( event ) => {
+			event.preventDefault();
+			this.selectItem( name, count, icon );
+		};
+	};
+
+	selectItem = ( childSelected, count, icon ) => {
+		this.setState( {
+			childSelected: childSelected,
+			selectedCount: count,
+			selectedIcon: icon,
+		} );
+
+		// eslint-disable-next-line no-console
+		console.log( 'Select Dropdown Item (selected):', childSelected );
+	};
+
+	onDropdownSelect( option ) {
+		// eslint-disable-next-line no-console
+		console.log( 'Select Dropdown (selected):', option );
+	}
+}
+
+export default SelectDropdownExample;

--- a/packages/components/src/select-dropdown/index.jsx
+++ b/packages/components/src/select-dropdown/index.jsx
@@ -1,0 +1,415 @@
+import classNames from 'classnames';
+import { filter, find, get, noop } from 'lodash';
+import PropTypes from 'prop-types';
+import { createRef, Children, cloneElement, Component, forwardRef } from 'react';
+import { v4 as uuid } from 'uuid';
+import { Count } from '../count';
+import Gridicon from '../gridicon';
+import DropdownItem from './item';
+import DropdownLabel from './label';
+import DropdownSeparator from './separator';
+import TranslatableString from './translatable/proptype';
+import './style.scss';
+
+class SelectDropdown extends Component {
+	static Item = DropdownItem;
+	static Separator = DropdownSeparator;
+	static Label = DropdownLabel;
+
+	static propTypes = {
+		id: PropTypes.string,
+		selectedText: TranslatableString,
+		selectedIcon: PropTypes.element,
+		selectedCount: PropTypes.number,
+		selectedSecondaryIcon: PropTypes.element,
+		positionSelectedSecondaryIconOnRight: PropTypes.bool,
+		initialSelected: PropTypes.string,
+		className: PropTypes.string,
+		style: PropTypes.object,
+		onSelect: PropTypes.func,
+		onToggle: PropTypes.func,
+		focusSibling: PropTypes.func,
+		tabIndex: PropTypes.number,
+		disabled: PropTypes.bool,
+		options: PropTypes.arrayOf(
+			PropTypes.shape( {
+				value: PropTypes.string.isRequired,
+				label: PropTypes.oneOfType( [ TranslatableString, PropTypes.node ] ).isRequired,
+				path: PropTypes.string,
+				icon: PropTypes.element,
+				secondaryIcon: PropTypes.element,
+			} )
+		),
+		isLoading: PropTypes.bool,
+		ariaLabel: PropTypes.string,
+		showSelectedOption: PropTypes.bool,
+		children: PropTypes.node,
+	};
+
+	static defaultProps = {
+		options: [],
+		onSelect: noop,
+		onToggle: noop,
+		style: {},
+		showSelectedOption: true,
+	};
+
+	instanceId = uuid();
+
+	state = {
+		isOpen: false,
+		selected: this.getInitialSelectedItem(),
+	};
+
+	itemRefs = [];
+
+	setItemRef = ( index ) => ( itemEl ) => {
+		this.itemRefs[ index ] = itemEl;
+	};
+
+	constructor( props ) {
+		super( props );
+		this.dropdownContainerRef = props.innerRef ?? createRef();
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'click', this.handleOutsideClick );
+	}
+
+	componentDidUpdate( prevProps, prevState ) {
+		if ( this.state.isOpen ) {
+			window.addEventListener( 'click', this.handleOutsideClick );
+		} else {
+			window.removeEventListener( 'click', this.handleOutsideClick );
+		}
+
+		if ( this.state.isOpen !== prevState.isOpen ) {
+			this.props.onToggle( {
+				target: this,
+				open: this.state.isOpen,
+			} );
+		}
+	}
+
+	getInitialSelectedItem() {
+		// This method is only useful for the case when the component is uncontrolled, i.e., the
+		// selected state is in local state as opposed to being maintained by parent container.
+		// The `SelectDropdown` is uncontrolled iff the items are specified as `options` prop.
+		// (And is controlled when the items are specified as `children`.)
+		if ( ! this.props.options.length ) {
+			return undefined;
+		}
+
+		// Use the `initialSelected` prop if specified
+		if ( this.props.initialSelected ) {
+			return this.props.initialSelected;
+		}
+
+		// Otherwise find the first option that is an item, i.e., not label or separator
+		return get(
+			find( this.props.options, ( item ) => item && ! item.isLabel ),
+			'value'
+		);
+	}
+
+	getSelectedText() {
+		const { options, selectedText } = this.props;
+		const { selected } = this.state;
+
+		if ( selectedText ) {
+			return selectedText;
+		}
+
+		// return currently selected text
+		return get( find( options, { value: selected } ), 'label' );
+	}
+
+	getSelectedIcon() {
+		const { options, selectedIcon } = this.props;
+		const { selected } = this.state;
+
+		if ( selectedIcon ) {
+			return selectedIcon;
+		}
+
+		// return currently selected icon
+		return get( find( options, { value: selected } ), 'icon' );
+	}
+
+	getSelectedSecondaryIcon() {
+		const { options, selectedSecondaryIcon } = this.props;
+		const { selected } = this.state;
+
+		if ( selectedSecondaryIcon ) {
+			return selectedSecondaryIcon;
+		}
+
+		return get( find( options, { value: selected } ), 'secondaryIcon' );
+	}
+
+	dropdownOptions() {
+		let refIndex = 0;
+
+		if ( this.props.children ) {
+			// add refs and focus-on-click handlers to children
+			return Children.map( this.props.children, ( child ) => {
+				if (
+					! child ||
+					! [ DropdownItem, DropdownSeparator, DropdownLabel ].includes( child.type )
+				) {
+					return null;
+				}
+
+				return cloneElement( child, {
+					ref: child.type === DropdownItem ? this.setItemRef( refIndex++ ) : null,
+					onClick: ( event ) => {
+						this.dropdownContainerRef.current.focus();
+						if ( typeof child.props.onClick === 'function' ) {
+							child.props.onClick( event );
+						}
+					},
+				} );
+			} );
+		}
+
+		return this.props.options
+			.filter( ( item ) => {
+				if ( this.props.showSelectedOption ) {
+					return true;
+				}
+				return item.value !== this.state.selected;
+			} )
+			.map( ( item, index ) => {
+				if ( ! item ) {
+					return <DropdownSeparator key={ 'dropdown-separator-' + index } />;
+				}
+
+				if ( item.isLabel ) {
+					return <DropdownLabel key={ 'dropdown-label-' + index }>{ item.label }</DropdownLabel>;
+				}
+
+				return (
+					<DropdownItem
+						key={ 'dropdown-item-' + item.value }
+						ref={ this.setItemRef( refIndex++ ) }
+						selected={ this.state.selected === item.value }
+						onClick={ this.onSelectItem( item ) }
+						path={ item.path }
+						icon={ item.icon }
+						secondaryIcon={ item.secondaryIcon }
+					>
+						{ item.label }
+					</DropdownItem>
+				);
+			} );
+	}
+
+	render() {
+		const dropdownClassName = classNames( 'select-dropdown', this.props.className, {
+			'is-compact': this.props.compact,
+			'is-open': this.state.isOpen && ! this.props.disabled,
+			'is-disabled': this.props.disabled,
+			'has-count': 'number' === typeof this.props.selectedCount,
+			'is-loading': this.props?.isLoading,
+		} );
+
+		const selectedText = this.getSelectedText();
+		const selectedIcon = this.getSelectedIcon();
+		const selectedSecondaryIcon = this.getSelectedSecondaryIcon();
+		const { positionSelectedSecondaryIconOnRight } = this.props;
+
+		return (
+			<div id={ this.props.id } style={ this.props.style } className={ dropdownClassName }>
+				<div
+					ref={ this.dropdownContainerRef }
+					className="select-dropdown__container"
+					onKeyDown={ this.navigateItem }
+					tabIndex={ this.props.tabIndex || 0 }
+					role="button"
+					aria-haspopup="true"
+					aria-owns={ 'select-submenu-' + this.instanceId }
+					aria-controls={ 'select-submenu-' + this.instanceId }
+					aria-expanded={ this.state.isOpen }
+					aria-disabled={ this.props.disabled }
+					data-tip-target={ this.props.tipTarget }
+					onClick={ this.toggleDropdown }
+				>
+					<div id={ 'select-dropdown-' + this.instanceId } className="select-dropdown__header">
+						<span className="select-dropdown__header-text" aria-label={ this.props.ariaLabel }>
+							{ ! positionSelectedSecondaryIconOnRight && selectedSecondaryIcon }
+							{ selectedIcon }
+							{ selectedText }
+						</span>
+						{ 'number' === typeof this.props.selectedCount && (
+							<Count count={ this.props.selectedCount } />
+						) }
+						{ positionSelectedSecondaryIconOnRight && selectedSecondaryIcon }
+						<Gridicon icon="chevron-down" size={ 18 } />
+					</div>
+
+					<ul
+						id={ 'select-submenu-' + this.instanceId }
+						className="select-dropdown__options"
+						role="listbox"
+						aria-labelledby={ 'select-dropdown-' + this.instanceId }
+						aria-expanded={ this.state.isOpen }
+					>
+						{ this.dropdownOptions() }
+					</ul>
+				</div>
+			</div>
+		);
+	}
+
+	toggleDropdown = () => {
+		if ( this.props && this.props.disabled ) {
+			return;
+		}
+
+		this.setState( {
+			isOpen: ! this.state.isOpen,
+		} );
+	};
+
+	openDropdown() {
+		if ( this.props && this.props.disabled ) {
+			return;
+		}
+		this.setState( {
+			isOpen: true,
+		} );
+	}
+
+	closeDropdown() {
+		if ( this.state.isOpen ) {
+			delete this.focused;
+			this.setState( {
+				isOpen: false,
+			} );
+		}
+	}
+
+	onSelectItem( option ) {
+		return this.selectItem.bind( this, option );
+	}
+
+	selectItem( option ) {
+		if ( ! option ) {
+			return;
+		}
+
+		if ( this.props.onSelect ) {
+			this.props.onSelect( option );
+		}
+
+		this.setState( {
+			selected: option.value,
+		} );
+
+		this.dropdownContainerRef.current.focus();
+	}
+
+	navigateItem = ( event ) => {
+		switch ( event.code ) {
+			case 'Tab':
+				this.navigateItemByTabKey( event );
+				break;
+			case 'Space':
+			case 'Enter':
+				event.preventDefault();
+				this.activateItem();
+				break;
+			case 'ArrowUp':
+				event.preventDefault();
+				this.focusSibling( 'previous' );
+				this.openDropdown();
+				break;
+			case 'ArrowDown':
+				event.preventDefault();
+				this.focusSibling( 'next' );
+				this.openDropdown();
+				break;
+			case 'Escape':
+				event.preventDefault();
+				this.closeDropdown();
+				this.dropdownContainerRef.current.focus();
+				break;
+		}
+	};
+
+	navigateItemByTabKey( event ) {
+		if ( ! this.state.isOpen ) {
+			return;
+		}
+
+		event.preventDefault();
+
+		const direction = event.shiftKey ? 'previous' : 'next';
+		this.focusSibling( direction );
+	}
+
+	activateItem() {
+		if ( ! this.state.isOpen ) {
+			return this.openDropdown();
+		}
+		document.activeElement.click();
+	}
+
+	focusSibling( direction ) {
+		// the initial up-arrow/down-arrow should only open the menu
+		if ( ! this.state.isOpen ) {
+			return;
+		}
+
+		let items;
+		let focusedIndex;
+
+		if ( this.props.options.length ) {
+			items = filter( this.props.options, ( item ) => {
+				if ( ! item || item.isLabel ) {
+					return false;
+				}
+
+				if ( ! this.props.showSelectedOption && item.value === this.state.selected ) {
+					return false;
+				}
+
+				return true;
+			} );
+
+			focusedIndex =
+				typeof this.focused === 'number'
+					? this.focused
+					: items.findIndex( ( item ) => item.value === this.state.selected );
+		} else {
+			items = filter( this.props.children, ( item ) => item.type === DropdownItem );
+
+			focusedIndex =
+				typeof this.focused === 'number'
+					? this.focused
+					: items.findIndex( ( item ) => item.props.selected );
+		}
+
+		const increment = direction === 'previous' ? -1 : 1;
+		const newIndex = focusedIndex + increment;
+
+		if ( newIndex >= items.length || newIndex < 0 ) {
+			return;
+		}
+
+		this.itemRefs[ newIndex ].focusLink();
+		this.focused = newIndex;
+	}
+
+	handleOutsideClick = ( event ) => {
+		if ( ! this.dropdownContainerRef.current.contains( event.target ) ) {
+			this.closeDropdown();
+		}
+	};
+}
+
+export default SelectDropdown;
+
+export const SelectDropdownForwardingRef = forwardRef( ( props, ref ) => (
+	<SelectDropdown { ...props } innerRef={ ref } />
+) );

--- a/packages/components/src/select-dropdown/index.stories.jsx
+++ b/packages/components/src/select-dropdown/index.stories.jsx
@@ -8,6 +8,7 @@ const Template = ( args ) => {
 
 export const Default = Template.bind( {} );
 Default.args = {
+	ariaLabel: 'select-dropdown-aria-label',
 	className: 'select-dropdown',
 	compact: false,
 	disabled: false,
@@ -18,6 +19,7 @@ Default.args = {
 		// eslint-disable-next-line no-console
 		console.log( `${ label } Dropdown item selected` );
 	},
+	initialSelected: 'pikachu',
 	options: [
 		{ value: 'pikachu', label: 'Pikachu' },
 		{ value: 'charmander', label: 'Charmander' },

--- a/packages/components/src/select-dropdown/index.stories.jsx
+++ b/packages/components/src/select-dropdown/index.stories.jsx
@@ -1,0 +1,26 @@
+import SelectDropdown from '.';
+
+export default { component: SelectDropdown, title: 'packages/components/SelectDropdown' };
+
+const Template = ( args ) => {
+	return <SelectDropdown { ...args } />;
+};
+
+export const Default = Template.bind( {} );
+Default.args = {
+	className: 'select-dropdown',
+	compact: false,
+	disabled: false,
+	isLoading: false,
+	// eslint-disable-next-line no-console
+	onToggle: () => console.log( 'Toggled' ),
+	onSelect: ( { label } ) => {
+		// eslint-disable-next-line no-console
+		console.log( `${ label } Dropdown item selected` );
+	},
+	options: [
+		{ value: 'pikachu', label: 'Pikachu' },
+		{ value: 'charmander', label: 'Charmander' },
+		{ value: 'bulbasaur', label: 'Bulbasaur' },
+	],
+};

--- a/packages/components/src/select-dropdown/item.jsx
+++ b/packages/components/src/select-dropdown/item.jsx
@@ -1,0 +1,75 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import { createRef, Component } from 'react';
+import Count from '../count';
+import TranslatableString from './translatable/proptype';
+
+class SelectDropdownItem extends Component {
+	static propTypes = {
+		children: PropTypes.oneOfType( [ TranslatableString, PropTypes.node ] ).isRequired,
+		compactCount: PropTypes.bool,
+		path: PropTypes.string,
+		selected: PropTypes.bool,
+		onClick: PropTypes.func,
+		count: PropTypes.number,
+		disabled: PropTypes.bool,
+		icon: PropTypes.element,
+		ariaLabel: PropTypes.string,
+		secondaryIcon: PropTypes.element,
+	};
+
+	static defaultProps = {
+		selected: false,
+	};
+
+	linkRef = createRef();
+
+	// called by the parent `SelectDropdown` component to focus the item on keyboard navigation
+	focusLink() {
+		this.linkRef.current.focus();
+	}
+
+	render() {
+		const optionClassName = classNames( 'select-dropdown__item', this.props.className, {
+			'is-selected': this.props.selected,
+			'is-disabled': this.props.disabled,
+			'has-icon': this.props.icon,
+		} );
+
+		const label = this.props.value || this.props.children;
+		const ariaLabel =
+			this.props.ariaLabel ||
+			( 'number' === typeof this.props.count ? `${ label } (${ this.props.count })` : label );
+
+		return (
+			<li className="select-dropdown__option">
+				<a
+					ref={ this.linkRef }
+					href={ this.props.path }
+					className={ optionClassName }
+					onClick={ this.props.disabled ? null : this.props.onClick }
+					data-bold-text={ label }
+					role="menuitem"
+					tabIndex="0"
+					aria-current={ this.props.selected }
+					aria-label={ ariaLabel }
+					data-e2e-title={ this.props.e2eTitle }
+				>
+					<span className="select-dropdown__item-text">
+						{ this.props.icon }
+						{ this.props.children }
+					</span>
+					{ 'number' === typeof this.props.count ? (
+						<span data-text={ this.props.count } className="select-dropdown__item-count">
+							<Count count={ this.props.count } compact={ this.props.compactCount } />
+						</span>
+					) : (
+						<>{ this.props.secondaryIcon }</>
+					) }
+				</a>
+			</li>
+		);
+	}
+}
+
+export default SelectDropdownItem;

--- a/packages/components/src/select-dropdown/label.jsx
+++ b/packages/components/src/select-dropdown/label.jsx
@@ -1,0 +1,12 @@
+import FormLabel from '../form-label';
+
+// Prevents the event from bubbling up the DOM tree
+const stopPropagation = ( event ) => event.stopPropagation();
+
+export default function SelectDropdownLabel( { children } ) {
+	return (
+		<li onClick={ stopPropagation } role="presentation" className="select-dropdown__label">
+			<FormLabel>{ children }</FormLabel>
+		</li>
+	);
+}

--- a/packages/components/src/select-dropdown/label.jsx
+++ b/packages/components/src/select-dropdown/label.jsx
@@ -1,4 +1,4 @@
-import FormLabel from '../form-label';
+import { FormLabel } from '../forms';
 
 // Prevents the event from bubbling up the DOM tree
 const stopPropagation = ( event ) => event.stopPropagation();

--- a/packages/components/src/select-dropdown/separator.jsx
+++ b/packages/components/src/select-dropdown/separator.jsx
@@ -1,0 +1,3 @@
+export default function SelectDropdownSeparator() {
+	return <li role="separator" className="select-dropdown__separator" />;
+}

--- a/packages/components/src/select-dropdown/style.scss
+++ b/packages/components/src/select-dropdown/style.scss
@@ -1,0 +1,307 @@
+@import "@automattic/typography/styles/variables";
+
+/**
+ * Select Dropdown
+ */
+$header-height: 43;
+$option-height: 40;
+$side-margin: 16;
+
+$compact-header-height: 35;
+
+.select-dropdown {
+	height: #{$header-height}px;
+	overflow: hidden;
+
+	&.is-open {
+		overflow: visible;
+	}
+
+	&.is-compact {
+		height: #{$compact-header-height}px;
+	}
+}
+
+.select-dropdown__container {
+	position: relative;
+	display: inline-block;
+	max-width: 100%;
+
+	.select-dropdown.is-open & {
+		z-index: z-index("root", ".select-dropdown.is-open .select-dropdown__container");
+	}
+
+	.accessible-focus &:focus,
+	.accessible-focus .select-dropdown.is-open & {
+		z-index: z-index("root", ".accessible-focus .select-dropdown.is-open .select-dropdown__container");
+		.select-dropdown__header {
+			border-color: var(--color-primary);
+		}
+	}
+
+	.accessible-focus & {
+		border-radius: 2px;
+	}
+
+	.accessible-focus &:focus {
+		border-color: #00aadc;
+		outline: 0;
+	}
+
+	.accessible-focus .select-dropdown.is-open & {
+		box-shadow: 0 0 0 2px var(--color-primary-light);
+	}
+}
+
+.select-dropdown__header {
+	height: #{$header-height}px;
+	line-height: #{$header-height - 3}px;
+	padding: 0 #{$side-margin}px 0 #{$side-margin}px;
+	box-sizing: border-box;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	border-style: solid;
+	border-color: var(--color-neutral-10);
+	border-width: 1px;
+	border-radius: 2px;
+	background-color: var(--color-surface);
+
+	font-size: $font-body-small;
+	font-weight: 600;
+	color: var(--color-neutral-70);
+	transition: background-color 0.2s ease;
+	cursor: pointer;
+
+	.gridicons-chevron-down {
+		fill: var(--color-neutral-50);
+		margin: 0;
+		flex-shrink: 0;
+		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+
+		.is-disabled & {
+			fill: var(--color-neutral-0);
+		}
+	}
+
+	.is-compact & {
+		height: #{$compact-header-height}px;
+		line-height: #{$compact-header-height - 3}px;
+		padding-right: #{$side-margin * 0.5}px;
+		font-size: $font-body-extra-small;
+
+		.count {
+			border-width: 0;
+			right: 25px;
+			top: #{( $compact-header-height - 18 ) * 0.5}px;
+		}
+	}
+
+	.is-disabled & {
+		color: var(--color-neutral-0);
+		background: var(--color-surface);
+		border-color: var(--color-neutral-0);
+		cursor: default;
+
+		&:active,
+		&.is-active {
+			border-width: 1px;
+		}
+	}
+
+	.is-loading & .count,
+	.is-loading & .select-dropdown__header-text {
+		animation: loading-fade 1.6s ease-in-out infinite;
+		color: var(--color-neutral-50);
+	}
+
+	.select-dropdown.is-open & {
+		border-radius: 2px 2px 0 0;
+		box-shadow: none;
+		background-color: var(--color-neutral-0);
+
+		.gridicons-chevron-down {
+			transform: rotate(-180deg);
+		}
+	}
+
+	.accessible-focus .select-dropdown:not(.is-open) .select-dropdown__container:focus & {
+		box-shadow: 0 0 0 2px var(--color-primary-light);
+	}
+
+	.count {
+		position: absolute;
+		right: 40px;
+		top: #{( $header-height - 18 - 2 ) * 0.5}px;
+	}
+}
+
+.select-dropdown__header-text {
+	display: block;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+
+	.has-count & {
+		padding-right: 40px;
+	}
+
+	.gridicon,
+	.material-icon {
+		margin-right: #{( $side-margin * 0.5 )}px;
+		margin-bottom: -4px;
+		vertical-align: text-bottom;
+
+		.is-compact & {
+			position: relative;
+			top: 2px;
+			margin-bottom: 0;
+		}
+	}
+}
+
+.select-dropdown__options {
+	box-sizing: border-box;
+	padding: 0;
+	list-style: none;
+	margin: -1px 0 0;
+	background-color: var(--color-surface);
+	border: 1px solid var(--color-neutral-10);
+	border-top: 0;
+	border-radius: 0 0 2px 2px;
+	visibility: hidden;
+
+	.accessible-focus & {
+		border: solid 1px var(--color-primary);
+		border-top-color: var(--color-neutral-10);
+	}
+
+	.select-dropdown.is-open & {
+		visibility: visible;
+	}
+}
+
+.select-dropdown__option {
+	height: #{$option-height}px;
+
+	&:last-child .select-dropdown__item {
+		border-radius: 0 0 2px 2px;
+	}
+
+	&:hover {
+		background-color: var(--color-neutral-5);
+	}
+}
+
+.select-dropdown__item {
+	display: block;
+	position: relative;
+	height: #{$option-height}px;
+	line-height: #{$option-height}px;
+	padding: 0 #{$side-margin + 46}px 0 #{$side-margin}px;
+
+	color: var(--color-neutral-70);
+	font-size: $font-body-small;
+	font-weight: 400;
+	white-space: nowrap;
+	overflow: hidden;
+	cursor: pointer;
+
+	// hack to set text width in bold weight
+	&::before {
+		content: attr(data-bold-text);
+		font-weight: 600;
+		white-space: nowrap;
+		opacity: 0;
+	}
+
+	&:visited {
+		color: var(--color-neutral-70);
+	}
+
+	&.is-selected {
+		background-color: var(--color-accent);
+		color: var(--color-text-inverted);
+
+		.count {
+			border-color: var(--color-border-inverted);
+			color: var(--color-text-inverted);
+		}
+	}
+
+	&.is-disabled {
+		background-color: var(--color-surface);
+		color: var(--color-neutral-light);
+		cursor: default;
+		opacity: 0.5;
+	}
+
+	.notouch & {
+		// Make sure :visited links stay blue
+		&:hover {
+			color: var(--color-accent);
+		}
+
+		&.is-selected:hover {
+			color: var(--color-text-inverted);
+		}
+	}
+
+	.extra-gridicon {
+		fill: var(--color-neutral);
+		position: absolute;
+		top: #{( $option-height - 18 ) * 0.5}px;
+		right: #{$side-margin - 8 }px;
+	}
+
+	.gridicon {
+		margin-right: #{( $side-margin * 0.5 )}px;
+		vertical-align: text-bottom;
+	}
+}
+
+.select-dropdown__item-count {
+	&::before {
+		content: attr(data-text);
+		opacity: 0;
+	}
+
+	.count {
+		position: absolute;
+		top: #{( $option-height - 18 ) * 0.5}px;
+		right: #{$side-margin}px;
+	}
+}
+
+.select-dropdown__item-text {
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	color: inherit;
+	display: inline-block;
+	max-width: 100%;
+	position: absolute;
+	left: #{$side-margin}px;
+	right: #{$side-margin}px;
+}
+
+.select-dropdown__separator {
+	border-top: 1px solid var(--color-neutral-10);
+	display: block;
+	margin: 8px 0;
+}
+
+.select-dropdown__label {
+	display: block;
+	color: var(--color-text-subtle);
+	line-height: 20px;
+
+	.form-label {
+		font-size: $font-body-extra-small;
+		font-weight: 400;
+		padding: 0 #{$side-margin}px;
+		margin-bottom: 0;
+		display: inline;
+	}
+}

--- a/packages/components/src/select-dropdown/test/index.js
+++ b/packages/components/src/select-dropdown/test/index.js
@@ -1,0 +1,217 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SelectDropdown from '../index';
+
+const DROPDOWN_OPTIONS = [
+	{ value: 'status-options', label: 'Statuses', isLabel: true },
+	{ value: 'published', label: 'Published' },
+	{ value: 'scheduled', label: 'Scheduled' },
+	{ value: 'drafts', label: 'Drafts' },
+	null,
+	{ value: 'trashed', label: 'Trashed' },
+];
+
+function renderDropdown( props ) {
+	return render( <SelectDropdown options={ DROPDOWN_OPTIONS } { ...props } /> );
+}
+
+describe( 'component rendering', () => {
+	test( 'should render a list with the provided options', () => {
+		renderDropdown();
+		expect( screen.getByRole( 'presentation' ) ).toHaveTextContent( 'Statuses' );
+		expect( screen.queryAllByRole( 'listitem' ) ).toHaveLength( 4 );
+	} );
+
+	test( 'should render a separator in place of any falsy option', () => {
+		renderDropdown();
+		expect( screen.queryAllByRole( 'separator' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should be initially closed', () => {
+		renderDropdown();
+		expect( screen.getByRole( 'button' ) ).toHaveAttribute( 'aria-expanded', 'false' );
+	} );
+
+	test( 'should execute toggleDropdown when clicked', async () => {
+		renderDropdown();
+
+		const btn = screen.getByRole( 'button' );
+		expect( btn ).toHaveAttribute( 'aria-expanded', 'false' );
+
+		await userEvent.click( btn );
+		expect( btn ).toHaveAttribute( 'aria-expanded', 'true' );
+
+		await userEvent.click( btn );
+		expect( btn ).toHaveAttribute( 'aria-expanded', 'false' );
+	} );
+
+	test( 'should not respond when clicked when disabled', async () => {
+		renderDropdown( { disabled: true } );
+
+		const btn = screen.getByRole( 'button' );
+		expect( btn ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		await userEvent.click( btn );
+		expect( btn ).toHaveAttribute( 'aria-expanded', 'false' );
+	} );
+
+	test( 'should be possible to open the dropdown via keyboard', async () => {
+		renderDropdown();
+
+		const btn = screen.getByRole( 'button' );
+
+		await userEvent.tab();
+		expect( btn ).toHaveFocus();
+
+		await userEvent.keyboard( '[Space]' );
+		expect( btn ).toHaveAttribute( 'aria-expanded', 'true' );
+	} );
+
+	test( 'should render a header with custom label', () => {
+		renderDropdown( { ariaLabel: 'Custom Field Label' } );
+
+		const btn = screen.getByRole( 'button' );
+		expect( btn.firstChild.firstChild ).toHaveAttribute( 'aria-label', 'Custom Field Label' );
+	} );
+} );
+
+describe( 'selected items', () => {
+	test( 'should return the initially selected value (if any)', () => {
+		renderDropdown( { initialSelected: 'drafts' } );
+
+		const selected = screen.queryByRole( 'menuitem', { current: true } );
+		expect( selected ).toHaveTextContent( 'Drafts' );
+
+		const btn = screen.getByRole( 'button' );
+		expect( btn.firstChild ).toHaveTextContent( 'Drafts' );
+	} );
+
+	test( "should return `undefined`, when there aren't options", () => {
+		render( <SelectDropdown /> );
+
+		const selected = screen.queryByRole( 'menuitem', { current: true } );
+		expect( selected ).toBeNull();
+
+		const btn = screen.getByRole( 'button' );
+		expect( btn.firstChild ).toHaveTextContent( '' );
+	} );
+
+	test( "should return the first not-label option, when there isn't a preselected value", () => {
+		renderDropdown();
+
+		const selected = screen.queryByRole( 'menuitem', { current: true } );
+		expect( selected ).toHaveTextContent( 'Published' );
+
+		const btn = screen.getByRole( 'button' );
+		expect( btn.firstChild ).toHaveTextContent( 'Published' );
+	} );
+
+	test( 'should return the initially selected text (if any)', () => {
+		renderDropdown( { selectedText: 'Drafts' } );
+
+		const btn = screen.getByRole( 'button' );
+		expect( btn.firstChild ).toHaveTextContent( 'Drafts' );
+	} );
+} );
+
+describe( 'selectItem', () => {
+	test( 'should run the `onSelect` hook, and then update the state', async () => {
+		const onSelectSpy = jest.fn();
+
+		renderDropdown( { onSelect: onSelectSpy } );
+
+		const item = screen.getByRole( 'menuitem', { name: DROPDOWN_OPTIONS[ 2 ].label } );
+
+		await userEvent.click( item );
+
+		const selected = screen.getByRole( 'menuitem', { current: true } );
+		expect( selected ).toHaveTextContent( DROPDOWN_OPTIONS[ 2 ].label );
+
+		expect( onSelectSpy ).toHaveBeenCalledTimes( 1 );
+		expect( onSelectSpy ).toHaveBeenCalledWith( DROPDOWN_OPTIONS[ 2 ] );
+	} );
+} );
+
+describe( 'navigateItem', () => {
+	test( "permits to navigate through the dropdown's options by pressing the TAB key", async () => {
+		renderDropdown();
+
+		const btn = screen.getByRole( 'button' );
+
+		await userEvent.click( btn );
+		await userEvent.tab();
+		await userEvent.keyboard( '[Space]' );
+
+		expect( screen.getByRole( 'menuitem', { current: true } ) ).toHaveTextContent( 'Scheduled' );
+	} );
+
+	test( 'permits to select an option by pressing ENTER', async () => {
+		const onSelectSpy = jest.fn();
+		renderDropdown( { onSelect: onSelectSpy } );
+
+		const btn = screen.getByRole( 'button' );
+		await userEvent.click( btn );
+		await userEvent.tab();
+		await userEvent.keyboard( '[Enter]' );
+
+		expect( onSelectSpy ).toHaveBeenCalledTimes( 1 );
+		expect( onSelectSpy ).toHaveBeenCalledWith( DROPDOWN_OPTIONS[ 2 ] );
+	} );
+
+	test( 'permits to select an option by pressing SPACE', async () => {
+		const onSelectSpy = jest.fn();
+		renderDropdown( { onSelect: onSelectSpy } );
+
+		const btn = screen.getByRole( 'button' );
+		await userEvent.click( btn );
+		await userEvent.tab();
+		await userEvent.keyboard( '[Space]' );
+
+		expect( onSelectSpy ).toHaveBeenCalledTimes( 1 );
+		expect( onSelectSpy ).toHaveBeenCalledWith( DROPDOWN_OPTIONS[ 2 ] );
+	} );
+
+	test( 'permits to close the dropdown by pressing ESCAPE', async () => {
+		renderDropdown();
+
+		const btn = screen.getByRole( 'button' );
+		await userEvent.click( btn );
+
+		expect( btn ).toHaveAttribute( 'aria-expanded', 'true' );
+
+		await userEvent.keyboard( '[Escape]' );
+
+		expect( btn ).toHaveAttribute( 'aria-expanded', 'false' );
+		expect( btn ).toHaveFocus();
+	} );
+
+	test( "permits to open the dropdown, and navigate through the dropdown's options with arrow keys", async () => {
+		renderDropdown();
+
+		const btn = screen.getByRole( 'button' );
+		const items = screen.getAllByRole( 'menuitem' );
+
+		await userEvent.tab();
+		await userEvent.keyboard( '[ArrowDown]' );
+
+		expect( btn ).toHaveAttribute( 'aria-expanded', 'true' );
+
+		await userEvent.keyboard( '[Escape]' );
+		expect( btn ).toHaveAttribute( 'aria-expanded', 'false' );
+
+		await userEvent.keyboard( '[ArrowUp]' );
+		expect( btn ).toHaveAttribute( 'aria-expanded', 'true' );
+
+		await userEvent.keyboard( '[ArrowDown]' );
+		expect( items[ 1 ] ).toHaveFocus();
+
+		await userEvent.keyboard( '[ArrowDown]' );
+		expect( items[ 2 ] ).toHaveFocus();
+
+		await userEvent.keyboard( '[ArrowUp]' );
+		expect( items[ 1 ] ).toHaveFocus();
+	} );
+} );

--- a/packages/components/src/select-dropdown/test/index.js
+++ b/packages/components/src/select-dropdown/test/index.js
@@ -3,6 +3,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
 import SelectDropdown from '../index';
 
 const DROPDOWN_OPTIONS = [

--- a/packages/components/src/select-dropdown/test/item.js
+++ b/packages/components/src/select-dropdown/test/item.js
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SelectDropdownItem from '../item';
+
+describe( 'item', () => {
+	describe( 'component rendering', () => {
+		test( 'should render a list entry', () => {
+			render( <SelectDropdownItem>Published</SelectDropdownItem> );
+			const item = screen.queryByRole( 'listitem' );
+			expect( item ).toBeInTheDocument();
+		} );
+
+		test( 'should contain a link', () => {
+			render( <SelectDropdownItem>Published</SelectDropdownItem> );
+			const item = screen.getByRole( 'listitem' );
+			const link = screen.getByRole( 'menuitem', { name: /published/i } );
+			expect( item.firstChild ).toHaveTextContent( 'Published' );
+			expect( item.firstChild ).toBe( link );
+		} );
+
+		test( 'should contain a default aria-label', () => {
+			render( <SelectDropdownItem>Published</SelectDropdownItem> );
+			const link = screen.getByRole( 'menuitem', { name: /published/i } );
+			expect( link ).toHaveAttribute( 'aria-label', 'Published' );
+		} );
+
+		test( 'should default aria-label include a count', () => {
+			render( <SelectDropdownItem count={ 123 }>Published</SelectDropdownItem> );
+			const link = screen.getByRole( 'menuitem', { name: /published/i } );
+			expect( link ).toHaveAttribute( 'aria-label', 'Published (123)' );
+		} );
+
+		test( 'should render custom aria-label if provided', () => {
+			render(
+				<SelectDropdownItem count={ 123 } ariaLabel="My Custom Label">
+					Published
+				</SelectDropdownItem>
+			);
+			const link = screen.getByRole( 'menuitem', { name: /my custom label/i } );
+			expect( link ).toHaveAttribute( 'aria-label', 'My Custom Label' );
+		} );
+	} );
+
+	describe( 'when the component is clicked', () => {
+		test( 'should do nothing when is disabled', async () => {
+			const onClickSpy = jest.fn();
+			render(
+				<SelectDropdownItem disabled={ true } onClick={ onClickSpy }>
+					Published
+				</SelectDropdownItem>
+			);
+
+			const link = screen.getByRole( 'menuitem', { name: /published/i } );
+			await userEvent.click( link );
+
+			expect( onClickSpy ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should run the `onClick` hook', async () => {
+			const onClickSpy = jest.fn();
+			render( <SelectDropdownItem onClick={ onClickSpy }>Published</SelectDropdownItem> );
+
+			const link = screen.getByRole( 'menuitem', { name: /published/i } );
+			await userEvent.click( link );
+
+			expect( onClickSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/packages/components/src/select-dropdown/test/item.js
+++ b/packages/components/src/select-dropdown/test/item.js
@@ -3,6 +3,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
 import SelectDropdownItem from '../item';
 
 describe( 'item', () => {

--- a/packages/components/src/select-dropdown/translatable/proptype.js
+++ b/packages/components/src/select-dropdown/translatable/proptype.js
@@ -1,0 +1,62 @@
+function translatableStringChecker( props, propName, componentName ) {
+	componentName = componentName || 'ANONYMOUS';
+
+	const value = props[ propName ];
+	if ( value !== undefined && value !== null ) {
+		if ( 'string' === typeof value ) {
+			return null;
+		}
+
+		// Translator Jumpstart old-style
+		if ( 'object' === typeof value && 'data' === value.type ) {
+			return null;
+		}
+
+		// Translator Jumpstart after #21591
+		if (
+			'object' === typeof value &&
+			[ 'object', 'function' ].includes( typeof value.type ) &&
+			( 'Translatable' === value.type.name ||
+				// Accept HOC wrappings (e.g. `localize( Translatable )`)
+				String( value.type.displayName ).match( /\(Translatable\)/ ) )
+		) {
+			return null;
+		}
+
+		return new Error(
+			'Invalid value for Translatable string in `' +
+				componentName +
+				'`. Please pass a translate() call.'
+		);
+	}
+
+	// assume all ok
+	return null;
+}
+
+function createChainableTypeChecker( validate ) {
+	function checkType( isRequired, props, propName, componentName, location ) {
+		componentName = componentName || 'ANONYMOUS';
+		if ( props[ propName ] === undefined ) {
+			if ( isRequired ) {
+				return new Error(
+					'Required ' +
+						location +
+						' `' +
+						propName +
+						'` was not specified in ' +
+						( '`' + componentName + '`.' )
+				);
+			}
+			return null;
+		}
+		return validate( props, propName, componentName, location );
+	}
+
+	const chainedCheckType = checkType.bind( null, false );
+	chainedCheckType.isRequired = checkType.bind( null, true );
+
+	return chainedCheckType;
+}
+
+export default createChainableTypeChecker( translatableStringChecker );

--- a/packages/components/src/select-dropdown/translatable/test/proptype.js
+++ b/packages/components/src/select-dropdown/translatable/test/proptype.js
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["assertPasses", "assertFails"] }] */
+
+import { localize } from 'i18n-calypso';
+import translatableString from '../proptype';
+
+function assertPasses( validator, { props }, propName = 'translatableString' ) {
+	expect( validator( props, 'translatableString', propName ) ).toBeNull();
+}
+
+function assertFails( validator, { props }, propName = 'translatableString' ) {
+	expect( validator( props, propName ) ).toBeInstanceOf( Error );
+}
+
+const Translatable = () => <span />;
+const LocalizedTranslatable = localize( Translatable );
+
+describe( 'translatable proptype', () => {
+	test( 'should pass when no propType Name declared', () => {
+		assertPasses( translatableString, <legend />, '' );
+	} );
+
+	test( 'should pass with string', () =>
+		assertPasses( translatableString, <legend translatableString="Los pollos hermanos" /> ) );
+
+	test( 'should pass with <Translatable /> component', () =>
+		assertPasses( translatableString, <legend translatableString={ <Translatable /> } /> ) );
+
+	test( 'should pass on <data /> object', () =>
+		assertPasses( translatableString, Object.assign( {}, <data /> ) ) );
+
+	test( 'should pass on nil/false values', () => {
+		assertPasses( translatableString, <legend translatableString={ null } /> );
+		assertPasses( translatableString, <legend translatableString={ undefined } /> );
+	} );
+
+	test( 'should fail on numbers', () => {
+		assertFails( translatableString, <legend translatableString={ 0 } /> );
+		assertFails( translatableString, <legend translatableString={ 2 } /> );
+	} );
+
+	test( 'should fail on unexpected functions', () =>
+		assertFails( translatableString, <legend translatableString={ function () {} } /> ) );
+
+	test( 'should fail on unexpected objects', () =>
+		assertFails( translatableString, <legend translatableString={ {} } /> ) );
+
+	it( 'should pass with valid value when required', () => {
+		assertPasses(
+			translatableString.isRequired,
+			<legend translatableString={ <Translatable /> } />
+		);
+		assertPasses(
+			translatableString.isRequired,
+			<legend translatableString="Los pollos hermanos" />
+		);
+	} );
+
+	it( 'should fail when required', () => assertFails( translatableString.isRequired, <legend /> ) );
+
+	it( 'should pass with <Translatable> component run through i18n-calypso.localize()', () =>
+		assertPasses(
+			translatableString.isRequired,
+			<legend translatableString={ <LocalizedTranslatable /> } />
+		) );
+} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,11 @@ __metadata:
     "@automattic/typography": "workspace:^"
     "@storybook/addon-actions": ^7.0.18
     "@storybook/react": ^7.0.18
+    "@testing-library/dom": ^9.0.0
     "@testing-library/jest-dom": ^5.17.0
     "@testing-library/react": ^14.0.0
     "@testing-library/react-hooks": 7.0.2
+    "@testing-library/user-event": ^14.4.3
     "@types/canvas-confetti": ^1.6.0
     "@types/react-slider": ^1.3.1
     "@wordpress/base-styles": ^4.29.0
@@ -541,6 +543,8 @@ __metadata:
     resize-observer-polyfill: ^1.5.1
     typescript: ^5.1.6
     utility-types: ^3.10.0
+    uuid: ^8.3.2
+    wpcom-proxy-request: "workspace:^"
   peerDependencies:
     "@wordpress/data": ^9.8.0
     react: ^18.2.0


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Dependent on https://github.com/Automattic/wp-calypso/pull/79257 and https://github.com/Automattic/wp-calypso/pull/79256
- Tracking issue https://github.com/Automattic/martech/issues/2023

## Proposed Changes

I understand that these seem like a large volume of changes, but we're simply cloning the existing `client/components/` select dropdown component into `@automattic/components` as we did in https://github.com/Automattic/wp-calypso/pull/79257 and https://github.com/Automattic/wp-calypso/pull/79256

The entirety of the migration is a 4 step process that creates easily digestible ( and revertible ) PRs to work with. See https://github.com/Automattic/martech/issues/2028. Unfortunately, this process also eliminates the git history from migrated files unless the 4 steps are condensed into a single one. I don't have a great answer to this, but the tradeoff, to me, is worth the added safety of more understandable, compact, iterative pull requests.

## GIFs
![2023-08-12 20 49 14](https://github.com/Automattic/wp-calypso/assets/5414230/086fce28-fa20-4486-8d6f-7cf69466c786)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure all tests pass. `yarn run test-packages packages/components/src/select-dropdown/test` if you'd like to run it locally, but the CI process should catch anything.
* At the root of the Calypso directory, run `yarn storybook:start`
* Ensure that the select-dropdown component renders properly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
