### PR TITLE
Domains: Fix domain-only purchases post-checkout page

### DIFF
--- a/client/lib/route/path.ts
+++ b/client/lib/route/path.ts
@@ -46,6 +46,14 @@ export function getSiteFragment( path: URLString ): SiteSlug | SiteId | false {
 	else if ( basePath.includes( '/offer-plan-upgrade/' ) && basePath.startsWith( '/checkout/' ) ) {
 		searchPositions = [ 2 ];
 	}
+	// For this specific path, the site fragment is in the last index position.
+	// e.g /checkout/offer-professional-email/new-domain.com/example.wordpress.com (last)
+	else if (
+		basePath.includes( '/offer-professional-email/' ) &&
+		basePath.startsWith( '/checkout/' )
+	) {
+		searchPositions = [ pieces.length - 1 ];
+	}
 
 	// Search for site slug in the URL positions defined in searchPositions.
 	for ( let i = 0; i < searchPositions.length; i++ ) {

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -160,6 +160,11 @@ describe( 'route', function () {
 						'/checkout/example.wordpress.com/offer-plan-upgrade/business-monthly/75806534'
 					)
 				).toEqual( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment(
+						'/checkout/offer-professional-email/new-domain.com/75806534/example.wordpress.com'
+					)
+				).toEqual( 'example.wordpress.com' );
 			} );
 			test( 'should return the correct site fragment on domain renewals', function () {
 				expect(

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -238,6 +238,16 @@ export default function () {
 		);
 	}
 
+	// Use `noSite` instead of the `siteSelection` middleware for the no-site route.
+	page(
+		'/checkout/offer-professional-email/:domain/:receiptId/no-site',
+		redirectLoggedOut,
+		noSite,
+		upsellNudge,
+		makeLayout,
+		clientRender
+	);
+
 	page(
 		'/checkout/offer-professional-email/:domain/:receiptId/:site?',
 		redirectLoggedOut,

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -92,7 +92,8 @@ const ProfessionalEmailUpsell = ( {
 	} );
 
 	const selectedSite = useSelector( getSelectedSite );
-	const isDomainOnlySite = selectedSite?.options?.is_domain_only ?? false;
+	const isDomainOnlySite =
+		selectedSite === null ? true : selectedSite?.options?.is_domain_only ?? false;
 
 	const isMobileView = useBreakpoint( MOBILE_BREAKPOINT );
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -460,7 +460,8 @@ export function noSite( context, next ) {
 	const { getState } = getStore( context );
 	const currentUser = getCurrentUser( getState() );
 	const hasSite = currentUser && currentUser.visible_site_count >= 1;
-	const isDomainOnlyFlow = context.query?.isDomainOnly === '1';
+	const siteFragment = context.params.site || getSiteFragment( context.path );
+	const isDomainOnlyFlow = context.query?.isDomainOnly === '1' || ! siteFragment;
 	const isJetpackCheckoutFlow = context.pathname.includes( '/checkout/jetpack' );
 	const isAkismetCheckoutFlow = context.pathname.includes( '/checkout/akismet' );
 	const isGiftCheckoutFlow = context.pathname.includes( '/gift/' );


### PR DESCRIPTION
## Proposed Changes
The post-checkout page for domain-only purchases is currently broken. This PR fixes it.
It also fixes some other small issues, such as the conditional text (`Getting your [ site | domain ] ready`) on the email upsell page. 

## Testing Instructions
- Build this branch locally;
- Go to `/start/domain/domain-only`;
- Try registering a domain with a domain-only purchase;
- Check that after completing the purchase, the email upsell and the checkout page are displayed.

## Preview

### Before
_(The blurred image at 0:20 is the site selector component)_

https://github.com/Automattic/wp-calypso/assets/18705930/159c85fb-7c7e-41a9-8a8c-1d0a3f0a8e2e


###  After

https://github.com/Automattic/wp-calypso/assets/18705930/f64b10f8-edf6-41c2-b91c-55c5f969cbcc

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
