### PR TITLE
Reader: remove old Discover functionality from full post

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -36,8 +36,6 @@ import { isFeaturedImageInContent } from 'calypso/lib/post-normalizer/utils';
 import scrollTo from 'calypso/lib/scroll-to';
 import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
 import ReaderMain from 'calypso/reader/components/reader-main';
-import { isDiscoverPost, isDiscoverSitePick } from 'calypso/reader/discover/helper';
-import DiscoverSiteAttribution from 'calypso/reader/discover/site-attribution';
 import { canBeMarkedAsSeen, getSiteName, isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import readerContentWidth from 'calypso/reader/lib/content-width';
 import LikeButton from 'calypso/reader/like-button';
@@ -474,7 +472,6 @@ export class FullPostView extends Component {
 			classes[ 'feed-' + post.feed_ID ] = true;
 		}
 
-		const externalHref = isDiscoverPost( referralPost ) ? referralPost.URL : post.URL;
 		const isLoading = ! post || post._state === 'pending' || post._state === 'minimal';
 		const startingCommentId = this.getCommentIdFromUrl();
 		const commentCount = get( post, 'discussion.comment_count' );
@@ -503,7 +500,7 @@ export class FullPostView extends Component {
 				<div className="reader-full-post__visit-site-container">
 					<ExternalLink
 						icon={ true }
-						href={ externalHref }
+						href={ post.URL }
 						onClick={ this.handleVisitSiteClick }
 						target="_blank"
 					>
@@ -583,10 +580,7 @@ export class FullPostView extends Component {
 							</EmbedContainer>
 						) }
 
-						{ post.use_excerpt && ! isDiscoverPost( post ) && (
-							<PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
-						) }
-						{ isDiscoverSitePick( post ) && <DiscoverSiteAttribution post={ post } /> }
+						{ post.use_excerpt && <PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> }
 						{ isDailyPostChallengeOrPrompt( post ) && (
 							<DailyPostButton post={ post } site={ site } />
 						) }


### PR DESCRIPTION
Now that the new Discover experience has been launched (it looks amazing 🤩), we have a bunch of old code lurking in Calypso that was specific to the old Discover experience. The old Discover was an A8C-published blog that hasn't been updated in several years. We used to give posts from the Discover blog special treatment in the Reader in a number of places.

This special treatment is no longer necessary, and it seems smart to remove the associated code, both to simplify things and to avoid confusion about what "Discover" is for future developers.

I worked on the original Discover so I'm probably a good person to do the cleanup. I'll try and do a series of small PRs when I have chance.

## Proposed Changes

Remove O.G. Discover functionality from Reader full post.

## Testing Instructions

Test that Reader full post does not have any regressions:

e.g. http://calypso.localhost:3000/read/feeds/107786307/posts/4801836568

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
