### PR TITLE
Checkout: Standardize submit button text for free purchases

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -148,10 +148,7 @@ function ButtonContents( {
 	}
 	if ( formStatus === FormStatus.READY && isPurchaseFree ) {
 		const defaultText = (
-			<CreditCardPayButtonWrapper>
-				<StyledMaterialIcon icon="credit_card" />
-				{ __( 'Complete Checkout' ) }
-			</CreditCardPayButtonWrapper>
+			<CreditCardPayButtonWrapper>{ __( 'Complete Checkout' ) }</CreditCardPayButtonWrapper>
 		);
 		/* translators: %s is the total to be paid in localized currency */
 		return <>{ activeButtonText || defaultText }</>;

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -6,7 +6,6 @@ import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import i18n, { getLocaleSlug } from 'i18n-calypso';
 import MaterialIcon from 'calypso/components/material-icon';
 import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
 import { actions, selectors } from './store';
@@ -15,7 +14,7 @@ import type { CardFieldState, CardStoreType } from './types';
 import type { ProcessPayment, LineItem } from '@automattic/composite-checkout';
 import type { ReactNode } from 'react';
 
-const debug = debugFactory( 'calypso:composite-checkout:credit-card' );
+const debug = debugFactory( 'calypso:credit-card' );
 
 export default function CreditCardPayButton( {
 	disabled,
@@ -143,21 +142,29 @@ function ButtonContents( {
 	activeButtonText?: ReactNode;
 } ) {
 	const { __ } = useI18n();
+	const isPurchaseFree = total.amount.value === 0;
 	if ( formStatus === FormStatus.SUBMITTING ) {
 		return <>{ __( 'Processing…' ) }</>;
+	}
+	if ( formStatus === FormStatus.READY && isPurchaseFree ) {
+		const defaultText = (
+			<CreditCardPayButtonWrapper>
+				<StyledMaterialIcon icon="credit_card" />
+				{ __( 'Complete Checkout' ) }
+			</CreditCardPayButtonWrapper>
+		);
+		/* translators: %s is the total to be paid in localized currency */
+		return <>{ activeButtonText || defaultText }</>;
 	}
 	if ( formStatus === FormStatus.READY ) {
 		const defaultText = (
 			<CreditCardPayButtonWrapper>
 				<StyledMaterialIcon icon="credit_card" />
-				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'Pay %s now' )
-					? sprintf(
-							/* translators: %s is the total to be paid in localized currency */
-							__( 'Pay %s now' ),
-							total.amount.displayValue
-					  )
-					: /* translators: %s is the total to be paid in localized currency */
-					  sprintf( __( 'Pay %s' ), total.amount.displayValue ) }
+				{ sprintf(
+					/* translators: %s is the total to be paid in localized currency */
+					__( 'Pay %s now' ),
+					total.amount.displayValue
+				) }
 			</CreditCardPayButtonWrapper>
 		);
 

--- a/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
@@ -9,7 +9,7 @@ import { styled } from '@automattic/wpcom-checkout';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import i18n, { useTranslate, getLocaleSlug } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import MaterialIcon from 'calypso/components/material-icon';
 import {
@@ -260,21 +260,29 @@ function ButtonContents( {
 	activeButtonText?: string;
 } ) {
 	const { __ } = useI18n();
+	const isPurchaseFree = total.amount.value === 0;
 	if ( formStatus === FormStatus.SUBMITTING ) {
 		return <>{ __( 'Processing…' ) }</>;
+	}
+	if ( formStatus === FormStatus.READY && isPurchaseFree ) {
+		const defaultText = (
+			<CreditCardPayButtonWrapper>
+				<StyledMaterialIcon icon="credit_card" />
+				{ __( 'Complete Checkout' ) }
+			</CreditCardPayButtonWrapper>
+		);
+		/* translators: %s is the total to be paid in localized currency */
+		return <>{ activeButtonText || defaultText }</>;
 	}
 	if ( formStatus === FormStatus.READY ) {
 		const defaultText = (
 			<CreditCardPayButtonWrapper>
 				<StyledMaterialIcon icon="credit_card" />
-				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'Pay %s now' )
-					? sprintf(
-							/* translators: %s is the total to be paid in localized currency */
-							__( 'Pay %s now' ),
-							total.amount.displayValue
-					  )
-					: /* translators: %s is the total to be paid in localized currency */
-					  sprintf( __( 'Pay %s' ), total.amount.displayValue ) }
+				{ sprintf(
+					/* translators: %s is the total to be paid in localized currency */
+					__( 'Pay %s now' ),
+					total.amount.displayValue
+				) }
 			</CreditCardPayButtonWrapper>
 		);
 		/* translators: %s is the total to be paid in localized currency */

--- a/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
@@ -266,10 +266,7 @@ function ButtonContents( {
 	}
 	if ( formStatus === FormStatus.READY && isPurchaseFree ) {
 		const defaultText = (
-			<CreditCardPayButtonWrapper>
-				<StyledMaterialIcon icon="credit_card" />
-				{ __( 'Complete Checkout' ) }
-			</CreditCardPayButtonWrapper>
+			<CreditCardPayButtonWrapper>{ __( 'Complete Checkout' ) }</CreditCardPayButtonWrapper>
 		);
 		/* translators: %s is the total to be paid in localized currency */
 		return <>{ activeButtonText || defaultText }</>;

--- a/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
@@ -7,7 +7,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import WordPressLogo from '../components/wordpress-logo';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
-import type { ResponseCart } from '@automattic/shopping-cart';
 
 export function createFreePaymentMethod(): PaymentMethod {
 	return {
@@ -28,8 +27,6 @@ function FreePurchaseSubmitButton( {
 	onClick?: ProcessPayment;
 } ) {
 	const { formStatus } = useFormStatus();
-	const cartKey = useCartKey();
-	const { responseCart } = useShoppingCart( cartKey );
 
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
@@ -52,18 +49,12 @@ function FreePurchaseSubmitButton( {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } responseCart={ responseCart } />
+			<ButtonContents formStatus={ formStatus } />
 		</Button>
 	);
 }
 
-function ButtonContents( {
-	formStatus,
-	responseCart,
-}: {
-	formStatus: FormStatus;
-	responseCart: ResponseCart;
-} ) {
+function ButtonContents( { formStatus }: { formStatus: FormStatus } ) {
 	const { __ } = useI18n();
 
 	if ( formStatus === FormStatus.SUBMITTING ) {
@@ -71,15 +62,6 @@ function ButtonContents( {
 	}
 
 	if ( formStatus === FormStatus.READY ) {
-		if ( doesPurchaseHaveFullCredits( responseCart ) ) {
-			const total = formatCurrency(
-				responseCart.sub_total_with_taxes_integer,
-				responseCart.currency,
-				{ isSmallestUnit: true, stripZeros: true }
-			);
-			/* translators: %s is the total to be paid in localized currency */
-			return <>{ sprintf( __( 'Pay %s with credits' ), total ) }</>;
-		}
 		return <>{ __( 'Complete Checkout' ) }</>;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/test/credit-card.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/credit-card.tsx
@@ -49,7 +49,7 @@ const customerName = 'Human Person';
 const cardNumber = '4242424242424242';
 const cardExpiry = '05/99';
 const cardCvv = '123';
-const activePayButtonText = 'Pay 0 now';
+const activePayButtonText = 'Complete Checkout';
 function getPaymentMethod( store: CardStoreType, additionalArgs = {} ) {
 	return createCreditCardMethod( {
 		store,


### PR DESCRIPTION
## Proposed Changes

The checkout submit button varies based on a number of factors and is defined separately for each payment method. Until https://github.com/Automattic/wp-calypso/pull/79083 and https://github.com/Automattic/wp-calypso/pull/79029, when the checkout total was 0, there was only one payment method available: the free payment method. Its submit button read either  "Pay X with credits" (where X is the subtotal before credits if the cause of the cart being free is credits) or "Complete Checkout".

Now that we display some other payment methods (existing cards and new cards) for free purchases, we have some variation in the submit button text. For those payment methods, the submit button reads "Pay 0 now". This variation in wording is leading to some confusion.

In this PR, we modify the submit buttons for all three payment methods to always read "Complete Checkout" when the cart total is 0. Hopefully this will be less confusing.

NOTE: arguably "Complete Checkout" should be sentence case to match the rest of checkout, but that would involve changing translations so we can do that later.

Fixes https://github.com/Automattic/wp-calypso/issues/79369

## Screenshots

Before, with a new or existing card:

<img width="605" alt="Screenshot 2023-07-13 at 3 57 34 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/990971d8-1948-40e6-ba59-c65fa9fb294c">

Before, with full credits and having selected "Assign a payment method later":

<img width="600" alt="Screenshot 2023-07-13 at 3 57 49 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/a9502e68-0441-46b6-9b4f-f9e87fc78dc1">

After, for everything:

<img width="606" alt="Screenshot 2023-07-13 at 3 57 29 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/e483ba4a-b67f-4206-b605-23b45b3f6b4d">


## Testing Instructions

- First we'll need a shopping cart with a 0 total. You can do this by using a 100% coupon, a domain credit, or credits.
- Use an account with at least one saved card.
- Visit checkout and move to the last step if it is not already active.
- Verify that the submit button reads "Complete Checkout" no matter which payment method is selected.