### PR TITLE
Domain-only user: Fix unusable pages for domain-only users with pending transfers.

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -55,7 +55,6 @@ import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selec
 import { successNotice, warningNotice, errorNotice } from 'calypso/state/notices/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { hasReceivedRemotePreferences, getPreference } from 'calypso/state/preferences/selectors';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getP2HubBlogId from 'calypso/state/selectors/get-p2-hub-blog-id';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
@@ -340,12 +339,6 @@ function onSelectedSiteAvailable( context ) {
 			context.params
 		)
 	) {
-		if ( ! primaryDomain ) {
-			const currentRoute = getCurrentRoute( state );
-			return page.redirect(
-				domainManagementEdit( selectedSite.slug, selectedSite.domain, currentRoute )
-			);
-		}
 		renderSelectedSiteIsDomainOnly( context, selectedSite );
 		return false;
 	}

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -12,14 +12,12 @@ import { composeHandlers } from 'calypso/controller/shared';
 import { render } from 'calypso/controller/web-util';
 import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { navigate } from 'calypso/lib/navigate';
 import { onboardingUrl } from 'calypso/lib/paths';
 import { addQueryArgs, getSiteFragment, sectionify, trailingslashit } from 'calypso/lib/route';
 import { withoutHttp } from 'calypso/lib/url';
-import DomainOnly from 'calypso/my-sites/domains/domain-management/list/domain-only';
 import {
 	domainManagementContactsPrivacy,
 	domainManagementDns,
@@ -167,20 +165,6 @@ export function renderNoVisibleSites( context ) {
 
 	makeLayout( context, noop );
 	clientRender( context );
-}
-
-function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
-	reactContext.primary = (
-		<>
-			<PageViewTracker path="/view/:site" title="Domain Only" />
-			<DomainOnly siteId={ selectedSite.ID } hasNotice={ false } />
-		</>
-	);
-
-	reactContext.secondary = createNavigation( reactContext );
-
-	makeLayout( reactContext, noop );
-	clientRender( reactContext );
 }
 
 function renderSelectedSiteIsDIFMLiteInProgress( reactContext, selectedSite ) {
@@ -345,7 +329,7 @@ function onSelectedSiteAvailable( context ) {
 			context.params
 		)
 	) {
-		renderSelectedSiteIsDomainOnly( context, selectedSite );
+		page.redirect( domainManagementRoot() );
 		return false;
 	}
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -55,6 +55,7 @@ import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selec
 import { successNotice, warningNotice, errorNotice } from 'calypso/state/notices/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { hasReceivedRemotePreferences, getPreference } from 'calypso/state/preferences/selectors';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getP2HubBlogId from 'calypso/state/selectors/get-p2-hub-blog-id';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
@@ -339,6 +340,12 @@ function onSelectedSiteAvailable( context ) {
 			context.params
 		)
 	) {
+		if ( ! primaryDomain ) {
+			const currentRoute = getCurrentRoute( state );
+			return page.redirect(
+				domainManagementEdit( selectedSite.slug, selectedSite.domain, currentRoute )
+			);
+		}
 		renderSelectedSiteIsDomainOnly( context, selectedSite );
 		return false;
 	}

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -34,6 +34,7 @@ import {
 	domainManagementDnsAddRecord,
 	domainManagementDnsEditRecord,
 	domainAddNew,
+	domainUseMyDomain,
 } from 'calypso/my-sites/domains/paths';
 import {
 	emailManagement,
@@ -55,7 +56,6 @@ import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selec
 import { successNotice, warningNotice, errorNotice } from 'calypso/state/notices/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { hasReceivedRemotePreferences, getPreference } from 'calypso/state/preferences/selectors';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getP2HubBlogId from 'calypso/state/selectors/get-p2-hub-blog-id';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
@@ -256,8 +256,13 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		`/purchases/billing-history/${ slug }`,
 		`/purchases/payment-methods/${ slug }`,
 		`/purchases/subscriptions/${ slug }`,
-		// Any page under `/domsina/manage/all` should be accessible in domain-only sites now that we allow multiple domains in them
+		// Any page under `/domains/manage/all` should be accessible in domain-only sites now that we allow multiple domains in them
 		'/domains/manage/all/',
+		// Add A Domain > Search for a domain
+		domainAddNew( slug ),
+		// Add A Domain > Use a domain I own
+		// Start Transfer button
+		domainUseMyDomain( slug ),
 	];
 
 	if ( some( startsWithPaths, ( startsWithPath ) => startsWith( path, startsWithPath ) ) ) {
@@ -340,12 +345,6 @@ function onSelectedSiteAvailable( context ) {
 			context.params
 		)
 	) {
-		if ( ! primaryDomain ) {
-			const currentRoute = getCurrentRoute( state );
-			return page.redirect(
-				domainManagementEdit( selectedSite.slug, selectedSite.domain, currentRoute )
-			);
-		}
 		renderSelectedSiteIsDomainOnly( context, selectedSite );
 		return false;
 	}

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -698,16 +698,12 @@ class AllDomains extends Component {
 			: [
 					this.maybeRenderSeeAllDomainsLink(),
 					this.renderDomainTableFilterButton(),
-					<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
-					<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
+					<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions allDomainsList />,
 			  ];
 
 		const mobileButtons = hasNoDomains
 			? []
-			: [
-					<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions />,
-					<OptionsDomainButton key="breadcrumb_button_3" ellipsisButton borderless />,
-			  ];
+			: [ <OptionsDomainButton key="breadcrumb_button_1" specificSiteActions allDomainsList /> ];
 
 		return <DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ mobileButtons } />;
 	}

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -13,7 +13,6 @@ import { emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 import './domain-only.scss';
@@ -98,7 +97,6 @@ export default connect(
 			currentRoute: getCurrentRoute( state ),
 			slug: getSiteSlug( state, ownProps.siteId ),
 			primaryDomain: getPrimaryDomainBySiteId( state, ownProps.siteId ),
-			domains: getDomainsBySiteId( state, ownProps.siteId ),
 		};
 	},
 	{ recordTracks: recordTracksEvent }

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -45,7 +45,7 @@ const DomainOnly = ( {
 						args: { domainName: domain.name },
 					} ) }
 					action={ translate( 'Manage domain' ) }
