### PR TITLE
Theme Showcase: Show the correct style variation screenshot in the Thank You screen

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon, Button } from '@automattic/components';
+import { DesignPreviewImage, isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -11,9 +12,10 @@ import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
 import { activate } from 'calypso/state/themes/actions';
 import {
+	getThemePreviewThemeOptions,
+	hasActivatedTheme,
 	isThemeActive,
 	isActivatingTheme,
-	hasActivatedTheme,
 } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useIsValidThankYouTheme from './use-is-valid-thank-you-theme';
@@ -34,11 +36,21 @@ const ThemeSectionImageContainer = styled.div`
 	border-radius: 16px;
 	box-shadow: 0px 15px 20px rgba( 0, 0, 0, 0.04 ), 0px 13px 10px rgba( 0, 0, 0, 0.03 ),
 		0px 6px 6px rgba( 0, 0, 0, 0.02 );
+	width: 100%;
+`;
+
+const ThemeSectionMShotsContainer = styled.div`
+	border-radius: 13px;
+	margin-bottom: 8px;
+	position: relative;
+	overflow: hidden;
+	padding-top: 74%;
+	width: 100%;
 `;
 
 const ThemeSectionImage = styled.img`
-	width: 100%;
 	border-radius: 13px;
+	width: 100%;
 `;
 
 const ThemeSectionContent = styled.div`
@@ -106,6 +118,10 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 		getCustomizeUrl( state, theme.id, siteId, isFSEActive )
 	);
 	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) ) ?? undefined;
+	const themeOptions = useSelector( ( state ) => getThemePreviewThemeOptions( state ) );
+
+	const themeStyleVariation =
+		themeOptions && themeOptions.themeId === theme.id ? themeOptions.styleVariation : undefined;
 
 	const isValidThankyouSectionTheme = useIsValidThankYouTheme( theme, siteId );
 
@@ -163,16 +179,25 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 					</ThemeSectionButtons>
 				</ThemeNameSectionWrapper>
 				<ThemeSectionImageContainer>
-					<ThemeSectionImage
-						src={ theme.screenshot }
-						alt={
-							translate( "%(theme)s's icon", {
-								args: {
-									theme: theme.name,
-								},
-							} ) as string
-						}
-					/>
+					{ ! isDefaultGlobalStylesVariationSlug( themeStyleVariation?.slug ) ? (
+						<ThemeSectionMShotsContainer>
+							<DesignPreviewImage
+								design={ { slug: theme.id, recipe: { stylesheet: theme.stylesheet } } }
+								styleVariation={ themeStyleVariation }
+							/>
+						</ThemeSectionMShotsContainer>
+					) : (
+						<ThemeSectionImage
+							src={ theme.screenshot }
+							alt={
+								translate( "%(theme)s's icon", {
+									args: {
+										theme: theme.name,
+									},
+								} ) as string
+							}
+						/>
+					) }
 				</ThemeSectionImageContainer>
 			</ThemeSectionContent>
 		</ThemeSectionContainer>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon, Button } from '@automattic/components';
 import { DesignPreviewImage, isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
+import { useLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -107,6 +108,7 @@ const ThemeNameSectionWrapper = styled.div`
 
 export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 	const translate = useTranslate();
+	const locale = useLocale();
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const isActive = useSelector( ( state ) => isThemeActive( state, theme.id, siteId ) );
@@ -182,7 +184,12 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 					{ ! isDefaultGlobalStylesVariationSlug( themeStyleVariation?.slug ) ? (
 						<ThemeSectionMShotsContainer>
 							<DesignPreviewImage
-								design={ { slug: theme.id, recipe: { stylesheet: theme.stylesheet } } }
+								design={ {
+									...theme,
+									slug: theme.id,
+									recipe: { stylesheet: theme.stylesheet },
+								} }
+								locale={ locale }
 								styleVariation={ themeStyleVariation }
 							/>
 						</ThemeSectionMShotsContainer>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -1,7 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon, Button } from '@automattic/components';
 import { DesignPreviewImage, isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
-import { useLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -108,7 +107,6 @@ const ThemeNameSectionWrapper = styled.div`
 
 export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 	const translate = useTranslate();
-	const locale = useLocale();
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const isActive = useSelector( ( state ) => isThemeActive( state, theme.id, siteId ) );
@@ -189,7 +187,6 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 									slug: theme.id,
 									recipe: { stylesheet: theme.stylesheet },
 								} }
-								locale={ locale }
 								styleVariation={ themeStyleVariation }
 							/>
 						</ThemeSectionMShotsContainer>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -44,6 +44,15 @@
 		padding: 0;
 		margin-bottom: 16px;
 		flex-grow: 1;
+
+		.mshots-image__container {
+			border-radius: 13px; /* stylelint-disable-line scales/radii */
+			height: auto;
+			min-height: 100%;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
 	}
 
 	.thank-you__header-title,

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -24,7 +24,7 @@ const makeOptionId = ( { slug }: Design ): string => `design-picker__option-name
 
 interface DesignPreviewImageProps {
 	design: Design;
-	locale: string;
+	locale?: string;
 	styleVariation?: StyleVariation;
 }
 
@@ -38,9 +38,9 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 	return (
 		<MShotsImage
 			url={ getDesignPreviewUrl( design, {
-				language: locale,
 				use_screenshot_overrides: true,
 				style_variation: styleVariation,
+				...( locale && { language: locale } ),
 			} ) }
 			aria-labelledby={ makeOptionId( design ) }
 			alt=""


### PR DESCRIPTION
## Proposed Changes

As suggested in https://github.com/Automattic/wp-calypso/pull/79335#issuecomment-1635097681, we should show the theme screenshot with the correct style variation in the Thank You screen. This PR implements this improvement.

| Before | After |
| --- | --- |
| ![Screenshot 2023-07-14 at 2 35 17 PM](https://github.com/Automattic/wp-calypso/assets/797888/220ca3eb-fe29-4a9b-b69e-cbf2dad56edb) | ![Screenshot 2023-07-14 at 2 35 47 PM](https://github.com/Automattic/wp-calypso/assets/797888/2f413b3b-87ba-438e-95de-a0fd627cfbd8) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Activate any theme with a style variation selected.
* Ensure that the Thank You screen shows the theme with the style variation selected.
* Ensure that the default theme style variation screenshot is displayed when no style variation is selected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
