### PR TITLE
fix: Hide AppBanner during Launchpad flows

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -1,5 +1,6 @@
 import { Button, Card } from '@automattic/components';
 import { compose } from '@wordpress/compose';
+import { getQueryArg } from '@wordpress/url';
 import classNames from 'classnames';
 import { localize, withRtl } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -64,14 +65,23 @@ export class AppBanner extends Component {
 	constructor( props ) {
 		super( props );
 
+		let isDraftPostModalShown = false;
 		if (
 			typeof window !== 'undefined' &&
 			window.sessionStorage?.getItem( 'wpcom_signup_complete_show_draft_post_modal' )
 		) {
-			this.state = { isDraftPostModalShown: true };
-		} else {
-			this.state = { isDraftPostModalShown: false };
+			isDraftPostModalShown = true;
 		}
+
+		let isLaunchpadEnabled = false;
+		if (
+			typeof window !== 'undefined' &&
+			getQueryArg( window.location.href, 'showLaunchpad' ) === 'true'
+		) {
+			isLaunchpadEnabled = true;
+		}
+
+		this.state = { isDraftPostModalShown, isLaunchpadEnabled };
 	}
 
 	stopBubblingEvents = ( event ) => {
@@ -194,7 +204,11 @@ export class AppBanner extends Component {
 	};
 
 	render() {
-		if ( ! this.props.shouldDisplayAppBanner || this.state.isDraftPostModalShown ) {
+		if (
+			! this.props.shouldDisplayAppBanner ||
+			this.state.isDraftPostModalShown ||
+			this.state.isLaunchpadEnabled
+		) {
 			return null;
 		}
 

--- a/client/state/selectors/should-display-app-banner.ts
+++ b/client/state/selectors/should-display-app-banner.ts
@@ -14,7 +14,8 @@ import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/prefe
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { shouldDisplayTosUpdateBanner } from 'calypso/state/selectors/should-display-tos-update-banner';
 import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
-import { getSectionName, appBannerIsEnabled } from 'calypso/state/ui/selectors';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSectionName, appBannerIsEnabled, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 
 /**
@@ -53,6 +54,13 @@ export const shouldDisplayAppBanner = ( state: AppState ): boolean | undefined =
 		return false;
 	}
 
+	// Do not show the banner if the user will be redirected to launchpad
+	const currentSiteId = getSelectedSiteId( state );
+	const launchpadScreen = getSiteOption( state, currentSiteId, 'launchpad_screen' );
+	if ( launchpadScreen === 'full' ) {
+		return false;
+	}
+
 	if ( ! includes( ALLOWED_SECTIONS, currentSection ) ) {
 		return false;
 	}
@@ -66,6 +74,7 @@ export const shouldDisplayAppBanner = ( state: AppState ): boolean | undefined =
 export default createSelector( shouldDisplayAppBanner, [
 	shouldDisplayTosUpdateBanner,
 	appBannerIsEnabled,
+	getSelectedSiteId,
 	hasReceivedRemotePreferences,
 	getSectionName,
 	isNotificationsOpen,

--- a/client/state/selectors/should-display-app-banner.ts
+++ b/client/state/selectors/should-display-app-banner.ts
@@ -5,6 +5,7 @@ import {
 	APP_BANNER_DISMISS_TIMES_PREFERENCE,
 	ALLOWED_SECTIONS,
 	GUTENBERG,
+	HOME,
 	isDismissed,
 	getCurrentSection,
 } from 'calypso/blocks/app-banner/utils';
@@ -57,7 +58,7 @@ export const shouldDisplayAppBanner = ( state: AppState ): boolean | undefined =
 	// Do not show the banner if the user will be redirected to launchpad
 	const currentSiteId = getSelectedSiteId( state );
 	const launchpadScreen = getSiteOption( state, currentSiteId, 'launchpad_screen' );
-	if ( launchpadScreen === 'full' ) {
+	if ( launchpadScreen === 'full' && HOME === currentSection ) {
 		return false;
 	}
 

--- a/client/state/selectors/test/should-display-app-banner.js
+++ b/client/state/selectors/test/should-display-app-banner.js
@@ -192,4 +192,31 @@ describe( 'shouldDisplayAppBanner()', () => {
 		const output = shouldDisplayAppBanner( state );
 		expect( output ).toBe( false );
 	} );
+
+	test( 'should return false if launchpad_screen is "full"', () => {
+		const state = {
+			ui: {
+				appBannerVisibility: true,
+				layoutFocus: {
+					current: 'not-sidebar',
+				},
+				section: {
+					name: 'gutenberg-editor',
+				},
+				selectedSiteId: 123,
+			},
+			preferences: {
+				remoteValues: [ 'something' ],
+			},
+			sites: {
+				items: {
+					123: {
+						options: { launchpad_screen: 'full' },
+					},
+				},
+			},
+		};
+		const output = shouldDisplayAppBanner( state );
+		expect( output ).toBe( false );
+	} );
 } );

--- a/client/state/selectors/test/should-display-app-banner.js
+++ b/client/state/selectors/test/should-display-app-banner.js
@@ -193,30 +193,61 @@ describe( 'shouldDisplayAppBanner()', () => {
 		expect( output ).toBe( false );
 	} );
 
-	test( 'should return false if launchpad_screen is "full"', () => {
-		const state = {
-			ui: {
-				appBannerVisibility: true,
-				layoutFocus: {
-					current: 'not-sidebar',
+	describe( 'when current section is HOME', () => {
+		test( 'should return false if launchpad_screen is "full"', () => {
+			const state = {
+				ui: {
+					appBannerVisibility: true,
+					layoutFocus: {
+						current: 'not-sidebar',
+					},
+					section: {
+						name: 'home',
+					},
+					selectedSiteId: 123,
 				},
-				section: {
-					name: 'gutenberg-editor',
+				preferences: {
+					remoteValues: [ 'something' ],
 				},
-				selectedSiteId: 123,
-			},
-			preferences: {
-				remoteValues: [ 'something' ],
-			},
-			sites: {
-				items: {
-					123: {
-						options: { launchpad_screen: 'full' },
+				sites: {
+					items: {
+						123: {
+							options: { launchpad_screen: 'full' },
+						},
 					},
 				},
-			},
-		};
-		const output = shouldDisplayAppBanner( state );
-		expect( output ).toBe( false );
+			};
+			const output = shouldDisplayAppBanner( state );
+			expect( output ).toBe( false );
+		} );
+	} );
+
+	describe( 'when current section is not HOME', () => {
+		test( 'should return true if launchpad_screen is "full"', () => {
+			const state = {
+				ui: {
+					appBannerVisibility: true,
+					layoutFocus: {
+						current: 'not-sidebar',
+					},
+					section: {
+						name: 'gutenberg-editor',
+					},
+					selectedSiteId: 123,
+				},
+				preferences: {
+					remoteValues: [ 'something' ],
+				},
+				sites: {
+					items: {
+						123: {
+							options: { launchpad_screen: 'full' },
+						},
+					},
+				},
+			};
+			const output = shouldDisplayAppBanner( state );
+			expect( output ).toBe( true );
+		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Address an issue reported in p1689187267270519-slack-C9EJ7KSGH. 

* Disable the app install banner when visiting the Dashboard (home) section and `launchpad_screen` is `"full"`. 
* Disable the app install banner when visiting Gutenberg and the `showLaunchpad` query parameter is `"true"`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> **Note**: 
> * Use the Calypso Live link for testing: https://github.com/Automattic/wp-calypso/pull/79388#issuecomment-1634915506. 
> * Each test case requires an account that has _not_ dismissed the app banners.
> * In order to see the app banners, you must be using a mobile device or emulating one via Chrome's developer tools. 
> * When testing the Calypso Live network, emulating a mobile device may result in seeing an "Unsupported Browser" warning. One can either (A) tap "Continue loading the page anyway" or (B) visit the page without running the emulator, allow the page to load, enable the emulator, and refresh the page. 
>     <details><summary>Unsupported Browser Warning</summary><img alt="unsupported-browser-warning" src="https://github.com/Automattic/wp-calypso/assets/438664/bc8c8b9e-d222-4c7b-b489-1b26798753ac" /></details>

### The app banner is _not_ displayed in the editor during Launchpad
1. Create a new account or use one that has not dismissed the app banners. 
1. In the same browser window, visit `<calypso-live-domain>/start`. 
1. Tap "Choose my domain later." 
1. Tap "Start with Free." 
1. Scroll to the bottom of the page and tap the "Continue." 
1. Scroll to the bottom of the page and tap "Open the editor." 
1. ✅ Verify the app install banner is _not_ displayed momentarily during redirects to the editor. 

### The app banner is _not_ displayed on the Dashboard during Launchpad
1. Create a new account or use one that has not dismissed the app banners. 
1. In the same browser window, visit `<calypso-live-domain>/start`. 
1. Tap "Choose my domain later." 
1. Tap "Start with Free." 
1. Scroll to the bottom of the page and tap the "Continue." 
1. Visit the Dashboard: `<calypso-live-domain>/home`. 
1. If presented with the site picker, choose the site that is being set up in the Launchpad flow.
1. ✅ Verify the app install banner is _not_ displayed momentarily during redirects to the Launchpad. 

### The app banner is displayed in the editor
1. Switch to a site that is not within the Launchpad flow, i.e. the site is "complete." 
1. Create a new post. 
1.  ✅ Verify the app install banner is displayed. 

### The app banner is displayed on the Dashboard
1. Switch to a site that is not within the Launchpad flow, i.e. the site is "complete." 
1. Visit the Dashboard: `<calypso-live-domain>/home`. 
1. If presented with the site picker, choose the site that is not within the Launchpad flow, i.e. the site is "complete." 
1. ✅ Verify the app install banner is displayed. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
