### PR TITLE
Newsletter onboarding: fix firing signup start event

### DIFF
--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -20,11 +20,11 @@ const flows: Record< string, { [ step: string ]: number } > = {
 	newsletter: {
 		intro: 0,
 		user: 0,
-		newsletterSetup: 1,
-		domains: 2,
-		'plans-newsletter': 3,
-		subscribers: 4,
-		launchpad: 5,
+		newsletterSetup: 0,
+		domains: 1,
+		'plans-newsletter': 2,
+		subscribers: 3,
+		launchpad: 4,
 	},
 	[ LINK_IN_BIO_FLOW ]: {
 		intro: 0,


### PR DESCRIPTION
Reported on Slack by @kurt213 (p1689333783538749-slack-C052XEUUBL4)

### Problem

In the newsletter flow when intro step is skipped, we don't fire "signup start" event.

"Intro" step gets skipped when coming from the landing page, and the URL has `?ref=newsletter-lp`. This was changed in https://github.com/Automattic/wp-calypso/pull/77392:

https://github.com/Automattic/wp-calypso/blob/5b4eb0dfd878f685f096909dbd4f91415fefdeda/client/landing/stepper/declarative-flow/newsletter.ts#L32-L37

### Fix

The flows looks into progress bar state to determine if the "flow start" code should run, which fires the signup start event:

https://github.com/Automattic/wp-calypso/blob/e21b9f617b3f21b2c2a1e73699629bbf35d9e025/client/landing/stepper/declarative-flow/internals/index.tsx#L85-L96
https://github.com/Automattic/wp-calypso/blob/e21b9f617b3f21b2c2a1e73699629bbf35d9e025/client/landing/stepper/declarative-flow/internals/index.tsx#L130-L134

To fix this, we adjust progress to `0` no matter if we're at "setup" step or "intro" step. Previously intro was `0` and setup `1` which only affected how the progress looks visually.

The flow controller (e.g. for [newsletters](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/newsletter.ts)) should probably just run `isFlowStart()` manually, instead as a proper fix later on, or we should look at current step and compare its position in the steps list within `useSteps`.

## Proposed Changes

* Switch "setup" step to have "progress" `0`

## Testing Instructions

* Make sure you track events, e.g. by adding this to console: `localStorage.debug="calypso:analytics"`
* Go through both flows, you can use [Calypso live links](https://github.com/Automattic/wp-calypso/pull/79425#issuecomment-1635888450) 
   *  `/setup/newsletter`
   *  `/setup/newsletter?ref=newsletter-lp`
 * Ensure you see `calypso_signup_start` event:

    <img width="707" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/bd91a84a-3323-4abe-97d2-0c1943456ed3">

* The progress bar still works — note that it dissapears during domains and plans steps:

    <img width="891" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/3ec54ab4-5734-4484-8358-be70b1a9a4e6">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?