### PR TITLE
i18n: Fix wrapping the "I am a developer" toggle for translation

### DIFF
--- a/client/me/profile/get-i-am-a-developer-copy.tsx
+++ b/client/me/profile/get-i-am-a-developer-copy.tsx
@@ -1,7 +1,7 @@
-import { translate } from 'i18n-calypso';
+import { translate as translateFunction } from 'i18n-calypso';
 
-export const getIAmDeveloperCopy = ( translateFunction: typeof translate ) =>
-	translateFunction(
+export const getIAmDeveloperCopy = ( translate: typeof translateFunction ) =>
+	translate(
 		'{{strong}}I am a developer.{{/strong}} Make my WordPress.com experience more powerful and grant me early access to developer features.',
 		{
 			components: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 643-gh-Automattic/i18n-issues

## Proposed Changes

The string wasn't picked up to be translated because it wasn't wrapped in a (literal) `translate` call. By switching the names of `translate` and `translateFunction`, the string _is_ wrapped in `translate`, and the string is extracted correctly. See [this related linter rule](https://github.com/Automattic/wp-calypso/blob/trunk/packages/eslint-plugin-wpcalypso/docs/rules/i18n-translate-identifier.md) for more details.

![image](https://github.com/Automattic/wp-calypso/assets/75777864/a231a3bb-9b15-49d3-a1df-e27df8e310e6)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the string is included in the `calypso-strings.pot` artifact of the Translate job.
* Visit `/me` (locally or on Calypso Live) and verify that the English string is still displayed normally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
