### PR TITLE
Assembler: Fix the styles of the navigator button

### DIFF
--- a/packages/onboarding/src/navigator/navigator-buttons/index.tsx
+++ b/packages/onboarding/src/navigator/navigator-buttons/index.tsx
@@ -55,7 +55,6 @@ export const NavigationButtonAsItem = ( { className, ...props }: Props ) => {
 		<NavigatorButton
 			as={ GenericButton }
 			className={ classnames( 'navigator-button', className ) }
-			// wrapperClassName="navigator-button__wrapper"
 			{ ...props }
 		/>
 	);

--- a/packages/onboarding/src/navigator/navigator-item-group/style.scss
+++ b/packages/onboarding/src/navigator/navigator-item-group/style.scss
@@ -3,14 +3,12 @@
 .navigator-item-group {
 	flex-shrink: 0;
 
-	.navigator-button__wrapper {
+	.components-item-group > div[role="listitem"] {
 		display: flex;
+	}
 
-		.navigator-button {
-			flex: 1;
-			// Expand sides out of wrapper in main screen
-			margin: 0 -11px;
-		}
+	.navigator-button {
+		flex-grow: 1;
 	}
 
 	&:nth-child(1 of &):nth-last-child(1 of &) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/79275#discussion_r1261744076

## Proposed Changes

* The `wrapperClassName` is no longer an accepted prop of the `Item` component. Hence, remove it and adjust some styles to make the layout look better

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/e7ef97be-022c-46bd-8094-f84d338e97cd) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/a077a7cf-f8ee-4ebb-8266-cab83860419e) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Scroll down to select the BCPA CTA
* When you land on the Assembler screen, ensure the buttons look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
