### PR TITLE
BackupBrowser: Hide changed extensions item

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -79,8 +79,6 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 			let childIsAlternate = isAlternate;
 
 			return backupFiles.map( ( childItem ) => {
-				childIsAlternate = ! childIsAlternate;
-
 				// Let's hide archives that don't have an extension version
 				// and changed extensions item node
 				if (
@@ -89,6 +87,8 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 				) {
 					return null;
 				}
+
+				childIsAlternate = ! childIsAlternate;
 
 				return (
 					<FileBrowserNode

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -82,7 +82,11 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 				childIsAlternate = ! childIsAlternate;
 
 				// Let's hide archives that don't have an extension version
-				if ( childItem.type === 'archive' && ! item.extensionVersion ) {
+				// and changed extensions item node
+				if (
+					( childItem.type === 'archive' && ! item.extensionVersion ) ||
+					childItem.extensionType === 'changed'
+				) {
 					return null;
 				}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/79394#issuecomment-1636264721

## Proposed Changes
* Hide changed extensions items. This is the one that says `backed up version with X changes`. The current plugin/theme directory includes the files that are changed in a plugin.

| Before | After |
|---|---|
| <img width="621" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/13168a97-483c-4d9a-8463-32bb8e094ab3"> | <img width="621" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/87035ae7-7ee9-4c4a-af2d-6ff4e43392c4"> |

## Testing Instructions
* Start a Jetpack Cloud or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Browse a plugin or theme that has changed files. Ensure you don't see the `backed up version with X changes` item.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
