### PR TITLE
Domains: Complete: Correct to auto-renew with hyphen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
@@ -30,7 +30,7 @@ export const CompleteDomainsTransferred = ( {
 									<li className="domain-complete-list-item" key={ key }>
 										<div>
 											<h2>{ meta }</h2>
-											<p>{ __( 'Auto renew enabled' ) }</p>
+											<p>{ __( 'Auto-renew enabled' ) }</p>
 										</div>
 										<a
 											href={ `/domains/manage/all/${ meta }/transfer/in/${ domain }` }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -73,8 +73,8 @@ const Complete: Step = function Complete( { flow } ) {
 							<>
 								<span>
 									{ _n(
-										"We've got it from here! We'll let you know when your newly transferred domain is ready to use!",
-										"We've got it from here! We'll let you know when your newly transferred domains are ready to use!",
+										"We've got it from here! We'll let you know when your newly transferred domain is ready to use.",
+										"We've got it from here! We'll let you know when your newly transferred domains are ready to use.",
 										newlyTransferredDomains?.length || storedDomainsAmount
 									) }
 								</span>


### PR DESCRIPTION
## Proposed Changes

* Correct "auto renew" to "auto-renew" for domain transfer complete step. 

<img width="1016" alt="Screenshot 2023-07-17 at 4 52 24 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/ec8db89d-329e-43ee-b801-b50850c794bd">



## Testing Instructions

* Checkout PR
* Go to `/setup/domain-transfer` and transfer domains
* On the complete step, after checkout, verify `auto-renew` has a hyphen

If you have transferred any domains previously, you can also hack the logic a bit around [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx#L34).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
