### PR TITLE
Jetpack Agency Dashboard - Presales Chat: modify/ignore chat staffing check

### DIFF
--- a/client/components/jetpack/portal-nav/index.tsx
+++ b/client/components/jetpack/portal-nav/index.tsx
@@ -56,7 +56,8 @@ export default function PortalNav( { className = '' }: Props ) {
 
 	usePresalesChat(
 		'jpAgency',
-		hasJetpackPartnerAccess && isSectionNameEnabled( 'jetpack-cloud-partner-portal' )
+		hasJetpackPartnerAccess && isSectionNameEnabled( 'jetpack-cloud-partner-portal' ),
+		true
 	);
 
 	// Route belongs dashboard when it starts with /dashboard or /plugins and no site is selected(multi-site view).

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -34,14 +34,21 @@ function getGroupName( keyType: KeyType ) {
 	}
 }
 
-export function usePresalesChat( keyType: KeyType, enabled = true ) {
+export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabilityCheck = false ) {
 	const isEnglishLocale = useIsEnglishLocale();
 	const isEligibleForPresalesChat = enabled && isEnglishLocale;
 
 	const group = getGroupName( keyType );
-	const { data: chatAvailability, isInitialLoading: isLoadingAvailability } =
-		useMessagingAvailability( group, isEligibleForPresalesChat );
-	const isPresalesChatAvailable = Boolean( chatAvailability?.is_available );
+	const { data: chatAvailability, isInitialLoading } = useMessagingAvailability(
+		group,
+		isEligibleForPresalesChat
+	);
+
+	//some types of chat should always show the widget, even if the chat is not available
+	const isPresalesChatAvailable = skipAvailabilityCheck
+		? true
+		: Boolean( chatAvailability?.is_available );
+	const isLoadingAvailability = skipAvailabilityCheck ? false : isInitialLoading;
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const zendeskKeyName = getConfigName( keyType );

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -39,16 +39,13 @@ export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabil
 	const isEligibleForPresalesChat = enabled && isEnglishLocale;
 
 	const group = getGroupName( keyType );
-	const { data: chatAvailability, isInitialLoading } = useMessagingAvailability(
-		group,
-		isEligibleForPresalesChat
-	);
 
 	//some types of chat should always show the widget, even if the chat is not available
-	const isPresalesChatAvailable = skipAvailabilityCheck
-		? true
-		: Boolean( chatAvailability?.is_available );
-	const isLoadingAvailability = skipAvailabilityCheck ? false : isInitialLoading;
+	const { data: chatAvailability, isInitialLoading: isLoadingAvailability } =
+		useMessagingAvailability( group, isEligibleForPresalesChat && ! skipAvailabilityCheck );
+
+	const isPresalesChatAvailable =
+		skipAvailabilityCheck || Boolean( chatAvailability?.is_available );
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const zendeskKeyName = getConfigName( keyType );

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -40,7 +40,6 @@ export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabil
 
 	const group = getGroupName( keyType );
 
-	//some types of chat should always show the widget, even if the chat is not available
 	const { data: chatAvailability, isInitialLoading: isLoadingAvailability } =
 		useMessagingAvailability( group, isEligibleForPresalesChat && ! skipAvailabilityCheck );
 


### PR DESCRIPTION
Related to # 1202619025189113-as-1204999336352649/f

## Proposed Changes

* JPOP has requested that the chat widget on the agency dashboard always shows regardless of staffing
* The agency dashboard, like other areas that implement chat use a shared library in Calypso which has the availability check baked in.
* This PR adds a third argument to the usePresalesChat function called skipAvailabilityCheck
* If that argument is true then the function will set chatAvailability to true regardless of the reality
* The argument has a default value of false so there will be no impact on other implementations of chat.

## Testing Instructions

Prerequisites

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud Live link (below) or pull this PR and run Jetpack Cloud in your local environment
* The tricky part, to test this, chat will need to be unstaffed.  Typically there is only one HE working in this queue at any given time.  You can ask in the #jpop-presales channel for the HE to go unavailable while you test
* When chat is unstaffed, visit the dashboard by appending /dashboard to the jetpack cloud link (you may already default to this address)
* You will see the chat widget appear in the lower right as always: 
<img width="672" alt="Screenshot 2023-07-17 at 10 53 04 AM" src="https://github.com/Automattic/wp-calypso/assets/12895386/c1a2955a-e026-4b1b-afac-d7bbda8f7ab4">

* Change the page to /pricing 
* You should NOT see the chat widget if chat is unstaffed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204999336352649