### PR TITLE
Plugins: Put category and search result breadcrumb always on the 2nd level

### DIFF
--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -109,26 +109,28 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 	const { localizePath } = useLocalizedPlugins();
 
 	const setBreadcrumbs = ( breadcrumbs = [] ) => {
+		const pluginsBreadcrumb = {
+			label: translate( 'Plugins' ),
+			href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
+			id: 'plugins',
+			helpBubble: translate(
+				'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
+					},
+				}
+			),
+		};
+
 		if ( breadcrumbs?.length === 0 || ( ! category && ! search ) ) {
 			dispatch( resetBreadcrumbs() );
-			dispatch(
-				appendBreadcrumb( {
-					label: translate( 'Plugins' ),
-					href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
-					id: 'plugins',
-					helpBubble: translate(
-						'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-						{
-							components: {
-								learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
-							},
-						}
-					),
-				} )
-			);
+			dispatch( appendBreadcrumb( pluginsBreadcrumb ) );
 		}
 
 		if ( category ) {
+			resetBreadcrumbs();
+			dispatch( appendBreadcrumb( pluginsBreadcrumb ) );
 			dispatch(
 				appendBreadcrumb( {
 					label: categoryName,
@@ -139,6 +141,8 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 		}
 
 		if ( search ) {
+			dispatch( resetBreadcrumbs() );
+			dispatch( appendBreadcrumb( pluginsBreadcrumb ) );
 			dispatch(
 				appendBreadcrumb( {
 					label: translate( 'Search Results' ),

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -7,7 +7,6 @@ import { setQueryArgs } from 'calypso/lib/query-args';
 import scrollTo from 'calypso/lib/scroll-to';
 import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { resetBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { useTermsSuggestions } from './useTermsSuggestions';
 import './style.scss';
@@ -29,11 +28,6 @@ const SearchBox = ( {
 
 	const pageToSearch = useCallback(
 		( search ) => {
-			const isCategoryPage = window.location.href.includes( '/plugins/browse/' );
-			if ( isCategoryPage ) {
-				dispatch( resetBreadcrumbs() );
-			}
-
 			page.show( localizePath( `/plugins/${ selectedSite?.slug || '' }` ) ); // Ensures location.href is on the main Plugins page before setQueryArgs uses it to construct the redirect.
 			setQueryArgs( '' !== search ? { s: search } : {} );
 
@@ -48,7 +42,7 @@ const SearchBox = ( {
 				} );
 			}
 		},
-		[ searchBoxRef, categoriesRef, dispatch, selectedSite, localizePath ]
+		[ searchBoxRef, categoriesRef, selectedSite, localizePath ]
 	);
 
 	const recordSearchEvent = ( eventName ) =>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/79469

## Proposed Changes

Reset breadcrumbs before showing the category or search breadcrumbs, this will guarantee they will always be on the 2nd level, after the `Plugins` one, the base for this page.

Before this change, those items were being appended in front of the ones already there, showing them in the 3rd position sometimes.

Let me know if there are cases where this is not the expected behavior, which means a case where a parent (not the `Plugins` one) is expected before the category or search breadcrumbs.

## Testing Instructions
* Go to the Plugins page (`/plugins`)
* Search for a term on the search input
* Check if the breadcrumbs will have the `Search Results` on the 2nd position
* Click on a category
* Check if the breadcrumbs will have the category breadcrumb on the 2nd position, the search one should be removed
* Search for another term on the search input
* Check if the breadcrumbs will have the `Search Results` on the 2nd position, the category one should be removed

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-07-17 at 14 11 23](https://github.com/Automattic/wp-calypso/assets/5039531/86c2b577-02da-4373-b345-5a5437b3b9ba)|![CleanShot 2023-07-17 at 14 12 56](https://github.com/Automattic/wp-calypso/assets/5039531/f681d11a-a154-4b8b-a07f-6bf19785082c)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
