### PR TITLE
Stats: Adding checkout redirect

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -5,37 +5,47 @@ import {
 } from '@automattic/calypso-products';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-const getStatsPurchaseURL = ( siteSlug: string, page: string ) => {
-	const purchasePath = `/checkout/${ siteSlug }/${ page }`;
+const getStatsPurchaseURL = ( siteSlug: string, product: string ) => {
+	const purchasePath = `/checkout/${ siteSlug }/${ product }`;
 
 	return `https://wordpress.com${ purchasePath }`;
 };
 
-const gotoCheckoutPage = ( type: 'pwyw' | 'free' | 'commercial', siteSlug: string ) => {
+const getYearlyPrice = ( monthlyPrice: number ) => {
+	return monthlyPrice * 12;
+};
+
+const gotoCheckoutPage = (
+	type: 'pwyw' | 'free' | 'commercial',
+	siteSlug: string,
+	price?: number
+) => {
 	let eventName = '';
-	let page: string;
+	let product: string;
 
 	switch ( type ) {
 		case 'pwyw':
 			// YEARLY!
 			eventName = 'pwyw';
-			page = PRODUCT_JETPACK_STATS_PWYW_YEARLY;
+			product = price
+				? `${ PRODUCT_JETPACK_STATS_PWYW_YEARLY }:-q-${ getYearlyPrice( price ) }` // specify price per unit or the plan will default to a free plan
+				: `${ PRODUCT_JETPACK_STATS_PWYW_YEARLY }`;
 			break;
 		case 'free':
 			eventName = 'free';
-			page = PRODUCT_JETPACK_STATS_FREE;
+			product = PRODUCT_JETPACK_STATS_FREE;
 			break;
 		case 'commercial':
 			// MONTHLY!
 			eventName = 'commercial';
-			page = PRODUCT_JETPACK_STATS_MONTHLY;
+			product = PRODUCT_JETPACK_STATS_MONTHLY;
 			break;
 	}
 
 	recordTracksEvent( `calypso_stats_${ eventName }_purchase_button_clicked` );
 
 	// Allow some time for the event to be recorded before redirecting.
-	setTimeout( () => ( window.location.href = getStatsPurchaseURL( siteSlug, page ) ), 250 );
+	setTimeout( () => ( window.location.href = getStatsPurchaseURL( siteSlug, product ) ), 250 );
 };
 
 export default gotoCheckoutPage;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -5,10 +5,21 @@ import {
 } from '@automattic/calypso-products';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-const getStatsPurchaseURL = ( siteSlug: string, product: string ) => {
-	const purchasePath = `/checkout/${ siteSlug }/${ product }`;
+const getStatsPurchaseURL = ( siteSlug: string, product: string, redirectUrl?: string ) => {
+	const checkoutUrl = new URL( 'https://wordpress.com/checkout/' );
+	const checkoutProductUrl = new URL( `${ checkoutUrl }${ siteSlug }/${ product }` );
 
-	return `https://wordpress.com${ purchasePath }`;
+	// Add redirect_to parameter
+	if ( redirectUrl ) {
+		checkoutProductUrl.searchParams.set( 'redirect_to', redirectUrl ); // TODO: add a redirect URL with query parameter showing proper success/fail banner
+	} else {
+		checkoutProductUrl.searchParams.set(
+			'redirect_to',
+			`https://wordpress.com/stats/${ siteSlug }`
+		);
+	}
+
+	return checkoutProductUrl.toString();
 };
 
 const getYearlyPrice = ( monthlyPrice: number ) => {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -1,0 +1,41 @@
+import {
+	PRODUCT_JETPACK_STATS_MONTHLY,
+	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
+	PRODUCT_JETPACK_STATS_FREE,
+} from '@automattic/calypso-products';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+
+const getStatsPurchaseURL = ( siteSlug: string, page: string ) => {
+	const purchasePath = `/checkout/${ siteSlug }/${ page }`;
+
+	return `https://wordpress.com${ purchasePath }`;
+};
+
+const gotoCheckoutPage = ( type: 'pwyw' | 'free' | 'commercial', siteSlug: string ) => {
+	let eventName = '';
+	let page: string;
+
+	switch ( type ) {
+		case 'pwyw':
+			// YEARLY!
+			eventName = 'pwyw';
+			page = PRODUCT_JETPACK_STATS_PWYW_YEARLY;
+			break;
+		case 'free':
+			eventName = 'free';
+			page = PRODUCT_JETPACK_STATS_FREE;
+			break;
+		case 'commercial':
+			// MONTHLY!
+			eventName = 'commercial';
+			page = PRODUCT_JETPACK_STATS_MONTHLY;
+			break;
+	}
+
+	recordTracksEvent( `calypso_stats_${ eventName }_purchase_button_clicked` );
+
+	// Allow some time for the event to be recorded before redirecting.
+	setTimeout( () => ( window.location.href = getStatsPurchaseURL( siteSlug, page ) ), 250 );
+};
+
+export default gotoCheckoutPage;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
@@ -4,13 +4,16 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import gotoCheckoutPage from './stats-purchase-checkout-redirect';
 import { COMPONENT_CLASS_NAME } from './stats-purchase-wizard';
+
 interface CommercialPurchaseProps {
 	planValue: number;
 	currencyCode: string;
+	siteSlug: string;
 }
 
-const CommercialPurchase = ( { planValue, currencyCode }: CommercialPurchaseProps ) => {
+const CommercialPurchase = ( { planValue, currencyCode, siteSlug }: CommercialPurchaseProps ) => {
 	const translate = useTranslate();
 	const planPriceObject = getCurrencyObject( planValue, currencyCode );
 
@@ -73,7 +76,7 @@ const CommercialPurchase = ( { planValue, currencyCode }: CommercialPurchaseProp
 				) }
 			</p>
 
-			<Button variant="primary">
+			<Button variant="primary" onClick={ () => gotoCheckoutPage( 'commercial', siteSlug ) }>
 				{ translate( 'Get Jetpack Stats for %(value)s per month', {
 					args: {
 						value: formatCurrency( planValue, currencyCode ),

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -166,7 +166,10 @@ const PersonalPurchase = ( {
 					{ translate( 'Continue with Jetpack Stats for free' ) }
 				</Button>
 			) : (
-				<Button variant="primary" onClick={ () => gotoCheckoutPage( 'pwyw', siteSlug ) }>
+				<Button
+					variant="primary"
+					onClick={ () => gotoCheckoutPage( 'pwyw', siteSlug, subscriptionValue ) }
+				>
 					{ translate( 'Get Jetpack Stats for %(value)s per month', {
 						args: {
 							value: formatCurrency( subscriptionValue, currencyCode ),

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -5,6 +5,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Button, CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
+import gotoCheckoutPage from './stats-purchase-checkout-redirect';
 import { COMPONENT_CLASS_NAME, PRICING_CONFIG } from './stats-purchase-wizard';
 
 interface PersonalPurchaseProps {
@@ -12,6 +13,7 @@ interface PersonalPurchaseProps {
 	setSubscriptionValue: ( value: number ) => number;
 	handlePlanSwap: ( e: React.MouseEvent< HTMLAnchorElement, MouseEvent > ) => void;
 	currencyCode: string;
+	siteSlug: string;
 }
 
 const PersonalPurchase = ( {
@@ -19,6 +21,7 @@ const PersonalPurchase = ( {
 	setSubscriptionValue,
 	handlePlanSwap,
 	currencyCode,
+	siteSlug,
 }: PersonalPurchaseProps ) => {
 	const translate = useTranslate();
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
@@ -158,11 +161,12 @@ const PersonalPurchase = ( {
 				<Button
 					variant="primary"
 					disabled={ ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked }
+					onClick={ () => gotoCheckoutPage( 'free', siteSlug ) }
 				>
 					{ translate( 'Continue with Jetpack Stats for free' ) }
 				</Button>
 			) : (
-				<Button variant="primary">
+				<Button variant="primary" onClick={ () => gotoCheckoutPage( 'pwyw', siteSlug ) }>
 					{ translate( 'Get Jetpack Stats for %(value)s per month', {
 						args: {
 							value: formatCurrency( subscriptionValue, currencyCode ),

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -161,11 +161,13 @@ const ProductCard = ( { siteSlug } ) => {
 											setSubscriptionValue={ setSubscriptionValue }
 											handlePlanSwap={ ( e ) => handlePlanSwap( e ) }
 											currencyCode={ currencyCode }
+											siteSlug={ siteSlug }
 										/>
 									) : (
 										<CommercialPurchase
 											planValue={ PRICING_CONFIG.FLAT_COMMERCIAL_PRICE }
 											currencyCode={ currencyCode }
+											siteSlug={ siteSlug }
 										/>
 									) }
 								</PanelRow>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79329 

The changes are branched of https://github.com/Automattic/wp-calypso/pull/79045 so merge in sequence.

## Proposed Changes

* redirect customers from the purchase page to the checkout

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch for this PR
* Navigate to `/stats/purchase/:siteSlug?flags=stats/paid-stats`
* Tests all purchase scenarios:
   * a commercial plan
   * a free personal plan
   * a custom amount for a personal plan
   * a different custom amount for a personal plan
* Make sure that the purchase page redirects to a checkout page and proper plan is applied
* Verify that the price on the checkout page changes based on a selected type

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
