### PR TITLE
/read/subscriptions/: Display non-wpcom RSS feed items in search results

### DIFF
--- a/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feed-item.tsx
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feed-item.tsx
@@ -33,8 +33,8 @@ const ReaderUnsubscribedFeedItem = ( {
 	onDisplayUrlClick,
 	onSubscribeClick,
 	onTitleClick,
-	subscribeDisabled = false,
 	hasSubscribed = false,
+	subscribeDisabled = false,
 	title,
 }: ReaderUnsubscribedFeedItemProps ) => {
 	const translate = useTranslate();

--- a/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feed-item.tsx
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feed-item.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -8,89 +7,71 @@ import { filterURLForDisplay } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import ExternalLink from 'calypso/components/external-link';
-import { getFeedUrl, getSiteName, getSiteUrl } from 'calypso/reader/get-helpers';
-import { useDispatch } from 'calypso/state';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 type ReaderUnsubscribedFeedItemProps = {
-	feed: Reader.FeedItem;
+	defaultIcon?: JSX.Element | null;
+	description?: string;
+	displayUrl: string;
+	feedUrl: string;
+	hasSubscribed?: boolean;
+	iconUrl?: string;
+	isSubscribing?: boolean;
+	onDisplayUrlClick?: () => void;
+	onSubscribeClick?: () => void;
+	onTitleClick?: () => void;
+	subscribeDisabled?: boolean;
+	title?: string;
 };
 
-const ReaderUnsubscribedFeedItem = ( { feed }: ReaderUnsubscribedFeedItemProps ) => {
-	if ( Number.isNaN( Number( feed.blog_ID ) ) ) {
-		throw new Error( 'Feed item blog_ID is NaN' );
-	}
-
-	const {
-		mutate: subscribe,
-		isLoading: subscribing,
-		isSuccess: subscribed,
-	} = SubscriptionManager.useSiteSubscribeMutation( feed.blog_ID );
-	const dispatch = useDispatch();
+const ReaderUnsubscribedFeedItem = ( {
+	defaultIcon,
+	description = '',
+	displayUrl,
+	feedUrl,
+	iconUrl,
+	isSubscribing = false,
+	onDisplayUrlClick,
+	onSubscribeClick,
+	onTitleClick,
+	subscribeDisabled = false,
+	hasSubscribed = false,
+	title,
+}: ReaderUnsubscribedFeedItemProps ) => {
 	const translate = useTranslate();
-
-	const { data: site, isLoading } = Reader.useReadFeedSiteQuery( Number( feed.blog_ID ) );
-	if ( isLoading ) {
-		return null; // TODO: render a placeholder
-	}
-
-	const siteName = getSiteName( { feed, site } );
-	const siteUrl = getSiteUrl( { feed, site } );
-
+	const filteredDisplayUrl = filterURLForDisplay( displayUrl );
 	return (
 		<HStack as="li" className="reader-unsubscribed-feed-item" alignItems="center" spacing={ 8 }>
 			<HStack className="reader-unsubscribed-feed-item__site-preview-h-stack" spacing={ 3 }>
-				<SiteIcon iconUrl={ site?.icon?.img ?? site?.icon?.ico } size={ 40 } />
+				<SiteIcon iconUrl={ iconUrl } defaultIcon={ defaultIcon } size={ 40 } />
 				<VStack className="reader-unsubscribed-feed-item__title-with-url-v-stack" spacing={ 0 }>
 					<a
 						className="reader-unsubscribed-feed-item__title"
-						href={ getFeedUrl( { feed, site } ) }
-						onClick={ () => undefined } // TODO: track click
+						href={ feedUrl }
+						onClick={ onTitleClick } // TODO: track click
 					>
-						{ siteName }
+						{ title ? title : filteredDisplayUrl }
 					</a>
 					<ExternalLink
 						className="reader-unsubscribed-feed-item__url"
-						href={ siteUrl }
+						href={ displayUrl }
 						rel="noreferrer noopener"
 						target="_blank"
-						onClick={ () => undefined } // TODO: track click
+						onClick={ onDisplayUrlClick } // TODO: track click
 					>
-						{ filterURLForDisplay( siteUrl ) }
+						{ filteredDisplayUrl }
 					</ExternalLink>
 				</VStack>
 			</HStack>
-			<div className="reader-unsubscribed-feed-item__description">{ site?.description }</div>
+			<div className="reader-unsubscribed-feed-item__description">{ description }</div>
 			<div>
+				{ /* TODO: track click */ }
 				<Button
 					primary
-					disabled={ site?.is_following || subscribing || subscribed }
-					busy={ subscribing }
-					onClick={ () => {
-						subscribe( {
-							blog_id: feed.blog_ID,
-							url: feed.subscribe_URL,
-							onSuccess: () => {
-								dispatch(
-									successNotice(
-										translate( 'Success! You are now subscribed to %s.', { args: siteName } ),
-										{ duration: 5000 }
-									)
-								);
-							},
-							onError: () => {
-								dispatch(
-									errorNotice(
-										translate( 'Sorry, we had a problem subscribing. Please try again.' ),
-										{ duration: 5000 }
-									)
-								);
-							},
-						} );
-						// TODO: track click
-					} }
+					disabled={ subscribeDisabled }
+					busy={ isSubscribing }
+					onClick={ onSubscribeClick }
 				>
-					{ site?.is_following
+					{ hasSubscribed
 						? translate( 'Subscribed', {
 								comment:
 									'The user just subscribed to the site that the button relates to, and so the button is in disabled state.',

--- a/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feeds-search-list.tsx
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feeds-search-list.tsx
@@ -1,5 +1,6 @@
 import { Reader } from '@automattic/data-stores';
 import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useMemo } from 'react';
 import { isNonWpcomFeedItem, isWpcomFeedItem } from 'calypso/reader/helpers/types';
 import ReaderUnsubscribedNonWpcomFeedItem from './reader-unsubscribed-non-wpcom-feed-item';
 import ReaderUnsubscribedWpcomFeedItem from './reader-unsubscribed-wpcom-feed-item';
@@ -8,33 +9,41 @@ import './style.scss';
 const ReaderUnsubscribedFeedsSearchList = () => {
 	const { feedItems, searchQueryResult } = Reader.useUnsubscribedFeedsSearch() ?? {};
 
-	if ( ! feedItems?.length || searchQueryResult?.isFetching ) {
+	const feedItemComponents = useMemo( () => {
+		if ( ! feedItems?.length ) {
+			return [];
+		}
+
+		return feedItems?.map( ( feed ) => {
+			if ( isWpcomFeedItem( feed ) ) {
+				return (
+					<ReaderUnsubscribedWpcomFeedItem
+						key={ `${ feed.blog_ID }-${ feed.feed_ID }` }
+						feed={ feed }
+					/>
+				);
+			}
+
+			if ( isNonWpcomFeedItem( feed ) ) {
+				return (
+					<ReaderUnsubscribedNonWpcomFeedItem
+						key={ `${ feed.feed_ID }-${ feed.subscribe_URL }` }
+						feed={ feed }
+					/>
+				);
+			}
+
+			return null;
+		} );
+	}, [ feedItems ] );
+
+	if ( ! feedItemComponents?.length || searchQueryResult?.isFetching ) {
 		return null;
 	}
 
 	return (
 		<VStack as="ul" className="reader-unsubscribed-feeds-search-list">
-			{ feedItems.map( ( feed ) => {
-				if ( isWpcomFeedItem( feed ) ) {
-					return (
-						<ReaderUnsubscribedWpcomFeedItem
-							key={ `${ feed.blog_ID }-${ feed.feed_ID }` }
-							feed={ feed }
-						/>
-					);
-				}
-
-				if ( isNonWpcomFeedItem( feed ) ) {
-					return (
-						<ReaderUnsubscribedNonWpcomFeedItem
-							key={ `${ feed.feed_ID }-${ feed.subscribe_URL }` }
-							feed={ feed }
-						/>
-					);
-				}
-
-				return null;
-			} ) }
+			{ feedItemComponents }
 		</VStack>
 	);
 };

--- a/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feeds-search-list.tsx
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feeds-search-list.tsx
@@ -1,6 +1,8 @@
 import { Reader } from '@automattic/data-stores';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import ReaderUnsubscribedFeedItem from './reader-unsubscribed-feed-item';
+import { isNonWpcomFeedItem, isWpcomFeedItem } from 'calypso/reader/helpers/types';
+import ReaderUnsubscribedNonWpcomFeedItem from './reader-unsubscribed-non-wpcom-feed-item';
+import ReaderUnsubscribedWpcomFeedItem from './reader-unsubscribed-wpcom-feed-item';
 import './style.scss';
 
 const ReaderUnsubscribedFeedsSearchList = () => {
@@ -13,9 +15,25 @@ const ReaderUnsubscribedFeedsSearchList = () => {
 	return (
 		<VStack as="ul" className="reader-unsubscribed-feeds-search-list">
 			{ feedItems.map( ( feed ) => {
-				return (
-					<ReaderUnsubscribedFeedItem key={ `${ feed.blog_ID }-${ feed.feed_ID }` } feed={ feed } />
-				);
+				if ( isWpcomFeedItem( feed ) ) {
+					return (
+						<ReaderUnsubscribedWpcomFeedItem
+							key={ `${ feed.blog_ID }-${ feed.feed_ID }` }
+							feed={ feed }
+						/>
+					);
+				}
+
+				if ( isNonWpcomFeedItem( feed ) ) {
+					return (
+						<ReaderUnsubscribedNonWpcomFeedItem
+							key={ `${ feed.feed_ID }-${ feed.subscribe_URL }` }
+							feed={ feed }
+						/>
+					);
+				}
+
+				return null;
 			} ) }
 		</VStack>
 	);

--- a/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-non-wpcom-feed-item.tsx
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-non-wpcom-feed-item.tsx
@@ -1,0 +1,60 @@
+import { SubscriptionManager, Reader } from '@automattic/data-stores';
+import { rss } from '@wordpress/icons';
+import { filterURLForDisplay } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { NonWpcomFeedItem } from 'calypso/reader/helpers/types';
+import { getFeedUrl } from 'calypso/reader/route';
+import { useDispatch } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import ReaderUnsubscribedFeedItem from './reader-unsubscribed-feed-item';
+
+type ReaderUnsubscribedNonWpcomFeedItemProps = {
+	feed: NonWpcomFeedItem;
+};
+
+const ReaderUnsubscribedNonWpcomFeedItem = ( {
+	feed: { subscribe_URL: subscribeUrl, feed_ID: feedId },
+}: ReaderUnsubscribedNonWpcomFeedItemProps ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const {
+		mutate: subscribe,
+		isLoading: subscribing,
+		isSuccess: subscribed,
+	} = SubscriptionManager.useSiteSubscribeMutation();
+	const filteredDisplayUrl = filterURLForDisplay( subscribeUrl );
+	const feedUrl = Reader.isValidId( feedId ) ? getFeedUrl( feedId ) : subscribeUrl;
+
+	return (
+		<ReaderUnsubscribedFeedItem
+			defaultIcon={ rss }
+			displayUrl={ subscribeUrl }
+			feedUrl={ feedUrl }
+			isSubscribing={ subscribing }
+			title={ filterURLForDisplay( subscribeUrl ) }
+			onSubscribeClick={ () => {
+				subscribe( {
+					url: subscribeUrl,
+					onSuccess: () => {
+						dispatch(
+							successNotice(
+								translate( 'Success! You are now subscribed to %s.', { args: filteredDisplayUrl } ),
+								{ duration: 5000 }
+							)
+						);
+					},
+					onError: () => {
+						dispatch(
+							errorNotice( translate( 'Sorry, we had a problem subscribing. Please try again.' ), {
+								duration: 5000,
+							} )
+						);
+					},
+				} );
+			} }
+			hasSubscribed={ subscribed }
+		/>
+	);
+};
+
+export default ReaderUnsubscribedNonWpcomFeedItem;

--- a/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-wpcom-feed-item.tsx
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-wpcom-feed-item.tsx
@@ -1,0 +1,67 @@
+import { Reader, SubscriptionManager } from '@automattic/data-stores';
+import { useTranslate } from 'i18n-calypso';
+import { getFeedUrl, getSiteName, getSiteUrl } from 'calypso/reader/get-helpers';
+import { WpcomFeedItem } from 'calypso/reader/helpers/types';
+import { useDispatch } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import ReaderUnsubscribedFeedItem from './reader-unsubscribed-feed-item';
+
+type ReaderUnsubscribedWpcomFeedItemProps = {
+	feed: WpcomFeedItem;
+};
+
+const ReaderUnsubscribedWpcomFeedItem = ( { feed }: ReaderUnsubscribedWpcomFeedItemProps ) => {
+	const {
+		mutate: subscribe,
+		isLoading: subscribing,
+		isSuccess: subscribed,
+	} = SubscriptionManager.useSiteSubscribeMutation();
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const { data: site, isLoading } = Reader.useReadFeedSiteQuery( Number( feed.blog_ID ) );
+	if ( isLoading ) {
+		return null; // TODO: render a placeholder
+	}
+
+	const siteName = getSiteName( { feed, site } );
+
+	return (
+		<ReaderUnsubscribedFeedItem
+			description={ site?.description }
+			displayUrl={ getSiteUrl( { feed, site } ) }
+			feedUrl={ getFeedUrl( { feed, site } ) }
+			iconUrl={ site?.icon?.img ?? site?.icon?.ico }
+			isSubscribing={ subscribing }
+			onDisplayUrlClick={ () => undefined } // TODO: track click
+			onSubscribeClick={ () => {
+				subscribe( {
+					blog_id: feed.blog_ID,
+					url: feed.subscribe_URL,
+					onSuccess: () => {
+						dispatch(
+							successNotice(
+								translate( 'Success! You are now subscribed to %s.', { args: siteName } ),
+								{ duration: 5000 }
+							)
+						);
+					},
+					onError: () => {
+						dispatch(
+							errorNotice( translate( 'Sorry, we had a problem subscribing. Please try again.' ), {
+								duration: 5000,
+							} )
+						);
+					},
+				} );
+				// TODO: track click
+			} }
+			onTitleClick={ () => undefined } // TODO: track click
+			subscribeDisabled={ site?.is_following || subscribing || subscribed }
+			hasSubscribed={ site?.is_following || subscribed }
+			title={ siteName }
+		/>
+	);
+};
+
+export default ReaderUnsubscribedWpcomFeedItem;

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
@@ -40,7 +40,7 @@ const SiteSubscriptionDetails = ( {
 		isLoading: subscribing,
 		isSuccess: subscribed,
 		error: subscribeError,
-	} = SubscriptionManager.useSiteSubscribeMutation( blogId );
+	} = SubscriptionManager.useSiteSubscribeMutation();
 	const {
 		mutate: unsubscribe,
 		isLoading: unsubscribing,

--- a/client/reader/helpers/types.ts
+++ b/client/reader/helpers/types.ts
@@ -1,0 +1,23 @@
+import { Reader } from '@automattic/data-stores';
+
+export type WpcomFeedItem = {
+	blog_ID: string;
+} & Reader.FeedItem;
+
+export const isWpcomFeedItem = ( item: Reader.FeedItem ): item is WpcomFeedItem => {
+	return Reader.isValidId( item.blog_ID );
+};
+
+export type NonWpcomFeedItem = {
+	subscribe_URL: string;
+	feed_ID?: string;
+	meta: {
+		links?: {
+			feed?: string;
+		};
+	};
+};
+
+export const isNonWpcomFeedItem = ( item: Reader.FeedItem ): item is NonWpcomFeedItem => {
+	return ! Reader.isValidId( item.blog_ID ) && item.subscribe_URL !== undefined;
+};

--- a/packages/data-stores/src/reader/helpers/cache-key.ts
+++ b/packages/data-stores/src/reader/helpers/cache-key.ts
@@ -1,0 +1,8 @@
+// change version to invalidate all cache keys
+export const version = 'v1';
+
+const buildCacheKey = ( key: string[], isLoggedIn: boolean, userId?: number ) => {
+	return [ ...key, version, isLoggedIn ? 'logged-in' : 'not-logged-in', userId ? userId : '' ];
+};
+
+export default buildCacheKey;

--- a/packages/data-stores/src/reader/helpers/cache-key.ts
+++ b/packages/data-stores/src/reader/helpers/cache-key.ts
@@ -1,8 +1,0 @@
-// change version to invalidate all cache keys
-export const version = 'v1';
-
-const buildCacheKey = ( key: string[], isLoggedIn: boolean, userId?: number ) => {
-	return [ ...key, version, isLoggedIn ? 'logged-in' : 'not-logged-in', userId ? userId : '' ];
-};
-
-export default buildCacheKey;

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -123,5 +123,5 @@ const isErrorResponse = (
 };
 
 export { callApi, applyCallbackToPages, getSubkey, getSubscriptionMutationParams, isErrorResponse };
-export { default as buildCacheKey } from './cache-key';
+export { default as buildQueryKey } from './query-key';
 export { default as isValidId } from './validators';

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -87,16 +87,24 @@ const applyCallbackToPages = < K extends string, T >(
 const getSubscriptionMutationParams = (
 	action: 'new' | 'delete',
 	isLoggedIn: boolean,
-	blogId: number | string,
+	blogId?: number | string,
 	url?: string,
 	emailId?: string
 ) => {
 	if ( isLoggedIn ) {
+		if ( ! url ) {
+			throw new Error( 'URL is required for wpcom user to subscribe' );
+		}
+
 		return {
 			path: `/read/following/mine/${ action }`,
 			apiVersion: '1.1',
 			body: { source: 'calypso', url: url, ...( emailId ? { email_id: emailId } : {} ) },
 		};
+	}
+
+	if ( ! blogId ) {
+		throw new Error( 'Blog ID is required for non-wpcom user to subscribe' );
 	}
 
 	return {
@@ -115,3 +123,5 @@ const isErrorResponse = (
 };
 
 export { callApi, applyCallbackToPages, getSubkey, getSubscriptionMutationParams, isErrorResponse };
+export { default as buildCacheKey } from './cache-key';
+export { default as isValidId } from './validators';

--- a/packages/data-stores/src/reader/helpers/query-key.ts
+++ b/packages/data-stores/src/reader/helpers/query-key.ts
@@ -1,0 +1,13 @@
+// change version to invalidate all cache keys
+export const version = 'v1';
+
+const buildQueryKey = ( keyPrefix: string[], isLoggedIn: boolean, userId?: number ) => {
+	return [
+		...keyPrefix,
+		version,
+		isLoggedIn ? 'logged-in' : 'not-logged-in',
+		userId ? userId : '',
+	];
+};
+
+export default buildQueryKey;

--- a/packages/data-stores/src/reader/helpers/validators.ts
+++ b/packages/data-stores/src/reader/helpers/validators.ts
@@ -1,0 +1,35 @@
+/**
+ * This function checks if a given ID is valid.
+ *
+ * @param {number | string | undefined} id - The ID to be validated. It can be of type number, string, or undefined.
+ * @returns {boolean} The function returns true if the ID is valid, false otherwise.
+ *
+ * An ID is considered valid if it meets the following criteria:
+ * - If it's a number, it must be a positive integer (including 0).
+ * - If it's a string, it must contain only digits and represent a positive integer (including 0) when converted to a number.
+ *
+ * If the ID is undefined or does not meet the above criteria, the function returns false.
+ */
+export const isValidId = ( id?: number | string ): id is number | string => {
+	if ( id === undefined ) {
+		return false;
+	}
+
+	if ( typeof id === 'number' ) {
+		return Number.isInteger( id ) && id >= 0;
+	}
+
+	if ( typeof id === 'string' ) {
+		// Check if the string contains only digits
+		const isOnlyDigits = /^[0-9]+$/.test( id );
+		if ( isOnlyDigits ) {
+			// If it contains only digits, convert it to a number and check if it's a positive integer or 0
+			const num = Number( id );
+			return Number.isInteger( num ) && num >= 0;
+		}
+	}
+
+	return false;
+};
+
+export default isValidId;

--- a/packages/data-stores/src/reader/hooks/use-cache-key.ts
+++ b/packages/data-stores/src/reader/hooks/use-cache-key.ts
@@ -1,9 +1,9 @@
-import buildCacheKey from '../helpers/cache-key';
+import buildQueryKey from '../helpers/query-key';
 import useIsLoggedIn from './use-is-logged-in';
 
-const useCacheKey = ( key: string[] ) => {
+const useCacheKey = ( keyPrefix: string[] ) => {
 	const { id, isLoggedIn } = useIsLoggedIn();
-	return buildCacheKey( key, isLoggedIn, id );
+	return buildQueryKey( keyPrefix, isLoggedIn, id );
 };
 
 export default useCacheKey;

--- a/packages/data-stores/src/reader/hooks/use-cache-key.ts
+++ b/packages/data-stores/src/reader/hooks/use-cache-key.ts
@@ -1,12 +1,9 @@
+import buildCacheKey from '../helpers/cache-key';
 import useIsLoggedIn from './use-is-logged-in';
-
-// change version to invalidate all cache keys
-const version = 'v1';
 
 const useCacheKey = ( key: string[] ) => {
 	const { id, isLoggedIn } = useIsLoggedIn();
-
-	return [ ...key, version, isLoggedIn ? 'logged-in' : 'not-logged-in', id ? id : '' ];
+	return buildCacheKey( key, isLoggedIn, id );
 };
 
 export default useCacheKey;

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -60,7 +60,6 @@ export {
 	SiteSubscriptionsSortBy,
 } from './constants';
 export { isErrorResponse, isValidId } from './helpers';
-export { useCacheKey } from './hooks';
 export { UnsubscribedFeedsSearchProvider, useUnsubscribedFeedsSearch } from './contexts';
 export { useReadFeedSearchQuery, useReadFeedSiteQuery, useReadFeedQuery } from './queries';
 

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -15,6 +15,7 @@ import {
 	useUserSettingsMutation,
 } from './mutations';
 import {
+	siteSubscriptionsQueryKeyPrefix,
 	usePendingPostSubscriptionsQuery,
 	usePendingSiteSubscriptionsQuery,
 	usePostSubscriptionsQuery,
@@ -26,6 +27,7 @@ import {
 
 export const SubscriptionManager = {
 	SiteSubscriptionsQueryPropsProvider,
+	siteSubscriptionsQueryKeyPrefix,
 	useCacheKey,
 	useIsLoggedIn,
 	usePendingPostConfirmMutation,
@@ -58,8 +60,9 @@ export {
 	SiteSubscriptionsSortBy,
 } from './constants';
 export { isErrorResponse, isValidId } from './helpers';
+export { useCacheKey } from './hooks';
 export { UnsubscribedFeedsSearchProvider, useUnsubscribedFeedsSearch } from './contexts';
-export { useReadFeedSearchQuery, useReadFeedSiteQuery } from './queries';
+export { useReadFeedSearchQuery, useReadFeedSiteQuery, useReadFeedQuery } from './queries';
 
 export * from './types';
 export type { FeedItem } from './queries';

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -57,7 +57,7 @@ export {
 	SiteSubscriptionsFilterBy,
 	SiteSubscriptionsSortBy,
 } from './constants';
-export { isErrorResponse } from './helpers';
+export { isErrorResponse, isValidId } from './helpers';
 export { UnsubscribedFeedsSearchProvider, useUnsubscribedFeedsSearch } from './contexts';
 export { useReadFeedSearchQuery, useReadFeedSiteQuery } from './queries';
 

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -47,13 +47,6 @@ const useSiteSubscribeMutation = () => {
 
 	return useMutation( {
 		mutationFn: async ( params: SubscribeParams ) => {
-			if ( ! params.blog_id ) {
-				throw new Error(
-					// reminder: translate this string when we add it to the UI
-					'Something went wrong while subscribing.'
-				);
-			}
-
 			const { path, apiVersion, body } = getSubscriptionMutationParams(
 				'new',
 				isLoggedIn,
@@ -163,7 +156,8 @@ const useSiteSubscribeMutation = () => {
 
 			queryClient.invalidateQueries( subscriptionsCountCacheKey );
 			queryClient.invalidateQueries( [ 'read', 'feed', 'search' ] );
-
+		},
+		onSuccess: ( data, params ) => {
 			params.onSuccess?.();
 		},
 	} );

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -1,11 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { buildCacheKey, callApi, getSubscriptionMutationParams, isValidId } from '../helpers';
+import { buildQueryKey, callApi, getSubscriptionMutationParams, isValidId } from '../helpers';
 import { useIsLoggedIn } from '../hooks';
 import { SiteSubscriptionsPages } from '../types';
 import type { SiteSubscriptionDetails } from '../types';
 
 type SubscribeParams = {
 	blog_id?: number | string;
+	feed_id?: number | string;
 	url?: string;
 	doNotInvalidateSiteSubscriptions?: boolean;
 	onSuccess?: () => void;
@@ -28,18 +29,18 @@ const buildSubscriptionDetailsCacheKey = (
 	isLoggedIn: boolean,
 	userId?: number
 ) => {
-	return buildCacheKey( [ 'read', 'site-subscription-details', blogId ], isLoggedIn, userId );
+	return buildQueryKey( [ 'read', 'site-subscription-details', blogId ], isLoggedIn, userId );
 };
 
 const useSiteSubscribeMutation = () => {
 	const { isLoggedIn, id: userId } = useIsLoggedIn();
 	const queryClient = useQueryClient();
-	const siteSubscriptionsCacheKey = buildCacheKey(
+	const siteSubscriptionsCacheKey = buildQueryKey(
 		[ 'read', 'site-subscriptions' ],
 		isLoggedIn,
 		userId
 	);
-	const subscriptionsCountCacheKey = buildCacheKey(
+	const subscriptionsCountCacheKey = buildQueryKey(
 		[ 'read', 'subscriptions-count' ],
 		isLoggedIn,
 		userId
@@ -154,8 +155,12 @@ const useSiteSubscribeMutation = () => {
 				queryClient.invalidateQueries( [ 'read', 'sites', Number( params.blog_id ) ] );
 			}
 
+			if ( isValidId( params.feed_id ) ) {
+				const feedCacheKey = [ 'read', 'feeds', Number( params.feed_id ) ];
+				queryClient.invalidateQueries( feedCacheKey );
+			}
+
 			queryClient.invalidateQueries( subscriptionsCountCacheKey );
-			queryClient.invalidateQueries( [ 'read', 'feed', 'search' ] );
 		},
 		onSuccess: ( data, params ) => {
 			params.onSuccess?.();

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { callApi, getSubscriptionMutationParams } from '../helpers';
-import { useIsLoggedIn, useCacheKey } from '../hooks';
+import { buildCacheKey, callApi, getSubscriptionMutationParams, isValidId } from '../helpers';
+import { useIsLoggedIn } from '../hooks';
 import { SiteSubscriptionsPages } from '../types';
 import type { SiteSubscriptionDetails } from '../types';
 
@@ -23,16 +23,27 @@ type SubscribeResponse = {
 	};
 };
 
-const useSiteSubscribeMutation = ( blog_id?: string ) => {
-	const { isLoggedIn } = useIsLoggedIn();
+const buildSubscriptionDetailsCacheKey = (
+	blogId: string,
+	isLoggedIn: boolean,
+	userId?: number
+) => {
+	return buildCacheKey( [ 'read', 'site-subscription-details', blogId ], isLoggedIn, userId );
+};
+
+const useSiteSubscribeMutation = () => {
+	const { isLoggedIn, id: userId } = useIsLoggedIn();
 	const queryClient = useQueryClient();
-	const siteSubscriptionsCacheKey = useCacheKey( [ 'read', 'site-subscriptions' ] );
-	const subscriptionsCountCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
-	const siteSubscriptionDetailsCacheKey = useCacheKey( [
-		'read',
-		'site-subscription-details',
-		...( blog_id ? [ blog_id ] : [] ),
-	] );
+	const siteSubscriptionsCacheKey = buildCacheKey(
+		[ 'read', 'site-subscriptions' ],
+		isLoggedIn,
+		userId
+	);
+	const subscriptionsCountCacheKey = buildCacheKey(
+		[ 'read', 'subscriptions-count' ],
+		isLoggedIn,
+		userId
+	);
 
 	return useMutation( {
 		mutationFn: async ( params: SubscribeParams ) => {
@@ -67,7 +78,28 @@ const useSiteSubscribeMutation = ( blog_id?: string ) => {
 			return response;
 		},
 		onMutate: async ( params ) => {
-			await queryClient.cancelQueries( siteSubscriptionDetailsCacheKey );
+			const isValidBlogId = isValidId( params.blog_id );
+			let previousSiteSubscriptionDetails: SiteSubscriptionDetails | undefined;
+
+			if ( isValidBlogId ) {
+				const siteSubscriptionDetailsCacheKey = buildSubscriptionDetailsCacheKey(
+					String( params.blog_id ),
+					isLoggedIn,
+					userId
+				);
+				await queryClient.cancelQueries( siteSubscriptionDetailsCacheKey );
+
+				previousSiteSubscriptionDetails = queryClient.getQueryData< SiteSubscriptionDetails >(
+					siteSubscriptionDetailsCacheKey
+				);
+
+				if ( previousSiteSubscriptionDetails ) {
+					queryClient.setQueryData( siteSubscriptionDetailsCacheKey, {
+						...previousSiteSubscriptionDetails,
+						subscriber_count: previousSiteSubscriptionDetails.subscriber_count + 1,
+					} );
+				}
+			}
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
@@ -93,17 +125,6 @@ const useSiteSubscribeMutation = ( blog_id?: string ) => {
 				} );
 			}
 
-			const previousSiteSubscriptionDetails = queryClient.getQueryData< SiteSubscriptionDetails >(
-				siteSubscriptionDetailsCacheKey
-			);
-
-			if ( previousSiteSubscriptionDetails ) {
-				queryClient.setQueryData( siteSubscriptionDetailsCacheKey, {
-					...previousSiteSubscriptionDetails,
-					subscriber_count: previousSiteSubscriptionDetails.subscriber_count + 1,
-				} );
-			}
-
 			return { previousSiteSubscriptions, previousSiteSubscriptionDetails };
 		},
 		onError: ( error, params, context ) => {
@@ -111,7 +132,12 @@ const useSiteSubscribeMutation = ( blog_id?: string ) => {
 				queryClient.setQueryData( siteSubscriptionsCacheKey, context.previousSiteSubscriptions );
 			}
 
-			if ( context?.previousSiteSubscriptionDetails ) {
+			if ( isValidId( params.blog_id ) && context?.previousSiteSubscriptionDetails ) {
+				const siteSubscriptionDetailsCacheKey = buildSubscriptionDetailsCacheKey(
+					String( params.blog_id ),
+					isLoggedIn,
+					userId
+				);
 				queryClient.setQueryData(
 					siteSubscriptionDetailsCacheKey,
 					context.previousSiteSubscriptionDetails
@@ -124,11 +150,20 @@ const useSiteSubscribeMutation = ( blog_id?: string ) => {
 			if ( params.doNotInvalidateSiteSubscriptions !== true ) {
 				queryClient.invalidateQueries( siteSubscriptionsCacheKey );
 			}
-			queryClient.invalidateQueries( subscriptionsCountCacheKey );
-			queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey );
-			queryClient.invalidateQueries( [ 'read', 'feed', 'search' ] );
-			params.blog_id &&
+
+			if ( isValidId( params.blog_id ) ) {
+				const siteSubscriptionDetailsCacheKey = buildSubscriptionDetailsCacheKey(
+					String( params.blog_id ),
+					isLoggedIn,
+					userId
+				);
+				queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey );
 				queryClient.invalidateQueries( [ 'read', 'sites', Number( params.blog_id ) ] );
+			}
+
+			queryClient.invalidateQueries( subscriptionsCountCacheKey );
+			queryClient.invalidateQueries( [ 'read', 'feed', 'search' ] );
+
 			params.onSuccess?.();
 		},
 	} );

--- a/packages/data-stores/src/reader/queries/index.ts
+++ b/packages/data-stores/src/reader/queries/index.ts
@@ -3,8 +3,12 @@ export { default as usePendingSiteSubscriptionsQuery } from './use-pending-site-
 export { default as usePostSubscriptionsQuery } from './use-post-subscriptions-query';
 export { default as useReadFeedSearchQuery, FeedSort } from './use-read-feed-search-query';
 export { default as useReadFeedSiteQuery } from './use-read-feed-site-query';
+export { default as useReadFeedQuery } from './use-read-feed-query';
 export { default as useSiteSubscriptionDetailsQuery } from './use-site-subscription-details-query';
-export { default as useSiteSubscriptionsQuery } from './use-site-subscriptions-query';
+export {
+	default as useSiteSubscriptionsQuery,
+	siteSubscriptionsQueryKeyPrefix,
+} from './use-site-subscriptions-query';
 export { default as useSubscriptionsCountQuery } from './use-subscriptions-count-query';
 export { default as useUserSettingsQuery } from './use-user-settings-query';
 

--- a/packages/data-stores/src/reader/queries/use-read-feed-query.ts
+++ b/packages/data-stores/src/reader/queries/use-read-feed-query.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import { isValidId } from '../helpers';
+
+export type ReadFeedResponse = {
+	URL: string;
+	blog_ID: string;
+	description: string;
+	feed_ID: string;
+	feed_URL: string;
+	image: string;
+	is_following: boolean;
+	last_checked: string;
+	last_update: string;
+	marked_for_refresh: boolean;
+	meta: {
+		links: {
+			self: string;
+			[ key: string ]: string;
+		};
+	};
+	name: string;
+	next_refresh_time: string | null;
+	organization_id: number;
+	subscribers_count: number;
+	unseen_count: number;
+};
+
+const useReadFeedQuery = ( feedId?: number | string ) => {
+	return useQuery( {
+		queryKey: [ 'read', 'feeds', Number( feedId ) ],
+		queryFn: async () => {
+			return wpcomRequest< ReadFeedResponse >( {
+				path: `/read/feed/${ feedId }`,
+				apiVersion: '1.1',
+				method: 'GET',
+			} );
+		},
+		enabled: isValidId( feedId ),
+	} );
+};
+
+export default useReadFeedQuery;

--- a/packages/data-stores/src/reader/queries/use-read-feed-search-query.ts
+++ b/packages/data-stores/src/reader/queries/use-read-feed-search-query.ts
@@ -15,19 +15,19 @@ type ReadFeedSearchQueryProps = {
 };
 
 export type FeedItem = {
-	URL: string;
-	blog_ID: string;
-	feed_ID: string;
+	URL?: string;
+	blog_ID?: string;
+	feed_ID?: string;
 	meta: {
-		links: {
-			feed: string;
-			site: string;
+		links?: {
+			feed?: string;
+			site?: string;
 		};
 	};
-	railcar: Railcar;
+	railcar?: Railcar;
 	subscribe_URL: string;
-	subscribers_count: number;
-	title: string;
+	subscribers_count?: number;
+	title?: string;
 };
 
 type FeedResponse = {

--- a/packages/data-stores/src/reader/queries/use-read-feed-search-query.ts
+++ b/packages/data-stores/src/reader/queries/use-read-feed-search-query.ts
@@ -65,6 +65,7 @@ const useReadFeedSearchQuery = ( {
 		{
 			enabled: Boolean( query ),
 			getNextPageParam: ( lastPage ) => lastPage?.next_page,
+			refetchOnWindowFocus: false,
 		}
 	);
 };

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -6,6 +6,8 @@ import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { SiteSubscription } from '../types';
 
+export const siteSubscriptionsQueryKeyPrefix = [ 'read', 'site-subscriptions' ];
+
 type SubscriptionManagerSiteSubscriptions = {
 	subscriptions: SiteSubscription[];
 	page: number;
@@ -47,7 +49,7 @@ const useSiteSubscriptionsQuery = ( {
 }: SubscriptionManagerSiteSubscriptionsQueryProps = {} ) => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
-	const cacheKey = useCacheKey( [ 'read', 'site-subscriptions' ] );
+	const cacheKey = useCacheKey( siteSubscriptionsQueryKeyPrefix );
 	const { searchTerm, filterOption, sortTerm } = useSiteSubscriptionsQueryProps();
 
 	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isFetching, ...rest } =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
![Screenshot 2023-07-13 at 13 51 58](https://github.com/Automattic/wp-calypso/assets/2019970/4b1ff1a7-2b96-4bd7-8b68-8bde1af2302e)


Fixes https://github.com/Automattic/wp-calypso/issues/78631

## Proposed Changes

* Display search results that match non-wpcom feed items - those results can be obtained when searching by URL that wpcom has in its DB of feeds

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/read/subscriptions
* Search for `https://edition.cnn.com/` or `https://justinpot.com/`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
