### PR TITLE
VideoPress stats: add headers to csv export

### DIFF
--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -262,7 +262,7 @@ class VideoPressStatsModule extends Component {
 							{ summary && (
 								<DownloadCsv
 									statType={ statType }
-									data={ completeVideoStats }
+									data={ csvData }
 									query={ query }
 									path={ path }
 									period={ period }

--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -165,11 +165,15 @@ class VideoPressStatsModule extends Component {
 
 		const isNewVideoPage = config.isEnabled( 'stats/new-video-summary' );
 
+		const csvData = [
+			[ 'post_id', 'title', 'impressions', 'watch_time', 'retention_rate', 'views' ],
+			...completeVideoStats,
+		];
 		const downloadCSV = (
 			<div className="stats-module__heaver-nav-button">
 				<DownloadCsv
 					statType={ statType }
-					data={ completeVideoStats }
+					data={ csvData }
 					query={ query }
 					path={ path }
 					period={ period }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

<img width="765" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4081020/70f0cecb-ccd9-4e70-bacf-7f5cb313d933">


## Proposed Changes

* add headers to the csv export

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn && yarn start` or use a calypso live link below
* view video stats for one of your test sites with videopress views `/stats/year/videoplays/{site-name}`
* click the "Download data as csv" button in the header
* view the downloaded file, it should include column headers

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
