### PR TITLE
Theme Showcase: Use demo site for screenshots of themes with style variations

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -1,6 +1,6 @@
 import { Card, Button, Gridicon } from '@automattic/components';
 import {
-	DesignPreviewImage,
+	DesignDemoSiteImage,
 	ThemeCard,
 	isDefaultGlobalStylesVariationSlug,
 } from '@automattic/design-picker';
@@ -144,7 +144,7 @@ export class Theme extends Component {
 
 	renderScreenshot() {
 		const { isExternallyManagedTheme, selectedStyleVariation, theme } = this.props;
-		const { description, screenshot } = theme;
+		const { demo_uri = '', description, screenshot } = theme;
 
 		if ( ! screenshot ) {
 			return (
@@ -161,13 +161,13 @@ export class Theme extends Component {
 		// that there is no flash of image transition from static image to mShots on page load.
 		if (
 			! isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug ) &&
-			! isExternallyManagedTheme
+			! isExternallyManagedTheme &&
+			demo_uri.length
 		) {
-			const { id: themeId, stylesheet } = theme;
-
 			return (
-				<DesignPreviewImage
-					design={ { slug: themeId, recipe: { stylesheet } } }
+				<DesignDemoSiteImage
+					demoUrl={ demo_uri }
+					description={ decodeEntities( description ) }
 					styleVariation={ selectedStyleVariation }
 				/>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -1,11 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon, Button } from '@automattic/components';
-import { DesignPreviewImage, isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
+import { DesignDemoSiteImage, isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
+import { decodeEntities } from 'calypso/lib/formatting';
 import ActivationModal from 'calypso/my-sites/themes/activation-modal';
 import { useSelector, useDispatch } from 'calypso/state';
 import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
@@ -179,14 +180,11 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 					</ThemeSectionButtons>
 				</ThemeNameSectionWrapper>
 				<ThemeSectionImageContainer>
-					{ ! isDefaultGlobalStylesVariationSlug( themeStyleVariation?.slug ) ? (
+					{ theme.demo_uri && ! isDefaultGlobalStylesVariationSlug( themeStyleVariation?.slug ) ? (
 						<ThemeSectionMShotsContainer>
-							<DesignPreviewImage
-								design={ {
-									...theme,
-									slug: theme.id,
-									recipe: { stylesheet: theme.stylesheet },
-								} }
+							<DesignDemoSiteImage
+								url={ theme.demo_uri }
+								description={ decodeEntities( theme.description ) }
 								styleVariation={ themeStyleVariation }
 							/>
 						</ThemeSectionMShotsContainer>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -3,7 +3,7 @@ import { Gridicon, Button } from '@automattic/components';
 import { DesignDemoSiteImage, isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { decodeEntities } from 'calypso/lib/formatting';
@@ -120,6 +120,7 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 	);
 	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) ) ?? undefined;
 	const themeOptions = useSelector( ( state ) => getThemePreviewThemeOptions( state ) );
+	const [ themeDemoUrl, setThemeDemoUrl ] = useState( theme.demo_uri );
 
 	const themeStyleVariation =
 		themeOptions && themeOptions.themeId === theme.id ? themeOptions.styleVariation : undefined;
@@ -143,6 +144,14 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 		sendTrackEvent( 'calypso_theme_thank_you_activate_theme_click' );
 		dispatch( activate( theme.id, siteId, 'marketplace-thank-you' ) );
 	};
+
+	// The theme state might mutate since some endpoints, such as /themes/mine or /themes?status=active
+	// will not return the theme with attributes like demo_uri.
+	useEffect( () => {
+		if ( typeof theme.demo_uri === 'string' ) {
+			setThemeDemoUrl( theme.demo_uri );
+		}
+	}, [ theme.theme_uri ] );
 
 	return (
 		<ThemeSectionContainer>
@@ -180,10 +189,10 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 					</ThemeSectionButtons>
 				</ThemeNameSectionWrapper>
 				<ThemeSectionImageContainer>
-					{ theme.demo_uri && ! isDefaultGlobalStylesVariationSlug( themeStyleVariation?.slug ) ? (
+					{ themeDemoUrl && ! isDefaultGlobalStylesVariationSlug( themeStyleVariation?.slug ) ? (
 						<ThemeSectionMShotsContainer>
 							<DesignDemoSiteImage
-								url={ theme.demo_uri }
+								demoUrl={ themeDemoUrl }
 								description={ decodeEntities( theme.description ) }
 								styleVariation={ themeStyleVariation }
 							/>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -32,7 +32,7 @@ const DesignMShotsImage: React.FC< DesignMShotsImage > = ( { url, altText } ) =>
 		<MShotsImage
 			url={ url }
 			aria-labelledby=""
-			alt={ altText }
+			alt={ altText || '' }
 			options={ getMShotOptions( { scrollable: false, highRes: ! isMobile, isMobile } ) }
 			scrollable={ false }
 		/>
@@ -70,14 +70,16 @@ const DesignDemoSiteImage: React.FC< DesignDemoSiteImageProps > = ( {
 	description,
 	styleVariation,
 } ) => {
-	const params = new URLSearchParams( {
-		iframe: true,
-		theme_preview: true,
-		...( styleVariation && { style_variation: styleVariation.title } ),
-	} );
+	const params = new URLSearchParams( { iframe: 'true', theme_preview: 'true' } );
+	if ( styleVariation?.title ) {
+		params.append( 'style_variation', styleVariation.title );
+	}
 
 	return (
-		<DesignMShotsImage url={ `${ demoUrl }?${ params.toString() }` } altText={ description } />
+		<DesignMShotsImage
+			url={ `${ demoUrl }?${ params.toString() }` }
+			altText={ description || '' }
+		/>
 	);
 };
 

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -20,7 +20,24 @@ import type { Design, StyleVariation } from '../types';
 import type { RefCallback } from 'react';
 import './style.scss';
 
-const makeOptionId = ( { slug }: Design ): string => `design-picker__option-name__${ slug }`;
+interface DesignMShotsImage {
+	url: string;
+	altText?: string;
+}
+
+const DesignMShotsImage: React.FC< DesignMShotsImage > = ( { url, altText } ) => {
+	const isMobile = useViewportMatch( 'small', '<' );
+
+	return (
+		<MShotsImage
+			url={ url }
+			aria-labelledby=""
+			alt={ altText }
+			options={ getMShotOptions( { scrollable: false, highRes: ! isMobile, isMobile } ) }
+			scrollable={ false }
+		/>
+	);
+};
 
 interface DesignPreviewImageProps {
 	design: Design;
@@ -32,21 +49,35 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 	design,
 	locale,
 	styleVariation,
+} ) => (
+	<DesignMShotsImage
+		url={ getDesignPreviewUrl( design, {
+			use_screenshot_overrides: true,
+			style_variation: styleVariation,
+			...( locale && { language: locale } ),
+		} ) }
+	/>
+);
+
+interface DesignDemoSiteImageProps {
+	demoUrl: string;
+	description?: string;
+	styleVariation?: StyleVariation;
+}
+
+const DesignDemoSiteImage: React.FC< DesignDemoSiteImageProps > = ( {
+	demoUrl,
+	description,
+	styleVariation,
 } ) => {
-	const isMobile = useViewportMatch( 'small', '<' );
+	const params = new URLSearchParams( {
+		iframe: true,
+		theme_preview: true,
+		...( styleVariation && { style_variation: styleVariation.title } ),
+	} );
 
 	return (
-		<MShotsImage
-			url={ getDesignPreviewUrl( design, {
-				use_screenshot_overrides: true,
-				style_variation: styleVariation,
-				...( locale && { language: locale } ),
-			} ) }
-			aria-labelledby={ makeOptionId( design ) }
-			alt=""
-			options={ getMShotOptions( { scrollable: false, highRes: ! isMobile, isMobile } ) }
-			scrollable={ false }
-		/>
+		<DesignMShotsImage url={ `${ demoUrl }?${ params.toString() }` } altText={ description } />
 	);
 };
 
@@ -325,4 +356,4 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	);
 };
 
-export { UnifiedDesignPicker as default, DesignPreviewImage };
+export { UnifiedDesignPicker as default, DesignDemoSiteImage, DesignPreviewImage };

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -6,6 +6,7 @@ export { default as ThemeCard } from './components/theme-card';
 export { default as ThemePreview } from './components/theme-preview';
 export {
 	default as UnifiedDesignPicker,
+	DesignDemoSiteImage,
 	DesignPreviewImage,
 } from './components/unified-design-picker';
 export { default as PatternAssemblerCta } from './components/pattern-assembler-cta';


### PR DESCRIPTION
## Proposed Changes

As discussed in https://github.com/Automattic/wp-calypso/pull/79403#discussion_r1263739068, we could use the theme demo site (instead of the block preview endpoint) as the source of the theme's screenshot image. 

Currently, this change only affects the Theme Showcase, since the theme screenshot in the Onboarding Design Picker still supports locale. @Automattic/lego should we also make the change in the Onboarding Design Picker? cc: @autumnfjeld 

mShots images using the demo site as source should look the same as the ones using the block preview endpoint. The different is that using demo site as source is more aligned with core functionalities.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/themes`.
* Click on any style variation, and ensure that the theme screenshot mShots work well.
* Activate the theme with a style variation selected, and ensure that the theme screenshot in the Thank You modal works well too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