-					actionURL={ domainManagementEdit( slug, domain.name, currentRoute ) }
+					actionURL="/domains/manage"
 					illustration={ Illustration }
 				></EmptyContent>
 			</div>

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -1,9 +1,10 @@
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Illustration from 'calypso/assets/images/domains/domain.svg';
-import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+// import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import EmptyContent from 'calypso/components/empty-content';
 import { canCurrentUserCreateSiteFromDomainOnly } from 'calypso/lib/domains';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
@@ -13,7 +14,7 @@ import { emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, getSiteDomain } from 'calypso/state/sites/selectors';
 
 import './domain-only.scss';
 
@@ -24,16 +25,23 @@ const DomainOnly = ( {
 	recordTracks,
 	siteId,
 	slug,
+	domain,
 	translate,
 } ) => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
+
 	if ( ! primaryDomain ) {
-		return (
-			<div>
-				<QuerySiteDomains siteId={ siteId } />
-				<EmptyContent className="domain-only-site__placeholder" illustration={ Illustration } />
-			</div>
-		);
+		return page.redirect( domainManagementEdit( slug, domain, currentRoute ) );
+
+		// Redirect to manage domain page as the placeholder needs fixing.
+		// Context: p1689208002859209-slack-C05CT832K2T
+		//
+		// return (
+		// 	<div>
+		// 		<QuerySiteDomains siteId={ siteId } />
+		// 		<EmptyContent className="domain-only-site__placeholder" illustration={ Illustration } />
+		// 	</div>
+		// );
 	}
 
 	const hasEmailWithUs = hasGSuiteWithUs( primaryDomain ) || hasTitanMailWithUs( primaryDomain );
@@ -97,6 +105,7 @@ export default connect(
 		return {
 			currentRoute: getCurrentRoute( state ),
 			slug: getSiteSlug( state, ownProps.siteId ),
+			domain: getSiteDomain( state, ownProps.siteId ),
 			primaryDomain: getPrimaryDomainBySiteId( state, ownProps.siteId ),
 		};
 	},

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -6,7 +6,6 @@ import Illustration from 'calypso/assets/images/domains/domain.svg';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import EmptyContent from 'calypso/components/empty-content';
 import { canCurrentUserCreateSiteFromDomainOnly } from 'calypso/lib/domains';
