### PR TITLE
Adding FAQs to domain transfer page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -15,6 +15,7 @@ import { domainTransfer } from 'calypso/lib/cart-values/cart-items';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import { ONBOARD_STORE } from '../../../../stores';
 import { DomainCodePair } from './domain-code-pair';
+import DomainTransferFAQ from './faqs';
 import type { OnboardSelect } from '@automattic/data-stores';
 
 const MAX_DOMAINS = 50;
@@ -214,6 +215,9 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 								numberOfValidDomains
 						  ) }
 				</Button>
+			</div>
+			<div className="bulk-domain-transfer__faqs">
+				<DomainTransferFAQ />
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
@@ -77,9 +77,9 @@ const DomainTransferFAQ: FC = () => {
 							className="domain-transfer-faq__section"
 						>
 							{ translate(
-								'No, when you transfer your domain, the remaining time you had left with your old registrar ' +
-									'is transferred over. In addition, we give you another free years registration when you ' +
-									'transfer from Google Domains.'
+								'No, the remaining time you have with your current registrar will be transferred ' +
+									"over when you move your domain. Furthermore, you will receive an additional year's " +
+									'registration free of charge when transferring any domain to WordPress.com'
 							) }
 						</FoldableFAQ>
 					</li>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
@@ -1,0 +1,148 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import FoldableFAQ from 'calypso/components/foldable-faq';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import type { FC } from 'react';
+
+import './styles.scss';
+
+const DomainTransferFAQ: FC = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
+
+	const onFaqToggle = useCallback(
+		( faqArgs: { id: string; buttonId: string; isExpanded: boolean; height: number } ) => {
+			const { id, buttonId, isExpanded } = faqArgs;
+			const tracksArgs = {
+				site_id: siteId,
+				faq_id: id,
+			};
+
+			const removeHash = () => {
+				history.replaceState( '', document.title, location.pathname + location.search );
+			};
+
+			// Add expanded FAQ buttonId to the URL hash
+			const addHash = () => {
+				history.replaceState(
+					'',
+					document.title,
+					location.pathname + location.search + `#${ buttonId }`
+				);
+			};
+
+			if ( isExpanded ) {
+				addHash();
+				// FAQ opened
+				dispatch( recordTracksEvent( 'calypso_plans_faq_open', tracksArgs ) );
+			} else {
+				removeHash();
+				// FAQ closed
+				dispatch( recordTracksEvent( 'calypso_plans_faq_closed', tracksArgs ) );
+			}
+		},
+		[ siteId, dispatch ]
+	);
+
+	return (
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		<>
+			<section>
+				<h2>{ translate( 'Frequently Asked Questions' ) }</h2>
+				<ul>
+					<li>
+						<FoldableFAQ
+							id="service-down"
+							question={ translate(
+								'Will my website or email service be down during the transfer?'
+							) }
+							onToggle={ onFaqToggle }
+							className="domain-transfer-faq__section"
+						>
+							{ translate(
+								'If your website and email settings were correctly configured before the transfer, there should be no downtime.'
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="time-left"
+							question={ translate(
+								'Do I lose the time left with my current registrar when I transfer?'
+							) }
+							onToggle={ onFaqToggle }
+							className="domain-transfer-faq__section"
+						>
+							{ translate(
+								'No, when you transfer your domain, the remaining time you had left with your old registrar ' +
+									'is transferred over. In addition, we give you another free years registration when you ' +
+									'transfer from Google Domains.'
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="dns-settings"
+							question={ translate(
+								'Will my custom name server DNS settings automatically be transferred over?'
+							) }
+							onToggle={ onFaqToggle }
+							className="domain-transfer-faq__section"
+						>
+							{ translate(
+								'When you transfer a domain name to WordPress.com, we will leave the nameserver associated with , ' +
+									'the domain unchanged so your DNS records will continue keep working the same as before the transfer.'
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="how-long"
+							question={ translate( 'How long does it take to transfer a domain name?' ) }
+							onToggle={ onFaqToggle }
+							className="domain-transfer-faq__section"
+						>
+							{ translate(
+								'The entire process generally takes a couple of days. The time it takes varies depending on the ' +
+									'registrar you are transferring the domain from, and the time it takes your current registrar ' +
+									'to complete the process. You can check the progress of your transfer in the Domain Management section of ' +
+									'your WordPress.com dashboard.'
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="transfer-fails"
+							question={ translate( 'What happens if my domain transfer fails?' ) }
+							onToggle={ onFaqToggle }
+							className="domain-transfer-faq__section"
+						>
+							{ translate(
+								'If your domain transfer fails, your domain will remain with your current registrar. You will ' +
+									'need to resolve any issues that caused the transfer failure before attempting to transfer again.'
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="privacy-protection"
+							question={ translate( 'Will privacy protection be turned on by default?' ) }
+							onToggle={ onFaqToggle }
+							className="domain-transfer-faq__section"
+						>
+							{ translate(
+								'Yes. Privacy protection is turned on by default for all domains transferred to WordPress.com.'
+							) }
+						</FoldableFAQ>
+					</li>
+				</ul>
+			</section>
+		</>
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	);
+};
+
+export default DomainTransferFAQ;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
@@ -93,8 +93,8 @@ const DomainTransferFAQ: FC = () => {
 							className="domain-transfer-faq__section"
 						>
 							{ translate(
-								'When you transfer a domain name to WordPress.com, we will leave the nameserver associated with , ' +
-									'the domain unchanged so your DNS records will continue keep working the same as before the transfer.'
+								'When you transfer a domain name to WordPress.com, we ensure that the associated name ' +
+									'server remains unchanged. This means your DNS records will continue to work as they did before the transfer.'
 							) }
 						</FoldableFAQ>
 					</li>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
@@ -37,11 +37,11 @@ const DomainTransferFAQ: FC = () => {
 			if ( isExpanded ) {
 				addHash();
 				// FAQ opened
-				dispatch( recordTracksEvent( 'calypso_plans_faq_open', tracksArgs ) );
+				dispatch( recordTracksEvent( 'calypso_domain_transfer_faq_open', tracksArgs ) );
 			} else {
 				removeHash();
 				// FAQ closed
-				dispatch( recordTracksEvent( 'calypso_plans_faq_closed', tracksArgs ) );
+				dispatch( recordTracksEvent( 'calypso_domain_transfer_faq_closed', tracksArgs ) );
 			}
 		},
 		[ siteId, dispatch ]

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -355,6 +355,19 @@
 			margin-top: 2px;
 		}
 
+		.bulk-domain-transfer__faqs {
+			h2 {
+				font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+				font-size: 2.75rem;
+				text-align: center;
+				margin: 48px 0;
+			}
+			ul {
+				list-style: none;
+				margin-bottom: 48px;
+			}
+		}
+
 		.bulk-domain-transfer__total-price {
 			display: flex;
 			justify-content: space-between;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -356,11 +356,24 @@
 		}
 
 		.bulk-domain-transfer__faqs {
+			.foldable-faq__question {
+				padding: 16px 0;
+			}
+			.foldable-faq__question-text {
+				/* stylelint-disable-next-line scales/font-sizes */
+				font-size: 1.15rem;
+			}
 			h2 {
 				font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-				font-size: 2.75rem;
+				font-size: 2rem;
+				margin: 24px 0;
 				text-align: center;
-				margin: 48px 0;
+			}
+			li {
+				font-size: 1rem;
+			}
+			section {
+				margin-top: 120px;
 			}
 			ul {
 				list-style: none;


### PR DESCRIPTION
## Description

Added a FAQ section to the new domain transfer page:

https://github.com/Automattic/wp-calypso/assets/5634774/1198d311-481c-4db3-a284-acefee8dc4fa

## Testing

Pretty straightforward:

- Load this PR locally (or via Calypso Live link)
- Head to http://calypso.localhost:3000/setup/domain-transfer/domains
- Scroll to bottom of page
- Click FAQs open and closed