### PR TITLE
Detect custom linker for Jetpack

### DIFF
--- a/client/lib/analytics/ga.js
+++ b/client/lib/analytics/ga.js
@@ -6,6 +6,8 @@ import {
 	fireGoogleAnalyticsEvent,
 } from 'calypso/lib/analytics/ad-tracking';
 import isAkismetCheckout from '../akismet/is-akismet-checkout';
+import isJetpackCheckout from '../jetpack/is-jetpack-checkout';
+import isJetpackCloud from '../jetpack/is-jetpack-cloud';
 import { mayWeTrackByTracker } from './tracker-buckets';
 
 const gaDebug = debug( 'calypso:analytics:ga' );
@@ -20,7 +22,7 @@ function initialize() {
 		};
 
 		// We enable custom cross-domain linking only for Akismet checkouts
-		if ( isAkismetCheckout() ) {
+		if ( isAkismetCheckout() || isJetpackCloud() || isJetpackCheckout() ) {
 			const queryParams = new URLSearchParams( location.search );
 			const gl = queryParams.get( '_gl' );
 

--- a/client/lib/analytics/ga.js
+++ b/client/lib/analytics/ga.js
@@ -21,7 +21,7 @@ function initialize() {
 			...getGoogleAnalyticsDefaultConfig(),
 		};
 
-		// We enable custom cross-domain linking only for Akismet checkouts
+		// We enable custom cross-domain linking for Akismet and Jetpack checkouts + Jetpack Cloud
 		if ( isAkismetCheckout() || isJetpackCloud() || isJetpackCheckout() ) {
 			const queryParams = new URLSearchParams( location.search );
 			const gl = queryParams.get( '_gl' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- D115915-code
- D115917-code
- https://github.com/Automattic/wp-calypso/pull/78183

## Proposed Changes

* Enable custom linker setup on jetpack cloud and checkout

## Testing Instructions

* Checkout the PR and run `yarn start-jetpack-cloud-p`
* Go to `http://jetpack.cloud.localhost:3001/pricing?flags=cookie-banner,ad-tracking`
* Accept cookie banner if necessary (EU region)
* Enable marketing debug logs (`localStorage.setItem( 'debug', 'calypso:analytics:*' );` in console)
* Open link: http://jetpack.cloud.localhost:3001/pricing?flags=ad-tracking&_gl_cid=123456789&_gl_sid=987654321
* Ensure that `calypso:analytics:ga parameters` object has correct `client_id` (_gl_cid) and `session_id` (_gl_sid)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?