### PR TITLE
Display overflowed PremiumBadge label as a tooltip

### DIFF
--- a/packages/components/src/theme-type-badge/premium-badge/index.tsx
+++ b/packages/components/src/theme-type-badge/premium-badge/index.tsx
@@ -46,7 +46,7 @@ const PremiumBadge = ( {
 		  );
 
 	const divRef = useRef( null );
-	const labelRef = useRef( null );
+	const labelRef = useRef< HTMLDivElement >( null );
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ isPressed, setIsPressed ] = useState( false );
@@ -59,9 +59,9 @@ const PremiumBadge = ( {
 
 	// Display the label as a tooltip if the tooltip is being hidden and the label is too long.
 	useLayoutEffect( () => {
-		setDisplayLabelAsTooltip(
-			!! shouldHideTooltip && labelRef.current?.scrollWidth > labelRef.current?.offsetWidth
-		);
+		const scrollWidth = labelRef?.current?.scrollWidth ?? 0;
+		const offsetWidth = labelRef?.current?.offsetWidth ?? 0;
+		setDisplayLabelAsTooltip( !! shouldHideTooltip && scrollWidth > offsetWidth );
 		// Now the dimensions of the label are known, it is safe to render the label in compact mode.
 		setMayRenderAsCompact( true );
 	}, [ shouldHideTooltip, labelRef ] );

--- a/packages/components/src/theme-type-badge/premium-badge/index.tsx
+++ b/packages/components/src/theme-type-badge/premium-badge/index.tsx
@@ -22,7 +22,7 @@ interface BadgeProps {
 
 const PremiumBadge = ( {
 	className,
-	labelText,
+	labelText: customLabelText,
 	tooltipContent,
 	tooltipClassName,
 	tooltipPosition = 'bottom left',
@@ -55,7 +55,7 @@ const PremiumBadge = ( {
 	// so that the label can be measured in its uncompacted state.
 	const [ mayRenderAsCompact, setMayRenderAsCompact ] = useState( false );
 
-	labelText = labelText || __( 'Premium' );
+	const labelText = customLabelText || __( 'Premium' );
 
 	// Display the label as a tooltip if the tooltip is being hidden and the label is too long.
 	useLayoutEffect( () => {

--- a/packages/components/src/theme-type-badge/premium-badge/index.tsx
+++ b/packages/components/src/theme-type-badge/premium-badge/index.tsx
@@ -1,6 +1,6 @@
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import { useMemo, useRef, useState } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import Gridicon from '../../gridicon';
 import Popover from '../../popover';
 
@@ -50,14 +50,21 @@ const PremiumBadge = ( {
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ isPressed, setIsPressed ] = useState( false );
-
-	// Display the label as a tooltip if the tooltip is being hidden and the label is too long.
-	const displayLabelAsTooltip =
-		!! shouldHideTooltip &&
-		!! labelRef.current?.offsetWidth &&
-		labelRef.current?.scrollWidth > labelRef.current?.offsetWidth;
+	const [ displayLabelAsTooltip, setDisplayLabelAsTooltip ] = useState( false );
+	// This is used to prevent the label from being rendered in compact mode before the first render
+	// so that the label can be measured in its uncompacted state.
+	const [ mayRenderAsCompact, setMayRenderAsCompact ] = useState( false );
 
 	labelText = labelText || __( 'Premium' );
+
+	// Display the label as a tooltip if the tooltip is being hidden and the label is too long.
+	useLayoutEffect( () => {
+		setDisplayLabelAsTooltip(
+			!! shouldHideTooltip && labelRef.current?.scrollWidth > labelRef.current?.offsetWidth
+		);
+		// Now the dimensions of the label are known, it is safe to render the label in compact mode.
+		setMayRenderAsCompact( true );
+	}, [ shouldHideTooltip, labelRef ] );
 
 	const isClickableProps = useMemo( () => {
 		if ( ! isClickable ) {
@@ -89,7 +96,7 @@ const PremiumBadge = ( {
 		<div
 			className={ classNames( 'premium-badge', className, {
 				'premium-badge__compact-animation': shouldCompactWithAnimation,
-				'premium-badge--compact': shouldCompactWithAnimation && ! isHovered,
+				'premium-badge--compact': shouldCompactWithAnimation && ! isHovered && mayRenderAsCompact,
 				'premium-badge--is-clickable': isClickable,
 			} ) }
 			ref={ divRef }

--- a/packages/components/src/theme-type-badge/premium-badge/index.tsx
+++ b/packages/components/src/theme-type-badge/premium-badge/index.tsx
@@ -139,7 +139,7 @@ const PremiumBadge = ( {
 					className={ classNames( 'premium-badge__popover', tooltipClassName ) }
 					context={ divRef.current }
 					isVisible={ isPopoverVisible }
-					position={ tooltipPosition }
+					position="bottom"
 					focusOnShow={ focusOnShow }
 				>
 					{ labelText }

--- a/packages/components/src/theme-type-badge/premium-badge/index.tsx
+++ b/packages/components/src/theme-type-badge/premium-badge/index.tsx
@@ -46,13 +46,16 @@ const PremiumBadge = ( {
 		  );
 
 	const divRef = useRef( null );
+	const labelRef = useRef( null );
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ isPressed, setIsPressed ] = useState( false );
 
 	// Display the label as a tooltip if the tooltip is being hidden and the label is too long.
 	const displayLabelAsTooltip =
-		shouldHideTooltip && divRef.current?.scrollWidth > divRef.current?.clientWidth;
+		!! shouldHideTooltip &&
+		!! labelRef.current?.offsetWidth &&
+		labelRef.current?.scrollWidth > labelRef.current?.offsetWidth;
 
 	labelText = labelText || __( 'Premium' );
 
@@ -110,7 +113,9 @@ const PremiumBadge = ( {
 					<Gridicon className="premium-badge__logo" icon="star" size={ 14 } />
 				</>
 			) }
-			<span className="premium-badge__label">{ labelText }</span>
+			<span className="premium-badge__label" ref={ labelRef }>
+				{ labelText }
+			</span>
 			{ ! shouldHideTooltip && (
 				<Popover
 					className={ classNames( 'premium-badge__popover', tooltipClassName ) }

--- a/packages/components/src/theme-type-badge/premium-badge/index.tsx
+++ b/packages/components/src/theme-type-badge/premium-badge/index.tsx
@@ -50,6 +50,12 @@ const PremiumBadge = ( {
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ isPressed, setIsPressed ] = useState( false );
 
+	// Display the label as a tooltip if the tooltip is being hidden and the label is too long.
+	const displayLabelAsTooltip =
+		shouldHideTooltip && divRef.current?.scrollWidth > divRef.current?.clientWidth;
+
+	labelText = labelText || __( 'Premium' );
+
 	const isClickableProps = useMemo( () => {
 		if ( ! isClickable ) {
 			return {};
@@ -104,7 +110,7 @@ const PremiumBadge = ( {
 					<Gridicon className="premium-badge__logo" icon="star" size={ 14 } />
 				</>
 			) }
-			<span className="premium-badge__label">{ labelText || __( 'Premium' ) }</span>
+			<span className="premium-badge__label">{ labelText }</span>
 			{ ! shouldHideTooltip && (
 				<Popover
 					className={ classNames( 'premium-badge__popover', tooltipClassName ) }
@@ -114,6 +120,17 @@ const PremiumBadge = ( {
 					focusOnShow={ focusOnShow }
 				>
 					{ tooltipContent || tooltipText }
+				</Popover>
+			) }
+			{ displayLabelAsTooltip && (
+				<Popover
+					className={ classNames( 'premium-badge__popover', tooltipClassName ) }
+					context={ divRef.current }
+					isVisible={ isPopoverVisible }
+					position={ tooltipPosition }
+					focusOnShow={ focusOnShow }
+				>
+					{ labelText }
 				</Popover>
 			) }
 		</div>

--- a/packages/components/src/theme-type-badge/premium-badge/style.scss
+++ b/packages/components/src/theme-type-badge/premium-badge/style.scss
@@ -110,6 +110,13 @@
 			}
 		}
 	}
+	&.is-bottom {
+		.popover__arrow {
+			&::before {
+				border-bottom-color: #000 !important;
+			}
+		}
+	}
 	.popover__arrow {
 		border-color: transparent;
 	}

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -111,7 +111,9 @@ const ColorPaletteVariations = ( {
 			</div>
 			<div className="global-styles-variations__group">
 				<h3 className="global-styles-variations__group-title">
-					{ translate( 'Custom styles' ) }
+					<span className="global-styles-variations__group-title-actual">
+						{ translate( 'Custom styles' ) }
+					</span>
 					{ limitGlobalStyles && (
 						<PremiumBadge
 							shouldHideTooltip

--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -63,3 +63,7 @@
 	letter-spacing: -0.15px;
 	line-height: 1.7;
 }
+
+.global-styles-variations__group-title-actual {
+	white-space: nowrap;
+}

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -112,7 +112,9 @@ const FontPairingVariations = ( {
 			</div>
 			<div className="global-styles-variations__group">
 				<h3 className="global-styles-variations__group-title">
-					{ translate( 'Custom fonts' ) }
+					<span className="global-styles-variations__group-title-actual">
+						{ translate( 'Custom fonts' ) }
+					</span>
 					{ limitGlobalStyles && (
 						<PremiumBadge
 							shouldHideTooltip

--- a/packages/global-styles/src/components/font-pairing-variations/style.scss
+++ b/packages/global-styles/src/components/font-pairing-variations/style.scss
@@ -63,3 +63,7 @@
 	letter-spacing: -0.15px;
 	line-height: 1.4;
 }
+
+.global-styles-variations__group-title-actual {
+	white-space: nowrap;
+}


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2919

## Proposed Changes

If the tooltip is not being used for the `PremiumBadge` and the content has overflowed then use the tooltip for the content rather than it being trimmed behind an ellipses.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1.  Use calypso live link
2.  Switch language to Spanish
3.  Go through the /start process choosing a free plan
4. At the design picker ensure that the "Premium", "WooCommerce" etc badges are displayed correctly and on hovering display some tooltip contents as on production but no other tooltips.
5.  Scroll to the bottom of the design picker and use the site assembler
6.  Open the fonts/colours panel and hover over the star, its contents should be trimmed to an ellipses and the tooltip should appear with the full text that should be displayed next to the star

Switch back to English, and try again, it should work exactly as on production - it does not need to show a tooltip because it doesn't overflow into ellipses.


Before | After
-------|------
<img width="322" alt="Screenshot 2023-07-18 at 12 25 06" src="https://github.com/Automattic/wp-calypso/assets/93301/1366f02a-2366-4504-a7b3-a1fc9cc75773"> | <img width="322" alt="Screenshot 2023-07-18 at 12 23 35" src="https://github.com/Automattic/wp-calypso/assets/93301/0109d48f-e828-484c-bdf1-44dd0d2791ce">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
