### PR TITLE
Remove paid option from newsletter setup screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -2,12 +2,8 @@ import { Onboard } from '@automattic/data-stores';
 import { hexToRgb, StepContainer, base64ImageToBlob } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
-import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormLabel from 'calypso/components/forms/form-label';
-import InfoPopover from 'calypso/components/info-popover';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
@@ -112,10 +108,6 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 		}
 	};
 
-	const onPaidSubscribersChanged = ( event: ChangeEvent< HTMLInputElement > ) => {
-		setPaidSubscribers( !! event?.target.checked );
-	};
-
 	return (
 		<StepContainer
 			stepName="newsletter-setup"
@@ -153,21 +145,6 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 							setAccentColor={ setAccentColor }
 							labelText={ newsletterFormText?.colorLabel }
 						/>
-						<FormFieldset className="newsletter-setup__paid-subscribers">
-							<FormLabel>
-								<FormInputCheckbox
-									name="paid_newsletters"
-									checked={ paidSubscribers }
-									onChange={ onPaidSubscribersChanged }
-								/>
-								<span>{ translate( 'I want to start a paid newsletter' ) }</span>
-							</FormLabel>
-							<InfoPopover position="bottom right">
-								{ translate(
-									'Let your audience support your work. Add paid subscriptions and gated content to your newsletter.'
-								) }
-							</InfoPopover>
-						</FormFieldset>
 					</>
 				</SetupForm>
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/79022 

## Proposed Changes

This PR removes the option checkbox for paid newsletters from the Newsletter Setup screen in onboarding. We'll be replacing this with a full screen for choosing a Newsletter goal (see [this PR](https://github.com/Automattic/wp-calypso/pull/79022)). 

**This PR should only be merged after https://github.com/Automattic/wp-calypso/pull/79022 is merged.**

<img width="1509" alt="paid-checkbox" src="https://github.com/Automattic/wp-calypso/assets/21228350/a9ccb4bf-b977-4f69-aa5a-7c1d8d052735">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and run yarn and yarn start if needed. 
2) Start newsletter site at http://calypso.localhost:3000/setup/newsletter/intro
3) On intro screen, confirm that the paid checkbox option no longer appears. 