### PR TITLE
Remove purchase references

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -554,7 +554,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 							<ProductPlan
 								siteSlug={ selectedSite.slug }
 								primaryPurchase={ primaryPurchase }
-								siteID={ selectedSite.ID }
+								purchases={ this.props.purchases }
 							/>
 						) }
 						{ this.props.children }

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -31,7 +31,6 @@ import page from 'page';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import PlanThankYouCard from 'calypso/blocks/plan-thank-you-card';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HappinessSupport from 'calypso/components/happiness-support';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
@@ -635,7 +634,6 @@ export class CheckoutThankYou extends Component<
 				) }
 				{ isRedesignV2( this.props ) && this.props.selectedSite?.ID && (
 					<>
-						<QuerySitePurchases siteId={ this.props.selectedSite.ID } />
 						<MasterbarStyled
 							onClick={ () => page( `/home/${ this.props.selectedSiteSlug ?? '' }` ) }
 							backText={ translate( 'Back to dashboard' ) }

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductPlan.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductPlan.tsx
@@ -1,62 +1,44 @@
-import { Button, Spinner } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { useEffect, useMemo, useState } from 'react';
-import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
-import { useSelector } from 'calypso/state';
-import {
-	getSitePurchases,
-	hasLoadedSitePurchasesFromServer,
-	isFetchingSitePurchases,
-} from 'calypso/state/purchases/selectors';
 import { ReceiptPurchase } from 'calypso/state/receipts/types';
 
 type ProductPlanProps = {
 	siteSlug: string;
 	primaryPurchase: ReceiptPurchase;
-	siteID: number;
+	purchases: ReceiptPurchase[];
 };
-const ProductPlan = ( { siteSlug, primaryPurchase, siteID }: ProductPlanProps ) => {
-	const isLoadingPurchases = useSelector(
-		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
-	);
+const ProductPlan = ( { siteSlug, primaryPurchase, purchases }: ProductPlanProps ) => {
 	const [ expirationDate, setExpirationDate ] = useState( '' );
 
-	const purchases = useSelector( ( state ) => getSitePurchases( state, siteID ) );
 	const productPurchase = useMemo(
-		() => getPurchaseByProductSlug( purchases, primaryPurchase.productSlug ),
+		() => purchases.find( ( purchase ) => purchase.productSlug === primaryPurchase.productSlug ),
 		[ primaryPurchase.productSlug, purchases ]
 	);
 
+	console.log( 'productPurchase', productPurchase );
 	useEffect( () => {
-		if ( ! isLoadingPurchases && productPurchase ) {
+		if ( productPurchase?.expiryDate ) {
 			setExpirationDate(
 				translate( 'Expires on %s', {
 					args: moment( productPurchase.expiryDate ).format( 'LL' ),
 				} ).toString()
 			);
 		}
-	}, [ isLoadingPurchases, productPurchase ] );
+	}, [ productPurchase ] );
 
 	return (
 		<div className="checkout-thank-you__header-details">
 			<div className="checkout-thank-you__header-details-content">
-				{ isLoadingPurchases ? (
-					<Spinner />
-				) : (
-					<>
-						<div className="checkout-thank-you__header-details-content-name">
-							{ translate( '%(productName)s plan', {
-								args: {
-									productName: primaryPurchase.productName,
-								},
-							} ) }
-						</div>
-						<div className="checkout-thank-you__header-details-content-expiry">
-							{ expirationDate }
-						</div>
-					</>
-				) }
+				<div className="checkout-thank-you__header-details-content-name">
+					{ translate( '%(productName)s plan', {
+						args: {
+							productName: primaryPurchase.productName,
+						},
+					} ) }
+				</div>
+				<div className="checkout-thank-you__header-details-content-expiry">{ expirationDate }</div>
 			</div>
 			<div className="checkout-thank-you__header-details-buttons">
 				<Button primary href={ `/home/${ siteSlug }` }>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductPlan.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductPlan.tsx
@@ -17,7 +17,6 @@ const ProductPlan = ( { siteSlug, primaryPurchase, purchases }: ProductPlanProps
 		[ primaryPurchase.productSlug, purchases ]
 	);
 
-	console.log( 'productPurchase', productPurchase );
 	useEffect( () => {
 		if ( productPurchase?.expiryDate ) {
 			setExpirationDate(

--- a/client/state/receipts/assembler.ts
+++ b/client/state/receipts/assembler.ts
@@ -58,6 +58,7 @@ export function createReceiptObject(
 				isRenewal: Boolean( purchase.is_renewal ),
 				willAutoRenew: Boolean( purchase.will_auto_renew ),
 				saasRedirectUrl: purchase.saas_redirect_url ?? '',
+				expiryDate: purchase.expiry ?? '',
 			};
 		} ),
 		failedPurchases: failedPurchases.map( ( purchase ) => {

--- a/client/state/receipts/types.ts
+++ b/client/state/receipts/types.ts
@@ -17,6 +17,7 @@ export interface ReceiptPurchase {
 	willAutoRenew: boolean;
 	saasRedirectUrl: string;
 	newQuantity: number | undefined;
+	expiryDate?: string;
 }
 
 export interface FailedReceiptPurchase {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/79462

Context for change p1689646053397159/1689628493.696659-slack-CKZHG0QCR

## Proposed Changes

* Remove purchase querying as we want to rely on receipt data for the thank you page.
* Remove purchase query isLoading logic, receipt data is loaded before the screen is rendered (we show a full page placeholder)

## Testing Instructions

* Upgrade your plan via the plans page http://calypso.localhost:3000/plans/
* Once on the thank you page for a particular plan purchase, e.g. http://calypso.localhost:3000/checkout/thank-you/test69068.wordpress.com/20085913
* The expiry date should no longer render (once we have the expiryDate value populated via `assemble_receipt` this will show again)

Before
![Screenshot 2023-07-18 at 15-21-40 Thank You — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/e8a304c8-fa42-4da0-8835-f95dd7e4a8f5)


After
![Screenshot 2023-07-18 at 15-21-27 Thank You — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/a4e2bd49-c646-40ca-b397-144f8f0733f2)