### PR TITLE
QR Login: Update QR login instructions

### DIFF
--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -220,7 +220,7 @@ function QRCodeLogin( { locale, redirectToAfterLoginUrl } ) {
 			},
 		} ),
 		translate( 'Tap the My Site Tab.' ),
-		translate( 'Tap your Profile image in the top right corner of the screen.' ),
+		translate( 'Tap your Profile image.' ),
 		translate( 'Tap the {{strong}}Scan Login Code{{/strong}} option.', {
 			components: {
 				strong: <strong />,

--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -11,6 +11,7 @@ import { setStoredItem, getStoredItem } from 'calypso/lib/browser-storage';
 import { useInterval } from 'calypso/lib/interval';
 import { login } from 'calypso/lib/paths';
 import { postLoginRequest, getErrorFromHTTPError } from 'calypso/state/login/utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 
 import './style.scss';
 
@@ -54,7 +55,7 @@ function TokenQRCode( { tokenData } ) {
 	};
 	return (
 		<QRCodeSVG
-			value={ `https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login?token=${ token }&data=${ encrypted }` }
+			value={ localizeUrl( `https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login?token=${ token }&data=${ encrypted }` ) }
 			size={ 300 }
 			imageSettings={ imageSettings }
 		/>

--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -55,7 +55,9 @@ function TokenQRCode( { tokenData } ) {
 	};
 	return (
 		<QRCodeSVG
-			value={ localizeUrl( `https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login?token=${ token }&data=${ encrypted }` ) }
+			value={ localizeUrl(
+				`https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login?token=${ token }&data=${ encrypted }`
+			) }
 			size={ 300 }
 			imageSettings={ imageSettings }
 		/>

--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -1,6 +1,7 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Card, Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { QRCodeSVG } from 'qrcode.react';
@@ -11,7 +12,6 @@ import { setStoredItem, getStoredItem } from 'calypso/lib/browser-storage';
 import { useInterval } from 'calypso/lib/interval';
 import { login } from 'calypso/lib/paths';
 import { postLoginRequest, getErrorFromHTTPError } from 'calypso/state/login/utils';
-import { localizeUrl } from '@automattic/i18n-utils';
 
 import './style.scss';
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Ref: pcdRpT-3aU-p2#comment-5327

"Tap your Profile image **in the top right corner of the screen.**" is no longer applicable for JPAndroid, since we moved the me menu to it's own dedicated tab in JPAndroid 22.7.

## Proposed Changes

* Updates the QR login instructions to be applicable to both JPiOS and JPAndroid. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to the log in page
2. Click on "Login via the mobile app"
3. ✅ Verify that step 3 reads "Tap on your profile image."

<img width="886" alt="Screenshot 2023-07-14 at 15 00 34" src="https://github.com/Automattic/wp-calypso/assets/6711616/1d38751b-c746-497f-bc30-ecbf3e000056">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?