### PR TITLE
Earn stats: Created initial structure of earn/stats inside /stats/earn

### DIFF
--- a/client/blocks/stats-navigation/constants.ts
+++ b/client/blocks/stats-navigation/constants.ts
@@ -43,6 +43,11 @@ const insights = {
 	path: '/stats/insights',
 	showIntervals: false,
 } as NavItem;
+const earn = {
+	label: translate( 'Earn' ),
+	path: '/stats/earn',
+	showIntervals: false,
+} as NavItem;
 // TODO: Consider adding subscriber counts into this nav item in the future.
 // See client/blocks/subscribers-count/index.jsx.
 const subscribers = {
@@ -78,6 +83,7 @@ export interface NavItems {
 const assembleNavItems = () => {
 	const navItems = {
 		traffic,
+		earn,
 		insights,
 		subscribers,
 		store,

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -254,6 +254,20 @@ export function insights( context, next ) {
 	next();
 }
 
+export function earn( context, next ) {
+	// moment and rangeOfPeriod format needed for summary page link for email mdule
+	const date = moment().locale( 'en' );
+
+	context.primary = (
+		<AsyncLoad
+			require="calypso/my-sites/stats/stats-earn"
+			placeholder={ PageLoading }
+			period={ rangeOfPeriod( 'week', date ) }
+		/>
+	);
+	next();
+}
+
 export function subscribers( context, next ) {
 	const givenSiteId = context.params.site;
 	const filters = getSiteFilters( givenSiteId );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -10,6 +10,7 @@ import {
 	site,
 	summary,
 	wordAds,
+	earn,
 	redirectToActivity,
 	redirectToDefaultModulePage,
 	redirectToDefaultSitePage,
@@ -60,6 +61,9 @@ export default function () {
 
 	// Stat Insights Page
 	statsPage( '/stats/insights/:site', insights );
+
+	// Stat Earn Page
+	statsPage( '/stats/earn/:site', earn );
 
 	// Stat Subscribers Page (do not confuse with people/subscribers/)
 	statsPage( '/stats/subscribers/:site', subscribers );

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -26,7 +26,8 @@ $sidebar-appearance-break-point: 783px;
 	> .stats__post-detail-highlights-section,
 	> .stats__post-detail-table-section,
 	> .stats__gmb-location-wrapper,
-	> .subscribers-page {
+	> .subscribers-page,
+	> .earn-page {
 		padding-top: $vertical-margin;
 		padding-bottom: $vertical-margin;
 	}

--- a/client/my-sites/stats/stats-earn/index.tsx
+++ b/client/my-sites/stats/stats-earn/index.tsx
@@ -1,0 +1,112 @@
+import config from '@automattic/calypso-config';
+import { Card } from '@automattic/components';
+import { formatCurrency } from '@automattic/format-currency';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import DomainTip from 'calypso/blocks/domain-tip';
+import StatsNavigation from 'calypso/blocks/stats-navigation';
+import DocumentHead from 'calypso/components/data/document-head';
+import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
+import JetpackColophon from 'calypso/components/jetpack-colophon';
+import Main from 'calypso/components/main';
+import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import CommissionFees from 'calypso/my-sites/earn/components/commission-fees';
+import { useSelector } from 'calypso/state';
+import { getEarningsWithDefaultsForSiteId } from 'calypso/state/memberships/earnings/selectors';
+import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import StatsPageHeader from '../stats-page-header';
+import PageViewTracker from '../stats-page-view-tracker';
+
+const StatsEarnPage = () => {
+	const translate = useTranslate();
+	// Use hooks for Redux pulls.
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	// Run-time configuration.
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+
+	const statsModuleListClass = classNames(
+		'stats__module-list stats__module--unified',
+		{
+			'is-odyssey-stats': isOdysseyStats,
+			'is-jetpack': isJetpack,
+		},
+		'earn-page'
+	);
+
+	const earnings = useSelector( ( state ) => getEarningsWithDefaultsForSiteId( state, siteId ) );
+
+	// Track the last viewed tab.
+	// Necessary to properly configure the fixed navigation headers.
+	// sessionStorage.setItem( 'jp-stats-last-tab', 'subscribers' );
+
+	return (
+		<Main fullWidthLayout>
+			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
+			<PageViewTracker path="/stats/earn/:site" title="Stats > Earn" />
+			<div className="stats">
+				<StatsPageHeader
+					page="subscribers"
+					subHeaderText={ translate( "View your site's performance and learn from trends." ) }
+				/>
+				{ siteId && (
+					<div>
+						<DomainTip
+							siteId={ siteId }
+							event="stats_subscribers_domain"
+							vendor={ getSuggestionsVendor() }
+						/>
+					</div>
+				) }
+				<StatsNavigation selectedItem="earn" siteId={ siteId } slug={ siteSlug } />
+				<QueryMembershipsEarnings siteId={ siteId } />
+
+				<div className={ statsModuleListClass }>
+					<h3 className="highlight-cards-heading">{ translate( 'Overview' ) }</h3>
+
+					<div className="highlight-cards-list">
+						<Card className="highlight-card">
+							<h4 className="highlight-card-heading">
+								{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
+							</h4>
+							<div className="highlight-card-info-item-list">
+								{ formatCurrency( earnings.total, earnings.currency ) }
+							</div>
+						</Card>
+						<Card className="highlight-card">
+							<h4 className="highlight-card-heading">
+								{ translate( 'Last 30 days', { context: 'Sum of earnings over last 30 days' } ) }
+							</h4>
+							<div className="highlight-card-info-item-list">
+								{ formatCurrency( earnings.last_month, earnings.currency ) }
+							</div>
+						</Card>
+						<Card className="highlight-card">
+							<h4 className="highlight-card-heading">
+								{ translate( 'Next month forecast', {
+									context: 'Forecast for the subscriptions due in the next 30 days',
+								} ) }
+							</h4>
+							<div className="highlight-card-info-item-list">
+								{ formatCurrency( earnings.forecast, earnings.currency ) }
+							</div>
+						</Card>
+					</div>
+				</div>
+
+				<CommissionFees
+					commission={ earnings.commission }
+					iconSize={ 12 }
+					siteSlug={ siteSlug }
+					className="memberships__earnings-breakdown-notes"
+				/>
+
+				<JetpackColophon />
+			</div>
+		</Main>
+	);
+};
+
+export default StatsEarnPage;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 3005-gh-Automattic/dotcom-forge

## Proposed Changes

It's looking like this currently. It works fine for Simple | Atomic | Self-hosted jetpack connected sites (inside WP.com):

<img width="1504" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/523cdabf-9366-4c77-92d8-77e0a8728601">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?