### PR TITLE
Domain transfer: fix domain transfer page

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -52,8 +52,8 @@ const domainTransfer: Flow = {
 
 		const logInUrl =
 			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Bulk+Transfer&redirect_to=/setup/${ flowName }/domain`
-				: `/start/account/user?variationName=${ flowName }&pageTitle=Bulk+Transfer&redirect_to=/setup/${ flowName }/pattedomainrns`;
+				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Bulk+Transfer&redirect_to=/setup/${ flowName }/domains`
+				: `/start/account/user?variationName=${ flowName }&pageTitle=Bulk+Transfer&redirect_to=/setup/${ flowName }/domains`;
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -119,29 +119,23 @@ export function DomainCodePair( {
 				</div>
 				<div className="domains__domain-controls">
 					<div className="domains__domain-refresh">
-						<FormFieldset>
-							<Button
-								title={ __( 'Refresh' ) }
-								disabled={ ! refetch }
-								icon={ update }
-								onClick={ () => refetch?.() }
-							/>
-							<FormLabel htmlFor={ id }>{ __( 'Refresh' ) }</FormLabel>
-						</FormFieldset>
+						<Button
+							title={ __( 'Refresh' ) }
+							disabled={ ! refetch }
+							icon={ update }
+							onClick={ () => refetch?.() }
+						>
+							<span className="refresh-label">{ __( 'Refresh' ) }</span>
+						</Button>
 					</div>
 					<div className="domains__domain-delete">
-						<FormFieldset>
-							<Button
-								className={ classnames( { 'has-delete-button': showDelete } ) }
-								icon={ trash }
-								onClick={ () => onRemove( id ) }
-							/>
-							{ showDelete && (
-								<FormLabel className="delete-label" htmlFor={ id }>
-									{ __( 'Delete' ) }
-								</FormLabel>
-							) }
-						</FormFieldset>
+						<Button
+							className={ classnames( { 'has-delete-button': showDelete } ) }
+							icon={ trash }
+							onClick={ () => onRemove( id ) }
+						>
+							<span className="delete-label">{ __( 'Delete' ) }</span>
+						</Button>
 					</div>
 				</div>
 				{ shouldReportError && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -134,7 +134,7 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 						( { domain: otherDomain }, otherIndex ) =>
 							otherDomain && otherDomain === domain.domain && otherIndex < index
 					) }
-					showDelete={ Object.values( domainsState ).length > 1 }
+					showDelete={ domainCount > 1 && index > 0 }
 				/>
 			) ) }
 			{ domainCount < MAX_DOMAINS && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -11,6 +11,10 @@
 	align-items: center;
 	gap: 30px;
 
+	button:disabled {
+		pointer-events: none;
+	}
+
 	&.domains {
 		padding: 0;
 		width: 754px;
@@ -129,9 +133,11 @@
 		// Show the titles on mobile and hide on desktop (except for the first one)
 		.form-label {
 			display: none;
-			@media ( max-width: $break-medium ) {
+
+			@media (max-width: $break-medium ) {
 				display: block;
 			}
+
 			&.is-first-label-title {
 				display: block;
 			}
@@ -177,23 +183,17 @@
 		gap: 16px;
 
 		.domains__domain-refresh {
-			.form-fieldset {
-				display: flex;
-				align-items: center;
-			}
-
 			button {
 				cursor: pointer;
 			}
 
-			label {
+			.refresh-label {
 				display: none;
 			}
 
 			@media (max-width: $break-medium ) {
-				label {
+				.refresh-label {
 					display: block;
-					margin-bottom: 0;
 				}
 			}
 		}
@@ -218,14 +218,8 @@
 			@media (max-width: $break-medium ) {
 				order: 1;
 
-				.form-fieldset {
-					display: flex;
-					align-items: center;
-
-					.delete-label {
-						margin: 0;
-						display: block;
-					}
+				.delete-label {
+					display: block;
 				}
 			}
 		}
@@ -297,6 +291,7 @@
 		width: 300px;
 		@include placeholder();
 	}
+
 	button.loading-placeholder {
 		width: 150px;
 		@include placeholder();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -65,7 +65,13 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		};
 	}
 
-	const availabilityNotice = getAvailabilityNotice( domain, validationResult?.status, null, true );
+	const availabilityNotice = getAvailabilityNotice(
+		domain,
+		validationResult?.status,
+		null,
+		true,
+		'_blank'
+	);
 
 	// final success
 	if ( validationResult?.auth_code_valid ) {
@@ -87,6 +93,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 			valid: false,
 			loading: false,
 			message: availabilityNotice?.message,
+			refetch,
 		};
 	}
 

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -18,7 +18,13 @@ import {
 	domainTransferIn,
 } from 'calypso/my-sites/domains/paths';
 
-function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = false ) {
+function getAvailabilityNotice(
+	domain,
+	error,
+	errorData,
+	isForTransferOnly = false,
+	linksTarget = '_self'
+) {
 	const tld = domain ? getTld( domain ) : null;
 	const { site, maintenanceEndTime, availabilityPreCheck } = errorData || {};
 
@@ -51,21 +57,34 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 			} );
 			break;
 		case domainAvailability.REGISTERED_OTHER_SITE_SAME_USER:
-			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already registered on your site %(site)s. Do you want to {{a}}move it to this site{{/a}}?',
-				{
-					args: { domain, site },
-					components: {
-						strong: <strong />,
-						a: (
-							<a
-								rel="noopener noreferrer"
-								href={ domainManagementTransferToOtherSite( site, domain ) }
-							/>
-						),
-					},
-				}
-			);
+			if ( site ) {
+				message = translate(
+					'{{strong}}%(domain)s{{/strong}} is already registered on your site %(site)s. Do you want to {{a}}move it to this site{{/a}}?',
+					{
+						args: { domain, site },
+						components: {
+							strong: <strong />,
+							a: (
+								<a
+									target={ linksTarget }
+									rel="noopener noreferrer"
+									href={ domainManagementTransferToOtherSite( site, domain ) }
+								/>
+							),
+						},
+					}
+				);
+			} else {
+				message = translate(
+					'{{strong}}%(domain)s{{/strong}} is already registered on another site you own.',
+					{
+						args: { domain },
+						components: {
+							strong: <strong />,
+						},
+					}
+				);
+			}
 			break;
 		case domainAvailability.IN_REDEMPTION:
 			message = translate(
@@ -76,12 +95,14 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 						strong: <strong />,
 						redemptionLink: (
 							<a
+								target={ linksTarget }
 								rel="noopener noreferrer"
 								href="https://www.icann.org/resources/pages/grace-2013-05-03-en"
 							/>
 						),
 						aboutRenewingLink: (
 							<a
+								target={ linksTarget }
 								rel="noopener noreferrer"
 								href="https://www.icann.org/news/blog/do-you-have-a-domain-name-here-s-what-you-need-to-know-part-5"
 							/>
@@ -102,19 +123,27 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 			);
 			break;
 		case domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE:
-			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already connected to this site, but registered somewhere else. Do you want to move ' +
-					'it from your current domain provider to WordPress.com so you can manage the domain and the site ' +
-					'together? {{a}}Yes, transfer it to WordPress.com.{{/a}}',
-				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-						a: <a rel="noopener noreferrer" href={ domainTransferIn( site, domain ) } />,
-					},
-				}
-			);
-			break;
+			if ( site ) {
+				message = translate(
+					'{{strong}}%(domain)s{{/strong}} is already connected to this site, but registered somewhere else. Do you want to move ' +
+						'it from your current domain provider to WordPress.com so you can manage the domain and the site ' +
+						'together? {{a}}Yes, transfer it to WordPress.com.{{/a}}',
+					{
+						args: { domain },
+						components: {
+							strong: <strong />,
+							a: (
+								<a
+									target={ linksTarget }
+									rel="noopener noreferrer"
+									href={ domainTransferIn( site, domain ) }
+								/>
+							),
+						},
+					}
+				);
+				break;
+			}
 		case domainAvailability.MAPPED_SAME_SITE_NOT_TRANSFERRABLE:
 			message = translate(
 				'{{strong}}%(domain)s{{/strong}} is already connected to this site and cannot be transferred to WordPress.com. {{a}}Learn more{{/a}}.',
@@ -124,6 +153,7 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 						strong: <strong />,
 						a: (
 							<a
+								target={ linksTarget }
 								rel="noopener noreferrer"
 								href={ localizeUrl( INCOMING_DOMAIN_TRANSFER_SUPPORTED_TLDS ) }
 							/>
@@ -140,7 +170,7 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 					args: { domain, site },
 					components: {
 						strong: <strong />,
-						a: <a rel="noopener noreferrer" href={ CALYPSO_CONTACT } />,
+						a: <a target={ linksTarget } rel="noopener noreferrer" href={ CALYPSO_CONTACT } />,
 					},
 				}
 			);
