### PR TITLE
Adding migration starting point event to migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -9,11 +9,12 @@ import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-s
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import { SITE_PICKER_FILTER_CONFIG } from 'calypso/landing/stepper/constants';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { triggerMigrationStartingEvent } from 'calypso/my-sites/migrate/helpers';
 import { redirect } from '../import/util';
 import type { Step } from '../../types';
-import type { OnboardSelect } from '@automattic/data-stores';
+import type { OnboardSelect, UserSelect } from '@automattic/data-stores';
 import './styles.scss';
 
 const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
@@ -21,6 +22,10 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 	const { __ } = useI18n();
 	const stepProgress = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
+		[]
+	);
+	const currentUser = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
 		[]
 	);
 	const { setIsMigrateFromWp } = useDispatch( ONBOARD_STORE );
@@ -42,6 +47,9 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 		if ( ! submit || ! sourceSiteMigrationStatus || isErrorSourceSiteMigrationStatus || ! sites ) {
 			return;
 		}
+
+		const migrationFlow = 'MtWplugin';
+		triggerMigrationStartingEvent( currentUser, migrationFlow );
 
 		submit( {
 			isFromMigrationPlugin: true,

--- a/client/my-sites/migrate/helpers/index.js
+++ b/client/my-sites/migrate/helpers/index.js
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import page from 'page';
 
@@ -34,4 +35,50 @@ export function getImportSectionLocation( siteSlug, isJetpack = false ) {
 	return isJetpack && ! config.isEnabled( 'importer/unified' )
 		? `https://${ siteSlug }/wp-admin/import.php`
 		: `/import/${ siteSlug }/?engine=wordpress`;
+}
+
+export function getImportFlowByURL() {
+	const url = window.location.href;
+	const parsedUrl = new URL( url );
+	const pathSegments = parsedUrl.pathname.split( '/' );
+	// E.g. setup/import-focused/import returns import-foceused
+	if ( pathSegments.length >= 3 ) {
+		return pathSegments[ 2 ];
+	}
+
+	return 'onboarding-flow';
+}
+
+export const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
+
+/**
+ * Returns a selector that tests if the user is newer than a given time
+ *
+ * @param {number} age Number of milliseconds
+ * @returns {Function} Selector function
+ */
+export const isUserNewerThan = ( age ) => ( user ) => {
+	const registrationDate = user && Date.parse( user.date );
+	if ( ! registrationDate ) {
+		return false;
+	}
+	const userAge = Date.now() - registrationDate;
+	return userAge <= age;
+};
+
+export const isNewUser = isUserNewerThan( WEEK_IN_MILLISECONDS );
+
+export function formatMigrationEventProps( user, from = '' ) {
+	const migrationFlow = from ? from : getImportFlowByURL();
+	return {
+		is_new_user: isNewUser( user ),
+		migration_flow: migrationFlow,
+	};
+}
+
+export function triggerMigrationStartingEvent( user, from = '' ) {
+	return recordTracksEvent(
+		'calypso_migration_starting_point',
+		formatMigrationEventProps( user, from )
+	);
 }

--- a/client/my-sites/migrate/helpers/index.js
+++ b/client/my-sites/migrate/helpers/index.js
@@ -36,14 +36,19 @@ export function getImportSectionLocation( siteSlug, isJetpack = false ) {
 		? `https://${ siteSlug }/wp-admin/import.php`
 		: `/import/${ siteSlug }/?engine=wordpress`;
 }
+// Flow mapping dictionary, key is the path segment, value is the flow name
+const flowMapping = {
+	'import-focused': 'import-focused',
+	'import-hosted-site': 'import-hosted-site',
+};
 
 export function getImportFlowByURL() {
 	const url = window.location.href;
 	const parsedUrl = new URL( url );
 	const pathSegments = parsedUrl.pathname.split( '/' );
 	// E.g. setup/import-focused/import returns import-foceused
-	if ( pathSegments.length >= 3 ) {
-		return pathSegments[ 2 ];
+	if ( pathSegments.length >= 3 && pathSegments[ 2 ] in flowMapping ) {
+		return flowMapping[ pathSegments[ 2 ] ];
 	}
 
 	return 'onboarding-flow';

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -10,8 +10,13 @@ import HeaderCake from 'calypso/components/header-cake';
 import Notice from 'calypso/components/notice';
 import wpcom from 'calypso/lib/wp';
 import SitesBlock from 'calypso/my-sites/migrate/components/sites-block';
-import { getImportSectionLocation, redirectTo } from 'calypso/my-sites/migrate/helpers';
+import {
+	getImportSectionLocation,
+	redirectTo,
+	triggerMigrationStartingEvent,
+} from 'calypso/my-sites/migrate/helpers';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import './section-migrate.scss';
 
 class StepSourceSelect extends Component {
@@ -104,7 +109,13 @@ class StepSourceSelect extends Component {
 	};
 
 	componentDidMount() {
+		const { user } = this.props;
 		this.props.recordTracksEvent( 'calypso_importer_wordpress_source_select_viewed' );
+
+		if ( user && user.ID ) {
+			const migrationFlow = 'in-product';
+			triggerMigrationStartingEvent( user, migrationFlow );
+		}
 	}
 
 	render() {
@@ -156,4 +167,9 @@ class StepSourceSelect extends Component {
 		);
 	}
 }
-export default connect( null, { recordTracksEvent } )( localize( StepSourceSelect ) );
+export default connect(
+	( state ) => ( {
+		user: getCurrentUser( state ) || {},
+	} ),
+	{ recordTracksEvent }
+)( localize( StepSourceSelect ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#2827

## Proposed Changes

* Add a new migration starting point event into all of our migration flow to help us identify if it's a new user and which flow does a user starts from. This helps us to have a better understanding when creating a funnel and also by looking at the event by itself.
* The way we identify if it's a new user is based on their registration time. If they signed up in a week and comes to the migration flow, we will consider them as a new user. Otherwise we consider them as an existing user. You'll see event prop `is_new_user` as boolean.
* We will be using `migration_flow` as event prop to track and see where did a user starts their journey. Currently the known ones are:
    * in-product
    * MtwPlugin
    * import-focused
    * import-hosted-site
    * onboarding-flow as default

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can check real time events by using Track Vigilante or turn on the logs by enter `localStorage.setItem('debug', 'calypso:analytics');` in your developer console.
* Start the migration flow via different route and see if event `calypso_migration_starting_point` gets triggered correctly and the event props are recorded correctly for you.

**Test case 1**
- Start from the migration plugin flow, once you landed on `migrationHandler` on WordPress.com, it should trigger the event, check and see if event prop `migration_flow` is `MtwPlugin`.
- Check and see if event prop `is_new_user` reflect to your current user. If your account is registered within a week, you'll see `is_new_user` mark as `true`, otherwise it will be `false`.

**Test case 2**
- Start from the in-product page flow by going to your dashboard, and navigate to Tools > Import > WordPress. it should trigger the event, check and see if event prop `migration_flow` is `in-product`.
- Check and see if event prop `is_new_user` reflect to your current user. If your account is registered within a week, you'll see `is_new_user` mark as `true`, otherwise it will be `false`.

**Test case 3**
- Start from the import-focused flow by navigate to `calypso.localhost:3000/setup/import-focused/import?siteSlug=${site_slug}`, it should trigger the event, check and see if event prop `migration_flow` is `import-focused`.
- Check and see if event prop `is_new_user` reflect to your current user. If your account is registered within a week, you'll see `is_new_user` mark as `true`, otherwise it will be `false`.

**Test case 4**
- Navigate to `/me` and toggle the `I am a developer` option.
- Navigate to `/sites` and click `Import an existing site` from the top right corner.
- You will be bring to the URL input screen. It should trigger the event, check and see if event prop `migration_flow` is `import-hosted-site`.
- Check and see if event prop `is_new_user` reflect to your current user. If your account is registered within a week, you'll see `is_new_user` mark as `true`, otherwise it will be `false`.

**Test case 5**
- Navigate to `/start`, go through the steps and select `Import my existing website content`.
- You will be bring to the URL input screen. It should trigger the event, check and see if event prop `migration_flow` is `onboarding-flow` because `site-setup` is not in the flow mapping.
- Check and see if event prop `is_new_user` reflect to your current user. If your account is registered within a week, you'll see `is_new_user` mark as `true`, otherwise it will be `false`.

Note: All these events should only triggered once in the beginning of the flow. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
