### PR TITLE
Fix potential issue with moment.calendar

### DIFF
--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -53,20 +53,22 @@ class PostRelativeTime extends PureComponent {
 				nextDay: this.props.translate( '[tomorrow at] LT', {
 					comment: 'LT refers to time (eg. 18:00)',
 				} ),
-				sameElse: this.props.translate( 'll [at] LT', {
-					comment:
-						'll refers to date (eg. 21 Apr) for when the post will be published & LT refers to time (eg. 18:00) - "at" is translated',
-				} ),
+				sameElse:
+					this.props.translate( 'll [at] LT', {
+						comment:
+							'll refers to date (eg. 21 Apr) for when the post will be published & LT refers to time (eg. 18:00) - "at" is translated',
+					} ) ?? '',
 			} );
 		} else {
 			if ( Math.abs( now.diff( this.getTimestamp(), 'days' ) ) < 7 ) {
 				return timestamp.fromNow();
 			}
 
-			const sameElse = this.props.translate( 'll [at] LT', {
-				comment:
-					'll refers to date (eg. 21 Apr) & LT refers to time (eg. 18:00) - "at" is translated',
-			} );
+			const sameElse =
+				this.props.translate( 'll [at] LT', {
+					comment:
+						'll refers to date (eg. 21 Apr) & LT refers to time (eg. 18:00) - "at" is translated',
+				} ) ?? '';
 
 			displayedTime = timestamp.calendar( null, {
 				sameElse,


### PR DESCRIPTION

Related to issue spotted in Sentry: https://sentry.io/organizations/a8c/issues/3557722036/?project=6313676

## Proposed Changes

* Default to translation to empty string to prevent `moment.calendar()` to fail
