### PR TITLE
Congrats: Update design for ecommerce plan

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductPlan.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductPlan.tsx
@@ -1,7 +1,9 @@
+import { isEcommercePlan } from '@automattic/calypso-products';
 import { Button, Spinner } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { useEffect, useMemo, useState } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import { useSelector } from 'calypso/state';
 import {
@@ -10,6 +12,7 @@ import {
 	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
 import { ReceiptPurchase } from 'calypso/state/receipts/types';
+import { getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
 
 type ProductPlanProps = {
 	siteSlug: string;
@@ -26,6 +29,12 @@ const ProductPlan = ( { siteSlug, primaryPurchase, siteID }: ProductPlanProps ) 
 	const productPurchase = useMemo(
 		() => getPurchaseByProductSlug( purchases, primaryPurchase.productSlug ),
 		[ primaryPurchase.productSlug, purchases ]
+	);
+	// TODO: Move data logic out of the component.
+	const siteHomeUrl = useSelector( ( state ) =>
+		isEcommercePlan( primaryPurchase.productSlug )
+			? getSiteWooCommerceUrl( state, siteID ) ?? `/home/${ siteSlug }`
+			: `/home/${ siteSlug }`
 	);
 
 	useEffect( () => {
@@ -59,10 +68,19 @@ const ProductPlan = ( { siteSlug, primaryPurchase, siteID }: ProductPlanProps ) 
 				) }
 			</div>
 			<div className="checkout-thank-you__header-details-buttons">
-				<Button primary href={ `/home/${ siteSlug }` }>
+				<Button
+					primary
+					href={ siteHomeUrl }
+					onClick={ () => recordTracksEvent( 'calypso_plan_thank_you_home_cta_click' ) }
+				>
 					{ translate( 'Let’s work on the site' ) }
 				</Button>
-				<Button href={ `/plans/my-plan/${ siteSlug }` }>{ translate( 'Manage plan' ) }</Button>
+				<Button
+					href={ `/plans/my-plan/${ siteSlug }` }
+					onClick={ () => recordTracksEvent( 'calypso_plan_thank_you_plan_click' ) }
+				>
+					{ translate( 'Manage plan' ) }
+				</Button>
 			</div>
 		</div>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/standard-checkout-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/standard-checkout-thank-you.tsx
@@ -1,0 +1,70 @@
+import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import { Card, ConfettiAnimation } from 'calypso/../packages/components/src';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import HappinessSupport from 'calypso/components/happiness-support';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import isRedesignV2 from './redesign-v2/is-redesign-v2';
+import MasterbarStyled from './redesign-v2/masterbar-styled';
+import { CheckoutThankYouCombinedProps } from '.';
+
+type AnalyticsProperties = {
+	delay?: number;
+	path: string;
+	recorder?: () => void;
+	hasSelectedSiteLoaded?: boolean;
+	selectedSiteId?: number;
+	properties?: Record< string, unknown >;
+	options?: Record< string, unknown >;
+};
+
+type StandardCheckoutThankYouProps = {
+	productRelatedMessages: () => JSX.Element;
+	isDataLoaded: () => boolean;
+	getAnalyticsProperties: () => AnalyticsProperties;
+	showHappinessSupport: boolean;
+	wasJetpackPlanPurchased: boolean;
+} & CheckoutThankYouCombinedProps;
+
+const StandardCheckoutThankYou = ( {
+	productRelatedMessages,
+	isDataLoaded,
+	getAnalyticsProperties,
+	showHappinessSupport,
+	wasJetpackPlanPurchased,
+	...props
+}: StandardCheckoutThankYouProps ) => {
+	return (
+		<Main
+			className={ classNames( 'checkout-thank-you', {
+				'is-redesign-v2': isRedesignV2( props ),
+			} ) }
+		>
+			<PageViewTracker { ...getAnalyticsProperties() } title="Checkout Thank You" />
+			{ isDataLoaded() && isRedesignV2( props ) && <ConfettiAnimation delay={ 1000 } /> }
+			{ isRedesignV2( props ) && props.selectedSite?.ID && (
+				<>
+					<QuerySitePurchases siteId={ props.selectedSite.ID } />
+					<MasterbarStyled
+						onClick={ () => page( `/home/${ props.selectedSiteSlug ?? '' }` ) }
+						backText={ translate( 'Back to dashboard' ) }
+						canGoBack={ true }
+						showContact={ true }
+					/>
+				</>
+			) }
+			<Card className="checkout-thank-you__content">{ productRelatedMessages() }</Card>
+			{ showHappinessSupport && (
+				<Card className="checkout-thank-you__footer">
+					<HappinessSupport
+						isJetpack={ wasJetpackPlanPurchased }
+						contactButtonEventName="calypso_plans_autoconfig_chat_initiated"
+					/>
+				</Card>
+			) }
+		</Main>
+	);
+};
+
+export default StandardCheckoutThankYou;

--- a/client/my-sites/checkout/checkout-thank-you/standard-checkout-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/standard-checkout-thank-you.tsx
@@ -1,6 +1,6 @@
+import { Card, ConfettiAnimation } from '@automattic/components';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-import { Card, ConfettiAnimation } from 'calypso/../packages/components/src';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HappinessSupport from 'calypso/components/happiness-support';
 import Main from 'calypso/components/main';

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -14,6 +14,7 @@ import {
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import * as mobileApp from 'calypso/lib/mobile-app';
 import CheckoutThankYouHeader from '../header';
 import { CheckoutThankYou } from '../index';
 
@@ -199,7 +200,8 @@ describe( 'CheckoutThankYou', () => {
 			isDotComPlan.mockImplementation( () => false );
 		} );
 
-		test( 'Should be there for AT', () => {
+		test( 'Should be there for AT (Woo mobile)', () => {
+			const isWcMobileAppSpy = jest.spyOn( mobileApp, 'isWcMobileApp' ).mockReturnValue( true );
 			render(
 				<Provider store={ store }>
 					<CheckoutThankYou
@@ -210,6 +212,7 @@ describe( 'CheckoutThankYou', () => {
 				</Provider>
 			);
 			expect( screen.queryByTestId( 'atomic-store-thank-you-card' ) ).toBeVisible();
+			isWcMobileAppSpy.mockRestore();
 		} );
 
 		test( 'Should not be there for AT', () => {
@@ -365,6 +368,35 @@ describe( 'CheckoutThankYou', () => {
 		render(
 			<Provider store={ store }>
 				<CheckoutThankYou { ...props } />
+			</Provider>
+		);
+
+		expect( await screen.findByText( 'component--redesign-v2-footer' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the redesignV2 footer content for ecommerce plan that has completed AT transfer', async () => {
+		const props = {
+			...defaultProps,
+			receiptId: 12,
+			selectedSite: {
+				ID: 12,
+			},
+			sitePlans: {
+				hasLoadedFromServer: true,
+			},
+			receipt: {
+				hasLoadedFromServer: true,
+				data: {
+					purchases: [ { productSlug: PLAN_ECOMMERCE } ],
+				},
+			},
+			refreshSitePlans: ( selectedSite ) => selectedSite,
+			planSlug: PLAN_ECOMMERCE,
+		};
+
+		render(
+			<Provider store={ store }>
+				<CheckoutThankYou { ...props } transferComplete={ true } isWooCommerceInstalled={ true } />
 			</Provider>
 		);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2723

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/fc381b2a-4ae0-4ff5-8fa7-adc3425cb5a5">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/d8aff9f1-5bfc-41ab-bd9f-084aaf3b49e0">|

* Update the design to align with the rest of the plans update
* Added/updated tests

## Testing Instructions

1. Upgrade to e-commerce plan through `/plans` page
2. Check to see the page update on desktop/mobile
3. Click on the buttons
4. Make sure tracks events are present
5. Test around and try to break it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
