### PR TITLE
Subscriptions Management: Hide site settings for external site subscriptions

### DIFF
--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -24,6 +24,7 @@ type SiteSettingsProps = {
 	emailMeNewComments: boolean;
 	onEmailMeNewCommentsChange: ( value: boolean ) => void;
 	updatingEmailMeNewComments: boolean;
+	isWpComSite?: boolean;
 };
 
 const SiteSettings = ( {
@@ -84,6 +85,7 @@ type SiteSettingsPopoverProps = SiteSettingsProps & {
 export const SiteSettingsPopover = ( {
 	onUnsubscribe,
 	unsubscribing,
+	isWpComSite = true,
 	...props
 }: SiteSettingsPopoverProps ) => {
 	const translate = useTranslate();
@@ -91,9 +93,12 @@ export const SiteSettingsPopover = ( {
 		<SubscriptionsEllipsisMenu popoverClassName="site-settings-popover">
 			{ ( close: () => void ) => (
 				<>
-					<SiteSettings { ...props } />
-
-					<hr className="subscriptions__separator" />
+					{ isWpComSite && (
+						<>
+							<SiteSettings { ...props } />
+							<hr className="subscriptions__separator" />
+						</>
+					) }
 
 					<Button
 						className={ classNames( 'unsubscribe-button', { 'is-loading': unsubscribing } ) }

--- a/client/landing/subscriptions/components/settings/site-settings/styles.scss
+++ b/client/landing/subscriptions/components/settings/site-settings/styles.scss
@@ -9,9 +9,12 @@
 		}
 	}
 
-	.unsubscribe-button.components-button.has-icon,
-	.resubscribe-button.components-button.has-icon {
-		margin-top: 24px;
+	.subscriptions__separator {
+		margin-bottom: 24px;
+	}
+
+	.unsubscribe-button {
+		display: flex;
+		width: 100%;
 	}
 }
-

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
+import { isValidId } from '@automattic/data-stores/src/reader';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useRef } from 'react';
@@ -319,6 +320,7 @@ const SiteRow = ( {
 						);
 					} }
 					unsubscribing={ unsubscribing }
+					isWpComSite={ isValidId( blog_id ) }
 				/>
 			</span>
 		</HStack>


### PR DESCRIPTION
## Proposed Changes

* Hide site settings for external site subscriptions. 

## Testing Instructions

* Apply this PR to your local end
* Go to http://calypso.localhost:3000/read/subscriptions
* Subscribe to a RSS feed (by search for the rss url and clicking on Subscribe)
  * Example: http://rss.cnn.com/rss/edition.rss
* You should see only the Unsubscribe button for external sites
* Make regression tests for WPCOM site subscriptions

<img width="528" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/c7676fb2-41f5-4412-b878-37cfc9e9ae2d">

--

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
