### PR TITLE
GF Signup : Fix the progress bar styling and the progress increment

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -65,6 +65,7 @@ button {
 /**
  * Site Setup
  */
+.onboarding-media,
 .import-hosted-site,
 .site-setup,
 .import-focused,

--- a/client/landing/stepper/declarative-flow/onboarding-pm.ts
+++ b/client/landing/stepper/declarative-flow/onboarding-pm.ts
@@ -4,6 +4,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import wpcom from 'calypso/lib/wp';
 import {
+	clearSignupDestinationCookie,
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 	setSignupCompleteSlug,
@@ -86,16 +87,16 @@ const onboarding: Flow = {
 					navigate( 'siteCreationStep' );
 					return;
 				case 'siteCreationStep':
-					// clearSignupDestinationCookie(); // not sure if this is needed and if it is, where it should go
+					clearSignupDestinationCookie();
 					navigate( 'processing' );
 					return;
 				case 'processing': {
-					// clearSignupDestinationCookie();
+					clearSignupDestinationCookie();
 					const destination = addQueryArgs( '/setup/site-setup/goals', {
 						siteSlug: providedDependencies.siteSlug,
 					} );
 
-					persistSignupDestination( destination ); // not sure if this is needed
+					persistSignupDestination( destination );
 					setSignupCompleteSlug( providedDependencies.siteSlug );
 					setSignupCompleteFlowName( flowName );
 

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -95,6 +95,10 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		user: 0,
 		domains: 1,
 		plans: 2,
+		siteCreationStep: 3,
+		processing: 4,
+		/** Phantom step that is outside stepper */
+		checkout: 5,
 	},
 	[ DOMAIN_TRANSFER ]: {
 		user: 0,


### PR DESCRIPTION
Partially Fixes - Automattic/martech#1882

## Proposed Changes

* Fixes a styling bug where the processing step top progress bar was broken.
* Progress filling is fixed based on the movement of step.
* Removed some comments

## Testing Instructions
* Go through the flow `/setup/onboarding-media` flow
* Make sure the progress bar in the top corner progresses incrementally with each step
* Progress will stay unfilled on the final "processing" screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
