### PR TITLE
Paid Stats: Add free plan purchase success banner

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -2,13 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
 export type Notices = {
+	free_plan_purchase_success: boolean;
 	new_stats_feedback: boolean;
 	opt_in_new_stats: boolean;
 	opt_out_new_stats: boolean;
 	traffic_page_highlights_module_settings: boolean;
 	traffic_page_settings: boolean;
 	do_you_love_jetpack_stats: boolean;
-	free_plan_purchase_success: boolean;
 };
 
 // These notices are mutually exclusive, so if one is active, the other should be hidden.

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -8,6 +8,7 @@ export type Notices = {
 	traffic_page_highlights_module_settings: boolean;
 	traffic_page_settings: boolean;
 	do_you_love_jetpack_stats: boolean;
+	free_plan_purchase_success: boolean;
 };
 
 // These notices are mutually exclusive, so if one is active, the other should be hidden.

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -48,7 +48,7 @@ import DatePicker from './stats-date-picker';
 import StatsModule from './stats-module';
 import StatsModuleEmails from './stats-module-emails';
 import StatsNotices from './stats-notices';
-// import FreePlanPurchaseSuccessJetpackStatsNotice from './stats-notices/free-plan-purchase-success-notice';
+import FreePlanPurchaseSuccessJetpackStatsNotice from './stats-notices/free-plan-purchase-success-notice';
 import StatsPageHeader from './stats-page-header';
 import PageViewTracker from './stats-page-view-tracker';
 import StatsPeriodHeader from './stats-period-header';
@@ -241,13 +241,10 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				<StatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
-<<<<<<< HEAD
 
 				{ statsPurchaseSuccess && <p>Thank you for using Jetpack Stats</p> }
 
-=======
-				{ /* <FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } /> */ }
->>>>>>> 91d4209d60 (test output of banner)
+				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
 				<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -48,6 +48,7 @@ import DatePicker from './stats-date-picker';
 import StatsModule from './stats-module';
 import StatsModuleEmails from './stats-module-emails';
 import StatsNotices from './stats-notices';
+// import FreePlanPurchaseSuccessJetpackStatsNotice from './stats-notices/free-plan-purchase-success-notice';
 import StatsPageHeader from './stats-page-header';
 import PageViewTracker from './stats-page-view-tracker';
 import StatsPeriodHeader from './stats-period-header';
@@ -240,9 +241,13 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				<StatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
+<<<<<<< HEAD
 
 				{ statsPurchaseSuccess && <p>Thank you for using Jetpack Stats</p> }
 
+=======
+				{ /* <FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } /> */ }
+>>>>>>> 91d4209d60 (test output of banner)
 				<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -48,7 +48,6 @@ import DatePicker from './stats-date-picker';
 import StatsModule from './stats-module';
 import StatsModuleEmails from './stats-module-emails';
 import StatsNotices from './stats-notices';
-import FreePlanPurchaseSuccessJetpackStatsNotice from './stats-notices/free-plan-purchase-success-notice';
 import StatsPageHeader from './stats-page-header';
 import PageViewTracker from './stats-page-view-tracker';
 import StatsPeriodHeader from './stats-period-header';
