### PR TITLE
Ensure property access is executed on defined object

### DIFF
--- a/client/components/data/query-domain-owner-username/index.ts
+++ b/client/components/data/query-domain-owner-username/index.ts
@@ -47,7 +47,7 @@ export function useDomainOwnerUserName(
 	//Due to Jetpack sites overriding the user.ID with a completely different thing,
 	//when Jetpack overrides this property, the original WordPress.com user Id
 	//ends stored as user.linked_user_ID, so in those cases, that's the ID we have to use.
-	const ownerUser = teams.users?.find(
+	const ownerUser = teams?.users?.find(
 		( user ) => ( user.linked_user_ID ?? user.ID ) === domainSubscription?.userId
 	);
 

--- a/client/components/data/query-email-owner-username/index.ts
+++ b/client/components/data/query-email-owner-username/index.ts
@@ -44,7 +44,7 @@ export function useEmailOwnerUserName(
 	}
 
 	const teams = data as InfiniteData< UsersData > & UsersData;
-	const ownerUser = teams.users?.find(
+	const ownerUser = teams?.users?.find(
 		( user ) => ( user.linked_user_ID ?? user.ID ) === emailSubscription?.userId
 	);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This proposes a fix for the error surfaced [here](p1688891279048109-slack-C04U5A26MJB) : `Cannot read properties of undefined (reading 'users')`

Related to #68158

## Proposed Changes

* Property access on data retrieved from `useUsersQuery()` is checked if undefined.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* I cannot reproduce this issue, so this is an adoption of the fix proposed by `GPT` in Slack.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?