### PR TITLE
Revert "Checkout: Standardize submit button text for free purchases"

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -6,6 +6,7 @@ import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
+import i18n, { getLocaleSlug } from 'i18n-calypso';
 import MaterialIcon from 'calypso/components/material-icon';
 import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
 import { actions, selectors } from './store';
@@ -14,7 +15,7 @@ import type { CardFieldState, CardStoreType } from './types';
 import type { ProcessPayment, LineItem } from '@automattic/composite-checkout';
 import type { ReactNode } from 'react';
 
-const debug = debugFactory( 'calypso:credit-card' );
+const debug = debugFactory( 'calypso:composite-checkout:credit-card' );
 
 export default function CreditCardPayButton( {
 	disabled,
@@ -142,26 +143,21 @@ function ButtonContents( {
 	activeButtonText?: ReactNode;
 } ) {
 	const { __ } = useI18n();
-	const isPurchaseFree = total.amount.value === 0;
 	if ( formStatus === FormStatus.SUBMITTING ) {
 		return <>{ __( 'Processing…' ) }</>;
-	}
-	if ( formStatus === FormStatus.READY && isPurchaseFree ) {
-		const defaultText = (
-			<CreditCardPayButtonWrapper>{ __( 'Complete Checkout' ) }</CreditCardPayButtonWrapper>
-		);
-		/* translators: %s is the total to be paid in localized currency */
-		return <>{ activeButtonText || defaultText }</>;
 	}
 	if ( formStatus === FormStatus.READY ) {
 		const defaultText = (
 			<CreditCardPayButtonWrapper>
 				<StyledMaterialIcon icon="credit_card" />
-				{ sprintf(
-					/* translators: %s is the total to be paid in localized currency */
-					__( 'Pay %s now' ),
-					total.amount.displayValue
-				) }
+				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'Pay %s now' )
+					? sprintf(
+							/* translators: %s is the total to be paid in localized currency */
+							__( 'Pay %s now' ),
+							total.amount.displayValue
+					  )
+					: /* translators: %s is the total to be paid in localized currency */
+					  sprintf( __( 'Pay %s' ), total.amount.displayValue ) }
 			</CreditCardPayButtonWrapper>
 		);
 

--- a/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
@@ -9,7 +9,7 @@ import { styled } from '@automattic/wpcom-checkout';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { Fragment } from 'react';
 import MaterialIcon from 'calypso/components/material-icon';
 import {
@@ -260,26 +260,21 @@ function ButtonContents( {
 	activeButtonText?: string;
 } ) {
 	const { __ } = useI18n();
-	const isPurchaseFree = total.amount.value === 0;
 	if ( formStatus === FormStatus.SUBMITTING ) {
 		return <>{ __( 'Processing…' ) }</>;
-	}
-	if ( formStatus === FormStatus.READY && isPurchaseFree ) {
-		const defaultText = (
-			<CreditCardPayButtonWrapper>{ __( 'Complete Checkout' ) }</CreditCardPayButtonWrapper>
-		);
-		/* translators: %s is the total to be paid in localized currency */
-		return <>{ activeButtonText || defaultText }</>;
 	}
 	if ( formStatus === FormStatus.READY ) {
 		const defaultText = (
 			<CreditCardPayButtonWrapper>
 				<StyledMaterialIcon icon="credit_card" />
-				{ sprintf(
-					/* translators: %s is the total to be paid in localized currency */
-					__( 'Pay %s now' ),
-					total.amount.displayValue
-				) }
+				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'Pay %s now' )
+					? sprintf(
+							/* translators: %s is the total to be paid in localized currency */
+							__( 'Pay %s now' ),
+							total.amount.displayValue
+					  )
+					: /* translators: %s is the total to be paid in localized currency */
+					  sprintf( __( 'Pay %s' ), total.amount.displayValue ) }
 			</CreditCardPayButtonWrapper>
 		);
 		/* translators: %s is the total to be paid in localized currency */

--- a/client/my-sites/checkout/composite-checkout/test/credit-card.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/credit-card.tsx
@@ -49,7 +49,7 @@ const customerName = 'Human Person';
 const cardNumber = '4242424242424242';
 const cardExpiry = '05/99';
 const cardCvv = '123';
-const activePayButtonText = 'Complete Checkout';
+const activePayButtonText = 'Pay 0 now';
 function getPaymentMethod( store: CardStoreType, additionalArgs = {} ) {
 	return createCreditCardMethod( {
 		store,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#79386