### PR TITLE
Experiment: implement the ExPlat integration part of the dotblog domain on Free plan experiment

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -25,26 +25,29 @@ const SubdomainSuggestion = styled.div`
 const FreePlanCustomDomainFeature: React.FC< {
 	paidDomainName: string;
 	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
-	isCustomDomainAllowedOnFreePlan?: boolean | null;
+	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >;
 } > = ( { paidDomainName, wpcomFreeDomainSuggestion, isCustomDomainAllowedOnFreePlan } ) => {
 	const translate = useTranslate();
+	const isLoading =
+		wpcomFreeDomainSuggestion.isLoading || isCustomDomainAllowedOnFreePlan.isLoading;
 
 	return (
 		<SubdomainSuggestion>
-			{ wpcomFreeDomainSuggestion.isLoading && <LoadingPlaceHolder /> }
-			{ isCustomDomainAllowedOnFreePlan ? (
-				<div>
-					{ translate( '%s will be a redirect', {
-						args: [ paidDomainName ],
-						comment: '%s is a domain name.',
-					} ) }
-				</div>
-			) : (
-				<>
-					<div className="is-domain-name">{ paidDomainName }</div>
-					<div>{ wpcomFreeDomainSuggestion.entry?.domain_name }</div>
-				</>
-			) }
+			{ isLoading && <LoadingPlaceHolder /> }
+			{ ! isLoading &&
+				( isCustomDomainAllowedOnFreePlan.entry ? (
+					<div>
+						{ translate( '%s will be a redirect', {
+							args: [ paidDomainName ],
+							comment: '%s is a domain name.',
+						} ) }
+					</div>
+				) : (
+					<>
+						<div className="is-domain-name">{ paidDomainName }</div>
+						<div>{ wpcomFreeDomainSuggestion.entry?.domain_name }</div>
+					</>
+				) ) }
 		</SubdomainSuggestion>
 	);
 };
@@ -56,7 +59,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
-	isCustomDomainAllowedOnFreePlan?: boolean | null;
+	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >;
 } > = ( {
 	features,
 	planName,

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -35,7 +35,7 @@ const FreePlanCustomDomainFeature: React.FC< {
 		<SubdomainSuggestion>
 			{ isLoading && <LoadingPlaceHolder /> }
 			{ ! isLoading &&
-				( isCustomDomainAllowedOnFreePlan.entry ? (
+				( isCustomDomainAllowedOnFreePlan.result ? (
 					<div>
 						{ translate( '%s will be a redirect', {
 							args: [ paidDomainName ],
@@ -45,7 +45,7 @@ const FreePlanCustomDomainFeature: React.FC< {
 				) : (
 					<>
 						<div className="is-domain-name">{ paidDomainName }</div>
-						<div>{ wpcomFreeDomainSuggestion.entry?.domain_name }</div>
+						<div>{ wpcomFreeDomainSuggestion.result?.domain_name }</div>
 					</>
 				) ) }
 		</SubdomainSuggestion>

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -6,7 +6,8 @@ import { LoadingPlaceHolder } from '../../plans-features-main/components/loading
 import { PlanFeaturesItem } from './item';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import type { TransformedFeatureObject } from '../types';
-import type { SingleFreeDomainSuggestion } from 'calypso/my-sites/plan-features-2023-grid/types';
+import type { DomainSuggestion } from '@automattic/data-stores';
+import type { DataResponse } from 'calypso/my-sites/plan-features-2023-grid/types';
 
 const SubdomainSuggestion = styled.div`
 	.is-domain-name {
@@ -23,7 +24,7 @@ const SubdomainSuggestion = styled.div`
 
 const FreePlanCustomDomainFeature: React.FC< {
 	paidDomainName: string;
-	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
+	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
 	isCustomDomainAllowedOnFreePlan?: boolean | null;
 } > = ( { paidDomainName, wpcomFreeDomainSuggestion, isCustomDomainAllowedOnFreePlan } ) => {
 	const translate = useTranslate();
@@ -52,7 +53,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	features: Array< TransformedFeatureObject >;
 	planName: string;
 	paidDomainName?: string;
-	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
+	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
 	isCustomDomainAllowedOnFreePlan?: boolean | null;

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -884,6 +884,7 @@ export class PlanFeatures2023Grid extends Component<
 							paidDomainName={ paidDomainName }
 							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
+							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 						/>
 					</Container>
 				);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -111,7 +111,7 @@ export type PlanFeatures2023GridProps = {
 	// Value of the `?feature=` query param, so we can highlight a given feature and hide plans without it.
 	selectedFeature?: string;
 	intent?: PlansIntent;
-	isCustomDomainAllowedOnFreePlan?: boolean | null; // indicate when a custom domain is allowed to be used with the Free plan.
+	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >; // indicate when a custom domain is allowed to be used with the Free plan.
 	isGlobalStylesOnPersonal?: boolean;
 	showLegacyStorageFeature?: boolean;
 	spotlightPlanSlug?: PlanSlug;

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -63,11 +63,12 @@ import PopularBadge from './components/popular-badge';
 import PlansGridContextProvider, { usePlansGridContext } from './grid-context';
 import useHighlightAdjacencyMatrix from './hooks/npm-ready/use-highlight-adjacency-matrix';
 import useIsLargeCurrency from './hooks/use-is-large-currency';
-import { PlanProperties, TransformedFeatureObject, SingleFreeDomainSuggestion } from './types';
+import { PlanProperties, TransformedFeatureObject, DataResponse } from './types';
 import { getStorageStringFromFeature } from './util';
 import type { PlansIntent } from './grid-context';
 import type { GridPlan } from './hooks/npm-ready/data-store/use-wpcom-plans-with-intent';
 import type { PlanActionOverrides } from './types';
+import type { DomainSuggestion } from '@automattic/data-stores';
 import type { IAppState } from 'calypso/state/types';
 import './style.scss';
 
@@ -99,7 +100,7 @@ export type PlanFeatures2023GridProps = {
 	onUpgradeClick?: ( cartItem?: MinimalRequestCartProduct | null ) => void;
 	flowName?: string | null;
 	paidDomainName?: string;
-	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
+	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
 	intervalType?: string;
 	currentSitePlanSlug?: string | null;
 	hidePlansFeatureComparison?: boolean;

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -35,6 +35,9 @@ export interface PlanActionOverrides {
 	};
 }
 
+// A generic type representing the response of an async request.
+// It's probably generic enough to be put outside of the pricing grid package,
+// but at the moment it's located here to reduce its scope of influence.
 export type DataResponse< T > = {
 	isLoading: boolean;
 	result?: T;

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -37,5 +37,5 @@ export interface PlanActionOverrides {
 
 export type DataResponse< T > = {
 	isLoading: boolean;
-	entry?: T;
+	result?: T;
 };

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -1,6 +1,5 @@
 import { applyTestFiltersToPlansList, PlanSlug } from '@automattic/calypso-products';
 import { FeatureObject } from 'calypso/lib/plans/features-list';
-import type { DomainSuggestion } from '@automattic/data-stores';
 import type { TranslateResult } from 'i18n-calypso';
 
 export type TransformedFeatureObject = FeatureObject & {
@@ -29,20 +28,14 @@ export type PlanProperties = {
 	planActionOverrides?: PlanActionOverrides;
 };
 
-// FIXME:
-// As raised in https://github.com/Automattic/wp-calypso/pull/79678#discussion_r1273391589,
-// this name is not ideal for various reasons. "Single" is redundant, the data structure itself
-// also doesn't convey any restriction about whether it can only holds a `DomainSuggestion` from a free domain or not.
-// We need a better naming for the fact that it's a single DomainSuggestion together with a loading flag since
-// fetching for a domain suggestion is an async request.
-export type SingleFreeDomainSuggestion = {
-	isLoading: boolean;
-	entry?: DomainSuggestion;
-};
-
 export interface PlanActionOverrides {
 	loggedInFreePlan?: {
 		callback: () => void;
 		text: TranslateResult;
 	};
 }
+
+export type DataResponse< T > = {
+	isLoading: boolean;
+	entry?: T;
+};

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -5,7 +5,8 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import usePlanPrices from '../../plans/hooks/use-plan-prices';
@@ -167,6 +168,8 @@ type DomainPlanDialogProps = {
 	onPlanSelected: () => void;
 };
 
+const MODAL_VIEW_EVENT_NAME = 'calypso_free_plan_paid_domain_modal_view';
+
 function DialogPaidPlanIsRequired( {
 	paidDomainName,
 	wpcomFreeDomainSuggestion,
@@ -176,6 +179,12 @@ function DialogPaidPlanIsRequired( {
 }: DomainPlanDialogProps ) {
 	const translate = useTranslate();
 	const [ isBusy, setIsBusy ] = useState( false );
+
+	useEffect( () => {
+		recordTracksEvent( MODAL_VIEW_EVENT_NAME, {
+			dialog_type: 'paid_plan_is_required',
+		} );
+	}, [] );
 
 	function handlePaidPlanClick() {
 		setIsBusy( true );
@@ -233,6 +242,12 @@ function DialogCustomDomainAndFreePlan( {
 }: DomainPlanDialogProps ) {
 	const translate = useTranslate();
 	const [ isBusy, setIsBusy ] = useState( false );
+
+	useEffect( () => {
+		recordTracksEvent( MODAL_VIEW_EVENT_NAME, {
+			dialog_type: 'custom_domain_and_free_plan',
+		} );
+	}, [] );
 
 	function handlePaidPlanClick() {
 		setIsBusy( true );

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -216,12 +216,12 @@ function DialogPaidPlanIsRequired( {
 				<Row>
 					<DomainName>
 						{ wpcomFreeDomainSuggestion.isLoading && <LoadingPlaceHolder /> }
-						{ wpcomFreeDomainSuggestion.entry && (
-							<div>{ wpcomFreeDomainSuggestion.entry.domain_name }</div>
+						{ wpcomFreeDomainSuggestion.result && (
+							<div>{ wpcomFreeDomainSuggestion.result.domain_name }</div>
 						) }
 					</DomainName>
 					<StyledButton
-						disabled={ wpcomFreeDomainSuggestion.isLoading || ! wpcomFreeDomainSuggestion.entry }
+						disabled={ wpcomFreeDomainSuggestion.isLoading || ! wpcomFreeDomainSuggestion.result }
 						busy={ isBusy }
 						onClick={ handleFreeDomainClick }
 					>
@@ -292,17 +292,17 @@ function DialogCustomDomainAndFreePlan( {
 				<Row>
 					<DomainName>
 						{ wpcomFreeDomainSuggestion.isLoading && <LoadingPlaceHolder /> }
-						{ wpcomFreeDomainSuggestion.entry &&
+						{ wpcomFreeDomainSuggestion.result &&
 							translate( '%(paidDomainName)s redirects to %(wpcomFreeDomain)s', {
 								args: {
 									paidDomainName,
-									wpcomFreeDomain: wpcomFreeDomainSuggestion.entry.domain_name,
+									wpcomFreeDomain: wpcomFreeDomainSuggestion.result.domain_name,
 								},
 								comment: '%(wpcomFreeDomain)s is a WordPress.com subdomain, e.g. foo.wordpress.com',
 							} ) }
 					</DomainName>
 					<StyledButton
-						disabled={ wpcomFreeDomainSuggestion.isLoading || ! wpcomFreeDomainSuggestion.entry }
+						disabled={ wpcomFreeDomainSuggestion.isLoading || ! wpcomFreeDomainSuggestion.result }
 						busy={ isBusy }
 						onClick={ handleFreePlanClick }
 					>
@@ -354,7 +354,7 @@ export function FreePlanPaidDomainDialog( {
 			/>
 			{ isCustomDomainAllowedOnFreePlan.isLoading && <LoadingPlaceHolder /> }
 			{ ! isCustomDomainAllowedOnFreePlan.isLoading &&
-				( isCustomDomainAllowedOnFreePlan.entry ? (
+				( isCustomDomainAllowedOnFreePlan.result ? (
 					<DialogCustomDomainAndFreePlan { ...dialogCommonProps } />
 				) : (
 					<DialogPaidPlanIsRequired { ...dialogCommonProps } />

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -10,7 +10,8 @@ import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import usePlanPrices from '../../plans/hooks/use-plan-prices';
 import { LoadingPlaceHolder } from './loading-placeholder';
-import type { SingleFreeDomainSuggestion } from 'calypso/my-sites/plan-features-2023-grid/types';
+import type { DomainSuggestion } from '@automattic/data-stores';
+import type { DataResponse } from 'calypso/my-sites/plan-features-2023-grid/types';
 
 const DialogContainer = styled.div`
 	padding: 24px;
@@ -160,7 +161,7 @@ function SuggestedPlanSection( {
 
 type DomainPlanDialogProps = {
 	paidDomainName: string;
-	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
+	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
 	suggestedPlanSlug: PlanSlug;
 	onFreePlanSelected: () => void;
 	onPlanSelected: () => void;
@@ -306,7 +307,10 @@ export function FreePlanPaidDomainDialog( {
 	onFreePlanSelected,
 	onPlanSelected,
 	onClose,
-}: DomainPlanDialogProps & { isCustomDomainAllowedOnFreePlan: boolean; onClose: () => void } ) {
+}: DomainPlanDialogProps & {
+	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >;
+	onClose: () => void;
+} ) {
 	const dialogCommonProps: DomainPlanDialogProps = {
 		paidDomainName,
 		wpcomFreeDomainSuggestion,
@@ -333,11 +337,13 @@ export function FreePlanPaidDomainDialog( {
 					}
 				` }
 			/>
-			{ isCustomDomainAllowedOnFreePlan ? (
-				<DialogCustomDomainAndFreePlan { ...dialogCommonProps } />
-			) : (
-				<DialogPaidPlanIsRequired { ...dialogCommonProps } />
-			) }
+			{ isCustomDomainAllowedOnFreePlan.isLoading && <LoadingPlaceHolder /> }
+			{ ! isCustomDomainAllowedOnFreePlan.isLoading &&
+				( isCustomDomainAllowedOnFreePlan.entry ? (
+					<DialogCustomDomainAndFreePlan { ...dialogCommonProps } />
+				) : (
+					<DialogPaidPlanIsRequired { ...dialogCommonProps } />
+				) ) }
 		</Dialog>
 	);
 }

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -168,7 +168,8 @@ type DomainPlanDialogProps = {
 	onPlanSelected: () => void;
 };
 
-const MODAL_VIEW_EVENT_NAME = 'calypso_free_plan_paid_domain_modal_view';
+// See p2-pbxNRc-2Ri#comment-4703 for more context
+const MODAL_VIEW_EVENT_NAME = 'calypso_plan_upsell_modal_view';
 
 function DialogPaidPlanIsRequired( {
 	paidDomainName,

--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -1,10 +1,11 @@
 import { getTld } from 'calypso/lib/domains';
 import { useExperiment } from 'calypso/lib/explat';
+import type { DataResponse } from 'calypso/my-sites/plan-features-2023-grid/types';
 
 const useIsCustomDomainAllowedOnFreePlan = (
 	flowName?: string | null,
 	domainName?: string
-): [ boolean, boolean ] => {
+): DataResponse< boolean > => {
 	const [ isLoadingAssignment, experimentAssignment ] = useExperiment(
 		'calypso_onboarding_plans_dotblog_on_free_plan_202307',
 		{
@@ -13,7 +14,10 @@ const useIsCustomDomainAllowedOnFreePlan = (
 		}
 	);
 
-	return [ isLoadingAssignment, experimentAssignment?.variationName === 'treatment' ];
+	return {
+		isLoading: isLoadingAssignment,
+		entry: experimentAssignment?.variationName === 'treatment',
+	};
 };
 
 export default useIsCustomDomainAllowedOnFreePlan;

--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -2,7 +2,7 @@ import { getTld } from 'calypso/lib/domains';
 import { useExperiment } from 'calypso/lib/explat';
 
 const useIsCustomDomainAllowedOnFreePlan = (
-	flowName?: string,
+	flowName?: string | null,
 	domainName?: string
 ): [ boolean, boolean ] => {
 	const [ isLoadingAssignment, experimentAssignment ] = useExperiment(

--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -1,12 +1,19 @@
-import config from '@automattic/calypso-config';
 import { getTld } from 'calypso/lib/domains';
+import { useExperiment } from 'calypso/lib/explat';
 
-const useIsCustomDomainAllowedOnFreePlan = ( domainName?: string ) => {
-	if ( ! domainName ) {
-		return false;
-	}
+const useIsCustomDomainAllowedOnFreePlan = (
+	flowName?: string,
+	domainName?: string
+): [ boolean, boolean ] => {
+	const [ isLoadingAssignment, experimentAssignment ] = useExperiment(
+		'calypso_onboarding_plans_dotblog_on_free_plan_202307',
+		{
+			isEligible:
+				flowName === 'onboarding' && domainName != null && getTld( domainName ) === 'blog',
+		}
+	);
 
-	return config.isEnabled( 'domains/blog-domain-free-plan' ) && getTld( domainName ) === 'blog';
+	return [ isLoadingAssignment, experimentAssignment?.variationName === 'treatment' ];
 };
 
 export default useIsCustomDomainAllowedOnFreePlan;

--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -16,7 +16,7 @@ const useIsCustomDomainAllowedOnFreePlan = (
 
 	return {
 		isLoading: isLoadingAssignment,
-		entry: experimentAssignment?.variationName === 'treatment',
+		result: experimentAssignment?.variationName === 'treatment',
 	};
 };
 

--- a/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
@@ -15,7 +15,7 @@ export function useSuggestedFreeDomainFromPaidDomain( paidDomainName?: string ):
 	return {
 		wpcomFreeDomainSuggestion: {
 			isLoading: isInitialLoading,
-			entry: ( ! isError && wordPressSubdomainSuggestions?.[ 0 ] ) || undefined,
+			result: ( ! isError && wordPressSubdomainSuggestions?.[ 0 ] ) || undefined,
 		},
 		invalidateDomainSuggestionCache,
 	};

--- a/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
@@ -1,8 +1,8 @@
 import { DomainSuggestions } from '@automattic/data-stores';
-import type { SingleFreeDomainSuggestion } from 'calypso/my-sites/plan-features-2023-grid/types';
+import type { DataResponse } from 'calypso/my-sites/plan-features-2023-grid/types';
 
 export function useSuggestedFreeDomainFromPaidDomain( paidDomainName?: string ): {
-	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
+	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestions.DomainSuggestion >;
 	invalidateDomainSuggestionCache: () => void;
 } {
 	const {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -275,7 +275,8 @@ const PlansFeaturesMain = ( {
 		( state: IAppState ) => siteId && canUpgradeToPlan( state, siteId, PLAN_PERSONAL )
 	);
 	const previousRoute = useSelector( ( state: IAppState ) => getPreviousRoute( state ) );
-	const isCustomDomainAllowedOnFreePlan = useIsCustomDomainAllowedOnFreePlan( paidDomainName );
+	const [ isLoadingCustomDomainAllowedOnFreePlan, isCustomDomainAllowedOnFreePlan ] =
+		useIsCustomDomainAllowedOnFreePlan( flowName, paidDomainName );
 
 	let _customerType = chooseDefaultCustomerType( {
 		currentCustomerType: customerType,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -428,13 +428,13 @@ const PlansFeaturesMain = ( {
 							return;
 						}
 
-						if ( ! isCustomDomainAllowedOnFreePlan.entry ) {
+						if ( ! isCustomDomainAllowedOnFreePlan.result ) {
 							removePaidDomain?.();
 						}
 						// Since this domain will not be available after it is selected, invalidate the cache.
 						invalidateDomainSuggestionCache();
-						wpcomFreeDomainSuggestion.entry &&
-							setSiteUrlAsFreeDomainSuggestion?.( wpcomFreeDomainSuggestion.entry );
+						wpcomFreeDomainSuggestion.result &&
+							setSiteUrlAsFreeDomainSuggestion?.( wpcomFreeDomainSuggestion.result );
 						onUpgradeClick?.( null );
 					} }
 					onPlanSelected={ () => {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -50,7 +50,7 @@ import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { PlanFeatures2023GridProps } from 'calypso/my-sites/plan-features-2023-grid';
 import type {
 	PlanActionOverrides,
-	SingleFreeDomainSuggestion,
+	DataResponse,
 } from 'calypso/my-sites/plan-features-2023-grid/types';
 import type { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import type { IAppState } from 'calypso/state/types';
@@ -100,7 +100,7 @@ type OnboardingPricingGrid2023Props = PlansFeaturesMainProps & {
 	sitePlanSlug?: PlanSlug | null;
 	siteSlug?: string | null;
 	intent?: PlansIntent;
-	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
+	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
 	isCustomDomainAllowedOnFreePlan?: boolean | null;
 };
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -101,7 +101,7 @@ type OnboardingPricingGrid2023Props = PlansFeaturesMainProps & {
 	siteSlug?: string | null;
 	intent?: PlansIntent;
 	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
-	isCustomDomainAllowedOnFreePlan?: boolean | null;
+	isCustomDomainAllowedOnFreePlan?: DataResponse< boolean >;
 };
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
@@ -275,8 +275,10 @@ const PlansFeaturesMain = ( {
 		( state: IAppState ) => siteId && canUpgradeToPlan( state, siteId, PLAN_PERSONAL )
 	);
 	const previousRoute = useSelector( ( state: IAppState ) => getPreviousRoute( state ) );
-	const [ isLoadingCustomDomainAllowedOnFreePlan, isCustomDomainAllowedOnFreePlan ] =
-		useIsCustomDomainAllowedOnFreePlan( flowName, paidDomainName );
+	const isCustomDomainAllowedOnFreePlan = useIsCustomDomainAllowedOnFreePlan(
+		flowName,
+		paidDomainName
+	);
 
 	let _customerType = chooseDefaultCustomerType( {
 		currentCustomerType: customerType,
@@ -422,7 +424,11 @@ const PlansFeaturesMain = ( {
 					isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 					onClose={ toggleIsFreePlanPaidDomainDialogOpen }
 					onFreePlanSelected={ () => {
-						if ( ! isCustomDomainAllowedOnFreePlan ) {
+						if ( isCustomDomainAllowedOnFreePlan.isLoading ) {
+							return;
+						}
+
+						if ( ! isCustomDomainAllowedOnFreePlan.entry ) {
 							removePaidDomain?.();
 						}
 						// Since this domain will not be available after it is selected, invalidate the cache.

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -101,7 +101,7 @@ type OnboardingPricingGrid2023Props = PlansFeaturesMainProps & {
 	siteSlug?: string | null;
 	intent?: PlansIntent;
 	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
-	isCustomDomainAllowedOnFreePlan?: DataResponse< boolean >;
+	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >;
 };
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1794

## Proposed Changes

This PR implements the ExPlat API integration part of the dotblog + Free plan experiment described in Automattic/martech#1794, based on https://github.com/Automattic/wp-calypso/pull/78825. The gist is to implement `useIsCustomDomainAllowedForFreePlan()` hook for real using the ExPlat hook this time :) 

For a quick reference:


|| control | treatment |
|-------------------|--------|-----------|
| /start/plans             | <img width="1259" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/b3b865f3-ecbb-4dd8-abc9-975c85ca313b">  | ![](https://user-images.githubusercontent.com/1842898/251617391-cbf5c358-7aa6-4fad-8a6e-31bb52161e0e.png) |
| The modal| <img width="1276" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/16d9e115-f404-4208-8ce7-1e5cc17b7a30"> |![](https://user-images.githubusercontent.com/1842898/251617422-85cd9983-8559-4efc-a248-f90c97769ff5.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to the ExPlat page of this experiment, 21291-explat-experiment and choose a test account. Note that you'd need to make sure to sandbox the public API and update your repo to the latest, otherwise it won't work.

* Assigning the test account as the `control` variation, `/start/plans` experience should act the same as in production.
* Assigning the test account as the `treatment` varation, `/start/plans` experience should act the same as https://github.com/Automattic/wp-calypso/pull/78825 described.
* Make sure the exposure event, `calypso_free_plan_paid_domain_modal_view`, acts as expected: when it's the "default" one, it should be fired with `dialog_type: paid_plan_is_required`. When it's the one describing that the paid domain will only be a redirect, it should be fired with `dialog_type: custom_domain_and_free_plan`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
