### PR TITLE
Subscription management: Handle empty search term

### DIFF
--- a/client/reader/site-subscriptions-manager/not-found-site-subscriptions.tsx
+++ b/client/reader/site-subscriptions-manager/not-found-site-subscriptions.tsx
@@ -8,14 +8,17 @@ const NotFoundSiteSubscriptions = () => {
 
 	return (
 		<div className="not-found-site-subscriptions">
-			{
-				/* translators: the string is the exact text that the user entered into the search input in site subscriptions manager in Reader */
-				translate( 'No results found for “%s”.', {
-					args: searchTerm,
-					comment:
-						"When users type something into the search field of their site subscriptions manager in Reader, they'll see this message if their search doesn't find any of the websites they're currently subscribed to.",
-				} )
-			}{ ' ' }
+			{ searchTerm
+				? /* translators: the string is the exact text that the user entered into the search input in site subscriptions manager in Reader */
+				  translate( 'No results found for “%s”.', {
+						args: searchTerm,
+						comment:
+							"When users type something into the search field of their site subscriptions manager in Reader, they'll see this message if their search doesn't find any of the websites they're currently subscribed to.",
+				  } )
+				: translate( 'No results found.', {
+						comment:
+							"When users type something into the search field of their site subscriptions manager in Reader, they'll see this message if their search doesn't find any of the websites they're currently subscribed to.",
+				  } ) }{ ' ' }
 			{ ( readFeedSearch?.feedItems.length ?? 0 ) > 0 &&
 				translate( 'Here are some other sites that match your search.' ) }
 		</div>

--- a/client/reader/site-subscriptions-manager/not-found-site-subscriptions.tsx
+++ b/client/reader/site-subscriptions-manager/not-found-site-subscriptions.tsx
@@ -8,7 +8,7 @@ const NotFoundSiteSubscriptions = () => {
 
 	return (
 		<div className="not-found-site-subscriptions">
-			{ searchTerm
+			{ searchTerm && searchTerm.length
 				? /* translators: the string is the exact text that the user entered into the search input in site subscriptions manager in Reader */
 				  translate( 'No results found for “%s”.', {
 						args: searchTerm,


### PR DESCRIPTION
Related to p1689604140144489/1689582265.438429-slack-C02TCEHP3HA

## Proposed Changes
The existing return block of the 'not-found-site-subscriptions' component was missing an edge case for an empty search term. Ensured that a generic 'No results found.' message would be displayed when no search term is input, providing better feedback in the UI. This change makes the search behavior more predictable and user friendly.

## Testing Instructions


1. Apply this PR
2. Visit http://calypso.localhost:3000/read/subscriptions
3. Make sure you have no paid subscriptions
4. Change the filter to "Paid"
5. You should see "No results found."

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?