### PR TITLE
Launchpad: Added file to centralize task actions

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
@@ -31,17 +31,7 @@ const LaunchpadIntentWrite = (): JSX.Element => {
 
 		const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
 
-		// Add Tracks events to all tasks before dispatching the original action.
-		return sortedTasks.map( ( task: Task ) => {
-			recordTracksEvent( 'calypso_launchpad_task_view', {
-				checklist_slug: checklistSlug,
-				task_id: task.id,
-				is_completed: task.completed,
-				context: 'customer-home',
-			} );
-
-			return task;
-		} );
+		return sortedTasks;
 	};
 
 	return (

--- a/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
@@ -30,9 +30,7 @@ const LaunchpadIntentWrite = (): JSX.Element => {
 		const completedTasks = tasksWithActions.filter( ( task: Task ) => task.completed );
 		const incompleteTasks = tasksWithActions.filter( ( task: Task ) => ! task.completed );
 
-		const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
-
-		return sortedTasks;
+		return [ ...completedTasks, ...incompleteTasks ];
 	};
 
 	return (

--- a/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
@@ -9,6 +9,7 @@ import type { Task } from '@automattic/launchpad';
 import type { AppState } from 'calypso/types';
 
 const checklistSlug = 'intent-write';
+const launchpadContext = 'customer-home';
 
 const LaunchpadIntentWrite = (): JSX.Element => {
 	const siteId = useSelector( getSelectedSiteId );
@@ -21,7 +22,7 @@ const LaunchpadIntentWrite = (): JSX.Element => {
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 	const tasklistCompleted = numberOfSteps > 0 && completedSteps === numberOfSteps;
-	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted };
+	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
 		const tasksWithActions = setUpActionsForTasks( tasks, siteSlug, tracksData );

--- a/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
@@ -25,7 +25,7 @@ const LaunchpadIntentWrite = (): JSX.Element => {
 	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
-		return setUpActionsForTasks( tasks, siteSlug, tracksData );
+		return setUpActionsForTasks( { tasks, siteSlug, tracksData } );
 	};
 
 	return (

--- a/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
@@ -25,12 +25,7 @@ const LaunchpadIntentWrite = (): JSX.Element => {
 	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
-		const tasksWithActions = setUpActionsForTasks( tasks, siteSlug, tracksData );
-
-		const completedTasks = tasksWithActions.filter( ( task: Task ) => task.completed );
-		const incompleteTasks = tasksWithActions.filter( ( task: Task ) => ! task.completed );
-
-		return [ ...completedTasks, ...incompleteTasks ];
+		return setUpActionsForTasks( tasks, siteSlug, tracksData );
 	};
 
 	return (

--- a/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
@@ -1,5 +1,5 @@
 import { useLaunchpad } from '@automattic/data-stores';
-import { setUpActions } from '@automattic/launchpad';
+import { setUpActionsForTasks } from '@automattic/launchpad';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -21,19 +21,10 @@ const LaunchpadIntentWrite = (): JSX.Element => {
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 	const tasklistCompleted = numberOfSteps > 0 && completedSteps === numberOfSteps;
-
-	const recordTaskClickTracksEvent = ( task: Task ) => {
-		recordTracksEvent( 'calypso_launchpad_task_clicked', {
-			checklist_slug: checklistSlug,
-			checklist_completed: tasklistCompleted,
-			task_id: task.id,
-			is_completed: task.completed,
-			context: 'customer-home',
-		} );
-	};
+	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted };
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
-		const tasksWithActions = setUpActions( tasks, siteSlug );
+		const tasksWithActions = setUpActionsForTasks( tasks, siteSlug, tracksData );
 
 		const completedTasks = tasksWithActions.filter( ( task: Task ) => task.completed );
 		const incompleteTasks = tasksWithActions.filter( ( task: Task ) => ! task.completed );
@@ -49,13 +40,7 @@ const LaunchpadIntentWrite = (): JSX.Element => {
 				context: 'customer-home',
 			} );
 
-			const originalAction = task.actionDispatch;
-			const newAction = () => {
-				recordTaskClickTracksEvent( task );
-				return originalAction?.();
-			};
-
-			return { ...task, actionDispatch: newAction };
+			return task;
 		} );
 	};
 

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -13,6 +13,7 @@ import type { Task } from '@automattic/launchpad';
 import './style.scss';
 
 const checklistSlug = 'keep-building';
+const launchpadContext = 'customer-home';
 
 interface LaunchpadKeepBuildingProps {
 	site: SiteDetails | null;
@@ -28,7 +29,7 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 	const tasklistCompleted = completedSteps === numberOfSteps;
-	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted };
+	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
 
 	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
 

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -31,28 +31,24 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted };
 
 	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