@@ -152,7 +182,13 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 					args: { domain },
 					components: {
 						strong: <strong />,
-						a: <a rel="noopener noreferrer" href={ domainManagementTransferIn( site, domain ) } />,
+						a: (
+							<a
+								target={ linksTarget }
+								rel="noopener noreferrer"
+								href={ site ? domainManagementTransferIn( site, domain ) : '/domains/manage' }
+							/>
+						),
 					},
 				}
 			);
@@ -167,6 +203,7 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 						strong: <strong />,
 						a: (
 							<a
+								target={ linksTarget }
 								rel="noopener noreferrer"
 								href={ localizeUrl( INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS ) }
 							/>
@@ -183,7 +220,13 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 						args: { tld },
 						components: {
 							strong: <strong />,
-							a: <a rel="noopener noreferrer" href={ localizeUrl( MAP_EXISTING_DOMAIN ) } />,
+							a: (
+								<a
+									target={ linksTarget }
+									rel="noopener noreferrer"
+									href={ localizeUrl( MAP_EXISTING_DOMAIN ) }
+								/>
+							),
 						},
 					}
 				);
@@ -239,7 +282,13 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 					'This domain cannot be transferred to WordPress.com but it can be connected instead. {{a}}Learn More.{{/a}}',
 					{
 						components: {
-							a: <a rel="noopener noreferrer" href={ localizeUrl( MAP_EXISTING_DOMAIN ) } />,
+							a: (
+								<a
+									target={ linksTarget }
+									rel="noopener noreferrer"
+									href={ localizeUrl( MAP_EXISTING_DOMAIN ) }
+								/>
+							),
 						},
 					}
 				);
