### PR TITLE
BackupBrowser: Add action to download backup's WordPress version

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -52,6 +52,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 			setFetchContentsOnMount( true );
 		}
 
+		// If the node doesn't have children, let's open the file info card
 		if ( ! item.hasChildren ) {
 			if ( ! isOpen ) {
 				setActiveNodePath( path );

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -52,7 +52,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 			setFetchContentsOnMount( true );
 		}
 
-		if ( ! item.hasChildren && item.type !== 'wordpress' ) {
+		if ( ! item.hasChildren ) {
 			if ( ! isOpen ) {
 				setActiveNodePath( path );
 			} else {
@@ -119,7 +119,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 	} );
 	const [ label, isLabelTruncated ] = useTruncatedFileName( item.name, 30, item.type );
 
-	const nodeClassName = classNames( 'file-browser-node', {
+	const nodeClassName = classNames( 'file-browser-node', item.type, {
 		'is-root': isRoot,
 	} );
 

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -50,7 +50,14 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 	const downloadFile = useCallback( () => {
 		setIsProcessingDownload( true );
 
-		if ( item.type !== 'archive' ) {
+		if ( item.type === 'wordpress' ) {
+			if ( fileInfo === undefined || ! fileInfo.downloadUrl ) {
+				return;
+			}
+
+			window.open( fileInfo.downloadUrl, '_blank' );
+			setIsProcessingDownload( false );
+		} else if ( item.type !== 'archive' ) {
 			const manifestPath = window.btoa( item.manifestPath ?? '' );
 			wp.req
 				.get( {

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -47,17 +47,24 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 	const size = fileInfo?.size !== undefined ? convertBytes( fileInfo.size ) : null;
 
 	const [ isProcessingDownload, setIsProcessingDownload ] = useState< boolean >( false );
+
+	const trackDownloadByType = useCallback(
+		( type: string ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_backup_browser_download', {
+					file_type: type,
+				} )
+			);
+
+			return;
+		},
+		[ dispatch ]
+	);
+
 	const downloadFile = useCallback( () => {
 		setIsProcessingDownload( true );
 
-		if ( item.type === 'wordpress' ) {
-			if ( fileInfo === undefined || ! fileInfo.downloadUrl ) {
-				return;
-			}
-
-			window.open( fileInfo.downloadUrl, '_blank' );
-			setIsProcessingDownload( false );
-		} else if ( item.type !== 'archive' ) {
+		if ( item.type !== 'archive' ) {
 			const manifestPath = window.btoa( item.manifestPath ?? '' );
 			wp.req
 				.get( {
@@ -70,11 +77,7 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 					window.open( downloadUrl, '_blank' );
 					setIsProcessingDownload( false );
 
-					dispatch(
-						recordTracksEvent( 'calypso_jetpack_backup_browser_download', {
-							file_type: item.type,
-						} )
-					);
+					trackDownloadByType( item.type );
 				} );
 		} else {
 			if ( fileInfo === undefined || parentItem === undefined ) {
@@ -105,14 +108,10 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 					window.open( response.url, '_blank' );
 					setIsProcessingDownload( false );
 
-					dispatch(
-						recordTracksEvent( 'calypso_jetpack_backup_browser_download', {
-							file_type: archiveType,
-						} )
-					);
+					trackDownloadByType( archiveType );
 				} );
 		}
-	}, [ dispatch, fileInfo, item, parentItem, rewindId, siteId ] );
+	}, [ fileInfo, item, parentItem, rewindId, siteId, trackDownloadByType ] );
 
 	const prepareDownloadClick = useCallback( () => {
 		if ( ! item.period || ! fileInfo?.manifestFilter || ! fileInfo?.dataType ) {
@@ -132,8 +131,9 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 
 		if ( prepareDownloadStatus === PREPARE_DOWNLOAD_STATUS.READY ) {
 			window.open( downloadUrl, '_blank' );
+			trackDownloadByType( item.type );
 		}
-	}, [ downloadUrl, prepareDownloadStatus ] );
+	}, [ downloadUrl, item, prepareDownloadStatus, trackDownloadByType ] );
 
 	const showActions =
 		item.type !== 'archive' || ( item.type === 'archive' && item.extensionType === 'unchanged' );
@@ -151,8 +151,6 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 		return null;
 	}
 
-	const requiresPreparation = item.type === 'table';
-
 	const downloadFileButton = (
 		<Button
 			className="file-card__action"
@@ -160,6 +158,17 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 			disabled={ isProcessingDownload }
 		>
 			{ isProcessingDownload ? <Spinner /> : translate( 'Download file' ) }
+		</Button>
+	);
+
+	const downloadWordPressButton = (
+		<Button
+			className="file-card__action"
+			href={ fileInfo?.downloadUrl }
+			onClick={ () => trackDownloadByType( item.type ) }
+			download
+		>
+			{ translate( 'Download file' ) }
 		</Button>
 	);
 
@@ -179,6 +188,17 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 			) }
 		</Button>
 	);
