### PR TITLE
fix order of videopress stats column headers in csv export

### DIFF
--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -166,7 +166,7 @@ class VideoPressStatsModule extends Component {
 		const isNewVideoPage = config.isEnabled( 'stats/new-video-summary' );
 
 		const csvData = [
-			[ 'post_id', 'title', 'impressions', 'watch_time', 'retention_rate', 'views' ],
+			[ 'post_id', 'title', 'views', 'impressions', 'watch_time', 'retention_rate' ],
 			...completeVideoStats,
 		];
 		const downloadCSV = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79302

## Proposed Changes

* fix the position of the `views` header

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn && yarn start` or use a calypso live link below
* view video stats for one of your test sites with videopress views `/stats/year/videoplays/{site-name}`
* click the "Download data as csv" button in the header
* view the downloaded file, it should include column headers
* the data + headers should match the data in the view (`views` will be out of order, but the values should be correct)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
