### PR TITLE
Theme Details Page: Crash due to missing blocks defined by style variations

### DIFF
--- a/packages/global-styles/src/components/global-styles-provider/index.tsx
+++ b/packages/global-styles/src/components/global-styles-provider/index.tsx
@@ -1,8 +1,8 @@
 import { GlobalStylesContext } from '@wordpress/edit-site/build-module/components/global-styles/context';
 import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
 import { isEmpty, mapValues } from 'lodash';
-import { useState, useMemo, useCallback, useEffect } from 'react';
-import { useGetGlobalStylesBaseConfig } from '../../hooks';
+import { useState, useMemo, useCallback } from 'react';
+import { useGetGlobalStylesBaseConfig, useRegisterCoreBlocks } from '../../hooks';
 import type { GlobalStylesObject } from '../../types';
 
 const cleanEmptyObject = ( object: any ) => {
@@ -84,26 +84,11 @@ interface Props {
 	placeholder: JSX.Element | null;
 }
 
-let blocksRegistered = false;
-
 const GlobalStylesProvider = ( { siteId, stylesheet, children, placeholder = null }: Props ) => {
 	const context = useGlobalStylesContext( siteId, stylesheet );
+	const isBlocksRegistered = useRegisterCoreBlocks();
 
-	useEffect( () => {
-		if ( blocksRegistered ) {
-			return;
-		}
-
-		blocksRegistered = true;
-
-		// The block-level styles have effects only when the specific blocks are registered so we have to register core blocks.
-		// See https://github.com/WordPress/gutenberg/blob/16486bd946f918d581e4818b73ceaaed82349f71/packages/block-editor/src/components/global-styles/use-global-styles-output.js#L1190
-		import( '@wordpress/block-library' ).then(
-			( { registerCoreBlocks }: typeof import('@wordpress/block-library') ) => registerCoreBlocks()
-		);
-	}, [] );
-
-	if ( ! context.isReady ) {
+	if ( ! context.isReady || ! isBlocksRegistered ) {
 		return placeholder;
 	}
 

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 import { translate, TranslateResult } from 'i18n-calypso';
 import { useMemo, useContext } from 'react';
 import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '../../constants';
+import { useRegisterCoreBlocks } from '../../hooks';
 import GlobalStylesVariationPreview from './preview';
 import type { GlobalStylesObject } from '../../types';
 import './style.scss';
@@ -107,6 +108,7 @@ const GlobalStylesVariations = ( {
 	displayFreeLabel = true,
 	globalStylesInPersonalPlan,
 }: GlobalStylesVariationsProps ) => {
+	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
 	const premiumStylesDescription = globalStylesInPersonalPlan
 		? translate(
 				'Unlock custom styles and tons of other features with the Personal plan, or try them out now for free.'
@@ -145,6 +147,10 @@ const GlobalStylesVariations = ( {
 	);
 
 	const headerText = splitDefaultVariation ? translate( 'Default Style' ) : translate( 'Styles' );
+
+	if ( ! isRegisteredCoreBlocks ) {
+		return null;
+	}
 
 	return (
 		<GlobalStylesContext.Provider value={ { base: baseGlobalStyles } }>

--- a/packages/global-styles/src/hooks/index.ts
+++ b/packages/global-styles/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { default as useColorPaletteVariations } from './use-color-palette-variations';
 export { default as useFontPairingVariations } from './use-font-pairing-variations';
 export { default as useGetGlobalStylesBaseConfig } from './use-get-global-styles-base-config';
+export { default as useRegisterCoreBlocks } from './use-register-core-blocks';
 export { default as useSyncGlobalStylesUserConfig } from './use-sync-global-styles-user-config';

--- a/packages/global-styles/src/hooks/use-register-core-blocks.ts
+++ b/packages/global-styles/src/hooks/use-register-core-blocks.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+
+// The blocks should be registered only one time, so use it to avoid multiple registration.
+let blocksRegistered = false;
+
+const useRegisterCoreBlocks = () => {
+	const [ isBlocksRegistered, setIsBlocksRegistered ] = useState( blocksRegistered );
+
+	useEffect( () => {
+		if ( blocksRegistered ) {
+			return;
+		}
+
+		// The block-level styles have effects only when the specific blocks are registered so we have to register core blocks.
+		// See https://github.com/WordPress/gutenberg/blob/16486bd946f918d581e4818b73ceaaed82349f71/packages/block-editor/src/components/global-styles/use-global-styles-output.js#L1190
+		import( '@wordpress/block-library' )
+			.then( ( { registerCoreBlocks }: typeof import('@wordpress/block-library') ) =>
+				registerCoreBlocks()
+			)
+			.then( () => {
+				blocksRegistered = true;
+				setIsBlocksRegistered( true );
+			} );
+	}, [] );
+
+	return isBlocksRegistered;
+};
+
+export default useRegisterCoreBlocks;

--- a/packages/global-styles/src/index.tsx
+++ b/packages/global-styles/src/index.tsx
@@ -10,6 +10,7 @@ export {
 export {
 	useColorPaletteVariations,
 	useFontPairingVariations,
+	useRegisterCoreBlocks,
 	useSyncGlobalStylesUserConfig,
 } from './hooks';
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1689648383135049-slack-C048CUFRGFQ

## Proposed Changes

The style variations contain the [block settings](https://github.com/Automattic/themes/blob/dbe6b3cef3747d4e9489afdff10d4bd63f207748/erma/styles/banana-biscuit.json#L34) but those blocks are not registered. Hence, it leads to the error below because the block selector cannot be found.

![image](https://github.com/Automattic/wp-calypso/assets/13596067/ca298610-e770-400e-8337-840c499d1f36)

This PR is proposing to register core blocks and check whether the core blocks are registered inside the `GlobalStylesVariations` to resolve this issue quickly. We can try to find a better place to do it later.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/theme/erma`
* Ensure the page won't be broken and you can see the style variations correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?