### PR TITLE
Add reader sub-section to performance tracking

### DIFF
--- a/client/blocks/conversations/empty.jsx
+++ b/client/blocks/conversations/empty.jsx
@@ -3,7 +3,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import charactersImage from 'calypso/assets/images/reader/reader-conversations-characters.svg';
 import EmptyContent from 'calypso/components/empty-content';
-import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { withReaderPerformanceTrackerStop } from 'calypso/reader/reader-performance-tracker';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
@@ -50,5 +50,5 @@ class ConversationsEmptyContent extends Component {
 }
 
 export default connect( null, { recordReaderTracksEvent } )(
-	withPerformanceTrackerStop( localize( ConversationsEmptyContent ) )
+	withReaderPerformanceTrackerStop( localize( ConversationsEmptyContent ) )
 );

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -31,7 +31,6 @@ import {
 	RelatedPostsFromSameSite,
 	RelatedPostsFromOtherSites,
 } from 'calypso/components/related-posts';
-import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { isFeaturedImageInContent } from 'calypso/lib/post-normalizer/utils';
 import scrollTo from 'calypso/lib/scroll-to';
 import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
@@ -42,6 +41,7 @@ import LikeButton from 'calypso/reader/like-button';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
 import PostExcerptLink from 'calypso/reader/post-excerpt-link';
 import { keyForPost } from 'calypso/reader/post-key';