@@ -284,11 +333,12 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 							strong: <strong />,
 							a1: (
 								<a
+									target={ linksTarget }
 									rel="noopener noreferrer"
 									href="http://wordpressfoundation.org/trademark-policy/"
 								/>
 							),
-							a2: <a href={ CALYPSO_CONTACT } />,
+							a2: <a target={ linksTarget } href={ CALYPSO_CONTACT } />,
 						},
 					}
 				);
@@ -343,7 +393,7 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 				'This domain expired recently. To get it back please {{a}}contact support{{/a}}.',
 				{
 					components: {
-						a: <a href={ CALYPSO_CONTACT } />,
+						a: <a target={ linksTarget } href={ CALYPSO_CONTACT } />,
 					},
 				}
 			);
@@ -387,16 +437,34 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 			break;
 
 		case domainAvailability.AVAILABLE_PREMIUM:
-			message = translate(
-				"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support purchasing this premium domain on WordPress.com, but if you purchase the domain elsewhere, you can {{a}}map it to your site{{/a}}.",
-				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-						a: <a rel="noopener noreferrer" href={ domainMapping( site, domain ) } />,
-					},
-				}
-			);
+			if ( site ) {
+				message = translate(
+					"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support purchasing this premium domain on WordPress.com, but if you purchase the domain elsewhere, you can {{a}}map it to your site{{/a}}.",
+					{
+						args: { domain },
+						components: {
+							strong: <strong />,
+							a: (
+								<a
+									target={ linksTarget }
+									rel="noopener noreferrer"
+									href={ domainMapping( site, domain ) }
+								/>
+							),
+						},
+					}
+				);
+			} else {
+				message = translate(
+					"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support purchasing this premium domain on WordPress.com.",
+					{
+						args: { domain },
+						components: {
+							strong: <strong />,
+						},
+					}
+				);
+			}
 			break;
 
 		case domainAvailability.AVAILABLE_RESERVED:
