### PR TITLE
Bulk Domain Transfer: Disable transfer button if filled rows not valid

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -145,7 +145,7 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 			) }
 			<div className="bulk-domain-transfer__cta-container">
 				<Button
-					disabled={ numberOfValidDomains === 0 }
+					disabled={ numberOfValidDomains === 0 || ! allGood }
 					className="bulk-domain-transfer__cta"
 					onClick={ handleAddTransfer }
 				>


### PR DESCRIPTION
## What

[Context](pdtkmj-1Cx-p2#comment-2908)
Despite having an invalid domain on the list, the transfer button looks enabled and I imagine I could continue transferring 1 domain as written in the button: Transfer 1 domain.

The button is instead enabled and clickable but doesn't redirect anywhere.


This PR disables the button in case of invalid rows.

## Testing

1. Live link and visit `/setup/domain-setup/domains`
2. Insert a valid row and an invalid one. You shouldn't be able to click the transfer button.
3. Try a valid row and an empty one. You should be able to continue


Fixes https://github.com/Automattic/wp-calypso/issues/79252
