### PR TITLE
Update logged out masterbar styles

### DIFF
--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -185,7 +185,7 @@ class MasterbarLoggedOut extends Component {
 		}
 
 		return (
-			<Masterbar>
+			<Masterbar className="masterbar__loggedout">
 				<Item className="masterbar__item-logo masterbar__item--always-show-content">
 					<WordPressLogo className="masterbar__wpcom-logo" />
 					<WordPressWordmark className="masterbar__wpcom-wordmark" />

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -33,12 +33,13 @@ class MasterbarLoggedOut extends Component {
 	};
 
 	renderTagsItem() {
-		const { locale, translate } = this.props;
+		const { translate } = this.props;
 
-		let tagsUrl = '/tags';
-		if ( ! isDefaultLocale( locale ) ) {
-			tagsUrl = addLocaleToPath( tagsUrl, locale );
-		}
+		const tagsUrl = '/tags';
+		// TODO - renable adding locale once we enable locales for these pages.
+		// if ( ! isDefaultLocale( locale ) ) {
+		// 	tagsUrl = addLocaleToPath( tagsUrl, locale );
+		// }
 
 		return (
 			<Item url={ tagsUrl }>
@@ -51,12 +52,13 @@ class MasterbarLoggedOut extends Component {
 	}
 
 	renderSearchItem() {
-		const { locale, translate } = this.props;
+		const { translate } = this.props;
 
-		let tagsUrl = '/read/search';
-		if ( ! isDefaultLocale( locale ) ) {
-			tagsUrl = addLocaleToPath( tagsUrl, locale );
-		}
+		const tagsUrl = '/read/search';
+		// TODO - renable adding locale once we enable locales for these pages.
+		// if ( ! isDefaultLocale( locale ) ) {
+		// 	tagsUrl = addLocaleToPath( tagsUrl, locale );
+		// }
 
 		return (
 			<Item url={ tagsUrl }>

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -32,6 +32,42 @@ class MasterbarLoggedOut extends Component {
 		title: '',
 	};
 
+	renderTagsItem() {
+		const { locale, translate } = this.props;
+
+		let tagsUrl = '/tags';
+		if ( ! isDefaultLocale( locale ) ) {
+			tagsUrl = addLocaleToPath( tagsUrl, locale );
+		}
+
+		return (
+			<Item url={ tagsUrl }>
+				{ translate( 'Popular Tags', {
+					context: 'Toolbar',
+					comment: 'Should be shorter than ~15 chars',
+				} ) }
+			</Item>
+		);
+	}
+
+	renderSearchItem() {
+		const { locale, translate } = this.props;
+
+		let tagsUrl = '/read/search';
+		if ( ! isDefaultLocale( locale ) ) {
+			tagsUrl = addLocaleToPath( tagsUrl, locale );
+		}
+
+		return (
+			<Item url={ tagsUrl }>
+				{ translate( 'Search', {
+					context: 'Toolbar',
+					comment: 'Should be shorter than ~12 chars',
+				} ) }
+			</Item>
+		);
+	}
+
 	renderLoginItem() {
 		const { currentQuery, currentRoute, sectionName, translate, redirectUri } = this.props;
 		if ( sectionName === 'login' ) {
@@ -156,8 +192,10 @@ class MasterbarLoggedOut extends Component {
 				</Item>
 				<Item className="masterbar__item-title">{ title }</Item>
 				<div className="masterbar__login-links">
-					{ this.renderSignupItem() }
+					{ this.renderTagsItem() }
+					{ this.renderSearchItem() }
 					{ this.renderLoginItem() }
+					{ this.renderSignupItem() }
 				</div>
 			</Masterbar>
 		);

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -172,6 +172,22 @@ class MasterbarLoggedOut extends Component {
 		);
 	}
 
+	renderWordPressItem() {
+		const { locale } = this.props;
+
+		let homeUrl = '/';
+		if ( ! isDefaultLocale( locale ) ) {
+			homeUrl = addLocaleToPath( homeUrl, locale );
+		}
+
+		return (
+			<Item url={ homeUrl } className="masterbar__item-logo masterbar__item--always-show-content">
+				<WordPressLogo className="masterbar__wpcom-logo" />
+				<WordPressWordmark className="masterbar__wpcom-wordmark" />
+			</Item>
+		);
+	}
+
 	render() {
 		const { title, isCheckout, isCheckoutPending } = this.props;
 
@@ -188,10 +204,7 @@ class MasterbarLoggedOut extends Component {
 
 		return (
 			<Masterbar className="masterbar__loggedout">
-				<Item className="masterbar__item-logo masterbar__item--always-show-content">
-					<WordPressLogo className="masterbar__wpcom-logo" />
-					<WordPressWordmark className="masterbar__wpcom-wordmark" />
-				</Item>
+				{ this.renderWordPressItem() }
 				<Item className="masterbar__item-title">{ title }</Item>
 				<div className="masterbar__login-links">
 					{ this.renderTagsItem() }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -928,16 +928,3 @@ a.masterbar__quick-language-switcher {
 		opacity: 1;
 	}
 }
-
-// .masterbar-logged-out__item-signup {
-// 	background-color: #fff;
-// 	border-radius: 2px;
-
-// 	.masterbar__item-content {
-// 		font-weight: 600;
-// 		color: var(--color-sidebar-text);
-// 		&:hover {
-// 			color: #fff;
-// 		}
-// 	}
-// }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -44,6 +44,21 @@ $masterbar-color-secondary: #101517;
 
 	&.masterbar__loggedout {
 		padding-top: 10px;
+
+		.masterbar__item:hover {
+			background: transparent;
+			text-decoration: underline;
+		}
+		.masterbar__item:last-child {
+			margin-left: 6px;
+		}
+		.masterbar__item:last-child:hover {
+			background: #fff;
+			text-decoration: none;
+		}
+		.masterbar__item:last-child:hover .masterbar__item-content {
+			color: var(--color-sidebar-text);
+		}
 	}
 
 	&.masterbar--is-checkout {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -27,7 +27,6 @@ $masterbar-color-secondary: #101517;
 	position: fixed;
 	left: 0;
 	top: 0;
-	padding-top: 10px;
 	width: 100%;
 	max-width: 100vw;
 	z-index: z-index("root", ".masterbar");
@@ -41,6 +40,10 @@ $masterbar-color-secondary: #101517;
 		// Use generic colors so that they override whatever theme colors the user has picked.
 		background: var(--studio-orange);
 		border-bottom: 1px solid var(--studio-orange-60);
+	}
+
+	&.masterbar__loggedout {
+		padding-top: 10px;
 	}
 
 	&.masterbar--is-checkout {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -27,6 +27,7 @@ $masterbar-color-secondary: #101517;
 	position: fixed;
 	left: 0;
 	top: 0;
+	padding-top: 10px;
 	width: 100%;
 	max-width: 100vw;
 	z-index: z-index("root", ".masterbar");
@@ -590,7 +591,22 @@ $masterbar-color-secondary: #101517;
 	}
 
 	.masterbar__item:last-child {
-		padding-right: 20px;
+		margin-right: 12px;
+		background-color: #fff;
+		border-radius: 2px;
+
+
+		.masterbar__item-content {
+			font-weight: 600;
+			color: var(--color-sidebar-text);
+		}
+
+		&:hover {
+			background-color: #aaa;
+			.masterbar__item-content {
+				color: #fff;
+			}
+		}
 	}
 }
 
@@ -912,3 +928,16 @@ a.masterbar__quick-language-switcher {
 		opacity: 1;
 	}
 }
+
+// .masterbar-logged-out__item-signup {
+// 	background-color: #fff;
+// 	border-radius: 2px;
+
+// 	.masterbar__item-content {
+// 		font-weight: 600;
+// 		color: var(--color-sidebar-text);
+// 		&:hover {
+// 			color: #fff;
+// 		}
+// 	}
+// }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -44,6 +44,7 @@ $masterbar-color-secondary: #101517;
 
 	&.masterbar__loggedout {
 		padding-top: 10px;
+		padding-bottom: 40px;
 
 		.masterbar__item:hover {
 			background: transparent;
@@ -51,6 +52,14 @@ $masterbar-color-secondary: #101517;
 		}
 		.masterbar__item:last-child {
 			margin-left: 6px;
+			margin-right: 12px;
+			background-color: #fff;
+			border-radius: 2px;
+
+			.masterbar__item-content {
+				font-weight: 600;
+				color: var(--color-sidebar-text);
+			}
 		}
 		.masterbar__item:last-child:hover {
 			background: #fff;
@@ -609,22 +618,7 @@ $masterbar-color-secondary: #101517;
 	}
 
 	.masterbar__item:last-child {
-		margin-right: 12px;
-		background-color: #fff;
-		border-radius: 2px;
-
-
-		.masterbar__item-content {
-			font-weight: 600;
-			color: var(--color-sidebar-text);
-		}
-
-		&:hover {
-			background-color: #aaa;
-			.masterbar__item-content {
-				color: #fff;
-			}
-		}
+		margin-right: 20px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Updates logged out masterbar styles per suggestions on pe7F0s-Zq-p2 

Im uncertain about the locale handling added here currently, it doesn't seem like logged out reader pages work with non-en locales so maybe we want to hide these for the non-default locale for the time being?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?