### PR TITLE
Launchpad: Wider layout for cards on the right

### DIFF
--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -108,7 +108,7 @@ body.is-section-home.theme-default.color-scheme {
 		@include grid-column( 1, 12 );
 		@include display-grid;
 		@include grid-template-columns( 12, 24px, 1fr );
-		grid-gap: 24px;
+		grid-gap: 32px;
 	}
 }
 
@@ -121,6 +121,29 @@ body.is-section-home.theme-default.color-scheme {
 .customer-home__layout-col-right {
 	@include breakpoint-deprecated( ">1040px" ) {
 		@include grid-column( 9, 4 );
+
+		> .card,
+		> .card.quick-links,
+		> .card.go-mobile {
+			padding: 16px 0;
+
+			.foldable-card__header {
+				padding: 16px 0 14px;
+
+				.foldable-card__action {
+					width: auto;
+					margin-right: 0;
+				}
+			}
+
+			.foldable-card__content {
+				padding-right: 0;
+				.quick-links__action-box {
+					padding-left: 0;
+					padding-right: 0;
+				}
+			}
+		}
 	}
 
 	& > .card,
@@ -131,29 +154,6 @@ body.is-section-home.theme-default.color-scheme {
 
 		@include breakpoint-deprecated( ">660px" ) {
 			margin-bottom: 16px;
-		}
-	}
-
-	> .card,
-	> .card.quick-links,
-	> .card.go-mobile {
-		padding: 16px 0;
-
-		.foldable-card__header {
-			padding: 16px 0 14px;
-
-			.foldable-card__action {
-				width: auto;
-				margin-right: 0;
-			}
-		}
-
-		.foldable-card__content {
-			padding-right: 0;
-			.quick-links__action-box {
-				padding-left: 0;
-				padding-right: 0;
-			}
 		}
 	}
 }

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -121,7 +121,9 @@ body.is-section-home.theme-default.color-scheme {
 .customer-home__layout-col-right {
 	@include breakpoint-deprecated( ">1040px" ) {
 		@include grid-column( 9, 4 );
+	}
 
+	@include break-small {
 		> .card,
 		> .card.quick-links,
 		> .card.go-mobile {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -123,7 +123,7 @@ body.is-section-home.theme-default.color-scheme {
 		@include grid-column( 9, 4 );
 	}
 
-	@include break-small {
+	@include break-mobile {
 		> .card,
 		> .card.quick-links,
 		> .card.go-mobile {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -133,6 +133,29 @@ body.is-section-home.theme-default.color-scheme {
 			margin-bottom: 16px;
 		}
 	}
+
+	> .card,
+	> .card.quick-links,
+	> .card.go-mobile {
+		padding: 16px 0;
+
+		.foldable-card__header {
+			padding: 16px 0 14px;
+
+			.foldable-card__action {
+				width: auto;
+				margin-right: 0;
+			}
+		}
+
+		.foldable-card__content {
+			padding-right: 0;
+			.quick-links__action-box {
+				padding-left: 0;
+				padding-right: 0;
+			}
+		}
+	}
 }
 
 .customer-home__loading-placeholder {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
When we included the site preview it was noticed that the width of the quick-links and go-mobile cards on the right of the home layout looked strange.
This work is a spinoff this comment: https://github.com/Automattic/wp-calypso/pull/79024#issuecomment-1630328667

More context paYKcK-3dT-p2 

## Proposed Changes

* Increase the main grid gap to 32px
* Remove the padding around the quick links card and the go-mobile card
* All this on Desktop, no changes to mobile.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff or use the Calypso live link below
* Go to /home
* Verify that the width of the column that separates the left from the right column is 32px (see [this comment](https://github.com/Automattic/wp-calypso/pull/79444#issuecomment-1638441703) for visual aid).
* Make sure to test this in at least two contexts, when launchpad is/isn't showing.
* This width is only added on desktop view, in mobile there should be no changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?