### PR TITLE
Add-Ons: Move Jetpack AI Assistant add-on card to production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -44,7 +44,7 @@
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/unified": true,
-		"jetpack/ai-assistant-request-limit": false,
+		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/production.json
+++ b/config/production.json
@@ -52,7 +52,7 @@
 		"importer/unified": true,
 		"is_running_in_jetpack_site": false,
 		"jetpack/agency-dashboard": true,
-		"jetpack/ai-assistant-request-limit": false,
+		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/api-cache": false,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -48,7 +48,7 @@
 		"i18n/empathy-mode": true,
 		"importer/unified": true,
 		"jetpack/agency-dashboard": true,
-		"jetpack/ai-assistant-request-limit": false,
+		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -60,7 +60,7 @@
 		"importers/substack": true,
 		"importer/unified": true,
 		"jetpack/agency-dashboard": true,
-		"jetpack/ai-assistant-request-limit": false,
+		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Move `jetpack/ai-assistant-request-limit` feature flag to production level, so the new Jetpack AI add-on card gets moved to production

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm the card is still visible on all testable environments (your local dev environment and the `wpcalypso` from the `calypso.live` link below, for example)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
