### PR TITLE
GS on Personal: Use correct plan on theme details checkout

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1132,8 +1132,8 @@ class ThemeSheet extends Component {
 			this.getPremiumGlobalStylesEventProps()
 		);
 
-		const { globalStylesOnPersonalExperiment } = this.props;
-		const plan = globalStylesOnPersonalExperiment ? 'personal' : 'premium';
+		const { globalStylesInPersonalPlan } = this.props;
+		const plan = globalStylesInPersonalPlan ? 'personal' : 'premium';
 
 		const params = new URLSearchParams();
 		params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -150,8 +150,8 @@ class ThemePreview extends Component {
 			this.getPremiumGlobalStylesEventProps()
 		);
 
-		const { globalStylesOnPersonalExperiment } = this.props;
-		const plan = globalStylesOnPersonalExperiment ? 'personal' : 'premium';
+		const { globalStylesInPersonalPlan } = this.props;
+		const plan = globalStylesInPersonalPlan ? 'personal' : 'premium';
 
 		const params = new URLSearchParams();
 		params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );


### PR DESCRIPTION
## Proposed Changes

Fixes an issue that was incorrectly adding the Premium plan to the checkout of treatment users upgrading through the theme details page.

## Testing Instructions

- Use the Calypso live link below
- Make sure you're assigned to the treatment variant of the GS on Personal experiment
- Go to a theme details page (e.g. `/theme/freddie/:site`)
- Pick a custom style variation
- Click on "Activate this design"
- Click on "Upgrade plan"
- Make sure the Personal plan is added to the checkout