### PR TITLE
Theme Showcase: Fix issue where the selected style variation is not applied

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -172,6 +172,14 @@ class ThemesSelection extends Component {
 	//intercept preview and add primary and secondary
 	getOptions = ( themeId, styleVariation, context ) => {
 		let options = this.props.getOptions( themeId, styleVariation );
+
+		const wrappedActivateAction = ( action ) => {
+			return ( t ) => {
+				this.props.setThemePreviewOptions( themeId, null, null, styleVariation );
+				return action( t, context );
+			};
+		};
+
 		const wrappedPreviewAction = ( action ) => {
 			let defaultOption;
 			let secondaryOption = this.props.secondaryOption;
@@ -200,6 +208,7 @@ class ThemesSelection extends Component {
 				} else {
 					defaultOption = options.activate;
 				}
+
 				this.props.setThemePreviewOptions(
 					themeId,
 					defaultOption,
@@ -212,6 +221,10 @@ class ThemesSelection extends Component {
 
 		if ( options ) {
 			options = addStyleVariation( options, styleVariation, this.props.isLoggedIn );
+			if ( options.activate ) {
+				options.activate.action = wrappedActivateAction( options.activate.action );
+			}
+
 			if ( options.preview ) {
 				options.preview.action = wrappedPreviewAction( options.preview.action );
 			}


### PR DESCRIPTION
## Proposed Changes

This PR fixes the issue where if the user activates a theme with a style variation, the activated theme would not have the selected style variation applied.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/themes`.
* Find a theme with style variation.
* Click on any of the style variations.
* Click on the ellipsis menu and select "Activate".
* Ensure that a POST request to the endpoint `https://public-api.wordpress.com/wp/v2/sites/${site_id}/global-styles/${global_styles_id}` is triggered.
* Head to the Site Editor, and ensure that the activated theme has the selected style variation applied.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
