### PR TITLE
Domain transfer: Clear store in complete step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/index.tsx
@@ -45,13 +45,19 @@ const Complete: Step = function Complete( { flow } ) {
 
 	useEffect( () => {
 		dispatch( fetchUserPurchases( userId ) );
-	}, [] );
+	}, [ dispatch, userId ] );
+
+	// Once user purchases are loaded, we don't need the information in the store anymore and can discard it.
+	useEffect( () => {
+		if ( userPurchases ) {
+			resetOnboardStore();
+		}
+	}, [ userPurchases, resetOnboardStore ] );
 
 	const clearDomainsStore = () => {
 		recordTracksEvent( 'calypso_domain_transfer_complete_click', {
 			destination: '/setup/domain-transfer',
 		} );
-		resetOnboardStore();
 	};
 
 	return (


### PR DESCRIPTION
This clears the domain transfer store information in the congrats step. We only reset the info after we no longer need the placeholders.

### Testing
1. Go to /setup/domain-transfer/domains.
2. Add two domains, don't have to be valid or anything.
3. Go to  /setup/domain-transfer/complete.
4. You should see two placeholders during loading.
5. Go to /setup/domain-transfer/domains.
6. Your domains should be gone.