### PR TITLE
Automattic Components: Add count to package

### DIFF
--- a/client/lib/domains/registration/test/availability-messages.js
+++ b/client/lib/domains/registration/test/availability-messages.js
@@ -6,6 +6,7 @@ import { domainAvailability } from 'calypso/lib/domains/constants';
 import { getAvailabilityNotice } from '../availability-messages';
 
 jest.mock( 'i18n-calypso', () => ( {
+	...jest.requireActual( 'i18n-calypso' ),
 	translate: jest.fn( () => 'default' ),
 } ) );
 

--- a/packages/components/src/count/README.md
+++ b/packages/components/src/count/README.md
@@ -1,0 +1,37 @@
+# Count
+
+Count is a React component that shows positive and negative integer numbers, by default with rounded corners. The component internationalizes the passed number. For example, it's used to show post and draft counts as well as the number of people on a team.
+
+![Example](https://cldup.com/KdVOxsaKhS-3000x3000.png)
+
+## Usage
+
+If you want to display a count of some sort -- number of posts, drafts, team members, etc. -- use this component to keep the style consistent across components and to not worry about i18n.
+
+```jsx
+function render() {
+	return (
+		<p>
+			<Count count={ this.props.postCount } /> Posts
+		</p>
+	);
+}
+```
+
+## Props
+
+### `count`
+
+The number to be displayed. Make sure it's a number, not a string containing a number.
+
+### `primary`
+
+Boolean. Applies `is-primary` class and related styles.
+
+### `compact`
+
+Boolean. Displays counts with a localized compact variant. For example instead of 1234, we see 1.2K for `en` or 1.2 mil for `es`
+
+## Custom Styling
+
+In some cases, it may be necessary to increase the font size or remove the border. In your component's style file, specify rules for the `.count` within your component's selector. For an example, see the `select-dropdown` component's style file.

--- a/packages/components/src/count/README.md
+++ b/packages/components/src/count/README.md
@@ -1,6 +1,6 @@
 # Count
 
-Count is a React component that shows positive and negative integer numbers, by default with rounded corners. The component internationalizes the passed number. For example, it's used to show post and draft counts as well as the number of people on a team.
+Count is a React component that shows positive and negative integer numbers by default with rounded corners. The component internationalizes the passed number. For example, it's used to show post and draft counts as well as the number of people on a team.
 
 ![Example](https://cldup.com/KdVOxsaKhS-3000x3000.png)
 

--- a/packages/components/src/count/docs/example.jsx
+++ b/packages/components/src/count/docs/example.jsx
@@ -1,0 +1,15 @@
+const count = () => {
+	/* Because Count is wrapped in Localize we have to store the example in a string */
+};
+
+count.defaultProps = {
+	exampleCode:
+		'<div>' +
+		'\n\t<Count count={ 65365 } />' +
+		'\n\t<Count primary count={ 65366 } />' +
+		'\n</div>',
+};
+
+count.displayName = 'Count';
+
+export default count;

--- a/packages/components/src/count/format-number-compact.js
+++ b/packages/components/src/count/format-number-compact.js
@@ -1,0 +1,62 @@
+import i18n, { numberFormat } from 'i18n-calypso';
+import { THOUSANDS } from './thousands';
+
+/**
+ * Formats a number to a short format given a language code
+ *
+ * @param   {number}     number              number to format
+ * @param   {string}     code                language code e.g. 'es'
+ * @returns {?string}                        A formatted string.
+ */
+export default function formatNumberCompact( number, code = i18n.getLocaleSlug() ) {
+	//use numberFormat directly from i18n in this case!
+	if ( isNaN( number ) || ! THOUSANDS[ code ] ) {
+		return null;
+	}
+
+	const { decimal, grouping, symbol, unitValue = 1000 } = THOUSANDS[ code ];
+
+	const sign = number < 0 ? '-' : '';
+	const absNumber = Math.abs( number );
+
+	// no-op if we have a small number
+	if ( absNumber < unitValue ) {
+		return `${ sign }${ absNumber }`;
+	}
+
+	//show 2 sig figs, otherwise take leading sig figs.
+	const decimals = absNumber < unitValue * 10 ? 1 : 0;
+
+	const value = numberFormat( absNumber / unitValue, {
+		decimals,
+		thousandsSep: grouping,
+		decPoint: decimal,
+	} );
+
+	return `${ sign }${ value }${ symbol }`;
+}
+
+const ONE_K = 1000;
+const ONE_M = ONE_K * 1000;
+const ONE_G = ONE_M * 1000;
+
+/*
+ * Format a number larger than 1000 by appending a metric unit (K, M, G) and rounding to
+ * the received decimal point, defaults to 0.
+ * TODO: merge with formatNumberCompact by adding support for metric units other than 'K'
+ */
+export function formatNumberMetric( number, decimalPoints = 1 ) {
+	if ( number < ONE_K ) {
+		return String( number );
+	}
+
+	if ( number < ONE_M ) {
+		return ( number / ONE_K ).toFixed( decimalPoints ) + 'K';
+	}
+
+	if ( number < ONE_G ) {
+		return ( number / ONE_M ).toFixed( decimalPoints ) + 'M';
+	}
+
+	return ( number / ONE_G ).toFixed( decimalPoints ) + 'G';
+}

--- a/packages/components/src/count/index.jsx
+++ b/packages/components/src/count/index.jsx
@@ -1,0 +1,36 @@
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import formatNumberCompact from './format-number-compact';
+
+import './style.scss';
+
+export const Count = ( { count, compact, numberFormat, forwardRef, primary, ...rest } ) => {
+	// Omit props passed from the `localize` higher-order component that we don't need.
+	const { translate, moment, ...inheritProps } = rest;
+
+	return (
+		<span
+			ref={ forwardRef }
+			className={ classnames( 'count', { 'is-primary': primary } ) }
+			{ ...inheritProps }
+		>
+			{ compact ? formatNumberCompact( count ) || numberFormat( count ) : numberFormat( count ) }
+		</span>
+	);
+};
+
+Count.propTypes = {
+	count: PropTypes.number.isRequired,
+	numberFormat: PropTypes.func,
+	primary: PropTypes.bool,
+	compact: PropTypes.bool,
+	refProp: PropTypes.oneOfType( [ PropTypes.func, PropTypes.shape( { current: PropTypes.any } ) ] ),
+};
+
+Count.defaultProps = {
+	primary: false,
+	compact: false,
+};
+
+export default localize( Count );

--- a/packages/components/src/count/index.stories.jsx
+++ b/packages/components/src/count/index.stories.jsx
@@ -1,0 +1,14 @@
+import Count from '.';
+
+export default { component: Count, title: 'packages/components/Count' };
+
+const Template = ( args ) => {
+	return <Count { ...args } />;
+};
+
+export const Default = Template.bind( {} );
+Default.args = {
+	compact: false,
+	primary: false,
+	count: 42000,
+};

--- a/packages/components/src/count/style.scss
+++ b/packages/components/src/count/style.scss
@@ -1,0 +1,19 @@
+@import "@automattic/typography/styles/variables";
+
+.count {
+	display: inline-block;
+	padding: 1px 6px;
+	border: solid 1px var(--color-border);
+	border-radius: 12px; /* stylelint-disable-line scales/radii */
+	font-size: $font-body-extra-small;
+	font-weight: 600;
+	line-height: 14px;
+	color: var(--color-text);
+	text-align: center;
+
+	&.is-primary {
+		color: var(--color-text-inverted);
+		border-color: var(--color-accent);
+		background-color: var(--color-accent);
+	}
+}

--- a/packages/components/src/count/test/index.jsx
+++ b/packages/components/src/count/test/index.jsx
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { Count } from '../';
+
+describe( 'Count', () => {
+	test( 'should call provided as prop numberFormat function', () => {
+		const numberFormatSpy = jest.fn();
+		render( <Count count={ 23 } numberFormat={ numberFormatSpy } /> );
+		expect( numberFormatSpy ).toHaveBeenCalledWith( 23 );
+	} );
+
+	test( 'should call `formatNumberCompact` if `compact` prop is `true`', () => {
+		const { container } = render( <Count count={ 1000 } compact /> );
+		expect( container.firstChild ).toHaveTextContent( '1.0K' );
+	} );
+
+	test( 'should render with primary class', () => {
+		const { container } = render( <Count count={ 23 } primary numberFormat={ () => {} } /> );
+		expect( container.firstChild ).toHaveClass( 'is-primary' );
+	} );
+} );

--- a/packages/components/src/count/test/index.jsx
+++ b/packages/components/src/count/test/index.jsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 import { Count } from '../';
 
 describe( 'Count', () => {

--- a/packages/components/src/count/thousands.js
+++ b/packages/components/src/count/thousands.js
@@ -1,0 +1,80 @@
+export const THOUSANDS = {
+	en: {
+		symbol: 'K',
+		grouping: ',',
+		decimal: '.',
+	},
+	es: {
+		symbol: ' mil',
+		grouping: '.',
+		decimal: ',',
+	},
+	'pt-br': {
+		symbol: ' mil',
+		grouping: '.',
+		decimal: ',',
+	},
+	de: {
+		symbol: ' Tsd.',
+		grouping: '.',
+		decimal: ',',
+	},
+	fr: {
+		symbol: ' k',
+		grouping: ' ',
+		decimal: ',',
+	},
+	he: {
+		symbol: 'K',
+		grouping: ',',
+		decimal: '.',
+	},
+	ja: {
+		symbol: '万',
+		unitValue: 10000,
+		grouping: ',',
+		decimal: '.',
+	},
+	nl: {
+		symbol: 'K',
+		grouping: '.',
+		decimal: ',',
+	},
+	tr: {
+		symbol: ' B',
+		grouping: '.',
+		decimal: ',',
+	},
+	id: {
+		symbol: ' rb',
+		grouping: '.',
+		decimal: ',',
+	},
+	'zh-cn': {
+		symbol: '万',
+		unitValue: 10000,
+		grouping: ',',
+		decimal: '.',
+	},
+	'zh-tw': {
+		symbol: '萬',
+		unitValue: 10000,
+		grouping: ',',
+		decimal: '.',
+	},
+	ko: {
+		symbol: '천',
+		grouping: ',',
+		decimal: '.',
+	},
+	ar: {
+		symbol: ' ألف',
+		grouping: '٬',
+		decimal: '٫',
+	},
+	sv: {
+		symbol: ' tn',
+		grouping: ' ',
+		decimal: ',',
+	},
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -4,6 +4,7 @@ export { default as Button } from './button';
 export * as Animation from './animation';
 export { default as Card } from './card';
 export { default as CompactCard } from './card/compact';
+export { default as Count } from './count';
 export * from './device-switcher';
 export { default as Dialog } from './dialog';
 export { default as FormInputValidation } from './forms/form-input-validation';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/79255
- Tracking issue https://github.com/Automattic/martech/issues/2023

To avoid creating another dependency on a non-packaged Calypso component, we want to migrate the dropdown we're using to @automattic/components

We migrating the count component because it is a dependency for the dropdown component, and is necessary to render said dropdown.

The entirety of the migration is a 4 step process that creates easily digestible ( and revertible ) PRs to work with. See https://github.com/Automattic/martech/issues/2028. Unfortunately, this process also eliminates the git history from migrated files unless the 4 steps are condensed into a single one. I don't have a great answer to this, but the tradeoff, to me, is worth the added safety of more understandable, compact, iterative pull requests.

## Proposed Changes

* Adds the count calypso component into the @automattic/components package

## Screenshots

![2023-08-05 21 07 04](https://github.com/Automattic/wp-calypso/assets/5414230/93136462-0f3a-4369-97b4-32af2c94eb01)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure all tests pass. `yarn run test-packages packages/components/src/count/test/index.jsx` if you'd like to run it locally, but the CI process should catch anything.
* At the root of the Calypso directory, run `yarn storybook:start`
* Ensure that the count component renders properly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
