### PR TITLE
Global content footer: update copy and style

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -18,10 +18,10 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 	<div class="support-content-cta">
 		<div class="support-content-cta-left">
 			<h4 class="support-content-resource__title">
-				<?php esc_html_e( 'Let us build your website', 'happy-blocks' ); ?>
+				<?php esc_html_e( 'Your site, built for you', 'happy-blocks' ); ?>
 			</h4>
 			<p>
-				<?php esc_html_e( 'Our professional website-building service can create the site of your dreams, no matter the scope of your project - from small websites and personal blogs to large-scale custom development and migrations.', 'happy-blocks' ); ?>
+				<?php esc_html_e( 'Sit back as our Built by WordPress.com team of experts builds a site you\'ll fall in love with. From single page sites to full stores, they\'ll help you make it happen.', 'happy-blocks' ); ?>
 			</p>
 			<div class="resource-link">
 				<a href="<?php echo esc_url( 'https://wordpress.com/website-design-service/?ref=banner-learn' ); ?>">
@@ -97,9 +97,9 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 			</p>
 		</div>
 		<div class="support-content-subscribe">
-			<p><?php esc_html_e( 'Sign up for educational resources updates:', 'happy-blocks' ); ?></p>
+			<p><?php esc_html_e( 'Get the latest learning in your inbox::', 'happy-blocks' ); ?></p>
 			<form action="https://subscribe.wordpress.com" method="post" accept-charset="utf-8" data-blog="<?php echo get_current_blog_id(); ?>" data-post_access_level="everybody" id="subscribe-blog">
-				<input class="support-content-subscribe-email" required="required" type="email" name="email" placeholder="<?php esc_html_e( 'Enter your best email', 'happy-blocks' ); ?>"  id="subscribe-field">
+				<input class="support-content-subscribe-email" required="required" type="email" name="email" placeholder="<?php esc_html_e( 'Type your email', 'happy-blocks' ); ?>"  id="subscribe-field">
 				<input type="hidden" name="action" value="subscribe">
 				<input type="hidden" name="blog_id" value="<?php echo get_current_blog_id(); ?>">
 				<input type="hidden" name="sub-type" value="subscribe-block">

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -74,8 +74,8 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 			min-width: 0;
 			overflow-wrap: break-word;
 			word-break: break-word;
-			border-bottom: 1px solid var(--studio-gray-5);
-			padding: 32px 16px 32px 0;
+			border-bottom: 1px solid var(--studio-gray-0);
+			padding: 0 16px 32px 0;
 			font-size: 1.25rem;
 		}
 
@@ -116,6 +116,10 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		display: flex;
 		justify-content: space-between;
 		margin-top: 3rem;
+
+		@media (min-width: $breakpoint-mobile) {
+			margin-bottom: 28px;
+		}
 
 		.support-content-subscribe-disclaimer {
 			color: var(--studio-gray-60);

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -11,7 +11,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	max-width: none !important;
 	align-items: normal !important;
 	box-sizing: border-box;
-	padding: 20px 24px;
+	padding: 96px 24px 64px 24px;
 
 	p {
 		font-size: 1rem;
@@ -116,10 +116,6 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		display: flex;
 		justify-content: space-between;
 		margin-top: 3rem;
-
-		@media (min-width: $breakpoint-mobile) {
-			margin-bottom: 28px;
-		}
 
 		.support-content-subscribe-disclaimer {
 			color: var(--studio-gray-60);


### PR DESCRIPTION
This PR updates the global content footer of support and learn.

## Before
![image](https://github.com/Automattic/wp-calypso/assets/52076348/c6d9bb5b-c035-400c-8555-2dc58aacbebe)


## After
![image](https://github.com/Automattic/wp-calypso/assets/52076348/c2046825-fb68-4756-9413-6067250a8ade)

## Testing
1. Checkout branch
2. `cd apps/happy-blocks` and `yarn dev --sync`
3. Visit `wordpress.com/support` and check the global footer