### PR TITLE
Subscription Management: Redirect /following/manage to /read/subscriptions

### DIFF
--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -1,8 +1,39 @@
+import { isEnabled } from '@automattic/calypso-config';
+import i18n from 'i18n-calypso';
 import page from 'page';
+import AsyncLoad from 'calypso/components/async-load';
+import { sectionify } from 'calypso/lib/route';
+import { trackPageLoad, setPageTitle } from 'calypso/reader/controller-helper';
+
+const analyticsPageTitle = 'Reader';
 
 const exported = {
 	followingManage( context, next ) {
-		page.redirect( '/read/subscriptions' );
+		if ( isEnabled( 'subscription-management-redirect-following' ) ) {
+			page.redirect( '/read/subscriptions' );
+		} else {
+			const basePath = sectionify( context.path );
+			const fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites';
+			const mcKey = 'following_manage';
+			const { q: sitesQuery, s: subsQuery, sort: subsSortOrder, showMoreResults } = context.query;
+
+			setPageTitle( context, i18n.translate( 'Manage followed sites' ) );
+
+			trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+
+			context.primary = (
+				<AsyncLoad
+					require="calypso/reader/following-manage"
+					key="following-manage"
+					initialFollowUrl={ context.query.follow }
+					sitesQuery={ sitesQuery }
+					subsQuery={ subsQuery }
+					showMoreResults={ Boolean( showMoreResults ) }
+					subsSortOrder={ subsSortOrder }
+					context={ context }
+				/>
+			);
+		}
 		next();
 	},
 };

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -1,37 +1,12 @@
-import i18n from 'i18n-calypso';
-import AsyncLoad from 'calypso/components/async-load';
-import { sectionify } from 'calypso/lib/route';
-import { trackPageLoad, setPageTitle } from 'calypso/reader/controller-helper';
-
-const analyticsPageTitle = 'Reader';
+import page from 'page';
 
 const exported = {
 	followingManage( context, next ) {
-		const basePath = sectionify( context.path );
-		const fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites';
-		const mcKey = 'following_manage';
-		const { q: sitesQuery, s: subsQuery, sort: subsSortOrder, showMoreResults } = context.query;
-
-		setPageTitle( context, i18n.translate( 'Manage followed sites' ) );
-
-		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-
-		context.primary = (
-			<AsyncLoad
-				require="calypso/reader/following-manage"
-				key="following-manage"
-				initialFollowUrl={ context.query.follow }
-				sitesQuery={ sitesQuery }
-				subsQuery={ subsQuery }
-				showMoreResults={ Boolean( showMoreResults ) }
-				subsSortOrder={ subsSortOrder }
-				context={ context }
-			/>
-		);
+		page.redirect( '/read/subscriptions' );
 		next();
 	},
 };
 
 export default exported;
 
-export const { followingEdit, followingManage } = exported;
+export const { followingManage } = exported;

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -10,30 +10,30 @@ const analyticsPageTitle = 'Reader';
 const exported = {
 	followingManage( context, next ) {
 		if ( isEnabled( 'subscription-management-redirect-following' ) ) {
-			page.redirect( '/read/subscriptions' );
-		} else {
-			const basePath = sectionify( context.path );
-			const fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites';
-			const mcKey = 'following_manage';
-			const { q: sitesQuery, s: subsQuery, sort: subsSortOrder, showMoreResults } = context.query;
-
-			setPageTitle( context, i18n.translate( 'Manage followed sites' ) );
-
-			trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-
-			context.primary = (
-				<AsyncLoad
-					require="calypso/reader/following-manage"
-					key="following-manage"
-					initialFollowUrl={ context.query.follow }
-					sitesQuery={ sitesQuery }
-					subsQuery={ subsQuery }
-					showMoreResults={ Boolean( showMoreResults ) }
-					subsSortOrder={ subsSortOrder }
-					context={ context }
-				/>
-			);
+			return page.redirect( '/read/subscriptions' );
 		}
+
+		const basePath = sectionify( context.path );
+		const fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites';
+		const mcKey = 'following_manage';
+		const { q: sitesQuery, s: subsQuery, sort: subsSortOrder, showMoreResults } = context.query;
+
+		setPageTitle( context, i18n.translate( 'Manage followed sites' ) );
+
+		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+
+		context.primary = (
+			<AsyncLoad
+				require="calypso/reader/following-manage"
+				key="following-manage"
+				initialFollowUrl={ context.query.follow }
+				sitesQuery={ sitesQuery }
+				subsQuery={ subsQuery }
+				showMoreResults={ Boolean( showMoreResults ) }
+				subsSortOrder={ subsSortOrder }
+				context={ context }
+			/>
+		);
 		next();
 	},
 };

--- a/config/development.json
+++ b/config/development.json
@@ -194,6 +194,7 @@
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
+		"subscription-management-redirect-following": true,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-poc": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -131,6 +131,7 @@
 		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
+		"subscription-management-redirect-following": false,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-poc": true,

--- a/config/production.json
+++ b/config/production.json
@@ -158,6 +158,7 @@
 		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
+		"subscription-management-redirect-following": false,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-poc": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -151,6 +151,7 @@
 		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
+		"subscription-management-redirect-following": false,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-poc": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -163,6 +163,7 @@
 		"subscription-management-add-sites-modal": false,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
+		"subscription-management-redirect-following": false,
 		"subscription-management/comments-list-controls": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-poc": true,


### PR DESCRIPTION
Related to #78796

## Proposed Changes

Redirects visitors of `/following/manage` to `/read/subscriptions`

## Testing Instructions

- Apply this PR
- Visit `http://calypso.localhost:3000/following/manage`
- You should be redirected to `/read/subscriptions`

This should only happen in the dev environment. To try it in other environments, append `?flags=subscription-management-redirect-following`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
