### PR TITLE
GF Signup : Fix domain related bugs in the paid media flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -90,6 +90,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		if ( ! suggestion ) {
 			setHideFreePlan( false );
 			setDomainCartItem( undefined );
+			setDomain( undefined );
 			return submit?.();
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -23,7 +23,6 @@ import { localize, useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
-import DomainSuggestion from 'calypso/components/domains/domain-suggestion';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { startedInHostingFlow } from 'calypso/landing/stepper/utils/hosting-flow';
@@ -33,7 +32,7 @@ import { getIntervalType } from 'calypso/signup/steps/plans/util';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPlanSlug } from 'calypso/state/plans/selectors';
 import { ONBOARD_STORE } from '../../../../stores';
-import type { OnboardSelect } from '@automattic/data-stores';
+import type { OnboardSelect, DomainSuggestion } from '@automattic/data-stores';
 import type { PlansIntent } from 'calypso/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-wpcom-plans-with-intent';
 import './style.scss';
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -23,6 +23,7 @@ import { localize, useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
+import DomainSuggestion from 'calypso/components/domains/domain-suggestion';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { startedInHostingFlow } from 'calypso/landing/stepper/utils/hosting-flow';
@@ -75,7 +76,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	}, [] );
 	const { flowName, hostingFlow } = props;
 
-	const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
+	const { setPlanCartItem, setDomain, setDomainCartItem } = useDispatch( ONBOARD_STORE );
 
 	const site = useSite();
 	const { __ } = useI18n();
@@ -109,7 +110,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		props.onSubmit?.( selectedPlan );
 	};
 
-	const getDomainName = () => {
+	const getPaidDomainName = () => {
 		return domainCartItem?.meta;
 	};
 
@@ -124,6 +125,10 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 				<LoadingEllipsis className="active" />
 			</div>
 		);
+	};
+	const replacePaidDomainWithFreeDomain = ( freeDomainSuggestion: DomainSuggestion ) => {
+		setDomain( freeDomainSuggestion );
+		setDomainCartItem( null );
 	};
 
 	const plansFeaturesList = () => {
@@ -142,13 +147,14 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					isStepperUpgradeFlow={ true }
 					intervalType={ getIntervalType() }
 					onUpgradeClick={ onSelectPlan }
-					domainName={ getDomainName() }
+					paidDomainName={ getPaidDomainName() }
 					customerType={ customerType }
 					plansWithScroll={ isDesktop }
 					flowName={ flowName }
 					isReskinned={ isReskinned }
 					hidePlansFeatureComparison={ hidePlansFeatureComparison }
 					intent={ plansIntent }
+					replacePaidDomainWithFreeDomain={ replacePaidDomainWithFreeDomain }
 				/>
 			</div>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -62,17 +62,24 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 
 	const urlData = useSelector( getUrlData );
 
-	const { domainCartItem, planCartItem, siteAccentColor, selectedSiteTitle, productCartItems } =
-		useSelect(
-			( select ) => ( {
-				domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
-				siteAccentColor: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteAccentColor(),
-				planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
-				productCartItems: ( select( ONBOARD_STORE ) as OnboardSelect ).getProductCartItems(),
-				selectedSiteTitle: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteTitle(),
-			} ),
-			[]
-		);
+	const {
+		domainItem,
+		domainCartItem,
+		planCartItem,
+		siteAccentColor,
+		selectedSiteTitle,
+		productCartItems,
+	} = useSelect(
+		( select ) => ( {
+			domainItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
+			domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
+			siteAccentColor: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteAccentColor(),
+			planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
+			productCartItems: ( select( ONBOARD_STORE ) as OnboardSelect ).getProductCartItems(),
+			selectedSiteTitle: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteTitle(),
+		} ),
+		[]
+	);
 
 	const username = useSelector( ( state ) => getCurrentUserName( state ) );
 
@@ -150,6 +157,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			siteAccentColor,
 			useThemeHeadstart,
 			username,
+			domainItem,
 			domainCartItem,
 			sourceSlug
 		);

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -21,16 +21,18 @@ const SubdomainSuggestion = styled.div`
 	}
 `;
 
