### PR TITLE
Jetpack Pro Dashboard: restrict users to add only one phone number to downtime monitoring

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/index.tsx
@@ -51,6 +51,15 @@ export default function ContactList( {
 		}
 	}, [ type, translate ] );
 
+	const showAddButton = useMemo( () => {
+		switch ( type ) {
+			case 'sms':
+				return items.length < 1;
+			default:
+				return true;
+		}
+	}, [ items.length, type ] );
+
 	return (
 		<>
 			{ type === 'sms' && ! items.length && (
@@ -72,11 +81,12 @@ export default function ContactList( {
 						showVerifiedBadge={ getContactItemValue( type, item ) === verifiedItemKey }
 					/>
 				) ) }
-
-				<Button compact className="contact-list__button" onClick={ onAddContact }>
-					<Icon size={ 18 } icon={ plus } />
-					{ addButtonLabel }
-				</Button>
+				{ showAddButton && (
+					<Button compact className="contact-list__button" onClick={ onAddContact }>
+						<Icon size={ 18 } icon={ plus } />
+						{ addButtonLabel }
+					</Button>
+				) }
 			</div>
 		</>
 	);


### PR DESCRIPTION
Related to 1204992567518369-as-1205068508514247

## Proposed Changes

This PR restricts users to add only one phone number to downtime monitoring.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-show-only-one-jitm` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link. 
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Click on the Mobile notification toggle, and click the "+ Add phone number" button -> Enter all the fields and click "Verify"
6. Verify that the "+ Add phone number" button is hidden after adding one SMS contact.
7. Verify you can see the "+ Add email address" button always, irrespective of no of email contacts added.

<img width="471" alt="Screenshot 2023-07-18 at 11 55 54 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/885a7ade-7202-4f68-a4cf-79635f54df8f">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?