### PR TITLE
Pro Dashboard: Hide yearly prices from the Prices section for products that do not have one

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -77,22 +77,32 @@ export default function Prices() {
 						<div>{ translate( 'Jetpack.com Pricing' ) }</div>
 						<span className="prices__th-detail">{ translate( 'billed yearly' ) }</span>
 					</div>
-					<div>
-						{ translate( '%(price)s/day', {
-							args: {
-								price: formatCurrency( dailyUserYearlyPrice, 'USD', currencyFormatOptions ),
-							},
-						} ) }
-					</div>
-					<div>
-						{ translate( '%(price)s/year', {
-							args: {
-								price:
-									userYearlyProduct &&
-									formatCurrency( userYearlyProduct.cost, 'USD', currencyFormatOptions ),
-							},
-						} ) }
-					</div>
+
+					{ /* If monthly and yearly prices are equal we're going to assume there is no yearly plan
+					  and hide the yearly price. Currently this is the case with the Jetpack AI Assistant product.
+					  */ }
+					{ userYearlyProduct.cost !== userMonthlyProduct?.cost && (
+						<>
+							<div>
+								{ translate( '%(price)s/day', {
+									args: {
+										price: formatCurrency( dailyUserYearlyPrice, 'USD', currencyFormatOptions ),
+									},
+								} ) }
+							</div>
+							<div>
+								{ translate( '%(price)s/year', {
+									args: {
+										price:
+											userYearlyProduct &&
+											formatCurrency( userYearlyProduct.cost, 'USD', currencyFormatOptions ),
+									},
+								} ) }
+							</div>
+						</>
+					) }
+
+					{ userYearlyProduct.cost === userMonthlyProduct?.cost && <Gridicon icon="minus" /> }
 				</td>
 				<td>
 					<div className="prices__mobile-description">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1201801459945917-as-1205066944515016

## Proposed Changes

* Pro Dashboard: Hide yearly prices from the Prices section for products that do not have one. This is currently the case for the AI Assistant product.

![Screenshot 2023-07-14 at 16 31 39](https://github.com/Automattic/wp-calypso/assets/22746396/ff2ea4db-5586-4bec-bb6b-8f0f022cd637)

## Testing Instructions

* Open up http://jetpack.cloud.localhost:3000/partner-portal/prices
* Make sure it shows a dash/minus where the yearly price for the AI Assistant product should be like in the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?