### PR TITLE
Bulk Transfer Flow: Validate auth after 6 characters

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -11,7 +11,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 	const [ authDebounced ] = useDebounce( auth, 500 );
 
 	const hasGoodDomain = doesStringResembleDomain( domainDebounced );
-	const hasGoodAuthCode = hasGoodDomain && auth.trim().length > 0;
+	const hasGoodAuthCode = hasGoodDomain && auth.trim().length > 6;
 
 	const passedLocalValidation = hasGoodDomain && hasGoodAuthCode && ! hasDuplicates;
 


### PR DESCRIPTION
[Context](p1689281767945339/1689272710.522089-slack-C05CT832K2T)

The authorization code validation now starts after the user digits at least 6 characters.

## Testing
1. Live link and reach `/setup/domain-transfer/domains`
2. Open dev tools and the network tab
3. Check that `is-available` request is sent only after 6 characters