### PR TITLE
GS on Personal: Fix user assignment

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -595,7 +595,7 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 		$blog_id = get_current_blog_id();
 	}
 
-	$cache_key                          = "global-styles-on-personal-$blog_id";
+	$cache_key                          = "global-styles-on-personal-v2-$blog_id";
 	$found_in_cache                     = false;
 	$has_global_styles_in_personal_plan = wp_cache_get( $cache_key, 'a8c_experiments', false, $found_in_cache );
 	if ( $found_in_cache ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -612,7 +612,7 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 		return false;
 	}
 
-	$experiment_assignment              = \ExPlat\_load_experiment_and_get_variation( 'calypso_global_styles_personal_v2', $owner, null, false );
+	$experiment_assignment              = \ExPlat\assign_user( 'calypso_global_styles_personal_v2', $owner );
 	$has_global_styles_in_personal_plan = 'treatment' === $experiment_assignment;
 	// Cache the experiment assignment to prevent duplicate DB queries in the frontend.
 	wp_cache_set( $cache_key, $has_global_styles_in_personal_plan, 'a8c_experiments', MONTH_IN_SECONDS );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -595,7 +595,7 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 		$blog_id = get_current_blog_id();
 	}
 
-	$cache_key                          = "global-styles-on-personal-v2-$blog_id";
+	$cache_key                          = "global-styles-on-personal-$blog_id";
 	$found_in_cache                     = false;
 	$has_global_styles_in_personal_plan = wp_cache_get( $cache_key, 'a8c_experiments', false, $found_in_cache );
 	if ( $found_in_cache ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -612,7 +612,7 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 		return false;
 	}
 
