### PR TITLE
Paid Stats: Add statsPurchaseSuccess param to controller

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -369,6 +369,7 @@ export function site( context, next ) {
 			chartTab={ chartTab }
 			context={ context }
 			period={ rangeOfPeriod( activeFilter.period, date ) }
+			statsPurchaseSuccess={ queryOptions.statsPurchaseSuccess }
 		/>
 	);
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -239,7 +239,7 @@ class StatsSite extends Component {
 					siteId={ siteId }
 					slug={ slug }
 				/>
-				{ isOdysseyStats && <StatsNotices siteId={ siteId } /> }
+				<StatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
 
 				{ statsPurchaseSuccess && <p>Thank you for using Jetpack Stats</p> }
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -172,6 +172,7 @@ class StatsSite extends Component {
 			isOdysseyStats,
 			context,
 			moduleSettings,
+			statsPurchaseSuccess,
 		} = this.props;
 
 		let defaultPeriod = PAST_SEVEN_DAYS;
@@ -238,7 +239,10 @@ class StatsSite extends Component {
 					siteId={ siteId }
 					slug={ slug }
 				/>
-				<StatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
+				{ isOdysseyStats && <StatsNotices siteId={ siteId } /> }
+
+				{ statsPurchaseSuccess && <p>Thank you for using Jetpack Stats</p> }
+
 				<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>


### PR DESCRIPTION
Related to #78449

## Proposed Changes

* This small PR modifies the controller and site.jsx in order to catch a GET param called `statsPurchaseSuccess`

## Testing Instructions

* Open the Calypso live branch and navigate to `/stats/day/{URL}` and confirm everything looks as expected. 
* Append the URL query param `?statsPurchaseSuccess=true` to the end of the URL 
* Confirm the text `Thank you for using Jetpack Stats` is now displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