@@ -412,16 +480,34 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 			break;
 
 		case domainAvailability.TRANSFERRABLE_PREMIUM:
-			message = translate(
-				"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support transfers of premium domains on WordPress.com, but if you are the owner of this domain, you can {{a}}map it to your site{{/a}}.",
-				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-						a: <a rel="noopener noreferrer" href={ domainMapping( site, domain ) } />,
-					},
-				}
-			);
+			if ( site ) {
+				message = translate(
+					"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support transfers of premium domains on WordPress.com, but if you are the owner of this domain, you can {{a}}map it to your site{{/a}}.",
+					{
+						args: { domain },
+						components: {
+							strong: <strong />,
+							a: (
+								<a
+									target={ linksTarget }
+									rel="noopener noreferrer"
+									href={ domainMapping( site, domain ) }
+								/>
+							),
+						},
+					}
+				);
+			} else {
+				message = translate(
+					"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support transfers of premium domains on WordPress.com.",
+					{
+						args: { domain },
+						components: {
+							strong: <strong />,
+						},
+					}
+				);
+			}
 			break;
 
 		case domainAvailability.RECENT_REGISTRATION_LOCK_NOT_TRANSFERRABLE:
@@ -454,7 +540,7 @@ function getAvailabilityNotice( domain, error, errorData, isForTransferOnly = fa
 				'Oops! Sorry an error has occurred. Please {{a}}click here{{/a}} to contact us so that we can fix it. Please remember that you have to provide the full, complete Blog URL, otherwise we can not fix it.',
 				{
 					components: {
-						a: <a rel="noopener noreferrer" href={ supportURL } />,
+						a: <a target={ linksTarget } rel="noopener noreferrer" href={ supportURL } />,
 					},
 				}
 			);


### PR DESCRIPTION
@niranjan-uma-shankar gave great feedback pdtkmj-1Cx-p2#comment-2906.

This PR addresses all of it.

### Fixes

> The intro screen is displayed again after signup. So here’s how it works: Intro screen -> click “I’m ready” CTA -> registration screen -> Intro screen (again). Should we show it the second time?

1. Using incognitro, go to /setup/domain-transfer.
2. Login, you should be taken to the domains step.

> It’s not clear to me if the refresh button works, I assume it doesn’t. I don’t see any network requests, and there’s no visual feedback that a refresh is in progress.

1. The disabled state shouldn't have hover effect.
2. The button should be enabled in many more cases now. 

> In mobile viewport, the delete button does not work, though it works fine in desktop.

1. Go to mobile viewport.
2. Make sure the labels are clickable.

> We should also try to prevent accidental clicks that navigate away, like for example the “Learn more” link below which opens a support page in the same tab.

1. Use niranjan.art domain and click the link in the error. It should open in a new tab.

> The link in the error message has an undefined param in the URL, maybe because I was testing it on a new account with no site –

1. Now all the errors that depend on the site are reworded away from this. You can try `niranjan.art` again, and you'll see it doesn't offer mapping to your site. 