+import { ReaderPerformanceTrackerStop } from 'calypso/reader/reader-performance-tracker';
 import { getStreamUrlFromPost } from 'calypso/reader/route';
 import {
 	recordAction,
@@ -592,7 +592,7 @@ export class FullPostView extends Component {
 							fullPost={ true }
 						/>
 
-						{ ! isLoading && <PerformanceTrackerStop /> }
+						{ ! isLoading && <ReaderPerformanceTrackerStop /> }
 
 						{ showRelatedPosts && (
 							<RelatedPostsFromSameSite

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -62,10 +62,17 @@ export const startPerformanceTracking = ( name, { fullPageLoad = false } = {} ) 
 	}
 };
 
-export const stopPerformanceTracking = ( name, { state = {}, metadata = {} } = {} ) => {
+export const stopPerformanceTracking = (
+	name,
+	{ state = {}, metadata = {}, extraCollectors = [] } = {}
+) => {
 	if ( isPerformanceTrackingEnabled() ) {
 		stop( name, {
-			collectors: [ buildDefaultCollector( state ), buildMetadataCollector( metadata ) ],
+			collectors: [
+				buildDefaultCollector( state ),
+				buildMetadataCollector( metadata ),
+				...extraCollectors.map( ( collector ) => collector( state, metadata ) ),
+			],
 		} );
 	}
 };

--- a/client/lib/performance-tracking/performance-tracker-stop.jsx
+++ b/client/lib/performance-tracking/performance-tracker-stop.jsx
@@ -1,7 +1,9 @@
 import { usePerformanceTrackerStop } from './use-performance-tracker-stop';
 
-const PerformanceTrackerStop = () => {
-	usePerformanceTrackerStop();
+const DEFAULT_EXTRA_COLLECTORS = [];
+
+const PerformanceTrackerStop = ( { extraCollectors = DEFAULT_EXTRA_COLLECTORS } ) => {
+	usePerformanceTrackerStop( extraCollectors );
 
 	// Nothing to render, this component is all about side effects
 	return null;

--- a/client/lib/performance-tracking/test/lib.js
+++ b/client/lib/performance-tracking/test/lib.js
@@ -183,6 +183,42 @@ describe( 'stopPerformanceTracking', () => {
 		expect( report.data.get( 'foo' ) ).toBe( 42 );
 	} );
 
+	it( 'uses state and metadata when invoking extra collectors', () => {
+		const report = {
+			data: new Map(),
+		};
+
+		const extraCollectors = [
+			( state ) => {
+				return ( rep ) => {
+					rep.data.set( 'stateFoo', state.foo );
+				};
+			},
+			( _, metadata ) => ( rep ) => {
+				rep.data.set( 'metadataBar', metadata.bar );
+			},
+		];
+
+		// Run the default collector
+		stopPerformanceTracking( 'pageName', {
+			state: {
+				foo: 42,
+			},
+			metadata: {
+				bar: 42,
+			},
+			extraCollectors,
+		} );
+
+		const extraCollector1 = stop.mock.calls[ 0 ][ 1 ].collectors[ 2 ];
+		extraCollector1( report );
+		const extraCollector2 = stop.mock.calls[ 0 ][ 1 ].collectors[ 3 ];
+		extraCollector2( report );
+
+		expect( report.data.get( 'stateFoo' ) ).toBe( 42 );
+		expect( report.data.get( 'metadataBar' ) ).toBe( 42 );
+	} );
+
 	it( 'detects performance of translation chunks', () => {
 		collectTranslationTimings.mockImplementation( () => ( {
 			count: 1,

--- a/client/lib/performance-tracking/test/use-performance-tracker-stop.js
+++ b/client/lib/performance-tracking/test/use-performance-tracker-stop.js
@@ -18,7 +18,7 @@ jest.mock( 'calypso/state/ui/selectors', () => ( {
 	getSectionName: jest.fn(),
 } ) );
 
-describe( 'usePerfomranceTrackerStop hook', () => {
+describe( 'usePerformanceTrackerStop hook', () => {
 	let originalRequestAnimationFrame;
 
 	beforeEach( () => {
@@ -42,6 +42,28 @@ describe( 'usePerfomranceTrackerStop hook', () => {
 		usePerformanceTrackerStop();
 
 		expect( stopPerformanceTracking ).toHaveBeenCalledWith( 'pageName', expect.anything() );
+	} );
+
+	it( 'calls stopPerformanceTracking with any extra collectors', () => {
+		getSectionName.mockImplementation( () => 'pageName' );
+
+		const extraCollectors = [
+			( state ) => {
+				return ( rep ) => {
+					rep.data.set( 'stateFoo', state.foo );
+				};
+			},
+			( _, metadata ) => ( rep ) => {
+				rep.data.set( 'metadataBar', metadata.bar );
+			},
+		];
+
+		usePerformanceTrackerStop( extraCollectors );
+
+		expect( stopPerformanceTracking ).toHaveBeenCalledWith(
+			'pageName',
+			expect.objectContaining( { extraCollectors } )
+		);
 	} );
 
 	it( 'calls stop using useLayoutEffect and requestAnimationFrame', () => {

--- a/client/lib/performance-tracking/use-performance-tracker-stop.js
+++ b/client/lib/performance-tracking/use-performance-tracker-stop.js
@@ -3,14 +3,16 @@ import { useSelector, useStore } from 'react-redux';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import { stopPerformanceTracking } from './lib';
 
-export function usePerformanceTrackerStop() {
+const DEFAULT_EXTRA_COLLECTORS = [];
+
+export function usePerformanceTrackerStop( extraCollectors = DEFAULT_EXTRA_COLLECTORS ) {
 	const sectionName = useSelector( getSectionName );
 	const store = useStore();
 
 	// Use `useLayoutEffect` + rAF to be as close as possible to the actual rendering
 	useLayoutEffect( () => {
 		requestAnimationFrame( () => {
-			stopPerformanceTracking( sectionName, { state: store.getState() } );
+			stopPerformanceTracking( sectionName, { state: store.getState(), extraCollectors } );
 		} );
-	}, [ sectionName, store ] );
+	}, [ sectionName, store, extraCollectors ] );
 }

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -2,9 +2,9 @@ import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
-import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { withReaderPerformanceTrackerStop } from '../reader-performance-tracker';
 
 class TagEmptyContent extends Component {
 	shouldComponentUpdate() {
@@ -44,4 +44,4 @@ class TagEmptyContent extends Component {
 
 export default connect( null, {
 	recordReaderTracksEvent,
-} )( withPerformanceTrackerStop( localize( TagEmptyContent ) ) );
+} )( withReaderPerformanceTrackerStop( localize( TagEmptyContent ) ) );

--- a/client/reader/reader-performance-tracker.js
+++ b/client/reader/reader-performance-tracker.js
@@ -1,0 +1,29 @@
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import getCurrentStream from 'calypso/state/selectors/get-reader-current-stream';
+
+const buildReaderCollector = ( state ) => {
+	const currentStream = getCurrentStream( state ) || '';
+
+	return ( report ) => {
+		// Report only the first part of the stream name, e.g. `tag` instead of `tag:tagName`.
+		report.data.set( 'subSection', currentStream.split( ':' )[ 0 ] );
+	};
+};
+
+const READER_EXTRA_COLLECTORS = [ buildReaderCollector ];
+
+export const ReaderPerformanceTrackerStop = () => {
+	return <PerformanceTrackerStop extraCollectors={ READER_EXTRA_COLLECTORS } />;
+};
+
+export const withReaderPerformanceTrackerStop = createHigherOrderComponent( ( Wrapped ) => {
+	return function WithReaderPerformanceTrackerStop( props ) {
+		return (
+			<>
+				<Wrapped { ...props } />
+				<ReaderPerformanceTrackerStop />
+			</>
+		);
+	};
+}, 'WithReaderPerformanceTrackerStop' );

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
-import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { withReaderPerformanceTrackerStop } from '../reader-performance-tracker';
 
 class SearchEmptyContent extends Component {
 	static propTypes = {
@@ -55,4 +55,4 @@ class SearchEmptyContent extends Component {
 
 export default connect( null, {
 	recordReaderTracksEvent,
-} )( withPerformanceTrackerStop( localize( SearchEmptyContent ) ) );
+} )( withReaderPerformanceTrackerStop( localize( SearchEmptyContent ) ) );

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -3,9 +3,9 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import welcomeImage from 'calypso/assets/images/reader/reader-welcome-illustration.svg';
 import EmptyContent from 'calypso/components/empty-content';
-import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { withReaderPerformanceTrackerStop } from '../reader-performance-tracker';
 
 class FollowingEmptyContent extends Component {
 	shouldComponentUpdate() {
@@ -48,4 +48,4 @@ class FollowingEmptyContent extends Component {
 
 export default connect( null, {
 	recordReaderTracksEvent,
-} )( withPerformanceTrackerStop( localize( FollowingEmptyContent ) ) );
+} )( withReaderPerformanceTrackerStop( localize( FollowingEmptyContent ) ) );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -12,7 +12,6 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { Interval, EVERY_MINUTE } from 'calypso/lib/interval';
-import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import scrollTo from 'calypso/lib/scroll-to';
 import withDimensions from 'calypso/lib/with-dimensions';
 import ReaderMain from 'calypso/reader/components/reader-main';
@@ -44,6 +43,7 @@ import { viewStream } from 'calypso/state/reader-ui/actions';
 import { resetCardExpansions } from 'calypso/state/reader-ui/card-expansions/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
+import { ReaderPerformanceTrackerStop } from '../reader-performance-tracker';
 import EmptyContent from './empty';
 import PostLifecycle from './post-lifecycle';
 import PostPlaceholder from './post-placeholder';
@@ -446,7 +446,7 @@ class ReaderStream extends Component {
 					siteId={ primarySiteId }
 					showFollowButton={ this.props.showFollowButton }
 				/>
-				{ index === 0 && <PerformanceTrackerStop /> }
+				{ index === 0 && <ReaderPerformanceTrackerStop /> }
 			</Fragment>
 		);
 	};

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
-import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { withReaderPerformanceTrackerStop } from '../reader-performance-tracker';
 
 class TagEmptyContent extends Component {
 	static propTypes = {
@@ -77,4 +77,4 @@ class TagEmptyContent extends Component {
 
 export default connect( null, {
 	recordReaderTracksEvent,
-} )( withPerformanceTrackerStop( localize( TagEmptyContent ) ) );
+} )( withReaderPerformanceTrackerStop( localize( TagEmptyContent ) ) );


### PR DESCRIPTION
We want to start tracking performance independently for the various Reader sub-sections, which are currently all lumped together into a single group.

This PR adds a mechanism for performance tracking stoppers to add extra data collectors, and then makes use of that mechanism to collect data on which stream is being viewed in Reader, which gets reported in a new `subSection` property.

@Automattic/team-calypso : Does this look like a reasonable way of collecting section-specific data?

## Proposed Changes

* Add a mechanism for performance tracking stoppers to provide extra data collectors
* Create Reader-specific performance tracking stoppers that make use of the above mechanism to log the sub-section
* Add tests

## Testing Instructions

* Open DevTools on the network tab
* Navigate to Reader
* Navigate to a different Reader sub-section by clicking on the side nav
* Ensure that the data logged to `logstash?http_envelope=1` includes a `subSection` property with the sub-section of Reader that you're viewing

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
