### PR TITLE
Purchases: Make ConfirmCancelDomain render loading while purchase missing

### DIFF
--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -242,7 +242,7 @@ class ConfirmCancelDomain extends Component {
 	};
 
 	render() {
-		if ( isDataLoading( this.props ) ) {
+		if ( isDataLoading( this.props ) || ! this.props.purchase ) {
 			return (
 				<div>
 					<QueryUserPurchases />


### PR DESCRIPTION
## Proposed Changes

`ConfirmCancelDomain` loads a specified domain purchase and then renders some information about it. However, it's possible for the purchase to be `undefined`. If that happens, the component's `componentDidUpdate` lifecycle function will run and should call `redirectIfDataIsInvalid()` to redirect away. Fatal errors like the one reported in p1689344222921699-slack-C04U5A26MJB suggest that this redirect might not be fast enough to prevent the component's render function from being called. When it is called, it calls `getDomainName()` with that undefined value, leading to the fatal error.

In this PR we modify the render function of the component to return early by showing the loading placeholder if the purchase is missing. This should give the redirect time to operate and prevent the fatal. 

## Testing Instructions

No idea but a static review should be enough.