### PR TITLE
GS on Personal A/B: Fix style variations split for personal plans

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -589,7 +589,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 						! isBundledWithWooCommerce &&
 						! isPremiumThemeAvailable &&
 						! didPurchaseSelectedTheme &&
-						! isPluginBundleEligible
+						! isPluginBundleEligible &&
+						shouldLimitGlobalStyles
 					}
 					title={ headerDesignTitle }
 					description={ selectedDesign.description }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -701,7 +701,8 @@ class ThemeSheet extends Component {
 			! this.props.isExternallyManagedTheme &&
 			! this.props.isThemePurchased &&
 			! this.props.isBundledSoftwareSet &&
-			! this.props.isPremium;
+			! this.props.isPremium &&
+			this.props.shouldLimitGlobalStyles;
 
 		return (
 			styleVariations.length > 0 && (


### PR DESCRIPTION
This fixes the issue found in [this slack conversation](p1689242603437999-slack-C04DZ8M0GHW)

When we have a user that's on the `treatment` group of the experiment and he purchases a `Personal` plan, he is still seeing the theme style variations split in two categories.

## Proposed Changes

* We now check if the site has global styles restrictions and if they don't we will show the style variations merged (all the previous conditions should be met too).

| Before | After |
-----|-----
![Screenshot 2023-07-13 at 12 01 49](https://github.com/Automattic/wp-calypso/assets/1989914/0e490ed9-dfc1-42c5-8035-a6d1fd4bf648)|![Captura de Pantalla 2023-07-13 a las 13 32 48](https://github.com/Automattic/wp-calypso/assets/1989914/d541d5fc-9f92-4a83-828b-8dd1e584ee69)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to http://calypso.localhost:3000/theme/attar/{site on personal plan}
* You should see that the style variations aren't split.
* You should not see a message indicating that you need to upgrade.
* Test on Premium and Business plans with control and treatment group.

You can change your group here (21268-explat-experiment), you also need to clear the cache when switching between groups by executing this command in your sandbox:
wp_cache_delete( 'global-styles-on-personal-{siteId}', 'a8c_experiments' );

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?