### PR TITLE
Added focus outline to ellipsis menu in Subscribers page

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-popover/subscriber-popover.tsx
+++ b/client/my-sites/subscribers/components/subscriber-popover/subscriber-popover.tsx
@@ -31,7 +31,7 @@ const SubscriberPopover = ( {
 		<div className="subscriber-popover__container">
 			<button
 				aria-label="Open subscriber menu"
-				className={ classNames( 'subscriber-popover__toggle', {
+				className={ classNames( 'components-button subscriber-popover__toggle', {
 					'is-popover-visible': isVisible,
 				} ) }
 				onClick={ onToggle }


### PR DESCRIPTION
## Proposed Changes

This PR adds the outline when the ellipsis is focused on the Subscriber page:
<img width="397" alt="Screenshot 2023-07-17 at 18 18 26" src="https://github.com/Automattic/wp-calypso/assets/3832570/bb6b8eb0-c626-41e8-8744-e18329d87f98">

## Testing Instructions

1. Apply this PR and start the application.
2. Go to `http://calypso.localhost:3000/subscribers/[your domain]`.
3. Click on one of the ellipsis menus and click it again so the menu is actually closed.
4. Navigate between them with the tab key. They should be outlined in blue.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
