### PR TITLE
Design Preview: Fix the preview is not visible if both Colors & Fonts are not enabled

### DIFF
--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -123,7 +123,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 				url={ previewUrl }
 				inlineCss={ inlineCss }
 				isFullscreen={ isFullscreen }
-				animated={ ! isDesktop }
+				animated={ ! isDesktop && screens.length > 0 }
 				recordDeviceClick={ recordDeviceClick }
 			/>
 		</div>

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -10,7 +10,7 @@ $design-preview-sidebar-width: 311px;
 	height: 100%;
 	padding: 0 20px;
 
-	&.design-preview--has-multiple-screens {
+	&:not(.design-preview--is-fullscreen) {
 		.design-preview__sidebar {
 			position: relative;
 			width: 100%;
@@ -32,10 +32,6 @@ $design-preview-sidebar-width: 311px;
 				margin-bottom: 32px;
 			}
 		}
-
-		.design-preview__sidebar-header {
-			display: block;
-		}
 	}
 
 	&.design-preview--is-fullscreen {
@@ -54,6 +50,10 @@ $design-preview-sidebar-width: 311px;
 			box-shadow: -4px 0 8px rgb(0 0 0 / 7%);
 			z-index: 1;
 			animation: sidebarFadeIn 0.3s ease-out;
+		}
+
+		.design-preview__sidebar-header {
+			display: none;
 		}
 
 		.design-preview__site-preview {
@@ -144,15 +144,8 @@ $design-preview-sidebar-width: 311px;
 }
 
 .design-preview__sidebar-header {
-	display: none;
-	margin-bottom: 32px;
-
-	.design-preview__sidebar--has-multiple-screens & {
-		display: block;
-	}
-
-	@include break-large {
-		display: block;
+	& ~ .navigator-item-group {
+		margin-top: 32px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adjust styles to avoid the height of the preview becoming 0 so that it's invisible when both Colors & Fonts are disabled

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/0189e461-4a2e-4e2b-ae29-d5e6ca12fe87) |![image](https://github.com/Automattic/wp-calypso/assets/13596067/156b082a-8d45-4ba8-a90a-f19d66562463) |

**Styles Variations Only**

| Desktop | Mobile |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/9e401fa2-823b-44a4-b4cb-f72122a7df10) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/636f004e-abe8-42c4-8efc-ddb3e3d73945) |

**Fonts Only**

| Desktop | Mobile |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/a486231b-badb-473a-996f-e862211f3f69) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/73634f4f-8430-4d73-9aad-3e1002c76b4e) |

**Colors & Fonts**

| Desktop | Mobile |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/14947b33-c439-49e9-89a7-f2db561f1287) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/1b39142d-7eef-4ac3-af35-9e11828422c4) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/d5318971-f0ab-4eb3-a38a-6ec976611e13) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/3ff7dc0d-5396-4069-b48b-0997d51dcb41) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/fca6f831-2fea-4029-bf77-288abe2b70d4) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/bca076d7-36cd-48c6-ac49-a1fa67694709) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?flags=-signup/design-picker-preview-fonts,-signup/design-picker-preview-colors&siteSlug=<your_site>
* Continue to Design Picker
* Preview the design without the variations
* Ensure you're able to preview the design

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
