### PR TITLE
Social: Show link preview even if account is not connected.

### DIFF
--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -96,7 +96,15 @@ class SharingPreviewPane extends PureComponent {
 		const siteDomain = get( site, 'domain', '' );
 		const imageUrl = getPostImage( post );
 
-		const postProps = {
+		const connection = find( connections, { service: selectedService } ) ?? {};
+
+		/**
+		 * Props to pass to the preview component. Will be populated with the connection
+		 * specific data if the selected service is connected.
+		 *
+		 * @type {Object}
+		 */
+		const previewProps = {
 			articleUrl,
 			articleTitle,
 			articleContent,
@@ -107,35 +115,12 @@ class SharingPreviewPane extends PureComponent {
 			siteDomain,
 			siteIcon,
 			siteName,
+			hidePostPreview: ! connection.ID,
+			externalDisplay: connection.external_display,
+			externalName: connection.external_name,
+			externalProfileURL: connection.external_profile_URL,
+			externalProfilePicture: connection.external_profile_picture,
 		};
-
-		/**
-		 * Props to pass to the preview component. Will be populated with the connection
-		 * specific data if the selected service is connected.
-		 *
-		 * @type {Object}
-		 */
-		const previewProps = { ...postProps };
-
-		const connection = find( connections, { service: selectedService } );
-
-		if ( ! connection ) {
-			previewProps.hidePostPreview = true;
-		} else {
-			const {
-				external_name: externalName,
-				external_profile_url: externalProfileURL,
-				external_profile_picture: externalProfilePicture,
-				external_display: externalDisplay,
-			} = connection;
-
-			Object.assign( previewProps, {
-				externalDisplay,
-				externalName,
-				externalProfileURL,
-				externalProfilePicture,
-			} );
-		}
 
 		const customImage = getPostCustomImage( post );
 

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -7,8 +7,6 @@ import { get, find, map } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
 import FacebookSharePreview from 'calypso/components/share/facebook-share-preview';
 import LinkedinSharePreview from 'calypso/components/share/linkedin-share-preview';
 import MastodonSharePreview from 'calypso/components/share/mastodon-share-preview';
@@ -83,30 +81,12 @@ class SharingPreviewPane extends PureComponent {
 	};
 
 	renderPreview() {
-		const { post, site, message, connections, translate, seoTitle, siteSlug, siteIcon, siteName } =
+		const { post, site, message, connections, translate, seoTitle, siteIcon, siteName } =
 			this.props;
 		const { selectedService } = this.state;
 
 		if ( ! selectedService ) {
 			return null;
-		}
-
-		const connection = find( connections, { service: selectedService } );
-
-		if ( ! connection ) {
-			return (
-				<Notice
-					text={ translate( 'Connect to %s to see the preview', {
-						args: serviceNames[ selectedService ],
-					} ) }
-					status="is-info"
-					showDismiss={ false }
-				>
-					<NoticeAction href={ '/marketing/connections/' + siteSlug }>
-						{ translate( 'Settings' ) }
-					</NoticeAction>
-				</Notice>
-			);
 		}
 
 		const articleUrl = get( post, 'URL', '' );
@@ -115,23 +95,12 @@ class SharingPreviewPane extends PureComponent {
 		const articleSummary = getSummaryForPost( post, translate );
 		const siteDomain = get( site, 'domain', '' );
 		const imageUrl = getPostImage( post );
-		const customImage = getPostCustomImage( post );
-		const {
-			external_name: externalName,
-			external_profile_url: externalProfileURL,
-			external_profile_picture: externalProfilePicture,
-			external_display: externalDisplay,
-		} = connection;
 
-		const previewProps = {
+		const postProps = {
 			articleUrl,
 			articleTitle,
 			articleContent,
 			articleSummary,
-			externalDisplay,
-			externalName,
-			externalProfileURL,
-			externalProfilePicture,
 			message,
 			imageUrl,
 			seoTitle,
@@ -139,6 +108,36 @@ class SharingPreviewPane extends PureComponent {
 			siteIcon,
 			siteName,
 		};
+
+		/**
+		 * Props to pass to the preview component. Will be populated with the connection
+		 * specific data if the selected service is connected.
+		 *
+		 * @type {Object}
+		 */
+		const previewProps = { ...postProps };
+
+		const connection = find( connections, { service: selectedService } );
+
+		if ( ! connection ) {
+			previewProps.hidePostPreview = true;
+		} else {
+			const {
+				external_name: externalName,
+				external_profile_url: externalProfileURL,
+				external_profile_picture: externalProfilePicture,
+				external_display: externalDisplay,
+			} = connection;
+
+			Object.assign( previewProps, {
+				externalDisplay,
+				externalName,
+				externalProfileURL,
+				externalProfilePicture,
+			} );
+		}
+
+		const customImage = getPostCustomImage( post );
 
 		switch ( selectedService ) {
 			case 'facebook':
@@ -157,13 +156,13 @@ class SharingPreviewPane extends PureComponent {
 					<TumblrSharePreview
 						{ ...previewProps }
 						articleContent={ post.content }
-						externalProfileURL={ connection.external_profile_URL }
+						externalProfileURL={ connection?.external_profile_URL }
 					/>
 				);
 			case 'linkedin':
 				return <LinkedinSharePreview { ...previewProps } />;
 			case 'twitter':
-				return <TwitterSharePreview { ...previewProps } externalDisplay={ externalDisplay } />;
+				return <TwitterSharePreview { ...previewProps } />;
 			case 'mastodon':
 				return (
 					<MastodonSharePreview

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -14,6 +14,7 @@ export class FacebookSharePreview extends PureComponent {
 		customImage: PropTypes.string,
 		message: PropTypes.string,
 		seoTitle: PropTypes.string,
+		hidePostPreview: PropTypes.bool,
 	};
 
 	render() {
@@ -27,6 +28,7 @@ export class FacebookSharePreview extends PureComponent {
 			message,
 			seoTitle,
 			customImage,
+			hidePostPreview,
 		} = this.props;
 
 		// The post object in the state has a default excerpt, which is the first words of the
@@ -47,6 +49,7 @@ export class FacebookSharePreview extends PureComponent {
 				customImage={ customImage }
 				user={ { displayName: externalDisplay, avatarUrl: externalProfilePicture } }
 				type={ TYPE_ARTICLE }
+				hidePostPreview={ hidePostPreview }
 			/>
 		);
 	}

--- a/client/components/share/linkedin-share-preview/index.jsx
+++ b/client/components/share/linkedin-share-preview/index.jsx
@@ -23,6 +23,7 @@ export class LinkedinSharePreview extends PureComponent {
 			externalProfilePicture,
 			imageUrl,
 			seoTitle,
+			hidePostPreview,
 		} = this.props;
 
 		return (
@@ -34,6 +35,7 @@ export class LinkedinSharePreview extends PureComponent {
 					title={ decodeEntities( seoTitle ) }
 					description={ decodeEntities( articleSummary ) }
 					url={ articleUrl }
+					hidePostPreview={ hidePostPreview }
 				/>
 			</div>
 		);

--- a/client/components/share/mastodon-share-preview/index.jsx
+++ b/client/components/share/mastodon-share-preview/index.jsx
@@ -16,6 +16,7 @@ export class MastodonSharePreview extends PureComponent {
 			customImage,
 			isSocialPost,
 			message,
+			hidePostPreview,
 		} = this.props;
 
 		return (
@@ -33,6 +34,7 @@ export class MastodonSharePreview extends PureComponent {
 					avatarUrl: externalProfilePicture,
 					address: externalDisplay,
 				} }
+				hidePostPreview={ hidePostPreview }
 			/>
 		);
 	}

--- a/client/components/share/tumblr-share-preview/index.jsx
+++ b/client/components/share/tumblr-share-preview/index.jsx
@@ -13,6 +13,7 @@ export class TumblrSharePreview extends PureComponent {
 			articleContent,
 			imageUrl,
 			message,
+			hidePostPreview,
 		} = this.props;
 
 		const username = externalProfileURL?.match( /[^/]+$/ )?.[ 0 ];
@@ -28,6 +29,7 @@ export class TumblrSharePreview extends PureComponent {
 					displayName: externalName === 'Untitled' && username ? username : externalName,
 					avatarUrl: externalProfilePicture,
 				} }
+				hidePostPreview={ hidePostPreview }
 			/>
 		);
 	}

--- a/client/components/share/twitter-share-preview/index.jsx
+++ b/client/components/share/twitter-share-preview/index.jsx
@@ -13,6 +13,7 @@ export class TwitterSharePreview extends PureComponent {
 			imageUrl,
 			seoTitle,
 			articleSummary,
+			hidePostPreview,
 		} = this.props;
 
 		return (
@@ -32,6 +33,7 @@ export class TwitterSharePreview extends PureComponent {
 							text: message,
 						},
 					] }
+					hidePostPreview={ hidePostPreview }
 				/>
 			</div>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

In Jetpack we show the link preview all the time, even if the connection is not present for the service. This is beneficial, because others can share the post as a link, and the user can check how it would look there. To follow Jetpack's direction, these changes sync up with Calypso, so the functionality is the same.

## Proposed Changes

* Updated the preview render function, so it's rendered even if the connection is not there. In that case we hide the post preview with the corresponding property.
* Updated each service's wrapper component, so the `hidePostPreview` can be sent down.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site that has Social, but have no connections.
* Open up a new post in Gutenberg, and check the social previews.
* Open up Calypso in another tab for the same site, and in `/posts` click the 3 dot menu on a post, click share, and then click preview. Compare the previews here with the one in Jetpack, should be the same.
* Do these steps again with a site that has connections.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
