### PR TITLE
Add product slug to pre-cancellation message

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.tsx
@@ -42,11 +42,13 @@ const PrecancellationChatButton: FC< Props > = ( {
 		onClick();
 	};
 
+	const purchaseDomain = purchase.isDomain
+		? `domain: ${ purchase.meta }`
+		: `site: ${ purchase.domain }`;
 	const initialMessage =
 		'User is contacting us from the pre-cancellation flow.\n' +
 		"Product they're attempting to cancel: " +
-		purchase.productName +
-		` (${ purchase.domain })`;
+		`${ purchase.productName } (slug: ${ purchase.productSlug }, ${ purchaseDomain })`;
 
 	return (
 		<ChatButton

--- a/client/lib/purchases/assembler.ts
+++ b/client/lib/purchases/assembler.ts
@@ -54,6 +54,7 @@ function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditCard ): 
 			  }
 			: null,
 		isCancelable: Boolean( purchase.is_cancelable ),
+		isDomain: Boolean( purchase.is_domain ),
 		isDomainRegistration: Boolean( purchase.is_domain_registration ),
 		isLocked: Boolean( purchase.is_locked ),
 		isInAppPurchase: Boolean( purchase.is_iap_purchase ),

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -28,6 +28,7 @@ export interface Purchase {
 	introductoryOffer: PurchaseIntroductoryOffer | null;
 	isAutoRenewEnabled: boolean;
 	isCancelable: boolean;
+	isDomain?: boolean;
 	isDomainRegistration?: boolean;
 	isInAppPurchase: boolean;
 	isLocked: boolean;
@@ -190,6 +191,7 @@ export interface RawPurchase {
 	included_domain_purchase_amount: number;
 	introductory_offer: RawPurchaseIntroductoryOffer | null;
 	is_cancelable: boolean;
+	is_domain: boolean;
 	is_domain_registration: boolean;
 	is_locked: boolean;
 	is_iap_purchase: boolean;

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -100,6 +100,7 @@ describe( 'selectors', () => {
 				introductoryOffer: null,
 				isAutoRenewEnabled: true,
 				isCancelable: false,
+				isDomain: false,
 				isDomainRegistration: false,
 				isLocked: false,
 				isInAppPurchase: false,


### PR DESCRIPTION
The product name is in the user's locale, so it's not always clear what it's referring to. Looks like the product slug is the closest we can get to an always English name.
Additionally, let's make sure to reference the domain name if we're dealing with a domain subscription (registration or connection).

Fixes p8wKgj-4gB-p2#comment-20528

## Testing Instructions

See https://github.com/Automattic/wp-calypso/pull/78173
It's enough to log `initialMessage` - the rest of the flow remains the same.

For non-domain subscriptions, it should look like this:
> User is contacting us from the pre-cancellation flow.
Product they're attempting to cancel: WordPress.com Premium (slug: value_bundle, site: example.wordpress.com)

For domain subscriptions, it should be:
> User is contacting us from the pre-cancellation flow.
Product they're attempting to cancel: Domain Registration (slug: domain_reg, domain: example.com)