### PR TITLE
VideoPress TV: Purchase flow.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
@@ -1,5 +1,10 @@
 import { Onboard } from '@automattic/data-stores';
-import { isWooExpressFlow, VIDEOPRESS_FLOW, VIDEOPRESS_TV_FLOW } from '@automattic/onboarding';
+import {
+	isWooExpressFlow,
+	VIDEOPRESS_FLOW,
+	VIDEOPRESS_TV_FLOW,
+	VIDEOPRESS_TV_PURCHASE_FLOW,
+} from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import WooPurpleHeart from 'calypso/assets/images/onboarding/woo-purple-heart.png';
@@ -142,7 +147,7 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 			{ title: __( "Let's head to the checkout" ), duration: 5000 },
 		];
 		return videoPressLoadingMessages;
-	} else if ( VIDEOPRESS_TV_FLOW === flow ) {
+	} else if ( VIDEOPRESS_TV_FLOW === flow || VIDEOPRESS_TV_PURCHASE_FLOW === flow ) {
 		const videoPressLoadingMessages = [
 			{ title: __( 'Starting up your channel' ), duration: 5000 },
 		];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
@@ -147,9 +147,16 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 			{ title: __( "Let's head to the checkout" ), duration: 5000 },
 		];
 		return videoPressLoadingMessages;
-	} else if ( VIDEOPRESS_TV_FLOW === flow || VIDEOPRESS_TV_PURCHASE_FLOW === flow ) {
+	} else if ( VIDEOPRESS_TV_FLOW === flow ) {
 		const videoPressLoadingMessages = [
 			{ title: __( 'Starting up your channel' ), duration: 5000 },
+		];
+		return videoPressLoadingMessages;
+	} else if ( VIDEOPRESS_TV_PURCHASE_FLOW === flow ) {
+		const videoPressLoadingMessages = [
+			{ title: __( 'Scouting the locations' ), duration: 5000 },
+			{ title: __( 'Kicking off the casting' ), duration: 5000 },
+			{ title: __( "Let's head to the checkout" ), duration: 5000 },
 		];
 		return videoPressLoadingMessages;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -75,7 +75,8 @@
 }
 
 .is-videopress-stepper.is-processing-step,
