### PR TITLE
Checkout: Add masterbar chat functionality on mobile web views

### DIFF
--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -18,8 +18,6 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import Item from './item';
 import Masterbar from './masterbar';
-import type { HelpCenterSelect } from '@automattic/data-stores';
-const HELP_CENTER_STORE = HelpCenter.register();
 
 interface Props {
 	title: string;
@@ -128,20 +126,9 @@ const CheckoutMasterbar = ( {
 			</div>
 			{ title && <Item className="masterbar__item-title">{ title }</Item> }
 
-			{ loadHelpCenterIcon && <DefaultMasterbarContact /> }
-
 			<div className="masterbar__item-help-icons">
-				{ loadHelpCenterIcon && (
-					<Item
-						onClick={ () => setShowHelpCenter( ! isShowingHelpCenter ) }
-						className={ classnames( 'masterbar__item-help', {
-							'is-active': isShowingHelpCenter,
-						} ) }
-						icon={ <HelpIcon /> }
-					>
-						{ translate( 'Help' ) }
-					</Item>
-				) }
+				{ loadHelpCenterIcon && <DefaultMasterbarContact /> }
+
 				<ChatButton
 					chatIntent="PRESALES"
 					initialMessage={ initialMessage }

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -85,6 +85,14 @@ const CheckoutMasterbar = ( {
 
 	const showCloseButton = isLeavingAllowed && checkoutType === 'wpcom';
 	const icon = 'chat_bubble';
+	const initialMessage =
+		'Customer is contacting us from the checkout pre-sales flow.\n' +
+		`Product${ responseCart.products.length > 1 && 's' } they're attempting to purchase: ` +
+		responseCart.products.map( ( product ) => product.product_name ).join( ', ' );
+
+	const handleClick = () => {
+		// Add tracks details here
+	};
 
 	return (
 		<Masterbar
@@ -130,9 +138,10 @@ const CheckoutMasterbar = ( {
 				) }
 				<ChatButton
 					chatIntent="PRESALES"
-					initialMessage="Test"
-					siteUrl="test"
-					className={ classnames( 'masterbar__item masterbar__item-help' ) }
+					initialMessage={ initialMessage }
+					siteUrl={ siteSlug }
+					className={ classnames( 'masterbar__item' ) }
+					onClick={ handleClick }
 				>
 					{ icon && <MaterialIcon icon={ icon } /> }
 				</ChatButton>

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -95,7 +95,7 @@ const CheckoutMasterbar = ( {
 	const handleClick = () => {
 		reduxDispatch(
 			recordTracksEvent( 'calypso_checkout_masterbar_support_click', {
-				cart: responseCart.products.map( ( product ) => product.product_name ).join( ', ' ),
+				cart: JSON.stringify( responseCart ),
 			} )
 		);
 	};

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -9,11 +9,13 @@ import AkismetLogo from 'calypso/components/akismet-logo';
 import ChatButton from 'calypso/components/chat-button';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import MaterialIcon from 'calypso/components/material-icon';
+import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { DefaultMasterbarContact } from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
 import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/leave-checkout';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import Item from './item';
 import Masterbar from './masterbar';
 import type { HelpCenterSelect } from '@automattic/data-stores';
@@ -91,7 +93,11 @@ const CheckoutMasterbar = ( {
 		responseCart.products.map( ( product ) => product.product_name ).join( ', ' );
 
 	const handleClick = () => {
-		// Add tracks details here
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_masterbar_support_click', {
+				cart: responseCart.products.map( ( product ) => product.product_name ).join( ', ' ),
+			} )
+		);
 	};
 
 	return (

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -6,7 +6,9 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import AkismetLogo from 'calypso/components/akismet-logo';
+import ChatButton from 'calypso/components/chat-button';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import MaterialIcon from 'calypso/components/material-icon';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { DefaultMasterbarContact } from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
@@ -14,6 +16,8 @@ import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import Item from './item';
 import Masterbar from './masterbar';
+import type { HelpCenterSelect } from '@automattic/data-stores';
+const HELP_CENTER_STORE = HelpCenter.register();
 
 interface Props {
 	title: string;
@@ -80,6 +84,7 @@ const CheckoutMasterbar = ( {
 	};
 
 	const showCloseButton = isLeavingAllowed && checkoutType === 'wpcom';
+	const icon = 'chat_bubble';
 
 	return (
 		<Masterbar
@@ -108,7 +113,31 @@ const CheckoutMasterbar = ( {
 				<span className="masterbar__secure-checkout-text">{ translate( 'Secure checkout' ) }</span>
 			</div>
 			{ title && <Item className="masterbar__item-title">{ title }</Item> }
+
 			{ loadHelpCenterIcon && <DefaultMasterbarContact /> }
+
+			<div className="masterbar__item-help-icons">
+				{ loadHelpCenterIcon && (
+					<Item
+						onClick={ () => setShowHelpCenter( ! isShowingHelpCenter ) }
+						className={ classnames( 'masterbar__item-help', {
+							'is-active': isShowingHelpCenter,
+						} ) }
+						icon={ <HelpIcon /> }
+					>
+						{ translate( 'Help' ) }
+					</Item>
+				) }
+				<ChatButton
+					chatIntent="PRESALES"
+					initialMessage="Test"
+					siteUrl="test"
+					className={ classnames( 'masterbar__item masterbar__item-help' ) }
+				>
+					{ icon && <MaterialIcon icon={ icon } /> }
+				</ChatButton>
+			</div>
+
 			<CheckoutModal
 				title={ modalTitleText }
 				copy={ modalBodyText }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -881,7 +881,6 @@ a.masterbar__quick-language-switcher {
 
 	@include breakpoint-deprecated( "<480px" ) {
 		flex: 1;
-		margin-left: 0;
 	}
 	.masterbar__wpcom-wordmark {
 		color: var(--color-checkout-masterbar-text);
@@ -936,6 +935,10 @@ a.masterbar__quick-language-switcher {
 .masterbar__item-help-icons {
 	display: flex;
 
+	div {
+		order: 1;
+	}
+
 	@include breakpoint-deprecated( "<480px") {
 		flex: 1;
 		justify-content: flex-end;
@@ -946,7 +949,7 @@ a.masterbar__quick-language-switcher {
 
 		@include breakpoint-deprecated( "<480px") {
 			display: flex;
-			order: 1;
+			order: 0;
 		}
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -877,8 +877,10 @@ a.masterbar__quick-language-switcher {
 .masterbar__secure-checkout {
 	display: flex;
 	align-items: center;
-	// margin-left: 24px;
 
+	@include breakpoint-deprecated( "<480px" ) {
+		flex: 1;
+	}
 	.masterbar__wpcom-wordmark {
 		color: var(--color-checkout-masterbar-text);
 		fill: var(--color-checkout-masterbar-text);
@@ -932,25 +934,25 @@ a.masterbar__quick-language-switcher {
 .masterbar__item-help-icons {
 	display: flex;
 
-	.chat-button {
-		order: 1;
+	@include breakpoint-deprecated( "<480px") {
+		flex: 1;
+		justify-content: flex-end;
+	}
 
-		@include breakpoint-deprecated( ">480px") {
-			display: none;
+	.chat-button {
+		display: none;
+
+		@include breakpoint-deprecated( "<480px") {
+			display: flex;
+			order: 1;
 		}
 	}
 }
 
 .masterbar__item-help {
-	// padding: 0 11px;
 	order: 2;
-
+	column-gap: 6px;
 	.masterbar--is-checkout & {
-		padding: 0 24px;
-
-		@include breakpoint-deprecated( "<480px" ) {
-			display: none;
-		}
 
 		&.is-active {
 			background: var(--color-checkout-masterbar-item-hover-background);
@@ -960,7 +962,6 @@ a.masterbar__quick-language-switcher {
 			box-shadow: none;
 		}
 	}
-
 
 	svg {
 		fill: var(--color-masterbar-text);

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -331,7 +331,6 @@ $masterbar-color-secondary: #101517;
 
 	&.masterbar__item-help {
 		cursor: pointer;
-		flex: 0;
 	}
 
 	.is-support-session &.is-active {
@@ -911,11 +910,13 @@ a.masterbar__quick-language-switcher {
 		line-height: 1.2em;
 		font-size: 0.75rem;
 		margin-left: 5px;
+		display: none;
 
 		@include breakpoint-deprecated( ">480px" ) {
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 100%;
 			margin-left: 0;
+			display: block;
 		}
 
 		.masterbar--is-jetpack & {
@@ -928,8 +929,34 @@ a.masterbar__quick-language-switcher {
 	}
 }
 
+.masterbar__item-help-icons {
+	display: flex;
+
+	.chat-button{
+		@include breakpoint-deprecated( ">480px") {
+			display: none;
+		}
+	}
+}
+
 .masterbar__item-help {
 	padding: 0 11px;
+
+	.masterbar--is-checkout & {
+		padding: 0 24px;
+
+		@include breakpoint-deprecated( "<480px" ) {
+			display: none;
+		}
+
+		&.is-active {
+			background: var(--color-checkout-masterbar-item-hover-background);
+		}
+
+		&:focus {
+			box-shadow: none;
+		}
+	}
 
 	svg {
 		fill: var(--color-masterbar-text);

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -877,9 +877,11 @@ a.masterbar__quick-language-switcher {
 .masterbar__secure-checkout {
 	display: flex;
 	align-items: center;
+	margin-left: 24px;
 
 	@include breakpoint-deprecated( "<480px" ) {
 		flex: 1;
+		margin-left: 0;
 	}
 	.masterbar__wpcom-wordmark {
 		color: var(--color-checkout-masterbar-text);
@@ -952,6 +954,11 @@ a.masterbar__quick-language-switcher {
 .masterbar__item-help {
 	order: 2;
 	column-gap: 6px;
+	padding: 0 24px;
+
+	@include breakpoint-deprecated( "<480px") {
+		padding: 0;
+	}
 	.masterbar--is-checkout & {
 
 		&.is-active {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -877,7 +877,7 @@ a.masterbar__quick-language-switcher {
 .masterbar__secure-checkout {
 	display: flex;
 	align-items: center;
-	margin-left: 24px;
+	// margin-left: 24px;
 
 	.masterbar__wpcom-wordmark {
 		color: var(--color-checkout-masterbar-text);
@@ -932,7 +932,9 @@ a.masterbar__quick-language-switcher {
 .masterbar__item-help-icons {
 	display: flex;
 
-	.chat-button{
+	.chat-button {
+		order: 1;
+
 		@include breakpoint-deprecated( ">480px") {
 			display: none;
 		}
@@ -940,7 +942,8 @@ a.masterbar__quick-language-switcher {
 }
 
 .masterbar__item-help {
-	padding: 0 11px;
+	// padding: 0 11px;
+	order: 2;
 
 	.masterbar--is-checkout & {
 		padding: 0 24px;
@@ -958,8 +961,13 @@ a.masterbar__quick-language-switcher {
 		}
 	}
 
+
 	svg {
 		fill: var(--color-masterbar-text);
+
+		.masterbar--is-checkout & {
+			fill: var(--color-checkout-masterbar-text);
+		}
 	}
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -1,0 +1,179 @@
+import { HelpCenter } from '@automattic/data-stores';
+import { ResponseCartMessage, useShoppingCart } from '@automattic/shopping-cart';
+import { isMobile, subscribeIsMobile } from '@automattic/viewport';
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+import { useSelect, useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSectionName } from 'calypso/state/ui/selectors';
+import type { Theme } from '@automattic/composite-checkout';
+import type { HelpCenterSelect } from '@automattic/data-stores';
+import type { KeyType } from 'calypso/lib/presales-chat';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+type StyledProps = {
+	theme?: Theme;
+};
+
+const CheckoutHelpLinkWrapper = styled.div< StyledProps >`
+	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+	margin: 0;
+	padding: 20px;
+
+	&:empty {
+		display: none;
+	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		background: transparent;
+		border-top: 0 none;
+		margin: 12px 0;
+		padding: 0;
+	}
+`;
+
+const CheckoutSummaryHelpButton = styled.button`
+	margin: 0;
+	padding: 0;
+	text-align: left;
+
+	.rtl & {
+		text-align: right;
+	}
+
+	span {
+		cursor: pointer;
+		text-decoration: underline;
+		color: var( --color-link );
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
+`;
+
+const pulse = keyframes`
+	0% { opacity: 1; }
+
+	70% { opacity: 0.25; }
+
+	100% { opacity: 1; }
+`;
+
+const LoadingButton = styled.p< StyledProps >`
+	animation: ${ pulse } 1.5s ease-in-out infinite;
+	background: ${ ( props ) => props.theme.colors.borderColorLight };
+	border-radius: 2px;
+	color: ${ ( props ) => props.theme.colors.borderColorLight };
+	content: '';
+	font-size: 14px;
+	height: 18px;
+	margin: 12px 8px 0;
+	padding: 0;
+	position: relative;
+`;
+
+function getKeyTypeForPresalesChat(): KeyType {
+	if ( isAkismetCheckout() ) {
+		return 'akismet';
+	}
+
+	if ( isJetpackCheckout() ) {
+		return 'jpCheckout';
+	}
+
+	return 'wpcom';
+}
+
+export default function CheckoutHelpLink() {
+	const reduxDispatch = useDispatch();
+	const translate = useTranslate();
+	const { setShowHelpCenter, setShowMessagingLauncher } = useDataStoreDispatch( HELP_CENTER_STORE );
+
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
+
+	const cartErrors = responseCart.messages?.persistent_errors || [];
+	const purchasesAreBlocked = cartErrors.some(
+		( error: ResponseCartMessage ) => error.code === 'blocked'
+	);
+
+	const { section } = useSelector( ( state ) => {
+		return {
+			section: getSectionName( state ),
+		};
+	} );
+
+	const handleHelpButtonClicked = () => {
+		reduxDispatch( setShowHelpCenter( true ) );
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_composite_summary_help_click', {
+				location: 'help-center',
+				section,
+			} )
+		);
+	};
+
+	const {
+		isChatActive,
+		isLoading: isLoadingChat,
+		isPresalesChatAvailable,
+	} = usePresalesChat( getKeyTypeForPresalesChat(), ! purchasesAreBlocked );
+
+	const { isMessagingWidgetShown } = useSelect( ( select ) => {
+		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
+		return {
+			isMessagingWidgetShown: helpCenterSelect.isMessagingWidgetShown(),
+		};
+	}, [] );
+
+	/* When we subscribe to subscribeIsMobile, we need to force a re-render of the component each time the viewport width updates
+	 * to ensure that the correct value is used for isMobile.
+	 */
+	const [ renderCount, setRenderCount ] = useState( 0 );
+	useEffect( () => {
+		return subscribeIsMobile( () => setRenderCount( ( count ) => count + 1 ) );
+	}, [] );
+
+	useEffect( () => {
+		if ( isChatActive && ! isMobile() ) {
+			setShowMessagingLauncher( true );
+		}
+		return () => {
+			if ( ! isMessagingWidgetShown && isChatActive ) {
+				setShowMessagingLauncher( false );
+			}
+		};
+	}, [ isChatActive, setShowMessagingLauncher, isMessagingWidgetShown, renderCount ] );
+
+	const shouldShowHelpLink = ! isChatActive && ! isPresalesChatAvailable;
+	if ( ! shouldShowHelpLink ) {
+		return null;
+	}
+
+	return (
+		<CheckoutHelpLinkWrapper>
+			{ isLoadingChat && <LoadingButton /> }
+			{ ! isLoadingChat && (
+				<CheckoutSummaryHelpButton onClick={ handleHelpButtonClicked }>
+					{ translate(
+						'Questions? {{underline}}Read more about plans and purchases{{/underline}}',
+						{
+							components: {
+								underline: <span />,
+							},
+						}
+					) }
+				</CheckoutSummaryHelpButton>
+			) }
+		</CheckoutHelpLinkWrapper>
+	);
+}

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import { isMobile } from '@automattic/viewport';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createPortal, useEffect, useRef } from '@wordpress/element';
 import { useSelector } from 'react-redux';
@@ -38,6 +39,9 @@ function useMessagingBindings( hasActiveChats: boolean, isMessagingScriptLoaded:
 			setShowMessagingWidget( true );
 		} );
 		window.zE( 'messenger:on', 'close', function () {
+			if ( isMobile() ) {
+				setShowMessagingLauncher( false );
+			}
 			setShowMessagingWidget( false );
 		} );
 		window.zE( 'messenger:on', 'unreadMessages', function ( count ) {


### PR DESCRIPTION
**UPDATE**- closing in favor of this PR https://github.com/Automattic/wp-calypso/pull/80724

As noted in #79018, the current Zendesk Messaging launcher overlaps the checkout payment button. The proposed solution is to add a secondary custom Zendesk launcher icon to the checkout masterbar when the viewport is at a mobile width (<480px) and to conditionally hide the bottom right Zendesk launcher FAB (fancy action button).

![image](https://github.com/Automattic/wp-calypso/assets/16580129/5f4cf7c1-1fc7-4016-a058-f30060d3f8bd)

Related to #79018 

## Proposed Changes

Steps to complete:

- [x] Add custom launcher code to masterbar
- [x] Update CSS to properly align checkout masterbar icons
- [ ] Fix checkout masterbar position on scroll
- [ ] Ensure custom launcher sends all required data to Zendesk agent
- [ ] Ensure custom launcher also tracks clicks correctly
- [x] Conditionally hide Zendesk launcher FAB when viewport is under 480px

## Testing Instructions

- Open up this PR locally or use the Calypso live link below
- Add a product to your cart and proceed to checkout
- While in checkout with a desktop viewport you should see the chat fancy button in the bottom right corner (Note: you ma need to refresh the page a few times as the launcher only appears if chat is available)
- Shrink the window to a mobile size, under 480px should work
- In a mobile viewport the bottom right chat launcher should be hidden and a new chat icon should appear in the checkout masterbar
- Click on the new chat icon, it should load the chat messaging widget
- Close the widget, ensure that the bottom right fancy chat button doesn't reappear in mobile view
- Load the help center by clicking on the ? symbol, loading the help center should minimize the chat, and vice versa
- Look for any functional or visual inconsistencies or degraded UX

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
