### PR TITLE
[ON HOLD] Color Variations: Support categorization

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { ColorPaletteVariations } from '@automattic/global-styles';
 import { NavigatorHeader } from '@automattic/onboarding';
@@ -41,6 +42,7 @@ const ScreenColorPalettes = ( {
 					selectedColorPaletteVariation={ selectedColorPaletteVariation }
 					onSelect={ onSelect }
 					limitGlobalStyles={ shouldLimitGlobalStyles }
+					enableCategorization={ isEnabled( 'signup/color-variations-categorization' ) }
 				/>
 			</div>
 			<div className="screen-container__footer">

--- a/config/development.json
+++ b/config/development.json
@@ -174,6 +174,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/color-variations-categorization": false,
 		"signup/design-picker-pattern-assembler": true,
 		"signup/design-picker-preview-colors": true,
 		"signup/design-picker-preview-fonts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -111,6 +111,7 @@
 		"settings/modernize-reading-settings": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,
+		"signup/color-variations-categorization": false,
 		"signup/design-picker-pattern-assembler": true,
 		"signup/design-picker-preview-colors": true,
 		"signup/design-picker-preview-fonts": true,

--- a/config/production.json
+++ b/config/production.json
@@ -136,6 +136,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/color-variations-categorization": false,
 		"signup/design-picker-pattern-assembler": true,
 		"signup/design-picker-preview-colors": false,
 		"signup/design-picker-preview-fonts": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -131,6 +131,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/color-variations-categorization": false,
 		"signup/design-picker-pattern-assembler": true,
 		"signup/design-picker-preview-colors": false,
 		"signup/design-picker-preview-fonts": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -143,6 +143,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/color-variations-categorization": false,
 		"signup/design-picker-pattern-assembler": true,
 		"signup/design-picker-preview-colors": true,
 		"signup/design-picker-preview-fonts": true,

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -97,6 +97,7 @@ const useScreens = ( {
 									stylesheet={ stylesheet }
 									limitGlobalStyles={ limitGlobalStyles }
 									selectedColorPaletteVariation={ selectedColorVariation }
+									enableCategorization={ isEnabled( 'signup/color-variations-categorization' ) }
 									onSelect={ onSelectColorVariation }
 								/>
 							</div>

--- a/packages/global-styles/src/types.ts
+++ b/packages/global-styles/src/types.ts
@@ -22,7 +22,6 @@ export interface GlobalStylesObject {
 	id?: number;
 	slug?: string;
 	title?: string;
-	inline_css?: string;
 	settings: {
 		color?: {
 			palette: {
@@ -38,6 +37,12 @@ export interface GlobalStylesObject {
 		};
 		typography?: Typography;
 	};
+
+	/**
+	 * WP.com only
+	 */
+	inline_css?: string;
+	wpcom_category?: string;
 }
 
 export enum GlobalStylesVariationType {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Introduce a feature flag `signup/color-variations-categorization` to control whether to categorize the Colors.
* Display Colors by their category

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/d75fa929-d011-4127-a3d3-a2ba85ca39d5) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/411802b9-b097-4161-8cbf-2ebc8c245666) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler screen directly
  * `/setup/with-theme-assembler/patternAssembler?theme=creatio&flags=signup/color-variations-categorization&siteSlug=<your_site>`
* On the Assembler screen
  * Select “Colors”
  * Ensure the colors are categorized correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
