### PR TITLE
Reader: remove isDiscover prop where no longer needed

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -31,7 +31,6 @@ class ReaderCombinedCardComponent extends Component {
 		site: PropTypes.object,
 		feed: PropTypes.object,
 		onClick: PropTypes.func,
-		isDiscover: PropTypes.bool,
 		postKey: PropTypes.object.isRequired,
 		selectedPostKey: PropTypes.object,
 		showFollowButton: PropTypes.bool,
@@ -42,7 +41,6 @@ class ReaderCombinedCardComponent extends Component {
 	};
 
 	static defaultProps = {
-		isDiscover: false,
 		showFollowButton: false,
 		blockedSites: [],
 	};
@@ -81,7 +79,6 @@ class ReaderCombinedCardComponent extends Component {
 			postKey,
 			selectedPostKey,
 			onClick,
-			isDiscover,
 			blockedSites,
 			translate,
 			hasOrganization,
@@ -145,7 +142,6 @@ class ReaderCombinedCardComponent extends Component {
 							postKey={ postKeys[ i ] }
 							streamUrl={ streamUrl }
 							onClick={ onClick }
-							isDiscover={ isDiscover }
 							isSelected={ isSelectedPost( post ) }
 							showFeaturedAsset={ mediaCount > 0 }
 							hasOrganization={ hasOrganization }

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -76,7 +76,6 @@ class ReaderCombinedCardPost extends Component {
 			currentRoute,
 			post,
 			streamUrl,
-			isDiscover,
 			isSelected,
 			postKey,
 			hasOrganization,
@@ -143,7 +142,7 @@ class ReaderCombinedCardPost extends Component {
 							</a>
 						</h1>
 					</AutoDirection>
-					<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
+					<ReaderExcerpt post={ post } />
 					<div className="reader-combined-card__post-author-and-time ignore-click">
 						<ReaderVisitLink href={ post.URL } iconSize={ 14 }>
 							{ this.props.translate( 'Visit' ) }

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -134,7 +134,6 @@ const ReaderExcerpt = ( { post } ) => {
 
 ReaderExcerpt.propTypes = {
 	post: PropTypes.object.isRequired,
-	isDiscover: PropTypes.bool,
 };
 
 export default ReaderExcerpt;

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -8,7 +8,6 @@ import FeaturedAsset from './featured-asset';
 const CompactPost = ( {
 	children,
 	post,
-	isDiscover,
 	expandCard,
 	postKey,
 	isExpanded,
@@ -47,7 +46,7 @@ const CompactPost = ( {
 							/>
 						) }
 					</div>
-					<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
+					<ReaderExcerpt post={ post } />
 				</div>
 				{ post.canonical_media && (
 					<div className="reader-post-card__post-media">
@@ -78,7 +77,6 @@ const CompactPost = ( {
 CompactPost.propTypes = {
 	post: PropTypes.object.isRequired,
 	postByline: PropTypes.object,
-	isDiscover: PropTypes.bool,
 };
 
 export default CompactPost;

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -6,7 +6,7 @@ import resizeImageUrl from 'calypso/lib/resize-image-url';
 import { getImagesFromPostToDisplay } from 'calypso/state/reader/posts/normalization-rules';
 import { READER_CONTENT_WIDTH } from 'calypso/state/reader/posts/sizes';
 
-function PostGallery( { post, isDiscover, children } ) {
+function PostGallery( { post, children } ) {
 	const imagesToDisplay = getImagesFromPostToDisplay( post, 10 );
 
 	function handleClick( event ) {
@@ -53,7 +53,7 @@ function PostGallery( { post, isDiscover, children } ) {
 						</a>
 					</h2>
 				</AutoDirection>
-				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
+				<ReaderExcerpt post={ post } />
 				{ children }
 			</div>
 		</div>

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -211,7 +211,6 @@ class ReaderPostCard extends Component {
 				<CompactPostCard
 					post={ post }
 					title={ title }
-					isDiscover={ isDiscover }
 					isExpanded={ isExpanded }
 					expandCard={ expandCard }
 					site={ site }
@@ -252,7 +251,6 @@ class ReaderPostCard extends Component {
 				<StandardPost
 					post={ post }
 					title={ title }
-					isDiscover={ isDiscover }
 					isExpanded={ isExpanded }
 					expandCard={ expandCard }
 					site={ site }

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -3,7 +3,7 @@ import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import AutoDirection from 'calypso/components/auto-direction';
 import FeaturedAsset from './featured-asset';
 
-const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpanded, site } ) => {
+const StandardPost = ( { post, children, expandCard, postKey, isExpanded, site } ) => {
 	const onVideoThumbnailClick =
 		post.canonical_media?.mediaType === 'video'
 			? () => expandCard( { postKey, post, site } )
@@ -26,7 +26,7 @@ const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpa
 						</a>
 					</h2>
 				</AutoDirection>
-				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
+				<ReaderExcerpt post={ post } />
 				{ children }
 			</div>
 		</div>
@@ -35,7 +35,6 @@ const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpa
 
 StandardPost.propTypes = {
 	post: PropTypes.object.isRequired,
-	isDiscover: PropTypes.bool,
 };
 
 export default StandardPost;


### PR DESCRIPTION
The ReaderExcerpt component previously accepted an `isDiscover` prop, but it is no longer used.

## Proposed Changes

This PR removes the redundant `isDiscover` prop from ReaderExcerpt, and any parent components that handed it down.

## Testing Instructions

Take a spin through Reader at http://calypso.localhost:3000/read. Check that there are no unexpected console messages or regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
