### PR TITLE
VideoPress stats: fix layout width when video title length causes overflow

### DIFF
--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -36,7 +36,7 @@
 
 .videopress-stats-module__grid-link {
 	color: var(--color-primary);
-	overflow-x: clip;
+	overflow-x: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

| before | after |
| -- | -- |
| <img width="963" alt="SCR-20230712-iqkb" src="https://github.com/Automattic/wp-calypso/assets/4081020/296ab5c2-6a77-44f5-b9f9-63e405862cad"> | <img width="970" alt="SCR-20230712-iqlt" src="https://github.com/Automattic/wp-calypso/assets/4081020/8169ebe8-3f1d-4372-9d7e-24e6e063c5c4"> |

## Proposed Changes

* use `overflow: hidden` instead of `overflow: clip` since it is causing width calculations for `content-fit` in Chrome to render too wide a layout (feels like a Chrome bug, but who knows)

 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn && yarn start` or use a calypso live link below
* test in Chrome + firefox + safari (or at least Chrome and 1 other browser)
* view video stats for one of your test sites with videopress views `/stats/year/videoplays/{site-name}`
* edit one of the video titles in the web inspector to be really long (append the following ` super long title to cause scrolling and see if it breaks layout by pushing content over`)
* the content should fit in the view and not display only the title
* shrink the browser's width, it should eventually overflow and allow for horizontal scrolling inside the view

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
