### PR TITLE
Fix default translation

### DIFF
--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -57,7 +57,7 @@ class PostRelativeTime extends PureComponent {
 					this.props.translate( 'll [at] LT', {
 						comment:
 							'll refers to date (eg. 21 Apr) for when the post will be published & LT refers to time (eg. 18:00) - "at" is translated',
-					} ) ?? '',
+					} ) ?? 'll [at] LT',
 			} );
 		} else {
 			if ( Math.abs( now.diff( this.getTimestamp(), 'days' ) ) < 7 ) {
@@ -68,7 +68,7 @@ class PostRelativeTime extends PureComponent {
 				this.props.translate( 'll [at] LT', {
 					comment:
 						'll refers to date (eg. 21 Apr) & LT refers to time (eg. 18:00) - "at" is translated',
-				} ) ?? '';
+				} ) ?? 'll [at] LT';
 
 			displayedTime = timestamp.calendar( null, {
 				sameElse,

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -258,6 +258,6 @@ export const getShortDateString = ( date: string ) => {
 export const getLongDateString = ( date: string ) => {
 	const timestamp = moment( Date.parse( date ) );
 	// translators: "ll" refers to date (eg. 21 Apr) & "LT" refers to time (eg. 18:00) - "at" is translated
-	const sameElse: string = __( 'll [at] LT' );
+	const sameElse: string = __( 'll [at] LT' ) ?? 'll [at] LT';
 	return timestamp.calendar( null, { sameElse } );
 };


### PR DESCRIPTION

Related to this comment: https://github.com/Automattic/wp-calypso/pull/79367#discussion_r1262655597

## Proposed Changes

* Default to the english String if `translate()` fails
