### PR TITLE
Reader: avoid rendering components speculatively

### DIFF
--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -6,10 +6,11 @@ import Stream from 'calypso/reader/stream';
 import ConversationsIntro from './intro';
 import './stream.scss';
 
+const emptyContent = () => <ConversationsEmptyContent />;
+
 export default function ( props ) {
 	const isInternal = get( props, 'store.id' ) === 'conversations-a8c';
-	const emptyContent = <ConversationsEmptyContent />;
-	const intro = <ConversationsIntro isInternal={ isInternal } />;
+	const intro = () => <ConversationsIntro isInternal={ isInternal } />;
 
 	const ConversationTitle = () => {
 		const translate = useTranslate();

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -200,7 +200,7 @@ const DiscoverStream = ( props ) => {
 		streamKey += recommendedStreamTags.reduce( ( acc, val ) => acc + `-${ val }`, '' );
 	}
 
-	const streamSidebar =
+	const streamSidebar = () =>
 		( isDefaultTab || selectedTab === 'latest' ) && recommendedSites?.length ? (
 			<>
 				<h2>{ translate( 'Popular Sites' ) }</h2>
@@ -216,7 +216,7 @@ const DiscoverStream = ( props ) => {
 	const streamProps = {
 		...props,
 		streamKey,
-		streamHeader: recommendedTags.length ? <DiscoverNavigation /> : null,
+		streamHeader: recommendedTags.length ? () => <DiscoverNavigation /> : null,
 		useCompactCards: true,
 		streamSidebar,
 		sidebarTabTitle: isDefaultTab ? translate( 'Sites' ) : translate( 'Related' ),

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -22,6 +22,8 @@ import EmptyContent from './empty';
 // If the blog_ID of a reader feed is 0, that means no site exists for it.
 const getReaderSiteId = ( feed ) => ( feed && feed.blog_ID === 0 ? null : feed && feed.blog_ID );
 
+const emptyContent = () => <EmptyContent />;
+
 const FeedStream = ( props ) => {
 	const { className = 'is-site-stream', feedId, showBack = true } = props;
 	const translate = useTranslate();
@@ -45,7 +47,6 @@ const FeedStream = ( props ) => {
 	} );
 
 	const siteTags = useSiteTags( siteId );
-	const emptyContent = <EmptyContent />;
 	const title = getSiteName( { feed, site } ) || translate( 'Loading Feed' );
 	const followerCount = getFollowerCount( feed, site );
 
@@ -57,7 +58,7 @@ const FeedStream = ( props ) => {
 		return <FeedError sidebarTitle={ title } />;
 	}
 
-	const streamSidebar = (
+	const streamSidebar = () => (
 		<FeedStreamSidebar
 			feed={ feed }
 			followerCount={ followerCount }

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -12,7 +12,7 @@ function FollowingStream( { ...props } ) {
 			<Stream
 				{ ...props }
 				className="following"
-				streamSidebar={ <ReaderListFollowedSites path={ window.location.pathname } /> }
+				streamSidebar={ () => <ReaderListFollowedSites path={ window.location.pathname } /> }
 			>
 				<FollowingIntro />
 			</Stream>

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -10,9 +10,10 @@ const documentTitle = translate( '%s ‹ Reader', {
 	comment: '%s is the section name. For example: "My Likes"',
 } );
 
+const emptyContent = () => <EmptyContent />;
+
 class LikedStream extends Component {
 	render() {
-		const emptyContent = <EmptyContent />;
 		return (
 			<Stream
 				{ ...this.props }

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -18,6 +18,8 @@ import ListStreamHeader from './header';
 import ListMissing from './missing';
 import './style.scss';
 
+const emptyContent = () => <EmptyContent />;
+
 class ListStream extends Component {
 	constructor( props ) {
 		super( props );
@@ -52,7 +54,6 @@ class ListStream extends Component {
 	render() {
 		const list = this.props.list;
 		const shouldShowFollow = list && ! list.is_owner;
-		const emptyContent = <EmptyContent />;
 		const listStreamIconClasses = 'gridicon gridicon__list';
 
 		if ( list ) {

--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -28,7 +28,7 @@ class PostResults extends Component {
 
 	render() {
 		const { query, translate } = this.props;
-		const emptyContent = <EmptyContent query={ query } />;
+		const emptyContent = () => <EmptyContent query={ query } />;
 		const transformStreamItems =
 			! query || query === ''
 				? ( postKey ) => ( { ...postKey, isRecommendation: true } )

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -20,6 +20,8 @@ import { isSiteBlocked } from 'calypso/state/reader/site-blocks/selectors';
 import { getSite } from 'calypso/state/reader/sites/selectors';
 import EmptyContent from './empty';
 
+const emptyContent = () => <EmptyContent />;
+
 const SiteStream = ( props ) => {
 	const { className = 'is-site-stream', showBack = true, siteId } = props;
 	const translate = useTranslate();
@@ -42,7 +44,6 @@ const SiteStream = ( props ) => {
 	}, [ site ] );
 
 	const siteTags = useSiteTags( siteId );
-	const emptyContent = <EmptyContent />;
 	const title = site ? site.name : translate( 'Loading Site' );
 	const followerCount = getFollowerCount( feed, site );
 
@@ -54,7 +55,7 @@ const SiteStream = ( props ) => {
 		return <FeedError sidebarTitle={ title } />;
 	}
 
-	const streamSidebar = (
+	const streamSidebar = () => (
 		<FeedStreamSidebar
 			feed={ feed }
 			followerCount={ followerCount }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -98,7 +98,7 @@ class TagStream extends Component {
 	};
 
 	render() {
-		const emptyContent = <EmptyContent decodedTagSlug={ this.props.decodedTagSlug } />;
+		const emptyContent = () => <EmptyContent decodedTagSlug={ this.props.decodedTagSlug } />;
 		const title = this.props.decodedTagSlug;
 		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );
 		const titleText = title.replace( /-/g, ' ' );
@@ -124,13 +124,13 @@ class TagStream extends Component {
 						showFollow={ false }
 						showBack={ this.props.showBack }
 					/>
-					{ emptyContent }
+					{ emptyContent() }
 				</ReaderMain>
 			);
 		}
 
 		// Put the tag stream header at the top of the body, so it can be even with the sidebar in the two column layout.
-		const tagHeader = (
+		const tagHeader = () => (
 			<TagStreamHeader
 				title={ titleText }
 				description={ this.props.description }
@@ -153,7 +153,7 @@ class TagStream extends Component {
 				streamHeader={ tagHeader }
 				showSiteNameOnCards={ false }
 				useCompactCards={ true }
-				streamSidebar={ <ReaderTagSidebar tag={ this.props.decodedTagSlug } /> }
+				streamSidebar={ () => <ReaderTagSidebar tag={ this.props.decodedTagSlug } /> }
 				sidebarTabTitle={ this.props.translate( 'Related' ) }
 			>
 				<QueryReaderFollowedTags />


### PR DESCRIPTION
The reader streams follow an anti-pattern, where rendered components are passed in as props. For example, this happens with the `emptyContent` prop:

```jsx
const emptyContent = <EmptyContent />;
return (
  <Stream
    { ...this.props }
    listName={ title }
    emptyContent={ emptyContent }
    showFollowInHeader={ true }
  >
  <DocumentHead title={ documentTitle } />
  </Stream>
);
```

These rendered components (`<EmptyContent />` in the above example) can then go on never to actually be placed anywhere in the actual render tree, because certain conditions are not met.

In the meantime, however, they have already been rendered in memory, wasting CPU time in the process.

However, where this becomes particularly problematic is when the components have side-effects; specifically, these `EmptyContent` components stop the rendering performance measurement. This behaviour is intentional when the components are displayed; if an empty list is shown, it's expected for the `EmptyContent` component to stop the clock. However, since it's being rendered ahead of time (and even when it's not needed), this effectively renders the metrics useless, since the clock gets stopped far too early for what we actually intend to measure.

This PR thus shifts all of these props to take nullary functions instead, so that the rendering can be delayed until the appropriate time, and take place only if any conditions are met.

```jsx
const emptyContent = () => <EmptyContent />;
```

In addition, it solves an initialisation problem in the `ReaderStream` component, where it acts as if it has already completed fetching data upon first mount (thus triggering the render of the empty content components).

## Proposed Changes

* Switch the `emptyComponent`, `intro`, `streamHeader`, and `streamSidebar` props to take functions instead of elements.
* Adjust all consumers of `ReaderStream` appropriately.
* Add an `isMounted` instance property to `ReaderStream`, and use it to avoid setting `isFetching` to `false` on first mount.

## Testing Instructions

* Smoke-test the reader and ensure that nothing is broken. Be particularly mindful of things like stale views.
* While navigating within the reader, keep the Network tab open in DevTools, and ensure that requests to `logstash?http_envelope=1` are only being made when the placeholders in the section you navigated to disappear; not immediately when you click to navigate.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
