### PR TITLE
BackupBrowser: Add a warning before previewing sensitive files

### DIFF
--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -138,6 +138,19 @@
 					max-height: 400px;
 				}
 			}
+
+			&__preview-sensitive {
+				background-color: var(--studio-gray-60);
+				color: #fff;
+				margin: 16px auto 0;
+				max-width: 100%;
+				padding: 20px 8px;
+				text-align: center;
+
+				p {
+					font-size: 0.875rem;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79152

## Proposed Changes

* Add a warning before previewing a sensitive file (`wp-config.php`). Design proposal: p1689015874978679-slack-C059R8T8Q15.
* After clicking on `Show preview` the file content will be displayed in the backup browser as we implemented in #79152.

## Screenshot
<img width="621" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/bc6909eb-5636-4026-bb64-93ce648a065b">

## Demo
https://github.com/Automattic/wp-calypso/assets/1488641/3839faf9-f6b3-4815-b908-3d423fea8317

## Testing Instructions
* Start a Jetpack Cloud or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Browse files and click on the `wp-config.php` file in the root. You should see a warning saying `This preview is hidden because it contains sensitive information.` with a `Show preview` button on it.
* Click on `Preview file` and it should load the file content preview.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?