### PR TITLE
Theme Detail page: Fix image preview height

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -352,15 +352,11 @@ $theme-sheet-content-max-width: 1462px;
 	width: 98%;
 	z-index: 1;
 
-	// with width: 98%, gives 4:3 ratio before the image loads
-	// also x-browser issues, so it's smaller than 4:3 proper
-	min-height: 36.15vw; // 36.75vw would be correct, but Safari is slightly off
-
 	@include breakpoint-deprecated( "<960px" ) {
 		border-radius: 0;
 		box-shadow: none;
 		position: relative;
-		height: 100vw; // force proportions
+		max-height: 100vw;
 		overflow: hidden;
 		margin-top: 0;
 		top: 0;


### PR DESCRIPTION
## Proposed Changes

When using the theme's screenshot image in the large preview, there are cases where the screenshot is shorter than the element's `min-height`. The value for this `min-height` was from a previous iteration of the Theme Detail page and isn't needed anymore.

| Before | After |
| --- | --- |
|  ![Screenshot 2023-07-12 at 2 12 50 PM](https://github.com/Automattic/wp-calypso/assets/797888/1400fd00-08fc-485c-8908-ef6572a10143)|![Screenshot 2023-07-12 at 2 13 07 PM](https://github.com/Automattic/wp-calypso/assets/797888/abf6149e-5a2d-49ab-9d31-837b0f2af464)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/themes`
* Select any theme without style variations and ensure that the large preview image doesn't have the extra vertical spacing.
* Ensure that the image looks good for short images, such as the ones for Lineup or Optimismo.
* Ensure that the image looks good for tall images, such as the ones for Paimio or Archeo.
* Ensure that the image looks good for Premium/WooCommerce/3PD themes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
