### PR TITLE
Reset theme activation modal after activating a theme

### DIFF
--- a/client/my-sites/themes/activation-modal.jsx
+++ b/client/my-sites/themes/activation-modal.jsx
@@ -15,7 +15,6 @@ import {
 } from 'calypso/state/themes/actions';
 import {
 	getCanonicalTheme,
-	hasActivatedTheme,
 	isActivatingTheme,
 	isThemeActive,
 	shouldShowActivationModal,
@@ -34,7 +33,6 @@ export class ActivationModal extends Component {
 			id: PropTypes.string,
 			name: PropTypes.string,
 		} ),
-		hasActivated: PropTypes.bool.isRequired,
 		isActivating: PropTypes.bool.isRequired,
 		siteId: PropTypes.number,
 		isVisible: PropTypes.bool,
@@ -45,21 +43,8 @@ export class ActivationModal extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			// Used to reset state when dialog re-opens, see `getDerivedStateFromProps`
-			wasVisible: props.isVisible,
 			hasConfirmed: false,
 		};
-	}
-
-	static getDerivedStateFromProps( nextProps, prevState ) {
-		// This component doesn't unmount when the dialog closes, so the state
-		// needs to be reset back to defaults each time it opens.
-		if ( nextProps.isVisible && ! prevState.wasVisible ) {
-			return { wasVisible: true };
-		} else if ( ! nextProps.isVisible && prevState.wasVisible ) {
-			return { wasVisible: false };
-		}
-		return null;
 	}
 
 	closeModalHandler =
@@ -98,7 +83,7 @@ export class ActivationModal extends Component {
 		};
 
 	render() {
-		const { theme, hasActivated, isActivating, isCurrentTheme, isVisible = false } = this.props;
+		const { theme, isActivating, isCurrentTheme, isVisible = false } = this.props;
 
 		const { hasConfirmed } = this.state;
 
@@ -107,8 +92,8 @@ export class ActivationModal extends Component {
 			return null;
 		}
 
-		// Hide while is activating or when it's activated.
-		if ( isActivating || hasActivated ) {
+		// Hide while is activating.
+		if ( isActivating ) {
 			return null;
 		}
 
@@ -194,7 +179,6 @@ export default connect(
 			installingThemeId,
 			theme: installingThemeId && getCanonicalTheme( state, siteId, installingThemeId ),
 			isActivating: !! isActivatingTheme( state, siteId ),
-			hasActivated: !! hasActivatedTheme( state, siteId ),
 			isCurrentTheme: isThemeActive( state, installingThemeId, siteId ),
 			isVisible: shouldShowActivationModal( state, installingThemeId ),
 		};


### PR DESCRIPTION
## Proposed Changes

Currently, we cannot activate a theme from a theme showcase two times in a row without refreshing the page. This is because the activation modal won't show up for the second time, thus blocking the entire activation flow.

This PR fixes this bug.

## Testing Instructions

1. Apply this PR / use Live Calypso link.
2. Go to the theme showcase (`/themes/<siteSlug>`).
3. Activate a theme.
4. Try to activate another theme.

|Before this PR|After this PR|
|-|-|
|Not possible. Need to refresh the page.|Possible now!|

## Implementation details

This PR removes the dependency to `hasActivatedTheme( state, siteId )` selector. This is because somehow this will return `true` if we have activated any theme at least once (in the current page load). By removing this, we only rely on the `isVisible: shouldShowActivationModal( state, installingThemeId )` props, which takes the theme to activate into consideration.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
