### PR TITLE
Checkout: Make sure tracks payment method changed slug has no hyphens

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
@@ -170,7 +170,7 @@ export function translateCheckoutPaymentMethodToTracksPaymentMethod(
 		case 'google-pay':
 			return 'web_payment';
 	}
-	return camelToSnakeCase( paymentMethodSlug );
+	return camelToSnakeCase( paymentMethodSlug ).replaceAll( '-', '_' );
 }
 
 export function isRedirectPaymentMethod( slug: CheckoutPaymentMethodSlug ): boolean {


### PR DESCRIPTION
## Proposed Changes

Noticed by @klimeryk [here](https://github.com/Automattic/wp-calypso/commit/f74c26ebb89a894e1a5040ef9c790c1dd4fd186a#r121614815), the `calypso_checkout_switch_to_` Tracks event (which tracks when the user selects a different Payment Method in checkout) sometimes contains a hyphen (eg `free-purchase`, `stripe-three-d-secure`, or `web-pay`). This makes the Tracks event illegal since event names cannot contain hyphens.

In this PR we replace the hyphens with underscores.

Before:

<img width="619" alt="Screenshot 2023-07-14 at 10 53 20 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/1826605c-89db-4b37-873b-ec4ecc4ba8ca">

After:

<img width="615" alt="Screenshot 2023-07-14 at 10 52 26 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/312f4c32-644e-44d9-bbc7-b2aaba2e72c7">


## Testing Instructions

- Load calypso, then run `localStorage.setItem('debug', 'calypso:analytics')` in your browser console and reload the page.
- Add enough credits to your account for a free purchase.
- Visit checkout with a product in your cart.
- In the final step, select "Assign a Payment Method Later".
- Verify that you see `calypso_checkout_switch_to_free_purchase` reported as a Tracks event in your console.