### PR TITLE
Plans 2023: Update ecommerce and business storage labels

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -873,7 +873,7 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_50GB_STORAGE ]: {
 		getSlug: () => FEATURE_50GB_STORAGE,
 		getTitle: () => i18n.translate( '50 GB storage space' ),
-
+		getCompareTitle: () => i18n.translate( '50 GB' ),
 		getDescription: () =>
 			i18n.translate( 'Storage space for adding images and documents to your website.' ),
 	},

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -318,6 +318,7 @@ type PlanComparisonGridProps = {
 	selectedPlan?: string;
 	selectedFeature?: string;
 	isGlobalStylesOnPersonal?: boolean;
+	showLegacyStorageFeature?: boolean;
 };
 
 type PlanComparisonGridHeaderProps = {
@@ -738,6 +739,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 	selectedPlan,
 	selectedFeature,
 	isGlobalStylesOnPersonal,
+	showLegacyStorageFeature,
 } ) => {
 	const translate = useTranslate();
 	// Check to see if we have at least one Woo Express plan we're comparing.
@@ -889,7 +891,8 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 				] );
 			}
 			previousPlan = planName;
-			const [ storageOption ] = planObject.get2023PricingGridSignupStorageOptions?.() ?? [];
+			const [ storageOption ] =
+				planObject.get2023PricingGridSignupStorageOptions?.( showLegacyStorageFeature ) ?? [];
 			planStorageOptionsMap[ planName ] = storageOption;
 
 			conditionalFeatureMap[ planName ] = new Set(
@@ -897,7 +900,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 			);
 		}
 		return { featureMap: planFeatureMap, planStorageOptionsMap, conditionalFeatureMap };
-	}, [ planProperties, isMonthly ] );
+	}, [ planProperties, isMonthly, showLegacyStorageFeature ] );
 
 	const allJetpackFeatures = useMemo( () => {
 		const jetpackFeatures = new Set(

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -834,7 +834,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderPlanStorageOptions( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		const { translate, showLegacyStorageFeature } = this.props;
+		const { translate } = this.props;
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties ) => {
@@ -849,7 +849,7 @@ export class PlanFeatures2023Grid extends Component<
 					}
 					return (
 						<div className="plan-features-2023-grid__storage-buttons" key={ planName }>
-							{ getStorageStringFromFeature( storageFeature, showLegacyStorageFeature ) }
+							{ getStorageStringFromFeature( storageFeature ) }
 						</div>
 					);
 				} );

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -15,6 +15,8 @@ import {
 	isWooExpressPlan,
 	PlanSlug,
 	isWooExpressPlusPlan,
+	FEATURE_200GB_STORAGE,
+	FEATURE_50GB_STORAGE,
 } from '@automattic/calypso-products';
 import {
 	JetpackLogo,
@@ -113,6 +115,7 @@ export type PlanFeatures2023GridProps = {
 	selectedFeature?: string;
 	intent?: PlansIntent;
 	isGlobalStylesOnPersonal?: boolean;
+	showLegacyStorageFeature?: boolean;
 };
 
 type PlanFeatures2023GridConnectedProps = {
@@ -831,7 +834,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderPlanStorageOptions( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		const { translate } = this.props;
+		const { translate, showLegacyStorageFeature } = this.props;
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties ) => {
@@ -846,7 +849,7 @@ export class PlanFeatures2023Grid extends Component<
 					}
 					return (
 						<div className="plan-features-2023-grid__storage-buttons" key={ planName }>
-							{ getStorageStringFromFeature( storageFeature ) }
+							{ getStorageStringFromFeature( storageFeature, showLegacyStorageFeature ) }
 						</div>
 					);
 				} );
@@ -892,6 +895,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 			selectedFeature,
 			intent,
 			isGlobalStylesOnPersonal,
+			showLegacyStorageFeature,
 		} = ownProps;
 		// TODO clk: canUserManagePlan should be passed through props instead of being calculated here
 		const canUserPurchasePlan = siteId
