### PR TITLE
Subscription Management: change copy & spacing of Import/Export

### DIFF
--- a/client/blocks/reader-export-button/index.tsx
+++ b/client/blocks/reader-export-button/index.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { saveAs } from 'browser-filesaver';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef, useCallback } from 'react';
@@ -35,6 +36,7 @@ const ReaderExportButton = ( {
 }: ReaderExportButtonProps ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const { hasTranslation } = useI18n();
 	const isMounted = useRef( false );
 	const [ isExportInProgress, setExportInProgress ] = useState( false );
 
@@ -93,7 +95,9 @@ const ReaderExportButton = ( {
 			{ ...props }
 		>
 			{ ! props.icon && <Gridicon icon="cloud-download" className="reader-export-button__icon" /> }
-			<span className="reader-export-button__label">{ translate( 'Export' ) }</span>
+			<span className="reader-export-button__label">
+				{ hasTranslation( 'Export OPML' ) ? translate( 'Export OPML' ) : translate( 'Export' ) }
+			</span>
 		</Button>
 	);
 };

--- a/client/blocks/reader-import-button/index.tsx
+++ b/client/blocks/reader-import-button/index.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FilePicker from 'calypso/components/file-picker';
@@ -24,6 +25,7 @@ const ReaderImportButton: React.FC< ReaderImportButtonProps > = ( {
 } ) => {
 	const [ disabled, setDisabled ] = useState( false );
 	const translate = useTranslate();
+	const { hasTranslation } = useI18n();
 	const dispatch = useDispatch();
 
 	const onClick = ( event: React.MouseEvent< HTMLButtonElement > ) => {
@@ -83,7 +85,9 @@ const ReaderImportButton: React.FC< ReaderImportButtonProps > = ( {
 		<Button className="reader-import-button" icon={ icon } iconSize={ iconSize }>
 			<FilePicker accept=".xml,.opml" onClick={ onClick } onPick={ onPick }>
 				{ ! icon && <Gridicon icon="cloud-upload" className="reader-import-button__icon" /> }
-				<span className="reader-import-button__label">{ translate( 'Import' ) }</span>
+				<span className="reader-import-button__label">
+					{ hasTranslation( 'Import OPML' ) ? translate( 'Import OPML' ) : translate( 'Import' ) }
+				</span>
 			</FilePicker>
 		</Button>
 	);

--- a/client/blocks/reader-import-button/style.scss
+++ b/client/blocks/reader-import-button/style.scss
@@ -5,6 +5,10 @@
 		vertical-align: middle;
 	}
 
+	svg {
+		min-width: 20px;
+	}
+
 	&__label {
 		padding-left: 4px;
 	}

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -54,12 +54,13 @@ const SiteSubscriptionsManager = () => {
 					/>
 					<Spacer />
 					<AddSitesButton />
+
 					<SubscriptionsEllipsisMenu
 						toggleTitle={ translate( 'More' ) }
 						popoverClassName="site-subscriptions-manager__import-export-popover"
 						verticalToggle
 					>
-						<VStack>
+						<VStack spacing={ 1 }>
 							<ReaderImportButton icon={ uploadCloud } iconSize={ 20 } />
 							<ReaderExportButton
 								icon={ downloadCloud }


### PR DESCRIPTION
Related to [#78792](https://github.com/Automattic/wp-calypso/issues/78792)

## Proposed Changes

- Change Import/Export to Import/Export OPML
- Make icons same size
- Reduce spacing

## Testing Instructions

1. Apply this PR
2. Visit `http://calypso.localhost:3000/read/subscriptions`
3. The Import/Export menu should look like the design: inDLaEQV8jJ21O4WXawIsJ-fi-2671_69466

The strings will display updated when the translations are in.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?