### PR TITLE
Google Ads: Add delay to conversion event to avoid request cancellation

### DIFF
--- a/client/lib/analytics/record-purchase.js
+++ b/client/lib/analytics/record-purchase.js
@@ -5,7 +5,7 @@ import { debug, TRACKING_IDS } from './ad-tracking/constants';
 import { gaRecordEvent } from './ga';
 import { mayWeTrackByTracker } from './tracker-buckets';
 
-export function recordPurchase( { cart, orderId, sitePlanSlug } ) {
+export async function recordPurchase( { cart, orderId, sitePlanSlug } ) {
 	if ( cart.total_cost >= 0.01 ) {
 		const usdValue = costToUSD( cart.total_cost, cart.currency );
 
@@ -32,5 +32,10 @@ export function recordPurchase( { cart, orderId, sitePlanSlug } ) {
 		];
 		debug( 'recordOrderInGoogleAds: WPCom Domain Transfer Purchase', params );
 		window.gtag( ...params );
+
+		// The page redirect to the domain transfer success page happens too quickly and
+		// cancels the conversion event before it's fired. We delay execution by 1 second
+		// to ensure that the conversion event is recorded
+		return new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -100,7 +100,7 @@ export default function useCreatePaymentCompleteCallback( {
 	const domains = useSiteDomains( siteId ?? undefined );
 
 	return useCallback(
-		( { paymentMethodId, transactionLastResponse }: PaymentEventCallbackArguments ): void => {
+		async ( { paymentMethodId, transactionLastResponse }: PaymentEventCallbackArguments ) => {
 			debug( 'payment completed successfully' );
 			const transactionResult = normalizeTransactionResponse( transactionLastResponse );
 
@@ -141,7 +141,7 @@ export default function useCreatePaymentCompleteCallback( {
 			debug( 'getThankYouUrl returned', url );
 
 			try {
-				recordPaymentCompleteAnalytics( {
+				await recordPaymentCompleteAnalytics( {
 					paymentMethodId,
 					transactionResult,
 					redirectUrl: url,
@@ -265,7 +265,7 @@ export default function useCreatePaymentCompleteCallback( {
 	);
 }
 
-function recordPaymentCompleteAnalytics( {
+async function recordPaymentCompleteAnalytics( {
 	paymentMethodId,
 	transactionResult,
 	redirectUrl,
@@ -298,7 +298,7 @@ function recordPaymentCompleteAnalytics( {
 	);
 
 	try {
-		recordPurchase( {
+		await recordPurchase( {
 			cart: responseCart,
 			orderId:
 				transactionResult && 'receipt_id' in transactionResult


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/79445 & https://github.com/Automattic/martech/issues/1942

After the recordPurchase analytics method is called, there is a page redirect. This will cancel the google analytics conversion event because the redirect happens so quickly. 

Unfortunately, gtag conversion events don't offer completion callbacks or hooks, so we add a delay to provide time for the gtag event to resolve.

## Proposed Changes

* Add a 1 second to delay after the google analytics domain transfers purchase event is fired

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Enable the `ad-tracking` and `cookie-banner` flag in development.json
* `yarn && yarn start`
* Ensure that correct Privacy settings are disabled
  * Make sure that browser `doNotTrack` setting is disabled. For example, in chrome, [follow these instructions to disable](https://support.google.com/chrome/answer/2790761?hl=en&co=GENIE.Platform%3DDesktop).
  * Enable the "Share information with our analytics tool about your use of services while logged in to your WordPress.com account" toggle in `/me` under the `Privacy` tab
  * From what I can tell, that should be enough to address all potential privacy blocks, but I might have missed something. There may be other settings that need to be disabled in your environment. The logic is outlined in [this file](https://github.com/Automattic/wp-calypso/blob/7b73d26cb9e233370224799b1e40cf359142f6c1/client/lib/analytics/tracker-buckets.ts#L131-L132) under the `mayWeTrackByTracker` method
* Navigate to http://calypso.localhost:3000/setup/domain-transfer/domains
  * Enter domain to transfer
  * Enter auth code
  * Click on transfer button
* Click on Pay $0 now
* Verify that the google ads conversion event was fired by checking the dev network tab for the `googleadservices.com/pagead/conversion/946162814` fetch request
* There are two ways to handle testing the actual domain transfer:
  1. Transfer the domain and cancel the transfer with your original domain registrar afterwards ( p1689366128054469-slack-C05CT832K2T ) 
  2. Change backend logic to permit an incorrect auth transfer code. Submit incorrect code, wait for system retries to complete, and then delete the transfer request in wordpress.com/domains/manage


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
