### PR TITLE
GS on Personal: Add sticker only once

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -664,7 +664,9 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 		$has_personal_plan = wpcom_site_has_personal_plan( $blog_id );
 		$note              = 'See https://wp.me/paYJgx-3yE';
 		if ( $has_personal_plan ) {
-			add_blog_sticker( 'wpcom-global-styles-personal-plan', $note, null, $blog_id );
+			if ( ! wpcom_global_styles_has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) ) {
+				add_blog_sticker( 'wpcom-global-styles-personal-plan', $note, null, $blog_id );
+			}
 		} else {
 			remove_blog_sticker( 'wpcom-global-styles-personal-plan', $note, null, $blog_id );
 		}


### PR DESCRIPTION
## Proposed Changes

Prevents the `wpcom-global-styles-personal-plan` blog sticker from being added if the site already has it.

## Testing Instructions

- Apply these changes to your sandbox
- Sandbox a site
- Assign yourself to the treatment group of the GS on Personal experiment
- Purchase a Personal plan on the sandboxed site
- Visit the frontend of the sandboxed site
- Visit the frontend again
- Visit the site editor
- Check the blog RC
- In the audit trail section, make sure there is only one note about the added blog sticker 
