### PR TITLE
Connections: Fix null reference error

### DIFF
--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -75,7 +75,7 @@ const SharingServiceAction = ( {
 	}
 
 	// See: https://developers.google.com/photos/library/guides/ux-guidelines
-	if ( 'google_photos' === service.ID && ! path.startsWith( '/marketing/connections/' ) ) {
+	if ( 'google_photos' === service.ID && ! path?.startsWith( '/marketing/connections/' ) ) {
 		return (
 			<Button primary onClick={ onClick } disabled={ isPending }>
 				{ translate( 'Connect to Google Photos' ) }


### PR DESCRIPTION
This fix is for Sentry issue CALYPSO-1941. In particular circumstances the ServiceAction component was being rendered without a site path property and was causing an error.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This change fixes it using optional chaining.

## Testing Instructions

* Go to the /marketing/connections screen for a site
* Open the site switcher and click the 'Add new site' button at the bottom.
* Without this change an error will be thrown `Cannot read properties of null (reading 'startsWith')`
* With this change it should work correctly and you'll be asked to pick a domain.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
