### PR TITLE
BackupBrowser: Add option to download unchanged plugins and themes

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -16,6 +16,7 @@ interface FileBrowserNodeProps {
 	isAlternate: boolean; // This decides if the node will have a background color or not
 	setActiveNodePath: ( path: string ) => void;
 	activeNodePath: string;
+	parentItem?: FileBrowserItem; // This is used to pass the extension details to the child node
 }
 
 const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
@@ -26,6 +27,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 	isAlternate,
 	setActiveNodePath,
 	activeNodePath,
+	parentItem,
 } ) => {
 	const isRoot = path === '/';
 	const isCurrentNodeClicked = activeNodePath === path;
@@ -88,6 +90,8 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 						isAlternate={ childIsAlternate }
 						activeNodePath={ activeNodePath }
 						setActiveNodePath={ setActiveNodePath }
+						// Hacky way to pass extensions details to the child node
+						{ ...( childItem.type === 'archive' ? { parentItem: item } : {} ) }
 					/>
 				);
 			} );
@@ -124,7 +128,14 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 					</Button>
 				) }
 			</div>
-			{ isCurrentNodeClicked && <FileInfoCard siteId={ siteId } item={ item } /> }
+			{ isCurrentNodeClicked && (
+				<FileInfoCard
+					siteId={ siteId }
+					rewindId={ rewindId }
+					item={ item }
+					parentItem={ parentItem }
+				/>
+			) }
 			{ isOpen && (
 				<>
 					{ item.hasChildren && (

--- a/client/my-sites/backup/backup-contents-page/file-browser/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/util.ts
@@ -163,7 +163,7 @@ export const parseBackupPathInfo = ( payload: BackupPathInfoResponse ): FileBrow
 	}
 
 	if ( payload.data_type !== undefined ) {
-		result.dataType = payload.data_type;
+		result.dataType = Number( payload.data_type );
 	}
 
 	if ( payload.manifest_filter !== undefined ) {


### PR DESCRIPTION
This PR enables the download option on unchanged plugins and themes.

## Proposed Changes

* Add option to download unchanged plugins and themes

## Screenshot

| Type of extension | Before | After |
|---|---|---|
| Plugins | <img width="594" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/5c8c1549-24ba-4b5d-9ae4-9f6d03998dd5"> | <img width="593" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/c47dfb73-2591-4953-8bfc-bcc483602c70"> |
| Themes | <img width="597" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/cddb807c-9ff4-4adb-95ea-3c2e16c85fb2"> | <img width="595" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/618c296d-9055-4716-9910-c29f9ed5d005"> |

## Testing Instructions
* Start a Jetpack Cloud or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Browse plugins and themes. Inside a plugin or theme, you should see an item similar to `original version X.X from WordPress.org`, unless it is a custom extension.
* Click on `original version X.X from WordPress.org` and ensure it downloads the specified extension.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
