### PR TITLE
Activity Log: show action to view backup files only on full backup activities

### DIFF
--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -179,7 +179,7 @@ const ActionsButton: React.FC< OwnProps > = ( {
 	const actionableRewindId = getActionableRewindId( activity );
 
 	// Let's validate if the activity is a successful backup so we could decide which actions to show.
-	const isSuccessfulBackup = SUCCESSFUL_BACKUP_ACTIVITIES.includes( activity.activityName );
+	const isSuccessfulBackup = SUCCESSFUL_BACKUP_ACTIVITIES.includes( activity?.activityName );
 
 	const isMultisite = useSelector( ( state ) => isJetpackSiteMultiSite( state, siteId ) );
 	if ( isMultisite ) {

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -8,6 +8,7 @@ import Button from 'calypso/components/forms/form-button';
 import missingCredentialsIcon from 'calypso/components/jetpack/daily-backup-status/missing-credentials.svg';
 import PopoverMenu from 'calypso/components/popover-menu';
 import { getActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id';
+import { SUCCESSFUL_BACKUP_ACTIVITIES } from 'calypso/lib/jetpack/backup-utils';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -24,12 +25,14 @@ type SingleSiteOwnProps = {
 	siteId: number;
 	siteSlug: string;
 	rewindId: string;
+	isSuccessfulBackup: boolean;
 };
 
 const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 	siteId,
 	siteSlug,
 	rewindId,
+	isSuccessfulBackup,
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -99,7 +102,7 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 						</div>
 					</div>
 				) }
-				<ViewFilesButton siteSlug={ siteSlug } rewindId={ rewindId } />
+				{ isSuccessfulBackup && <ViewFilesButton siteSlug={ siteSlug } rewindId={ rewindId } /> }
 				<Button
 					borderless
 					compact
@@ -175,6 +178,9 @@ const ActionsButton: React.FC< OwnProps > = ( {
 	// to a valid restore/download point when they click an action button
 	const actionableRewindId = getActionableRewindId( activity );
 
+	// Let's validate if the activity is a successful backup so we could decide which actions to show.
+	const isSuccessfulBackup = SUCCESSFUL_BACKUP_ACTIVITIES.includes( activity.activityName );
+
 	const isMultisite = useSelector( ( state ) => isJetpackSiteMultiSite( state, siteId ) );
 	if ( isMultisite ) {
 		return (
@@ -197,6 +203,7 @@ const ActionsButton: React.FC< OwnProps > = ( {
 			siteId={ siteId }
 			siteSlug={ siteSlug ?? '' }
 			rewindId={ actionableRewindId ?? '' }
+			isSuccessfulBackup={ isSuccessfulBackup }
 		/>
 	);
 };


### PR DESCRIPTION
Related to p1689251815295929-slack-C059R8T8Q15

## Proposed Changes

* Show action `View files` only on full backup activities in the Activity Log.

| Before | After |
|---|---|
| <img width="762" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/d229bb76-c14c-4515-b7d1-b6dd91fd5b60"> | <img width="760" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/c9ceb2b4-ec21-41af-9bfc-5f6aedb81e91"> |

## Testing Instructions
* Start a Jetpack Cloud or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Ensure your site has full backups and real-time updates, like an image upload.
* Navigate to Activity Log page.
* Validate that any full backup activity has the action `View files` when you click on `(+) Actions`.
* Validate that real-time updates like image uploads don't have the `View files` action when you click on `(+) Actions`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?