### PR TITLE
Design Preview: Fix the height of the site preview on mobile

### DIFF
--- a/packages/design-preview/src/components/animated-fullscreen.tsx
+++ b/packages/design-preview/src/components/animated-fullscreen.tsx
@@ -19,11 +19,11 @@ const AnimatedFullscreen = ( { className, children, isFullscreen, enabled }: Pro
 			return;
 		}
 
-		const { offsetLeft, offsetTop, offsetHeight } = positionerRef.current;
+		const { offsetLeft, offsetTop, offsetHeight, offsetWidth } = positionerRef.current;
+		targetRef.current.style.height = `${ offsetHeight }px`;
+		targetRef.current.style.width = `${ offsetWidth }px`;
 		targetRef.current.style.left = `${ offsetLeft }px`;
-		targetRef.current.style.right = `${ offsetLeft }px`;
 		targetRef.current.style.top = `${ offsetTop }px`;
-		targetRef.current.style.bottom = `${ offsetTop + offsetHeight }px`;
 	}, [ isFullscreen, width, height, enabled ] );
 
 	if ( ! enabled ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78419

## Proposed Changes

* Fix the height of the site preview is incorrect as the assigned bottom is not relative to the bottom of the screen. So, change to assign the height and width to resolve the issue.

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/f9555590-c0c5-443a-96d2-4b824b4fe8ad) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6f3fdc1e-60ca-4910-80e0-41f6c4e34378) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site> on the small screen
* Continue until you land on the Design Picker
* Preview a design without the style variations, e.g.: Poema
* Select “Colors”
* Scroll down to the bottom and ensure you can see the bottom of the site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
