### PR TITLE
Disable refunds for Marketplace SaaS products

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -631,7 +631,7 @@ export function isRechargeable( purchase: Purchase ): boolean {
  * contacts a Happiness Engineer), use maybeWithinRefundPeriod().
  */
 export function isRefundable( purchase: Purchase ): boolean {
-	return purchase.isRefundable;
+	return purchase.isRefundable && purchase.productType !== 'saas_plugin';
 }
 
 /**


### PR DESCRIPTION
Related to #69601

## Proposed Changes

* Make Marketplace SaaS products non-refundable.

## Testing Instructions

* Check out this branch locally.
* Important: Sandbox the Store
* Purchase MailPoet by making the following request using curl or postman. Change user_id and blog_id according to your user and blog. The authorization token can be found in the following D109145-code
curl --location --request POST 'https://public-api.wordpress.com/wpcom/v2/marketplace/vendor/billing-intent' \
--header 'cache-control: no-cache' \
--header 'Authorization: Bearer XXXXX \
--header 'Content-Type: application/json' \
--data-raw '{
    "product_slug": "mailpoet-business",
    "blog_id": " ",
    "user_id": " ",
    "name": "Business 500",
    "price": 4000,
    "billing_period": "month",
    "billing_interval": 1,
    "return_url": "https://example.com"
}'
* Complete the checkout
* Go to Upgrades - Purchases and click on the MailPoet subscription.
* Confirm the cancel subscription button disables auto-renew subscription, and the text "Want to request a refund? [Ask a Happiness Engineer!](http://calypso.localhost:3000/help/contact)" is displayed.

<img width="1049" alt="Screenshot 2023-07-13 at 12 40 17 AM" src="https://github.com/Automattic/wp-calypso/assets/351784/bde680e5-a790-4fe1-a33c-c2d1e4b679a9">

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?