### PR TITLE
Improve cross-domain tracking on Jetpack GA4

### DIFF
--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -60,7 +60,7 @@ export const TRACKING_IDS = {
 	wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
 	wpcomGoogleGA4Gtag: 'G-1H4VG5F5JF',
 	jetpackGoogleAnalyticsGtag: 'UA-52447-43', // Jetpack Gtag (Analytics) for use in Jetpack x WordPress.com Flows
-	jetpackGoogleGA4Gtag: 'G-YELRMVV4YG',
+	jetpackGoogleGA4Gtag: 'G-K8CRH0LL00',
 	jetpackGoogleAdsGtagPurchase: 'AW-946162814/kIF1CL3ApfsBEP6YlcMD',
 	akismetGoogleGA4Gtag: 'G-V8X5PZE9F8',
 	akismetGoogleTagManagerId: 'GTM-NLFBXG5',

--- a/client/lib/analytics/ad-tracking/google-analytics.js
+++ b/client/lib/analytics/ad-tracking/google-analytics.js
@@ -1,5 +1,4 @@
 import { getCurrentUser } from '@automattic/calypso-analytics';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getGaGtag } from '../utils/get-ga-gtag';
 import * as GA4 from './google-analytics-4';
 
@@ -28,7 +27,7 @@ export function getGoogleAnalyticsDefaultConfig() {
 		custom_map: {
 			dimension3: 'client_id',
 		},
-		linker: isJetpackCloud() ? { domains: [ 'wordpress.com' ] } : { accept_incoming: true },
+		linker: { accept_incoming: true },
 	};
 }
 


### PR DESCRIPTION
- Unify data streams with jetpack.com
- Clean up linker property

## Proposed Changes

Together with changes of the GA4 config in the admin panel, we want to:
- remove interfering options from the gtag.js config object
- changing tag id so to unify data streams across jetpack.com and cloud.jetpack.com (otherwise cross-domain traffic is recognized as referrals)

## Testing Instructions

* Run `yarn start-jetpack-cloud-p`
* Open `http://jetpack.cloud.localhost:3001/pricing?flags=ad-tracking,cookie-banner`
* If in the GDPR region, make sure you accepted the cookie banner
* Put `localStorage.setItem( 'debug', 'calypso:analytics:*' );` and reload page
* In DOM, ensure `https://www.googletagmanager.com/gtag/js?id=G-K8CRH0LL00` has loaded (instead of `G-YELRMVV4YG`)
* Find in console logs, the `config` event for tag id `G-K8CRH0LL00` and find out that linker is set `linker: { accept_incoming: true }`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
