### PR TITLE
GS on Personal: Fix wrong typeof check

### DIFF
--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -91,7 +91,7 @@ export function useSiteGlobalStylesStatus(
 		queryFn: () => getExperimentAssignment( 'calypso_global_styles_personal' ),
 		placeholderData: null,
 		refetchOnWindowFocus: false,
-		enabled: typeof window !== undefined && siteId === null && isLoggedIn,
+		enabled: typeof window !== 'undefined' && siteId === null && isLoggedIn,
 	} );
 	const currentUserHasGlobalStylesInPersonalPlan =
 		globalStylesOnPersonalExperimentAssignment === 'treatment';


### PR DESCRIPTION
## Proposed Changes

Fixes a wrong `typeof` check that was preventing the GS on Personal A/B assignment from being fetched for new users.

## Testing Instructions

- Use the Calypso live link below
- Observe the requests in the browser devtools
- Go to `/start`
- Create a new account
- Enter a domain
- While in the plans grid, make sure there is a request to fetch the GS on Personal A/B assignment