-	const extraTaskActions = {
-		setShareSiteModalIsOpen,
-	};
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
-		const tasksWithActions = setUpActionsForTasks( tasks, siteSlug, tracksData, extraTaskActions );
+		const tasksWithActions = setUpActionsForTasks( tasks, siteSlug, tracksData );
+
+		// Add action to `share_site` task, which has a custom UI.
+		const shareSiteTask = tasksWithActions.find( ( task: Task ) => task.id === 'share_site' );
+		if ( shareSiteTask ) {
+			shareSiteTask.actionDispatch = () => {
+				setShareSiteModalIsOpen( true );
+			};
+		}
+
 		const completedTasks = tasksWithActions.filter( ( task: Task ) => task.completed );
 		const incompleteTasks = tasksWithActions.filter( ( task: Task ) => ! task.completed );
 
 		const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
 
-		// Add Tracks events to all tasks before dispatching the original action.
-		return sortedTasks.map( ( task: Task ) => {
-			recordTracksEvent( 'calypso_launchpad_task_view', {
-				checklist_slug: checklistSlug,
-				task_id: task.id,
-				is_completed: task.completed,
-				context: 'customer-home',
-			} );
-
-			return task;
-		} );
+		return sortedTasks;
 	};
 
 	return (

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -47,9 +47,7 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 		const completedTasks = tasksWithActions.filter( ( task: Task ) => task.completed );
 		const incompleteTasks = tasksWithActions.filter( ( task: Task ) => ! task.completed );
 
-		const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
-
-		return sortedTasks;
+		return [ ...completedTasks, ...incompleteTasks ];
 	};
 
 	return (

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -1,6 +1,5 @@
 import { useLaunchpad } from '@automattic/data-stores';
-import { isMobile } from '@automattic/viewport';
-import { addQueryArgs } from '@wordpress/url';
+import { setUpActions } from '@automattic/launchpad';
 import { useState } from 'react';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -43,72 +42,37 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
-		const completedTasks = tasks.filter( ( task: Task ) => task.completed );
-		const incompleteTasks = tasks.filter( ( task: Task ) => ! task.completed );
+		const tasksWithActions = setUpActions( tasks, siteSlug );
+
+		// Add action to `share_site` task, which has with custom UI.
+		const shareSiteTask = tasksWithActions.find( ( task: Task ) => task.id === 'share_site' );
+		if ( shareSiteTask ) {
+			shareSiteTask.actionDispatch = () => {
+				setShareSiteModalIsOpen( true );
+			};
+		}
+
+		const completedTasks = tasksWithActions.filter( ( task: Task ) => task.completed );
+		const incompleteTasks = tasksWithActions.filter( ( task: Task ) => ! task.completed );
 
 		const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
 
+		// Add Tracks events to all tasks before dispatching the original action.
 		return sortedTasks.map( ( task: Task ) => {
-			let actionDispatch;
+			recordTracksEvent( 'calypso_launchpad_task_view', {
+				checklist_slug: checklistSlug,
+				task_id: task.id,
+				is_completed: task.completed,
+				context: 'customer-home',
+			} );
 
-			switch ( task.id ) {
-				case 'site_title':
-					actionDispatch = () => {
-						recordTaskClickTracksEvent( task );
-						window.location.assign( `/settings/general/${ siteSlug }` );
-					};
-					break;
+			const originalAction = task.actionDispatch;
+			const newAction = () => {
+				recordTaskClickTracksEvent( task );
+				return originalAction?.();
+			};
 
-				case 'design_edited':
-					actionDispatch = () => {
-						recordTaskClickTracksEvent( task );
-						window.location.assign(
-							addQueryArgs( `/site-editor/${ siteSlug }`, {
-								canvas: 'edit',
-							} )
-						);
-					};
-					break;
-
-				case 'domain_claim':
-				case 'domain_upsell':
-				case 'domain_customize':
-					actionDispatch = () => {
-						recordTaskClickTracksEvent( task );
-						window.location.assign( `/domains/add/${ siteSlug }` );
-					};
-					break;
-				case 'drive_traffic':
-					actionDispatch = () => {
-						recordTaskClickTracksEvent( task );
-						const url = isMobile()
-							? `/marketing/connections/${ siteSlug }`
-							: `/marketing/connections/${ siteSlug }?tour=marketingConnectionsTour`;
-						window.location.assign( url );
-					};
-					break;
-				case 'add_new_page':
-					actionDispatch = () => {
-						recordTaskClickTracksEvent( task );
-						window.location.assign( `/page/${ siteSlug }` );
-					};
-					break;
-				case 'edit_page':
-					actionDispatch = () => {
-						recordTaskClickTracksEvent( task );
-						window.location.assign( `/pages/${ siteSlug }` );
-					};
-					break;
-
-				case 'share_site':
-					actionDispatch = () => {
-						recordTaskClickTracksEvent( task );
-						setShareSiteModalIsOpen( true );
-					};
-					break;
-			}
-
-			return { ...task, actionDispatch };
+			return { ...task, actionDispatch: newAction };
 		} );
 	};
 

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -26,28 +26,16 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 		data: { checklist },
 	} = useLaunchpad( siteSlug, checklistSlug );
 
