### PR TITLE
reader search: Make search suggestions use the same component as search results

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -201,11 +201,14 @@ const DiscoverStream = ( props ) => {
 	}
 
 	const streamSidebar =
-		isDefaultTab || selectedTab === 'latest' ? (
-			<ReaderPopularSitesSidebar
-				items={ recommendedSites }
-				followSource={ READER_DISCOVER_POPULAR_SITES }
-			/>
+		( isDefaultTab || selectedTab === 'latest' ) && recommendedSites?.length ? (
+			<>
+				<h2>{ translate( 'Popular Sites' ) }</h2>
+				<ReaderPopularSitesSidebar
+					items={ recommendedSites }
+					followSource={ READER_DISCOVER_POPULAR_SITES }
+				/>
+			</>
 		) : (
 			<ReaderTagSidebar tag={ selectedTab } />
 		);

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -13,6 +13,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 import withDimensions from 'calypso/lib/with-dimensions';
 import BlankSuggestions from 'calypso/reader/components/reader-blank-suggestions';
 import ReaderMain from 'calypso/reader/components/reader-main';
+import { READER_SEARCH_POPULAR_SITES } from 'calypso/reader/follow-sources';
 import { getSearchPlaceholderText } from 'calypso/reader/search/utils';
 import SearchFollowButton from 'calypso/reader/search-stream/search-follow-button';
 import { recordAction } from 'calypso/reader/stats';
@@ -23,6 +24,8 @@ import {
 	SORT_BY_LAST_UPDATED,
 } from 'calypso/state/reader/feed-searches/actions';
 import { getReaderAliasedFollowFeedUrl } from 'calypso/state/reader/follows/selectors';
+import { getTransformedStreamItems } from 'calypso/state/reader/streams/selectors';
+import ReaderPopularSitesSidebar from '../stream/reader-popular-sites-sidebar';
 import PostResults from './post-results';
 import SearchStreamHeader, { SEARCH_TYPES } from './search-stream-header';
 import SiteResults from './site-results';
@@ -144,9 +147,7 @@ class SearchStream extends React.Component {
 			comment: 'A sort order, showing the most recent posts first.',
 		} );
 
-		const searchStreamResultsClasses = classnames( 'search-stream__results', {
-			'is-two-columns': !! query,
-		} );
+		const searchStreamResultsClasses = classnames( 'search-stream__results', 'is-two-columns' );
 
 		const singleColumnResultsClasses = classnames( 'search-stream__single-column-results', {
 			'is-post-results': searchType === SEARCH_TYPES.POSTS && query,
@@ -198,17 +199,17 @@ class SearchStream extends React.Component {
 							</SegmentedControl.Item>
 						</SegmentedControl>
 					) }
-					{ ! hidePostsAndSites && query && (
-						<SearchStreamHeader
-							selected={ searchType }
-							onSelection={ this.handleSearchTypeSelection }
-							wideDisplay={ wideDisplay }
-						/>
-					) }
 					{ ! query && (
 						<BlankSuggestions
 							suggestions={ suggestionList }
 							trackTagsPageLinkClick={ this.trackTagsPageLinkClick }
+						/>
+					) }
+					{ ! hidePostsAndSites && (
+						<SearchStreamHeader
+							selected={ searchType }
+							onSelection={ this.handleSearchTypeSelection }
+							wideDisplay={ wideDisplay }
 						/>
 					) }
 				</div>
@@ -218,28 +219,38 @@ class SearchStream extends React.Component {
 						<div className="search-stream__post-results">
 							<PostResults { ...this.props } />
 						</div>
-						{ query && (
-							<div className="search-stream__site-results">
+						<div className="search-stream__site-results">
+							{ query && (
 								<SiteResults
 									query={ query }
 									sort={ pickSort( sortOrder ) }
 									onReceiveSearchResults={ this.setSearchFeeds }
 								/>
-							</div>
-						) }
+							) }
+							{ ! query && (
+								<ReaderPopularSitesSidebar
+									items={ this.props.items }
+									followSource={ READER_SEARCH_POPULAR_SITES }
+								/>
+							) }
+						</div>
 					</div>
 				) }
 				{ ! hidePostsAndSites && ! wideDisplay && (
 					<div className={ singleColumnResultsClasses }>
-						{ ( ( searchType === SEARCH_TYPES.POSTS || ! query ) && (
-							<PostResults { ...this.props } />
-						) ) || (
-							<SiteResults
-								query={ query }
-								sort={ pickSort( sortOrder ) }
-								onReceiveSearchResults={ this.setSearchFeeds }
-							/>
-						) }
+						{ ( searchType === SEARCH_TYPES.POSTS && <PostResults { ...this.props } /> ) ||
+							( query && (
+								<SiteResults
+									query={ query }
+									sort={ pickSort( sortOrder ) }
+									onReceiveSearchResults={ this.setSearchFeeds }
+								/>
+							) ) || (
+								<ReaderPopularSitesSidebar
+									items={ this.props.items }
+									followSource={ READER_SEARCH_POPULAR_SITES }
+								/>
+							) }
 					</div>
 				) }
 			</div>
