### PR TITLE
Anchor.fm: Fix css rules that break after removing Anchor from stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
@@ -2,6 +2,7 @@
 import { Button, FormInputValidation } from '@automattic/components';
 import { TextControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
 import { Dispatch, FormEvent, ReactNode, SetStateAction, useEffect } from 'react';
 import { ForwardedAutoresizingFormTextarea } from 'calypso/blocks/comments/autoresizing-form-textarea';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -9,7 +10,6 @@ import FormLabel from 'calypso/components/forms/form-label';
 import { SiteIconWithPicker } from 'calypso/components/site-icon-with-picker';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import type { SiteDetails } from '@automattic/data-stores';
-
 import './style.scss';
 
 interface TranslatedStrings {
@@ -36,6 +36,7 @@ interface SetupFormProps {
 	translatedText?: TranslatedStrings;
 	isLoading?: boolean;
 	isSubmitError?: boolean;
+	className?: string;
 	children?: ReactNode;
 }
 
@@ -54,6 +55,7 @@ const SetupForm = ( {
 	translatedText,
 	isLoading = false,
 	isSubmitError = false,
+	className = '',
 	children,
 }: SetupFormProps ) => {
 	const { __ } = useI18n();
@@ -73,8 +75,9 @@ const SetupForm = ( {
 		}
 	}, [ siteTitle, invalidSiteTitle, setInvalidSiteTitle ] );
 
+	const formClasses = classnames( 'setup-form__form', className );
 	return (
-		<form className="setup-form__form" onSubmit={ handleSubmit }>
+		<form className={ formClasses } onSubmit={ handleSubmit }>
 			<SiteIconWithPicker
 				site={ site }
 				placeholderText={ translatedText?.iconPlaceholder || __( 'Upload a profile image' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
@@ -100,6 +100,7 @@ const NewsletterPostSetup: Step = ( { navigation } ) => {
 					translatedText={ newsletterFormText }
 					isLoading={ isLoading }
 					isSubmitError={ isSubmitError }
+					className="newsletter-setup-form"
 				/>
 			}
 			recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -115,6 +115,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 					setBase64Image={ setBase64Image }
 					handleSubmit={ handleSubmit }
 					translatedText={ newsletterFormText }
+					className="newsletter-setup-form"
 				/>
 			}
 			recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -47,4 +47,23 @@
 			margin-top: -2px;
 		}
 	}
+
+	.newsletter-setup-form {
+		textarea,
+		pre {
+			color: var(--studio-gray-100);
+			font-size: $font-body-small;
+			padding: 12px 16px;
+		}
+
+		textarea {
+			font-family: "SF Pro Text", $sans;
+			font-weight: 400;
+		}
+
+		pre {
+			border: none;
+			line-height: 20px;
+		}
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -59,6 +59,10 @@
 		textarea {
 			font-family: "SF Pro Text", $sans;
 			font-weight: 400;
+
+			&::placeholder {
+				color: var(--studio-gray-30);
+			}
 		}
 
 		pre {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/75387

## Proposed Changes
Adds specificity to css rules so they wont clash with `.expanding-area` when the [Anchor removal PR](https://github.com/Automattic/wp-calypso/pull/78958) gets merged. Details in [this comment](https://github.com/Automattic/wp-calypso/pull/78958#issuecomment-1630877988).


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing should be done on both, local env and calypso.live.
* Go to `/setup/newsletter/newsletterSetup` and verify the layout looks exactly like `https://wordpress.com/setup/newsletter/newsletterSetup`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
