### PR TITLE
Remove themes/interlaced-dotorg-themes feature flag

### DIFF
--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { isMagnificentLocale, addLocaleToPath } from '@automattic/i18n-utils';
 import { mapValues } from 'lodash';
 import titlecase from 'to-title-case';
@@ -171,7 +170,7 @@ export function interlaceThemes( wpComThemes, wpOrgThemes, searchTerm, isLastPag
 	);
 
 	// 3. WP.org themes (only if the list of WP.com themes has reached the last page).
-	if ( isEnabled( 'themes/interlaced-dotorg-themes' ) && isLastPage ) {
+	if ( isLastPage ) {
 		interlacedThemes.push(
 			...validWpOrgThemes.filter( ( theme ) => theme.id !== matchingTheme?.id )
 		);

--- a/config/development.json
+++ b/config/development.json
@@ -199,7 +199,6 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-poc": true,
 		"themes/display-thank-you-page-for-woo": true,
-		"themes/interlaced-dotorg-themes": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": true,
 		"themes/theme-switch-persist-template": false,

--- a/config/test.json
+++ b/config/test.json
@@ -100,7 +100,6 @@
 		"stats/paid-stats": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
-		"themes/interlaced-dotorg-themes": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -168,7 +168,6 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-poc": true,
 		"themes/display-thank-you-page-for-woo": true,
-		"themes/interlaced-dotorg-themes": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2752

## Proposed Changes

Removing this feature flag will mean that uses performing searches on the theme showcase will see wporg results mixed in their search results.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso live link
2. Go to /themes and select a site
3. Search for something like 'coffee'
4. Notice that the search results will show any exact title matches first, then any matching dotcom themes, then wporg themes (marked as 'Community')

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
