### PR TITLE
All Domains Page: Add margin to all domains table

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain-header/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain-header/style.scss
@@ -71,3 +71,17 @@
 		height: 76px;
 	}
 }
+
+.domain-settings-page {
+	.domain-header__spacer {
+		height: 40px;
+
+		@include breakpoint-deprecated( "<960px" ) {
+			height: 66px;
+		}
+
+		@include breakpoint-deprecated( "<660px" ) {
+			height: 76px;
+		}
+	}
+}

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -412,21 +412,23 @@ class AllDomains extends Component {
 		return (
 			<>
 				<div className="all-domains__filter">{ this.renderDomainTableFilterButton() }</div>
-				<DomainsTable
-					currentRoute={ currentRoute }
-					domains={ domains }
-					handleDomainItemToggle={ this.handleDomainItemToggle }
-					domainsTableColumns={ domainsTableColumns }
-					isManagingAllSites={ true }
-					isContactEmailEditContext={ isContactEmailEditContext }
-					goToEditDomainRoot={ this.handleDomainItemClick }
-					isLoading={ this.isLoading() }
-					purchases={ purchases }
-					sites={ sites }
-					requestingSiteDomains={ requestingSiteDomains }
-					hasLoadedPurchases={ hasLoadedUserPurchases }
-					isSavingContactInfo={ isSavingContactInfo }
-				/>
+				<div className="all-domains__table-container">
+					<DomainsTable
+						currentRoute={ currentRoute }
+						domains={ domains }
+						handleDomainItemToggle={ this.handleDomainItemToggle }
+						domainsTableColumns={ domainsTableColumns }
+						isManagingAllSites={ true }
+						isContactEmailEditContext={ isContactEmailEditContext }
+						goToEditDomainRoot={ this.handleDomainItemClick }
+						isLoading={ this.isLoading() }
+						purchases={ purchases }
+						sites={ sites }
+						requestingSiteDomains={ requestingSiteDomains }
+						hasLoadedPurchases={ hasLoadedUserPurchases }
+						isSavingContactInfo={ isSavingContactInfo }
+					/>
+				</div>
 			</>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -118,6 +118,10 @@
 	}
 }
 
+.all-domains__table-container {
+	margin-top: 24px;
+}
+
 .empty-domains-list-card__wrapper,
 .domain-only-upsell-carousel__card-wrapper {
 	display: flex;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1689287377789059-slack-C05CT832K2T

## Proposed Changes

* Adds container element that wraps the all domains table
* Adds margin to the container to patch content overlap issue

## Screenshots
### Before
<img width="1496" alt="Screenshot 2023-07-13 at 3 49 34 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/7760a189-51f7-4307-9536-c5a74b85dcc1">

### After
<img width="1496" alt="Screenshot 2023-07-13 at 3 48 40 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/348a031b-e287-44b1-8f26-1a8a72001276">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* `yarn && yarn start`
* Navigate to calypso.localhost:3000/domains/manage and verify that there is no longer content overlap

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?