### PR TITLE
Treat classic and FSE wporg themes equally

### DIFF
--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -172,26 +172,9 @@ export function interlaceThemes( wpComThemes, wpOrgThemes, searchTerm, isLastPag
 
 	// 3. WP.org themes (only if the list of WP.com themes has reached the last page).
 	if ( isEnabled( 'themes/interlaced-dotorg-themes' ) && isLastPage ) {
-		const restWpOrgBlockThemes = [];
-		const restWpOrgClassicThemes = [];
-
-		validWpOrgThemes.forEach( ( theme ) => {
-			if ( theme.id === matchingTheme?.id ) {
-				return;
-			}
-			if (
-				theme.taxonomies?.theme_feature?.some(
-					( feature ) => feature?.slug === 'full-site-editing'
-				)
-			) {
-				restWpOrgBlockThemes.push( theme );
-			} else {
-				restWpOrgClassicThemes.push( theme );
-			}
-		} );
-
-		interlacedThemes.push( ...restWpOrgBlockThemes );
-		interlacedThemes.push( ...restWpOrgClassicThemes );
+		interlacedThemes.push(
+			...validWpOrgThemes.filter( ( theme ) => theme.id !== matchingTheme?.id )
+		);
 	}
 
 	return interlacedThemes;

--- a/client/my-sites/themes/test/helpers.js
+++ b/client/my-sites/themes/test/helpers.js
@@ -35,7 +35,7 @@ describe( 'helpers', () => {
 			expect( interlacedThemes[ 0 ] ).toEqual( { id: 'wporg-theme-2' } );
 		} );
 
-		test( 'prioritizes WP.org block themes over WP.org classic themes', () => {
+		test( 'Uses the WP.org theme order as-is', () => {
 			const wpOrgClassicAndBlockThemes = [
 				{ id: 'wporg-classic-theme' },
 				{
@@ -49,8 +49,8 @@ describe( 'helpers', () => {
 				'test',
 				true
 			);
-			expect( interlacedThemes[ 2 ].id ).toEqual( 'wporg-block-theme' );
-			expect( interlacedThemes[ 3 ].id ).toEqual( 'wporg-classic-theme' );
+			expect( interlacedThemes[ 2 ].id ).toEqual( 'wporg-classic-theme' );
+			expect( interlacedThemes[ 3 ].id ).toEqual( 'wporg-block-theme' );
 		} );
 	} );
 } );


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79353

## Proposed Changes

When searching the theme showcase we listed all of the FSE results from dotorg above the classic themes from dotorg. We've decided to instead trust to market forces (i.e. wporgs popularity sort) to decide the order instead.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Use the Calypso live link below.
2. Go to Appearance > Themes.
3. Enter a search term that produces results that include WP.org block themes and WP.org classic themes (e.g. Hotel).
4. Make sure WP.org block themes (e.g. Elevated Lite, Strategist FSE) are not prioritized over WP.org classic themes (e.g. Entr, Avantex), the order should match the order returned from the wporg API call.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
