### PR TITLE
[E2E][GB] Make the locator for `previewButton` in the `EditorToolbasrComponent` work across viewports

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -16,7 +16,7 @@ const selectors = {
 	switchToDraftButton: `${ panel } button.editor-post-switch-to-draft`,
 
 	// Preview
-	previewButton: `${ panel } [aria-label="Preview"]:visible`,
+	previewButton: `${ panel } :text("Preview"):visible, [aria-label="Preview"]:visible`,
 	desktopPreviewMenuItem: ( target: EditorPreviewOptions ) =>
 		`button[role="menuitem"] span:text("${ target }")`,
 	previewPane: ( target: EditorPreviewOptions ) => `.is-${ target.toLowerCase() }-preview`,


### PR DESCRIPTION
## Proposed Changes

While checking the failure for the GB edge here: p1689036910937589-slack-CBTN58FTJ, I noticed that the "Launch Preview" failure was only happening on mobile. Happens that the fix here worked well for Desktop but failed in the Mobile viewport due to markup differences. 

This is the button markup in the Desktop viewport:

```html
<button type="button" aria-haspopup="true" aria-expanded="false" class="components-button block-editor-post-preview__button-toggle components-dropdown-menu__toggle has-icon" aria-label="Preview"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M20.5 16h-.7V8c0-1.1-.9-2-2-2H6.2c-1.1 0-2 .9-2 2v8h-.7c-.8 0-1.5.7-1.5 1.5h20c0-.8-.7-1.5-1.5-1.5zM5.7 8c0-.3.2-.5.5-.5h11.6c.3 0 .5.2.5.5v7.6H5.7V8z"></path></svg></button>
```

And in mobile:

```html
<a href="https://e2eflowtestingsimplepersonal.wordpress.com/?p=1336823&amp;preview=true" target="wp-preview-1336823" class="components-button editor-post-preview is-tertiary">Preview<span data-wp-c16t="true" data-wp-component="VisuallyHidden" class="components-visually-hidden css-0 e19lxcc00" style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; overflow-wrap: normal;">(opens in a new tab)</span></a>
```

Notice how one uses `aria-label` and the other has the text in its inner HTML. AFAIK, `:text` won't work for selecting both cases. To solve that, I used two selectors separated by `,` (effectively an `or` operator).

## Testing Instructions

* Tests should pass.