### PR TITLE
Bulk Domain Transfer: Add wpcom_product_purchase tracking

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { OnboardSelect } from '@automattic/data-stores';
 import { useSelect, useDispatch as useWpDataDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -5,11 +6,11 @@ import { useEffect } from 'react';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector, useDispatch } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { fetchUserPurchases } from 'calypso/state/purchases/actions';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { usePastBillingTransactions } from 'calypso/state/sites/hooks/use-billing-history';
 import { CompleteDomainsTransferred } from './complete-domains-transferred';
 import type { Step } from '../../types';
 import './styles.scss';
@@ -17,6 +18,7 @@ import './styles.scss';
 const Complete: Step = function Complete( { flow } ) {
 	const { __, _n } = useI18n();
 	const dispatch = useDispatch();
+	const { billingTransactions, isLoading: isLoadingTransactions } = usePastBillingTransactions();
 
 	// Use the stored domains as a clue for the number of domains that were transferred to render placeholders.
 	// This number is used as a rough guess, and shouldn't be used to render anything.
@@ -37,6 +39,10 @@ const Complete: Step = function Complete( { flow } ) {
 			Date.now() - new Date( purchase.subscribedDate ).getTime() < oneDay
 	);
 
+	const newlyTransferredDomainsTransactions = billingTransactions?.filter(
+		( transaction ) => Date.now() - new Date( transaction.date ).getTime() < oneDay
+	);
+
 	const handleUserClick = ( destination: string ) => {
 		recordTracksEvent( 'calypso_domain_transfer_complete_click', {
 			destination,
@@ -46,6 +52,35 @@ const Complete: Step = function Complete( { flow } ) {
 	useEffect( () => {
 		dispatch( fetchUserPurchases( userId ) );
 	}, [] );
+
+	useEffect( () => {
+		if ( ! isLoadingTransactions && newlyTransferredDomains?.length ) {
+			newlyTransferredDomainsTransactions?.forEach( ( transaction ) => {
+				const { id } = transaction;
+
+				transaction.items
+					?.filter( ( item ) => item.wpcom_product_slug === 'domain_transfer' )
+					.forEach( ( item ) => {
+						const { amount_integer, wpcom_product_slug, variation } = item;
+
+						const productId = newlyTransferredDomains?.find(
+							( purchase ) => purchase.productSlug === wpcom_product_slug
+						)?.productId;
+
+						recordTracksEvent( 'wpcom_product_purchase', {
+							cost: amount_integer,
+							free_trial: false,
+							product_category: 'Domain',
+							product_id: productId,
+							product_name: variation,
+							product_slug: wpcom_product_slug,
+							receipt_id: id,
+							receipt_item_id: item.id,
+						} );
+					} );
+			} );
+		}
+	}, [ newlyTransferredDomainsTransactions, isLoadingTransactions, newlyTransferredDomains ] );
 
 	const clearDomainsStore = () => {
 		recordTracksEvent( 'calypso_domain_transfer_complete_click', {


### PR DESCRIPTION
This PR adds the `wpcom_product_purchase` event upon completion of the domain transfer flow.

## Testing
1. Live link
2. Go through `setup/domain-transfer`
3. Reaching the completion step, check the events triggered



Related to https://github.com/Automattic/dotcom-forge/issues/3029