### PR TITLE
Register PLAN_MIGRATION_TRIAL constants

### DIFF
--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -50,7 +50,7 @@ export const PLAN_WPCOM_PRO_MONTHLY = 'pro-plan-monthly';
 export const PLAN_WPCOM_PRO_2_YEARS = 'pro-plan-2y';
 export const PLAN_WPCOM_STARTER = 'starter-plan';
 export const PLAN_ENTERPRISE_GRID_WPCOM = 'plan-enterprise-grid-wpcom'; // Not a real plan; we show the VIP section in the plans grid as part of pdgrnI-1Qp-p2.
-export const PLAN_MIGRATION_TRIAL = 'wp_bundle_migration_trial_monthly';
+export const PLAN_MIGRATION_TRIAL_MONTHLY = 'wp_bundle_migration_trial_monthly';
 
 export const WPCOM_PLANS = <const>[
 	PLAN_BUSINESS_MONTHLY,
@@ -70,8 +70,9 @@ export const WPCOM_PLANS = <const>[
 	PLAN_ECOMMERCE_MONTHLY,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
-	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_ECOMMERCE_3_YEARS,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_MIGRATION_TRIAL_MONTHLY,
 	PLAN_FREE,
 	PLAN_HOST_BUNDLE,
 	PLAN_WPCOM_ENTERPRISE,
@@ -90,7 +91,6 @@ export const WPCOM_PLANS = <const>[
 	PLAN_WOOEXPRESS_SMALL,
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 	PLAN_WOOEXPRESS_PLUS,
-	PLAN_MIGRATION_TRIAL,
 ];
 
 export const WPCOM_MONTHLY_PLANS = <const>[
@@ -99,6 +99,7 @@ export const WPCOM_MONTHLY_PLANS = <const>[
 	PLAN_PERSONAL_MONTHLY,
 	PLAN_ECOMMERCE_MONTHLY,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_MIGRATION_TRIAL_MONTHLY,
 	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 	PLAN_WOOEXPRESS_PLUS,

--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -50,6 +50,7 @@ export const PLAN_WPCOM_PRO_MONTHLY = 'pro-plan-monthly';
 export const PLAN_WPCOM_PRO_2_YEARS = 'pro-plan-2y';
 export const PLAN_WPCOM_STARTER = 'starter-plan';
 export const PLAN_ENTERPRISE_GRID_WPCOM = 'plan-enterprise-grid-wpcom'; // Not a real plan; we show the VIP section in the plans grid as part of pdgrnI-1Qp-p2.
+export const PLAN_MIGRATION_TRIAL = 'wp_bundle_migration_trial_monthly';
 
 export const WPCOM_PLANS = <const>[
 	PLAN_BUSINESS_MONTHLY,
@@ -89,6 +90,7 @@ export const WPCOM_PLANS = <const>[
 	PLAN_WOOEXPRESS_SMALL,
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 	PLAN_WOOEXPRESS_PLUS,
+	PLAN_MIGRATION_TRIAL,
 ];
 
 export const WPCOM_MONTHLY_PLANS = <const>[

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -408,7 +408,7 @@ import {
 	FEATURE_SELL_60_COUNTRIES,
 	FEATURE_SHIPPING_INTEGRATIONS,
 	FEATURE_THE_READER,
-	PLAN_MIGRATION_TRIAL,
+	PLAN_MIGRATION_TRIAL_MONTHLY,
 } from './constants';
 import type {
 	BillingTerm,
@@ -2540,12 +2540,12 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getPathSlug: () => 'business-monthly',
 	},
 
-	[ PLAN_MIGRATION_TRIAL ]: {
+	[ PLAN_MIGRATION_TRIAL_MONTHLY ]: {
 		...getPlanBusinessDetails(),
 		term: TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Business Trial' ),
 		getProductId: () => 1057,
-		getStoreSlug: () => PLAN_MIGRATION_TRIAL,
+		getStoreSlug: () => PLAN_MIGRATION_TRIAL_MONTHLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
 	},
 

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -2543,6 +2543,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 	[ PLAN_MIGRATION_TRIAL ]: {
 		...getPlanBusinessDetails(),
 		term: TERM_ANNUALLY,
+		getTitle: () => i18n.translate( 'Business Trial' ),
 		getProductId: () => 1057,
 		getStoreSlug: () => PLAN_MIGRATION_TRIAL,
 		getBillingTimeFrame: WPComGetBillingTimeframe,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -408,7 +408,6 @@ import {
 	FEATURE_SELL_60_COUNTRIES,
 	FEATURE_SHIPPING_INTEGRATIONS,
 	FEATURE_THE_READER,
-	PLAN_MIGRATION_TRIAL_MONTHLY,
 } from './constants';
 import type {
 	BillingTerm,
@@ -2538,15 +2537,6 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getProductId: () => 1018,
 		getStoreSlug: () => PLAN_BUSINESS_MONTHLY,
 		getPathSlug: () => 'business-monthly',
-	},
-
-	[ PLAN_MIGRATION_TRIAL_MONTHLY ]: {
-		...getPlanBusinessDetails(),
-		term: TERM_ANNUALLY,
-		getTitle: () => i18n.translate( 'Business Trial' ),
-		getProductId: () => 1057,
-		getStoreSlug: () => PLAN_MIGRATION_TRIAL_MONTHLY,
-		getBillingTimeFrame: WPComGetBillingTimeframe,
 	},
 
 	[ PLAN_BUSINESS ]: {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -408,6 +408,7 @@ import {
 	FEATURE_SELL_60_COUNTRIES,
 	FEATURE_SHIPPING_INTEGRATIONS,
 	FEATURE_THE_READER,
+	PLAN_MIGRATION_TRIAL,
 } from './constants';
 import type {
 	BillingTerm,
@@ -2537,6 +2538,11 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getProductId: () => 1018,
 		getStoreSlug: () => PLAN_BUSINESS_MONTHLY,
 		getPathSlug: () => 'business-monthly',
+	},
+
+	[ PLAN_MIGRATION_TRIAL ]: {
+		...getPlanBusinessDetails(),
+		getProductId: () => 1057,
 	},
 
 	[ PLAN_BUSINESS ]: {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -2542,7 +2542,10 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 
 	[ PLAN_MIGRATION_TRIAL ]: {
 		...getPlanBusinessDetails(),
+		term: TERM_ANNUALLY,
 		getProductId: () => 1057,
+		getStoreSlug: () => PLAN_MIGRATION_TRIAL,
+		getBillingTimeFrame: WPComGetBillingTimeframe,
 	},
 
 	[ PLAN_BUSINESS ]: {


### PR DESCRIPTION
Related to #2996

## Proposed Changes
* Add new `PLAN_MIGRATION_TRIAL_MONTHLY` constant

## Testing Instructions
No need to run tests. Preexisting unit tests are enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