-.is-videopress-tv-stepper {
+.is-videopress-tv-stepper,
+.is-videopress-tv-purchase-stepper {
 	padding: 0;
 	color: #fff;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-redirect/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-redirect/index.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+import { StepContainer } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
+import React from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
+
+import './styles.scss';
+
+const VideoPressTvRedirect: Step = function VideoPressTvRedirect( { data } ) {
+	const { __ } = useI18n();
+
+	const stepContent = (
+		<div className="videopress-tv-trial-exists__step-content intro__button-row">
+			<button
+				className="button intro__button is-primary"
+				onClick={ () => ( window.location.href = String( data?.url ) ) }
+			>
+				Visit your site
+			</button>
+		</div>
+	);
+
+	return (
+		<StepContainer
+			stepName="trial-exists"
+			isWideLayout={ true }
+			hideBack={ true }
+			flowName="videopress-tv"
+			formattedHeader={
+				<FormattedHeader
+					id="videopress-tv-trial-exists-header"
+					headerText={ __( 'Redirecting To you VideoPress TV site' ) }
+					align="center"
+				/>
+			}
+			stepContent={ stepContent }
+			recordTracksEvent={ recordTracksEvent }
+			showVideoPressPowered
+		/>
+	);
+};
+
+export default VideoPressTvRedirect;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-redirect/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-redirect/index.tsx
@@ -13,7 +13,7 @@ const VideoPressTvRedirect: Step = function VideoPressTvRedirect( { data } ) {
 	const { __ } = useI18n();
 
 	const stepContent = (
-		<div className="videopress-tv-trial-exists__step-content intro__button-row">
+		<div className="videopress-tv-purchase-redirect__step-content intro__button-row">
 			<button
 				className="button intro__button is-primary"
 				onClick={ () => ( window.location.href = String( data?.url ) ) }
@@ -25,14 +25,14 @@ const VideoPressTvRedirect: Step = function VideoPressTvRedirect( { data } ) {
 
 	return (
 		<StepContainer
-			stepName="trial-exists"
+			stepName="redirect"
 			isWideLayout={ true }
 			hideBack={ true }
-			flowName="videopress-tv"
+			flowName="videopress-tv-purchase"
 			formattedHeader={
 				<FormattedHeader
-					id="videopress-tv-trial-exists-header"
-					headerText={ __( 'Redirecting To you VideoPress TV site' ) }
+					id="videopress-tv-purchase-redirect-header"
+					headerText={ __( 'Redirecting To you VideoPress TV video site' ) }
 					align="center"
 				/>
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-redirect/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-redirect/styles.scss
@@ -1,0 +1,26 @@
+@import "@automattic/onboarding/styles/mixins";
+@import "../../videopress.scss";
+
+body.is-videopress-tv-stepper .videopress-tv.trial-exists {
+	justify-content: space-around;
+
+	.step-container__content {
+		flex-grow: 0;
+		min-height: revert;
+	}
+}
+
+.videopress-tv-trial-exists__step-content {
+	display: flex;
+	justify-content: center;
+
+	.button {
+		background: #ffe61c;
+		color: #000;
+		transition: box-shadow 0.4s ease-in-out;
+
+		&:hover {
+			box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1) inset, 0 2px 24px rgba(255, 230, 28, 0.3), 0 0 8px rgba(255, 230, 28, 0.18), 0 0 4px rgba(255, 230, 28, 0.15), 0 0 2.5px rgba(255, 230, 28, 0.12), 0 0 4px rgba(255, 230, 28, 0.1), 0 0 2px rgba(0, 0, 0, 0.8);
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-redirect/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-redirect/styles.scss
@@ -1,7 +1,8 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "../../videopress.scss";
 
-body.is-videopress-tv-stepper .videopress-tv.trial-exists {
+body.is-videopress-tv-stepper .videopress-tv.redirect,
+body.is-videopress-tv-purchase-stepper.videopress-tv-purchase.redirect {
 	justify-content: space-around;
 
 	.step-container__content {
@@ -10,7 +11,7 @@ body.is-videopress-tv-stepper .videopress-tv.trial-exists {
 	}
 }
 
-.videopress-tv-trial-exists__step-content {
+.videopress-tv-purchase-redirect__step-content {
 	display: flex;
 	justify-content: center;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-trial-exists/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-tv-trial-exists/index.tsx
@@ -16,7 +16,7 @@ const VideoPressTvTrialExists: Step = function VideoPressTvTrialExists( { data }
 		<div className="videopress-tv-trial-exists__step-content intro__button-row">
 			<button
 				className="button intro__button is-primary"
-				onClick={ () => ( window.location.href = data?.url ) }
+				onClick={ () => ( window.location.href = String( data?.url ) ) }
 			>
 				Visit your site
 			</button>

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -3,7 +3,8 @@
 
 
 body.is-videopress-stepper,
-body.is-videopress-tv-stepper {
+body.is-videopress-tv-stepper,
+body.is-videopress-tv-purchase-stepper {
 	background-color: #010101;
 	color: $videopress-theme-base-text-color;
 
@@ -12,7 +13,8 @@ body.is-videopress-tv-stepper {
 	}
 
 	.videopress,
-	.videopress-tv {
+	.videopress-tv,
+	.videopress-tv-purchase {
 		input[type="text"]:focus,
 		textarea:focus {
 			box-shadow: none;

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -9,6 +9,7 @@ import {
 	DOMAIN_TRANSFER,
 	ONBOARDING_PM_FLOW,
 	VIDEOPRESS_TV_FLOW,
+	VIDEOPRESS_TV_PURCHASE_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -33,6 +34,11 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	[ VIDEOPRESS_TV_FLOW ]: () =>
 		import( /* webpackChunkName: "videopress-tv-flow" */ `../declarative-flow/videopress-tv` ),
+
+	[ VIDEOPRESS_TV_PURCHASE_FLOW ]: () =>
+		import(
+			/* webpackChunkName: "videopress-tv-flow" */ `../declarative-flow/videopress-tv-purchase`
+		),
 
 	'link-in-bio': () =>
 		import( /* webpackChunkName: "link-in-bio-flow" */ '../declarative-flow/link-in-bio' ),

--- a/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
@@ -1,0 +1,92 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { VIDEOPRESS_TV_PURCHASE_FLOW } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
+import { USER_STORE, ONBOARD_STORE } from '../stores';
+import './internals/videopress.scss';
+import ProcessingStep from './internals/steps-repository/processing-step';
+import type { Flow, ProvidedDependencies } from './internals/types';
+import type { UserSelect } from '@automattic/data-stores';
+
+const videopressTvPurchase: Flow = {
+	name: VIDEOPRESS_TV_PURCHASE_FLOW,
+	get title() {
+		return translate( 'VideoPress TV' );
+	},
+	useSteps() {
+		return [ { slug: 'processing', component: ProcessingStep } ];
+	},
+
+	useStepNavigation( _currentStep, navigate ) {
+		if ( document.body ) {
+			// Make sure we only target videopress tv stepper for body css
+			if ( ! document.body.classList.contains( 'is-videopress-tv-stepper' ) ) {
+				document.body.classList.add( 'is-videopress-tv-stepper' );
+			}
+		}
+
+		const name = this.name;
+		const locale = useLocale();
+		const { setPendingAction, setProgress } = useDispatch( ONBOARD_STORE );
+		const { supportedPlans } = useSupportedPlans( locale, 'MONTHLY' );
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+
+		const addVideoPressPendingAction = () => {
+			// if the supported plans haven't been received yet, wait for next rerender to try again.
+			if ( 0 === supportedPlans.length ) {
+				return;
+			}
+
+			setPendingAction( async () => {
+				setProgress( 0 );
+				setProgress( 0.5 );
+				setProgress( 0.75 );
+			} );
+		};
+
+		// needs to be wrapped in a useEffect because validation can call `navigate` which needs to be called in a useEffect
+		useEffect( () => {
+			switch ( _currentStep ) {
+				case 'processing':
+					if ( ! userIsLoggedIn ) {
+						window.location.replace(
+							`/start/videopress-account/user/${ locale }?variationName=${ name }&flow=${ name }&pageTitle=VideoPress.TV&redirect_to=/setup/videopress-tv-purchase/processing`
+						);
+						return;
+					}
+					addVideoPressPendingAction();
+					break;
+				default:
+					break;
+			}
+		} );
+
+		async function submit( providedDependencies: ProvidedDependencies = {} ) {
+			return providedDependencies;
+		}
+
+		const goBack = () => {
+			return;
+		};
+
+		const goNext = () => {
+			switch ( _currentStep ) {
+				default:
+					return navigate( 'processing' );
+			}
+		};
+
+		const goToStep = ( step: string ) => {
+			return navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};
+
+export default videopressTvPurchase;

--- a/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
@@ -2,13 +2,16 @@ import { useLocale } from '@automattic/i18n-utils';
 import { VIDEOPRESS_TV_PURCHASE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
-import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { PLANS_STORE, SITE_STORE, USER_STORE, ONBOARD_STORE } from '../stores';
 import './internals/videopress.scss';
 import ProcessingStep from './internals/steps-repository/processing-step';
 import type { Flow, ProvidedDependencies } from './internals/types';
-import type { UserSelect } from '@automattic/data-stores';
+import type { UserSelect, SiteSelect, PlansSelect } from '@automattic/data-stores';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const videopressTvPurchase: Flow = {
 	name: VIDEOPRESS_TV_PURCHASE_FLOW,
@@ -22,19 +25,34 @@ const videopressTvPurchase: Flow = {
 	useStepNavigation( _currentStep, navigate ) {
 		if ( document.body ) {
 			// Make sure we only target videopress tv stepper for body css
-			if ( ! document.body.classList.contains( 'is-videopress-tv-stepper' ) ) {
-				document.body.classList.add( 'is-videopress-tv-stepper' );
+			if ( ! document.body.classList.contains( 'is-videopress-tv-purchase-stepper' ) ) {
+				document.body.classList.add( 'is-videopress-tv-purchase-stepper' );
 			}
 		}
 
 		const name = this.name;
 		const locale = useLocale();
-		const { setPendingAction, setProgress } = useDispatch( ONBOARD_STORE );
+		const { setPendingAction, setProgress, setSelectedSite } = useDispatch( ONBOARD_STORE );
 		const { supportedPlans } = useSupportedPlans( locale, 'MONTHLY' );
+		const _siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
+		const userData = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+			[]
+		);
+		const siteData = useSelect(
+			( select ) => ( select( SITE_STORE ) as SiteSelect ).getSite( _siteSlug ),
+			[]
+		);
+		const getPlanProduct = useSelect(
+			( select ) => ( select( PLANS_STORE ) as PlansSelect ).getPlanProduct,
+			[]
+		);
+
+		const [ isVideoPressTvPurchasePending, setIsVideoPressTvPurchasePending ] = useState( false );
 
 		const addVideoPressPendingAction = () => {
 			// if the supported plans haven't been received yet, wait for next rerender to try again.
@@ -42,10 +60,73 @@ const videopressTvPurchase: Flow = {
 				return;
 			}
 
+			// If the site is already on a plan, we don't need to add a pending action. Maybe redirect to site?
+			const siteFreePlan = siteData?.plan?.is_free;
+			if ( ! siteFreePlan ) {
+				return;
+			}
+
+			// If the user is not logged in, we don't need to add a pending action.
+			if ( ! userIsLoggedIn ) {
+				return;
+			}
+
+			// If the user is logged in, and the site does not belong to them, we don't need to add a pending action.
+			if ( userData?.ID !== siteData?.site_owner ) {
+				return;
+			}
+
+			// only allow one call to this action to occur
+			if ( isVideoPressTvPurchasePending ) {
+				return;
+			}
+
+			setIsVideoPressTvPurchasePending( true );
+
+			setSelectedSite( siteData?.ID );
+			// If the user is logged in, and the site belongs to them, and they are not on a plan, we need to add a pending action.
 			setPendingAction( async () => {
 				setProgress( 0 );
+
+				// select the premium plan for now. This will be replaced with our video plan.
+				let planObject = supportedPlans.find( ( plan ) => 'premium' === plan.periodAgnosticSlug );
+				if ( ! planObject ) {
+					planObject = supportedPlans.find( ( plan ) => 'business' === plan.periodAgnosticSlug );
+				}
+
+				const cartKey = _siteSlug
+					? await cartManagerClient.getCartKeyForSiteSlug( _siteSlug )
+					: null;
+				if ( ! cartKey ) {
+					return;
+				}
 				setProgress( 0.5 );
+
+				const planProductObject = getPlanProduct( planObject?.periodAgnosticSlug, 'MONTHLY' );
+				const productsToAdd: MinimalRequestCartProduct[] = planProductObject
+					? [
+							{
+								product_slug: planProductObject.storeSlug,
+								extra: {
+									signup_flow: VIDEOPRESS_TV_PURCHASE_FLOW,
+								},
+							},
+					  ]
+					: [];
+
+				// Add plan to cart.
 				setProgress( 0.75 );
+				cartManagerClient
+					.forCartKey( cartKey )
+					.actions.addProductsToCart( productsToAdd )
+					.then( () => {
+						setProgress( 1.0 );
+						const redirectTo = encodeURIComponent( `${ _siteSlug }&message=purchase-complete` );
+
+						window.location.replace(
+							`/checkout/${ _siteSlug }?signup=1&redirect_to=${ redirectTo }`
+						);
+					} );
 			} );
 		};
 

--- a/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
@@ -135,8 +135,11 @@ const videopressTvPurchase: Flow = {
 			switch ( _currentStep ) {
 				case 'processing':
 					if ( ! userIsLoggedIn ) {
+						const redirectTo = encodeURIComponent(
+							`/setup/videopress-tv-purchase?siteSlug=${ _siteSlug }`
+						);
 						window.location.replace(
-							`/start/videopress-account/user/${ locale }?variationName=${ name }&flow=${ name }&pageTitle=VideoPress.TV&redirect_to=/setup/videopress-tv-purchase/processing`
+							`/start/videopress-account/user/${ locale }?variationName=${ name }&flow=${ name }&pageTitle=VideoPress.TV&redirect_to=${ redirectTo }`
 						);
 						return;
 					}

--- a/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
@@ -43,10 +43,11 @@ const videopressTvPurchase: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
 			[]
 		);
-		const siteData = useSelect(
-			( select ) => ( select( SITE_STORE ) as SiteSelect ).getSite( _siteSlug ),
-			[]
-		);
+		const siteData =
+			useSelect(
+				( select ) => ( select( SITE_STORE ) as SiteSelect ).getSite( _siteSlug || '' ),
+				[]
+			) || {};
 		const getPlanProduct = useSelect(
 			( select ) => ( select( PLANS_STORE ) as PlansSelect ).getPlanProduct,
 			[]

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -73,7 +73,7 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		processing: 1,
 	},
 	[ VIDEOPRESS_TV_PURCHASE_FLOW ]: {
-		processing: 1,
+		processing: 0,
 	},
 	sensei: {
 		senseiSetup: 1,

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -8,6 +8,7 @@ import {
 	ONBOARDING_PM_FLOW,
 	DOMAIN_TRANSFER,
 	VIDEOPRESS_TV_FLOW,
+	VIDEOPRESS_TV_PURCHASE_FLOW,
 } from '../utils/flows';
 
 /* eslint-disable no-restricted-imports */
@@ -69,6 +70,9 @@ const flows: Record< string, { [ step: string ]: number } > = {
 	},
 	[ VIDEOPRESS_TV_FLOW ]: {
 		intro: 0,
+		processing: 1,
+	},
+	[ VIDEOPRESS_TV_PURCHASE_FLOW ]: {
 		processing: 1,
 	},
 	sensei: {

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -70,6 +70,8 @@ export const isTailoredSignupFlow = ( flowName: string | null ) => {
 		flowName &&
 			( isNewsletterOrLinkInBioFlow( flowName ) ||
 				VIDEOPRESS_FLOW === flowName ||
+				VIDEOPRESS_TV_FLOW === flowName ||
+				VIDEOPRESS_TV_PURCHASE_FLOW === flowName ||
 				ECOMMERCE_FLOW === flowName ||
 				FREE_FLOW === flowName )
 	);


### PR DESCRIPTION
Fixes https://github.com/Automattic/greenhouse/issues/1787

## Proposed Changes

* Creates The VideoPress TV Purchase flow.
* Adds the logic that redirects to the checkout step

## Testing Instructions


* Navigate to `/setup/videopress-tv-purchase?siteSlug=SITE_SLUG` logged in and not logged in.
* If not logged in, you are redirected to login/signup
* Otherwise, you see the processing step.
* You are redirected to checkout with either a premium or a business plan.
* Purchase.
* You are redirected back to your site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
