### PR TITLE
Reading settings: correctly update incoming fields based on prevState to avoid race condition

### DIFF
--- a/client/lib/track-form/index.jsx
+++ b/client/lib/track-form/index.jsx
@@ -11,16 +11,17 @@ export const trackForm = ( WrappedComponent ) =>
 		};
 
 		updateFields = ( fields, callback ) => {
-			const newState = {
-				dirtyFields: [ ...new Set( [].concat( this.state.dirtyFields, Object.keys( fields ) ) ) ],
-				fields: {
-					...this.state.fields,
-					...fields,
-				},
-			};
-			debug( 'updateFields', { fields, newState } );
-
-			this.setState( newState, callback );
+			this.setState( ( prevState ) => {
+				const newState = {
+					dirtyFields: [ ...new Set( [].concat( prevState.dirtyFields, Object.keys( fields ) ) ) ],
+					fields: {
+						...prevState.fields,
+						...fields,
+					},
+				};
+				debug( 'updateFields', { fields, newState } );
+				return newState;
+			}, callback );
 		};
 
 		replaceFields = ( fields, callback, keepPrevFields = true ) => {

--- a/client/lib/track-form/index.jsx
+++ b/client/lib/track-form/index.jsx
@@ -26,13 +26,14 @@ export const trackForm = ( WrappedComponent ) =>
 
 		replaceFields = ( fields, callback, keepPrevFields = true ) => {
 			debug( 'replaceFields', { fields, keepPrevFields } );
-			const prevFields = keepPrevFields ? this.state.fields : {};
-			const newFields = {
-				...prevFields,
-				...fields,
-			};
-
-			this.setState( { fields: newFields }, callback );
+			this.setState( ( prevState ) => {
+				const prevFields = keepPrevFields ? prevState.fields : {};
+				const newFields = {
+					...prevFields,
+					...fields,
+				};
+				return { fields: newFields };
+			}, callback );
 		};
 
 		clearDirtyFields = () => {


### PR DESCRIPTION
Related to:

- #79506

## Proposed Changes

So, after a long investigation, the bug was accidentally caused by this PR:

- #72418

What's happening? Basically, this piece of code from the above PR:

https://github.com/Automattic/wp-calypso/blob/f5c3046bc476215eb27c63d52b16274d0d494ef7/client/my-sites/site-settings/reading-newsletter-settings/index.tsx#L42-L46

happens at the same with:

https://github.com/Automattic/wp-calypso/blob/f5c3046bc476215eb27c63d52b16274d0d494ef7/client/my-sites/site-settings/wrap-settings-form.jsx#L52-L57

which happens when the site options are updated (after a theme switch).

React sees two state updates and batch them in one render. Unfortunately, the current implementation of `updateFields()` sets the state without considering the previous state (`prevState`) correctly. Therefore, sometimes (or consistently, depending on React's internal implementation), one of the old state from the two state updates will still remain.

This PR fixes this, by using the correct `this.setState()` overload, which takes the `prevState` into account.

## Testing Instructions

See:

- #79506

Verify that now the Reading Setting values are correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