-import { transferStatus, type as domainTypes } from 'calypso/lib/domains/constants';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import { domainManagementEdit, createSiteFromDomainOnly } from 'calypso/my-sites/domains/paths';
@@ -22,36 +21,12 @@ import './domain-only.scss';
 const DomainOnly = ( {
 	currentRoute,
 	primaryDomain,
-	domains,
 	hasNotice,
 	recordTracks,
 	siteId,
 	slug,
 	translate,
 } ) => {
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	const domain = domains.find( ( item ) => item.name === slug );
-
-	if (
-		! primaryDomain &&
-		domain &&
-		domain.type === domainTypes.TRANSFER &&
-		domain.transferStatus !== transferStatus.COMPLETED
-	) {
-		return (
-			<div>
-				<EmptyContent
-					title={ translate( '%(domainName)s is not ready yet.', {
-						args: { domainName: domain.name },
-					} ) }
-					action={ translate( 'Manage domain' ) }
-					actionURL="/domains/manage"
-					illustration={ Illustration }
-				></EmptyContent>
-			</div>
-		);
-	}
-
 	if ( ! primaryDomain ) {
 		return (
 			<div>

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -1,10 +1,9 @@
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import page from 'page';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Illustration from 'calypso/assets/images/domains/domain.svg';
-// import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import EmptyContent from 'calypso/components/empty-content';
 import { canCurrentUserCreateSiteFromDomainOnly } from 'calypso/lib/domains';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
@@ -14,7 +13,7 @@ import { emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
-import { getSiteSlug, getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 import './domain-only.scss';
 
@@ -25,23 +24,16 @@ const DomainOnly = ( {
 	recordTracks,
 	siteId,
 	slug,
-	domain,
 	translate,
 } ) => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-
 	if ( ! primaryDomain ) {
-		return page.redirect( domainManagementEdit( slug, domain, currentRoute ) );
-
-		// Redirect to manage domain page as the placeholder needs fixing.
-		// Context: p1689208002859209-slack-C05CT832K2T
-		//
-		// return (
-		// 	<div>
-		// 		<QuerySiteDomains siteId={ siteId } />
-		// 		<EmptyContent className="domain-only-site__placeholder" illustration={ Illustration } />
-		// 	</div>
-		// );
+		return (
+			<div>
+				<QuerySiteDomains siteId={ siteId } />
+				<EmptyContent className="domain-only-site__placeholder" illustration={ Illustration } />
+			</div>
+		);
 	}
 
 	const hasEmailWithUs = hasGSuiteWithUs( primaryDomain ) || hasTitanMailWithUs( primaryDomain );
@@ -105,7 +97,6 @@ export default connect(
 		return {
 			currentRoute: getCurrentRoute( state ),
 			slug: getSiteSlug( state, ownProps.siteId ),
-			domain: getSiteDomain( state, ownProps.siteId ),
 			primaryDomain: getPrimaryDomainBySiteId( state, ownProps.siteId ),
 		};
 	},

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -104,7 +104,7 @@ class DomainRow extends PureComponent {
 		return (
 			<div className="domain-row__site-cell">
 				<Button href={ domainManagementList( site?.slug, currentRoute ) } plain>
-					{ site?.title || site?.slug }
+					{ ! site.options?.is_domain_only ? site?.title || site?.slug : '' }
 				</Button>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/list/helpers.ts
+++ b/client/my-sites/domains/domain-management/list/helpers.ts
@@ -1,3 +1,4 @@
+import { type as domainTypes } from 'calypso/lib/domains/constants';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import type { SiteDetails } from '@automattic/data-stores';
 type FilterDomainsByOwnerType = (
@@ -23,6 +24,6 @@ export const filterDomainsByOwner: FilterDomainsByOwnerType = ( domains, filter 
 
 export const filterDomainOnlyDomains: FilterDomainsDomainOnlyType = ( domains, sites ) => {
 	return domains.filter( ( domain: ResponseDomain ) => {
-		return sites[ domain.blogId ].options?.is_domain_only;
+		return domain.type === domainTypes.REGISTERED && sites[ domain.blogId ].options?.is_domain_only;
 	} );
 };

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -23,12 +23,14 @@ class AddDomainButton extends Component {
 		specificSiteActions: PropTypes.bool,
 		ellipsisButton: PropTypes.bool,
 		borderless: PropTypes.bool,
+		allDomainsList: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		specificSiteActions: false,
 		ellipsisButton: false,
 		borderless: false,
+		allDomainsList: false,
 	};
 
 	state = {
@@ -60,7 +62,27 @@ class AddDomainButton extends Component {
 	};
 
 	renderOptions = () => {
-		const { selectedSiteSlug, specificSiteActions, translate } = this.props;
+		const { allDomainsList, selectedSiteSlug, specificSiteActions, translate } = this.props;
+
+		if ( allDomainsList ) {
+			return (
+				<Fragment>
+					<PopoverMenuItem icon="plus" href="/new" onClick={ this.trackMenuClick }>
+						{ translate( 'Add a domain to a new site' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem icon="domains" href="/start/domain" onClick={ this.trackMenuClick }>
+						{ translate( 'Add a domain without a site' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem
+						icon="domains"
+						href="/setup/domain-transfer"
+						onClick={ this.trackMenuClick }
+					>
+						{ translate( 'Transfer domains' ) }
+					</PopoverMenuItem>
+				</Fragment>
+			);
+		}
 
 		if ( specificSiteActions ) {
 			const useYourDomainUrl = domainUseMyDomain( this.props.selectedSiteSlug );

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -43,7 +43,6 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { setPrimaryDomain } from 'calypso/state/sites/domains/actions';
 import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
-import DomainOnly from './domain-only';
 import DomainsTable from './domains-table';
 import DomainsTableFilterButton from './domains-table-filter-button';
 import { filterDomainsByOwner } from './helpers';
@@ -344,15 +343,8 @@ export class SiteDomains extends Component {
 
 		if ( this.props.isDomainOnly ) {
 			if ( ! this.props.renderAllSites ) {
-				return (
-					<Main>
-						<DocumentHead title={ this.props.translate( 'Settings' ) } />
-						<DomainOnly
-							hasNotice={ this.isFreshDomainOnlyRegistration() }
-							siteId={ this.props.selectedSite.ID }
-						/>
-					</Main>
-				);
+				page.redirect( domainManagementRoot() );
+				return null;
 			}
 
 			if ( filterOutWpcomDomains( this.props.domains ).length === 0 ) {

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -28,10 +28,11 @@ function registerStandardDomainManagementPages( pathFunction, controller ) {
 
 function getCommonHandlers( {
 	noSitePath = paths.domainManagementRoot(),
+	noSiteSelection = false,
 	warnIfJetpack = true,
 } = {} ) {
 	const handlers = [
-		siteSelection,
+		...( noSiteSelection ? [] : [ siteSelection ] ),
 		navigation,
 		wpForTeamsGeneralNotSupportedRedirect,
 		stagingSiteNotSupportedRedirect,
@@ -140,7 +141,7 @@ export default function () {
 
 	page(
 		paths.domainManagementRoot(),
-		...getCommonHandlers( { noSitePath: false } ),
+		...getCommonHandlers( { noSitePath: false, noSiteSelection: true } ),
 		domainManagementController.domainManagementListAllSites,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3019
Related to pdtkmj-1Cx-p2#comment-2944
More info on Slack thread p1689208002859209-slack-C05CT832K2T

## Proposed Changes
* Fix unable to access `/domains/manage`.
* ~~Fix broken "Add a Domain > Search for a domain" at `/domains/add/<slug>`.~~ I (@hambai) removed this one
* ~~Fix broken "Add a Domain > Use a domain I own" at `/domains/add/use-my-domain/<slug>`.~~  I (@hambai) removed this one too
* ~~Introduces a new placeholder page that replaces the old placeholder page where the loading indicator keeps spinning forever. ~~  I (@hambai) removed this one too - we should get rid of the placeholder page as it doesn't show anything useful
  * This fixes the broken `/view/<slug>` and `/domain/manage/<slug>` page.

In addition to the above I (@hambai) also made the following changes:

* I've added redirect from the placeholder view to the all domains view
* I've updated the "Add a domain" button in the all domains list to show links to relevant flows (that would be /new, /start/domain and /setup/domain-transfer) and got rid of the extra ... button as there's nothing else to show
* Do not render the site column from the all domains list view for domain-only sites
* Do not render the upsell in the all domains list if there are only transfers in the list
 
## Known Issue

* I am unable to fix the Back button navigation quirkiness on various pages in this PR. Let's get this out and fix it in another PR. Or if someone could take over and fix before I get to it. (see attached video for example).
* Sometimes there's a "blinking" when clicking on the menus as we're rendering something but then redirecting to a different page. Still not sure exactly when it happens

## Dependencies

This PR would work after D116105-code is merged. All accounts and/or domain-only sites that were created before that might be in a weird state

## Testing Instructions

**Setup**

Quick way:
1. You can use the following test user mentioned in the Slack thread. p1689234822952489/1689208002.859209-slack-C05CT832K2T

Slow way (if you have domains to test with):
1. In an incognito window, go to https://wordpress.com/setup/domain-transfer/intro.
2. Create a new user during transfer.
3. Transfer one or multiple domains.

**Test**
1. Spin up your local calypso (or via the Calypso live link).
2. Test all the domain navigation links (like those mentioned in the PR description above).


## Screenshots

https://github.com/Automattic/wp-calypso/assets/1287077/ab04a787-bdcf-450a-a3df-9d43b7bbd964


![2023-07-13_22-18-12](https://github.com/Automattic/wp-calypso/assets/1287077/6a764732-3285-47f9-bbd2-473f498225f8)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?