+	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
+
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 	const tasklistCompleted = completedSteps === numberOfSteps;
 	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
-
-	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
+	const extraActions = { setShareSiteModalIsOpen };
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
-		const tasksWithActions = setUpActionsForTasks( tasks, siteSlug, tracksData );
-
-		// Add action to `share_site` task, which has a custom UI.
-		const shareSiteTask = tasksWithActions.find( ( task: Task ) => task.id === 'share_site' );
-		if ( shareSiteTask ) {
-			shareSiteTask.actionDispatch = () => {
-				setShareSiteModalIsOpen( true );
-			};
-		}
-
-		const completedTasks = tasksWithActions.filter( ( task: Task ) => task.completed );
-		const incompleteTasks = tasksWithActions.filter( ( task: Task ) => ! task.completed );
-
-		return [ ...completedTasks, ...incompleteTasks ];
+		return setUpActionsForTasks( tasks, siteSlug, tracksData, extraActions );
 	};
 
 	return (

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -35,7 +35,7 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 	const extraActions = { setShareSiteModalIsOpen };
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
-		return setUpActionsForTasks( tasks, siteSlug, tracksData, extraActions );
+		return setUpActionsForTasks( { tasks, siteSlug, tracksData, extraActions } );
 	};
 
 	return (

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -2,4 +2,4 @@ export { default as Checklist } from './checklist';
 export { default as ChecklistItem } from './checklist-item';
 export { default as Launchpad } from './launchpad';
 export { setUpActionsForTasks } from './setup-actions';
-export * from './types';
+export type * from './types';

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Checklist } from './checklist';
 export { default as ChecklistItem } from './checklist-item';
 export { default as Launchpad } from './launchpad';
+export { setUpActions } from './setup-actions';
 export * from './types';

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -2,4 +2,4 @@ export { default as Checklist } from './checklist';
 export { default as ChecklistItem } from './checklist-item';
 export { default as Launchpad } from './launchpad';
 export { setUpActionsForTasks } from './setup-actions';
