### PR TITLE
Fixed unsubscribe button margin in reader

### DIFF
--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -79,3 +79,12 @@
 		border-block-start: 1px solid $site-subscriptions-list-row-divider-color;
 	}
 }
+
+hr.subscriptions__separator {
+	width: 100%;
+	height: 0;
+	margin: 0;
+	padding: 0;
+	border: none;
+	border-top: 1px solid $studio-gray-5;
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/79408

## Proposed Changes

This PR fixes the height of the unsubscribe button in the Reader integration of Subscription Manager.

Before:
![image](https://github.com/Automattic/wp-calypso/assets/3832570/2b6dc61c-e9b1-43b7-917b-c2e94769071f)

After:
<img width="271" alt="Screenshot 2023-07-14 at 11 40 24" src="https://github.com/Automattic/wp-calypso/assets/3832570/8370e641-9f89-41d9-b1f7-691bcb853d93">


## Testing Instructions

1. Apply this PR and start the application.
2. Go to `http://calypso.localhost:3000/read/subscriptions`.
3. Click on one of the ellipsis icons in a site row. Check that the `unsubscribe button` is correctly positioned.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
