### PR TITLE
Fix small error in input chrono example

### DIFF
--- a/client/components/input-chrono/docs/example.jsx
+++ b/client/components/input-chrono/docs/example.jsx
@@ -14,9 +14,9 @@ const InputChronoExample = localize(
 
 			componentDidMount() {
 				this.interval = setInterval( () => {
-					const date = this.props.moment( self.state.date );
+					const date = this.props.moment( this.state.date );
 					date.hours( date.hours() + 1 );
-					self.setState( { date: date } );
+					this.setState( { date: date } );
 				}, 1000 );
 			}
 


### PR DESCRIPTION
Fix a small error in the `input-chrono` example, where `self` is being used instead of `this`.

Fixes [this Sentry issue](https://a8c.sentry.io/issues/3230642779/?project=6313676).

## Proposed Changes

* Fix a small error in the `input-chrono` example, where `self` is being used instead of `this`

## Testing Instructions

* Open `/devdocs/design/input-chrono`
* Ensure that there are no console errors
* Ensure that the example time advances by one hour every second

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
