### PR TITLE
Assembler: Fix the main layout is broken

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -5,7 +5,7 @@ import {
 	NavigatorItemGroup,
 } from '@automattic/onboarding';
 import {
-	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
 import { focus } from '@wordpress/dom';
@@ -97,7 +97,7 @@ const ScreenMain = ( {
 				hideBack
 			/>
 			<div className="screen-container__body" ref={ wrapperRef }>
-				<HStack direction="column" alignment="top" spacing="4" expanded={ false }>
+				<VStack spacing="4">
 					<NavigatorItemGroup title={ translate( 'Patterns' ) }>
 						<NavigationButtonAsItem
 							checked={ hasHeader }
@@ -149,7 +149,7 @@ const ScreenMain = ( {
 							</NavigationButtonAsItem>
 						</>
 					</NavigatorItemGroup>
-				</HStack>
+				</VStack>
 				{ ! surveyDismissed && <Survey setSurveyDismissed={ setSurveyDismissed } /> }
 			</div>
 			<div className="screen-container__footer">

--- a/packages/onboarding/src/navigator/navigator-buttons/index.tsx
+++ b/packages/onboarding/src/navigator/navigator-buttons/index.tsx
@@ -54,7 +54,8 @@ export const NavigationButtonAsItem = ( { className, ...props }: Props ) => {
 	return (
 		<NavigatorButton
 			as={ GenericButton }
-			className={ classnames( 'navigator-button__wrapper', 'navigator-button', className ) }
+			className={ classnames( 'navigator-button', className ) }
+			wrapperClassName="navigator-button__wrapper"
 			{ ...props }
 		/>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/78711

## Proposed Changes

* The main layout of the Assembler is broken so proposing to resolve it

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/8bdaafad-f3d9-4ba0-8f05-73e171144cf6) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6c55476c-359b-47f5-997d-cbd590c734a2) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Scroll down to select the BCPA CTA
* When you land on the Assembler screen, ensure the layout looks good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
