### PR TITLE
Domain name property change was not replicated in the onboarding flow plans step 

### DIFF
--- a/client/signup/steps/plans-pm/index.jsx
+++ b/client/signup/steps/plans-pm/index.jsx
@@ -57,7 +57,7 @@ export class PlansStepPM extends Component {
 					hideFreePlan={ true }
 					intervalType={ getIntervalType() }
 					onUpgradeClick={ ( cartItem ) => buildUpgradeFunction( this.props, cartItem ) }
-					domainName={ getDomainName( this.props.signupDependencies.domainItem ) }
+					paidDomainName={ getDomainName( this.props.signupDependencies.domainItem ) }
 					plansWithScroll={ this.state.isDesktop }
 					flowName={ flowName }
 					isAllPaidPlansShown={ true }

--- a/client/signup/steps/plans-pm/index.jsx
+++ b/client/signup/steps/plans-pm/index.jsx
@@ -57,7 +57,7 @@ export class PlansStepPM extends Component {
 					hideFreePlan={ true }
 					intervalType={ getIntervalType() }
 					onUpgradeClick={ ( cartItem ) => buildUpgradeFunction( this.props, cartItem ) }
-					paidDomainName={ getDomainName( this.props.signupDependencies.domainItem ) }
+					domainName={ getDomainName( this.props.signupDependencies.domainItem ) }
 					plansWithScroll={ this.state.isDesktop }
 					flowName={ flowName }
 					isAllPaidPlansShown={ true }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -144,7 +144,7 @@ export class PlansStep extends Component {
 			);
 		}
 
-		const domainName = getDomainName( this.props.signupDependencies.domainItem );
+		const paidDomainName = getDomainName( this.props.signupDependencies.domainItem );
 
 		return (
 			<div>
@@ -155,7 +155,7 @@ export class PlansStep extends Component {
 					isLaunchPage={ isLaunchPage }
 					intervalType={ intervalType }
 					onUpgradeClick={ ( cartItem ) => this.onSelectPlan( cartItem ) }
-					domainName={ domainName }
+					paidDomainName={ paidDomainName }
 					customerType={ this.getCustomerType() }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain } // TODO clk investigate
 					plansWithScroll={ this.state.isDesktop }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79331

## Proposed Changes

* In #79331 we change the name of the domainName to paidDomainName to avoid confusion between the free subdomain and a paid domain when passing it around. The prop passed to <PlanFeaturesMain /> was changed to `paidDomainName`.

https://github.com/Automattic/wp-calypso/blob/a6230f12907226181c1266255d41f9e6c86a0fd6/client/my-sites/plans-features-main/index.tsx#L66

This was not replicated in the JSX based onboarding flow (signup framework's) plans step.


## Testing Instructions
1 - Go to `/start`
2 - Select a paid domain Or Use A domain you own and connect
3 - In the plan step click on the free plan
4 - A modal popup should be shown

When a user selects "Use a domain I own" > "Domain Connection" option,


In onboarding flow, a user can proceed with "Free Plan". We do NOT show a modal, but we add 1-year Premium Plan by default. When they land on the checkout page, they see 1-year Premium Plan with Domain Connection product in the cart.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
