### PR TITLE
Bulk Domain: Update copies on complete step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
@@ -30,7 +30,7 @@ export const CompleteDomainsTransferred = ( {
 									<li className="domain-complete-list-item" key={ key }>
 										<div>
 											<h2>{ meta }</h2>
-											<p>{ __( 'Auto-renew enabled' ) }</p>
+											<p>{ __( 'Auto renew enabled' ) }</p>
 										</div>
 										<a
 											href={ `/domains/manage/all/${ meta }/transfer/in/${ domain }` }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -66,7 +66,7 @@ const Complete: Step = function Complete( { flow } ) {
 						id="domains-header"
 						headerText={ _n(
 							'Your domain transfer has started',
-							'Your domain transfers has started',
+							'Your domain transfers have started',
 							newlyTransferredDomains?.length || storedDomainsAmount
 						) }
 						subHeaderText={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -65,16 +65,16 @@ const Complete: Step = function Complete( { flow } ) {
 					<FormattedHeader
 						id="domains-header"
 						headerText={ _n(
-							'Congrats on your domain transfer!',
-							'Congrats on your domain transfers!',
+							'Your domain transfer has started',
+							'Your domain transfers has started',
 							newlyTransferredDomains?.length || storedDomainsAmount
 						) }
 						subHeaderText={
 							<>
 								<span>
 									{ _n(
-										"We got it from here! We'll let you know when your newly transferred domain is ready to use!",
-										"We got it from here! We'll let you know when your newly transferred domains are ready to use!",
+										"We've got it from here! We'll let you know when your newly transferred domain is ready to use!",
+										"We've got it from here! We'll let you know when your newly transferred domains are ready to use!",
 										newlyTransferredDomains?.length || storedDomainsAmount
 									) }
 								</span>


### PR DESCRIPTION
Related to #3010

## Proposed Changes

Update copies on `/setup/domain-transfer/complete`

## Testing Instructions

- Use calypso live link and navigate to `/setup/domain-transfer/complete`
- You should see the copies matching the [thread here](https://github.com/Automattic/dotcom-forge/issues/3010#issuecomment-1635862721)
