### PR TITLE
Subscription Management: Fix chevron margin

### DIFF
--- a/client/landing/subscriptions/styles/list-actions-bar.scss
+++ b/client/landing/subscriptions/styles/list-actions-bar.scss
@@ -28,6 +28,10 @@
 		.select-dropdown__item.is-selected {
 			background-color: var(--color-primary);
 		}
+
+		.gridicon {
+			margin-left: 10px;
+		}
 	}
 
 	.subscription-manager-sort-controls {


### PR DESCRIPTION
## Proposed Changes

* fixes chevron margin on the View filter drop-down. It will now match to the same margin as similar chevron on the Subscribers page has:

![Markup on 2023-07-31 at 09:53:18](https://github.com/Automattic/wp-calypso/assets/25105483/0fe17ef0-a1ba-41cc-8090-9760cda234b0)

| Before | After |
|--------|--------|
| ![Markup on 2023-07-31 at 09:49:52](https://github.com/Automattic/wp-calypso/assets/25105483/3d6d47c9-7f79-48c9-9b00-5817a9457afb) | ![Markup on 2023-07-31 at 09:50:22](https://github.com/Automattic/wp-calypso/assets/25105483/8c8332e6-17ed-4260-9b37-47b3bcebe545) | 

Context: p1689604465297239/1689582265.438429-slack-C02TCEHP3HA

## Testing Instructions

1. Navigate to http://calypso.localhost:3000/read/subscriptions and review the chevron margin 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?