### PR TITLE
Subscribers Page: Add the `README.md` file

### DIFF
--- a/client/my-sites/subscribers/README.md
+++ b/client/my-sites/subscribers/README.md
@@ -12,8 +12,8 @@ The section displays all the users that subscribed to a certain site, including:
 - `index.js` provides all the routes for this section
 - `controller.js` decides which component to render
 - `main.js` includes the main component with the list of subscribers
-- `subscriber-details-page.tsx` is the component that displays page with individual subscribers details.
+- `subscriber-details-page.tsx` displays page with individual subscribers details
 
 ## Data
 
-The data are retrieved and mutated using React Query. Please review the `/queries` and `/mutations` folders for details.
+The data are retrieved and mutated using React Query. Please review the `/queries` and `/mutations` folders for details (e.g. which endpoints are used).

--- a/client/my-sites/subscribers/README.md
+++ b/client/my-sites/subscribers/README.md
@@ -1,0 +1,19 @@
+# Subscribers
+
+The contents of this folder handle the `/subscribers` section of Calypso.
+
+The section displays all the users that subscribed to a certain site, including:
+
+- **Email subscribers** (users that used their email address to subscribe and don't have a WordPress.com account)
+- **WordPress.com subscribers** (users that used their WordPress.com account to subscribe)
+
+## Main files
+
+- `index.js` provides all the routes for this section
+- `controller.js` decides which component to render
+- `main.js` includes the main component with the list of subscribers
+- `subscriber-details-page.tsx` is the component that displays page with individual subscribers details.
+
+## Data
+
+The data are retrieved and mutated using React Query. Please review the `/queries` and `/mutations` folders for details.


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/77836.

## Proposed Changes

* add the `README.md` file

## Testing Instructions

There's nothing functional to test. Please review the file for typos or missing information that you think could be useful to share and are not likely to be outdated quickly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
