### PR TITLE
/read/subscriptions/: Add missing translation call

### DIFF
--- a/client/reader/site-subscriptions-manager/reader-site-subscriptions.tsx
+++ b/client/reader/site-subscriptions-manager/reader-site-subscriptions.tsx
@@ -1,4 +1,5 @@
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
+import { useTranslate } from 'i18n-calypso';
 import { UnsubscribedFeedsSearchList } from 'calypso/blocks/reader-unsubscribed-feeds-search-list';
 import {
 	SiteSubscriptionsList,
@@ -8,6 +9,7 @@ import { RecommendedSites } from '../recommended-sites';
 import NotFoundSiteSubscriptions from './not-found-site-subscriptions';
 
 const ReaderSiteSubscriptions = () => {
+	const translate = useTranslate();
 	const { searchTerm } = SubscriptionManager.useSiteSubscriptionsQueryProps();
 	const siteSubscriptionsQuery = SubscriptionManager.useSiteSubscriptionsQuery();
 	const unsubscribedFeedsSearch = Reader.useUnsubscribedFeedsSearch();
@@ -23,9 +25,7 @@ const ReaderSiteSubscriptions = () => {
 
 			{ hasSomeSubscriptions && hasSomeUnsubscribedSearchResults ? (
 				<div className="site-subscriptions__search-recommendations-label">
-					{
-						'Here are some other sites that match your search.' // TODO: translate once we have the final string
-					}
+					{ translate( 'Here are some other sites that match your search.' ) }
 				</div>
 			) : null }
 			<UnsubscribedFeedsSearchList />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/78631

## Proposed Changes

* Adding missing translation call
   - Related conversation: p1688572932711179-slack-C02TCEHP3HA

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/read/subscriptions/
* Type in such text into the search input, so that it matches some of your subscriptions, and it also produces some unsubscribed feed items results

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?