### PR TITLE
Recommended sites: place holder updated

### DIFF
--- a/client/reader/recommended-sites/placeholder.tsx
+++ b/client/reader/recommended-sites/placeholder.tsx
@@ -4,22 +4,22 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import ReaderAvatar from 'calypso/blocks/reader-avatar';
 
 export const RecommendedSitePlaceholder = () => {
 	return (
-		<Card className="recommended-site" as="li">
+		<Card className="recommended-site is-placeholder" as="li">
 			<Flex justify="flex-end">
 				<div className="recommended-site__dismiss-button is-placeholder">Dismiss Button</div>
 			</Flex>
-			<HStack justify="flex-start" spacing="4">
-				<ReaderAvatar showPlaceholder isCompact />
-				<VStack spacing={ 0 } className="is-placeholder">
+			<HStack justify="flex-start" className="recommended-site__profile" spacing="4">
+				<span className="recommended-site__profile-avatar is-placeholder">Avatar</span>
+				<VStack spacing={ 0 } className="recommended-site__profile-data is-placeholder">
 					<h3 className="recommended-site__site-title is-placeholder">Site title</h3>
 					<span className="recommended-site__site-url is-placeholder">Site domain</span>
 				</VStack>
 			</HStack>
-			<p className="recommended-site__site-description is-placeholder">Site description</p>
+			<p className="recommended-site__site-description is-placeholder">Site description 1</p>
+			<p className="recommended-site__site-description is-placeholder">Site description 2</p>
 			<div className="recommended-site__subscribe-button is-placeholder">Subscribe</div>
 		</Card>
 	);

--- a/client/reader/recommended-sites/placeholder.tsx
+++ b/client/reader/recommended-sites/placeholder.tsx
@@ -11,7 +11,7 @@ export const RecommendedSitePlaceholder = () => {
 			<Flex justify="flex-end">
 				<div className="recommended-site__dismiss-button is-placeholder">Dismiss Button</div>
 			</Flex>
-			<HStack justify="flex-start" className="recommended-site__profile" spacing="4">
+			<HStack justify="flex-start" className="recommended-site__profile is-placeholder" spacing="4">
 				<span className="recommended-site__profile-avatar is-placeholder">Avatar</span>
 				<VStack spacing={ 0 } className="recommended-site__profile-data is-placeholder">
 					<h3 className="recommended-site__site-title is-placeholder">Site title</h3>

--- a/client/reader/recommended-sites/recommended-sites.tsx
+++ b/client/reader/recommended-sites/recommended-sites.tsx
@@ -96,7 +96,9 @@ const RecommendedSites = () => {
 					);
 				} ) }
 				{ filteredRecommendedSites.length < displayRecommendedSitesTotal && (
-					<RecommendedSitesPlaceholder count={ amountOfPlaceHolders } />
+					<RecommendedSitesPlaceholder
+						count={ amountOfPlaceHolders - filteredRecommendedSites.length }
+					/>
 				) }
 			</RecommendedSitesResponsiveContainer>
 		</div>

--- a/client/reader/recommended-sites/recommended-sites.tsx
+++ b/client/reader/recommended-sites/recommended-sites.tsx
@@ -54,6 +54,7 @@ const RecommendedSitesPlaceholder = ( { count }: { count: number } ) => {
 const RecommendedSites = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const amountOfPlaceHolders = useBreakpoint( '<1040px' ) ? 1 : 2;
 
 	const recommendedSites = useSelector(
 		( state ) => getReaderRecommendedSites( state, seed ) as RecommendedSiteType[]
@@ -95,9 +96,7 @@ const RecommendedSites = () => {
 					);
 				} ) }
 				{ filteredRecommendedSites.length < displayRecommendedSitesTotal && (
-					<RecommendedSitesPlaceholder
-						count={ displayRecommendedSitesTotal - filteredRecommendedSites.length }
-					/>
+					<RecommendedSitesPlaceholder count={ amountOfPlaceHolders } />
 				) }
 			</RecommendedSitesResponsiveContainer>
 		</div>

--- a/client/reader/recommended-sites/style.scss
+++ b/client/reader/recommended-sites/style.scss
@@ -37,6 +37,10 @@
 		border-radius: 4px;
 		list-style-type: none;
 
+		&__profile {
+			margin-top: -5px;
+		}
+
 		.reader-avatar {
 			margin: 0;
 			color: $studio-gray-50;
@@ -46,11 +50,16 @@
 			}
 		}
 