@@ -263,6 +274,10 @@ export default connect(
 		readerAliasedFollowFeedUrl:
 			ownProps.query && getReaderAliasedFollowFeedUrl( state, ownProps.query ),
 		isLoggedIn: isUserLoggedIn( state ),
+		items: getTransformedStreamItems( state, {
+			streamKey: ownProps.streamKey,
+			recsStreamKey: ownProps.recsStreamKey,
+		} ),
 	} ),
 	{
 		recordReaderTracksEvent,

--- a/client/reader/stream/empty-search-recommended-post.jsx
+++ b/client/reader/stream/empty-search-recommended-post.jsx
@@ -1,32 +1,23 @@
-import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
+import { useDispatch } from 'react-redux';
 import { recordTrackForPost, recordAction } from 'calypso/reader/stats';
+import { showSelectedPost } from 'calypso/reader/utils';
+import Post from './post';
 
-export default function EmptySearchRecommendedPost( { post } ) {
+export default function EmptySearchRecommendedPost( { post, postKey, streamKey } ) {
+	const dispatch = useDispatch();
+
 	function handlePostClick() {
 		recordTrackForPost( 'calypso_reader_recommended_post_clicked', post, {
 			recommendation_source: 'empty-search',
 		} );
 		recordAction( 'search_page_rec_post_click' );
+		dispatch(
+			showSelectedPost( {
+				postKey: postKey,
+				streamKey,
+			} )
+		);
 	}
 
-	function handleSiteClick() {
-		recordTrackForPost( 'calypso_reader_recommended_site_clicked', post, {
-			recommendation_source: 'empty-search',
-		} );
-		recordAction( 'search_page_rec_site_click' );
-	}
-
-	const site = { title: post && post.site_name };
-
-	/* eslint-disable  wpcalypso/jsx-classname-namespace */
-	return (
-		<div className="search-stream__recommendation-list-item" key={ post && post.global_ID }>
-			<RelatedPostCard
-				post={ post }
-				site={ site }
-				onSiteClick={ handleSiteClick }
-				onPostClick={ handlePostClick }
-			/>
-		</div>
-	);
+	return <Post post={ post } handleClick={ handlePostClick } />;
 }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -16,7 +16,6 @@ import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import scrollTo from 'calypso/lib/scroll-to';
 import withDimensions from 'calypso/lib/with-dimensions';
 import ReaderMain from 'calypso/reader/components/reader-main';
-import { READER_SEARCH_POPULAR_SITES } from 'calypso/reader/follow-sources';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
 import { keysAreEqual, keyToString } from 'calypso/reader/post-key';
 import UpdateNotice from 'calypso/reader/update-notice';
@@ -48,7 +47,6 @@ import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import EmptyContent from './empty';
 import PostLifecycle from './post-lifecycle';
 import PostPlaceholder from './post-placeholder';
-import ReaderPopularSitesSidebar from './reader-popular-sites-sidebar';
 import './style.scss';
 
 const WIDE_DISPLAY_CUTOFF = 900;
@@ -494,17 +492,9 @@ class ReaderStream extends Component {
 				/>
 			);
 
-			let sidebarContent = this.props.streamSidebar;
+			const sidebarContent = this.props.streamSidebar;
 
-			// Add the sidebar on the search page when there's no search input. Sidebar is handled by `<SiteResults>' when there's a search query.
-			// TODO: use `streamSidebar` prop in search stream component, rather than using conditionals here.
-			if ( streamType === 'custom_recs_sites_with_images' ) {
-				sidebarContent = (
-					<ReaderPopularSitesSidebar items={ items } followSource={ READER_SEARCH_POPULAR_SITES } />
-				);
-			}
-
-			// Exclude the sidebar layout when there's a search query, since it's handled by `<SiteResults>`.
+			// Exclude the sidebar layout for the search stream, since it's handled by `<SiteResults>`.
 			if ( ! sidebarContent || streamType === 'search' ) {
 				body = <div className="reader__content">{ bodyContent }</div>;
 			} else if ( wideDisplay ) {

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -53,7 +53,9 @@ class PostLifecycle extends Component {
 				</div>
 			);
 		} else if ( ! isDiscoverStream && streamKey.indexOf( 'rec' ) > -1 ) {
-			return <EmptySearchRecommendedPost post={ post } site={ postKey } />;
+			return (
+				<EmptySearchRecommendedPost post={ post } postKey={ postKey } streamKey={ streamKey } />
+			);
 		} else if ( postKey.isGap ) {
 			return (
 				<ListGap

--- a/client/reader/stream/reader-popular-sites-sidebar/index.jsx
+++ b/client/reader/stream/reader-popular-sites-sidebar/index.jsx
@@ -1,4 +1,3 @@
-import { useTranslate } from 'i18n-calypso';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import '../style.scss';
 
@@ -24,8 +23,6 @@ const getSiteFromItem = ( item ) => {
 };
 
 const ReaderPopularSitesSidebar = ( { items, followSource } ) => {
-	const translate = useTranslate();
-
 	const sites = items
 		.map( ( item ) => getSiteFromItem( item ) )
 		.filter( ( site ) => site !== null );
@@ -48,12 +45,7 @@ const ReaderPopularSitesSidebar = ( { items, followSource } ) => {
 		return null;
 	}
 
-	return (
-		<div className="reader-tag-sidebar-recommended-sites">
-			<h2>{ translate( 'Popular Sites' ) }</h2>
-			{ popularSitesLinks }
-		</div>
-	);
+	return <div className="reader-tag-sidebar-recommended-sites">{ popularSitesLinks }</div>;
 };
 
 export default ReaderPopularSitesSidebar;


### PR DESCRIPTION
The search recommendation appears on the /read/search page when no search has been entered. It looks like the search results component but has several limitations.
* Only the follow button is shown
* Links do not open in a new tab when logged out. See https://github.com/Automattic/wp-calypso/issues/79240
* The follow button is misaligned on mobile
* 
This replaces the component with the same <Post/> component that is used by search results, giving a consistent experience

It turned into a bigger change than I expected, but I think the code makes a little more sense now and has a better user experience

**Before:** 
<img width="600" alt="Screen Shot 2023-07-13 at 2 21 15 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/4c9274be-fd65-40e3-a22d-bb6501cf7ec1">

**After:**
<img width="600" alt="Screen Shot 2023-07-13 at 2 21 01 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/cb923bc8-cf03-436e-b57a-9f56d5fcbd67">

### Testing instructions
Test `/read/search` mobile & desktop, with and without search query, logged in and logged out
Also test the discover page