@@ -1009,10 +1013,17 @@ const ConnectedPlanFeatures2023Grid = connect(
 					isWpcomEnterpriseGridPlan( plan ) && planConstantObj.getPathSlug
 						? planConstantObj.getPathSlug()
 						: planObject?.product_name_short ?? '';
-				const storageOptions =
+				let storageOptions =
 					( planConstantObj.get2023PricingGridSignupStorageOptions &&
 						planConstantObj.get2023PricingGridSignupStorageOptions() ) ||
 					[];
+
+				if ( showLegacyStorageFeature ) {
+					storageOptions = storageOptions.map( ( option ) =>
+						option === FEATURE_50GB_STORAGE ? FEATURE_200GB_STORAGE : option
+					);
+				}
+
 				const availableForPurchase =
 					isInSignup || ( siteId ? isPlanAvailableForPurchase( state, siteId, plan ) : false );
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -15,8 +15,6 @@ import {
 	isWooExpressPlan,
 	PlanSlug,
 	isWooExpressPlusPlan,
-	FEATURE_200GB_STORAGE,
-	FEATURE_50GB_STORAGE,
 } from '@automattic/calypso-products';
 import {
 	JetpackLogo,
@@ -270,6 +268,7 @@ export class PlanFeatures2023Grid extends Component<
 			isGlobalStylesOnPersonal,
 			planRecords,
 			visiblePlans,
+			showLegacyStorageFeature,
 		} = this.props;
 		return (
 			<PlansGridContextProvider
@@ -324,6 +323,7 @@ export class PlanFeatures2023Grid extends Component<
 								selectedPlan={ selectedPlan }
 								selectedFeature={ selectedFeature }
 								isGlobalStylesOnPersonal={ isGlobalStylesOnPersonal }
+								showLegacyStorageFeature={ showLegacyStorageFeature }
 							/>
 							<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
 								<Button onClick={ this.toggleShowPlansComparisonGrid }>
@@ -1013,16 +1013,10 @@ const ConnectedPlanFeatures2023Grid = connect(
 					isWpcomEnterpriseGridPlan( plan ) && planConstantObj.getPathSlug
 						? planConstantObj.getPathSlug()
 						: planObject?.product_name_short ?? '';
-				let storageOptions =
+				const storageOptions =
 					( planConstantObj.get2023PricingGridSignupStorageOptions &&
-						planConstantObj.get2023PricingGridSignupStorageOptions() ) ||
+						planConstantObj.get2023PricingGridSignupStorageOptions( showLegacyStorageFeature ) ) ||
 					[];
-
-				if ( showLegacyStorageFeature ) {
-					storageOptions = storageOptions.map( ( option ) =>
-						option === FEATURE_50GB_STORAGE ? FEATURE_200GB_STORAGE : option
-					);
-				}
 
 				const availableForPurchase =
 					isInSignup || ( siteId ? isPlanAvailableForPurchase( state, siteId, plan ) : false );

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -83,6 +83,7 @@ export interface PlansFeaturesMainProps {
 	isPlansInsideStepper?: boolean;
 	showBiennialToggle?: boolean;
 	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
+	showLegacyStorageFeature?: boolean;
 }
 
 type OnboardingPricingGrid2023Props = PlansFeaturesMainProps & {
@@ -134,6 +135,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		sitePlanSlug,
 		siteSlug,
 		intent,
+		showLegacyStorageFeature,
 	} = props;
 	const translate = useTranslate();
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
@@ -179,6 +181,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		planActionOverrides,
 		intent,
 		isGlobalStylesOnPersonal: globalStylesInPersonalPlan,
+		showLegacyStorageFeature,
 	};
 
 	const asyncPlanFeatures2023Grid = (
@@ -233,6 +236,7 @@ const PlansFeaturesMain = ( {
 	isPlansInsideStepper = false,
 	isStepperUpgradeFlow = false,
 	isLaunchPage = false,
+	showLegacyStorageFeature = false,
 }: PlansFeaturesMainProps ) => {
 	const [ isFreePlanPaidDomainDialogOpen, setIsFreePlanPaidDomainDialogOpen ] = useState( false );
 	const currentPlan = useSelector( ( state: IAppState ) => getCurrentPlan( state, siteId ) );
@@ -435,6 +439,7 @@ const PlansFeaturesMain = ( {
 						sitePlanSlug={ sitePlanSlug }
 						siteSlug={ siteSlug }
 						intent={ intent }
+						showLegacyStorageFeature={ showLegacyStorageFeature }
 					/>
 				</>
 			) }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -9,6 +9,7 @@ import {
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 	PLAN_WOOEXPRESS_MEDIUM,
 	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
+	FEATURE_LEGACY_STORAGE_200GB,
 } from '@automattic/calypso-products';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { withShoppingCart } from '@automattic/shopping-cart';
@@ -44,6 +45,7 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -274,6 +276,7 @@ class Plans extends Component {
 				siteId={ selectedSite?.ID }
 				plansWithScroll={ false }
 				hidePlansFeatureComparison={ this.props.isDomainAndPlanPackageFlow }
+				showLegacyStorageFeature={ this.props.siteHasLegacyStorage }
 				intent={ plansIntent }
 			/>
 		);
@@ -470,6 +473,7 @@ const ConnectedPlans = connect( ( state ) => {
 		isDomainUpsellSuggested: getCurrentQueryArguments( state )?.domain === 'true',
 		isFreePlan: isFreePlanProduct( currentPlan ),
 		domainFromHomeUpsellFlow: getDomainFromHomeUpsellInQuery( state ),
+		siteHasLegacyStorage: siteHasFeature( state, selectedSiteId, FEATURE_LEGACY_STORAGE_200GB ),
 	};
 } )( withCartKey( withShoppingCart( localize( withTrackingTool( 'HotJar' )( Plans ) ) ) ) );
 

--- a/config/development.json
+++ b/config/development.json
@@ -145,6 +145,7 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
+		"plans/updated-storage-labels": true,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -40,6 +40,7 @@ export const FEATURE_6GB_STORAGE = '6gb-storage';
 export const FEATURE_13GB_STORAGE = '13gb-storage';
 export const FEATURE_50GB_STORAGE = '50gb-storage';
 export const FEATURE_200GB_STORAGE = '200gb-storage';
+export const FEATURE_LEGACY_STORAGE_200GB = 'upload-space-200gb';
 export const FEATURE_UNLIMITED_STORAGE = 'unlimited-storage';
 export const FEATURE_COMMUNITY_SUPPORT = 'community-support';
 export const FEATURE_EMAIL_SUPPORT = 'email-support';

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1013,7 +1013,11 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_PAYMENT_TRANSACTION_FEES_0,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [],
-	get2023PricingGridSignupStorageOptions: () => {
+	get2023PricingGridSignupStorageOptions: ( showLegacyStorageFeature ) => {
+		if ( showLegacyStorageFeature ) {
+			return [ FEATURE_200GB_STORAGE ];
+		}
+
 		return isEnabled( 'plans/updated-storage-labels' )
 			? [ FEATURE_50GB_STORAGE ]
 			: [ FEATURE_200GB_STORAGE ];
@@ -1584,7 +1588,11 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SHIPPING_INTEGRATIONS,
 		FEATURE_SHARES_SOCIAL_MEDIA_JP,
 	],
-	get2023PricingGridSignupStorageOptions: () => {
+	get2023PricingGridSignupStorageOptions: ( showLegacyStorageFeature ) => {
+		if ( showLegacyStorageFeature ) {
+			return [ FEATURE_200GB_STORAGE ];
+		}
+
 		return isEnabled( 'plans/updated-storage-labels' )
 			? [ FEATURE_50GB_STORAGE ]
 			: [ FEATURE_200GB_STORAGE ];

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1013,7 +1013,11 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_PAYMENT_TRANSACTION_FEES_0,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [],
-	get2023PricingGridSignupStorageOptions: () => [ FEATURE_200GB_STORAGE ],
+	get2023PricingGridSignupStorageOptions: () => {
+		return isEnabled( 'plans/updated-storage-labels' )
+			? [ FEATURE_50GB_STORAGE ]
+			: [ FEATURE_200GB_STORAGE ];
+	},
 	get2023PlanComparisonConditionalFeatures: () => [ FEATURE_SHARES_SOCIAL_MEDIA_JP ],
 	getHostingSignupFeatures: ( term ) => () =>
 		compact( [
@@ -1580,7 +1584,11 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SHIPPING_INTEGRATIONS,
 		FEATURE_SHARES_SOCIAL_MEDIA_JP,
 	],
-	get2023PricingGridSignupStorageOptions: () => [ FEATURE_200GB_STORAGE ],
+	get2023PricingGridSignupStorageOptions: () => {
+		return isEnabled( 'plans/updated-storage-labels' )
+			? [ FEATURE_50GB_STORAGE ]
+			: [ FEATURE_200GB_STORAGE ];
+	},
 	getHostingSignupFeatures: ( term ) => () =>
 		compact( [
 			term !== TERM_MONTHLY && FEATURE_CUSTOM_DOMAIN,

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -228,7 +228,7 @@ export type Plan = BillingTerm & {
 	 */
 	get2023PlanComparisonConditionalFeatures?: () => Feature[];
 
-	get2023PricingGridSignupStorageOptions?: () => Feature[];
+	get2023PricingGridSignupStorageOptions?: ( showLegacyStorageFeature?: boolean ) => Feature[];
 	getProductId: () => number;
 	getPathSlug?: () => string;
 	getStoreSlug: () => PlanSlug;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1906

## Proposed Changes

* Changes the ecommerce and business storage feature labels from 200GB to 50GB
* Adds changes behind feature flag
* Maintains 200GB label for legacy sites created with 200GB of storage on the /plans page

## Screenshots
<img width="1494" alt="Screenshot 2023-07-14 at 6 21 10 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/8e37f714-46cf-4ea7-876d-7e84487a8657">

<img width="1480" alt="Screenshot 2023-07-14 at 6 21 16 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/12cfeb87-1575-4259-90d2-e31a35515e19">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch
* `yarn && yarn start`
* Navigate to calypso.localhost:3000/start/plans
* Verify that the storage feature label in the features grid _and_ plans comparison grid is 50GB for business and ecommerce plans
* Verify that, for legacy sites ( Ex. a site created several weeks ago or even earlier ), on the `/plans` page, the features grid _and_ plans comparison grid is 200GB for business and ecommerce plans
* Add the query param `?flags=%2Fplans%2Fupdated-storage-labels` to the URL and refresh the page
* Verify that the feature flag works and that the storage feature label in the features grid _and_ plans comparison grid reverts to 200GB for business and ecommerce plans

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
