### PR TITLE
Subscription management: add "Add sites" button & modal skeleton

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -493,6 +493,7 @@ module.exports = {
 					'__experimentalDivider',
 					'__experimentalHStack',
 					'__experimentalVStack',
+					'__experimentalSpacer',
 					'__experimentalItem',
 					'__experimentalItemGroup',
 					'__experimentalNavigationBackButton',

--- a/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
+++ b/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -7,6 +8,10 @@ import { AddSitesModal } from 'calypso/landing/subscriptions/components/add-site
 const AddSitesButton = () => {
 	const translate = useTranslate();
 	const [ isAddSitesModalVisible, setIsAddSitesModalVisible ] = useState( false );
+
+	if ( ! isEnabled( 'subscription-management-add-sites-modal' ) ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
+++ b/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import './styles.scss';
+import { AddSitesModal } from 'calypso/landing/subscriptions/components/add-sites-modal';
+
+const AddSitesButton = () => {
+	const translate = useTranslate();
+	const [ isAddSitesModalVisible, setIsAddSitesModalVisible ] = useState( false );
+
+	return (
+		<>
+			<Button
+				primary
+				className="subscriptions-add-sites-button"
+				onClick={ () => setIsAddSitesModalVisible( true ) }
+			>
+				{ translate( 'Add sites' ) }
+			</Button>
+			<AddSitesModal
+				showModal={ isAddSitesModalVisible }
+				onClose={ () => setIsAddSitesModalVisible( false ) }
+				onAddFinished={ () => setIsAddSitesModalVisible( false ) }
+			/>
+		</>
+	);
+};
+
+export default AddSitesButton;

--- a/client/landing/subscriptions/components/add-sites-button/index.ts
+++ b/client/landing/subscriptions/components/add-sites-button/index.ts
@@ -1,0 +1,1 @@
+export { default as AddSitesButton } from './add-sites-button';

--- a/client/landing/subscriptions/components/add-sites-button/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-button/styles.scss
@@ -1,0 +1,3 @@
+.subscriptions-add-sites-button {
+	margin-top: 12px;
+}

--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -1,0 +1,12 @@
+type AddSitesFormProps = {
+	recordTracksEvent: ( eventName: string, eventProperties?: Record< string, unknown > ) => void;
+	onClose: () => void;
+	onAddFinished: () => void;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const AddSitesForm = ( { recordTracksEvent, onClose, onAddFinished }: AddSitesFormProps ) => {
+	return <div>Skeleton</div>;
+};
+
+export default AddSitesForm;

--- a/client/landing/subscriptions/components/add-sites-form/index.ts
+++ b/client/landing/subscriptions/components/add-sites-form/index.ts
@@ -1,0 +1,1 @@
+export { default as AddSitesForm } from './add-sites-form';

--- a/client/landing/subscriptions/components/add-sites-modal/add-sites-modal.tsx
+++ b/client/landing/subscriptions/components/add-sites-modal/add-sites-modal.tsx
@@ -1,0 +1,38 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { AddSitesForm } from 'calypso/landing/subscriptions/components/add-sites-form';
+
+type AddSitesModalProps = {
+	showModal: boolean;
+	onClose: () => void;
+	onAddFinished: () => void;
+};
+
+const AddSitesModal = ( { showModal, onClose, onAddFinished }: AddSitesModalProps ) => {
+	const translate = useTranslate();
+
+	const modalTitle = translate( 'Add sites', {
+		context: 'Modal title',
+	} );
+
+	if ( ! showModal ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ modalTitle as string }
+			onRequestClose={ onClose }
+			overlayClassName="add-sites-modal"
+		>
+			<AddSitesForm
+				recordTracksEvent={ recordTracksEvent }
+				onClose={ onClose }
+				onAddFinished={ onAddFinished }
+			/>
+		</Modal>
+	);
+};
+
+export default AddSitesModal;

--- a/client/landing/subscriptions/components/add-sites-modal/index.ts
+++ b/client/landing/subscriptions/components/add-sites-modal/index.ts
@@ -1,0 +1,1 @@
+export { default as AddSitesModal } from './add-sites-modal';

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -1,6 +1,8 @@
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
+	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -10,6 +12,7 @@ import ReaderImportButton from 'calypso/blocks/reader-import-button';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import { AddSitesButton } from 'calypso/landing/subscriptions/components/add-sites-button';
 import {
 	SubscriptionsPortal,
 	SubscriptionManagerContextProvider,
@@ -44,12 +47,14 @@ const SiteSubscriptionsManager = () => {
 			<Main className="site-subscriptions-manager">
 				<DocumentHead title={ translate( 'Manage subscriptions' ) } />
 
-				<HStack className="site-subscriptions-manager__header-h-stack" justifyContent="center">
+				<HStack className="site-subscriptions-manager__header-h-stack">
 					<FormattedHeader
 						headerText={ translate( 'Manage subscribed sites' ) }
 						subHeaderText={ translate( 'Manage your newsletter and blog subscriptions.' ) }
 						align="left"
 					/>
+					<Spacer />
+					<AddSitesButton />
 					<SubscriptionsEllipsisMenu
 						toggleTitle={ translate( 'More' ) }
 						popoverClassName="site-subscriptions-manager__import-export-popover"

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -1,7 +1,6 @@
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';

--- a/client/wp-components-types.d.ts
+++ b/client/wp-components-types.d.ts
@@ -8,7 +8,6 @@ declare module '@wordpress/components' {
 	export const __experimentalDivider: React.ComponentType< Props >;
 	export const __experimentalHStack: React.ComponentType< Props >;
 	export const __experimentalVStack: React.ComponentType< Props >;
-
 	export const __experimentalSpacer: React.ComponentType< Props >;
 	export const __experimentalItem: React.ComponentType< Props >;
 	export const __experimentalItemGroup: React.ComponentType< Props >;

--- a/client/wp-components-types.d.ts
+++ b/client/wp-components-types.d.ts
@@ -8,6 +8,8 @@ declare module '@wordpress/components' {
 	export const __experimentalDivider: React.ComponentType< Props >;
 	export const __experimentalHStack: React.ComponentType< Props >;
 	export const __experimentalVStack: React.ComponentType< Props >;
+
+	export const __experimentalSpacer: React.ComponentType< Props >;
 	export const __experimentalItem: React.ComponentType< Props >;
 	export const __experimentalItemGroup: React.ComponentType< Props >;
 	export const __experimentalNavigatorBackButton: React.ComponentType< Props >;

--- a/config/development.json
+++ b/config/development.json
@@ -190,6 +190,7 @@
 		"subscriber-importer": true,
 		"subscribers-page-new": true,
 		"subscription-gifting": true,
+		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -127,6 +127,7 @@
 		"subscriber-importer": true,
 		"subscribers-page-new": false,
 		"subscription-gifting": true,
+		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,

--- a/config/production.json
+++ b/config/production.json
@@ -154,6 +154,7 @@
 		"subscriber-importer": true,
 		"subscribers-page-new": false,
 		"subscription-gifting": true,
+		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -147,6 +147,7 @@
 		"subscriber-importer": true,
 		"subscribers-page-new": false,
 		"subscription-gifting": true,
+		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -159,6 +159,7 @@
 		"subscriber-importer": true,
 		"subscribers-page-new": false,
 		"subscription-gifting": true,
+		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,


### PR DESCRIPTION
Closes #79226

## Proposed Changes

This PR:

- Adds a `<AddSitesButton />`,  `<AddSitesModal />` & `<AddSitesForm />`
- Implements the button inside Reader
- Adds some groundwork for future PR's (such as passing needed props to AddSitesForm)

The button will only show when the feature flag `subscription-management-add-sites-modal` is set. This feature flag is enabled for development.

## Testing Instructions

- Apply this PR
- Visit `http://calypso.localhost:3000/read/subscriptions`
- You should see the `Add sites` button
- Clicking it should show the skeleton modal

![CleanShot 2023-07-12 at 11 37 32@2x](https://github.com/Automattic/wp-calypso/assets/528287/bbff7256-17f2-4366-93e8-d9c4e26a5d2f)

- Disable the feature flag in `config/development.json` (line 193)
- Restart Calypso
- The button should not be shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
