### PR TITLE
Remove "See all domains" on Manage Domains page

### DIFF
--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -607,31 +607,6 @@ class AllDomains extends Component {
 		);
 	}
 
-	maybeRenderSeeAllDomainsLink() {
-		const { context, translate, dispatch } = this.props;
-
-		const selectedFilter = context?.query?.filter || 'all-domains';
-
-		if ( selectedFilter === 'all-domains' ) {
-			return null;
-		}
-
-		const handleClick = () => {
-			dispatch( recordTracksEvent( 'calypso_domain_management_see_all_domains_link_click' ) );
-		};
-
-		return (
-			<a
-				className="domains-table-see-all-domains-link"
-				href={ domainManagementRoot() }
-				key="breadcrumb_see_all_domains_link"
-				onClick={ handleClick }
-			>
-				{ translate( 'Reset filter' ) }
-			</a>
-		);
-	}
-
 	renderDomainTableFilterButton() {
 		const { context, translate, sites } = this.props;
 
@@ -696,7 +671,6 @@ class AllDomains extends Component {
 		const buttons = hasNoDomains
 			? []
 			: [
-					this.maybeRenderSeeAllDomainsLink(),
 					this.renderDomainTableFilterButton(),
 					<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
 					<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -627,7 +627,7 @@ class AllDomains extends Component {
 				key="breadcrumb_see_all_domains_link"
 				onClick={ handleClick }
 			>
-				{ translate( 'See all domains' ) }
+				{ translate( 'Reset filter' ) }
 			</a>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3014

## Proposed Changes

* Remove "See all domains" (previously we were changing the copy, but in a walkthrough we realized this link isn't needed.)

Before:
<img width="355" alt="Screen Shot 2023-07-12 at 4 27 56 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/729dfe25-6543-4eb8-8be1-bcc63a696b51">

After:
<img width="384" alt="Screen Shot 2023-07-17 at 4 15 08 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/b0a008ab-d4cc-4ab6-a11a-c2b4af2ef6de">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains/manage
* Use the dropdown to flip between your domains and all domains. You shouldn't see a "See all domains link."
* Go to /domains/manage/{site}
* Use the dropdown to flip between domain filters. You shouldn't see a "See all domains link."

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
