### PR TITLE
Revert "reader search: Make search suggestions use the same component as search results"

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -201,14 +201,11 @@ const DiscoverStream = ( props ) => {
 	}
 
 	const streamSidebar =
-		( isDefaultTab || selectedTab === 'latest' ) && recommendedSites?.length ? (
-			<>
-				<h2>{ translate( 'Popular Sites' ) }</h2>
-				<ReaderPopularSitesSidebar
-					items={ recommendedSites }
-					followSource={ READER_DISCOVER_POPULAR_SITES }
-				/>
-			</>
+		isDefaultTab || selectedTab === 'latest' ? (
+			<ReaderPopularSitesSidebar
+				items={ recommendedSites }
+				followSource={ READER_DISCOVER_POPULAR_SITES }
+			/>
 		) : (
 			<ReaderTagSidebar tag={ selectedTab } />
 		);

--- a/client/reader/stream/empty-search-recommended-post.jsx
+++ b/client/reader/stream/empty-search-recommended-post.jsx
@@ -1,23 +1,32 @@
-import { useDispatch } from 'react-redux';
+import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
 import { recordTrackForPost, recordAction } from 'calypso/reader/stats';
-import { showSelectedPost } from 'calypso/reader/utils';
-import Post from './post';
 
-export default function EmptySearchRecommendedPost( { post, postKey, streamKey } ) {
-	const dispatch = useDispatch();
-
+export default function EmptySearchRecommendedPost( { post } ) {
 	function handlePostClick() {
 		recordTrackForPost( 'calypso_reader_recommended_post_clicked', post, {
 			recommendation_source: 'empty-search',
 		} );
 		recordAction( 'search_page_rec_post_click' );
-		dispatch(
-			showSelectedPost( {
-				postKey: postKey,
-				streamKey,
-			} )
-		);
 	}
 
-	return <Post post={ post } handleClick={ handlePostClick } />;
+	function handleSiteClick() {
+		recordTrackForPost( 'calypso_reader_recommended_site_clicked', post, {
+			recommendation_source: 'empty-search',
+		} );
+		recordAction( 'search_page_rec_site_click' );
+	}
+
+	const site = { title: post && post.site_name };
+
+	/* eslint-disable  wpcalypso/jsx-classname-namespace */
+	return (
+		<div className="search-stream__recommendation-list-item" key={ post && post.global_ID }>
+			<RelatedPostCard
+				post={ post }
+				site={ site }
+				onSiteClick={ handleSiteClick }
+				onPostClick={ handlePostClick }
+			/>
+		</div>
+	);
 }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -16,6 +16,7 @@ import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import scrollTo from 'calypso/lib/scroll-to';
 import withDimensions from 'calypso/lib/with-dimensions';
 import ReaderMain from 'calypso/reader/components/reader-main';
+import { READER_SEARCH_POPULAR_SITES } from 'calypso/reader/follow-sources';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
 import { keysAreEqual, keyToString } from 'calypso/reader/post-key';
 import UpdateNotice from 'calypso/reader/update-notice';
@@ -47,6 +48,7 @@ import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import EmptyContent from './empty';
 import PostLifecycle from './post-lifecycle';
 import PostPlaceholder from './post-placeholder';
+import ReaderPopularSitesSidebar from './reader-popular-sites-sidebar';
 import './style.scss';
 
 const WIDE_DISPLAY_CUTOFF = 900;
@@ -492,9 +494,17 @@ class ReaderStream extends Component {
 				/>
 			);
 
-			const sidebarContent = this.props.streamSidebar;
+			let sidebarContent = this.props.streamSidebar;
 
-			// Exclude the sidebar layout for the search stream, since it's handled by `<SiteResults>`.
+			// Add the sidebar on the search page when there's no search input. Sidebar is handled by `<SiteResults>' when there's a search query.
+			// TODO: use `streamSidebar` prop in search stream component, rather than using conditionals here.
+			if ( streamType === 'custom_recs_sites_with_images' ) {
+				sidebarContent = (
+					<ReaderPopularSitesSidebar items={ items } followSource={ READER_SEARCH_POPULAR_SITES } />
+				);
+			}
+
+			// Exclude the sidebar layout when there's a search query, since it's handled by `<SiteResults>`.
 			if ( ! sidebarContent || streamType === 'search' ) {
 				body = <div className="reader__content">{ bodyContent }</div>;
 			} else if ( wideDisplay ) {

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -53,9 +53,7 @@ class PostLifecycle extends Component {
 				</div>
 			);
 		} else if ( ! isDiscoverStream && streamKey.indexOf( 'rec' ) > -1 ) {
-			return (
-				<EmptySearchRecommendedPost post={ post } postKey={ postKey } streamKey={ streamKey } />
-			);
+			return <EmptySearchRecommendedPost post={ post } site={ postKey } />;
 		} else if ( postKey.isGap ) {
 			return (
 				<ListGap

--- a/client/reader/stream/reader-popular-sites-sidebar/index.jsx
+++ b/client/reader/stream/reader-popular-sites-sidebar/index.jsx
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import '../style.scss';
 
@@ -23,6 +24,8 @@ const getSiteFromItem = ( item ) => {
 };
 
 const ReaderPopularSitesSidebar = ( { items, followSource } ) => {
+	const translate = useTranslate();
+
 	const sites = items
 		.map( ( item ) => getSiteFromItem( item ) )
 		.filter( ( site ) => site !== null );
@@ -45,7 +48,12 @@ const ReaderPopularSitesSidebar = ( { items, followSource } ) => {
 		return null;
 	}
 
-	return <div className="reader-tag-sidebar-recommended-sites">{ popularSitesLinks }</div>;
+	return (
+		<div className="reader-tag-sidebar-recommended-sites">
+			<h2>{ translate( 'Popular Sites' ) }</h2>
+			{ popularSitesLinks }
+		</div>
+	);
 };
 
 export default ReaderPopularSitesSidebar;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#79333

I found a bug before shipping: when you click on a site and then use the browser back button, there is a null reference exception