### PR TITLE
Plans: Convert LegacyPlanNotice to a TypeScript component

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -43,7 +43,7 @@ import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings';
 import JetpackChecklist from 'calypso/my-sites/plans/current-plan/jetpack-checklist';
 import PlanRenewalMessage from 'calypso/my-sites/plans/jetpack-plans/plan-renewal-message';
-import legacyPlanNotice from 'calypso/my-sites/plans/legacy-plan-notice';
+import LegacyPlanNotice from 'calypso/my-sites/plans/legacy-plan-notice';
 import ModernizedLayout from 'calypso/my-sites/plans/modernized-layout';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
@@ -296,7 +296,10 @@ class CurrentPlan extends Component {
 								</Notice>
 							) }
 
-							{ legacyPlanNotice( eligibleForProPlan, selectedSite ) }
+							<LegacyPlanNotice
+								eligibleForProPlan={ eligibleForProPlan }
+								plan={ selectedSite.plan }
+							/>
 
 							{ isEcommerceTrial ? this.renderEcommerceTrialPage() : this.renderMain() }
 

--- a/client/my-sites/plans/legacy-plan-notice.tsx
+++ b/client/my-sites/plans/legacy-plan-notice.tsx
@@ -1,17 +1,21 @@
 import { isBlogger, isPersonal, isPremium } from '@automattic/calypso-products';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import Notice from 'calypso/components/notice';
+import type { SiteDetails } from '@automattic/data-stores';
 
 /**
  * Renders a "You're on a legacy plan" for sites on legacy plans (excluding free, business, and ecommerce plan).
- *
- * @param {boolean} eligibleForProPlan - Is the user eligible for pro plan?
- * @param {Object} selectedSite - Site object from store.
- * @param {Object} selectedSite.plan - The plan object nested inside the selectedSite object.
- * @returns {import('react').Element} - Legacy plan Notice component.
  */
-const maybeRenderLegacyPlanNotice = ( eligibleForProPlan, { plan } ) => {
-	const eligibleLegacyPlan = isBlogger( plan ) || isPersonal( plan ) || isPremium( plan );
+const LegacyPlanNotice = ( {
+	eligibleForProPlan,
+	plan,
+}: {
+	eligibleForProPlan: boolean;
+	plan: SiteDetails[ 'plan' ];
+} ) => {
+	const translate = useTranslate();
+	const eligibleLegacyPlan =
+		plan && ( isBlogger( plan ) || isPersonal( plan ) || isPremium( plan ) );
 
 	if ( eligibleForProPlan && eligibleLegacyPlan ) {
 		return (
@@ -28,4 +32,4 @@ const maybeRenderLegacyPlanNotice = ( eligibleForProPlan, { plan } ) => {
 	return null;
 };
 
-export default maybeRenderLegacyPlanNotice;
+export default LegacyPlanNotice;


### PR DESCRIPTION
## Proposed Changes

This PR converts the `maybeRenderLegacyPlanNotice()` function into a React component (it basically was one already) and converts it to TypeScript. In so doing it adds a guard to prevent calling `isBlogger()` with an undefined value that was causing fatal errors like the one reported here: p1689304075525229-slack-C04U5A26MJB

## Testing Instructions

- You'll need a site that has a subscription to a legacy plan like Blogger, Personal, or Premium.

... wait, is this still needed now that the Pro plan is deprecated?
