### PR TITLE
Jetpack Connection: validate redirect_after_auth before redirect

### DIFF
--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -2,6 +2,7 @@ import config, { isCalypsoLive } from '@automattic/calypso-config';
 import { includes, isEmpty } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
+import validUrl from 'valid-url';
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
 import { navigate } from 'calypso/lib/navigate';
 import { addQueryArgs, untrailingslashit } from 'calypso/lib/route';
@@ -36,7 +37,9 @@ export function authQueryTransformer( queryObject ) {
 		blogname: queryObject.blogname || null,
 		from: queryObject.from || '[unknown]',
 		jpVersion: queryObject.jp_version || null,
-		redirectAfterAuth: queryObject.redirect_after_auth || null,
+		redirectAfterAuth: validUrl.isWebUri( queryObject.redirect_after_auth )
+			? queryObject.redirect_after_auth
+			: null,
 		siteIcon: queryObject.site_icon || null,
 		siteUrl: queryObject.site_url || null,
 		userEmail: queryObject.user_email || null,


### PR DESCRIPTION
pdWQjU-mi-p2

## Proposed Changes

* Validate the `redirect_after_auth` parameter to make sure it contains a valid URL

## Testing Instructions

1. Connect Jetpack, purchase any non-free plan.
2. Disconnect Jetpack and initiate the connection flow again.
3. Open the Calypso Live link and login there.
4. Once you get to the "Approve" page, replace `https://wordpress.com` with the Calypso Live URL. The "Approve" page should load fine.
5. Finish the connection flow and confirm it went well. You should skip the "Plans" page and get back straight to your Jetpack site.

See pdWQjU-mi-p2 for more instructions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
