### PR TITLE
Checkout: Add source query param to setup intent endpoint call

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -272,7 +272,9 @@ export default function PaymentMethodAddWrapper( {
 
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
-			<StripeSetupIntentIdProvider fetchStipeSetupIntentId={ getStripeConfiguration }>
+			<StripeSetupIntentIdProvider
+				fetchStripeSetupIntentId={ () => getStripeConfiguration( { needs_intent: true } ) }
+			>
 				<PaymentMethodAdd selectedSite={ selectedSite } />
 			</StripeSetupIntentIdProvider>
 		</StripeHookProvider>

--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -85,7 +85,9 @@ export default function AccountLevelAddNewPaymentMethodWrapper() {
 	const locale = useSelector( getCurrentUserLocale );
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
-			<StripeSetupIntentIdProvider fetchStipeSetupIntentId={ getStripeConfiguration }>
+			<StripeSetupIntentIdProvider
+				fetchStripeSetupIntentId={ () => getStripeConfiguration( { needs_intent: true } ) }
+			>
 				<AddNewPaymentMethod />
 			</StripeSetupIntentIdProvider>
 		</StripeHookProvider>

--- a/client/me/purchases/manage-purchase/change-payment-method/index.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.tsx
@@ -121,7 +121,9 @@ export default function ChangePaymentMethodWrapper( props: ChangePaymentMethodPr
 	const locale = useSelector( getCurrentUserLocale );
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
-			<StripeSetupIntentIdProvider fetchStipeSetupIntentId={ getStripeConfiguration }>
+			<StripeSetupIntentIdProvider
+				fetchStripeSetupIntentId={ () => getStripeConfiguration( { needs_intent: true } ) }
+			>
 				<ChangePaymentMethod { ...props } />
 			</StripeSetupIntentIdProvider>
 		</StripeHookProvider>

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -835,7 +835,9 @@ function InnerCheckoutMainWrapper( props: CheckoutMainProps ) {
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
 	return (
 		<StripeSetupIntentIdProvider
-			fetchStripeSetupIntentId={ () => getStripeConfiguration( { needs_intent: true } ) }
+			fetchStripeSetupIntentId={ () =>
+				getStripeConfiguration( { needs_intent: true, source: 'checkout' } )
+			}
 			isDisabled={ ! isPurchaseFree || isLoading || isPendingUpdate }
 		>
 			<CheckoutMain { ...props } />

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -835,7 +835,7 @@ function InnerCheckoutMainWrapper( props: CheckoutMainProps ) {
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
 	return (
 		<StripeSetupIntentIdProvider
-			fetchStipeSetupIntentId={ getStripeConfiguration }
+			fetchStripeSetupIntentId={ () => getStripeConfiguration( { needs_intent: true } ) }
 			isDisabled={ ! isPurchaseFree || isLoading || isPendingUpdate }
 		>
 			<CheckoutMain { ...props } />

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -170,7 +170,9 @@ export function SiteLevelAddNewPaymentMethod( props: { siteSlug: string } ) {
 	const locale = useSelector( getCurrentUserLocale );
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
-			<StripeSetupIntentIdProvider fetchStipeSetupIntentId={ getStripeConfiguration }>
+			<StripeSetupIntentIdProvider
+				fetchStripeSetupIntentId={ () => getStripeConfiguration( { needs_intent: true } ) }
+			>
 				<SiteLevelAddNewPaymentMethodForm { ...props } />
 			</StripeSetupIntentIdProvider>
 		</StripeHookProvider>

--- a/packages/calypso-stripe/README.md
+++ b/packages/calypso-stripe/README.md
@@ -18,7 +18,7 @@ You'll need to wrap this context provider around any component that wishes to us
 You'll need to wrap this context provider around any component that wishes to use `useStripeSetupIntentId`. It accepts the following props:
 
 - `children: React.ReactNode`
-- `fetchStripeConfiguration: GetStripeSetupIntentId` A function to fetch the stripe configuration from the WP.com HTTP API. It will be passed `{needs_intent: true}`.
+- `fetchStripeSetupIntentId: GetStripeSetupIntentId` A function to fetch the stripe setup intent from the WP.com HTTP API.
 - `isDisabled?: boolean` An option to disable the fetching of the setup intent if it is not needed.
 
 ## useStripe

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -79,9 +79,9 @@ export interface UseStripeJs {
 }
 
 export type GetStripeConfigurationArgs = { country?: string };
-export type GetStripeSetupIntentId = ( requestArgs: {
-	needs_intent?: boolean;
-} ) => Promise< { setup_intent_id: StripeSetupIntentId | undefined } >;
+export type GetStripeSetupIntentId = () => Promise< {
+	setup_intent_id: StripeSetupIntentId | undefined;
+} >;
 export type GetStripeConfiguration = (
 	requestArgs: GetStripeConfigurationArgs & { needs_intent?: boolean }
 ) => Promise< StripeConfiguration & { setup_intent_id: StripeSetupIntentId | undefined } >;
@@ -424,8 +424,6 @@ function useStripeConfiguration(
 	return { stripeConfiguration, stripeConfigurationError };
 }
 
-const setupIntentRequestArgs = { needs_intent: true };
-
 /**
  * React custom Hook for loading a Stripe setup intent id
  *
@@ -436,7 +434,7 @@ const setupIntentRequestArgs = { needs_intent: true };
  * configuration to reload by calling `reload()`.
  */
 function useFetchSetupIntentId(
-	fetchStripeConfiguration: GetStripeSetupIntentId,
+	fetchStripeSetupIntentId: GetStripeSetupIntentId,
 	{ isDisabled }: { isDisabled?: boolean }
 ): {
 	setupIntentId: StripeSetupIntentId | undefined;
@@ -457,7 +455,7 @@ function useFetchSetupIntentId(
 			};
 		}
 		debug( 'loading stripe setup intent id' );
-		fetchStripeConfiguration( setupIntentRequestArgs )
+		fetchStripeSetupIntentId()
 			.then( ( configuration ) => {
 				if ( ! isSubscribed ) {
 					return;
@@ -477,7 +475,7 @@ function useFetchSetupIntentId(
 		return () => {
 			isSubscribed = false;
 		};
-	}, [ stripeReloadCount, fetchStripeConfiguration, isDisabled ] );
+	}, [ stripeReloadCount, fetchStripeSetupIntentId, isDisabled ] );
 	return { setupIntentId, error, reload };
 }
 
@@ -493,13 +491,13 @@ function areRequestArgsEqual(
 
 export function StripeSetupIntentIdProvider( {
 	children,
-	fetchStipeSetupIntentId,
+	fetchStripeSetupIntentId,
 	isDisabled,
 }: PropsWithChildren< {
-	fetchStipeSetupIntentId: GetStripeSetupIntentId;
+	fetchStripeSetupIntentId: GetStripeSetupIntentId;
 	isDisabled?: boolean;
 } > ) {
-	const setupIntentData = useFetchSetupIntentId( fetchStipeSetupIntentId, { isDisabled } );
+	const setupIntentData = useFetchSetupIntentId( fetchStripeSetupIntentId, { isDisabled } );
 
 	return (
 		<StripeSetupIntentContext.Provider value={ setupIntentData }>


### PR DESCRIPTION
## Proposed Changes

This adds an optional `source` query parameter to the call to the endpoint that creates stripe setup intents, `/me/stripe-configuration?needs_intent=true`. This can be used to differentiate the pages which call it on the backend.

This PR sets the new parameter for just one page so far: checkout.

See D116236-code which needs this.

## Testing Instructions

With a free purchase, visit checkout and verify that you see a call to `/me/stripe-configuration?needs_intent=true&source=checkout` in the network devtools panel.