### PR TITLE
GF Signup :  Fix existing oboarding media flow default theme to be initialized

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -14,6 +14,7 @@ import {
 	isWooExpressFlow,
 	isNewHostedSiteCreationFlow,
 	isBlogOnboardingFlow,
+	isOnboardingMediaFlow,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -79,7 +80,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
 	let theme: string;
-	if ( isMigrationFlow( flow ) || isCopySiteFlow( flow ) ) {
+	if ( isMigrationFlow( flow ) || isCopySiteFlow( flow ) || isOnboardingMediaFlow( flow ) ) {
 		theme = DEFAULT_WP_SITE_THEME;
 	} else if ( isWooExpressFlow( flow ) ) {
 		theme = DEFAULT_WOOEXPRESS_FLOW;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -13,8 +13,9 @@ import {
 	isStartWritingFlow,
 	isWooExpressFlow,
 	isNewHostedSiteCreationFlow,
+	isNewsletterFlow,
 	isBlogOnboardingFlow,
-	isOnboardingMediaFlow,
+	isOnboardingPMFlow,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -40,7 +41,7 @@ import type { Step } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import './styles.scss';
 
-const DEFAULT_WP_SITE_THEME = 'pub/zoologist';
+const DEFAULT_SITE_MIGRATION_THEME = 'pub/zoologist';
 const DEFAULT_LINK_IN_BIO_THEME = 'pub/lynx';
 const DEFAULT_WOOEXPRESS_FLOW = 'pub/twentytwentytwo';
 const DEFAULT_NEWSLETTER_THEME = 'pub/lettre';
@@ -79,19 +80,17 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
-	let theme: string;
-	if ( isMigrationFlow( flow ) || isCopySiteFlow( flow ) || isOnboardingMediaFlow( flow ) ) {
-		theme = DEFAULT_WP_SITE_THEME;
+	// when it's empty, the default WordPress theme will be used.
+	let theme = '';
+	if ( isMigrationFlow( flow ) || isCopySiteFlow( flow ) ) {
+		theme = DEFAULT_SITE_MIGRATION_THEME;
 	} else if ( isWooExpressFlow( flow ) ) {
 		theme = DEFAULT_WOOEXPRESS_FLOW;
 	} else if ( isStartWritingFlow( flow ) ) {
 		theme = DEFAULT_START_WRITING_THEME;
-	} else if ( isNewHostedSiteCreationFlow( flow ) ) {
-		// Causes no theme to be set, so WordPress's default theme gets used.
-		theme = '';
 	} else if ( isLinkInBioFlow( flow ) ) {
 		theme = DEFAULT_LINK_IN_BIO_THEME;
-	} else {
+	} else if ( isNewsletterFlow( flow ) ) {
 		theme = DEFAULT_NEWSLETTER_THEME;
 	}
 	const isPaidDomainItem = Boolean( domainCartItem?.product_slug );
@@ -114,6 +113,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		isMigrationFlow( flow ) ||
 		isBlogOnboardingFlow( flow ) ||
 		isNewHostedSiteCreationFlow( flow ) ||
+		isOnboardingPMFlow( flow ) ||
 		wooFlows.includes( flow || '' )
 	) {
 		siteVisibility = Site.Visibility.PublicNotIndexed;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -100,10 +100,6 @@ export const isCopySiteFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ COPY_SITE_FLOW ].includes( flowName ) );
 };
 
-export const isOnboardingMediaFlow = ( flowName?: string | null ) => {
-	return Boolean( flowName && [ ONBOARDING_PM_FLOW ].includes( flowName ) );
-};
-
 export const isWooExpressFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ WOOEXPRESS_FLOW ].includes( flowName ) );
 };

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -100,6 +100,10 @@ export const isCopySiteFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ COPY_SITE_FLOW ].includes( flowName ) );
 };
 
+export const isOnboardingMediaFlow = ( flowName?: string | null ) => {
+	return Boolean( flowName && [ ONBOARDING_PM_FLOW ].includes( flowName ) );
+};
+
 export const isWooExpressFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ WOOEXPRESS_FLOW ].includes( flowName ) );
 };


### PR DESCRIPTION
Partially Fixes - https://github.com/Automattic/martech/issues/1882

## Proposed Changes

Change the theme initialised by the onboarding flow to be the default theme.


<img width="1683" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/83df9686-8375-4ae4-9744-4875192eec55">


## Testing Instructions
* Go through the onboarding media flow `/setup/onboarding-media`
* Reach the launch pad
* The above themes should be active 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
