### PR TITLE
Validate redirect url in woo core profiler

### DIFF
--- a/client/layout/masterbar/index.d.ts
+++ b/client/layout/masterbar/index.d.ts
@@ -1,3 +1,3 @@
 declare module 'valid-url' {
-	export function isWebUri( url: string ): boolean;
+	export function isWebUri( url: string | null ): boolean;
 }

--- a/client/layout/masterbar/index.d.ts
+++ b/client/layout/masterbar/index.d.ts
@@ -1,0 +1,3 @@
+declare module 'valid-url' {
+	export function isWebUri( url: string ): boolean;
+}

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -3,6 +3,9 @@ import { Button } from '@wordpress/components';
 import { getQueryArg } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
 import { Fragment } from 'react';
+// @ts-expect-error Missing definition
+// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
+import validUrl from 'valid-url';
 import WooLogo from 'calypso/assets/images/icons/woocommerce-logo.svg';
 import SVGIcon from 'calypso/components/svg-icon';
 import './typekit';
@@ -62,17 +65,19 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 							</a>
 						</li>
 						<li className="masterbar__woo-nav-item">
-							{ shouldShowNoThanks && typeof redirectTo === 'string' && redirectTo.length && (
-								<Button
-									onClick={ () => {
-										recordTracksEvent( 'calypso_jpc_wc_coreprofiler_skip' );
-										window.location.href = redirectTo;
-									} }
-									className="masterbar__no-thanks-button"
-								>
-									{ translate( 'No, Thanks' ) }
-								</Button>
-							) }
+							{ shouldShowNoThanks &&
+								typeof redirectTo === 'string' &&
+								validUrl.isWebUri( redirectTo ) && (
+									<Button
+										onClick={ () => {
+											recordTracksEvent( 'calypso_jpc_wc_coreprofiler_skip' );
+											window.location.href = redirectTo;
+										} }
+										className="masterbar__no-thanks-button"
+									>
+										{ translate( 'No, Thanks' ) }
+									</Button>
+								) }
 						</li>
 					</ul>
 				</nav>

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -3,9 +3,7 @@ import { Button } from '@wordpress/components';
 import { getQueryArg } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
 import { Fragment } from 'react';
-// @ts-expect-error Missing definition
-// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
-import validUrl from 'valid-url';
+import { isWebUri } from 'valid-url';
 import WooLogo from 'calypso/assets/images/icons/woocommerce-logo.svg';
 import SVGIcon from 'calypso/components/svg-icon';
 import './typekit';
@@ -65,19 +63,17 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 							</a>
 						</li>
 						<li className="masterbar__woo-nav-item">
-							{ shouldShowNoThanks &&
-								typeof redirectTo === 'string' &&
-								validUrl.isWebUri( redirectTo ) && (
-									<Button
-										onClick={ () => {
-											recordTracksEvent( 'calypso_jpc_wc_coreprofiler_skip' );
-											window.location.href = redirectTo;
-										} }
-										className="masterbar__no-thanks-button"
-									>
-										{ translate( 'No, Thanks' ) }
-									</Button>
-								) }
+							{ shouldShowNoThanks && typeof redirectTo === 'string' && isWebUri( redirectTo ) && (
+								<Button
+									onClick={ () => {
+										recordTracksEvent( 'calypso_jpc_wc_coreprofiler_skip' );
+									} }
+									href={ redirectTo }
+									className="masterbar__no-thanks-button"
+								>
+									{ translate( 'No, Thanks' ) }
+								</Button>
+							) }
 						</li>
 					</ul>
 				</nav>


### PR DESCRIPTION
Related to p7H4VZ-4sH-p2#comment-11308

## Proposed Changes

* Validate redirect to URL from query parameter, if it's invalid, hide the "no thanks" button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. go to `/jetpack/connect/authorize?client_id=219799967&redirect_uri=https%3A%2F%2Fawesome-store.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D3f81798d85%26redirect%3Dhttps%253A%252F%252Fawesome-store.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3Ae0a0df66fa6e6d2b7c0969d37fa165d4&user_email=chi-hsuan.huang%40automattic.com&jp_version=12.1.1&secret=uDAtkilHDeWP4lnJewWTAH5Gv7EQVJxt&blogname=Awesome%20Store&site_url=https%3A%2F%2Fawesome-store.jurassic.ninja&home_url=https%3A%2F%2Fawesome-store.jurassic.ninja&site_icon=&site_lang=en_US&allow_site_connection=1&_ui=42367338&_ut=wpcom%3Auser_id&_wp_nonce=e48c9f86a6&redirect_after_auth=https%3A%2F%2Fawesome-store.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fawesome-store.jurassic.ninja&from=woocommerce-core-profiler`
2. Should take you to https://awesome-store.jurassic.ninja/wp-admin/admin.php?page=wc-admin
3. Go back and change `redirect_after_auth` query value to `javascript:alert(document.domain)`
4. `No, Thanks` button should not be shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?