### PR TITLE
Subscription Management: change copy of header

### DIFF
--- a/client/landing/subscriptions/hooks/use-subheader-text.tsx
+++ b/client/landing/subscriptions/hooks/use-subheader-text.tsx
@@ -1,4 +1,5 @@
 import { SubscriptionManager } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -6,12 +7,14 @@ import { useMemo } from 'react';
 const useSubheaderText = () => {
 	const emailAddress = SubscriptionManager.useSubscriberEmailAddress();
 	const translate = useTranslate();
+	const locale = useLocale();
 	const { hasTranslation } = useI18n();
 	return useMemo( () => {
 		if ( emailAddress ) {
-			return hasTranslation(
-				'Manage WordPress.com sites and newsletters you’ve subscribed to with {{span}}%(emailAddress)s{{/span}}.'
-			)
+			return locale.startsWith( 'en' ) ||
+				hasTranslation(
+					'Manage WordPress.com sites and newsletters you’ve subscribed to with {{span}}%(emailAddress)s{{/span}}.'
+				)
 				? translate(
 						'Manage WordPress.com sites and newsletters you’ve subscribed to with {{span}}%(emailAddress)s{{/span}}.',
 						{
@@ -35,7 +38,8 @@ const useSubheaderText = () => {
 						}
 				  );
 		}
-		return hasTranslation( 'Manage your WordPress.com site and newsletter subscriptions.' )
+		return locale.startsWith( 'en' ) ||
+			hasTranslation( 'Manage your WordPress.com site and newsletter subscriptions.' )
 			? translate( 'Manage your WordPress.com site and newsletter subscriptions.' )
 			: translate( 'Manage your WordPress.com blog and newsletter subscriptions.' );
 	}, [ emailAddress, translate ] );

--- a/client/landing/subscriptions/hooks/use-subheader-text.tsx
+++ b/client/landing/subscriptions/hooks/use-subheader-text.tsx
@@ -1,26 +1,43 @@
 import { SubscriptionManager } from '@automattic/data-stores';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 
 const useSubheaderText = () => {
 	const emailAddress = SubscriptionManager.useSubscriberEmailAddress();
 	const translate = useTranslate();
-
+	const { hasTranslation } = useI18n();
 	return useMemo( () => {
 		if ( emailAddress ) {
-			return translate(
-				"Manage the WordPress.com newsletter and blogs you've subscribed to with {{span}}%(emailAddress)s{{/span}}.",
-				{
-					args: {
-						emailAddress: emailAddress,
-					},
-					components: {
-						span: <span className="email-address" />,
-					},
-				}
-			);
+			return hasTranslation(
+				'Manage WordPress.com blogs and subscriptions you’ve subscribed with {{span}}%(emailAddress)s{{/span}}.'
+			)
+				? translate(
+						'Manage WordPress.com blogs and subscriptions you’ve subscribed with {{span}}%(emailAddress)s{{/span}}.',
+						{
+							args: {
+								emailAddress: emailAddress,
+							},
+							components: {
+								span: <span className="email-address" />,
+							},
+						}
+				  )
+				: translate(
+						"Manage the WordPress.com newsletter and blogs you've subscribed to with {{span}}%(emailAddress)s{{/span}}.",
+						{
+							args: {
+								emailAddress: emailAddress,
+							},
+							components: {
+								span: <span className="email-address" />,
+							},
+						}
+				  );
 		}
-		return translate( 'Manage your WordPress.com blog and newsletter subscriptions.' );
+		return hasTranslation( 'Manage your blog and newsletter subscriptions' )
+			? translate( 'Manage your blog and newsletter subscriptions' )
+			: translate( 'Manage your WordPress.com blog and newsletter subscriptions.' );
 	}, [ emailAddress, translate ] );
 };
 

--- a/client/landing/subscriptions/hooks/use-subheader-text.tsx
+++ b/client/landing/subscriptions/hooks/use-subheader-text.tsx
@@ -35,8 +35,8 @@ const useSubheaderText = () => {
 						}
 				  );
 		}
-		return hasTranslation( 'Manage your blog and newsletter subscriptions.' )
-			? translate( 'Manage your blog and newsletter subscriptions.' )
+		return hasTranslation( 'Manage your WordPress.com site and newsletter subscriptions.' )
+			? translate( 'Manage your WordPress.com site and newsletter subscriptions.' )
 			: translate( 'Manage your WordPress.com blog and newsletter subscriptions.' );
 	}, [ emailAddress, translate ] );
 };

