### PR TITLE
Add-Ons: Hide Jetpack AI add-on card for sites that already support the feature

### DIFF
--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -4,6 +4,7 @@ import {
 	PRODUCT_WPCOM_CUSTOM_DESIGN,
 	PRODUCT_WPCOM_UNLIMITED_THEMES,
 	PRODUCT_1GB_SPACE,
+	WPCOM_FEATURES_AI_ASSISTANT,
 } from '@automattic/calypso-products';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
@@ -139,7 +140,7 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 				// remove the Jetpack AI add-on if the site already supports the feature
 				if (
 					addOn.productSlug === PRODUCT_JETPACK_AI_MONTHLY &&
-					siteFeatures?.active?.includes( 'ai-assistant' )
+					siteFeatures?.active?.includes( WPCOM_FEATURES_AI_ASSISTANT )
 				) {
 					return false;
 				}

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -15,6 +15,7 @@ import {
 	getProductName,
 } from 'calypso/state/products-list/selectors';
 import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
+import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import { usePastBillingTransactions } from 'calypso/state/sites/hooks/use-billing-history';
 import { STORAGE_LIMIT } from '../constants';
 import customDesignIcon from '../icons/custom-design';
@@ -103,6 +104,8 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 	const { billingTransactions, isLoading } = usePastBillingTransactions();
 
 	return useSelector( ( state ): ( AddOnMeta | null )[] => {
+		// get the list of supported features
+		const siteFeatures = getFeaturesBySiteId( state, siteId );
 		const filter = getBillingTransactionFilters( state, 'past' );
 		const filteredTransactions =
 			billingTransactions && filterTransactions( billingTransactions, filter, siteId );
@@ -130,6 +133,14 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 
 				// remove the Jetpack AI add-on if the feature flag is not enabled for the current environment
 				if ( addOn.productSlug === PRODUCT_JETPACK_AI_MONTHLY && ! aiAssistantAddOnIsEnabled ) {
+					return false;
+				}
+
+				// remove the Jetpack AI add-on if the site already supports the feature
+				if (
+					addOn.productSlug === PRODUCT_JETPACK_AI_MONTHLY &&
+					siteFeatures?.active?.includes( 'ai-assistant' )
+				) {
 					return false;
 				}
 

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -44,7 +44,7 @@
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/unified": true,
-		"jetpack/ai-assistant-request-limit": false,
+		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -48,7 +48,7 @@
 		"i18n/empathy-mode": true,
 		"importer/unified": true,
 		"jetpack/agency-dashboard": true,
-		"jetpack/ai-assistant-request-limit": false,
+		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -60,7 +60,7 @@
 		"importers/substack": true,
 		"importer/unified": true,
 		"jetpack/agency-dashboard": true,
-		"jetpack/ai-assistant-request-limit": false,
+		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -237,6 +237,7 @@ export const FEATURE_WOOCOMMERCE = 'woocommerce';
 export const FEATURE_SOCIAL_MEDIA_TOOLS = 'social-media-tools';
 
 // From class-wpcom-features.php in WPCOM
+export const WPCOM_FEATURES_AI_ASSISTANT = 'ai-assistant';
 export const WPCOM_FEATURES_AKISMET = 'akismet';
 export const WPCOM_FEATURES_ANTISPAM = 'antispam';
 export const WPCOM_FEATURES_ATOMIC = 'atomic';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Include a check on the site's active feature list, and remove the Jetpack AI assistant card when the `ai-assistant` feature is already supported by the site by other means that not the Jetpack AI plan
* Move `jetpack/ai-assistant-request-limit` feature flag to the last level before production

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch on your local machine (see instructions on the repository's README file)
* Open calypso on your browser and go to `Upgrades > Add-Ons`
* Confirm that the `Jetpack AI` add-on card only shows up for free sites (if a site has an upgrade, the card should not be visible)
* Confirm that the `Jetpack AI` add-on card is not present if the site has an upgrade or has the Jetpack AI plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
