### PR TITLE
Checkout: Hide site header for siteless checkout with multiple domain products

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -1,4 +1,8 @@
-import { isDomainMapping, isDomainRegistration } from '@automattic/calypso-products';
+import {
+	isDomainMapping,
+	isDomainRegistration,
+	isDomainTransfer,
+} from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, joinClasses } from '@automattic/wpcom-checkout';
@@ -229,12 +233,9 @@ function getDomainToDisplayInCheckoutHeader(
 		return primaryDomainForMapping;
 	}
 
-	const firstDomainProduct = responseCart.products.find(
-		( product ) => isDomainRegistration( product ) || isDomainMapping( product )
-	);
-
-	if ( firstDomainProduct?.meta ) {
-		return firstDomainProduct.meta;
+	const domainUrl = getDomainProductUrlToDisplayInCheckoutHeader( responseCart, selectedSiteData );
+	if ( domainUrl ) {
+		return domainUrl;
 	}
 
 	if ( responseCart.gift_details?.receiver_blog_url ) {
@@ -250,4 +251,28 @@ function getDomainToDisplayInCheckoutHeader(
 	}
 
 	return undefined;
+}
+
+function getDomainProductUrlToDisplayInCheckoutHeader(
+	responseCart: ResponseCart,
+	selectedSiteData: SiteDetails | undefined | null
+): string | undefined {
+	const domainProducts = responseCart.products.filter(
+		( product ) =>
+			isDomainTransfer( product ) || isDomainRegistration( product ) || isDomainMapping( product )
+	);
+
+	const firstDomainProduct = domainProducts.length > 0 ? domainProducts[ 0 ] : undefined;
+
+	const isPurchaseSiteless = ! selectedSiteData;
+
+	if ( ! firstDomainProduct?.meta ) {
+		return undefined;
+	}
+
+	if ( isPurchaseSiteless && domainProducts.length > 1 ) {
+		return undefined;
+	}
+
+	return firstDomainProduct.meta;
 }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -20,7 +20,8 @@ import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
-import type { RemoveProductFromCart, CouponStatus } from '@automattic/shopping-cart';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { ResponseCart, RemoveProductFromCart, CouponStatus } from '@automattic/shopping-cart';
 
 const SiteSummary = styled.div`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
@@ -104,18 +105,8 @@ export default function WPCheckoutOrderReview( {
 
 	const selectedSiteData = useSelector( getSelectedSite );
 
-	const primaryDomain = selectedSiteData?.options?.is_mapped_domain
-		? selectedSiteData?.domain
-		: null;
-	const firstDomainProduct = responseCart.products.find(
-		( product ) =>
-			isDomainTransfer( product ) || isDomainRegistration( product ) || isDomainMapping( product )
-	);
-	const domainUrl =
-		primaryDomain ??
-		firstDomainProduct?.meta ??
-		responseCart?.gift_details?.receiver_blog_url ??
-		siteUrl;
+	// This is what will be displayed at the top of checkout prefixed by "Site: ".
+	const domainUrl = getDomainToDisplayInCheckoutHeader( responseCart, selectedSiteData, siteUrl );
 
 	const removeCouponAndClearField = () => {
 		couponFieldStateProps.setCouponFieldValue( '' );
@@ -134,9 +125,7 @@ export default function WPCheckoutOrderReview( {
 		<div
 			className={ joinClasses( [ className, 'checkout-review-order', isSummary && 'is-summary' ] ) }
 		>
-			{ ! planIsP2Plus && domainUrl && 'no-user' !== domainUrl && (
-				<SiteSummary>{ translate( 'Site: %s', { args: domainUrl } ) }</SiteSummary>
-			) }
+			{ domainUrl && <SiteSummary>{ translate( 'Site: %s', { args: domainUrl } ) }</SiteSummary> }
 			{ planIsP2Plus && selectedSiteData?.name && (
 				<SiteSummary>
 					{ translate( 'Upgrade: {{strong}}%s{{/strong}}', {
@@ -226,4 +215,40 @@ function CouponFieldArea( {
 			</CouponEnableButton>
 		</CouponLinkWrapper>
 	);
+}
+
+function getDomainToDisplayInCheckoutHeader(
+	responseCart: ResponseCart,
+	selectedSiteData: SiteDetails | undefined | null,
+	sitelessCheckoutSlug: string | undefined
+): string | undefined {
+	if ( hasP2PlusPlan( responseCart ) ) {
+		return undefined;
+	}
+
+	const primaryDomainForMapping = selectedSiteData?.options?.is_mapped_domain
+		? selectedSiteData?.domain
+		: undefined;
+	if ( primaryDomainForMapping ) {
+		return primaryDomainForMapping;
+	}
+
+	const firstDomainProduct = responseCart.products.find(
+		( product ) =>
+			isDomainTransfer( product ) || isDomainRegistration( product ) || isDomainMapping( product )
+	);
+
+	if ( firstDomainProduct?.meta ) {
+		return firstDomainProduct.meta;
+	}
+
+	if ( responseCart.gift_details?.receiver_blog_url ) {
+		return responseCart.gift_details.receiver_blog_url;
+	}
+
+	if ( sitelessCheckoutSlug && sitelessCheckoutSlug !== 'no-user' ) {
+		return sitelessCheckoutSlug;
+	}
+
+	return undefined;
 }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -246,7 +246,11 @@ function getDomainToDisplayInCheckoutHeader(
 		return responseCart.gift_details.receiver_blog_url;
 	}
 
-	if ( sitelessCheckoutSlug && sitelessCheckoutSlug !== 'no-user' ) {
+	if (
+		sitelessCheckoutSlug &&
+		sitelessCheckoutSlug !== 'no-user' &&
+		sitelessCheckoutSlug !== 'no-site'
+	) {
 		return sitelessCheckoutSlug;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -1,8 +1,4 @@
-import {
-	isDomainMapping,
-	isDomainRegistration,
-	isDomainTransfer,
-} from '@automattic/calypso-products';
+import { isDomainMapping, isDomainRegistration } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, joinClasses } from '@automattic/wpcom-checkout';
@@ -234,8 +230,7 @@ function getDomainToDisplayInCheckoutHeader(
 	}
 
 	const firstDomainProduct = responseCart.products.find(
-		( product ) =>
-			isDomainTransfer( product ) || isDomainRegistration( product ) || isDomainMapping( product )
+		( product ) => isDomainRegistration( product ) || isDomainMapping( product )
 	);
 
 	if ( firstDomainProduct?.meta ) {


### PR DESCRIPTION
## Proposed Changes

When purchasing a domain transfer and there is no site selected, there's not really any need to display the domain name being transferred in checkout's header since the domain name will appear in the line item itself and in the sidebar. This is made considerably worse when multiple domains are being transferred without a selected site, since only the domain name of the first transfer would be shown. This also applies to checkout when purchasing multiple domain registrations for different sites.

In this PR we modify checkout so that the "Site: XXXXX" header is not shown when there are multiple domain products for siteless checkout.

Fixes https://github.com/Automattic/dotcom-forge/issues/2927

## Screenshots

Before:

![before-site-with-transfer](https://github.com/Automattic/wp-calypso/assets/2036909/572c1163-e14b-4ddf-8dc4-aaba3948bfae)

After:

<img width="1260" alt="after-site-with-transfer" src="https://github.com/Automattic/wp-calypso/assets/2036909/e6e38835-429b-4db9-9bc7-8a58961a1d9a">


## Testing Instructions

- Start at `/setup/domain-transfer/domains`.
- Add multiple domain transfer products to your cart. To do this you'll need to own more than one domain registration on a different host than WordPress.com. Make sure all the domains you plan to use are unlocked and you have their transfer codes ready. **You do not need to complete the purchase to test this PR.**
- Press "Transfer" and you will be taken to checkout.
- Verify that you do not see "Site: XXXXX" at the top of checkout (see screenshots above).