### PR TITLE
Fix localStorage exceptions

### DIFF
--- a/client/lib/analytics/queue.js
+++ b/client/lib/analytics/queue.js
@@ -21,7 +21,11 @@ function clear() {
 		return; // Not possible.
 	}
 
-	window.localStorage.removeItem( lsKey() );
+	try {
+		window.localStorage.removeItem( lsKey() );
+	} catch {
+		// Do nothing.
+	}
 }
 
 function get() {
@@ -29,12 +33,16 @@ function get() {
 		return []; // Not possible.
 	}
 
-	let items = window.localStorage.getItem( lsKey() );
+	try {
+		let items = window.localStorage.getItem( lsKey() );
 
-	items = items ? JSON.parse( items ) : [];
-	items = Array.isArray( items ) ? items : [];
+		items = items ? JSON.parse( items ) : [];
+		items = Array.isArray( items ) ? items : [];
 
-	return items;
+		return items;
+	} catch {
+		return [];
+	}
 }
 
 function runTrigger( moduleName, trigger, ...args ) {
@@ -62,14 +70,19 @@ export function addToQueue( moduleName, trigger, ...args ) {
 		return runTrigger( moduleName, trigger, ...args );
 	}
 
-	let items = get();
-	const newItem = { moduleName, trigger, args };
+	try {
+		let items = get();
+		const newItem = { moduleName, trigger, args };
 
-	items.push( newItem );
-	items = items.slice( -100 ); // Upper limit.
+		items.push( newItem );
+		items = items.slice( -100 ); // Upper limit.
 
-	queueDebug( 'Adding new item to queue.', newItem );
-	window.localStorage.setItem( lsKey(), JSON.stringify( items ) );
+		queueDebug( 'Adding new item to queue.', newItem );
+		window.localStorage.setItem( lsKey(), JSON.stringify( items ) );
+	} catch {
+		// If an error happens while enqueuing, trigger it now.
+		return runTrigger( moduleName, trigger, ...args );
+	}
 }
 
 /**


### PR DESCRIPTION
Some browsers like doing odd things with `localStorage`, where they pretend that it's available, only to emit exceptions when you try to use it.

This PR adds a bunch of `try`/`catch` blocks to handle the errors without surfacing them to the client, and to stop Sentry from ~nagging~ helpfully informing about them.

## Proposed Changes

* Add try/catch blocks to usage of `localStorage` in `lib/analytics` and `lib/browser-storage`

## Testing Instructions

Smoke-test the changes and ensure that nothing breaks.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
