### PR TITLE
Subscription Management: Fix the default site icon style

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { SubscriptionManager } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { memo, useMemo } from 'react';
@@ -45,13 +44,7 @@ const CommentRow = ( {
 				</span>
 				<a href={ site_url } rel="noreferrer noopener" className="title-box" target="_blank">
 					<span className="title-box" role="cell">
-						<SiteIcon
-							iconUrl={ site_icon }
-							/* eslint-disable wpcalypso/jsx-gridicon-size */
-							defaultIcon={ <Gridicon key="globe-icon" icon="globe" size={ 40 } /> }
-							size={ 40 }
-							alt={ site_title }
-						/>
+						<SiteIcon iconUrl={ site_icon } size={ 40 } alt={ site_title } />
 						<span className="title-column">
 							<span className="name">
 								{ site_title }

--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -85,14 +85,6 @@
 
 			.site-icon {
 				max-width: 40px;
-
-				&.is-blank {
-					background-color: transparent;
-
-					.gridicon {
-						fill: var(--color-neutral-100);
-					}
-				}
 			}
 
 			.title-column {

--- a/client/landing/subscriptions/components/pending-list/pending-post-list/pending-post-row.tsx
+++ b/client/landing/subscriptions/components/pending-list/pending-post-list/pending-post-row.tsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { useMemo } from 'react';
 import { SiteIcon } from 'calypso/blocks/site-icon';
@@ -35,13 +34,7 @@ export default function PendingPostRow( {
 				</span>
 				<a href={ site_url } rel="noreferrer noopener" className="title-box" target="_blank">
 					<span className="title-box" role="cell">
-						<SiteIcon
-							iconUrl={ site_icon }
-							/* eslint-disable wpcalypso/jsx-gridicon-size */
-							defaultIcon={ <Gridicon key="globe-icon" icon="globe" size={ 40 } /> }
-							size={ 40 }
-							alt={ site_title }
-						/>
+						<SiteIcon iconUrl={ site_icon } size={ 40 } alt={ site_title } />
 						<span className="title-column">
 							<span className="name">{ site_title }</span>
 							<span className="url">{ hostname }</span>

--- a/client/landing/subscriptions/components/pending-list/pending-site-list/pending-site-row.tsx
+++ b/client/landing/subscriptions/components/pending-list/pending-site-list/pending-site-row.tsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { SubscriptionManager, Reader } from '@automattic/data-stores';
 import { useMemo } from 'react';
 import { SiteIcon } from 'calypso/blocks/site-icon';
@@ -24,13 +23,7 @@ export default function PendingSiteRow( {
 		<li className="row" role="row">
 			<a href={ site_url } rel="noreferrer noopener" className="title-box" target="_blank">
 				<span className="title-box" role="cell">
-					<SiteIcon
-						iconUrl={ site_icon }
-						/* eslint-disable wpcalypso/jsx-gridicon-size */
-						defaultIcon={ <Gridicon key="globe-icon" icon="globe" size={ 40 } /> }
-						size={ 40 }
-						alt={ site_title }
-					/>
+					<SiteIcon iconUrl={ site_icon } size={ 40 } alt={ site_title } />
 					<span className="title-column">
 						<span className="name">{ site_title }</span>
 						<span className="url">{ hostname }</span>

--- a/client/landing/subscriptions/components/pending-list/styles.scss
+++ b/client/landing/subscriptions/components/pending-list/styles.scss
@@ -30,14 +30,6 @@
 
 			.site-icon {
 				max-width: 40px;
-
-				&.is-blank {
-					background-color: transparent;
-
-					.gridicon {
-						fill: var(--color-neutral-100);
-					}
-				}
 			}
 
 			.title-column {

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-details.tsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { SubscriptionManager, Reader } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
@@ -194,13 +193,7 @@ const SiteSubscriptionDetails = ( {
 	return (
 		<>
 			<header className="site-subscription-page__header site-subscription-page__centered-content">
-				<SiteIcon
-					iconUrl={ siteIcon }
-					/* eslint-disable wpcalypso/jsx-gridicon-size */
-					defaultIcon={ <Gridicon key="globe-icon" icon="globe" size={ 116 } /> }
-					size={ 116 }
-					alt={ name }
-				/>
+				<SiteIcon iconUrl={ siteIcon } size={ 116 } alt={ name } />
 				<FormattedHeader brandFont headerText={ name } subHeaderText={ subHeaderText } />
 			</header>
 

--- a/client/landing/subscriptions/components/site-subscription-page/styles.scss
+++ b/client/landing/subscriptions/components/site-subscription-page/styles.scss
@@ -37,16 +37,6 @@
 		flex-direction: column;
 		align-items: center;
 
-		.site-icon {
-			&.is-blank {
-				background-color: transparent;
-
-				.gridicon {
-					fill: var(--color-neutral-100);
-				}
-			}
-		}
-
 		.formatted-header {
 			&__title {
 				font-weight: 600;

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
@@ -199,13 +199,7 @@ const SiteRow = ( {
 						recordSiteIconClicked( { blog_id, feed_id, source: SOURCE_SUBSCRIPTIONS_SITE_LIST } );
 					} }
 				>
-					<SiteIcon
-						iconUrl={ site_icon }
-						/* eslint-disable wpcalypso/jsx-gridicon-size */
-						defaultIcon={ <Gridicon key="globe-icon" icon="globe" size={ 40 } /> }
-						size={ 40 }
-						alt={ name }
-					/>
+					<SiteIcon iconUrl={ site_icon } size={ 40 } alt={ name } />
 				</Link>
 				<span className="title-column">
 					<Link

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -98,16 +98,6 @@
 				fill: $studio-gray-50;
 			}
 		}
-
-		.site-icon {
-			&.is-blank {
-				background-color: transparent;
-
-				.gridicon {
-					fill: var(--color-neutral-100);
-				}
-			}
-		}
 	}
 
 	@media (max-width: $break-xlarge) {


### PR DESCRIPTION
## Proposed Changes

* fix the site icon styling in the Subscription Management portal 

| Before | After |
|--------|--------|
| ![Markup on 2023-07-17 at 17:30:04](https://github.com/Automattic/wp-calypso/assets/25105483/034f2f71-ec69-47f6-97b2-6ec6b344a42e) | ![Markup on 2023-07-17 at 17:29:10](https://github.com/Automattic/wp-calypso/assets/25105483/1f31305e-d349-4644-afad-5e4b2eec1948) | 

Context: p1689340215804119-slack-C02TCEHP3HA

## Testing Instructions

1. Check out the PR branch and build the app.
2. Make sure your WordPress.com and External users are subscribed to some sites / comments.
3. With the WordPress.com user navigate to http://calypso.localhost:3000/read/subscriptions and check sites without the custom site icon. The correct default gray site icon should be displayed.
4. With the External user navigate to http://calypso.localhost:3000/subscriptions/sites and http://calypso.localhost:3000/subscriptions/comments and confirm all default site icons are displayed correctly there as well. You can review the Pending tab (http://calypso.localhost:3000/subscriptions/pending) as well.

ℹ️ To test with the External user on local Calypso, the "subkey cookie dance" is necessary. 🙂 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?