### PR TITLE
VideoPress HQ: only 1 trial per account

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-trial-exists/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-trial-exists/index.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+import { StepContainer } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
+import React from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
+
+import './styles.scss';
+
+const VideoPressTvTrialExists: Step = function VideoPressTvTrialExists( { data } ) {
+	const { __ } = useI18n();
+
+	const stepContent = (
+		<div className="videopress-tv-trial-exists__step-content intro__button-row">
+			<button
+				className="button intro__button is-primary"
+				onClick={ () => ( window.location.href = data?.url ) }
+			>
+				Visit your site
+			</button>
+		</div>
+	);
+
+	return (
+		<StepContainer
+			stepName="trial-exists"
+			isWideLayout={ true }
+			hideBack={ true }
+			flowName="videopress-tv"
+			formattedHeader={
+				<FormattedHeader
+					id="videopress-tv-trial-exists-header"
+					headerText={ __( 'You already have a trial VideoPress TV site' ) }
+					align="center"
+				/>
+			}
+			stepContent={ stepContent }
+			recordTracksEvent={ recordTracksEvent }
+			showVideoPressPowered
+		/>
+	);
+};
+
+export default VideoPressTvTrialExists;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-trial-exists/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-trial-exists/styles.scss
@@ -1,0 +1,26 @@
+@import "@automattic/onboarding/styles/mixins";
+@import "../../videopress.scss";
+
+body.is-videopress-tv-stepper .videopress-tv.trial-exists {
+	justify-content: space-around;
+
+	.step-container__content {
+		flex-grow: 0;
+		min-height: revert;
+	}
+}
+
+.videopress-tv-trial-exists__step-content {
+	display: flex;
+	justify-content: center;
+
+	.button {
+		background: #ffe61c;
+		color: #000;
+		transition: box-shadow 0.4s ease-in-out;
+
+		&:hover {
+			box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1) inset, 0 2px 24px rgba(255, 230, 28, 0.3), 0 0 8px rgba(255, 230, 28, 0.18), 0 0 4px rgba(255, 230, 28, 0.15), 0 0 2.5px rgba(255, 230, 28, 0.12), 0 0 4px rgba(255, 230, 28, 0.1), 0 0 2px rgba(0, 0, 0, 0.8);
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/greenhouse/issues/1775

<img width="1492" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4081020/84e6f445-57c9-4bd0-9a5b-39153edc4314">


## Proposed Changes

* Add a new step to display if a `trial_exists` error comes back from the site creation request

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply D115787-code to your sandbox and sandbox `public-api`
* `yarn && yarn start` or use a calypso live link
* visit `/setup/videopress-tv`
* create a new account
* complete the flow to see your new trial site. Remember the URL!
* start the flow over again
* proceed through the flow
* After the "processing" step you should be sent to a "you already have a trial" page
* Click the "Visit your site" link, it should match the site you created earlier
* add the Premium plan to your trial site
* Go through the trial flow AGAIN
* this time you should get a new trial site (since your original one is no longer a trial)
   * IF we don't like this behaviour we can change it in the diff... however, we may want to allow people to create new trials so they can then subscribe on many VideoPress TV sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
