### PR TITLE
Reader: Properly handle thumbnail fetch errors

### DIFF
--- a/client/state/reader/thumbnails/actions.js
+++ b/client/state/reader/thumbnails/actions.js
@@ -28,6 +28,22 @@ export function receiveThumbnail( embedUrl, thumbnailUrl ) {
 }
 
 /**
+ * Handle the fetch response.
+ * Throws an error if response is not OK.
+ * Converts to JSON if response is OK.
+ *
+ * @param {Promise} response A promise that resolves to a Response object.
+ * @returns {string} Reponse, converted to JSON.
+ * @throws Error If the response is not OK.
+ */
+function handleFetchResponse( response ) {
+	if ( ! response.ok ) {
+		throw Error( response.statusText );
+	}
+	return response.json();
+}
+
+/**
  * Either instantly returns an action for the thumbnail info or
  * triggers a network request to fetch a thumbnailUrl if necessary
  *
@@ -48,7 +64,8 @@ export const requestThumbnail = ( embedUrl ) => ( dispatch ) => {
 			try {
 				return globalThis
 					.fetch( posterEndpoint )
-					.then( ( response ) => response.json() )
+					.then( handleFetchResponse )
+					.catch( () => {} )
 					.then( ( json ) => {
 						const thumbnailUrl = json?.poster ?? '';
 						if ( thumbnailUrl ) {
@@ -64,7 +81,8 @@ export const requestThumbnail = ( embedUrl ) => ( dispatch ) => {
 			try {
 				return globalThis
 					.fetch( fetchUrl )
-					.then( ( response ) => response.json() )
+					.then( handleFetchResponse )
+					.catch( () => {} )
 					.then( ( json ) => {
 						const thumbnailUrl = get( json, [ 0, 'thumbnail_large' ] );
 						if ( thumbnailUrl ) {

--- a/client/state/reader/thumbnails/actions.js
+++ b/client/state/reader/thumbnails/actions.js
@@ -65,13 +65,13 @@ export const requestThumbnail = ( embedUrl ) => ( dispatch ) => {
 				return globalThis
 					.fetch( posterEndpoint )
 					.then( handleFetchResponse )
-					.catch( () => {} )
 					.then( ( json ) => {
 						const thumbnailUrl = json?.poster ?? '';
 						if ( thumbnailUrl ) {
 							dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
 						}
-					} );
+					} )
+					.catch( () => {} );
 			} catch ( error ) {}
 		}
 		case 'vimeo': {
@@ -82,13 +82,13 @@ export const requestThumbnail = ( embedUrl ) => ( dispatch ) => {
 				return globalThis
 					.fetch( fetchUrl )
 					.then( handleFetchResponse )
-					.catch( () => {} )
 					.then( ( json ) => {
 						const thumbnailUrl = get( json, [ 0, 'thumbnail_large' ] );
 						if ( thumbnailUrl ) {
 							dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
 						}
-					} );
+					} )
+					.catch( () => {} );
 			} catch ( error ) {}
 		}
 		default:

--- a/client/state/reader/thumbnails/test/actions.js
+++ b/client/state/reader/thumbnails/test/actions.js
@@ -31,9 +31,11 @@ describe( 'actions', () => {
 	describe( '#requestThumbnail', () => {
 		const thumbnailUrl = 'https://i.vimeocdn.com/video/459553940_640.webp';
 		const successfulEmbedUrl = 'https://vimeo.com/6999927';
+		const unSuccessfulEmbedUrl = 'https://vimeo.com/6999928';
 		const youtubeEmbedUrl = 'https://youtube.com/?v=UoOCrbV3ZQ';
 		const youtubeThumbnailUrl = 'https://img.youtube.com/vi/UoOCrbV3ZQ/mqdefault.jpg';
 		const videopressEmbedUrl = 'https://videopress.com/v/ABCDabcd';
+		const failingVideopressEmbedUrl = 'https://videopress.com/v/FOO0barr';
 		const videopressThumbnailUrl =
 			'https://videos.files.wordpress.com/ABCDabcd/filename.original.jpg';
 
@@ -47,6 +49,9 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com' )
 				.get( '/rest/v1.1/videos/ABCDabcd/poster' )
 				.reply( 200, deepFreeze( sampleVideoPressResponse ) );
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.1/videos/FOO0barr/poster' )
+				.reply( 500, deepFreeze( {} ) );
 		} );
 
 		afterAll( () => {
@@ -77,6 +82,26 @@ describe( 'actions', () => {
 			} );
 
 			expect( dispatchSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'vimeo: should handle fetch failures properly', async () => {
+			const dispatchSpy = jest.fn();
+
+			expect( async () => {
+				await requestThumbnail( unSuccessfulEmbedUrl )( dispatchSpy );
+			} ).not.toThrowError();
+
+			expect( dispatchSpy ).not.toHaveBeenCalled();
+		} );
+
+		test( 'videopress: should handle fetch failures properly', async () => {
+			const dispatchSpy = jest.fn();
+
+			expect( async () => {
+				await requestThumbnail( failingVideopressEmbedUrl )( dispatchSpy );
+			} ).not.toThrowError();
+
+			expect( dispatchSpy ).not.toHaveBeenCalled();
 		} );
 
 		test( 'youtube: should dispatch action with thumbnail instantly', () => {


### PR DESCRIPTION
## Proposed Changes

This builds on top of the #79111 fix, and we ensure that we throw an error if the request fails, then that error will be caught by our pre-existing `try/catch` block. I've added a couple of unit tests to verify that the new behavior works as expected, and even though an error is thrown, it's properly caught on time.

## Testing Instructions

* Open the Reader and find some videos.
* Verify their thumbnails in feeds still load correctly.
* Verify unit tests pass.
