### PR TITLE
/subscriptions/sites/: Clicking site title for non-wpcom site subscriptions should open the feed's Reader page

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
@@ -208,25 +208,46 @@ const SiteRow = ( {
 					/>
 				</Link>
 				<span className="title-column">
-					<Link
-						className="title-name"
-						href={ siteTitleUrl }
-						onClick={ () => {
-							recordSiteTitleClicked( {
-								blog_id,
-								feed_id,
-								source: SOURCE_SUBSCRIPTIONS_SITE_LIST,
-							} );
-						} }
-					>
-						{ name }
-						{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
-						{ !! is_paid_subscription && (
-							<span className="paid-label">
-								{ translate( 'Paid', { context: 'Label for a paid subscription plan' } ) }
-							</span>
-						) }
-					</Link>
+					{
+						// When clicking on a title of non-wpcom site subscription in the subscriptions portal, we want to open the site in a new tab
+						! Reader.isValidId( blog_id ) && isSubscriptionsPortal ? (
+							<ExternalLink
+								className="title-name"
+								href={ url }
+								onClick={ () => {
+									recordSiteTitleClicked( {
+										blog_id: null,
+										feed_id,
+										source: SOURCE_SUBSCRIPTIONS_SITE_LIST,
+									} );
+								} }
+								rel="noreferrer noopener"
+								target="_blank"
+							>
+								{ name }
+							</ExternalLink>
+						) : (
+							<Link
+								className="title-name"
+								href={ siteTitleUrl }
+								onClick={ () => {
+									recordSiteTitleClicked( {
+										blog_id,
+										feed_id,
+										source: SOURCE_SUBSCRIPTIONS_SITE_LIST,
+									} );
+								} }
+							>
+								{ name }
+								{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
+								{ !! is_paid_subscription && (
+									<span className="paid-label">
+										{ translate( 'Paid', { context: 'Label for a paid subscription plan' } ) }
+									</span>
+								) }
+							</Link>
+						)
+					}
 					<ExternalLink
 						className="title-url"
 						{ ...( url && { href: url } ) }

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
@@ -153,6 +153,10 @@ const SiteRow = ( {
 		}
 
 		if ( isSubscriptionsPortal ) {
+			if ( ! Reader.isValidId( blog_id ) ) {
+				// If it is a non-wpcom feed item, we want to open the reader's page for that feed
+				return `/read/feeds/${ feed_id }`;
+			}
 			return `/subscriptions/site/${ blog_id }`;
 		}
 	}, [ blog_id, feed_id, isReaderPortal, isSubscriptionsPortal ] );
@@ -208,46 +212,25 @@ const SiteRow = ( {
 					/>
 				</Link>
 				<span className="title-column">
-					{
-						// When clicking on a title of non-wpcom site subscription in the subscriptions portal, we want to open the site in a new tab
-						! Reader.isValidId( blog_id ) && isSubscriptionsPortal ? (
-							<ExternalLink
-								className="title-name"
-								href={ url }
-								onClick={ () => {
-									recordSiteTitleClicked( {
-										blog_id: null,
-										feed_id,
-										source: SOURCE_SUBSCRIPTIONS_SITE_LIST,
-									} );
-								} }
-								rel="noreferrer noopener"
-								target="_blank"
-							>
-								{ name }
-							</ExternalLink>
-						) : (
-							<Link
-								className="title-name"
-								href={ siteTitleUrl }
-								onClick={ () => {
-									recordSiteTitleClicked( {
-										blog_id,
-										feed_id,
-										source: SOURCE_SUBSCRIPTIONS_SITE_LIST,
-									} );
-								} }
-							>
-								{ name }
-								{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
-								{ !! is_paid_subscription && (
-									<span className="paid-label">
-										{ translate( 'Paid', { context: 'Label for a paid subscription plan' } ) }
-									</span>
-								) }
-							</Link>
-						)
-					}
+					<Link
+						className="title-name"
+						href={ siteTitleUrl }
+						onClick={ () => {
+							recordSiteTitleClicked( {
+								blog_id,
+								feed_id,
+								source: SOURCE_SUBSCRIPTIONS_SITE_LIST,
+							} );
+						} }
+					>
+						{ name }
+						{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
+						{ !! is_paid_subscription && (
+							<span className="paid-label">
+								{ translate( 'Paid', { context: 'Label for a paid subscription plan' } ) }
+							</span>
+						) }
+					</Link>
 					<ExternalLink
 						className="title-url"
 						{ ...( url && { href: url } ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* In the subscriptions portal, clicking on a title of a non-wpcom subscription should redirect the user to the feed's Reader page. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/subscriptions/sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
