### PR TITLE
Google Ads: Fire conversion event if domain transfer is purchased

### DIFF
--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -58,6 +58,7 @@ export const TRACKING_IDS = {
 	wpcomGoogleAdsGtagSignup: 'AW-946162814/5-NnCKy3xZQBEP6YlcMD', // "All Calypso Signups (WordPress.com)"
 	wpcomGoogleAdsGtagAddToCart: 'AW-946162814/MF4yCNi_kZYBEP6YlcMD', // "WordPress.com AddToCart"
 	wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
+	wpcomGoogleAdsGtagDomainTransferPurchase: 'AW-946162814/8T2PCL3d7rsYEP6YlcMD',
 	wpcomGoogleGA4Gtag: 'G-1H4VG5F5JF',
 	jetpackGoogleAnalyticsGtag: 'UA-52447-43', // Jetpack Gtag (Analytics) for use in Jetpack x WordPress.com Flows
 	jetpackGoogleGA4Gtag: 'G-K8CRH0LL00',

--- a/client/lib/analytics/record-purchase.js
+++ b/client/lib/analytics/record-purchase.js
@@ -21,7 +21,7 @@ export function recordPurchase( { cart, orderId, sitePlanSlug } ) {
 		recordOrder( cart, orderId, sitePlanSlug );
 	}
 
-	if ( hasTransferProduct && mayWeTrackByTracker( 'googleAds' ) ) {
+	if ( hasTransferProduct( cart ) && mayWeTrackByTracker( 'googleAds' ) ) {
 		const params = [
 			'event',
 			'conversion',

--- a/client/lib/analytics/record-purchase.js
+++ b/client/lib/analytics/record-purchase.js
@@ -27,9 +27,10 @@ export function recordPurchase( { cart, orderId, sitePlanSlug } ) {
 			'conversion',
 			{
 				send_to: TRACKING_IDS.wpcomGoogleAdsGtagDomainTransferPurchase,
+				transaction_id: orderId,
 			},
 		];
-		debug( 'adTrackSignupStart: [Google Ads Gtag]', params );
+		debug( 'recordOrderInGoogleAds: WPCom Domain Transfer Purchase', params );
 		window.gtag( ...params );
 	}
 }

--- a/client/lib/analytics/record-purchase.js
+++ b/client/lib/analytics/record-purchase.js
@@ -1,6 +1,9 @@
 import { recordOrder } from 'calypso/lib/analytics/ad-tracking';
 import { costToUSD } from 'calypso/lib/analytics/utils';
+import { hasTransferProduct } from '../cart-values/cart-items';
+import { debug, TRACKING_IDS } from './ad-tracking/constants';
 import { gaRecordEvent } from './ga';
+import { mayWeTrackByTracker } from './tracker-buckets';
 
 export function recordPurchase( { cart, orderId, sitePlanSlug } ) {
 	if ( cart.total_cost >= 0.01 ) {
@@ -16,5 +19,17 @@ export function recordPurchase( { cart, orderId, sitePlanSlug } ) {
 
 		// Marketing
 		recordOrder( cart, orderId, sitePlanSlug );
+	}
+
+	if ( hasTransferProduct && mayWeTrackByTracker( 'googleAds' ) ) {
+		const params = [
+			'event',
+			'conversion',
+			{
+				send_to: TRACKING_IDS.wpcomGoogleAdsGtagDomainTransferPurchase,
+			},
+		];
+		debug( 'adTrackSignupStart: [Google Ads Gtag]', params );
+		window.gtag( ...params );
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1942

## Proposed Changes

* Fires off google ads signup conversion event if domain transfer is purchased

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Enable the `ad-tracking` and `cookie-banner` flag in development.json
* `yarn && yarn start`
* Ensure that correct Privacy settings are disabled
  * Make sure that browser `doNotTrack` setting is disabled. For example, in chrome, [follow these instructions to disable](https://support.google.com/chrome/answer/2790761?hl=en&co=GENIE.Platform%3DDesktop).
  * Enable the "Share information with our analytics tool about your use of services while logged in to your WordPress.com account" toggle in `/me` under the `Privacy` tab
  * From what I can tell, that should be enough to address all potential privacy blocks, but I might have missed something. There may be other settings that need to be disabled in your environment. The logic is outlined in [this file](https://github.com/Automattic/wp-calypso/blob/7b73d26cb9e233370224799b1e40cf359142f6c1/client/lib/analytics/tracker-buckets.ts#L131-L132) under the `mayWeTrackByTracker` method
* Navigate to http://calypso.localhost:3000/setup/domain-transfer/domains
  * Enter domain to transfer
  * Enter auth code
  * Click on transfer button
* Click on Pay $0 now
* Verify that the google ads conversion event was fired by checking the google ads platform
* Feel free to transfer the domain and cancel the transfer with your original domain registrar afterwards ( p1689366128054469-slack-C05CT832K2T ) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?