-export type * from './types';
+export * from './types';

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -1,5 +1,5 @@
 export { default as Checklist } from './checklist';
 export { default as ChecklistItem } from './checklist-item';
 export { default as Launchpad } from './launchpad';
-export { setUpActions } from './setup-actions';
+export { setUpActionsForTasks } from './setup-actions';
 export * from './types';

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -1,14 +1,12 @@
 import { isMobile } from '@automattic/viewport';
-import type { LaunchpadTracksData, Task } from './types';
+import type { LaunchpadTaskActions, Task } from './types';
 
-export const setUpActionsForTasks = (
-	tasks: Task[],
-	siteSlug: string | null,
-	tracksData: LaunchpadTracksData,
-	extraActions?: {
-		setShareSiteModalIsOpen: ( isOpen: boolean ) => void;
-	}
-): Task[] => {
+export const setUpActionsForTasks = ( {
+	siteSlug,
+	tasks,
+	tracksData,
+	extraActions,
+}: LaunchpadTaskActions ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
 	const { setShareSiteModalIsOpen } = extraActions || {};
 

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -6,7 +6,7 @@ export const setUpActionsForTasks = (
 	siteSlug: string | null,
 	tracksData: LaunchpadTracksData
 ): Task[] => {
-	const { recordTracksEvent, checklistSlug, tasklistCompleted } = tracksData;
+	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
 
 	//Record click events for tasks
 	const recordTaskClickTracksEvent = ( task: Task ) => {
@@ -15,7 +15,7 @@ export const setUpActionsForTasks = (
 			checklist_completed: tasklistCompleted,
 			task_id: task.id,
 			is_completed: task.completed,
-			context: 'customer-home',
+			context: launchpadContext,
 		} );
 	};
 

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -1,12 +1,12 @@
 import { isMobile } from '@automattic/viewport';
-import type { LaunchpadTaskActions, Task } from './types';
+import type { LaunchpadTaskActionsProps, Task } from './types';
 
 export const setUpActionsForTasks = ( {
 	siteSlug,
 	tasks,
 	tracksData,
 	extraActions,
-}: LaunchpadTaskActions ): Task[] => {
+}: LaunchpadTaskActionsProps ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
 	const { setShareSiteModalIsOpen } = extraActions || {};
 

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -66,7 +66,7 @@ export const setUpActionsForTasks = (
 				break;
 			case 'share_site':
 				action = () => {
-					setShareSiteModalIsOpen( true );
+					setShareSiteModalIsOpen?.( true );
 				};
 				break;
 		}

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -39,16 +39,6 @@ export const setUpActionsForTasks = (
 				};
 				break;
 
-			case 'design_edited':
-				action = () => {
-					window.location.assign(
-						addQueryArgs( `/site-editor/${ siteSlug }`, {
-							canvas: 'edit',
-						} )
-					);
-				};
-				break;
-
 			case 'domain_claim':
 			case 'domain_upsell':
 			case 'domain_customize':

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -23,14 +23,6 @@ export const setUpActionsForTasks = (
 	return tasks.map( ( task: Task ) => {
 		let action: () => void;
 
-		//Record task view tracks event
-		recordTracksEvent( 'calypso_launchpad_task_view', {
-			checklist_slug: checklistSlug,
-			task_id: task.id,
-			is_completed: task.completed,
-			context: 'customer-home',
-		} );
-
 		switch ( task.id ) {
 			case 'site_title':
 				action = () => {

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -4,9 +4,13 @@ import type { LaunchpadTracksData, Task } from './types';
 export const setUpActionsForTasks = (
 	tasks: Task[],
 	siteSlug: string | null,
-	tracksData: LaunchpadTracksData
+	tracksData: LaunchpadTracksData,
+	extraActions?: {
+		setShareSiteModalIsOpen: ( isOpen: boolean ) => void;
+	}
 ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
+	const { setShareSiteModalIsOpen } = extraActions || {};
 
 	//Record click events for tasks
 	const recordTaskClickTracksEvent = ( task: Task ) => {
@@ -19,8 +23,13 @@ export const setUpActionsForTasks = (
 		} );
 	};
 
-	// Add actions to known tasks
-	return tasks.map( ( task: Task ) => {
+	// Sort task by completion status.
+	const completedTasks = tasks.filter( ( task: Task ) => task.completed );
+	const incompleteTasks = tasks.filter( ( task: Task ) => ! task.completed );
+	const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
+
+	// Add actions to sorted tasks.
+	return sortedTasks.map( ( task: Task ) => {
 		let action: () => void;
 
 		switch ( task.id ) {
@@ -53,6 +62,11 @@ export const setUpActionsForTasks = (
 			case 'edit_page':
 				action = () => {
 					window.location.assign( `/pages/${ siteSlug }` );
+				};
+				break;
+			case 'share_site':
+				action = () => {
+					setShareSiteModalIsOpen( true );
 				};
 				break;
 		}

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -1,5 +1,4 @@
 import { isMobile } from '@automattic/viewport';
-import { addQueryArgs } from '@wordpress/url';
 import type { LaunchpadTracksData, Task } from './types';
 
 export const setUpActionsForTasks = (

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -5,12 +5,10 @@ import type { LaunchpadTracksData, Task } from './types';
 export const setUpActionsForTasks = (
 	tasks: Task[],
 	siteSlug: string | null,
-	tracksData: LaunchpadTracksData,
-	extraActions?: {
-		setShareSiteModalIsOpen: ( isOpen: boolean ) => void;
-	}
+	tracksData: LaunchpadTracksData
 ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted } = tracksData;
+
 	//Record click events for tasks
 	const recordTaskClickTracksEvent = ( task: Task ) => {
 		recordTracksEvent( 'calypso_launchpad_task_clicked', {
@@ -25,6 +23,14 @@ export const setUpActionsForTasks = (
 	// Add actions to known tasks
 	return tasks.map( ( task: Task ) => {
 		let action: () => void;
+
+		//Record task view tracks event
+		recordTracksEvent( 'calypso_launchpad_task_view', {
+			checklist_slug: checklistSlug,
+			task_id: task.id,
+			is_completed: task.completed,
+			context: 'customer-home',
+		} );
 
 		switch ( task.id ) {
 			case 'site_title':
@@ -66,11 +72,6 @@ export const setUpActionsForTasks = (
 			case 'edit_page':
 				action = () => {
 					window.location.assign( `/pages/${ siteSlug }` );
-				};
-				break;
-			case 'share_site':
-				action = () => {
-					extraActions?.setShareSiteModalIsOpen( true );
 				};
 				break;
 		}

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -1,0 +1,56 @@
+import { isMobile } from '@automattic/viewport';
+import { addQueryArgs } from '@wordpress/url';
+import type { Task } from './types';
+
+export const setUpActions = ( tasks: Task[], siteSlug: string | null ): Task[] => {
+	// Add actions to known tasks
+	return tasks.map( ( task: Task ) => {
+		let actionDispatch;
+
+		switch ( task.id ) {
+			case 'site_title':
+				actionDispatch = () => {
+					window.location.assign( `/settings/general/${ siteSlug }` );
+				};
+				break;
+
+			case 'design_edited':
+				actionDispatch = () => {
+					window.location.assign(
+						addQueryArgs( `/site-editor/${ siteSlug }`, {
+							canvas: 'edit',
+						} )
+					);
+				};
+				break;
+
+			case 'domain_claim':
+			case 'domain_upsell':
+			case 'domain_customize':
+				actionDispatch = () => {
+					window.location.assign( `/domains/add/${ siteSlug }` );
+				};
+				break;
+			case 'drive_traffic':
+				actionDispatch = () => {
+					const url = isMobile()
+						? `/marketing/connections/${ siteSlug }`
+						: `/marketing/connections/${ siteSlug }?tour=marketingConnectionsTour`;
+					window.location.assign( url );
+				};
+				break;
+			case 'add_new_page':
+				actionDispatch = () => {
+					window.location.assign( `/page/${ siteSlug }` );
+				};
+				break;
+			case 'edit_page':
+				actionDispatch = () => {
+					window.location.assign( `/pages/${ siteSlug }` );
+				};
+				break;
+		}
+
+		return { ...task, actionDispatch };
+	} );
+};

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -1,7 +1,7 @@
 export interface Task {
 	id: string;
-	completed?: boolean;
-	disabled?: boolean;
+	completed: boolean;
+	disabled: boolean;
 	title?: string;
 	subtitle?: string | React.ReactNode | null;
 	badge_text?: string;

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -15,6 +15,7 @@ export type LaunchpadTracksData = {
 	recordTracksEvent: ( event: string, properties: Record< string, unknown > ) => void;
 	checklistSlug: string;
 	tasklistCompleted: boolean;
+	launchpadContext: string;
 };
 
 export interface LaunchpadFlowTaskList {

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -11,6 +11,12 @@ export interface Task {
 
 export type LaunchpadChecklist = Task[];
 
+export type LaunchpadTracksData = {
+	recordTracksEvent: ( event: string, properties: Record< string, unknown > ) => void;
+	checklistSlug: string;
+	tasklistCompleted: boolean;
+};
+
 export interface LaunchpadFlowTaskList {
 	[ string: string ]: string[];
 }

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -12,10 +12,10 @@ export interface Task {
 export type LaunchpadChecklist = Task[];
 
 export type LaunchpadTracksData = {
-	recordTracksEvent: ( event: string, properties: Record< string, unknown > ) => void;
 	checklistSlug: string;
-	tasklistCompleted: boolean;
 	launchpadContext: string;
+	recordTracksEvent: ( event: string, properties: Record< string, unknown > ) => void;
+	tasklistCompleted: boolean;
 };
 
 export interface LaunchpadFlowTaskList {
@@ -45,4 +45,13 @@ export interface LaunchpadResponse {
 	site_intent: string;
 	launchpad_screen: boolean | string;
 	checklist_statuses: LaunchpadStatuses[];
+}
+
+export interface LaunchpadTaskActions {
+	siteSlug: string | null;
+	tasks: Task[];
+	tracksData: LaunchpadTracksData;
+	extraActions?: {
+		setShareSiteModalIsOpen?: ( isOpen: boolean ) => void;
+	};
 }

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -1,7 +1,7 @@
 export interface Task {
 	id: string;
-	completed: boolean;
-	disabled: boolean;
+	completed?: boolean;
+	disabled?: boolean;
 	title?: string;
 	subtitle?: string | React.ReactNode | null;
 	badge_text?: string;

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -47,7 +47,7 @@ export interface LaunchpadResponse {
 	checklist_statuses: LaunchpadStatuses[];
 }
 
-export interface LaunchpadTaskActions {
+export interface LaunchpadTaskActionsProps {
 	siteSlug: string | null;
 	tasks: Task[];
 	tracksData: LaunchpadTracksData;


### PR DESCRIPTION
## Proposed Changes

* This PR moves some of the logic and task actions to a separate file in the launchpad package, so it can be reused in different contexts.
* The actions include what to do when a user clicks on a task, as well as each Tracks click event for that task.
* It also refactors the `keep-building` and `intent-write` checklists to use the new setup actions file.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site from `/start` with the `build` intent (select "Promote myself and business" during the intent selection step), and Launch the site.
* Check that the Launchpad in Customer Home still works (you can click on tasks and complete them).
* Check that the Tracks events for `calypso_launchpad_tasklist_view`, `calypso_launchpad_task_view`, and `calypso_launchpad_task_clicked` still fire and have the [appropriate properties.](https://github.com/Automattic/wp-calypso/issues/77616)
* Repeat the above testing steps with a new site with the `write` intent: Create a new site from `/start` with the `write` intent (select "Write & publish" during the intent selection step), and Launch the site.
* There should be no visual changes.