### PR TITLE
Pro dashboard: add downtime monitoring upgrade popover message.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -9,6 +10,7 @@ import { useSelector } from 'calypso/state';
 import { getSiteMonitorStatuses } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { useJetpackAgencyDashboardRecordTrackEvent, useToggleActivateMonitor } from '../../hooks';
 import NotificationSettings from '../notification-settings';
+import UpgradePopover from '../upgrade-popover';
 import type { AllowedStatusTypes, MonitorSettings, Site } from '../../sites-overview/types';
 
 import './style.scss';
@@ -40,6 +42,13 @@ export default function ToggleActivateMonitoring( {
 	const statuses = useSelector( getSiteMonitorStatuses );
 	const [ showNotificationSettings, setShowNotificationSettings ] = useState< boolean >( false );
 	const [ showTooltip, setShowTooltip ] = useState( false );
+
+	const isDowntimeMonitoringPaidTierEnabled = isEnabled(
+		'jetpack/pro-dashboard-monitor-paid-tier'
+	);
+
+	// TODO: Need to figure out if current site has not existing paid version of downtime monitoring.
+	const shouldDisplayUpgradePopover = isDowntimeMonitoringPaidTierEnabled;
 
 	const handleShowTooltip = () => {
 		setShowTooltip( true );
@@ -147,27 +156,14 @@ export default function ToggleActivateMonitoring( {
 		);
 	}
 
-	return (
+	const displayablePopover = shouldDisplayUpgradePopover ? (
+		<UpgradePopover
+			context={ statusContentRef.current }
+			isVisible={ showTooltip }
+			position="bottom left"
+		/>
+	) : (
 		<>
-			<span
-				ref={ statusContentRef }
-				role="button"
-				tabIndex={ 0 }
-				onMouseEnter={ handleShowTooltip }
-				onMouseLeave={ handleHideTooltip }
-				onMouseDown={ handleHideTooltip }
-				className="toggle-activate-monitoring__toggle-button"
-			>
-				{ toggleContent }
-			</span>
-			{ showNotificationSettings && (
-				<NotificationSettings
-					onClose={ handleToggleNotificationSettings }
-					sites={ [ site ] }
-					settings={ settings }
-					isLargeScreen={ isLargeScreen }
-				/>
-			) }
 			{ tooltip && (
 				<Tooltip
 					id={ tooltipId }
@@ -178,6 +174,33 @@ export default function ToggleActivateMonitoring( {
 				>
 					{ tooltip }
 				</Tooltip>
+			) }
+		</>
+	);
+
+	return (
+		<>
+			<span
+				className="toggle-activate-monitoring__toggle-button"
+				onMouseDown={ handleHideTooltip }
+				onMouseEnter={ handleShowTooltip }
+				onMouseLeave={ handleHideTooltip }
+				ref={ statusContentRef }
+				role="button"
+				tabIndex={ 0 }
+			>
+				{ toggleContent }
+
+				{ displayablePopover }
+			</span>
+
+			{ showNotificationSettings && (
+				<NotificationSettings
+					onClose={ handleToggleNotificationSettings }
+					sites={ [ site ] }
+					settings={ settings }
+					isLargeScreen={ isLargeScreen }
+				/>
 			) }
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -47,8 +47,8 @@ export default function ToggleActivateMonitoring( {
 		'jetpack/pro-dashboard-monitor-paid-tier'
 	);
 
-	// TODO: Need to figure out if current site has not existing paid version of downtime monitoring.
-	const shouldDisplayUpgradePopover = isDowntimeMonitoringPaidTierEnabled;
+	// TODO: Need to figure out if current site has no existing paid version of downtime monitoring.
+	const shouldDisplayUpgradePopover = status === 'success' && isDowntimeMonitoringPaidTierEnabled;
 
 	const handleShowTooltip = () => {
 		setShowTooltip( true );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -161,6 +161,7 @@ export default function ToggleActivateMonitoring( {
 			context={ statusContentRef.current }
 			isVisible={ showTooltip }
 			position="bottom left"
+			onClose={ handleHideTooltip }
 		/>
 	) : (
 		<>
@@ -182,7 +183,9 @@ export default function ToggleActivateMonitoring( {
 		<>
 			<span
 				className="toggle-activate-monitoring__toggle-button"
-				onMouseDown={ handleHideTooltip }
+				// We don't want to hide the tooltip when the user clicks on the
+				// upgrade popover since it has buttons that user can interact with.
+				onMouseDown={ shouldDisplayUpgradePopover ? undefined : handleHideTooltip }
 				onMouseEnter={ handleShowTooltip }
 				onMouseLeave={ handleHideTooltip }
 				ref={ statusContentRef }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -43,12 +43,10 @@ export default function ToggleActivateMonitoring( {
 	const [ showNotificationSettings, setShowNotificationSettings ] = useState< boolean >( false );
 	const [ showTooltip, setShowTooltip ] = useState( false );
 
-	const isDowntimeMonitoringPaidTierEnabled = isEnabled(
-		'jetpack/pro-dashboard-monitor-paid-tier'
-	);
+	const isPaidTierEnabled = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
 
 	// TODO: Need to figure out if current site has no existing paid version of downtime monitoring.
-	const shouldDisplayUpgradePopover = status === 'success' && isDowntimeMonitoringPaidTierEnabled;
+	const shouldDisplayUpgradePopover = status === 'success' && isPaidTierEnabled;
 
 	const handleShowTooltip = () => {
 		setShowTooltip( true );
@@ -156,7 +154,7 @@ export default function ToggleActivateMonitoring( {
 		);
 	}
 
-	const displayablePopover = shouldDisplayUpgradePopover ? (
+	const upgradePopoverOrTooltip = shouldDisplayUpgradePopover ? (
 		<UpgradePopover
 			context={ statusContentRef.current }
 			isVisible={ showTooltip }
@@ -164,19 +162,17 @@ export default function ToggleActivateMonitoring( {
 			onClose={ handleHideTooltip }
 		/>
 	) : (
-		<>
-			{ tooltip && (
-				<Tooltip
-					id={ tooltipId }
-					context={ statusContentRef.current }
-					isVisible={ showTooltip }
-					position="bottom"
-					className="sites-overview__tooltip"
-				>
-					{ tooltip }
-				</Tooltip>
-			) }
-		</>
+		tooltip && (
+			<Tooltip
+				id={ tooltipId }
+				context={ statusContentRef.current }
+				isVisible={ showTooltip }
+				position="bottom"
+				className="sites-overview__tooltip"
+			>
+				{ tooltip }
+			</Tooltip>
+		)
 	);
 
 	return (
@@ -194,7 +190,7 @@ export default function ToggleActivateMonitoring( {
 			>
 				{ toggleContent }
 
-				{ displayablePopover }
+				{ upgradePopoverOrTooltip }
 			</span>
 
 			{ showNotificationSettings && (

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
@@ -1,0 +1,39 @@
+import { Popover, Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+type Props = {
+	context: HTMLElement | null;
+	isVisible: boolean;
+	position?: string;
+};
+
+export default function UpgradePopover( { context, isVisible, position }: Props ) {
+	const translate = useTranslate();
+
+	const onClick = () => {
+		// TODO: Add event tracking and show/hide modal
+	};
+
+	return (
+		<Popover
+			className="upgrade-popover"
+			context={ context }
+			isVisible={ isVisible }
+			position={ position }
+		>
+			<h2 className="upgrade-popover__heading">{ translate( 'Maximise uptime' ) }</h2>
+
+			<ul className="upgrade-popover__list">
+				<li>{ translate( '1 minute monitoring interval' ) }</li>
+				<li>{ translate( 'SMS Notifications' ) }</li>
+				<li>{ translate( 'Multiple email recipients' ) }</li>
+			</ul>
+
+			<Button className="upgrade-popover__button" primary onClick={ onClick }>
+				{ translate( 'Explore' ) }
+			</Button>
+		</Popover>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
@@ -1,5 +1,14 @@
 import { Popover, Button } from '@automattic/components';
+import { close, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import {
+	JETPACK_DASHBOARD_DOWNTIME_MONITORING_UPGRADE_TOOLTIP_PREFERENCE as tooltipPreference,
+	getJetpackDashboardPreference as getPreference,
+} from 'calypso/state/jetpack-agency-dashboard/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { PreferenceType } from '../../sites-overview/types';
 
 import './style.scss';
 
@@ -7,14 +16,44 @@ type Props = {
 	context: HTMLElement | null;
 	isVisible: boolean;
 	position?: string;
+	onClose: () => void;
 };
 
-export default function UpgradePopover( { context, isVisible, position }: Props ) {
+export default function UpgradePopover( { context, isVisible, position, onClose }: Props ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
-	const onClick = () => {
-		// TODO: Add event tracking and show/hide modal
+	const preference = useSelector( ( state ) => getPreference( state, tooltipPreference ) );
+
+	const isDismissed = preference?.dismiss;
+
+	const savePreferenceType = useCallback(
+		( type: PreferenceType ) => {
+			dispatch( savePreference( tooltipPreference, { ...preference, [ type ]: true } ) );
+		},
+		[ dispatch, preference ]
+	);
+
+	const handleDismissPopover = () => {
+		onClose();
+		savePreferenceType( 'dismiss' );
 	};
+
+	const handleClose = () => {
+		handleDismissPopover();
+		// TODO: Add event tracking here
+	};
+
+	const handleClickExplore = () => {
+		handleDismissPopover();
+		// TODO: Add event tracking here
+		// TODO: Hanle show upgrade modal
+	};
+
+	// Don't show the popover if the user has dismissed it
+	if ( isDismissed ) {
+		return null;
+	}
 
 	return (
 		<Popover
@@ -24,14 +63,16 @@ export default function UpgradePopover( { context, isVisible, position }: Props 
 			position={ position }
 		>
 			<h2 className="upgrade-popover__heading">{ translate( 'Maximise uptime' ) }</h2>
+			<Button borderless className="upgrade-popover__close-button">
+				<Icon icon={ close } onClick={ handleClose } size={ 16 } />
+			</Button>
 
 			<ul className="upgrade-popover__list">
 				<li>{ translate( '1 minute monitoring interval' ) }</li>
 				<li>{ translate( 'SMS Notifications' ) }</li>
 				<li>{ translate( 'Multiple email recipients' ) }</li>
 			</ul>
-
-			<Button className="upgrade-popover__button" primary onClick={ onClick }>
+			<Button className="upgrade-popover__button" primary onClick={ handleClickExplore }>
 				{ translate( 'Explore' ) }
 			</Button>
 		</Popover>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/style.scss
@@ -26,8 +26,15 @@
 
 	li {
 		background: url(calypso/assets/images/jetpack/jetpack-green-checkmark.svg) no-repeat 0 2px;
-		padding-left: 24px;
+		padding-inline-start: 24px;
 		background-size: 16px;
 		background-position-y: 2px;
+		margin-block: 4px;
 	}
+}
+
+.upgrade-popover__close-button {
+	position: absolute;
+	top: 12px;
+	right: 20px;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/style.scss
@@ -1,0 +1,33 @@
+.upgrade-popover {
+	border-radius: 4px;
+
+	.popover__inner {
+		display: flex;
+		gap: 16px;
+		padding: 16px;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+}
+
+.upgrade-popover__heading {
+	font-size: rem(14px);
+	line-height: 1.5;
+}
+
+.upgrade-popover__list {
+	margin: 0;
+	list-style: none;
+	font-size: rem(14px);
+	text-align: left;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+
+	li {
+		background: url(../../../../../assets/images/jetpack/jetpack-green-checkmark.svg) no-repeat 0 2px;
+		padding-left: 24px;
+		background-size: 16px;
+		background-position-y: 2px;
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/style.scss
@@ -25,7 +25,7 @@
 	gap: 2px;
 
 	li {
-		background: url(../../../../../assets/images/jetpack/jetpack-green-checkmark.svg) no-repeat 0 2px;
+		background: url(calypso/assets/images/jetpack/jetpack-green-checkmark.svg) no-repeat 0 2px;
 		padding-left: 24px;
 		background-size: 16px;
 		background-position-y: 2px;

--- a/client/state/jetpack-agency-dashboard/selectors.ts
+++ b/client/state/jetpack-agency-dashboard/selectors.ts
@@ -22,6 +22,9 @@ export const JETPACK_DASHBOARD_DOWNTIME_MONITORING_UPGRADE_BANNER_PREFERENCE =
 export const JETPACK_DASHBOARD_CHECKOUT_REDIRECT_MODAL_DISMISSED =
 	'agency-program-checkout-redirect-modal-dismissed';
 
+export const JETPACK_DASHBOARD_DOWNTIME_MONITORING_UPGRADE_TOOLTIP_PREFERENCE =
+	'jetpack-dashboard-agency-program-downtime-monitoring-upgrade-tooltip-preference';
+
 /**
  * Returns preference associated with the key provided.
  */


### PR DESCRIPTION
Related to 1204992567518369-as-1204995191652306

## Proposed Changes

This PR adds the Downtime monitoring upgrade popover message in the Pro Dashboard site table.

<img width="337" alt="Screenshot 2023-07-18 at 5 24 57 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/077f6c14-ad9e-4943-a3df-a984024de0ec">


## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link and go to `/dashboard`.
* Hover on the monitoring toggle and confirm the **upgrade popover** shows up.
* Move the cursor to the popover and confirm it stays visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?