### PR TITLE
Reader: Update `Latest` menu item to `Recent` (with language fallback)

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { hasTranslation } from '@wordpress/i18n';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
 import { defer, startsWith } from 'lodash';
@@ -141,7 +142,8 @@ export class ReaderSidebar extends Component {
 	};
 
 	renderSidebar() {
-		const { path, translate, teams } = this.props;
+		const { path, translate, teams, locale } = this.props;
+		const recentLabelTranslationReady = hasTranslation( 'Recent' ) || locale.startsWith( 'en' );
 		return (
 			<SidebarMenu>
 				<QueryReaderLists />
@@ -166,7 +168,11 @@ export class ReaderSidebar extends Component {
 					className={ ReaderSidebarHelper.itemLinkClass( '/read', path, {
 						'sidebar-streams__following': true,
 					} ) }
-					label={ isSubscriptionManagerEnabled ? translate( 'Latest' ) : translate( 'Following' ) }
+					label={
+						isSubscriptionManagerEnabled && recentLabelTranslationReady
+							? translate( 'Recent' )
+							: translate( 'Following' )
+					}
 					onNavigate={ this.handleReaderSidebarFollowedSitesClicked }
 					customIcon={ <ReaderFollowingIcon /> }
 					link="/read"


### PR DESCRIPTION
## Proposed Changes

* update `Latest` menu item to `Recent` (with language fallback)

Related discussion: p1689333450919849-slack-C02TCEHP3HA.

| Before | After |
|--------|--------|
| ![Markup on 2023-07-14 at 13:35:34](https://github.com/Automattic/wp-calypso/assets/25105483/a7eebe6c-1d9d-4e55-81b4-b1c8b373cf33) | ![Markup on 2023-07-14 at 14:13:42](https://github.com/Automattic/wp-calypso/assets/25105483/7e91d627-06a4-4cfb-82e8-09c6e7a90651) | 

## Testing Instructions

1. Check out the branch PR and build the app.
2. Navigate to http://calypso.localhost:3000/read.
3. If the locale is set to English, the `Recent` label should be used instead of `Latest`.
4. Other locales should still display the old translated `Latest` label (since `Recent` hasn't been translated yet).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?