### PR TITLE
Bugfix: Footer branding to be supported in multiple languages 

### DIFF
--- a/packages/wpcom-template-parts/src/utils.tsx
+++ b/packages/wpcom-template-parts/src/utils.tsx
@@ -3,57 +3,57 @@ import { translate as translateMethod } from 'i18n-calypso';
 export const getAutomatticBrandingNoun = ( translate: typeof translateMethod ) => {
 	const automatticRoger = [
 		translate( 'An {{Automattic/}} brainchild', {
-			args: { Automattic: <AutomatticBrand /> },
+			components: { Automattic: <AutomatticBrand /> },
 			comment:
 				'Branding to be shown on the Footer of the page, Automattic\'s variable will always contains the word "Automattic"',
 		} ),
 		translate( 'An {{Automattic/}} contraption', {
-			args: { Automattic: <AutomatticBrand /> },
+			components: { Automattic: <AutomatticBrand /> },
 			comment:
 				'Branding to be shown on the Footer of the page, Automattic\'s variable will always contains the word "Automattic"',
 		} ),
 		translate( 'An {{Automattic/}} creation', {
-			args: { Automattic: <AutomatticBrand /> },
+			components: { Automattic: <AutomatticBrand /> },
 			comment:
 				'Branding to be shown on the Footer of the page, Automattic\'s variable will always contains the word "Automattic"',
 		} ),
 		translate( 'An {{Automattic/}} experiment', {
-			args: { Automattic: <AutomatticBrand /> },
+			components: { Automattic: <AutomatticBrand /> },
 			comment:
 				'Branding to be shown on the Footer of the page, Automattic\'s variable will always contains the word "Automattic"',
 		} ),
 		translate( 'An {{Automattic/}} invention', {
-			args: { Automattic: <AutomatticBrand /> },
+			components: { Automattic: <AutomatticBrand /> },
 			comment:
 				'Branding to be shown on the Footer of the page, Automattic\'s variable will always contains the word "Automattic"',
 		} ),
 		translate( 'An {{Automattic/}} joint', {
-			args: { Automattic: <AutomatticBrand /> },
+			components: { Automattic: <AutomatticBrand /> },
 			comment:
 				'Branding to be shown on the Footer of the page, Automattic\'s variable will always contains the word "Automattic"',
 		} ),
 		translate( 'An {{Automattic/}} medley', {
-			args: { Automattic: <AutomatticBrand /> },
+			components: { Automattic: <AutomatticBrand /> },
 			comment:
 				'Branding to be shown on the Footer of the page, Automattic\'s variable will always contains the word "Automattic"',
 		} ),
 		translate( 'An {{Automattic/}} opus', {
-			args: { Automattic: <AutomatticBrand /> },
+			components: { Automattic: <AutomatticBrand /> },
 			comment:
 				'Branding to be shown on the Footer of the page, Automattic\'s variable will always contains the word "Automattic"',
 		} ),
 		translate( 'An {{Automattic/}} production', {
-			args: { Automattic: <AutomatticBrand /> },
+			components: { Automattic: <AutomatticBrand /> },
 			comment:
 				'Branding to be shown on the Footer of the page, Automattic\'s variable will always contains the word "Automattic"',
 		} ),
 		translate( 'An {{Automattic/}} ruckus', {
-			args: { Automattic: <AutomatticBrand /> },
+			components: { Automattic: <AutomatticBrand /> },
 			comment:
 				'Branding to be shown on the Footer of the page, Automattic\'s variable will always contains the word "Automattic"',
 		} ),
 		translate( 'An {{Automattic/}} thingamajig', {
-			args: { Automattic: <AutomatticBrand /> },
+			components: { Automattic: <AutomatticBrand /> },
 			comment:
 				'Branding to be shown on the Footer of the page, Automattic\'s variable will always contains the word "Automattic"',
 		} ),


### PR DESCRIPTION

Related to #78916

## Proposed Changes

Update property from args to components as the branding will use an SVG.

## Testing Instructions
* On a logged-out tab
* Go to a page that displays the footer. Ex: /theme/miniature
* Change the language (Ex: `Español`) and confirm the name Automattic is not being translated


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
