### PR TITLE
Pro dashboard: Add Downtime monitoring paid tier feature flag.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -30,6 +30,7 @@ import DashboardDataContext from './dashboard-data-context';
 import SiteAddLicenseNotification from './site-add-license-notification';
 import SiteContent from './site-content';
 import SiteContentHeader from './site-content-header';
+import SiteDowntimeMonitoringPaidTierBanner from './site-downtime-monitoring-paid-tier-banner';
 import SiteSearchFilterContainer from './site-search-filter-container/SiteSearchFilterContainer';
 import SiteSurveyBanner from './site-survey-banner';
 import SiteWelcomeBanner from './site-welcome-banner';
@@ -240,6 +241,8 @@ export default function SitesOverview() {
 					<div className="sites-overview__content-wrapper">
 						<SiteSurveyBanner isDashboardView />
 						<SiteWelcomeBanner isDashboardView />
+						<SiteDowntimeMonitoringPaidTierBanner />
+
 						{ data?.sites && <SiteAddLicenseNotification /> }
 						<SiteContentHeader
 							content={ renderIssueLicenseButton() }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-downtime-monitoring-paid-tier-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-downtime-monitoring-paid-tier-banner/index.tsx
@@ -1,0 +1,31 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useTranslate } from 'i18n-calypso';
+import tipIcon from 'calypso/assets/images/jetpack/tip-icon.svg';
+import Banner from 'calypso/components/banner';
+
+export default function SiteDowntimeMonitoringPaidTierBanner() {
+	const translate = useTranslate();
+
+	const isDowntimeMonitoringPaidTierEnabled = isEnabled(
+		'jetpack/pro-dashboard-monitor-paid-tier'
+	);
+
+	if ( ! isDowntimeMonitoringPaidTierEnabled ) {
+		return null;
+	}
+
+	// TODO: This is a temporary banner for feature flag demo only. We will need to update this with proper implementation.
+	return (
+		<Banner
+			title={ translate( 'Your uptime, our priority: enhanced Downtime Monitoring' ) }
+			description={ translate(
+				'Maximise uptime with our swift 1-minute interval alerts, now supporting multi-emails and SMS notifications.'
+			) }
+			disableCircle
+			horizontal
+			iconPath={ tipIcon }
+			callToAction={ translate( 'Explore' ) }
+			href=""
+		/>
+	);
+}

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -51,6 +51,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": true,
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": true,
+		"jetpack/pro-dashboard-monitor-paid-tier": true,
 		"jetpack/pro-dashboard-monitor-sms-notification": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -45,6 +45,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": false,
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": true,
+		"jetpack/pro-dashboard-monitor-paid-tier": true,
 		"jetpack/pro-dashboard-monitor-sms-notification": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -48,6 +48,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": false,
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": false,
+		"jetpack/pro-dashboard-monitor-paid-tier": false,
 		"jetpack/pro-dashboard-monitor-sms-notification": false,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -48,6 +48,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": false,
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": false,
+		"jetpack/pro-dashboard-monitor-paid-tier": false,
 		"jetpack/pro-dashboard-monitor-sms-notification": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,


### PR DESCRIPTION
Related to 1204992567518369-as-1205001268610070

## Proposed Changes

This PR adds the Downtime monitoring Paid tier feature flag. I also added a temporary banner for the paid tier on the Site overview page for demo purposes only.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.


* Use the Jetpack cloud live link and go to `/dashboard`.
* Confirm that the Downtime monitoring paid tier banner is visible.
<img width="1393" alt="Screen Shot 2023-07-12 at 12 03 28 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/4a4e0117-d953-4fc2-b3dd-1c3857dee8cd">

* Additionally, check the changes and confirm that the feature flag is only enabled in **Development** and **Horizon**.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?