### PR TITLE
Stats: Always show notice for personal plan

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -46,18 +46,16 @@ const PersonalPurchase = ( {
 
 	return (
 		<div>
-			{ subscriptionValue < 10 && (
-				<div className={ `${ COMPONENT_CLASS_NAME }__notice` }>
-					{ translate(
-						'This plan is for personal sites only. If your site is used for a commercial activity, {{Button}}you will need to choose a commercial plan{{/Button}}.',
-						{
-							components: {
-								Button: <Button variant="link" href="#" onClick={ ( e ) => handlePlanSwap( e ) } />,
-							},
-						}
-					) }
-				</div>
-			) }
+			<div className={ `${ COMPONENT_CLASS_NAME }__notice` }>
+				{ translate(
+					'This plan is for personal sites only. If your site is used for a commercial activity, {{Button}}you will need to choose a commercial plan{{/Button}}.',
+					{
+						components: {
+							Button: <Button variant="link" href="#" onClick={ ( e ) => handlePlanSwap( e ) } />,
+						},
+					}
+				) }
+			</div>
 			<PricingSlider
 				className={ `${ COMPONENT_CLASS_NAME }__slider` }
 				value={ subscriptionValue }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -38,8 +38,13 @@ const PersonalPurchase = ( {
 
 		return (
 			<div { ...props }>
-				{ formatCurrency( state?.valueNow || subscriptionValue, currencyCode ) }/
-				{ translate( 'month' ) } { subscriptionValue > 0 && emoji }
+				{ translate( '%(value)s/month', {
+					args: {
+						value: formatCurrency( state?.valueNow || subscriptionValue, currencyCode ),
+					},
+					comment: 'Price per month selected by the user via the pricing slider',
+				} ) }
+				{ subscriptionValue > 0 && emoji }
 			</div>
 		);
 	} ) as RenderThumbFunction;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

A follow-up to #79045

## Proposed Changes

<img width="583" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/a4be0259-2bbb-4e95-8569-07afa7c24e92">

* Tweaks translated string to give more context to translators
* Permanently shows the noncommercial notice for personal plan purchases.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch for this PR.
* Navigate to `/stats/purchase/:siteSlug?flags=stats/paid-stats`.
* Ensure that the personal plan notice remains regardless of the selected price.
* Ensure that the page is correctly translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
