### PR TITLE
reader: shouldSiteBeFetched: Stop infinite loop when site is 410 gone

### DIFF
--- a/client/state/reader/sites/selectors.js
+++ b/client/state/reader/sites/selectors.js
@@ -15,7 +15,8 @@ const DAY_IN_MILLIS = 24 * 60 * 1000 * 1000;
 export function shouldSiteBeFetched( state, siteId ) {
 	const isNotQueued = ! state.reader.sites.queuedRequests[ siteId ];
 	const isMissing = ! getSite( state, siteId );
-	return isNotQueued && ( isMissing || isStale( state, siteId ) );
+	const staleWithoutError = isStale( state, siteId ) && ! isError( state, siteId );
+	return isNotQueued && ( isMissing || staleWithoutError );
 }
 
 function isStale( state, siteId ) {
@@ -24,6 +25,11 @@ function isStale( state, siteId ) {
 		return true;
 	}
 	return lastFetched <= Date.now() - DAY_IN_MILLIS;
+}
+
+function isError( state, siteId ) {
+	const site = getSite( state, siteId );
+	return site && site.is_error;
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

I noticed on the `/read` page, if you have a site returning a 410 deleted error, the reader makes infinite requests against the site, because `shouldFetch` ([link](https://github.com/Automattic/wp-calypso/blob/3de60af9b16c650e9c98599261e562f13cc6d79a/client/components/data/query-reader-site/index.jsx#L9)) keeps flipping between true and false.  Because it can't get up to date data on the site, it thinks it is stale ([link](https://github.com/Automattic/wp-calypso/blob/3de60af9b16c650e9c98599261e562f13cc6d79a/client/state/reader/sites/selectors.js#L22-L28)) and should be refetched. 

In this patch, I changed the "isStale" check to "staleWithoutError" which seems to fix the problem. Not sure if it's the best way to go though.

## Testing Instructions

* Sandbox public-api
* On your sandbox, force all sites to return a 410 deleted error
```diff
diff --git a/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-read-site-endpoint.php b/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-read-site-endpoint.php
index 1de97ad3a5..4002d292d5 100644
--- a/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-read-site-endpoint.php
+++ b/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-read-site-endpoint.php
@@ -17,7 +17,7 @@ class WPCOM_JSON_API_Read_Site_Endpoint extends WPCOM_JSON_API_GET_Site_Endpoint
                require_lib( 'wpforteams' );
                require_lib( 'seen-posts' );
 
-               if ( $this->is_deleted_site( $blog_id_or_url ) ) {
+               if ( true || $this->is_deleted_site( $blog_id_or_url ) ) {
                        return new WP_Error( 'site_gone', 'The site has been deleted', 410 );
                }
 
```
* Visit http://calypso.localhost:3000/read
* Open network tab
* Notice an infinite loop of requests made to urls like `public-api.wordpress.com/rest/v1.1/read/sites/<number>`
* On this branch, the infinite loop should be fixed