### PR TITLE
Sites: redirect to sites if marked as their landing page, regardless of the site count

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import globalPageInstance from 'page';
-import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { fetchPreferences } from 'calypso/state/preferences/actions';
 import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
@@ -76,9 +76,7 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 	await dispatch( waitForPrefs() );
 	const useSitesAsLandingPage = hasSitesAsLandingPage( getState() );
 
-	const siteCount = getCurrentUser( getState() )?.site_count;
-
-	if ( useSitesAsLandingPage && siteCount > 1 ) {
+	if ( useSitesAsLandingPage ) {
 		return '/sites';
 	}
 

--- a/client/test/root-section.ts
+++ b/client/test/root-section.ts
@@ -135,32 +135,4 @@ describe( 'Logged In Landing Page', () => {
 
 		await waitFor( () => expect( page.current ).toBe( '/sites' ) );
 	} );
-
-	test( 'user who opts in but only has 1 site does not go to sites page', async () => {
-		const state = {
-			currentUser: {
-				id: 1,
-				capabilities: { 1: { edit_posts: true } },
-				user: { primary_blog: 1, site_count: 1 },
-			},
-			preferences: {
-				localValues: {
-					'sites-landing-page': { useSitesAsLandingPage: true, updatedAt: 1111 },
-				},
-			},
-			sites: {
-				items: {
-					1: {
-						ID: 1,
-						URL: 'https://test.wordpress.com',
-					},
-				},
-			},
-		};
-		const { page } = initRouter( { state } );
-
-		page( '/' );
-
-		await waitFor( () => expect( page.current ).toBe( '/home/test.wordpress.com' ) );
-	} );
 } );


### PR DESCRIPTION
Related to pdKhl6-2jp-p2#comment-3444.

## Proposed Changes

If the user has marked `/sites` as their landing page, it should not matter how many sites they have -- let's make them go to /sites and see our empty states that induce them to create a site. Follow-up PRs to improve the empty state are going to be worked on.

The reason we were not sending the user to /sites if they had one site was that we thought at the time that it would be handier for the user to go directly to their site. However, it means that they would see /sites less often, defeating the purpose of the setting. Seeing /sites more frequently also surfaces hosting configuration more, and that's the direction that we want to follow moving forward.

## Testing Instructions

1. Login to an account that has no sites;
2. Toggle on "Admin home" in /me/account;
3. Browse / and verify that you're redirected to /sites.