+
+	// Render the download button based on the file type
+	const renderDownloadButton = () => {
+		if ( item.type === 'wordpress' ) {
+			return downloadWordPressButton;
+		} else if ( item.type === 'table' ) {
+			return prepareDownloadButton;
+		}
+
+		return downloadFileButton;
+	};
 
 	return (
 		<div className="file-card">
@@ -228,11 +248,7 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 				) }
 			</div>
 
-			{ showActions && (
-				<div className="file-card__actions">
-					{ requiresPreparation ? prepareDownloadButton : downloadFileButton }
-				</div>
-			) }
+			{ showActions && <div className="file-card__actions">{ renderDownloadButton() }</div> }
 
 			{ fileInfo?.size !== undefined && fileInfo.size > 0 && (
 				<FilePreview item={ item } siteId={ siteId } />

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -164,7 +164,7 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 	const downloadWordPressButton = (
 		<Button
 			className="file-card__action"
-			href={ fileInfo?.downloadUrl }
+			href={ fileInfo.downloadUrl }
 			onClick={ () => trackDownloadByType( item.type ) }
 			download
 		>

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -49,10 +49,10 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 	const [ isProcessingDownload, setIsProcessingDownload ] = useState< boolean >( false );
 
 	const trackDownloadByType = useCallback(
-		( type: string ) => {
+		( fileType: string ) => {
 			dispatch(
 				recordTracksEvent( 'calypso_jetpack_backup_browser_download', {
-					file_type: type,
+					file_type: fileType,
 				} )
 			);
 

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -51,6 +51,10 @@
 			margin-left: 0;
 		}
 
+		&.wordpress > .file-card .file-card__actions {
+			margin-top: 0;
+		}
+
 		&__loading {
 			&.placeholder {
 				height: 26px;


### PR DESCRIPTION
## Proposed Changes
* Add action to download backup's WordPress version
* Remove margin-top on file's info when clicking on the WordPress version
* Refactor Tracks event handler to trigger when downloading the WordPress version, and also database tables.

## Screenshot
<img width="653" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/58ea0ee6-49be-4099-921c-9e2a16acceba">


## Testing Instructions
* Start a Jetpack Cloud or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Click on the first item listed in the browser (`WordPress version X.X.X`). It will load and display a `Download file` button.
* Click `Download file` and it will prompt the download for that WordPress version.

### Regression test
This PR affects the way the `Download` button is rendered and also how the Tracks events are triggered for this functionality. It will now vary depending on the type of file (`archive`, `table`, `wordpress` and other files), so I will recommend to do a regression testing validating WordPress, database tables, a plugin or theme, and any other file (like images, HTML file, etc.).
* Validate it downloads the desired file
* Validate it triggers the `t.gif` call for Tracks passing the appropriate file_type. This is similar to #78964.
  * <img width="150" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/f7e157a6-c65c-49df-8b98-525d8eda6f71">

 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
