### PR TITLE
Remove fixed width on domain transfer button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -393,7 +393,6 @@
 			.bulk-domain-transfer__cta {
 				justify-content: center;
 				color: var(--black-white-white, #fff);
-				width: 157px;
 				height: 48px;
 				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 				border-radius: 0.25rem;


### PR DESCRIPTION
## Description

Currently, the CTA wraps in a multiline.

### Before

![image](https://github.com/Automattic/wp-calypso/assets/5634774/f6837940-f07b-4639-b917-f76539864a13)

### After

![image](https://github.com/Automattic/wp-calypso/assets/5634774/b1728afc-a734-42df-aa55-7abcefd7a6c5)

## Fixes

https://github.com/Automattic/dotcom-forge/issues/3081

## Testing

- Load this PR locally or in Calypso Live
- Go to http://calypso.localhost:3000/setup/domain-transfer/domains
- Edit button at bottom of the page to be something like "Transfer 4998 domain"