### PR TITLE
Billing: Conditionally render vendor tax id if available on receipt page

### DIFF
--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -21,9 +21,11 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 					<div key={ addressLine }>{ addressLine }</div>
 				) ) }
 			</span>
-			<span className="receipt__vat-vendor-details-number">
-				<strong>{ vendorInfo.tax_name }</strong> { vendorInfo.vat_id }
-			</span>
+			{ vendorInfo.vat_id && (
+				<span className="receipt__vat-vendor-details-number">
+					<strong>{ vendorInfo.tax_name }</strong> { vendorInfo.vat_id }
+				</span>
+			) }
 		</li>
 	);
 }


### PR DESCRIPTION
For countries with no tax id available [like Egypt], on the receipt page we will see a `VAT` key word followed by blank value like this:

![HdKnNF.png](https://github.com/Automattic/payments-shilling/assets/552016/612b43f3-1221-4413-8e9b-eb262cdfcb5c)


Fixes https://github.com/Automattic/payments-shilling/issues/1822

## Proposed Changes

* This PR tries to render the VAT ID conditionally. It renders the `VAT ID` keyword and the vat id itself only if it is available.

## Testing Instructions

1. Purchase a premium plan with the country Egypt & Postal code `11511` in the sandbox mode.
2. Now visit the Receipt page from `Upgrades >> Purchases >> Billing History >> View Receipt` to see the first screenshot above
3. Apply the patch
4. Now we can see the same receipt where the awkward keyword is not displayed anymore:  ![HvNeFT.png](https://github.com/Automattic/wp-calypso/assets/552016/7cb55708-ea6f-4ef3-820f-5a6e8e2ca730)
