### PR TITLE
Bulk Domain Transfer: Minimum of 5 characters for auth validation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -11,7 +11,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 	const [ authDebounced ] = useDebounce( auth, 500 );
 
 	const hasGoodDomain = doesStringResembleDomain( domainDebounced );
-	const hasGoodAuthCode = hasGoodDomain && auth.trim().length > 6;
+	const hasGoodAuthCode = hasGoodDomain && auth.trim().length > 5;
 
 	const passedLocalValidation = hasGoodDomain && hasGoodAuthCode && ! hasDuplicates;
 


### PR DESCRIPTION
Quick fix for https://github.com/Automattic/wp-calypso/pull/79427
We're reducing the minimum number of auth values to 5, from 6.

## Testing
1. Live link and reach `/setup/domain-transfer/domains`
2. Open dev tools and the network tab
3. Check that `is-available` request is sent only after 6 characters