### PR TITLE
Checkout: fix help hover state

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -891,6 +891,14 @@ a.masterbar__quick-language-switcher {
 		@include breakpoint-deprecated( "<480px" ) {
 			display: none;
 		}
+
+		&.is-active {
+			background: transparent;
+		}
+
+		&:focus {
+			box-shadow: none;
+		}
 	}
 
 	svg {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -893,7 +893,7 @@ a.masterbar__quick-language-switcher {
 		}
 
 		&.is-active {
-			background: transparent;
+			background: var(--color-checkout-masterbar-item-hover-background);
 		}
 
 		&:focus {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3003

## Proposed Changes

* Remove active/focus styles for the Help item in the Checkout nav.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open checkout
2. Click on Help in the upper right
3. Mouse over the Help modal that opens

The Help nav item should stay the same.

Before | After
------- | ----
![Image](https://user-images.githubusercontent.com/1689238/252797041-340bf730-b79b-4257-8478-7f8f167b1aca.png) | <img width="468" alt="Screen Shot 2023-07-12 at 10 15 23 AM" src="https://github.com/Automattic/wp-calypso/assets/1689238/b12e3937-a95b-4c2b-bc24-bc8f4e770c53">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
