### PR TITLE
BackupBrowser: polish styles and horizontal scrolling

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -63,7 +63,13 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 
 	const renderChildren = () => {
 		if ( isInitialLoading ) {
-			return <div className="file-browser-node__loading placeholder" />;
+			return (
+				<>
+					<div className="file-browser-node__loading placeholder" />
+					<div className="file-browser-node__loading placeholder" />
+					<div className="file-browser-node__loading placeholder" />
+				</>
+			);
 		}
 
 		// @TODO: Add a message when the API fails to fetch
@@ -107,7 +113,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 	const nodeItemClassName = classNames( 'file-browser-node__item', {
 		'is-alternate': isAlternate,
 	} );
-	const [ label, isLabelTruncated ] = useTruncatedFileName( item.name, 50, item.type );
+	const [ label, isLabelTruncated ] = useTruncatedFileName( item.name, 30, item.type );
 
 	const nodeContentsClassName = classNames( 'file-browser-node__contents', {
 		'is-root': isRoot,

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -115,12 +115,12 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 	} );
 	const [ label, isLabelTruncated ] = useTruncatedFileName( item.name, 30, item.type );
 
-	const nodeContentsClassName = classNames( 'file-browser-node__contents', {
+	const nodeClassName = classNames( 'file-browser-node', {
 		'is-root': isRoot,
 	} );
 
 	return (
-		<div className="file-browser-node">
+		<div className={ nodeClassName }>
 			<div className={ nodeItemClassName }>
 				{ ! isRoot && (
 					<Button
@@ -138,7 +138,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 			{ isOpen && (
 				<>
 					{ item.hasChildren && (
-						<div className={ nodeContentsClassName }>{ renderChildren() }</div>
+						<div className="file-browser-node__contents">{ renderChildren() }</div>
 					) }
 				</>
 			) }

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -107,7 +107,11 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 	const nodeItemClassName = classNames( 'file-browser-node__item', {
 		'is-alternate': isAlternate,
 	} );
-	const [ label, isLabelTruncated ] = useTruncatedFileName( item.name, 30, item.type );
+	const [ label, isLabelTruncated ] = useTruncatedFileName( item.name, 50, item.type );
+
+	const nodeContentsClassName = classNames( 'file-browser-node__contents', {
+		'is-root': isRoot,
+	} );
 
 	return (
 		<div className="file-browser-node">
@@ -128,7 +132,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 			{ isOpen && (
 				<>
 					{ item.hasChildren && (
-						<div className="file-browser-node__contents">{ renderChildren() }</div>
+						<div className={ nodeContentsClassName }>{ renderChildren() }</div>
 					) }
 				</>
 			) }

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -25,6 +25,10 @@
 	}
 
 	.file-browser-node {
+		margin-top: 2px;
+		margin-left: 2px;
+		min-width: fit-content;
+
 		&__loading {
 			&.placeholder {
 				height: 26px;
@@ -36,11 +40,11 @@
 		&__contents {
 			display: flex;
 			flex-direction: column;
-			overflow-x: auto;
 			background-color: #fff;
+			padding-left: 26px;
 
-			&:not(:first-child) {
-				padding-left: 26px;
+			&.is-root {
+				padding-left: 0;
 			}
 		}
 

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -20,7 +20,7 @@
 	// which is at 660px instead of the 600px break-small breakpoint.
 	@include breakpoint-deprecated( ">660px" ) {
 		&__back-button.components-button.is-link {
-			padding: 0;
+			padding: 0 0 12px 0;
 			margin: 0;
 		}
 	}

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -29,8 +29,9 @@
 
 	&__body {
 		border-top: 1px solid var(--studio-gray-5);
-		overflow-x: scroll;
+		overflow-x: auto;
 		padding-top: 30px;
+		padding-bottom: 14px;
 	}
 
 	.file-browser-node {

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -1,6 +1,10 @@
 @import "@automattic/onboarding/styles/mixins";
 
 .backup-contents-page {
+	.card {
+		padding: 24px 22px;
+	}
+
 	&__back-button.components-button.is-link {
 		color: #000;
 		padding: 12px 0;
@@ -22,6 +26,8 @@
 	}
 
 	&__header {
+		padding-left: 2px;
+		padding-right: 2px;
 		padding-bottom: 30px;
 
 		&.daily-backup-status {
@@ -41,6 +47,10 @@
 		margin-left: 2px;
 		min-width: fit-content;
 
+		&.is-root {
+			margin-left: 0;
+		}
+
 		&__loading {
 			&.placeholder {
 				height: 26px;
@@ -54,10 +64,10 @@
 			flex-direction: column;
 			background-color: #fff;
 			padding-left: 26px;
+		}
 
-			&.is-root {
-				padding-left: 0;
-			}
+		&.is-root > .file-browser-node__contents {
+			padding-left: 0;
 		}
 
 		.file-browser-node__title {

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -12,7 +12,9 @@
 		}
 	}
 
-	@include break-mobile {
+	// We are using the deprecated mixin to match the when the mobile navigation appears
+	// which is at 660px instead of the 600px break-small breakpoint.
+	@include breakpoint-deprecated( ">660px" ) {
 		&__back-button.components-button.is-link {
 			padding: 0;
 			margin: 0;

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -3,10 +3,19 @@
 .backup-contents-page {
 	&__back-button.components-button.is-link {
 		color: #000;
+		padding: 12px 0;
 		text-decoration: none;
+		margin: 4px 0;
 
 		svg {
 			margin-right: 2px;
+		}
+	}
+
+	@include break-mobile {
+		&__back-button.components-button.is-link {
+			padding: 0;
+			margin: 0;
 		}
 	}
 
@@ -82,6 +91,7 @@
 			@include break-mobile {
 				&__detail-group {
 					display: flex;
+					flex-wrap: wrap;
 					justify-content: space-between;
 				}
 			}
@@ -109,8 +119,9 @@
 
 			&__preview {
 				margin: 16px auto 0;
-				max-width: max-content;
 				padding: 0 8px;
+				max-width: 620px;
+				text-align: center;
 
 				&--is-loading {
 					margin-bottom: 0;
@@ -125,7 +136,6 @@
 
 				audio,
 				video,
-				pre,
 				img {
 					max-width: 100%;
 				}
@@ -139,7 +149,7 @@
 				&.code,
 				&.text {
 					margin-bottom: -12px;
-					max-width: 100%;
+					text-align: initial;
 				}
 
 				pre {


### PR DESCRIPTION
## Proposed Changes
* Fix focus border being cut when an item is clicked
* Remove `padding-left` on the root node, so we could fit better the backup browser on the space available
* More spacing on `Go Back` button on mobile
* Fix horizontal scrolling when browsing files in high depth
* Improve loading placeholder when opening directories (adding 3-bars instead of just 1)

| Description | Before | After |
|---|---|---|
| Fix focus border being cut when an item is clicked | <img width="197" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/08afd128-f54b-4603-bc43-0c0d3dd1afb2"> | <img width="204" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/21e2d3e9-483c-4493-8663-bfcd4a96f315"> |
| Remove `padding-left` on the root node, so we could fit better the backup browser on the space available | ![image](https://github.com/Automattic/wp-calypso/assets/1488641/3f86b331-3a68-4bc8-9995-8b3436f0c058) | ![image](https://github.com/Automattic/wp-calypso/assets/1488641/543734c4-bfda-4e5e-82a9-796b10d731e6) |
| More spacing on `Go Back` button on mobile | <img width="383" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/a691f53d-f5e6-4e25-9b90-90977efbd991"> | <img width="384" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/9893730b-ef23-41d3-9f5c-712d754f5557"> |
| Fix horizontal scrolling when browsing files in high depth | ![image](https://github.com/Automattic/wp-calypso/assets/1488641/4a741be6-917b-4693-898d-f956aad92342) | ![image](https://github.com/Automattic/wp-calypso/assets/1488641/e3794a4e-7ffa-474c-bee1-e27597f8d515) |
| Improve loading placeholder when opening directories (adding 3-bars instead of just 1) | ![CleanShot 2023-07-13 at 22 58 42](https://github.com/Automattic/wp-calypso/assets/1488641/dcaca10a-1e0e-4f2d-b7e3-30d1f0427794) | ![CleanShot 2023-07-13 at 23 01 17](https://github.com/Automattic/wp-calypso/assets/1488641/eaf0501f-830d-4ccf-b860-25b9458e3dac) |

## Testing Instructions
* Start a Jetpack Cloud or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Navigate through the backup browser and validate the changes proposed:
  * **Fix focus border being cut when an item is clicked**
    * Click on multiple items and ensure the focus indicator is not being cut off.
  * **Remove `padding-left` on the root node, so we could fit better the backup browser on the space available**
    * You should notice the backup browser doesn't have that additional space in the left side
  * **More spacing on `Go Back` button on mobile**
    * Try navigating as a mobile device. The `Go back` button should have more spacing now.
  * **Fix horizontal scrolling when browsing files in high depth**
    * If you have a site with multiple directories nested, you could try to open them all and ensure the horizontal scrollbar is working in the wrapper of the backup browser.
  * **Improve loading placeholder when opening directories (adding 3 items instead of just 1)**
    * When opening a directory, you should see the 3-bars loading indicator.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