--- a/client/landing/subscriptions/hooks/use-subheader-text.tsx
+++ b/client/landing/subscriptions/hooks/use-subheader-text.tsx
@@ -10,10 +10,10 @@ const useSubheaderText = () => {
 	return useMemo( () => {
 		if ( emailAddress ) {
 			return hasTranslation(
-				'Manage WordPress.com blogs and subscriptions you’ve subscribed with {{span}}%(emailAddress)s{{/span}}.'
+				'Manage WordPress.com sites and newsletters you’ve subscribed to with {{span}}%(emailAddress)s{{/span}}.'
 			)
 				? translate(
-						'Manage WordPress.com blogs and subscriptions you’ve subscribed with {{span}}%(emailAddress)s{{/span}}.',
+						'Manage WordPress.com sites and newsletters you’ve subscribed to with {{span}}%(emailAddress)s{{/span}}.',
 						{
 							args: {
 								emailAddress: emailAddress,
@@ -35,8 +35,8 @@ const useSubheaderText = () => {
 						}
 				  );
 		}
-		return hasTranslation( 'Manage your blog and newsletter subscriptions' )
-			? translate( 'Manage your blog and newsletter subscriptions' )
+		return hasTranslation( 'Manage your blog and newsletter subscriptions.' )
+			? translate( 'Manage your blog and newsletter subscriptions.' )
 			: translate( 'Manage your WordPress.com blog and newsletter subscriptions.' );
 	}, [ emailAddress, translate ] );
 };

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -53,8 +53,8 @@ const SiteSubscriptionsManager = () => {
 					<FormattedHeader
 						headerText={ translate( 'Manage subscribed sites' ) }
 						subHeaderText={
-							hasTranslation( 'Manage your blog and newsletter subscriptions.' )
-								? translate( 'Manage your blog and newsletter subscriptions.' )
+							hasTranslation( 'Manage your site, RSS, and newsletter subscriptions.' )
+								? translate( 'Manage your site, RSS, and newsletter subscriptions.' )
 								: translate( 'Manage your newsletter and blog subscriptions.' )
 						}
 						align="left"

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -1,3 +1,4 @@
+import { useLocale } from '@automattic/i18n-utils';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -36,6 +37,7 @@ const useMarkFollowsAsStaleOnUnmount = () => {
 
 const SiteSubscriptionsManager = () => {
 	const translate = useTranslate();
+	const locale = useLocale();
 	const { hasTranslation } = useI18n();
 
 	// Mark follows as stale on unmount to ensure that the reader
@@ -53,6 +55,7 @@ const SiteSubscriptionsManager = () => {
 					<FormattedHeader
 						headerText={ translate( 'Manage subscribed sites' ) }
 						subHeaderText={
+							locale.startsWith( 'en' ) ||
 							hasTranslation( 'Manage your site, RSS, and newsletter subscriptions.' )
 								? translate( 'Manage your site, RSS, and newsletter subscriptions.' )
 								: translate( 'Manage your newsletter and blog subscriptions.' )

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -3,6 +3,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import ReaderExportButton from 'calypso/blocks/reader-export-button';
@@ -35,6 +36,8 @@ const useMarkFollowsAsStaleOnUnmount = () => {
 
 const SiteSubscriptionsManager = () => {
 	const translate = useTranslate();
+	const { hasTranslation } = useI18n();
+
 	// Mark follows as stale on unmount to ensure that the reader
 	// redux store is in a consistent state when the user navigates.
 	// This is necessary because the subscription manager does not
@@ -49,7 +52,11 @@ const SiteSubscriptionsManager = () => {
 				<HStack className="site-subscriptions-manager__header-h-stack">
 					<FormattedHeader
 						headerText={ translate( 'Manage subscribed sites' ) }
-						subHeaderText={ translate( 'Manage your newsletter and blog subscriptions.' ) }
+						subHeaderText={
+							hasTranslation( 'Manage your blog and newsletter subscriptions.' )
+								? translate( 'Manage your blog and newsletter subscriptions.' )
+								: translate( 'Manage your newsletter and blog subscriptions.' )
+						}
 						align="left"
 					/>
 					<Spacer />


### PR DESCRIPTION
Closes #78789

## Proposed Changes

- Changes the copy as required by the ticket above
- Adds checks to only show the new strings when the translations are ready.

## Testing Instructions

I don't think you should be able to see the new strings, since translations are not yet available. A code review should be fine.


Area for improvement: the code is duplicated (not introduces by this PR). It would be nice to also use `useSubheaderText` in Reader. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