@@ -244,7 +243,6 @@ class StatsSite extends Component {
 
 				{ statsPurchaseSuccess && <p>Thank you for using Jetpack Stats</p> }
 
-				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
 				<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -32,10 +32,10 @@ const FreePlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps
 	// 	30 * 24 * 3600
 	// );
 
-	const dismissNotice = () => {
-		setNoticeDismissed( true );
-		postponeNoticeAsync();
-	};
+	// const dismissNotice = () => {
+	// 	setNoticeDismissed( true );
+	// 	postponeNoticeAsync();
+	// };
 
 	// const gotoJetpackStatsProduct = () => {
 	// 	isOdysseyStats
@@ -49,17 +49,17 @@ const FreePlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps
 	// 	setTimeout( () => ( window.location.href = getStatsPurchaseURL( siteId ) ), 250 );
 	// };
 
-	useEffect( () => {
-		if ( ! noticeDismissed && showNotice ) {
-			isOdysseyStats
-				? recordTracksEvent( 'jetpack_odyssey_stats_free_plan_purchase_success_notice_viewed' )
-				: recordTracksEvent( 'calypso_stats_free_plan_purchase_success_notice_viewed' );
-		}
-	}, [ noticeDismissed, showNotice, isOdysseyStats ] );
+	// useEffect( () => {
+	// 	if ( ! noticeDismissed && showNotice ) {
+	// 		isOdysseyStats
+	// 			? recordTracksEvent( 'jetpack_odyssey_stats_free_plan_purchase_success_notice_viewed' )
+	// 			: recordTracksEvent( 'calypso_stats_free_plan_purchase_success_notice_viewed' );
+	// 	}
+	// }, [ noticeDismissed, showNotice, isOdysseyStats ] );
 
-	if ( noticeDismissed || ! showNotice ) {
-		return null;
-	}
+	// if ( noticeDismissed || ! showNotice ) {
+	// 	return null;
+	// }
 
 	return (
 		<div className="inner-notice-container has-odyssey-stats-bg-color">

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -32,7 +32,7 @@ const FreePlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps
 	};
 
 	if ( noticeDismissed || ! showNotice ) {
-		// return null;
+		// return null; this is for testing purposes. TODO uncomment
 	}
 
 	return (

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -1,82 +1,59 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { JETPACK_STATS_PRODUCT_LANDING_PAGE_URL } from '@automattic/calypso-products';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
-// import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
+import { useState } from 'react';
+import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import useNoticeVisibilityQuery from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { StatsNoticeProps } from './types';
 
-// const getStatsPurchaseURL = ( siteId: number | null ) => {
-// 	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats`;
-// 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-// 	if ( ! isOdysseyStats ) {
-// 		return purchasePath;
-// 	}
-// 	return `https://wordpress.com${ purchasePath }`;
-// };
+const getStatsPurchaseURL = ( siteId: number | null ) => {
+	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats`;
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	if ( ! isOdysseyStats ) {
+		return purchasePath;
+	}
+	return `https://wordpress.com${ purchasePath }`;
+};
 
 const FreePlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 	const translate = useTranslate();
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 	const { data: showNotice } = useNoticeVisibilityQuery(
 		siteId,
 		'jetpack_stats_free_plan_purchase_success'
 	);
-	// const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
-	// 	siteId,
-	// 	'do_you_love_jetpack_stats',
-	// 	'postponed',
-	// 	30 * 24 * 3600
-	// );
+	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
+		siteId,
+		'free_plan_purchase_success',
+		'postponed',
+		30 * 24 * 3600
+	);
 
-	// const dismissNotice = () => {
-	// 	setNoticeDismissed( true );
-	// 	postponeNoticeAsync();
-	// };
+	const dismissNotice = () => {
+		setNoticeDismissed( true );
+		postponeNoticeAsync();
+	};
 
-	// const gotoJetpackStatsProduct = () => {
-	// 	isOdysseyStats
-	// 		? recordTracksEvent(
-	// 				'jetpack_odyssey_stats_free_plan_purchase_success_notice_support_button_clicked'
-	// 		  )
-	// 		: recordTracksEvent(
-	// 				'calypso_stats_free_plan_purchase_success_notice_support_button_clicked'
-	// 		  );
-	// 	// Allow some time for the event to be recorded before redirecting.
-	// 	setTimeout( () => ( window.location.href = getStatsPurchaseURL( siteId ) ), 250 );
-	// };
-
-	// useEffect( () => {
-	// 	if ( ! noticeDismissed && showNotice ) {
-	// 		isOdysseyStats
-	// 			? recordTracksEvent( 'jetpack_odyssey_stats_free_plan_purchase_success_notice_viewed' )
-	// 			: recordTracksEvent( 'calypso_stats_free_plan_purchase_success_notice_viewed' );
-	// 	}
-	// }, [ noticeDismissed, showNotice, isOdysseyStats ] );
-
-	// if ( noticeDismissed || ! showNotice ) {
-	// 	return null;
-	// }
+	if ( noticeDismissed || ! showNotice ) {
+		return null;
+	}
 
 	return (
 		<div className="inner-notice-container has-odyssey-stats-bg-color">
 			<NoticeBanner
-				level="info"
+				level="success"
 				title={ translate( 'Thank you for using Jetpack Stats!' ) }
 				onClose={ dismissNotice }
 			>
 				{ translate(
-					'{{p}}We appreciate your continued support. If you want to access upcoming features,{{jetpackStatsProductLink}} please consider upgrading.{{/jetpackStatsProductLink}}{{/p}}',
+					'{{p}}We appreciate your continued support. If you want to access upcoming features, {{jetpackStatsProductLink}} please consider upgrading{{/jetpackStatsProductLink}}.{{/p}}',
 					{
 						components: {
 							p: <p />,
 							jetpackStatsProductLink: (
 								<a
-									// className="notice-banner__action-link"
-									href={ JETPACK_STATS_PRODUCT_LANDING_PAGE_URL }
+									className="notice-banner__action-link"
+									href={ getStatsPurchaseURL( siteId ) }
 									target="_blank"
 									rel="noreferrer"
 								/>

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -32,7 +32,7 @@ const FreePlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps
 	};
 
 	if ( noticeDismissed || ! showNotice ) {
-		return null;
+		// return null;
 	}
 
 	return (

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -18,10 +18,7 @@ const getStatsPurchaseURL = ( siteId: number | null ) => {
 const FreePlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
-	const { data: showNotice } = useNoticeVisibilityQuery(
-		siteId,
-		'jetpack_stats_free_plan_purchase_success'
-	);
+	const { data: showNotice } = useNoticeVisibilityQuery( siteId, 'free_plan_purchase_success' );
 	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
 		siteId,
 		'free_plan_purchase_success',

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -1,0 +1,92 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import { JETPACK_STATS_PRODUCT_LANDING_PAGE_URL } from '@automattic/calypso-products';
+import NoticeBanner from '@automattic/components/src/notice-banner';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+// import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
+import useNoticeVisibilityQuery from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import { StatsNoticeProps } from './types';
+
+// const getStatsPurchaseURL = ( siteId: number | null ) => {
+// 	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats`;
+// 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+// 	if ( ! isOdysseyStats ) {
+// 		return purchasePath;
+// 	}
+// 	return `https://wordpress.com${ purchasePath }`;
+// };
+
+const FreePlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
+	const translate = useTranslate();
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
+	const { data: showNotice } = useNoticeVisibilityQuery(
+		siteId,
+		'jetpack_stats_free_plan_purchase_success'
+	);
+	// const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
+	// 	siteId,
+	// 	'do_you_love_jetpack_stats',
+	// 	'postponed',
+	// 	30 * 24 * 3600
+	// );
+
+	const dismissNotice = () => {
+		setNoticeDismissed( true );
+		postponeNoticeAsync();
+	};
+
+	// const gotoJetpackStatsProduct = () => {
+	// 	isOdysseyStats
+	// 		? recordTracksEvent(
+	// 				'jetpack_odyssey_stats_free_plan_purchase_success_notice_support_button_clicked'
+	// 		  )
+	// 		: recordTracksEvent(
+	// 				'calypso_stats_free_plan_purchase_success_notice_support_button_clicked'
+	// 		  );
+	// 	// Allow some time for the event to be recorded before redirecting.
+	// 	setTimeout( () => ( window.location.href = getStatsPurchaseURL( siteId ) ), 250 );
+	// };
+
+	useEffect( () => {
+		if ( ! noticeDismissed && showNotice ) {
+			isOdysseyStats
+				? recordTracksEvent( 'jetpack_odyssey_stats_free_plan_purchase_success_notice_viewed' )
+				: recordTracksEvent( 'calypso_stats_free_plan_purchase_success_notice_viewed' );
+		}
+	}, [ noticeDismissed, showNotice, isOdysseyStats ] );
+
+	if ( noticeDismissed || ! showNotice ) {
+		return null;
+	}
+
+	return (
+		<div className="inner-notice-container has-odyssey-stats-bg-color">
+			<NoticeBanner
+				level="info"
+				title={ translate( 'Thank you for using Jetpack Stats!' ) }
+				onClose={ dismissNotice }
+			>
+				{ translate(
+					'{{p}}We appreciate your continued support. If you want to access upcoming features,{{jetpackStatsProductLink}} please consider upgrading.{{/jetpackStatsProductLink}}{{/p}}',
+					{
+						components: {
+							p: <p />,
+							jetpackStatsProductLink: (
+								<a
+									// className="notice-banner__action-link"
+									href={ JETPACK_STATS_PRODUCT_LANDING_PAGE_URL }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+			</NoticeBanner>
+		</div>
+	);
+};
+
+export default FreePlanPurchaseSuccessJetpackStatsNotice;

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -43,7 +43,13 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 					<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
 				</>
 			) }
+<<<<<<< HEAD
 >>>>>>> 9a4ffb0a11 (add banner display to stats-notices index)
+=======
+			{ config.isEnabled( 'stats/paid-stats' ) && (
+				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
+			) }
+>>>>>>> d91649b752 (test notice display)
 			{ isOdysseyStats && <OptOutNotice siteId={ siteId } /> }
 			{ isOdysseyStats && <FeedbackNotice siteId={ siteId } /> }
 		</>

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -35,11 +35,17 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 	return (
 		<>
 <<<<<<< HEAD
+<<<<<<< HEAD
 			{ showPaidStatsNotice && <DoYouLoveJetpackStatsNotice siteId={ siteId } /> }
 =======
+=======
+			<>
+				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
+				<DoYouLoveJetpackStatsNotice siteId={ siteId } />
+			</>
+>>>>>>> df2b0895be (temp change for testing purposes)
 			{ config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic && ! hasPaidStats && (
 				<>
-					<DoYouLoveJetpackStatsNotice siteId={ siteId } />
 					<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
 				</>
 			) }

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -2,8 +2,8 @@ import config from '@automattic/calypso-config';
 import { useSelector } from 'react-redux';
 import version_compare from 'calypso/lib/version-compare';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
-import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
-import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
+// import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
+// import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
 import FeedbackNotice from './feedback-notice';
 import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
@@ -18,10 +18,10 @@ import './style.scss';
  * New notices are based on async API call and hence is faster than the old notices.
  */
 const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
-	const hasPaidStats = useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) );
-	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
-		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
-	);
+	// const hasPaidStats = useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) );
+	// const isSiteJetpackNotAtomic = useSelector( ( state ) =>
+	// 	isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	// );
 
 	// TODO: Display error messages on the notice.
 	const { hasLoadedPurchases } = usePurchasesToUpdateSiteProducts( isOdysseyStats, siteId );
@@ -36,13 +36,18 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 		<>
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 			{ showPaidStatsNotice && <DoYouLoveJetpackStatsNotice siteId={ siteId } /> }
 =======
 =======
+=======
+			{ /* { config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic && ! hasPaidStats && ( */ }
+>>>>>>> 21fc7827d2 (more testing changes)
 			<>
 				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
 				<DoYouLoveJetpackStatsNotice siteId={ siteId } />
 			</>
+<<<<<<< HEAD
 >>>>>>> df2b0895be (temp change for testing purposes)
 			{ config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic && ! hasPaidStats && (
 				<>
@@ -52,6 +57,9 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 <<<<<<< HEAD
 >>>>>>> 9a4ffb0a11 (add banner display to stats-notices index)
 =======
+=======
+			{ /* ) } */ }
+>>>>>>> 21fc7827d2 (more testing changes)
 			{ config.isEnabled( 'stats/paid-stats' ) && (
 				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
 			) }

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -6,7 +6,7 @@ import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-si
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
 import FeedbackNotice from './feedback-notice';
-import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
+// import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
 import LegacyStatsNotices from './legacy-notices';
 import OptOutNotice from './opt-out-notice';
 import { StatsNoticesProps } from './types';

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -32,7 +32,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 		! hasPaidStats &&
 		hasLoadedPurchases;
 
-	const showFreePlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' );
+	const showFreePlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' ) && false;
 
 	return (
 		<>

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -6,7 +6,7 @@ import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-si
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
 import FeedbackNotice from './feedback-notice';
-// import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
+import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
 import LegacyStatsNotices from './legacy-notices';
 import OptOutNotice from './opt-out-notice';
 import { StatsNoticesProps } from './types';
@@ -32,8 +32,13 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 		! hasPaidStats &&
 		hasLoadedPurchases;
 
+	const showFreePlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' );
+
 	return (
 		<>
+			{ showFreePlanPurchaseSuccessNotice && (
+				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
+			) }
 			{ showPaidStatsNotice && <DoYouLoveJetpackStatsNotice siteId={ siteId } /> }
 			{ isOdysseyStats && <OptOutNotice siteId={ siteId } /> }
 			{ isOdysseyStats && <FeedbackNotice siteId={ siteId } /> }

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -6,6 +6,7 @@ import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-si
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
 import FeedbackNotice from './feedback-notice';
+import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
 import LegacyStatsNotices from './legacy-notices';
 import OptOutNotice from './opt-out-notice';
 import { StatsNoticesProps } from './types';
@@ -33,7 +34,16 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 
 	return (
 		<>
+<<<<<<< HEAD
 			{ showPaidStatsNotice && <DoYouLoveJetpackStatsNotice siteId={ siteId } /> }
+=======
+			{ config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic && ! hasPaidStats && (
+				<>
+					<DoYouLoveJetpackStatsNotice siteId={ siteId } />
+					<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
+				</>
+			) }
+>>>>>>> 9a4ffb0a11 (add banner display to stats-notices index)
 			{ isOdysseyStats && <OptOutNotice siteId={ siteId } /> }
 			{ isOdysseyStats && <FeedbackNotice siteId={ siteId } /> }
 		</>

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -2,8 +2,8 @@ import config from '@automattic/calypso-config';
 import { useSelector } from 'react-redux';
 import version_compare from 'calypso/lib/version-compare';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
-// import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
-// import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
+import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
 import FeedbackNotice from './feedback-notice';
 import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
@@ -18,10 +18,10 @@ import './style.scss';
  * New notices are based on async API call and hence is faster than the old notices.
  */
 const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
-	// const hasPaidStats = useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) );
-	// const isSiteJetpackNotAtomic = useSelector( ( state ) =>
-	// 	isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
-	// );
+	const hasPaidStats = useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) );
+	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
 
 	// TODO: Display error messages on the notice.
 	const { hasLoadedPurchases } = usePurchasesToUpdateSiteProducts( isOdysseyStats, siteId );
@@ -34,36 +34,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 
 	return (
 		<>
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 			{ showPaidStatsNotice && <DoYouLoveJetpackStatsNotice siteId={ siteId } /> }
-=======
-=======
-=======
-			{ /* { config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic && ! hasPaidStats && ( */ }
->>>>>>> 21fc7827d2 (more testing changes)
-			<>
-				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
-				<DoYouLoveJetpackStatsNotice siteId={ siteId } />
-			</>
-<<<<<<< HEAD
->>>>>>> df2b0895be (temp change for testing purposes)
-			{ config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic && ! hasPaidStats && (
-				<>
-					<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
-				</>
-			) }
-<<<<<<< HEAD
->>>>>>> 9a4ffb0a11 (add banner display to stats-notices index)
-=======
-=======
-			{ /* ) } */ }
->>>>>>> 21fc7827d2 (more testing changes)
-			{ config.isEnabled( 'stats/paid-stats' ) && (
-				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
-			) }
->>>>>>> d91649b752 (test notice display)
 			{ isOdysseyStats && <OptOutNotice siteId={ siteId } /> }
 			{ isOdysseyStats && <FeedbackNotice siteId={ siteId } /> }
 		</>

--- a/packages/components/src/notice-banner/style.scss
+++ b/packages/components/src/notice-banner/style.scss
@@ -162,4 +162,11 @@
 	.notice-banner__icon {
 		fill: var(--jp-green);
 	}
+
+	.notice-banner__action-link {
+		color: var(--jp-green);
+		text-decoration: underline;
+	}
+
+
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#78449](https://github.com/Automattic/wp-calypso/issues/78449)

## Proposed Changes

* This PR adds the free plan purchase success banner. **note:** this only adds the banner, and a little background additions to make the banner possible. It does not add the logic for when/how to show the banner. That shall come in a followup PR next and this banner will not display by default until then. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test using this branch on your local Calypso env (not using live branches) 
* Locate the file `/my-sites/stats/stats-notices/index.tsx` and replace the line `35` `	const showFreePlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' ) && false;` with `const showFreePlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' ) && true;` in order to display the banner
* Navigate to `/stats/day/{siteURL}`
* Verify you can see the `Thank you for using Jetpack Stats!` banner in green, and that the layout, formatting and design looks okay and that the upgrade link works as expected. 

![image](https://github.com/Automattic/wp-calypso/assets/30754158/f3bf8fbc-396e-465c-9d77-e56678d812d1)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
