### PR TITLE
Subscribers Page: Update "Subscriber type" drop-down - labels and styling

### DIFF
--- a/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
+++ b/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
@@ -4,9 +4,17 @@ import { SubscribersFilterBy } from 'calypso/my-sites/subscribers/constants';
 
 const FilterBy = SubscribersFilterBy;
 
-const useSubscribersFilterOptions = () => {
+const useSubscribersFilterOptions = ( newDropdownOptionsReady: boolean ) => {
 	const translate = useTranslate();
-	return useMemo(
+	const newDropdownOptions = useMemo(
+		() => [
+			{ value: FilterBy.All, label: translate( 'All' ) },
+			{ value: FilterBy.Email, label: translate( 'Via Email' ) },
+			{ value: FilterBy.WPCOM, label: translate( 'Via WordPress.com' ) },
+		],
+		[ translate ]
+	);
+	const oldDropdownOptions = useMemo(
 		() => [
 			{ value: FilterBy.All, label: translate( 'All' ) },
 			{ value: FilterBy.Email, label: translate( 'Email subscriber' ) },
@@ -14,6 +22,11 @@ const useSubscribersFilterOptions = () => {
 		],
 		[ translate ]
 	);
+
+	if ( newDropdownOptionsReady ) {
+		return newDropdownOptions;
+	}
+	return oldDropdownOptions;
 };
 
 export default useSubscribersFilterOptions;

--- a/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
+++ b/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
@@ -26,6 +26,7 @@ const useSubscribersFilterOptions = ( newDropdownOptionsReady: boolean ) => {
 	if ( newDropdownOptionsReady ) {
 		return newDropdownOptions;
 	}
+
 	return oldDropdownOptions;
 };
 

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/style.scss
@@ -14,7 +14,7 @@
 		&.select-dropdown,
 		.select-dropdown__header {
 			height: 48px;
-			justify-content: normal;
+			justify-content: space-between;
 
 			.gridicon {
 				margin-left: 10px;

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -1,4 +1,6 @@
+import { useLocale } from '@automattic/i18n-utils';
 import SearchInput from '@automattic/search';
+import { useI18n } from '@wordpress/react-i18n/';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import SelectDropdown from 'calypso/components/select-dropdown';
@@ -27,9 +29,23 @@ const ListActionsBar = () => {
 		filterOption,
 		setFilterOption,
 	} = useSubscribersPage();
+	const locale = useLocale();
+	const { hasTranslation } = useI18n();
+	const newDropdownOptionsReady =
+		locale.startsWith( 'en' ) ||
+		( hasTranslation( 'Subscribers: %s' ) &&
+			hasTranslation( 'Via Email' ) &&
+			hasTranslation( 'Via WordPress.com' ) );
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
 	const recordSort = useRecordSort();
-	const filterOptions = useSubscribersFilterOptions();
+	const filterOptions = useSubscribersFilterOptions( newDropdownOptionsReady );
+	const selectedText = newDropdownOptionsReady
+		? translate( 'Subscribers: %s', {
+				args: getOptionLabel( filterOptions, filterOption ) || '',
+		  } )
+		: translate( 'Subscriber type: %s', {
+				args: getOptionLabel( filterOptions, filterOption ) || '',
+		  } );
 
 	return (
 		<div className="list-actions-bar">
@@ -48,9 +64,7 @@ const ListActionsBar = () => {
 					setFilterOption( selectedOption.value );
 					pageChangeCallback( 1 );
 				} }
-				selectedText={ translate( 'Subscriber type: %s', {
-					args: getOptionLabel( filterOptions, filterOption ) || '',
-				} ) }
+				selectedText={ selectedText }
 				initialSelected={ filterOption }
 			/>
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/78949.
Fixes https://github.com/Automattic/wp-calypso/issues/79296.

## Proposed Changes

* update the labels of the "Subscriber type" drop-down (with language fallback)
* fix alignment of the "Subscriber type" drop-down chevron

| Before | After |
|--------|--------|
| ![Markup on 2023-07-13 at 10:54:31](https://github.com/Automattic/wp-calypso/assets/25105483/97f5bde2-9d04-4a6a-ab29-8912914a91b8) | ![Markup on 2023-07-13 at 10:55:09](https://github.com/Automattic/wp-calypso/assets/25105483/4d2497b7-621b-434c-bad3-ad495c694567) |
| ![Markup on 2023-07-13 at 10:52:42](https://github.com/Automattic/wp-calypso/assets/25105483/42980d01-cff8-4b17-ba52-abe8ddc4ad78) | ![Markup on 2023-07-13 at 10:38:25](https://github.com/Automattic/wp-calypso/assets/25105483/680e71dc-3415-460c-9479-89b5a26acd82) | 

## Testing Instructions

1. Check out the branch PR and build the app.
2. Navigate to the Subscribers page at _Users → Subscribers_.
3. If the locale is set to English, the the new drop-down labels should be used. Otherwise, the old ones should be visible instead.
4. The chevron should be correctly aligned to the side of the drop-down.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