-const FreePlanCustomDomainFeature: React.FC< { domainName: string } > = ( { domainName } ) => {
+const FreePlanCustomDomainFeature: React.FC< { paidDomainName: string } > = ( {
+	paidDomainName,
+} ) => {
 	const {
 		data: wordPressSubdomainSuggestions,
 		isInitialLoading,
 		isError,
-	} = DomainSuggestions.useGetWordPressSubdomain( domainName );
+	} = DomainSuggestions.useGetWordPressSubdomain( paidDomainName );
 
 	return (
 		<SubdomainSuggestion>
-			<div className="is-domain-name">{ domainName }</div>
+			<div className="is-domain-name">{ paidDomainName }</div>
 			{ isInitialLoading && <LoadingPlaceHolder /> }
 			{ ! isError && <div>{ wordPressSubdomainSuggestions?.[ 0 ]?.domain_name }</div> }
 		</SubdomainSuggestion>
@@ -40,10 +42,10 @@ const FreePlanCustomDomainFeature: React.FC< { domainName: string } > = ( { doma
 const PlanFeatures2023GridFeatures: React.FC< {
 	features: Array< TransformedFeatureObject >;
 	planName: string;
-	domainName?: string;
+	paidDomainName?: string;
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
-} > = ( { features, planName, domainName, hideUnavailableFeatures, selectedFeature } ) => {
+} > = ( { features, planName, paidDomainName, hideUnavailableFeatures, selectedFeature } ) => {
 	const translate = useTranslate();
 	return (
 		<>
@@ -57,7 +59,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 				const isFreePlanAndCustomDomainFeature =
 					currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN && isFreePlan( planName );
 
-				if ( isFreePlanAndCustomDomainFeature && ! domainName ) {
+				if ( isFreePlanAndCustomDomainFeature && ! paidDomainName ) {
 					return null;
 				}
 
@@ -86,18 +88,18 @@ const PlanFeatures2023GridFeatures: React.FC< {
 									{ isFreePlanAndCustomDomainFeature ? (
 										<Plans2023Tooltip
 											text={ translate( '%s is not included', {
-												args: [ domainName as string ],
+												args: [ paidDomainName as string ],
 												comment: '%s is a domain name.',
 											} ) }
 										>
 											<FreePlanCustomDomainFeature
 												key={ key }
-												domainName={ domainName as string }
+												paidDomainName={ paidDomainName as string }
 											/>
 										</Plans2023Tooltip>
 									) : (
 										<Plans2023Tooltip text={ currentFeature.getDescription?.() }>
-											{ currentFeature.getTitle( domainName ) }
+											{ currentFeature.getTitle( paidDomainName ) }
 										</Plans2023Tooltip>
 									) }
 								</span>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -100,7 +100,7 @@ export type PlanFeatures2023GridProps = {
 	isReskinned?: boolean;
 	onUpgradeClick?: ( cartItem?: MinimalRequestCartProduct | null ) => void;
 	flowName?: string | null;
-	domainName?: string;
+	paidDomainName?: string;
 	placeholder?: string;
 	intervalType?: string;
 	currentSitePlanSlug?: string | null;
@@ -456,11 +456,11 @@ export class PlanFeatures2023Grid extends Component<
 		if ( isMonthlyPlan || isWpComFreePlan( planName ) || isWpcomEnterpriseGridPlan( planName ) ) {
 			return null;
 		}
-		const { domainName } = this.props;
+		const { paidDomainName } = this.props;
 
-		const displayText = domainName
-			? translate( '%(domainName)s is included', {
-					args: { domainName },
+		const displayText = paidDomainName
+			? translate( '%(paidDomainName)s is included', {
+					args: { paidDomainName },
 			  } )
 			: translate( 'Free domain for one year' );
 
@@ -784,7 +784,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderPlanFeaturesList( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		const { domainName, translate, hideUnavailableFeatures, selectedFeature } = this.props;
+		const { paidDomainName, translate, hideUnavailableFeatures, selectedFeature } = this.props;
 		const planProperties = planPropertiesObj.filter(
 			( properties ) =>
 				! isWpcomEnterpriseGridPlan( properties.planName ) &&
@@ -804,7 +804,7 @@ export class PlanFeatures2023Grid extends Component<
 						<PlanFeatures2023GridFeatures
 							features={ features }
 							planName={ planName }
-							domainName={ domainName }
+							paidDomainName={ paidDomainName }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
 							selectedFeature={ selectedFeature }
 						/>
@@ -822,7 +822,7 @@ export class PlanFeatures2023Grid extends Component<
 						<PlanFeatures2023GridFeatures
 							features={ jpFeatures }
 							planName={ planName }
-							domainName={ domainName }
+							paidDomainName={ paidDomainName }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
 						/>
 					</Container>

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -120,13 +120,13 @@ const StyledButton = styled( Button )`
 `;
 
 export function FreePlanPaidDomainDialog( {
-	domainName,
+	paidDomainName,
 	suggestedPlanSlug,
 	onFreePlanSelected,
 	onPlanSelected,
 	onClose,
 }: {
-	domainName: string;
+	paidDomainName: string;
 	suggestedPlanSlug: PlanSlug;
 	onClose: () => void;
 	onFreePlanSelected: ( domainSuggestion: DomainSuggestion ) => void;
@@ -141,7 +141,7 @@ export function FreePlanPaidDomainDialog( {
 		data: wordPressSubdomainSuggestions,
 		isInitialLoading,
 		isError,
-	} = DomainSuggestions.useGetWordPressSubdomain( domainName );
+	} = DomainSuggestions.useGetWordPressSubdomain( paidDomainName );
 	const planTitle = getPlan( suggestedPlanSlug )?.getTitle();
 
 	function handlePaidPlanClick() {
@@ -152,7 +152,9 @@ export function FreePlanPaidDomainDialog( {
 	function handleFreeDomainClick() {
 		setIsBusy( true );
 		// Since this domain will not be available after it is selected, invalidate the cache.
-		queryClient.invalidateQueries( DomainSuggestions.getDomainSuggestionsQueryKey( domainName ) );
+		queryClient.invalidateQueries(
+			DomainSuggestions.getDomainSuggestionsQueryKey( paidDomainName )
+		);
 		if ( wordPressSubdomainSuggestions && wordPressSubdomainSuggestions.length ) {
 			onFreePlanSelected( wordPressSubdomainSuggestions[ 0 ] );
 		}
@@ -186,7 +188,7 @@ export function FreePlanPaidDomainDialog( {
 				<ButtonContainer>
 					<RowWithBorder>
 						<DomainName>
-							<div>{ domainName }</div>
+							<div>{ paidDomainName }</div>
 							<FreeDomainText>{ translate( 'Free for one year ' ) }</FreeDomainText>
 						</DomainName>
 						<StyledButton busy={ isBusy } primary onClick={ handlePaidPlanClick }>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -63,7 +63,7 @@ export interface PlansFeaturesMainProps {
 	onUpgradeClick?: ( cartItemForPlan?: MinimalRequestCartProduct | null ) => void;
 	redirectToAddDomainFlow?: boolean;
 	hidePlanTypeSelector?: boolean;
-	domainName?: string;
+	paidDomainName?: string;
 	flowName?: string | null;
 	replacePaidDomainWithFreeDomain?: ( freeDomainSuggestion: DomainSuggestion ) => void;
 	intervalType?: IntervalType;
@@ -117,7 +117,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 	const {
 		planRecords,
 		visiblePlans,
-		domainName,
+		paidDomainName,
 		isInSignup,
 		isLaunchPage,
 		flowName,
@@ -161,7 +161,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 	}
 
 	const asyncProps: PlanFeatures2023GridProps = {
-		domainName,
+		paidDomainName,
 		isInSignup,
 		isLaunchPage,
 		onUpgradeClick,
@@ -202,7 +202,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 };
 
 const PlansFeaturesMain = ( {
-	domainName,
+	paidDomainName,
 	flowName,
 	replacePaidDomainWithFreeDomain,
 	onUpgradeClick,
@@ -283,7 +283,7 @@ const PlansFeaturesMain = ( {
 		// - only applicable to main onboarding flow (default `/start`)
 		if (
 			( 'onboarding' === flowName || isOnboardingPMFlow( flowName ) ) &&
-			domainName &&
+			paidDomainName &&
 			! cartItemForPlan
 		) {
 			toggleIsFreePlanPaidDomainDialogOpen();
@@ -380,9 +380,9 @@ const PlansFeaturesMain = ( {
 			<QueryPlans />
 			<QuerySites siteId={ siteId } />
 			<QuerySitePlans siteId={ siteId } />
-			{ domainName && isFreePlanPaidDomainDialogOpen && (
+			{ paidDomainName && isFreePlanPaidDomainDialogOpen && (
 				<FreePlanPaidDomainDialog
-					domainName={ domainName }
+					paidDomainName={ paidDomainName }
 					suggestedPlanSlug={ PLAN_PERSONAL }
 					onClose={ toggleIsFreePlanPaidDomainDialogOpen }
 					onFreePlanSelected={ ( freeDomainSuggestion ) => {
@@ -416,7 +416,7 @@ const PlansFeaturesMain = ( {
 					<OnboardingPricingGrid2023
 						planRecords={ gridPlanRecords }
 						visiblePlans={ Object.keys( visiblePlans ) as PlanSlug[] }
-						domainName={ domainName }
+						paidDomainName={ paidDomainName }
 						isInSignup={ isInSignup }
 						isLaunchPage={ isLaunchPage }
 						flowName={ flowName }

--- a/packages/data-stores/src/domain-suggestions/queries.ts
+++ b/packages/data-stores/src/domain-suggestions/queries.ts
@@ -58,8 +58,8 @@ export function useGetDomainSuggestions(
 /**
  * Returns the expected *.wordpress.com for a given domain name
  */
-export function useGetWordPressSubdomain( domainName: string ) {
-	return useGetDomainSuggestions( domainName, {
+export function useGetWordPressSubdomain( paidDomainName: string ) {
+	return useGetDomainSuggestions( paidDomainName, {
 		quantity: 1,
 		include_wordpressdotcom: true,
 		include_dotblogsubdomain: false,

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
-import { NewSiteSuccessResponse, Site } from '@automattic/data-stores';
+import { DomainSuggestion, NewSiteSuccessResponse, Site } from '@automattic/data-stores';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import debugFactory from 'debug';
 import { getLocaleSlug } from 'i18n-calypso';
@@ -104,10 +104,11 @@ export const createSiteWithCart = async (
 	siteAccentColor: string,
 	useThemeHeadstart: boolean,
 	username: string,
-	domainItem?: MinimalRequestCartProduct,
+	domainItem?: DomainSuggestion,
+	domainCartItem?: MinimalRequestCartProduct,
 	sourceSlug?: string
 ) => {
-	const siteUrl = domainItem?.meta;
+	const siteUrl = domainItem?.domain_name;
 	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' );
 
 	const newSiteParams = getNewSiteParams( {
@@ -166,7 +167,7 @@ export const createSiteWithCart = async (
 		themeSlugWithRepo,
 		flowName,
 		userIsLoggedIn,
-		domainItem
+		domainCartItem
 	);
 
 	return providedDependencies;


### PR DESCRIPTION
Partially Fixes - Automattic/martech#1882

## Proposed Changes

* Fixes invalid domain name being set when progressing through flow as explained in 
* Refactor/Rename domainName to paidDomainName so that it's explicit that we are talking about the paidDomain and not a free subdomain. When the free subdomain is selected this field will be empty
* Accurately utilise both setDomain and setDomainCartItem respectively for a domain suggestion and when there is a paid domain selected. The domainCartItem will now not be set if a free subdomain is selected
* Also fixes a bug where the plans page was not accurately showing the strike through domain dynamics as highlighted in [this comment](https://github.com/Automattic/wp-calypso/pull/79109#pullrequestreview-1518573293).

## Testing Instructions
* Makes sure the cases outlined with [this comment](https://github.com/Automattic/wp-calypso/pull/79109#pullrequestreview-1518573293) are fixed
* Any variations and use cases related to any flow of the stepper framework which utilizes the domain step should work as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
