### PR TITLE
Theme Showcase: Rename Paid themes to Marketplace themes

### DIFF
--- a/client/components/theme-type-badge/index.tsx
+++ b/client/components/theme-type-badge/index.tsx
@@ -83,8 +83,8 @@ const ThemeTypeBadge = ( {
 			<PremiumBadge
 				{ ...badgeContentProps }
 				className={ classNames( badgeContentProps.className, 'is-marketplace' ) }
-				labelText={ translate( 'Paid', {
-					context: 'Refers to paid service, such as paid theme',
+				labelText={ translate( 'Marketplace', {
+					context: 'This theme is developed and supported by a third-party creator',
 					textOnly: true,
 				} ) }
 			/>

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -111,7 +111,10 @@ const ThemeTypeBadgeTooltip = ( {
 				textOnly: true,
 			} ),
 			[ WOOCOMMERCE_THEME ]: translate( 'WooCommerce theme' ),
-			[ MARKETPLACE_THEME ]: translate( 'Paid theme' ),
+			[ MARKETPLACE_THEME ]: translate( 'Marketplace theme', {
+				context: 'This theme is developed and supported by a third-party creator',
+				textOnly: true,
+			} ),
 		} as { [ key: string ]: string };
 
 		if ( ! ( type in headers ) ) {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -195,8 +195,8 @@ class ThemeShowcase extends Component {
 
 		tiers.push( {
 			value: 'marketplace',
-			label: this.props.translate( 'Paid', {
-				context: 'Refers to paid service, such as paid theme',
+			label: this.props.translate( 'Marketplace', {
+				context: 'This theme is developed and supported by a third-party creator',
 			} ),
 		} );
 


### PR DESCRIPTION
## Proposed Changes

As discussed in p1689200222553109-slack-C048CUFRGFQ, the term `Marketplace` seems to better convey themes from third-party creators. Thus, we are updating the copy from `Paid` to `Marketplace` in the following three places:

| Before | After |
| --- | --- |
| ![Screenshot 2023-07-13 at 6 00 55 PM](https://github.com/Automattic/wp-calypso/assets/797888/2f137bca-c3f3-4729-96ce-7bbf1f3a6f63) |  ![Screenshot 2023-07-13 at 6 01 45 PM](https://github.com/Automattic/wp-calypso/assets/797888/06e175db-8490-4688-a38b-8d0898968d72) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/theme`.
* Ensure that the pricing filter UI, the theme type badge, and the theme type badge's tooltip are all updated as shown above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?