### PR TITLE
Pro Dashboard: Move Woo extensions into their own section on the issue license screen

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -55,9 +55,16 @@ export default function IssueMultipleLicensesForm( {
 		allProducts?.filter(
 			( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-packs'
 		) || [];
+	const wooExtensions =
+		allProducts?.filter(
+			( { family_slug }: { family_slug: string } ) =>
+				family_slug.substring( 0, 'woocommerce-'.length ) === 'woocommerce-'
+		) || [];
 	const products =
 		allProducts?.filter(
-			( { family_slug }: { family_slug: string } ) => family_slug !== 'jetpack-packs'
+			( { family_slug }: { family_slug: string } ) =>
+				family_slug !== 'jetpack-packs' &&
+				family_slug.substring( 0, 'woocommerce-'.length ) !== 'woocommerce-'
 		) || [];
 
 	const hasPurchasedProductsWithoutBundle = useSelector( ( state ) =>
@@ -205,23 +212,45 @@ export default function IssueMultipleLicensesForm( {
 								/>
 							) ) }
 					</div>
-					<hr className="issue-multiple-licenses-form__separator" />
-					<p className="issue-multiple-licenses-form__description">
-						{ translate( 'Or select any of our {{strong}}recommended bundles{{/strong}}:', {
-							components: { strong: <strong /> },
-						} ) }
-					</p>
-					<div className="issue-multiple-licenses-form__bottom">
-						{ bundles &&
-							bundles.map( ( productOption, i ) => (
-								<LicenseBundleCard
-									key={ productOption.slug }
-									product={ productOption }
-									onSelectProduct={ onSelectProduct }
-									tabIndex={ 100 + ( products?.length || 0 ) + i }
-								/>
-							) ) }
-					</div>
+					{ bundles && (
+						<>
+							<hr className="issue-multiple-licenses-form__separator" />
+							<p className="issue-multiple-licenses-form__description">
+								{ translate( 'Or select any of our {{strong}}recommended bundles{{/strong}}:', {
+									components: { strong: <strong /> },
+								} ) }
+							</p>
+							<div className="issue-multiple-licenses-form__bottom">
+								{ bundles.map( ( productOption, i ) => (
+									<LicenseBundleCard
+										key={ productOption.slug }
+										product={ productOption }
+										onSelectProduct={ onSelectProduct }
+										tabIndex={ 100 + ( products?.length || 0 ) + i }
+									/>
+								) ) }
+							</div>
+						</>
+					) }
+					{ wooExtensions && (
+						<>
+							<hr className="issue-multiple-licenses-form__separator" />
+							<p className="issue-multiple-licenses-form__description">
+								{ translate( 'WooCommerce Extensions:' ) }
+							</p>
+							<div className="issue-multiple-licenses-form__bottom">
+								{ wooExtensions &&
+									wooExtensions.map( ( productOption, i ) => (
+										<LicenseBundleCard
+											key={ productOption.slug }
+											product={ productOption }
+											onSelectProduct={ onSelectProduct }
+											tabIndex={ 100 + ( products?.length || 0 ) + bundles.length + i }
+										/>
+									) ) }
+							</div>
+						</>
+					) }
 				</>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -241,11 +241,15 @@ export default function IssueMultipleLicensesForm( {
 							<div className="issue-multiple-licenses-form__bottom">
 								{ wooExtensions &&
 									wooExtensions.map( ( productOption, i ) => (
-										<LicenseBundleCard
+										<LicenseProductCard
+											isMultiSelect
 											key={ productOption.slug }
 											product={ productOption }
 											onSelectProduct={ onSelectProduct }
-											tabIndex={ 100 + ( products?.length || 0 ) + bundles.length + i }
+											isSelected={ selectedProductSlugs.includes( productOption.slug ) }
+											isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
+											tabIndex={ 100 + i }
+											suggestedProduct={ suggestedProduct }
 										/>
 									) ) }
 							</div>


### PR DESCRIPTION
Related to 1204137270272763-as-1204910524245480

## Proposed Changes

* Pro Dashboard: Separate the new WooCommerce extension licenses into their own section at the bottom to reduce product clutter as a short-term solution until the screen is redesigned.

## Testing Instructions

* Make sure your billing scheme is set to 871 (please reach out to team Avalon if this means nothing to you)
* Make sure all Woo extensions show up in their own section like this:

![Screenshot 2023-07-12 at 13 29 04](https://github.com/Automattic/wp-calypso/assets/22746396/fa4230ca-40e1-4c2f-9c45-3a874f07c926)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?