### PR TITLE
Bulk domain transfer: Update/add copies 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
@@ -77,10 +77,10 @@ export const CompleteDomainsTransferred = ( {
 						</a>
 					</div>
 					<div>
-						<h2> { __( 'Move your sites too' ) }</h2>
+						<h2> { __( 'Consider moving your sites too?' ) }</h2>
 						<p>
 							{ __(
-								'Why stop at the domain? Check out our step-by-step guides to bring your existing site to WordPress.com.'
+								'You can find step-by-step guides below that will help you move your site to WordPress.com'
 							) }
 						</p>
 						<a

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -69,11 +69,20 @@ const Complete: Step = function Complete( { flow } ) {
 							'Congrats on your domain transfers!',
 							newlyTransferredDomains?.length || storedDomainsAmount
 						) }
-						subHeaderText={ _n(
-							"We've got it from here! We'll let you know when your newly transferred domain is ready to use.",
-							"We've got it from here! We'll let you know when your newly transferred domains are ready to use.",
-							newlyTransferredDomains?.length || storedDomainsAmount
-						) }
+						subHeaderText={
+							<>
+								<span>
+									{ _n(
+										'Hold tight as we complete the set up of your newly transferred domain.',
+										'Hold tight as we complete the set up of your newly transferred domains',
+										newlyTransferredDomains?.length || storedDomainsAmount
+									) }
+								</span>
+								<span className="formatted-header-subtitle__bold">
+									{ __( 'Domain transfers may take up to 5-10 days.' ) }
+								</span>
+							</>
+						}
 						align="center"
 						children={
 							<div className="domain-header-buttons">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -73,8 +73,8 @@ const Complete: Step = function Complete( { flow } ) {
 							<>
 								<span>
 									{ _n(
-										'Hold tight as we complete the set up of your newly transferred domain.',
-										'Hold tight as we complete the set up of your newly transferred domains',
+										"We got it from here! We'll let you know when your newly transferred domain is ready to use!",
+										"We got it from here! We'll let you know when your newly transferred domains are ready to use!",
 										newlyTransferredDomains?.length || storedDomainsAmount
 									) }
 								</span>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/styles.scss
@@ -21,6 +21,11 @@
 			}
 			.formatted-header__subtitle {
 				text-align: center;
+
+				.formatted-header-subtitle__bold {
+					font-weight: 600;
+					display: block;
+				}
 			}
 			@media ( max-width: $break-medium ) {
 				text-align: left;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -25,7 +25,7 @@ const Intro: Step = function Intro( { navigation, flow } ) {
 			formattedHeader={
 				<FormattedHeader
 					id="domain-transfer-header"
-					headerText={ __( 'Add unlocked domains' ) }
+					headerText={ __( 'Add your unlocked domains' ) }
 					subHeaderText={ __(
 						'Next, add your domain name and authorization code below, you can transfer as many domains as you like.'
 					) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -26,7 +26,10 @@ const Intro: Step = function Intro( { navigation, flow } ) {
 				<FormattedHeader
 					id="domain-transfer-header"
 					headerText={ __( 'Add unlocked domains' ) }
-					align="left"
+					subHeaderText={ __(
+						'Next, add your domain name and authorization code below, you can transfer as many domains as you like.'
+					) }
+					align="center"
 				/>
 			}
 			stepContent={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -25,11 +25,8 @@ const Intro: Step = function Intro( { navigation, flow } ) {
 			formattedHeader={
 				<FormattedHeader
 					id="domain-transfer-header"
-					headerText={ __( 'Add your unlocked domains' ) }
-					subHeaderText={ __(
-						'Next, add your domain name and authorization code below, you can transfer as many domains as you like.'
-					) }
-					align="center"
+					headerText={ __( 'Add unlocked domains' ) }
+					align="left"
 				/>
 			}
 			stepContent={


### PR DESCRIPTION
## Proposed Changes

Update copies to match [design](mbuq4o5QxohQpBU9YoexXo-fi-298%3A7816) 

<img width="953" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/cf0991ae-f43f-4b95-8731-ec4508c0d8ff">


## Testing Instructions

- Pull and run this branch or use calypso live links
- Navigate to `/setup/domain-transfer/complete`
- Compare the copies with the ones from the design
