### PR TITLE
GS on Personal: Do not rely on "isUserLoggedIn" selector

### DIFF
--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -87,7 +87,7 @@ export function useSiteGlobalStylesStatus(
 	} );
 
 	const { data: globalStylesOnPersonalExperimentAssignment } = useQuery( {
-		queryKey: [ 'globalStylesOnPersonalExperimentAssignment', siteId ],
+		queryKey: [ 'globalStylesOnPersonalExperimentAssignment', siteId, isLoggedIn ],
 		queryFn: () => getExperimentAssignment( 'calypso_global_styles_personal' ),
 		placeholderData: null,
 		refetchOnWindowFocus: false,

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -84,7 +84,7 @@ function shouldRunGlobalStylesOnPersonalExperiment(
 	}
 
 	// Do not run it on the logged-out theme showcase.
-	if ( ! isLoggedIn && window.location.pathname.startsWith( '/themes' ) ) {
+	if ( ! isLoggedIn && window.location.pathname.startsWith( '/theme' ) ) {
 		return false;
 	}
 
@@ -113,7 +113,7 @@ export function useSiteGlobalStylesStatus(
 	} );
 
 	const { data: globalStylesOnPersonalExperimentAssignment } = useQuery( {
-		queryKey: [ 'globalStylesOnPersonalExperimentAssignment', siteId, isLoggedIn ],
+		queryKey: [ 'globalStylesOnPersonalExperimentAssignment', siteId ],
 		queryFn: () => getExperimentAssignment( 'calypso_global_styles_personal' ),
 		placeholderData: null,
 		refetchOnWindowFocus: false,


### PR DESCRIPTION
## Proposed Changes

Stop relying on the `isUserLoggedIn` selector because it has an incorrect value after a new user signs up.

## Testing Instructions

- Use the Calypso live link below
- Observe the requests in the browser devtools
- Go to `/start`
- Create a new account
- Enter a domain
- While in the plans grid, make sure there is a request to fetch the GS on Personal A/B assignment
- Go to `/themes` while logged out
- Make sure there are no requests to fetch the GS on Personal A/B assignment