### PR TITLE
Domains: Remove "Create site" button from domain-only sites pages

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -5,7 +5,7 @@ import {
 	buildDomainStepForLaunchpadNextSteps,
 	buildDomainStepForProfessionalEmail,
 } from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index';
-import { domainManagementList, createSiteFromDomainOnly } from 'calypso/my-sites/domains/paths';
+import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import type {
 	DomainThankYouParams,
@@ -43,21 +43,6 @@ const domainRegistrationThankYouProps = ( {
 		true
 	);
 
-	const createSiteStep = {
-		stepKey: 'domain_registration_whats_next_create-site',
-		stepTitle: translate( 'Add a site' ),
-		stepDescription: translate( 'Choose a theme, customize and launch your site.' ),
-		stepCta: (
-			<FullWidthButton
-				href={ createSiteFromDomainOnly( domain, null ) }
-				busy={ false }
-				disabled={ false }
-			>
-				{ translate( 'Create a site' ) }
-			</FullWidthButton>
-		),
-	};
-
 	const viewDomainsStep = {
 		stepKey: 'domain_registration_whats_next_view_domains',
 		stepTitle: selectedSiteSlug
@@ -90,11 +75,7 @@ const domainRegistrationThankYouProps = ( {
 				sectionTitle: translate( 'What’s next?' ),
 				nextSteps: launchpadNextSteps
 					? [ launchpadNextSteps ]
-					: [
-							...( professionalEmail ? [ professionalEmail ] : [] ),
-							...( ! selectedSiteSlug ? [ createSiteStep ] : [] ),
-							viewDomainsStep,
-					  ],
+					: [ ...( professionalEmail ? [ professionalEmail ] : [] ), viewDomainsStep ],
 			},
 		],
 		thankYouImage: {

--- a/client/my-sites/domains/domain-management/list/domain-only-upsell-carousel.tsx
+++ b/client/my-sites/domains/domain-management/list/domain-only-upsell-carousel.tsx
@@ -4,7 +4,6 @@ import moment from 'moment';
 import { useEffect, useState, useRef } from 'react';
 import { connect } from 'react-redux';
 import addEmailImage from 'calypso/assets/images/domains/add-email.svg';
-import createSiteImage from 'calypso/assets/images/domains/create-site.svg';
 import DotPager from 'calypso/components/dot-pager';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
@@ -15,7 +14,6 @@ import { hasPaidEmailWithUs } from 'calypso/lib/emails';
 import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { IAppState } from 'calypso/state/types';
-import { createSiteFromDomainOnly } from '../../paths';
 import {
 	DomainOnlyUpsellCarouselConnectedProps,
 	DomainOnlyUpsellCarouselOwnProps,
@@ -36,14 +34,11 @@ const shouldHideCard = ( date: string | null ): boolean => {
 
 const DomainOnlyUpsellCarousel = ( props: DomainOnlyUpsellCarouselProps ) => {
 	const translate = useTranslate();
-	const [ areHideSiteCardOptionsVisible, setHideSiteCardOptionsVisible ] = useState( false );
 	const [ areHideEmailCardOptionsVisible, setHideEmailCardOptionsVisible ] = useState( false );
-	const hideCreateSiteCardButtonRef = useRef( null );
 	const hideAddEmailCardButtonRef = useRef( null );
 	const [ isRequestingDomainNotices, setIsRequestingDomainNotices ] = useState( false );
 	const [ isUpdatingDomainNotices, setIsUpdatingDomainNotices ] = useState( false );
 	const [ hideAddEmailCard, setHideEmailCard ] = useState( false );
-	const [ hideCreateSiteCard, setHideCreateSiteCard ] = useState( false );
 
 	const { domain, dispatchRecordTracksEvent } = props;
 
@@ -60,16 +55,12 @@ const DomainOnlyUpsellCarousel = ( props: DomainOnlyUpsellCarouselProps ) => {
 					setHideEmailCard(
 						shouldHideCard( domainNotices[ UpsellCardNoticeType.HIDE_ADD_EMAIL_CARD ] )
 					);
-					setHideCreateSiteCard(
-						shouldHideCard( domainNotices[ UpsellCardNoticeType.HIDE_CREATE_SITE_CARD ] )
-					);
 				}
 				setIsRequestingDomainNotices( false );
 			},
 			() => {
 				setIsRequestingDomainNotices( false );
 				setHideEmailCard( true );
-				setHideCreateSiteCard( true );
 			}
 		);
 	}, [ domainName ] );
@@ -86,7 +77,6 @@ const DomainOnlyUpsellCarousel = ( props: DomainOnlyUpsellCarouselProps ) => {
 		noticeType: UpsellCardNoticeType,
 		sourceCardType: string
 	) => {
-		setHideSiteCardOptionsVisible( false );
 		setHideEmailCardOptionsVisible( false );
 		const mapReminderToMomentArgs = {
 			[ HideCardDuration.ONE_WEEK ]: { weeks: 1 },
@@ -107,8 +97,6 @@ const DomainOnlyUpsellCarousel = ( props: DomainOnlyUpsellCarouselProps ) => {
 					setIsUpdatingDomainNotices( false );
 					if ( noticeType === UpsellCardNoticeType.HIDE_ADD_EMAIL_CARD ) {
 						setHideEmailCard( true );
-					} else if ( noticeType === UpsellCardNoticeType.HIDE_CREATE_SITE_CARD ) {
-						setHideCreateSiteCard( true );
 					}
 				}
 			},
@@ -213,26 +201,6 @@ const DomainOnlyUpsellCarousel = ( props: DomainOnlyUpsellCarouselProps ) => {
 	}
 
 	const cards = [];
-
-	if ( ! hideCreateSiteCard ) {
-		cards.push(
-			renderCard( {
-				actionUrl: createSiteFromDomainOnly( domain.domain, domain.blogId ),
-				imageUrl: createSiteImage,
-				title: translate( 'Create a site for %(domain)s', {
-					args: { domain: domain.domain },
-				} ),
-				subtitle: translate( 'Choose a theme, customize and launch your site.' ),
-				ref: hideCreateSiteCardButtonRef,
-				buttonLabel: translate( 'Create site' ),
-				cardName: 'create-site',
-				cardNoticeType: UpsellCardNoticeType.HIDE_CREATE_SITE_CARD,
-				eventTrackViewName: 'calypso_domain_only_upsell_carousel_card_impression',
-				areHideOptionsVisible: areHideSiteCardOptionsVisible,
-				setHideOptionsVisible: setHideSiteCardOptionsVisible,
-			} )
-		);
-	}
 
 	if ( ! hasPaidEmailWithUs( domain ) && ! hideAddEmailCard ) {
 		cards.push(

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -5,10 +5,9 @@ import { connect } from 'react-redux';
 import Illustration from 'calypso/assets/images/domains/domain.svg';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import EmptyContent from 'calypso/components/empty-content';
-import { canCurrentUserCreateSiteFromDomainOnly } from 'calypso/lib/domains';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
-import { domainManagementEdit, createSiteFromDomainOnly } from 'calypso/my-sites/domains/paths';
+import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -38,8 +37,6 @@ const DomainOnly = ( {
 
 	const hasEmailWithUs = hasGSuiteWithUs( primaryDomain ) || hasTitanMailWithUs( primaryDomain );
 	const domainName = primaryDomain.name;
-	const canCreateSite = canCurrentUserCreateSiteFromDomainOnly( primaryDomain );
-	const createSiteUrl = createSiteFromDomainOnly( slug, siteId );
 
 	const recordEmailClick = () => {
 		const tracksName = hasEmailWithUs
@@ -54,14 +51,8 @@ const DomainOnly = ( {
 		<div>
 			<EmptyContent
 				title={ translate( '%(domainName)s is ready when you are.', { args: { domainName } } ) }
-				line={
-					canCreateSite &&
-					translate( 'Start a site now to unlock everything WordPress.com can offer.' )
-				}
-				action={ canCreateSite && translate( 'Create site' ) }
-				actionURL={ canCreateSite && createSiteUrl }
-				secondaryAction={ translate( 'Manage domain' ) }
-				secondaryActionURL={ domainManagementEdit( slug, domainName, currentRoute ) }
+				action={ translate( 'Manage domain' ) }
+				actionURL={ domainManagementEdit( slug, domainName, currentRoute ) }
 				illustration={ Illustration }
 			>
 				<Button

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -1,5 +1,5 @@
 import { Button, Spinner } from '@automattic/components';
-import { Icon, home, info, redo, plus } from '@wordpress/icons';
+import { Icon, home, info, redo } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
@@ -32,7 +32,6 @@ import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
 import TransferConnectedDomainNudge from 'calypso/my-sites/domains/domain-management/components/transfer-connected-domain-nudge';
 import {
-	createSiteFromDomainOnly,
 	domainManagementDns,
 	domainManagementEditContactInfo,
 	domainManagementList,
@@ -424,12 +423,6 @@ class DomainRow extends PureComponent {
 						>
 							<Icon icon={ redo } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
 							{ translate( 'Transfer to WordPress.com' ) }
-						</PopoverMenuItem>
-					) }
-					{ site.options?.is_domain_only && domain.type !== domainTypes.TRANSFER && (
-						<PopoverMenuItem href={ createSiteFromDomainOnly( site.slug, site.siteId ) }>
-							<Icon icon={ plus } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
-							{ translate( 'Create site' ) }
 						</PopoverMenuItem>
 					) }
 				</EllipsisMenu>

--- a/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
@@ -1,10 +1,7 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import {
-	createSiteFromDomainOnly,
-	domainManagementTransferToOtherSite,
-} from 'calypso/my-sites/domains/paths';
+import { domainManagementTransferToOtherSite } from 'calypso/my-sites/domains/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { IAppState } from 'calypso/state/types';
 import type { DomainOnlyConnectCardProps } from './types';
@@ -21,10 +18,6 @@ const DomainOnlyConnectCard = ( props: DomainOnlyConnectCardProps ) => {
 				<p>{ translate( 'Your domain is not associated with a WordPress.com site.' ) }</p>
 			</div>
 			<div className="domain-only-connect__card-button-container">
-				<Button href={ createSiteFromDomainOnly( selectedDomainName, selectedSite.ID ) } primary>
-					{ translate( 'Create a site' ) }
-				</Button>
-
 				<Button
 					href={ domainManagementTransferToOtherSite(
 						selectedSite.slug,


### PR DESCRIPTION
## Proposed Changes
See here for more information: p1689230922152949/1689225408.499109-slack-C0BNMNMNG.
Tl;dr: In order to proceed with the new domain transfer/domain-only sites changes, this PR temporarily removes the "Create site" button from all domain-only site pages. 

## Testing Instructions
- Analyze the code statically;
- Ensure all unit tests are passing;
- Confirm that all references to the "Create site" button were removed:
  - Try purchasing a domain for a domain-only site and ensure that the button isn't displayed on the post-checkout page;
  - Go to a domain-only management page (`/domains/manage/:site`) and ensure that the button isn't displayed;
  - Ensure that on the "All domains" page, there's no upsell card with the "Create site" button;

## Preview

### Upsell card
#### Before
![image](https://github.com/Automattic/wp-calypso/assets/18705930/7b58da0c-dbd2-4a0a-a275-cac2127fc6ef)

#### After
![image](https://github.com/Automattic/wp-calypso/assets/18705930/0965dd35-747f-4c35-99b8-92b62efe9763)

### Empty content
#### Before
![image](https://github.com/Automattic/wp-calypso/assets/18705930/0d985b53-5d21-4ef8-ad43-a1c22b87bcf5)

#### After
![image](https://github.com/Automattic/wp-calypso/assets/18705930/f2e3fde3-8612-4676-9715-86e1dea9d040)

### Post-checkout page
#### Before
![image](https://github.com/Automattic/wp-calypso/assets/18705930/76f6b6cc-8d87-4e2e-9ea0-a954a9b355f7)

#### After
![image](https://github.com/Automattic/wp-calypso/assets/18705930/0070733f-0cdd-4a9f-aaa5-4fccea5d912d)

### Management page
#### Before
![image](https://github.com/Automattic/wp-calypso/assets/18705930/e8deb976-85ff-4831-a0f8-2e2d71130ffa)

#### After
![image](https://github.com/Automattic/wp-calypso/assets/18705930/dc65993c-6d82-45af-8496-2d3f2e25d4b0)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?