### PR TITLE
Pro dashboard: Add 1 minute interval options for Paid Downtime Monitoring.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
@@ -24,8 +24,7 @@ export default function NotificationDuration( {
 	const showPaidDuration = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
 
 	const selectableDuration = useMemo(
-		() =>
-			showPaidDuration ? durations : durations.filter( ( duration ) => ! duration.paid_tier ),
+		() => ( showPaidDuration ? durations : durations.filter( ( duration ) => ! duration.isPaid ) ),
 		[ showPaidDuration ]
 	);
 
@@ -54,7 +53,7 @@ export default function NotificationDuration( {
 						key={ duration.time }
 						selected={ duration.time === selectedDuration?.time }
 						onClick={ () => selectDuration( duration ) }
-						disabled={ duration.paid_tier && ! enablePaidDurations }
+						disabled={ duration.isPaid && ! enablePaidDurations }
 					>
 						{ duration.label }
 					</SelectDropdown.Item>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
@@ -1,21 +1,32 @@
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { availableNotificationDurations as durations } from '../../../sites-overview/utils';
 import type { MonitorDuration } from '../../../sites-overview/types';
 
 interface Props {
+	disablePaidDuration?: boolean;
 	selectedDuration?: MonitorDuration;
 	selectDuration: ( duration: MonitorDuration ) => void;
+	showPaidDuration?: boolean;
 	recordEvent: ( action: string, params?: object ) => void;
 }
 
 export default function NotificationDuration( {
+	disablePaidDuration = true,
 	selectedDuration,
 	selectDuration,
+	showPaidDuration,
 	recordEvent,
 }: Props ) {
 	const translate = useTranslate();
+
+	const selectableDuration = useMemo(
+		() =>
+			showPaidDuration ? durations : durations.filter( ( duration ) => ! duration.paid_tier ),
+		[ showPaidDuration ]
+	);
 
 	return (
 		<div className="notification-settings__content-block">
@@ -37,11 +48,12 @@ export default function NotificationDuration( {
 				}
 				selectedText={ selectedDuration?.label }
 			>
-				{ durations.map( ( duration ) => (
+				{ selectableDuration.map( ( duration ) => (
 					<SelectDropdown.Item
 						key={ duration.time }
 						selected={ duration.time === selectedDuration?.time }
 						onClick={ () => selectDuration( duration ) }
+						disabled={ duration.paid_tier && disablePaidDuration }
 					>
 						{ duration.label }
 					</SelectDropdown.Item>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
@@ -6,21 +7,21 @@ import { availableNotificationDurations as durations } from '../../../sites-over
 import type { MonitorDuration } from '../../../sites-overview/types';
 
 interface Props {
-	disablePaidDuration?: boolean;
+	enablePaidDurations?: boolean;
 	selectedDuration?: MonitorDuration;
 	selectDuration: ( duration: MonitorDuration ) => void;
-	showPaidDuration?: boolean;
 	recordEvent: ( action: string, params?: object ) => void;
 }
 
 export default function NotificationDuration( {
-	disablePaidDuration = true,
+	enablePaidDurations,
 	selectedDuration,
 	selectDuration,
-	showPaidDuration,
 	recordEvent,
 }: Props ) {
 	const translate = useTranslate();
+
+	const showPaidDuration = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
 
 	const selectableDuration = useMemo(
 		() =>
@@ -53,7 +54,7 @@ export default function NotificationDuration( {
 						key={ duration.time }
 						selected={ duration.time === selectedDuration?.time }
 						onClick={ () => selectDuration( duration ) }
-						disabled={ duration.paid_tier && disablePaidDuration }
+						disabled={ duration.paid_tier && ! enablePaidDurations }
 					>
 						{ duration.label }
 					</SelectDropdown.Item>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -98,6 +98,13 @@ export default function NotificationSettings( {
 		'jetpack/pro-dashboard-monitor-sms-notification'
 	);
 
+	const isDowntimeMonitoringPaidTierEnabled = isEnabled(
+		'jetpack/pro-dashboard-monitor-paid-tier'
+	);
+
+	// TODO: Need to figure out where to fetch site license information from.
+	const hasDowntimeMonitoringPaidLicense = false;
+
 	const isContactListMatch = (
 		list1: ReadonlyArray< MonitorSettingsContact >,
 		list2: ReadonlyArray< MonitorSettingsContact >
@@ -334,7 +341,14 @@ export default function NotificationSettings( {
 				foundDuration = durations.find(
 					( duration ) => duration.time === settings.monitor_deferment_time
 				);
-				setSelectedDuration( foundDuration );
+
+				// We need to make sure that we are not setting a paid duration if there is no license.
+				if (
+					( foundDuration?.paid_tier && hasDowntimeMonitoringPaidLicense ) ||
+					! foundDuration?.paid_tier
+				) {
+					setSelectedDuration( foundDuration );
+				}
 			}
 
 			// Set initial settings
@@ -353,6 +367,7 @@ export default function NotificationSettings( {
 			getAllPhoneItems,
 			handleSetEmailItems,
 			handleSetPhoneItems,
+			hasDowntimeMonitoringPaidLicense,
 			isMultipleEmailEnabled,
 			isSMSNotificationEnabled,
 		]
@@ -462,6 +477,8 @@ export default function NotificationSettings( {
 					recordEvent={ recordEvent }
 					selectedDuration={ selectedDuration }
 					selectDuration={ selectDuration }
+					showPaidDuration={ ! isBulkUpdate && isDowntimeMonitoringPaidTierEnabled }
+					disablePaidDuration={ ! hasDowntimeMonitoringPaidLicense }
 				/>
 				{ isSMSNotificationEnabled && (
 					<SMSNotification

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -477,7 +477,7 @@ export default function NotificationSettings( {
 					recordEvent={ recordEvent }
 					selectedDuration={ selectedDuration }
 					selectDuration={ selectDuration }
-					showPaidDuration={ ! isBulkUpdate && isDowntimeMonitoringPaidTierEnabled }
+					showPaidDuration={ isDowntimeMonitoringPaidTierEnabled }
 					disablePaidDuration={ ! hasDowntimeMonitoringPaidLicense }
 				/>
 				{ isSMSNotificationEnabled && (

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -339,7 +339,7 @@ export default function NotificationSettings( {
 				);
 
 				// We need to make sure that we are not setting a paid duration if there is no license.
-				if ( hasDowntimeMonitoringPaidLicense || ! foundDuration?.paid_tier ) {
+				if ( hasDowntimeMonitoringPaidLicense || ! foundDuration?.isPaid ) {
 					setSelectedDuration( foundDuration );
 				}
 			}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -98,10 +98,6 @@ export default function NotificationSettings( {
 		'jetpack/pro-dashboard-monitor-sms-notification'
 	);
 
-	const isDowntimeMonitoringPaidTierEnabled = isEnabled(
-		'jetpack/pro-dashboard-monitor-paid-tier'
-	);
-
 	// TODO: Need to figure out where to fetch site license information from.
 	const hasDowntimeMonitoringPaidLicense = false;
 
@@ -343,10 +339,7 @@ export default function NotificationSettings( {
 				);
 
 				// We need to make sure that we are not setting a paid duration if there is no license.
-				if (
-					( foundDuration?.paid_tier && hasDowntimeMonitoringPaidLicense ) ||
-					! foundDuration?.paid_tier
-				) {
+				if ( hasDowntimeMonitoringPaidLicense || ! foundDuration?.paid_tier ) {
 					setSelectedDuration( foundDuration );
 				}
 			}
@@ -477,8 +470,7 @@ export default function NotificationSettings( {
 					recordEvent={ recordEvent }
 					selectedDuration={ selectedDuration }
 					selectDuration={ selectDuration }
-					showPaidDuration={ isDowntimeMonitoringPaidTierEnabled }
-					disablePaidDuration={ ! hasDowntimeMonitoringPaidLicense }
+					enablePaidDurations={ hasDowntimeMonitoringPaidLicense }
 				/>
 				{ isSMSNotificationEnabled && (
 					<SMSNotification

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -203,4 +203,5 @@ export default function ToggleActivateMonitoring( {
 			) }
 		</>
 	);
+
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -203,5 +203,4 @@ export default function ToggleActivateMonitoring( {
 			) }
 		</>
 	);
-
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -491,6 +491,11 @@ export const getProductSlugFromProductType = ( type: string ): string | undefine
 
 export const availableNotificationDurations = [
 	{
+		time: 1,
+		label: translate( 'After 1 minute' ),
+		paid_tier: true,
+	},
+	{
 		time: 5,
 		label: translate( 'After 5 minutes' ),
 	},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -493,7 +493,7 @@ export const availableNotificationDurations = [
 	{
 		time: 1,
 		label: translate( 'After 1 minute' ),
-		paid_tier: true,
+		isPaid: true,
 	},
 	{
 		time: 5,


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/79280

Related to 1204992567518369-as-1204995327932156

## Proposed Changes

This PR adds the '1-minute' interval options in the Paid Downtime Monitoring settings.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

1. Check out this branch and run the local jetpack cloud server by executing `yarn start-jetpack-cloud`.
1. go to http://jetpack.cloud.localhost:3000/dashboard.
1. Select any site from the site table and click the monitor toggle to enable monitoring.
1. Click on the interval icon to show the Notification settings.
1. Confirm that the '1-minute' interval is visible but is disabled in the Interval select component.
<img width="503" alt="Screen Shot 2023-07-13 at 2 57 26 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/2c4debd0-0241-4b1c-93ad-051361e5b413">

### Temporarily Enable '1-minute' interval.
* To test how the option would look when enabled. Modify the [following constant](https://github.com/Automattic/wp-calypso/pull/79336/files#diff-f35a450c1de6fd82f8c57a51c2645903df5dfee0a8b89847db7de1f960eaf200R106) to be **true**. _Note that the UI will throw an error when attempting to save this_. 

```
const hasDowntimeMonitoringPaidLicense = true;
```
<img width="506" alt="Screen Shot 2023-07-13 at 3 08 39 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9a8e22a6-5ca6-44f5-9768-98b1db89904f">


### Additional Regression testing ###
Please also test that the existing functionality works as expected by turning off the feature flag using the link below.

http://jetpack.cloud.localhost:3000/dashboard?flags=-jetpack/pro-dashboard-monitor-paid-tier



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?