### PR TITLE
Congrats: Fix expiry date data for plans

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -554,7 +554,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 							<ProductPlan
 								siteSlug={ selectedSite.slug }
 								primaryPurchase={ primaryPurchase }
-								purchases={ this.props.purchases }
+								siteID={ selectedSite.ID }
 							/>
 						) }
 						{ this.props.children }

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductPlan.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductPlan.tsx
@@ -2,10 +2,10 @@ import { Button, Spinner } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { useEffect, useMemo, useState } from 'react';
-import { Purchase } from 'calypso/lib/plugins/utils';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import { useSelector } from 'calypso/state';
 import {
+	getSitePurchases,
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
@@ -14,14 +14,15 @@ import { ReceiptPurchase } from 'calypso/state/receipts/types';
 type ProductPlanProps = {
 	siteSlug: string;
 	primaryPurchase: ReceiptPurchase;
-	purchases: Purchase[];
+	siteID: number;
 };
-const ProductPlan = ( { siteSlug, primaryPurchase, purchases }: ProductPlanProps ) => {
+const ProductPlan = ( { siteSlug, primaryPurchase, siteID }: ProductPlanProps ) => {
 	const isLoadingPurchases = useSelector(
 		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
 	);
 	const [ expirationDate, setExpirationDate ] = useState( '' );
 
+	const purchases = useSelector( ( state ) => getSitePurchases( state, siteID ) );
 	const productPurchase = useMemo(
 		() => getPurchaseByProductSlug( purchases, primaryPurchase.productSlug ),
 		[ primaryPurchase.productSlug, purchases ]
@@ -40,18 +41,22 @@ const ProductPlan = ( { siteSlug, primaryPurchase, purchases }: ProductPlanProps
 	return (
 		<div className="checkout-thank-you__header-details">
 			<div className="checkout-thank-you__header-details-content">
-				<div className="checkout-thank-you__header-details-content-name">
-					{ isLoadingPurchases ? (
-						<Spinner />
-					) : (
-						translate( '%(productName)s plan', {
-							args: {
-								productName: primaryPurchase.productName,
-							},
-						} )
-					) }
-				</div>
-				<div className="checkout-thank-you__header-details-content-expiry">{ expirationDate }</div>
+				{ isLoadingPurchases ? (
+					<Spinner />
+				) : (
+					<>
+						<div className="checkout-thank-you__header-details-content-name">
+							{ translate( '%(productName)s plan', {
+								args: {
+									productName: primaryPurchase.productName,
+								},
+							} ) }
+						</div>
+						<div className="checkout-thank-you__header-details-content-expiry">
+							{ expirationDate }
+						</div>
+					</>
+				) }
 			</div>
 			<div className="checkout-thank-you__header-details-buttons">
 				<Button primary href={ `/home/${ siteSlug }` }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/79462
Context: p1689665299108159/1689628493.696659-slack-CKZHG0QCR

## Proposed Changes

Fix by reading the purchase data from the `/purchases` endpoint. We are getting that from `<QuerySitePurchases>` [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/checkout/checkout-thank-you/index.tsx#L657). 

![After](https://github.com/Automattic/wp-calypso/assets/6586048/320029b2-6996-4dc8-b7b0-ce4da57af5cf)


* Load purchase data from the correct source

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Upgrade your plan via the plans page http://calypso.localhost:3000/plans/ (lower than e-commerce)
* Once on the thank you page for a particular plan purchase, e.g. http://calypso.localhost:3000/checkout/thank-you/test69068.wordpress.com/20085913
* The expiry date should be correct 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?