### PR TITLE
calypso-color-schemes: Add root-only entry point

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -25,6 +25,7 @@ node_modules/
 packages/calypso-color-schemes/src/__color-studio
 packages/calypso-color-schemes/css
 packages/calypso-color-schemes/js
+packages/calypso-color-schemes/root-only
 
 #
 # Eslint won't lint json, but prettier shares this ignore

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -6,6 +6,7 @@ node_modules
 vendor
 dist
 packages/calypso-color-schemes/css
+packages/calypso-color-schemes/root-only
 packages/calypso-color-schemes/src/__color-studio
 
 apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/synced-newspack-blocks/

--- a/packages/calypso-color-schemes/.gitignore
+++ b/packages/calypso-color-schemes/.gitignore
@@ -1,3 +1,4 @@
 src/__color-studio
 css
 js
+root-only

--- a/packages/calypso-color-schemes/CHANGELOG.md
+++ b/packages/calypso-color-schemes/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added a new color for Nextdoor.
+- Add `root-only` entry point.
 
 ## 3.0.0
 

--- a/packages/calypso-color-schemes/README.md
+++ b/packages/calypso-color-schemes/README.md
@@ -25,6 +25,12 @@ import '@automattic/calypso-color-schemes';
 
 And this will give you the CSS.
 
+If you want only the `:root` rules without all the schemes, you can do
+
+```js
+import '@automattic/calypso-color-schemes/root-only';
+```
+
 ### Using the JS output
 
 Sometimes, `calypso-color-schemes` properties are consumed in JavaScript. To avoid parsing CSS syntax on your own, or to help `postcss-custom-properties` use them without parsing the CSS (much faster), use the JS output as follows:

--- a/packages/calypso-color-schemes/bin/build-css.js
+++ b/packages/calypso-color-schemes/bin/build-css.js
@@ -6,11 +6,17 @@ const postcssCustomProperties = require( 'postcss-custom-properties' );
 const { renderSync } = require( 'sass' );
 
 const INPUT_FILE = join( __dirname, '..', 'src', 'calypso-color-schemes.scss' );
+const INPUT_ROOT_FILE = join( __dirname, '..', 'src', 'calypso-color-schemes-root.scss' );
 const OUTPUT_FILE = join( __dirname, '..', 'css', 'index.css' );
+const OUTPUT_ROOT_FILE = join( __dirname, '..', 'root-only', 'index.css' );
 const OUTPUT_JS_FILE = join( __dirname, '..', 'js', 'index.js' );
 
 if ( ! existsSync( dirname( OUTPUT_FILE ) ) ) {
 	mkdirSync( dirname( OUTPUT_FILE ), { recursive: true } );
+}
+
+if ( ! existsSync( dirname( OUTPUT_ROOT_FILE ) ) ) {
+	mkdirSync( dirname( OUTPUT_ROOT_FILE ), { recursive: true } );
 }
 
 if ( ! existsSync( dirname( OUTPUT_JS_FILE ) ) ) {
@@ -20,6 +26,10 @@ if ( ! existsSync( dirname( OUTPUT_JS_FILE ) ) ) {
 const output = renderSync( { file: INPUT_FILE } );
 
 writeFileSync( OUTPUT_FILE, output.css );
+
+const rootOutput = renderSync( { file: INPUT_ROOT_FILE } );
+
+writeFileSync( OUTPUT_ROOT_FILE, rootOutput.css );
 
 // export CSS properties into a JavaScript file, so whoever uses it doesn't need to parse CSS over and over
 postcss( [

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -22,7 +22,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"clean": "rm -rf js css src/__color-studio",
+		"clean": "rm -rf js css root-only src/__color-studio",
 		"prepare": "node bin/prepare-sass-assets.js && node bin/build-css.js"
 	},
 	"devDependencies": {

--- a/packages/calypso-color-schemes/src/calypso-color-schemes-root.scss
+++ b/packages/calypso-color-schemes/src/calypso-color-schemes-root.scss
@@ -1,0 +1,4 @@
+@import "shared/colors";
+
+// Default color scheme
+@import "shared/color-schemes/default";

--- a/packages/calypso-color-schemes/src/calypso-color-schemes.scss
+++ b/packages/calypso-color-schemes/src/calypso-color-schemes.scss
@@ -1,7 +1,4 @@
-@import "shared/colors";
-
-// Default color scheme
-@import "shared/color-schemes/default";
+@import "calypso-color-schemes-root";
 
 // Color schemes that override default properties
 @import "shared/color-schemes/aquatic";


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Some users (e.g. `postcss-custom-properties` v13 where `importFrom` was removed) may need a CSS file containing just the default `:root` rules without all the extra color schemes. This provides that.

Specifically, we're looking for exactly that for exactly that reason in Jetpack. See pdWQjU-kM-p2 for details.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build, then check that the `css/index.css` and `js/index.js` are unchanged while `root-only/index.css` now exists with the proper subset of rules.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?