+		&__profile-data {
+			height: 40px;
+		}
+
 		&__dismiss-button {
 			color: $studio-gray-60;
 			padding: 0;
 			min-height: unset;
 			height: fit-content;
+			line-height: rem(20px);
 		}
 
 		&__site-title {
@@ -58,9 +67,9 @@
 			font-style: normal;
 			font-weight: 600;
 			font-size: $font-body;
-			line-height: rem(22px);
+			line-height: rem(20px);
 			color: $studio-gray-100;
-			margin-right: 36px; // width of dismiss button
+			width: 182px;
 			@extend %ellipsis;
 		}
 
@@ -69,7 +78,7 @@
 			font-style: normal;
 			font-weight: 400;
 			font-size: $font-body-extra-small;
-			line-height: rem(18px);
+			line-height: rem(13px);
 			color: $studio-gray-40;
 			@extend %ellipsis;
 		}
@@ -95,6 +104,7 @@
 			padding-right: 24px;
 		}
 
+		&__profile-avatar.is-placeholder,
 		&__dismiss-button.is-placeholder,
 		&__site-title.is-placeholder,
 		&__site-url.is-placeholder,
@@ -102,6 +112,34 @@
 		&__subscribe-button.is-placeholder {
 			@include placeholder();
 		}
+
+		&__profile-avatar.is-placeholder {
+			height: 40px;
+			width: 40px;
+		}
+
+		&__site-url.is-placeholder {
+			width: 85px;
+		}
+
+		&__site-description.is-placeholder {
+			height: auto;
+			margin: 18px 0 7px 0;
+		}
+
+		&__subscribe-button.is-placeholder {
+			width: 68px;
+			height: 40px;
+		}
+
+		&__dismiss-button.is-placeholder {
+			width: 36px;
+			height: 20px;
+		}
+	}
+
+	.recommended-site.is-placeholder p:last-of-type {
+		margin: 0 0 15px 0;
 	}
 
 	.dot-pager {

--- a/client/reader/recommended-sites/style.scss
+++ b/client/reader/recommended-sites/style.scss
@@ -37,10 +37,6 @@
 		border-radius: 4px;
 		list-style-type: none;
 
-		&__profile {
-			margin-top: -5px;
-		}
-
 		.reader-avatar {
 			margin: 0;
 			color: $studio-gray-50;
@@ -48,10 +44,6 @@
 			&.is-compact {
 				max-height: 40px;
 			}
-		}
-
-		&__profile-data {
-			height: 40px;
 		}
 
 		&__dismiss-button {
@@ -67,9 +59,9 @@
 			font-style: normal;
 			font-weight: 600;
 			font-size: $font-body;
-			line-height: rem(20px);
+			line-height: rem(22px);
 			color: $studio-gray-100;
-			width: 182px;
+			margin-right: 36px;
 			@extend %ellipsis;
 		}
 
@@ -78,7 +70,7 @@
 			font-style: normal;
 			font-weight: 400;
 			font-size: $font-body-extra-small;
-			line-height: rem(13px);
+			line-height: rem(18px);
 			color: $studio-gray-40;
 			@extend %ellipsis;
 		}
@@ -113,12 +105,26 @@
 			@include placeholder();
 		}
 
+		&__site-title.is-placeholder {
+			line-height: rem(20px);
+			width: 182px;
+		}
+
+		&__profile.is-placeholder {
+			margin-top: -5px;
+		}
+
+		&__profile-data.is-placeholder {
+			height: 40px;
+		}
+
 		&__profile-avatar.is-placeholder {
 			height: 40px;
 			width: 40px;
 		}
 
 		&__site-url.is-placeholder {
+			line-height: rem(13px);
 			width: 85px;
 		}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78790

## Proposed Changes

This PR updates the shape of the Recommended Sites card placeholder according to the Figma design: inDLaEQV8jJ21O4WXawIsJ-fi-3751_74615

<img width="1004" alt="Screenshot 2023-07-13 at 17 06 24" src="https://github.com/Automattic/wp-calypso/assets/3832570/a2d42ed6-9858-4414-abf6-ca5e4353d3cd">

## Testing Instructions

1. Apply this PR and run the application.
2. Go to `http://calypso.localhost:3000/read/subscriptions` and check the loading state of the cards. They should match the ones in the design (considering the cards are responsive).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
