### PR TITLE
Stats: Adding support for more currencies

### DIFF
--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -8,6 +8,7 @@ import { ProductsList } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Main from 'calypso/components/main';
@@ -72,6 +73,7 @@ const StatsPurchasePage = () => {
 			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 			<PageViewTracker path="/stats/purchase/:site" title="Stats > Purchase" />
 			<div className="stats">
+				<QueryProductsList />
 				{
 					// TODO: style loading state
 				 }

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -1,13 +1,34 @@
 import config from '@automattic/calypso-config';
+import {
+	PRODUCT_JETPACK_STATS_MONTHLY,
+	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
+	PRODUCT_JETPACK_STATS_FREE,
+} from '@automattic/calypso-products';
+import { ProductsList } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Main from 'calypso/components/main';
 import { useSelector } from 'calypso/state';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import getSiteProducts, { SiteProduct } from 'calypso/state/sites/selectors/get-site-products';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PageViewTracker from '../stats-page-view-tracker';
 import StatsPurchaseWizard from './stats-purchase-wizard';
+
+const isProductOwned = ( ownedProducts: SiteProduct[] | null, searchedProduct: string ) => {
+	if ( ! ownedProducts ) {
+		return false;
+	}
+
+	return ownedProducts
+		.filter( ( product ) => ! product.expired )
+		.map( ( product ) => product.productSlug )
+		.includes( searchedProduct );
+};
 
 const StatsPurchasePage = () => {
 	const translate = useTranslate();
@@ -20,12 +41,59 @@ const StatsPurchasePage = () => {
 		page( '/stats', '/stats/day' );
 	}
 
+	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
+
+	// Determine whether a product is owned.
+	const isFreeOwned = useMemo( () => {
+		return isProductOwned( siteProducts, PRODUCT_JETPACK_STATS_FREE );
+	}, [ siteProducts ] );
+	const isCommercialOwned = useMemo( () => {
+		return isProductOwned( siteProducts, PRODUCT_JETPACK_STATS_MONTHLY );
+	}, [ siteProducts ] );
+	const isPWYWOwned = useMemo( () => {
+		return isProductOwned( siteProducts, PRODUCT_JETPACK_STATS_PWYW_YEARLY );
+	}, [ siteProducts ] );
+
+	const commercialProduct = useSelector( ( state ) =>
+		getProductBySlug( state, PRODUCT_JETPACK_STATS_MONTHLY )
+	) as ProductsList.ProductsListItem | null;
+
+	const pwywProduct = useSelector( ( state ) =>
+		getProductBySlug( state, PRODUCT_JETPACK_STATS_PWYW_YEARLY )
+	) as ProductsList.ProductsListItem | null;
+
+	// eslint-disable-next-line no-console
+	console.log( 'product debug:', commercialProduct, pwywProduct );
+
+	const isLoading = ! commercialProduct || ! pwywProduct;
+
 	return (
 		<Main fullWidthLayout>
 			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
-			<PageViewTracker path="/stats/participation/:site" title="Stats > Purchase" />
+			<PageViewTracker path="/stats/purchase/:site" title="Stats > Purchase" />
 			<div className="stats">
-				{ isPurchaseEnabled && <StatsPurchaseWizard siteSlug={ siteSlug } /> }
+				{
+					// TODO: style loading state
+				 }
+				{ isLoading && <LoadingEllipsis /> }
+				{ ! isLoading && (
+					<>
+						{ ( isFreeOwned || isCommercialOwned || isPWYWOwned ) && (
+							<>
+								{
+									// TODO: add a banner handling information about existing purchase
+								 }
+							</>
+						) }
+						{ isPurchaseEnabled && (
+							<StatsPurchaseWizard
+								siteSlug={ siteSlug }
+								commercialProduct={ commercialProduct }
+								pwywProduct={ pwywProduct }
+							/>
+						) }
+					</>
+				) }
 				<JetpackColophon />
 			</div>
 		</Main>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -14,6 +14,8 @@ interface PersonalPurchaseProps {
 	handlePlanSwap: ( e: React.MouseEvent< HTMLAnchorElement, MouseEvent > ) => void;
 	currencyCode: string;
 	siteSlug: string;
+	sliderStep: number;
+	maxSliderPrice: number;
 }
 
 const PersonalPurchase = ( {
@@ -22,6 +24,8 @@ const PersonalPurchase = ( {
 	handlePlanSwap,
 	currencyCode,
 	siteSlug,
+	sliderStep,
+	maxSliderPrice,
 }: PersonalPurchaseProps ) => {
 	const translate = useTranslate();
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
@@ -69,8 +73,8 @@ const PersonalPurchase = ( {
 				value={ subscriptionValue }
 				renderThumb={ sliderLabel }
 				onChange={ setSubscriptionValue }
-				maxValue={ PRICING_CONFIG.MAX_SLIDER_PRICE }
-				step={ PRICING_CONFIG.SLIDER_STEP }
+				maxValue={ maxSliderPrice }
+				step={ sliderStep }
 			/>
 
 			<p className={ `${ COMPONENT_CLASS_NAME }__average-price` }>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -20,8 +20,6 @@ const TYPE_COMMERCIAL = 'Commercial';
 // TODO: Get pricing config from an API
 const PRICING_CONFIG = {
 	AVERAGE_PRICE_INFO: 6, // used to display how much a users pays on average (below price slider)
-	MAX_SLIDER_PRICE: 10, // max slider amount for PWYW slider
-	SLIDER_STEP: 0.5, // single step for PWYW slider
 	EMOJI_HEART_TIER: 5, // value when slider emoji is changed to a heart emoji
 	IMAGE_CELEBRATION_PRICE: 8, // minimal price that enables image celebration image
 	DEFAULT_STARTING_PRICE: 6, // default position for PWYW slider
@@ -43,7 +41,7 @@ const TitleNode = ( { label, indicatorNumber, active } ) => {
 	);
 };
 
-const ProductCard = ( { siteSlug } ) => {
+const ProductCard = ( { siteSlug, commercialProduct, pwywProduct } ) => {
 	const [ subscriptionValue, setSubscriptionValue ] = useState(
 		PRICING_CONFIG.DEFAULT_STARTING_PRICE
 	);
@@ -55,6 +53,9 @@ const ProductCard = ( { siteSlug } ) => {
 	const personalLabel = translate( 'Personal site' );
 	const commercialLabel = translate( 'Commercial site' );
 	const selectedTypeLabel = siteType === TYPE_PERSONAL ? personalLabel : commercialLabel;
+
+	const maxSliderPrice = commercialProduct.cost;
+	const sliderStep = pwywProduct.cost / 2;
 
 	const setPersonalSite = () => {
 		setSiteType( TYPE_PERSONAL );
@@ -162,12 +163,15 @@ const ProductCard = ( { siteSlug } ) => {
 											handlePlanSwap={ ( e ) => handlePlanSwap( e ) }
 											currencyCode={ currencyCode }
 											siteSlug={ siteSlug }
+											sliderStep={ sliderStep }
+											maxSliderPrice={ maxSliderPrice }
 										/>
 									) : (
 										<CommercialPurchase
-											planValue={ PRICING_CONFIG.FLAT_COMMERCIAL_PRICE }
+											planValue={ commercialProduct?.cost }
 											currencyCode={ currencyCode }
 											siteSlug={ siteSlug }
+											commercialProduct={ commercialProduct }
 										/>
 									) }
 								</PanelRow>
@@ -190,8 +194,14 @@ const ProductCard = ( { siteSlug } ) => {
 	);
 };
 
-const StatsPurchaseWizard = ( { siteSlug } ) => {
-	return <ProductCard siteSlug={ siteSlug } />;
+const StatsPurchaseWizard = ( { siteSlug, commercialProduct, pwywProduct } ) => {
+	return (
+		<ProductCard
+			siteSlug={ siteSlug }
+			commercialProduct={ commercialProduct }
+			pwywProduct={ pwywProduct }
+		/>
+	);
 };
 
 export { StatsPurchaseWizard as default, COMPONENT_CLASS_NAME, PRICING_CONFIG };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79516

## Proposed Changes

* retrieving price information about stats monthly and pwyw products to display price in user's currency
* detect if the site has one of the stats products already purchased

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch for this PR
* Navigate to `/stats/purchase/:siteSlug?flags=stats/paid-stats`
* Verify that price information is available for both personal and commercial prices
* Change your currency and verify that the price is converted to the selected currency

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
