### PR TITLE
Fix Jetpack Starter Upgrade button in /me/purchases page.

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -33,7 +33,9 @@ import {
 	isAkismetProduct,
 	isAkismetFreeProduct,
 	isJetpackBackupT1Slug,
+	isJetpackStarterPlan,
 	AKISMET_UPGRADES_PRODUCTS_MAP,
+	JETPACK_STARTER_UPGRADE_MAP,
 } from '@automattic/calypso-products';
 import { Spinner, Button, Card, CompactCard, ProductIcon, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
@@ -471,6 +473,14 @@ class ManagePurchase extends Component<
 			return AKISMET_UPGRADES_PRODUCTS_MAP[
 				purchase.productSlug as keyof typeof AKISMET_UPGRADES_PRODUCTS_MAP
 			];
+		}
+
+		if ( isJetpackStarterPlan( purchase.productSlug ) ) {
+			const upgradePlan =
+				JETPACK_STARTER_UPGRADE_MAP[
+					purchase.productSlug as keyof typeof JETPACK_STARTER_UPGRADE_MAP
+				];
+			return `/checkout/${ siteSlug }/${ upgradePlan }`;
 		}
 
 		if ( isUpgradeableBackupProduct || isUpgradeableSecurityPlan ) {

--- a/packages/calypso-products/src/constants/jetpack.ts
+++ b/packages/calypso-products/src/constants/jetpack.ts
@@ -465,6 +465,11 @@ export const JETPACK_PLAN_UPGRADE_MAP: Record< string, string[] > = {
 	],
 };
 
+export const JETPACK_STARTER_UPGRADE_MAP: Record< string, string > = {
+	[ PLAN_JETPACK_STARTER_YEARLY ]: PLAN_JETPACK_SECURITY_T1_YEARLY,
+	[ PLAN_JETPACK_STARTER_MONTHLY ]: PLAN_JETPACK_SECURITY_T1_MONTHLY,
+};
+
 // Categories
 export const JETPACK_SECURITY_CATEGORY = 'jetpack_security_category';
 export const JETPACK_PERFORMANCE_CATEGORY = 'jetpack_performance_category';

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -8,6 +8,7 @@ import {
 	TYPE_PRO,
 	TYPE_FREE,
 	TYPE_FLEXIBLE,
+	TYPE_JETPACK_STARTER,
 	TYPE_STARTER,
 	TYPE_BLOGGER,
 	TYPE_PERSONAL,
@@ -346,6 +347,10 @@ export function isFlexiblePlan( planSlug: string ): boolean {
 
 export function isStarterPlan( planSlug: string ): boolean {
 	return planMatches( planSlug, { type: TYPE_STARTER } );
+}
+
+export function isJetpackStarterPlan( planSlug: string ): boolean {
+	return planMatches( planSlug, { type: TYPE_JETPACK_STARTER } );
 }
 
 export function isSecurityDailyPlan( planSlug: string ): boolean {


### PR DESCRIPTION
Currently (prior to this PR), clicking the "Upgrade" button in `me/purchases` for the Jetpack Starter plan simply takes the user to the `/plans` page.
This PR fixes this where now the "Upgrade" button takes the user to Checkout with Jetpack Security T1 in the cart, where when purchased, the user's Starter plan gets replaced/upgraded with the Security T1 plan.

Note: Even though we are deprecating Jetpack Starter, we still want to have the "Upgrade" button working properly so we can hopefully get people to upgrade to Security from it.

Asana task: 1198218726984184-as-1204960320641467/f
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Added a Starter plan upgrade map object to the calypso-products package.
* Added a `isJetpackStarterPlan()` function to calypso-products package.
* Made the 'Upgrade' button for the Jetpack Starter plan to upgrade to the Jetpack Security T1 plan.

## Testing Instructions

**Prerequisite:** You'll need a connected Jetpack site with a Jetpack Starter subscription. You can create a Jurassic.Ninja site or an Ephemeral site and purchase Jetpack Starter for it.

- Do either of these:
    - Checkout this PR and spin up Calypso blue (`yarn start`), OR:
    - Click the _**Calypso Live (direct link)**_ link below.
- Click "Switch site" and select your site (your site which has a Jetpack Starter subscription).
- Go to Upgrades --> Purchases.
- Click on the Jetpack Starter plan.
- Verify that you see an "Upgrade" button.
- Click the "Upgrade" button and verify that you are taken to checkout with Jetpack Security T1 in the cart.
- Complete the purchase and verify that your site now has a Jetpack Security T1 plan that has replaced the Jetpack Starter plan. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?