-	$experiment_assignment              = \ExPlat\get_user_assignment( 'calypso_global_styles_personal', $owner );
+	$experiment_assignment              = \ExPlat\_load_experiment_and_get_variation( 'calypso_global_styles_personal_v2', $owner, null, false );
 	$has_global_styles_in_personal_plan = 'treatment' === $experiment_assignment;
 	// Cache the experiment assignment to prevent duplicate DB queries in the frontend.
 	wp_cache_set( $cache_key, $has_global_styles_in_personal_plan, 'a8c_experiments', MONTH_IN_SECONDS );

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -67,15 +67,13 @@ const getGlobalStylesInfoForSite = ( siteId: number | null ): Promise< GlobalSty
 	}
 
 	if ( siteId === null ) {
-		return new Promise( ( resolve ) =>
-			loadExperimentAssignment( 'calypso_global_styles_personal_v2' ).then(
-				( experimentAssignment ) =>
-					resolve( {
-						shouldLimitGlobalStyles: true,
-						globalStylesInUse: false,
-						globalStylesInPersonalPlan: experimentAssignment.variationName === 'treatment',
-					} )
-			)
+		return loadExperimentAssignment( 'calypso_global_styles_personal_v2' ).then(
+			( experimentAssignment ) =>
+				Promise.resolve( {
+					shouldLimitGlobalStyles: true,
+					globalStylesInUse: false,
+					globalStylesInPersonalPlan: experimentAssignment.variationName === 'treatment',
+				} )
 		);
 	}
 

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -88,7 +88,7 @@ export function useSiteGlobalStylesStatus(
 
 	const { data: globalStylesOnPersonalExperimentAssignment } = useQuery( {
 		queryKey: [ 'globalStylesOnPersonalExperimentAssignment', siteId ],
-		queryFn: () => getExperimentAssignment( 'calypso_global_styles_personal' ),
+		queryFn: () => getExperimentAssignment( 'calypso_global_styles_personal_v2' ),
 		placeholderData: null,
 		refetchOnWindowFocus: false,
 		enabled: typeof window !== 'undefined' && siteId === null && isLoggedIn,

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -72,12 +72,13 @@ const getGlobalStylesInfoForSite = ( siteId: number | null ): Promise< GlobalSty
 
 	if ( siteId === null ) {
 		return new Promise( ( resolve ) =>
-			loadExperimentAssignment( 'calypso_global_styles_personal' ).then( ( experimentAssignment ) =>
-				resolve( {
-					shouldLimitGlobalStyles: true,
-					globalStylesInUse: false,
-					globalStylesInPersonalPlan: experimentAssignment.variationName === 'treatment',
-				} )
+			loadExperimentAssignment( 'calypso_global_styles_personal_v2' ).then(
+				( experimentAssignment ) =>
+					resolve( {
+						shouldLimitGlobalStyles: true,
+						globalStylesInUse: false,
+						globalStylesInPersonalPlan: experimentAssignment.variationName === 'treatment',
+					} )
 			)
 		);
 	}

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -1,15 +1,55 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { ExperimentAssignment } from '@automattic/explat-client';
+
+/*
+ * We cannot import `loadExperimentAssignment` directly from 'calypso/lib/explat'
+ * because it runs a side effect that produces an error on SSR contexts.
+ */
+let loadExperimentAssignment = ( experimentName: string ): Promise< ExperimentAssignment > =>
+	new Promise( ( resolve ) =>
+		resolve( { experimentName, variationName: null, retrievedTimestamp: 0, ttl: 0 } )
+	);
+( async () => {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	try {
+		( { loadExperimentAssignment } = await import( 'calypso/lib/explat' ) );
+	} catch ( e ) {}
+} )();
 
 export type GlobalStylesStatus = {
 	shouldLimitGlobalStyles: boolean;
 	globalStylesInUse: boolean;
 	globalStylesInPersonalPlan: boolean;
 };
+
+function shouldRunGlobalStylesOnPersonalExperiment( siteId: number | null ): boolean {
+	// Do not run it on SSR contexts.
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+
+	// Always run it if a site has been selected.
+	if ( siteId !== null ) {
+		return true;
+	}
+
+	// Do not run it on the logged-out theme showcase.
+	if ( window.location.pathname.startsWith( '/theme' ) ) {
+		return false;
+	}
+
+	// Run it by default. Ideally, we should not run it if the user is logged out, but
+	// we cannot rely on the `isUserLoggedIn` selector for users who just signed up
+	// (see pbxNRc-2HR-p2#comment-4607). So, we assume that this hook is not used in
+	// any logged-out context apart from the theme showcase.
+	return true;
+}
 
 // While we are loading the Global Styles Info we can't assume that we should limit global styles, or we would be
 // showing notices for paid sites until we fetch the data from the server.
@@ -19,42 +59,27 @@ const DEFAULT_GLOBAL_STYLES_INFO: GlobalStylesStatus = {
 	globalStylesInPersonalPlan: false,
 };
 
-function isObject( x: unknown ): x is Record< string, unknown > {
-	return typeof x === 'object' && x !== null;
-}
+const getGlobalStylesInfoForSite = ( siteId: number | null ): Promise< GlobalStylesStatus > => {
+	if ( ! shouldRunGlobalStylesOnPersonalExperiment( siteId ) ) {
+		return new Promise( ( resolve ) =>
+			resolve( {
+				shouldLimitGlobalStyles: true,
+				globalStylesInUse: false,
+				globalStylesInPersonalPlan: false,
+			} )
+		);
+	}
 
-const getExperimentAssignment = ( experimentName: string ): string | null => {
-	return wpcom.req
-		.get(
-			{
-				path: '/experiments/0.1.0/assignments/calypso',
-				apiNamespace: 'wpcom/v2',
-			},
-			{
-				experiment_name: experimentName,
-			}
-		)
-		.then( ( response: unknown ) =>
-			isObject( response ) &&
-			isObject( response.variations ) &&
-			typeof response.ttl === 'number' &&
-			0 < response.ttl
-				? response.variations[ experimentName ]
-				: null
-		)
-		.catch( () => null );
-};
-
-const getGlobalStylesInfoForSite = (
-	siteId: number | null,
-	currentUserHasGlobalStylesInPersonalPlan: boolean
-): GlobalStylesStatus => {
-	if ( siteId == null ) {
-		return {
-			shouldLimitGlobalStyles: true,
-			globalStylesInUse: false,
-			globalStylesInPersonalPlan: currentUserHasGlobalStylesInPersonalPlan,
-		};
+	if ( siteId === null ) {
+		return new Promise( ( resolve ) =>
+			loadExperimentAssignment( 'calypso_global_styles_personal' ).then( ( experimentAssignment ) =>
+				resolve( {
+					shouldLimitGlobalStyles: true,
+					globalStylesInUse: false,
+					globalStylesInPersonalPlan: experimentAssignment.variationName === 'treatment',
+				} )
+			)
+		);
 	}
 
 	return wpcom.req
@@ -73,7 +98,6 @@ export function useSiteGlobalStylesStatus(
 	siteIdOrSlug: number | string | null = null
 ): GlobalStylesStatus {
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	// When site id is null it means that the site hasn't been created yet.
 	const siteId = useSelector( ( state ) => {
@@ -86,19 +110,9 @@ export function useSiteGlobalStylesStatus(
 		return site?.ID ?? null;
 	} );
 
-	const { data: globalStylesOnPersonalExperimentAssignment } = useQuery( {
-		queryKey: [ 'globalStylesOnPersonalExperimentAssignment', siteId ],
-		queryFn: () => getExperimentAssignment( 'calypso_global_styles_personal_v2' ),
-		placeholderData: null,
-		refetchOnWindowFocus: false,
-		enabled: typeof window !== 'undefined' && siteId === null && isLoggedIn,
-	} );
-	const currentUserHasGlobalStylesInPersonalPlan =
-		globalStylesOnPersonalExperimentAssignment === 'treatment';
-
 	const { data: globalStylesInfo } = useQuery( {
-		queryKey: [ 'globalStylesInfo', siteId, currentUserHasGlobalStylesInPersonalPlan ],
-		queryFn: () => getGlobalStylesInfoForSite( siteId, currentUserHasGlobalStylesInPersonalPlan ),
+		queryKey: [ 'globalStylesInfo', siteId ],
+		queryFn: () => getGlobalStylesInfoForSite( siteId ),
 		placeholderData: DEFAULT_GLOBAL_STYLES_INFO,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -13,14 +13,14 @@ let loadExperimentAssignment = ( experimentName: string ): Promise< ExperimentAs
 	new Promise( ( resolve ) =>
 		resolve( { experimentName, variationName: null, retrievedTimestamp: 0, ttl: 0 } )
 	);
-( async () => {
-	if ( typeof window === 'undefined' ) {
-		return;
-	}
-	try {
-		( { loadExperimentAssignment } = await import( 'calypso/lib/explat' ) );
-	} catch ( e ) {}
-} )();
+if ( typeof window !== 'undefined' ) {
+	import( 'calypso/lib/explat' )
+		.then( ( module ) => {
+			loadExperimentAssignment = module.loadExperimentAssignment;
+		} )
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		.catch( () => {} );
+}
 
 export type GlobalStylesStatus = {
 	shouldLimitGlobalStyles: boolean;

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -10,9 +10,7 @@ import type { ExperimentAssignment } from '@automattic/explat-client';
  * because it runs a side effect that produces an error on SSR contexts.
  */
 let loadExperimentAssignment = ( experimentName: string ): Promise< ExperimentAssignment > =>
-	new Promise( ( resolve ) =>
-		resolve( { experimentName, variationName: null, retrievedTimestamp: 0, ttl: 0 } )
-	);
+	Promise.resolve( { experimentName, variationName: null, retrievedTimestamp: 0, ttl: 0 } );
 if ( typeof window !== 'undefined' ) {
 	import( 'calypso/lib/explat' )
 		.then( ( module ) => {

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -61,13 +61,11 @@ const DEFAULT_GLOBAL_STYLES_INFO: GlobalStylesStatus = {
 
 const getGlobalStylesInfoForSite = ( siteId: number | null ): Promise< GlobalStylesStatus > => {
 	if ( ! shouldRunGlobalStylesOnPersonalExperiment( siteId ) ) {
-		return new Promise( ( resolve ) =>
-			resolve( {
-				shouldLimitGlobalStyles: true,
-				globalStylesInUse: false,
-				globalStylesInPersonalPlan: false,
-			} )
-		);
+		return Promise.resolve( {
+			shouldLimitGlobalStyles: true,
+			globalStylesInUse: false,
+			globalStylesInPersonalPlan: false,
+		} );
 	}
 
 	if ( siteId === null ) {


### PR DESCRIPTION
## Proposed Changes

- Ensures that users are properly assigned to the GS on Personal experiment by using the new `\ExPlat\assign_user()` function introduced in D116083-code.
- Stop relying on the `isUserLoggedIn` selector because it has an incorrect value after a new user signs up.
- Addresses feedback from @jessie-ross and imports the `loadExperimentAssignment` hook into the `useSiteGlobalStylesStatus` hook with a dynamic import so it doesn't produce any error in SSR contexts.

## Testing Instructions

- Open the Calypso live link below in a incognito window.
- Observe the network requests with your browser devtools.
- Go to `/themes` while logged out.
- Make sure it renders correctly.
- Make sure there are no requests to the `/experiments/0.1.0/assignments/calypso` endpoint (because you are in the logged out theme showcase logged out).
- While logged out, go to `/start`.
- Log in.
- After logging in, once you're in the plans grid screen, make sure there is a request to the `/experiments/0.1.0/assignments/calypso` endpoint (because you're logged in and you didn't select/create a site yet).
- Go to `/themes` while logged in and pick a site.
- Make sure there are no requests to the `/experiments/0.1.0/assignments/calypso` endpoint (because you're logged in and you selected a site, so the experiment assignment is fetched from the `sites/:site/global-styles/status` endpoint instead).