### PR TITLE
Design Preview: Fix the Creatio theme cannot be previewed

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
@@ -2,7 +2,7 @@ import { isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
 import { useColorPaletteVariations, useFontPairingVariations } from '@automattic/global-styles';
 import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { ONBOARD_STORE } from '../../../../../stores';
 import type { GlobalStyles, OnboardSelect, StarterDesigns } from '@automattic/data-stores';
@@ -45,10 +45,23 @@ const useRecipe = (
 
 	const [ globalStyles, setGlobalStyles ] = useState< GlobalStylesObject | null >( null );
 
-	const preselectedTheme = searchParams.get( 'theme' );
-	const preselectedStyle = searchParams.get( 'style_variation' );
-	const preselectedColorVariationTitle = searchParams.get( 'color_variation_title' );
-	const preselectedFontVariationTitle = searchParams.get( 'font_variation_title' );
+	/**
+	 * Get the preselect data only when mounting and ignore any changes later.
+	 */
+	const {
+		preselectedTheme,
+		preselectedStyle,
+		preselectedColorVariationTitle,
+		preselectedFontVariationTitle,
+	} = useMemo(
+		() => ( {
+			preselectedTheme: searchParams.get( 'theme' ),
+			preselectedStyle: searchParams.get( 'style_variation' ),
+			preselectedColorVariationTitle: searchParams.get( 'color_variation_title' ),
+			preselectedFontVariationTitle: searchParams.get( 'font_variation_title' ),
+		} ),
+		[]
+	);
 
 	const { stylesheet = '' } = selectedDesign?.recipe || {};
 
@@ -167,8 +180,10 @@ const useRecipe = (
 			return;
 		}
 
-		const requestedDesign = allDesigns.designs.find(
-			( design ) => design.recipe?.slug === preselectedTheme || design.slug === preselectedTheme
+		const requestedDesign = allDesigns.designs.find( ( design ) =>
+			design.is_virtual
+				? design.recipe?.slug === preselectedTheme
+				: design.slug === preselectedTheme
 		);
 		if ( ! requestedDesign ) {
 			return;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The preview of the Creatio theme is incorrect since it's the base theme of the virtual themes. So, use `is_virtual` to determine which slug should be used to restore the preselected design from the query string.
* There is another issue that we will restore the preselected design once the value from the query string changed. Hence, use `useMemo` to get the preselected value only when the component is mounting and ignore any changes later.

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/d737c4d7-4025-4273-8b44-5c269e8d6822) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/213a6321-1b42-437f-a3ea-01b3c639e7a4) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>
* Continue to Design Picker
* Preview “Creatio”, and ensure you see the preview of the “Creatio” theme correctly
* Refresh the page, and ensure you still see the preview of the “Creatio” theme correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
