### PR TITLE
Subscription management: Add text input field to AddSitesForm component & add URL validation

### DIFF
--- a/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
+++ b/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
@@ -17,7 +17,7 @@ const AddSitesButton = () => {
 		<>
 			<Button
 				primary
-				className="subscriptions-add-sites-button"
+				className="subscriptions-add-sites__button"
 				onClick={ () => setIsAddSitesModalVisible( true ) }
 			>
 				{ translate( 'Add sites' ) }

--- a/client/landing/subscriptions/components/add-sites-button/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-button/styles.scss
@@ -1,3 +1,3 @@
-.subscriptions-add-sites-button {
+.subscriptions-add-sites__button {
 	margin-top: 12px;
 }

--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -1,3 +1,11 @@
+import { FormInputValidation } from '@automattic/components';
+import { TextControl } from '@wordpress/components';
+import { check, Icon } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
+import './styles.scss';
+
 type AddSitesFormProps = {
 	recordTracksEvent: ( eventName: string, eventProperties?: Record< string, unknown > ) => void;
 	onClose: () => void;
@@ -6,7 +14,67 @@ type AddSitesFormProps = {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const AddSitesForm = ( { recordTracksEvent, onClose, onAddFinished }: AddSitesFormProps ) => {
-	return <div>Skeleton</div>;
+	const translate = useTranslate();
+	const [ inputValue, setInputValue ] = useState( '' );
+	const [ inputFieldError, setInputFieldError ] = useState< string | null >( null );
+	const [ isValidUrl, setIsValidUrl ] = useState( false );
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [ isUploading, setIsUploading ] = useState( false );
+
+	const handleInvalidUrl = useCallback(
+		( showError: boolean ) => {
+			setIsValidUrl( false );
+			if ( showError ) {
+				setInputFieldError( translate( 'Please enter a valid URL' ) );
+			}
+		},
+		[ translate ]
+	);
+
+	const handleValidUrl = useCallback( () => {
+		setIsValidUrl( true );
+		setInputFieldError( null );
+	}, [] );
+
+	const validateInputValue = useCallback(
+		( url: string, showError = false ) => {
+			if ( url.length === 0 || ! CAPTURE_URL_RGX.test( url ) ) {
+				handleInvalidUrl( showError );
+			} else {
+				handleValidUrl();
+			}
+		},
+		[ translate, handleInvalidUrl, handleValidUrl ]
+	);
+
+	const onTextFieldChange = useCallback(
+		( value: string ) => {
+			setInputValue( value );
+			validateInputValue( value );
+		},
+		[ inputFieldError, validateInputValue ]
+	);
+
+	return (
+		<div className="subscriptions-add-sites__form--container">
+			<label className="subscriptions-add-sites__form-label-url">
+				<strong>{ translate( 'Address' ) }</strong>
+			</label>
+
+			<TextControl
+				className={ inputFieldError ? 'is-error' : '' }
+				disabled={ isUploading }
+				placeholder={ translate( 'https://www.site.com' ) }
+				value={ inputValue }
+				type="url"
+				onChange={ onTextFieldChange }
+				help={ isValidUrl ? <Icon icon={ check } /> : undefined }
+				onBlur={ () => validateInputValue( inputValue, true ) }
+			/>
+
+			{ inputFieldError ? <FormInputValidation isError={ true } text={ inputFieldError } /> : null }
+		</div>
+	);
 };
 
 export default AddSitesForm;

--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -1,6 +1,7 @@
 import { FormInputValidation } from '@automattic/components';
 import { TextControl } from '@wordpress/components';
 import { check, Icon } from '@wordpress/icons';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
@@ -21,30 +22,24 @@ const AddSitesForm = ( { recordTracksEvent, onClose, onAddFinished }: AddSitesFo
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [ isUploading, setIsUploading ] = useState( false );
 
-	const handleInvalidUrl = useCallback(
-		( showError: boolean ) => {
-			setIsValidUrl( false );
-			if ( showError ) {
-				setInputFieldError( translate( 'Please enter a valid URL' ) );
+	const validateInputValue = useCallback(
+		( url: string, showError = false ) => {
+			if ( url.length === 0 ) {
+				setIsValidUrl( false );
+				setInputFieldError( null );
+				return;
+			}
+			if ( ! CAPTURE_URL_RGX.test( url ) ) {
+				setIsValidUrl( false );
+				if ( showError ) {
+					setInputFieldError( translate( 'Please enter a valid URL' ) );
+				}
+			} else {
+				setInputFieldError( null );
+				setIsValidUrl( true );
 			}
 		},
 		[ translate ]
-	);
-
-	const handleValidUrl = useCallback( () => {
-		setIsValidUrl( true );
-		setInputFieldError( null );
-	}, [] );
-
-	const validateInputValue = useCallback(
-		( url: string, showError = false ) => {
-			if ( url.length === 0 || ! CAPTURE_URL_RGX.test( url ) ) {
-				handleInvalidUrl( showError );
-			} else {
-				handleValidUrl();
-			}
-		},
-		[ translate, handleInvalidUrl, handleValidUrl ]
 	);
 
 	const onTextFieldChange = useCallback(
@@ -62,7 +57,10 @@ const AddSitesForm = ( { recordTracksEvent, onClose, onAddFinished }: AddSitesFo
 			</label>
 
 			<TextControl
-				className={ inputFieldError ? 'is-error' : '' }
+				className={ classnames(
+					'subscriptions-add-sites__form-input',
+					inputFieldError ? 'is-error' : ''
+				) }
 				disabled={ isUploading }
 				placeholder={ translate( 'https://www.site.com' ) }
 				value={ inputValue }

--- a/client/landing/subscriptions/components/add-sites-form/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-form/styles.scss
@@ -1,0 +1,59 @@
+.subscriptions-add-sites__form--container {
+	label {
+		display: block;
+		width: 100%;
+		font-size: rem(14px);
+		line-height: rem(20px);
+		font-weight: 500;
+	}
+
+	.components-base-control.is-error input {
+		border-color: var(--color-error);
+
+		&:focus {
+			box-shadow: 0 0 0 2px var(--color-error-10);
+		}
+	}
+
+	.components-base-control__field {
+		margin: rem(6px) auto;
+	}
+
+	.components-text-control__input {
+		border-color: var(--studio-gray-10);
+		border-radius: 4px;
+		box-sizing: border-box;
+		font-size: 0.875rem;
+		padding: rem(10px) rem(16px);
+		/* We need to allow space for the SVG checkmark */
+		padding-right: calc(0.5rem + 24px);
+
+		&::placeholder {
+			color: var(--studio-gray-20);
+		}
+
+		&[disabled] {
+			background: var(--studio-gray-5);
+		}
+
+		&:focus {
+			border-color: var(--studio-gray-10);
+			box-shadow: 0 0 0 2px var(--color-primary-10);
+			outline: none;
+		}
+	}
+
+	.components-base-control {
+		position: relative;
+	}
+
+	.components-base-control__help {
+		position: absolute;
+		top: 0;
+		right: 0.5rem;
+
+		svg {
+			fill: var(--color-success-50);
+		}
+	}
+}

--- a/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, fireEvent, screen } from '@testing-library/react';
+import AddSitesForm from '../add-sites-form';
+
+describe( 'AddSitesForm', () => {
+	const mockProps = {
+		recordTracksEvent: jest.fn(),
+		onClose: jest.fn(),
+		onAddFinished: jest.fn(),
+	};
+
+	test( 'displays an error message with invalid URL', () => {
+		render( <AddSitesForm { ...mockProps } /> );
+		const input = document.querySelector( '.subscriptions-add-sites__form-input input' );
+
+		fireEvent.change( input, {
+			target: { value: 'not-a-url' },
+		} );
+
+		fireEvent.blur( input );
+
+		expect( screen.getByText( 'Please enter a valid URL' ) ).toBeInTheDocument();
+	} );
+
+	test( 'does not display an error message with valid URL', () => {
+		render( <AddSitesForm { ...mockProps } /> );
+		const input = document.querySelector( '.subscriptions-add-sites__form-input input' );
+
+		fireEvent.change( input, {
+			target: { value: 'https://www.valid-url.com' },
+		} );
+
+		fireEvent.blur( input );
+
+		expect( screen.queryByText( 'Please enter a valid URL' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'does not display an error message when input field is empty and blurred', () => {
+		render( <AddSitesForm { ...mockProps } /> );
+		const input = document.querySelector( '.subscriptions-add-sites__form-input input' );
+
+		fireEvent.change( input, {
+			target: { value: '' },
+		} );
+
+		fireEvent.blur( input );
+
+		expect( screen.queryByText( 'Please enter a valid URL' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'displays an SVG when a valid URL is entered', () => {
+		render( <AddSitesForm { ...mockProps } /> );
+		const input = document.querySelector( '.subscriptions-add-sites__form-input input' );
+
+		fireEvent.change( input, {
+			target: { value: 'https://www.valid-url.com' },
+		} );
+
+		fireEvent.blur( input );
+
+		const checkIcon = document.querySelector( '.components-base-control__help' );
+		expect( checkIcon ).toBeInTheDocument();
+		expect( checkIcon.innerHTML ).toContain( 'svg' );
+	} );
+} );


### PR DESCRIPTION
Closes #[79232](https://github.com/Automattic/wp-calypso/issues/79232)

## Proposed Changes
This pull request introduces a new URL input field to the `AddSitesForm` component. The purpose is to allow users to add new sites to their subscriptions by inputting the site URL.

The URL input field comes with integrated validation logic, giving users real-time feedback about the validity of the URL they've entered. The validation checks if the input is an empty string or a non-matching value against the `CAPTURE_URL_RGX` regular expression.

In the case of an invalid URL (either an empty string or a mismatch against the regex), an error message prompts the user to enter a valid URL. On the other hand, when the URL input is valid, a check icon indicates the acceptable status of the input.
Furthermore, this field becomes disabled during the uploading state, prohibiting users from modifying the URL during the process.

The decision to not put the URL input field into a separate component was made to maintain simplicity, as this field is particular to the `AddSitesForm` component. Extracting it to a standalone component could have led to unnecessary complexity without providing significant benefits, given that it's not anticipated to be reused elsewhere in the application at this time.

## Testing Instructions

1. Checkout this branch & start Calypso
2. Run the tests: `yarn test-client client/landing/subscriptions/components/add-sites-form`
3. Visit http://calypso.localhost:3000/read/subscriptions & click the Add sites button
4. Test the following scenarios:
- Focus the input and then click somewhere else. No validation error should be thrown.
-  Input a string that is not a valid URL (e.g., not-a-url). Once you lose focus on the field, you should see a validation error message that reads 'Please enter a valid URL'
- Input a valid URL (e.g., https://www.site.com). The error message (if previously visible) should disappear, and you should see a check icon instead indicating the internet address is valid.
- Ensure the field is not editable when isUploading state is true (change this in the code)
5. Verify that the Figma design is matched: inDLaEQV8jJ21O4WXawIsJ-fi-3850_47488


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?