### PR TITLE
[Odysseus] Add customised prompts for each section and QoL changes

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -29,7 +29,6 @@ import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
-import OdysseusAssistant from 'calypso/odysseus';
 import { OdysseusAssistantProvider } from 'calypso/odysseus/context';
 import { isOffline } from 'calypso/state/application/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -321,7 +320,6 @@ class Layout extends Component {
 						{ this.shouldShowOdysseusAssistant() ? (
 							<OdysseusAssistantProvider sectionName={ this.props.sectionName }>
 								{ this.props.primary }
-								<OdysseusAssistant />
 							</OdysseusAssistantProvider>
 						) : (
 							this.props.primary

--- a/client/odysseus/context/index.tsx
+++ b/client/odysseus/context/index.tsx
@@ -1,7 +1,9 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import type { Chat, Context, Message, Nudge } from '../types';
+import OdysseusAssistant from '..';
+import { getOdysseusInitialPrompt } from './initial-prompts';
+import type { Chat, Context, Message, Nudge, OdysseusAllowedSectionNames } from '../types';
 import type { ReactNode } from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -67,7 +69,7 @@ const OdysseusAssistantProvider = ( {
 	sectionName,
 	children,
 }: {
-	sectionName: string;
+	sectionName: OdysseusAllowedSectionNames;
 	children: ReactNode;
 } ) => {
 	const siteId = useSelector( getSelectedSiteId );
@@ -76,12 +78,22 @@ const OdysseusAssistantProvider = ( {
 	const [ isNudging, setIsNudging ] = useState( false );
 	const [ lastNudge, setLastNudge ] = useState< Nudge | null >( null );
 	const [ messages, setMessages ] = useState< Message[] >( [
-		{ content: 'Hello, I am Wapuu! Your personal assistant.', role: 'bot', type: 'message' },
+		{ content: getOdysseusInitialPrompt( sectionName ), role: 'bot', type: 'message' },
 	] );
 	const [ chat, setChat ] = useState< Chat >( {
 		context: { section_name: sectionName, site_id: siteId },
 		messages,
 	} );
+
+	useEffect( () => {
+		setChat( {
+			chat_id: null,
+			context: { section_name: sectionName, site_id: siteId },
+			messages: [
+				{ content: getOdysseusInitialPrompt( sectionName ), role: 'bot', type: 'message' },
+			],
+		} );
+	}, [ sectionName, siteId ] );
 
 	const addMessage = ( message: Message ) => {
 		setMessages( ( prevMessages ) => {
@@ -115,6 +127,7 @@ const OdysseusAssistantProvider = ( {
 			} }
 		>
 			{ children }
+			<OdysseusAssistant />
 		</OdysseusAssistantContext.Provider>
 	);
 };

--- a/client/odysseus/context/initial-prompts.ts
+++ b/client/odysseus/context/initial-prompts.ts
@@ -1,0 +1,23 @@
+import { OdysseusAllowedSectionNames, OdysseusAllowedBots } from '../types';
+
+// This is a temporal solution, we might need to move this to the backend.
+const getWapuuInitialPrompts = ( sectionName: OdysseusAllowedSectionNames ): string => {
+	switch ( sectionName ) {
+		case 'plans':
+			return 'Hello, I am Wapuu! I am here to help you choose the best plan for your site. You can ask me about our plans and their features.';
+		default:
+			return 'Hello, I am Wapuu! Your personal assistant.';
+	}
+};
+
+export const getOdysseusInitialPrompt = (
+	sectionName: OdysseusAllowedSectionNames,
+	botNameSlug: OdysseusAllowedBots = 'wapuu'
+): string => {
+	switch ( botNameSlug ) {
+		case 'wapuu':
+			return getWapuuInitialPrompts( sectionName );
+		default:
+			return 'Hello, I am your personal assistant.';
+	}
+};

--- a/client/odysseus/index.tsx
+++ b/client/odysseus/index.tsx
@@ -17,7 +17,6 @@ const OdysseusAssistant = () => {
 	const {
 		lastNudge,
 		chat,
-		isLoadingChat,
 		addMessage,
 		setMessages,
 		isLoading,
@@ -32,20 +31,6 @@ const OdysseusAssistant = () => {
 	const { data: chatData } = useOdysseusGetChatPollQuery( chat.chat_id ?? null );
 
 	const dispatch = useDispatch();
-
-	useEffect( () => {
-		if ( isLoadingChat ) {
-			setMessages( [
-				{ content: 'Remembering any previous conversation...', role: 'bot', type: 'message' },
-			] );
-		} else if ( ! chat ) {
-			setMessages( [
-				{ content: 'Hello, I am Wapuu! Your personal assistant.', role: 'bot', type: 'message' },
-			] );
-		} else if ( chat ) {
-			setMessages( chat.messages );
-		}
-	}, [ chat, isLoadingChat, setMessages, chat.messages ] );
 
 	useEffect( () => {
 		if ( chatData ) {
@@ -86,7 +71,7 @@ const OdysseusAssistant = () => {
 				clearTimeout( timeoutId );
 			};
 		}
-	}, [ lastNudge, setMessages ] );
+	}, [ lastNudge, setIsNudging, setMessages ] );
 
 	const handleMessageChange = ( text: string ) => {
 		setInput( text );

--- a/client/odysseus/types/index.ts
+++ b/client/odysseus/types/index.ts
@@ -27,3 +27,13 @@ export type Chat = {
 	messages: Message[];
 	context: Context;
 };
+
+export type OdysseusAllowedSectionNames =
+	| 'plans'
+	| 'add-ons'
+	| 'domains'
+	| 'email'
+	| 'site-purchases'
+	| 'checkout';
+
+export type OdysseusAllowedBots = 'wapuu';


### PR DESCRIPTION
Related to https://github.com/Automattic/ai-services/issues/128

## Proposed Changes

Improving the code in Layout section, reducing the needed code to add Odysseus to a section
Customised prompts for each sectionName/Bot

## Testing Instructions

Please, refer to: https://github.com/Automattic/ai-services/issues/128

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
