### PR TITLE
Plans 2023: Remove placeholder props as unused

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -28,7 +28,6 @@ type PlanFeaturesActionsButtonProps = {
 	current: boolean;
 	freePlan: boolean;
 	manageHref: string;
-	isPlaceholder?: boolean;
 	isPopular?: boolean;
 	isInSignup?: boolean;
 	isLaunchPage?: boolean | null;
@@ -57,13 +56,11 @@ const DummyDisabledButton = styled.div`
 
 const SignupFlowPlanFeatureActionButton = ( {
 	freePlan,
-	isPlaceholder,
 	planName,
 	classes,
 	handleUpgradeButtonClick,
 }: {
 	freePlan: boolean;
-	isPlaceholder: boolean;
 	planName: TranslateResult;
 	classes: string;
 	handleUpgradeButtonClick: () => void;
@@ -82,7 +79,7 @@ const SignupFlowPlanFeatureActionButton = ( {
 	}
 
 	return (
-		<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+		<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 			{ btnText }
 		</Button>
 	);
@@ -90,13 +87,11 @@ const SignupFlowPlanFeatureActionButton = ( {
 
 const LaunchPagePlanFeatureActionButton = ( {
 	freePlan,
-	isPlaceholder,
 	planName,
 	classes,
 	handleUpgradeButtonClick,
 }: {
 	freePlan: boolean;
-	isPlaceholder: boolean;
 	planName: TranslateResult;
 	classes: string;
 	handleUpgradeButtonClick: () => void;
@@ -105,7 +100,7 @@ const LaunchPagePlanFeatureActionButton = ( {
 
 	if ( freePlan ) {
 		return (
-			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+			<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 				{ translate( 'Keep this plan', {
 					comment:
 						'A selection to keep the current plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
@@ -115,7 +110,7 @@ const LaunchPagePlanFeatureActionButton = ( {
 	}
 
 	return (
-		<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+		<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 			{ translate( 'Select %(plan)s', {
 				args: {
 					plan: planName,
@@ -130,7 +125,6 @@ const LaunchPagePlanFeatureActionButton = ( {
 
 const LoggedInPlansFeatureActionButton = ( {
 	freePlan,
-	isPlaceholder,
 	availableForPurchase,
 	classes,
 	handleUpgradeButtonClick,
@@ -143,7 +137,6 @@ const LoggedInPlansFeatureActionButton = ( {
 	planActionOverrides,
 }: {
 	freePlan: boolean;
-	isPlaceholder: boolean;
 	availableForPurchase?: boolean;
 	classes: string;
 	handleUpgradeButtonClick: () => void;
@@ -194,7 +187,7 @@ const LoggedInPlansFeatureActionButton = ( {
 
 	// If the current plan is on a higher-term but lower-tier, then show a "Contact support" button.
 	if (
-		( availableForPurchase || isPlaceholder ) &&
+		availableForPurchase &&
 		currentSitePlanSlug &&
 		! current &&
 		currentSitePlanSlug !== PLAN_ECOMMERCE_TRIAL_MONTHLY &&
@@ -211,7 +204,7 @@ const LoggedInPlansFeatureActionButton = ( {
 
 	// If the current plan matches on a lower-term, then show an "Upgrade to..." button.
 	if (
-		( availableForPurchase || isPlaceholder ) &&
+		availableForPurchase &&
 		currentSitePlanSlug &&
 		! current &&
 		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug ) &&
@@ -219,11 +212,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	) {
 		if ( planMatches( planType, { term: TERM_TRIENNIALLY } ) ) {
 			return (
-				<Button
-					className={ classes }
-					onClick={ handleUpgradeButtonClick }
-					disabled={ isPlaceholder }
-				>
+				<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 					{ buttonText || translate( 'Upgrade to Triennial' ) }
 				</Button>
 			);
@@ -231,11 +220,7 @@ const LoggedInPlansFeatureActionButton = ( {
 
 		if ( planMatches( planType, { term: TERM_BIENNIALLY } ) ) {
 			return (
-				<Button
-					className={ classes }
-					onClick={ handleUpgradeButtonClick }
-					disabled={ isPlaceholder }
-				>
+				<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 					{ buttonText || translate( 'Upgrade to Biennial' ) }
 				</Button>
 			);
@@ -243,11 +228,7 @@ const LoggedInPlansFeatureActionButton = ( {
 
 		if ( planMatches( planType, { term: TERM_ANNUALLY } ) ) {
 			return (
-				<Button
-					className={ classes }
-					onClick={ handleUpgradeButtonClick }
-					disabled={ isPlaceholder }
-				>
+				<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 					{ buttonText || translate( 'Upgrade to Yearly' ) }
 				</Button>
 			);
@@ -256,9 +237,9 @@ const LoggedInPlansFeatureActionButton = ( {
 
 	const buttonTextFallback = buttonText ?? translate( 'Upgrade', { context: 'verb' } );
 
-	if ( availableForPurchase || isPlaceholder ) {
+	if ( availableForPurchase ) {
 		return (
-			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+			<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 				{ buttonTextFallback }
 			</Button>
 		);
@@ -288,7 +269,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	current = false,
 	freePlan = false,
 	manageHref,
-	isPlaceholder = false,
 	isInSignup,
 	isLaunchPage,
 	onUpgradeClick,
@@ -309,10 +289,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	} );
 
 	const handleUpgradeButtonClick = () => {
-		if ( isPlaceholder ) {
-			return;
-		}
-
 		if ( ! freePlan ) {
 			recordTracksEvent( 'calypso_plan_features_upgrade_click', {
 				current_plan: currentSitePlanSlug,
@@ -368,7 +344,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 		return (
 			<LaunchPagePlanFeatureActionButton
 				freePlan={ freePlan }
-				isPlaceholder={ isPlaceholder }
 				planName={ planName }
 				classes={ classes }
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
@@ -378,7 +353,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 		return (
 			<SignupFlowPlanFeatureActionButton
 				freePlan={ freePlan }
-				isPlaceholder={ isPlaceholder }
 				planName={ planName }
 				classes={ classes }
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
@@ -389,7 +363,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	return (
 		<LoggedInPlansFeatureActionButton
 			freePlan={ freePlan }
-			isPlaceholder={ isPlaceholder }
 			availableForPurchase={ availableForPurchase }
 			classes={ classes }
 			handleUpgradeButtonClick={ handleUpgradeButtonClick }

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -463,7 +463,6 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 				className={ getPlanClass( planName ) }
 				freePlan={ isFreePlan( planName ) }
 				isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planName ) }
-				isPlaceholder={ planPropertiesObj.isPlaceholder }
 				isInSignup={ isInSignup }
 				isLaunchPage={ isLaunchPage }
 				planName={ planConstantObj.getTitle() }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -8,7 +8,6 @@ import {
 	isWpcomEnterpriseGridPlan,
 	isMonthly,
 	isBusinessPlan,
-	PLAN_ENTERPRISE_GRID_WPCOM,
 	isPremiumPlan,
 	isWooExpressMediumPlan,
 	isWooExpressSmallPlan,
@@ -101,7 +100,6 @@ export type PlanFeatures2023GridProps = {
 	onUpgradeClick?: ( cartItem?: MinimalRequestCartProduct | null ) => void;
 	flowName?: string | null;
 	paidDomainName?: string;
-	placeholder?: string;
 	intervalType?: string;
 	currentSitePlanSlug?: string | null;
 	hidePlansFeatureComparison?: boolean;
@@ -646,7 +644,7 @@ export class PlanFeatures2023Grid extends Component<
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties: PlanProperties ) => {
-				const { planName, isPlaceholder, planConstantObj, current } = properties;
+				const { planName, planConstantObj, current } = properties;
 				const classes = classNames(
 					'plan-features-2023-grid__table-item',
 					'is-top-buttons',
@@ -678,7 +676,6 @@ export class PlanFeatures2023Grid extends Component<
 							freePlan={ isFreePlan( planName ) }
 							isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planName ) }
 							isWooExpressPlusPlan={ isWooExpressPlusPlan( planName ) }
-							isPlaceholder={ isPlaceholder ?? false }
 							isInSignup={ isInSignup }
 							isLaunchPage={ isLaunchPage }
 							onUpgradeClick={ () => this.handleUpgradeClick( properties ) }
@@ -886,7 +883,6 @@ const withIsLargeCurrency = ( Component: LocalizedComponent< typeof PlanFeatures
 const ConnectedPlanFeatures2023Grid = connect(
 	( state: IAppState, ownProps: PlanFeatures2023GridType ) => {
 		const {
-			placeholder,
 			planRecords,
 			visiblePlans,
 			isInSignup,
@@ -908,15 +904,10 @@ const ConnectedPlanFeatures2023Grid = connect(
 		// TODO clk: plan properties should be passed through props instead of being calculated here
 		const planProperties: PlanProperties[] = ( Object.keys( planRecords ) as PlanSlug[] ).map(
 			( plan: PlanSlug ) => {
-				let isPlaceholder = false;
 				const planConstantObj = applyTestFiltersToPlansList( plan, undefined );
 				const planProductId = planConstantObj.getProductId();
 				const planObject = getPlan( state, planProductId );
 				const isMonthlyPlan = isMonthly( plan );
-
-				if ( placeholder || ( ! planObject && plan !== PLAN_ENTERPRISE_GRID_WPCOM ) ) {
-					isPlaceholder = true;
-				}
 
 				let planFeatures = [];
 				let jetpackFeatures: FeatureObject[] = [];
@@ -957,7 +948,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 
 				// This is the per month price of a monthly plan. E.g. $14 for Premium monthly.
 				const annualPlansOnlyFeatures = planConstantObj.getAnnualPlansOnlyFeatures?.() || [];
-				let planFeaturesTransformed: Array< TransformedFeatureObject > = [];
+				const planFeaturesTransformed: Array< TransformedFeatureObject > = [];
 				let jetpackFeaturesTransformed: Array< TransformedFeatureObject > = [];
 				const topFeature = selectedFeature
 					? planFeatures.find( ( feature ) => feature.getSlug() === selectedFeature )
@@ -1002,13 +993,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 					};
 				} );
 
-				// Strip annual-only features out for the site's /plans page
-				if ( isPlaceholder ) {
-					planFeaturesTransformed = planFeaturesTransformed.filter(
-						( { availableForCurrentPlan = true } ) => availableForCurrentPlan
-					);
-				}
-
 				const isCurrentPlan = currentSitePlanSlug === plan;
 				const product_name_short =
 					isWpcomEnterpriseGridPlan( plan ) && planConstantObj.getPathSlug
@@ -1029,7 +1013,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 					availableForPurchase,
 					features: planFeaturesTransformed,
 					jpFeatures: jetpackFeaturesTransformed,
-					isPlaceholder,
 					planConstantObj,
 					planName: plan,
 					// TODO clk: snake_case?

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -419,11 +419,6 @@ $mobile-card-max-width: 440px;
 		}
 	}
 
-	.is-placeholder {
-		width: 60%;
-		margin: 5px auto;
-	}
-
 	.plan-features-2023-grid__item-info {
 		display: flex;
 		flex-direction: column;

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -15,7 +15,6 @@ export type PlanProperties = {
 	currencyCode?: string | null;
 	features: TransformedFeatureObject[];
 	jpFeatures: TransformedFeatureObject[];
-	isPlaceholder?: boolean;
 	isVisible: boolean;
 	planConstantObj: ReturnType< typeof applyTestFiltersToPlansList >;
 	planName: PlanSlug;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This is always `false` in my tests. Presumably logic that was ported over from the previous/older implementations. I can't find a respective use right now.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/plans/[paid]` and confirm buttons render as disabled in lower-tier plans. This looks like the only area of relevance  for the `isPlaceholder` prop.
- Go to `/start` and confirm everything is sane - buttons work.
- Try a tailored flow `/setup/newsletter` and `/setup/wooexpress`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
