### PR TITLE
Bulk domain transfer: Add Auto-renew enabled copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
@@ -28,7 +28,10 @@ export const CompleteDomainsTransferred = ( {
 						? newlyTransferredDomains.map( ( { meta, domain }, key ) => {
 								return (
 									<li className="domain-complete-list-item" key={ key }>
-										<h2>{ meta }</h2>
+										<div>
+											<h2>{ meta }</h2>
+											<p>{ __( 'Auto-renew enabled' ) }</p>
+										</div>
 										<a
 											href={ `/domains/manage/all/${ meta }/transfer/in/${ domain }` }
 											className="components-button is-secondary"
@@ -44,7 +47,11 @@ export const CompleteDomainsTransferred = ( {
 						: [ ...Array( placeHolderCount ) ].map( ( data, key ) => {
 								return (
 									<li className="domain-complete-list-item" key={ key }>
-										<p className="loading-placeholder"></p>
+										<div>
+											<p className="loading-placeholder"></p>
+											<p className="loading-placeholder"></p>
+										</div>
+
 										<button className="components-button loading-placeholder"></button>
 									</li>
 								);


### PR DESCRIPTION
Related to #2933

## Proposed Changes
Add temporary "Auto-renew enabled" copy on the congrats step, more details p1689147594821049-slack-C05CT832K2T

<img width="773" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/82c7bcc7-c0e7-4e60-9296-f249a4835bbe">


## Testing Instructions

- Pull and run this branch or use calypso live link
- Navigate to `setup/domain-transfer` and complete the flow
- Check if every domain has the copy "Auto-renew enabled"  below the domain name (as the screenshot)


## Why temporary?

[Context](p1689175636039669/1689147594.821049-slack-C05CT832K2T)