### PR TITLE
Checkout: use sentence case for payment method text

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
@@ -101,7 +101,7 @@ function WordPressFreePurchaseLabel() {
 	if ( ! isCartAllOneTimePurchases && ! doesCartHaveRenewalWithPaymentMethod ) {
 		return (
 			<>
-				<div>{ __( 'Assign a Payment Method Later' ) }</div>
+				<div>{ __( 'Assign a payment method later' ) }</div>
 				<WordPressLogo />
 			</>
 		);

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.tsx
@@ -72,7 +72,7 @@ describe( 'Checkout contact step', () => {
 	it( 'renders the step after the contact step as active if the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
-		expect( await screen.findByText( 'Assign a Payment Method Later' ) ).toBeVisible();
+		expect( await screen.findByText( 'Assign a payment method later' ) ).toBeVisible();
 	} );
 
 	it( 'renders the contact step when the purchase is not free', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
@@ -118,7 +118,7 @@ describe( 'Checkout payment methods list', () => {
 			/>
 		);
 		await waitFor( () => {
-			expect( screen.getByText( 'Assign a Payment Method Later' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Assign a payment method later' ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -223,7 +223,7 @@ describe( 'Checkout payment methods list', () => {
 			/>
 		);
 		await waitFor( () => {
-			expect( screen.getByText( 'Assign a Payment Method Later' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Assign a payment method later' ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -250,7 +250,7 @@ describe( 'Checkout payment methods list', () => {
 		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			expect( screen.queryByText( 'Free Purchase' ) ).not.toBeInTheDocument();
-			expect( screen.queryByText( 'Assign a Payment Method Later' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Assign a payment method later' ) ).not.toBeInTheDocument();
 		} );
 	} );
 
@@ -299,7 +299,7 @@ describe( 'Checkout payment methods list', () => {
 			/>
 		);
 		await waitFor( () => {
-			expect( screen.getByText( 'Assign a Payment Method Later' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Assign a payment method later' ) ).toBeInTheDocument();
 		} );
 	} );
 


### PR DESCRIPTION
I just noticed while using the checkout on a test site that we consistently use sentence case capitalization throughout the payment step, except for the text "Assign a Payment Method Later". 

<img width="647" alt="Screenshot 2023-07-13 at 2 25 36 PM" src="https://github.com/Automattic/wp-calypso/assets/17325/139f89fc-a40f-426a-9ff9-37ccf371a2f8">

## Proposed Changes

Change the text "Assign a Payment Method Later" to sentence case to be consistent with the rest of the payment step.

## Testing Instructions

Make a purchase from an account with WordPress.com credits so that you're shown the free purchase checkout (e.g. purchasing a Jetpack plan via a jurassic.ninja site). Ensure that the capitalization is consistent on the payment step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
