### PR TITLE
Theme preview: Fix issue where the theme description is HTML-encoded

### DIFF
--- a/packages/design-preview/package.json
+++ b/packages/design-preview/package.json
@@ -35,6 +35,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
 		"@wordpress/components": "^23.0.0",
+		"@wordpress/html-entities": "^3.37.0",
 		"@wordpress/icons": "^9.14.0",
 		"@wordpress/react-i18n": "^3.21.0",
 		"classnames": "^2.3.1",

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { NavigatorScreens, useNavigatorButtons } from '@automattic/onboarding';
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { useTranslate } from 'i18n-calypso';
 import type { Category } from '@automattic/design-picker/src/types';
 import type { NavigatorScreenObject } from '@automattic/onboarding';
@@ -55,6 +56,16 @@ const Sidebar: React.FC< SidebarProps > = ( {
 	const isShowDescriptionToggle = shortDescription && description !== shortDescription;
 	const navigatorButtons = useNavigatorButtons( screens );
 
+	const decodedDescription = useMemo(
+		() => ( description ? decodeEntities( description ) : undefined ),
+		[ description ]
+	);
+
+	const decodedShortDescription = useMemo(
+		() => ( shortDescription ? decodeEntities( shortDescription ) : undefined ),
+		[ shortDescription ]
+	);
+
 	return (
 		<div className="design-preview__sidebar">
 			<NavigatorScreens screens={ screens } onNavigatorPathChange={ onNavigatorPathChange }>
@@ -80,12 +91,12 @@ const Sidebar: React.FC< SidebarProps > = ( {
 								) ) }
 							</div>
 						) }
-						{ ( description || shortDescription ) && (
+						{ ( decodedDescription || decodedShortDescription ) && (
 							<div className="design-preview__sidebar-description">
 								<p>
 									{ isShowDescriptionToggle ? (
 										<>
-											{ isShowFullDescription ? description : shortDescription }
+											{ isShowFullDescription ? decodedDescription : decodedShortDescription }
 											<Button
 												borderless
 												onClick={ () => setIsShowFullDescription( ! isShowFullDescription ) }
@@ -96,7 +107,7 @@ const Sidebar: React.FC< SidebarProps > = ( {
 											</Button>
 										</>
 									) : (
-										description ?? shortDescription
+										decodedDescription ?? decodedShortDescription
 									) }
 								</p>
 							</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -668,6 +668,7 @@ __metadata:
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": ^14.0.0
     "@wordpress/components": ^23.0.0
+    "@wordpress/html-entities": ^3.37.0
     "@wordpress/icons": ^9.14.0
     "@wordpress/react-i18n": ^3.21.0
     classnames: ^2.3.1


### PR DESCRIPTION
## Proposed Changes

This PR fixes the issue where the theme preview description are HTML-encoded. See screenshots before for reference:

| Before | After |
| --- | --- | 
| ![Screenshot 2023-07-18 at 2 59 08 PM](https://github.com/Automattic/wp-calypso/assets/797888/1ab2e40b-bb36-453f-a4f5-24a2f3a46667) | ![Screenshot 2023-07-18 at 2 59 39 PM](https://github.com/Automattic/wp-calypso/assets/797888/7407ac4a-a3a4-4560-9cbe-7bd18d0ed41c) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Design Picker `/setup/site-setup/designSetup?siteSlug=${site_slug}&theme=the-menu`
* Ensure that the theme description is no longer HTML encoded
* Another theme that has this issue is Tenaz

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
