### PR TITLE
Add Jetpack Stats product icon

### DIFF
--- a/client/assets/images/jetpack/jetpack-product-icon-stats-light.svg
+++ b/client/assets/images/jetpack/jetpack-product-icon-stats-light.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.25 5H12.75V20H11.25V5Z" fill="white"/>
+<path d="M6 10H7.5V20H6V10Z" fill="white"/>
+<path d="M18 14H16.5V20H18V14Z" fill="white"/>
+</svg>

--- a/client/assets/images/jetpack/jetpack-product-icon-stats.svg
+++ b/client/assets/images/jetpack/jetpack-product-icon-stats.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.25 5H12.75V20H11.25V5Z" fill="black"/>
+<path d="M6 10H7.5V20H6V10Z" fill="black"/>
+<path d="M18 14H16.5V20H18V14Z" fill="black"/>
+</svg>

--- a/client/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon.ts
@@ -10,6 +10,7 @@ import {
 	JETPACK_VIDEOPRESS_PRODUCTS,
 	JETPACK_COMPLETE_PLANS,
 	JETPACK_SECURITY_PLANS,
+	JETPACK_STATS_PRODUCTS,
 } from '@automattic/calypso-products';
 import JetpackProductIconAILight from 'calypso/assets/images/jetpack/jetpack-product-icon-ai-light.svg';
 import JetpackProductIconAI from 'calypso/assets/images/jetpack/jetpack-product-icon-ai.svg';
@@ -29,6 +30,8 @@ import JetpackProductIconSearch from 'calypso/assets/images/jetpack/jetpack-prod
 import JetpackProductIconSecurity from 'calypso/assets/images/jetpack/jetpack-product-icon-security.svg';
 import JetpackProductIconSocialLight from 'calypso/assets/images/jetpack/jetpack-product-icon-social-light.svg';
 import JetpackProductIconSocial from 'calypso/assets/images/jetpack/jetpack-product-icon-social.svg';
+import JetpackProductIconStatsLight from 'calypso/assets/images/jetpack/jetpack-product-icon-stats-light.svg';
+import JetpackProductIconStats from 'calypso/assets/images/jetpack/jetpack-product-icon-stats.svg';
 import JetpackProductIconVideopressLight from 'calypso/assets/images/jetpack/jetpack-product-icon-videopress-light.svg';
 import JetpackProductIconVideopress from 'calypso/assets/images/jetpack/jetpack-product-icon-videopress.svg';
 import { productIconProps } from '../types';
@@ -77,6 +80,10 @@ const PRODUCT_ICON_MAP: Record< string, IconResource > = {
 	...setProductsIcon( JETPACK_CRM_PRODUCTS, {
 		regular: JetpackProductIconCRM,
 		light: JetpackProductIconCRMLight,
+	} ),
+	...setProductsIcon( JETPACK_STATS_PRODUCTS, {
+		regular: JetpackProductIconStats,
+		light: JetpackProductIconStatsLight,
 	} ),
 	...setProductsIcon( JETPACK_COMPLETE_PLANS, {
 		regular: JetpackProductIconComplete,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79092

## Proposed Changes

* Add Jetpack Stats icon and set it in getProductIcon() function

## Testing Instructions

* Purchase Stats product and assign it to your website: https://wordpress.com/checkout/jetpack/jetpack_stats_pwyw_yearly:-q-24 (e.g. fresh Jurassic Ninja site)
* Go to https://wordpress.com/plans/<site_slug> - it will crash (blank page)
* Go to https://container-focused-grothendieck.calypso.live/plans/<site_slug> - it will load
* Note that Stats shows up on product grid, and it has only icon but no content - it will still be worked on before publishing (this PR is only bug fix):
<img width="652" alt="CleanShot 2023-07-13 at 17 20 59@2x" src="https://github.com/Automattic/wp-calypso/assets/8419292/42ba6631-ba70-4b91-a3eb-b81ddb4f1cb7">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
