### PR TITLE
Theme Showcase: Remove the `subject:` Filter from Dotorg Queries

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -377,6 +377,7 @@ export const ConnectedThemesSelection = connect(
 			// We limit the WP.org themes to one page only.
 			page: 1,
 			// WP.com theme filters don't match WP.org ones, so we add them to the search term.
+			// Filters are slugified and concatenated, so we clear `-` and `+` characters; we also remove the `subject:` prefix that can appear when changing categories.
 			search: filter
 				? `${ search } ${ filter.replaceAll( 'subject:', '' ).replace( /[+-]/g, ' ' ) }`
 				: search,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -377,7 +377,9 @@ export const ConnectedThemesSelection = connect(
 			// We limit the WP.org themes to one page only.
 			page: 1,
 			// WP.com theme filters don't match WP.org ones, so we add them to the search term.
-			search: filter ? `${ search } ${ filter.replace( /[+-]/g, ' ' ) }` : search,
+			search: filter
+				? `${ search } ${ filter.replaceAll( 'subject:', '' ).replace( /[+-]/g, ' ' ) }`
+				: search,
 		};
 		const wpOrgThemes = shouldFetchWpOrgThemes
 			? getThemesForQueryIgnoringPage( state, 'wporg', wpOrgQuery ) || []


### PR DESCRIPTION
## Proposed Changes

When filtering the Theme Showcase by subject, the filter term gains a `subject:` prefix, which affects searching the Dotorg themes repository.

In this PR, we simply remove it before passing the filter string to the Dotorg API.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/themes` and look at the Network dev tool, filtered by `wordpress.org`.
* Search for a Dotorg theme such as "Astra".
* Change subject to Blog".
* Ensure there are search results coming from the Dotorg themes repository.
  * _Note: searching for Astra in Blog has currently no results in the wpcalypso environment._
* Check the request, and ensure it contains `request[search]: astra blog`.
* Try searching different filters and ensure the query and its results are as expected.
