### PR TITLE
Design Preview: Add metrics of the Colors & Fonts

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -261,6 +261,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		} );
 	}
 
+	function recordDesignPreviewSelectScreen( screenSlug: string ) {
+		recordTracksEvent( 'calypso_signup_design_preview_screen_select', { name: screenSlug } );
+	}
+
 	// ********** Logic for unlocking a selected premium design
 
 	useQueryThemes( 'wpcom', { tier: '-marketplace', number: 1000 } );
@@ -616,6 +620,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					onSelectFontVariation={ setSelectedFontVariation }
 					onGlobalStylesChange={ setGlobalStyles }
 					onNavigatorPathChange={ ( path?: string ) => setShouldHideActionButtons( path !== '/' ) }
+					onSelectScreen={ recordDesignPreviewSelectScreen }
 				/>
 			</>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -266,15 +266,44 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		} );
 	}
 
-	function recordDesignPreviewSelectScreen( screenSlug: string ) {
-		recordTracksEvent( 'calypso_signup_design_preview_screen_select', { name: screenSlug } );
+	function recordDesignPreviewScreenSelect( screenSlug: string ) {
+		recordTracksEvent( 'calypso_signup_design_preview_screen_select', {
+			screen_slug: screenSlug,
+			...getEventPropsByDesign( selectedDesign as Design, {
+				styleVariation: selectedStyleVariation,
+				colorVariation: selectedColorVariation,
+				fontVariation: selectedFontVariation,
+			} ),
+		} );
+	}
+
+	function recordDesignPreviewScreenBack( screenSlug: string ) {
+		recordTracksEvent( 'calypso_signup_design_preview_screen_back', {
+			screen_slug: screenSlug,
+			...getEventPropsByDesign( selectedDesign as Design, {
+				styleVariation: selectedStyleVariation,
+				colorVariation: selectedColorVariation,
+				fontVariation: selectedFontVariation,
+			} ),
+		} );
+	}
+
+	function recordDesignPreviewScreenSubmit( screenSlug: string ) {
+		recordTracksEvent( 'calypso_signup_design_preview_screen_submit', {
+			screen_slug: screenSlug,
+			...getEventPropsByDesign( selectedDesign as Design, {
+				styleVariation: selectedStyleVariation,
+				colorVariation: selectedColorVariation,
+				fontVariation: selectedFontVariation,
+			} ),
+		} );
 	}
 
 	function handleSelectColorVariation( colorVariation: GlobalStyles | null ) {
 		setSelectedColorVariation( colorVariation );
 		recordTracksEvent(
 			'calypso_signup_design_preview_color_variation_preview_click',
-			getEventPropsByDesign( selectedDesign!, { colorVariation } )
+			getEventPropsByDesign( selectedDesign as Design, { colorVariation } )
 		);
 	}
 
@@ -282,7 +311,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		setSelectedFontVariation( fontVariation );
 		recordTracksEvent(
 			'calypso_signup_design_preview_font_variation_preview_click',
-			getEventPropsByDesign( selectedDesign!, { fontVariation } )
+			getEventPropsByDesign( selectedDesign as Design, { fontVariation } )
 		);
 	}
 
@@ -665,7 +694,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					onSelectFontVariation={ handleSelectFontVariation }
 					onGlobalStylesChange={ setGlobalStyles }
 					onNavigatorPathChange={ ( path?: string ) => setShouldHideActionButtons( path !== '/' ) }
-					onSelectScreen={ recordDesignPreviewSelectScreen }
+					onScreenSelect={ recordDesignPreviewScreenSelect }
+					onScreenBack={ recordDesignPreviewScreenBack }
+					onScreenSubmit={ recordDesignPreviewScreenSubmit }
 				/>
 			</>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -57,7 +57,12 @@ import UpgradeModal from './upgrade-modal';
 import getThemeIdFromDesign from './utils/get-theme-id-from-design';
 import type { Step, ProvidedDependencies } from '../../types';
 import './style.scss';
-import type { OnboardSelect, SiteSelect, StarterDesigns } from '@automattic/data-stores';
+import type {
+	OnboardSelect,
+	SiteSelect,
+	StarterDesigns,
+	GlobalStyles,
+} from '@automattic/data-stores';
 import type { Design, StyleVariation } from '@automattic/design-picker';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 
@@ -212,18 +217,18 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	function getEventPropsByDesign(
 		design: Design,
-		styleVariation?: StyleVariation,
-		colorVariation?: GlobalStylesObject | null,
-		fontVariation?: GlobalStylesObject | null
+		options: {
+			styleVariation?: StyleVariation;
+			colorVariation?: GlobalStylesObject | null;
+			fontVariation?: GlobalStylesObject | null;
+		} = {}
 	) {
 		return {
 			...getDesignEventProps( {
+				...options,
 				flow,
 				intent,
 				design,
-				styleVariation,
-				colorVariation,
-				fontVariation,
 			} ),
 			category: categorization.selection,
 			...( design.recipe?.pattern_ids && { pattern_ids: design.recipe.pattern_ids.join( ',' ) } ),
@@ -243,13 +248,13 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	function recordPreviewStyleVariation( design: Design, styleVariation?: StyleVariation ) {
 		recordTracksEvent(
 			'calypso_signup_design_preview_style_variation_preview_click',
-			getEventPropsByDesign( design, styleVariation )
+			getEventPropsByDesign( design, { styleVariation } )
 		);
 	}
 
 	function onChangeVariation( design: Design, styleVariation?: StyleVariation ) {
 		recordTracksEvent( 'calypso_signup_design_picker_style_variation_button_click', {
-			...getEventPropsByDesign( design, styleVariation ),
+			...getEventPropsByDesign( design, { styleVariation } ),
 			...getVirtualDesignProps( design ),
 		} );
 	}
@@ -263,6 +268,22 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	function recordDesignPreviewSelectScreen( screenSlug: string ) {
 		recordTracksEvent( 'calypso_signup_design_preview_screen_select', { name: screenSlug } );
+	}
+
+	function handleSelectColorVariation( colorVariation: GlobalStyles | null ) {
+		setSelectedColorVariation( colorVariation );
+		recordTracksEvent(
+			'calypso_signup_design_preview_color_variation_preview_click',
+			getEventPropsByDesign( selectedDesign!, { colorVariation } )
+		);
+	}
+
+	function handleSelectFontVariation( fontVariation: GlobalStyles | null ) {
+		setSelectedFontVariation( fontVariation );
+		recordTracksEvent(
+			'calypso_signup_design_preview_font_variation_preview_click',
+			getEventPropsByDesign( selectedDesign!, { fontVariation } )
+		);
 	}
 
 	// ********** Logic for unlocking a selected premium design
@@ -306,7 +327,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		if ( selectedDesign ) {
 			recordTracksEvent(
 				'calypso_signup_design_preview_unlock_theme_click',
-				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
+				getEventPropsByDesign( selectedDesign, {
+					styleVariation: selectedStyleVariation,
+					colorVariation: selectedColorVariation,
+					fontVariation: selectedFontVariation,
+				} )
 			);
 		}
 
@@ -361,7 +386,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		if ( selectedDesign && numOfSelectedGlobalStyles ) {
 			recordTracksEvent(
 				'calypso_signup_design_global_styles_gating_modal_show',
-				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
+				getEventPropsByDesign( selectedDesign, {
+					styleVariation: selectedStyleVariation,
+					colorVariation: selectedColorVariation,
+					fontVariation: selectedFontVariation,
+				} )
 			);
 			setShowPremiumGlobalStylesModal( true );
 		}
@@ -372,7 +401,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		if ( selectedDesign && numOfSelectedGlobalStyles ) {
 			recordTracksEvent(
 				'calypso_signup_design_global_styles_gating_modal_close_button_click',
-				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
+				getEventPropsByDesign( selectedDesign, {
+					styleVariation: selectedStyleVariation,
+					colorVariation: selectedColorVariation,
+					fontVariation: selectedFontVariation,
+				} )
 			);
 			setShowPremiumGlobalStylesModal( false );
 		}
@@ -383,7 +416,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		if ( selectedDesign && numOfSelectedGlobalStyles && siteSlugOrId ) {
 			recordTracksEvent(
 				'calypso_signup_design_global_styles_gating_modal_checkout_button_click',
-				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
+				getEventPropsByDesign( selectedDesign, {
+					styleVariation: selectedStyleVariation,
+					colorVariation: selectedColorVariation,
+					fontVariation: selectedFontVariation,
+				} )
 			);
 
 			goToCheckout( {
@@ -404,7 +441,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		if ( selectedDesign && numOfSelectedGlobalStyles ) {
 			recordTracksEvent(
 				'calypso_signup_design_global_styles_gating_modal_try_button_click',
-				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
+				getEventPropsByDesign( selectedDesign, {
+					styleVariation: selectedStyleVariation,
+					colorVariation: selectedColorVariation,
+					fontVariation: selectedFontVariation,
+				} )
 			);
 			pickDesign();
 		}
@@ -498,7 +539,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		if ( isPreviewingDesign ) {
 			recordTracksEvent(
 				'calypso_signup_design_preview_exit',
-				getEventPropsByDesign( selectedDesign as Design, selectedStyleVariation )
+				getEventPropsByDesign( selectedDesign as Design, {
+					styleVariation: selectedStyleVariation,
+					colorVariation: selectedColorVariation,
+					fontVariation: selectedFontVariation,
+				} )
 			);
 
 			resetPreview();
@@ -615,9 +660,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					stylesheet={ selectedDesign.recipe?.stylesheet }
 					isVirtual={ selectedDesign.is_virtual }
 					selectedColorVariation={ selectedColorVariation }
-					onSelectColorVariation={ setSelectedColorVariation }
+					onSelectColorVariation={ handleSelectColorVariation }
 					selectedFontVariation={ selectedFontVariation }
-					onSelectFontVariation={ setSelectedFontVariation }
+					onSelectFontVariation={ handleSelectFontVariation }
 					onGlobalStylesChange={ setGlobalStyles }
 					onNavigatorPathChange={ ( path?: string ) => setShouldHideActionButtons( path !== '/' ) }
 					onSelectScreen={ recordDesignPreviewSelectScreen }

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -35,7 +35,9 @@ interface DesignPreviewProps {
 	limitGlobalStyles: boolean;
 	globalStylesInPersonalPlan: boolean;
 	onNavigatorPathChange?: ( path?: string ) => void;
-	onSelectScreen?: ( screenSlug: string ) => void;
+	onScreenSelect?: ( screenSlug: string ) => void;
+	onScreenBack?: ( screenSlug: string ) => void;
+	onScreenSubmit?: ( screenSlug: string ) => void;
 }
 
 // @todo Get the style variations of theme, and then combine the selected one with colors & fonts for consistency
@@ -64,7 +66,9 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	onGlobalStylesChange,
 	limitGlobalStyles,
 	globalStylesInPersonalPlan,
-	onSelectScreen,
+	onScreenSelect,
+	onScreenBack,
+	onScreenSubmit,
 	onNavigatorPathChange,
 } ) => {
 	const isDesktop = useViewportMatch( 'large' );
@@ -91,7 +95,9 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 		onSelectVariation,
 		onSelectColorVariation,
 		onSelectFontVariation,
-		onSelectScreen,
+		onScreenSelect,
+		onScreenBack,
+		onScreenSubmit,
 	} );
 
 	const isFullscreen = ! isDesktop && ( screens.length === 1 || ! isInitialScreen );

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -35,6 +35,7 @@ interface DesignPreviewProps {
 	limitGlobalStyles: boolean;
 	globalStylesInPersonalPlan: boolean;
 	onNavigatorPathChange?: ( path?: string ) => void;
+	onSelectScreen?: ( screenSlug: string ) => void;
 }
 
 // @todo Get the style variations of theme, and then combine the selected one with colors & fonts for consistency
@@ -63,6 +64,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	onGlobalStylesChange,
 	limitGlobalStyles,
 	globalStylesInPersonalPlan,
+	onSelectScreen,
 	onNavigatorPathChange,
 } ) => {
 	const isDesktop = useViewportMatch( 'large' );
@@ -89,6 +91,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 		onSelectVariation,
 		onSelectColorVariation,
 		onSelectFontVariation,
+		onSelectScreen,
 	} );
 
 	const isFullscreen = ! isDesktop && ( screens.length === 1 || ! isInitialScreen );

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -27,6 +27,7 @@ interface Props {
 	onSelectVariation: ( variation: StyleVariation ) => void;
 	onSelectColorVariation: ( variation: GlobalStylesObject | null ) => void;
 	onSelectFontVariation: ( variation: GlobalStylesObject | null ) => void;
+	onSelectScreen?: ( screenSlug: string ) => void;
 }
 
 const useScreens = ( {
@@ -43,6 +44,7 @@ const useScreens = ( {
 	onSelectVariation,
 	onSelectColorVariation,
 	onSelectFontVariation,
+	onSelectScreen,
 }: Props ) => {
 	const translate = useTranslate();
 
@@ -51,6 +53,7 @@ const useScreens = ( {
 			[
 				variations &&
 					variations.length > 0 && {
+						slug: 'style-variations',
 						checked: ! isDefaultGlobalStylesVariationSlug( selectedVariation?.slug ),
 						icon: styles,
 						label: translate( 'Styles' ),
@@ -74,6 +77,7 @@ const useScreens = ( {
 							</div>
 						),
 						actionText: translate( 'Save styles' ),
+						onSelect: onSelectScreen,
 					},
 				variations &&
 					variations.length === 0 &&
@@ -81,6 +85,7 @@ const useScreens = ( {
 					! isVirtual &&
 					! COLOR_VARIATIONS_BLOCK_LIST.includes( stylesheet ) &&
 					isEnabled( 'signup/design-picker-preview-colors' ) && {
+						slug: 'color-palettes',
 						checked: !! selectedColorVariation,
 						icon: color,
 						label: translate( 'Colors' ),
@@ -102,10 +107,12 @@ const useScreens = ( {
 							</div>
 						),
 						actionText: translate( 'Save colors' ),
+						onSelect: onSelectScreen,
 					},
 				variations &&
 					variations.length === 0 &&
 					isEnabled( 'signup/design-picker-preview-fonts' ) && {
+						slug: 'font-pairings',
 						checked: !! selectedFontVariation,
 						icon: typography,
 						label: translate( 'Fonts' ),
@@ -124,6 +131,7 @@ const useScreens = ( {
 							</div>
 						),
 						actionText: translate( 'Save fonts' ),
+						onSelect: onSelectScreen,
 					},
 			].filter( Boolean ) as NavigatorScreenObject[],
 		[

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -27,7 +27,9 @@ interface Props {
 	onSelectVariation: ( variation: StyleVariation ) => void;
 	onSelectColorVariation: ( variation: GlobalStylesObject | null ) => void;
 	onSelectFontVariation: ( variation: GlobalStylesObject | null ) => void;
-	onSelectScreen?: ( screenSlug: string ) => void;
+	onScreenSelect?: ( screenSlug: string ) => void;
+	onScreenBack?: ( screenSlug: string ) => void;
+	onScreenSubmit?: ( screenSlug: string ) => void;
 }
 
 const useScreens = ( {
@@ -44,7 +46,9 @@ const useScreens = ( {
 	onSelectVariation,
 	onSelectColorVariation,
 	onSelectFontVariation,
-	onSelectScreen,
+	onScreenSelect,
+	onScreenBack,
+	onScreenSubmit,
 }: Props ) => {
 	const translate = useTranslate();
 
@@ -77,7 +81,9 @@ const useScreens = ( {
 							</div>
 						),
 						actionText: translate( 'Save styles' ),
-						onSelect: onSelectScreen,
+						onSelect: onScreenSelect,
+						onBack: onScreenBack,
+						onSubmit: onScreenSubmit,
 					},
 				variations &&
 					variations.length === 0 &&
@@ -107,7 +113,9 @@ const useScreens = ( {
 							</div>
 						),
 						actionText: translate( 'Save colors' ),
-						onSelect: onSelectScreen,
+						onSelect: onScreenSelect,
+						onBack: onScreenBack,
+						onSubmit: onScreenSubmit,
 					},
 				variations &&
 					variations.length === 0 &&
@@ -131,7 +139,9 @@ const useScreens = ( {
 							</div>
 						),
 						actionText: translate( 'Save fonts' ),
-						onSelect: onSelectScreen,
+						onSelect: onScreenSelect,
+						onBack: onScreenBack,
+						onSubmit: onScreenSubmit,
 					},
 			].filter( Boolean ) as NavigatorScreenObject[],
 		[

--- a/packages/onboarding/src/navigator/navigator-screens/hooks/use-navigator-buttons.tsx
+++ b/packages/onboarding/src/navigator/navigator-screens/hooks/use-navigator-buttons.tsx
@@ -13,14 +13,14 @@ const useNavigatorButtons = ( screens: NavigatorScreenObject[] ) => {
 
 	return (
 		<NavigatorItemGroup>
-			{ screens.map( ( { checked, icon, label, path, onSelect } ) => (
+			{ screens.map( ( { slug, checked, icon, label, path, onSelect } ) => (
 				<NavigationButtonAsItem
 					key={ path }
 					checked={ checked }
 					icon={ icon }
 					path={ path }
 					aria-label={ label }
-					onClick={ onSelect }
+					onClick={ () => onSelect?.( slug ) }
 				>
 					{ label }
 				</NavigationButtonAsItem>

--- a/packages/onboarding/src/navigator/navigator-screens/hooks/use-navigator-screens.tsx
+++ b/packages/onboarding/src/navigator/navigator-screens/hooks/use-navigator-screens.tsx
@@ -11,14 +11,25 @@ const useNavigatorScreens = ( screens: NavigatorScreenObject[] ) => {
 	const translate = useTranslate();
 
 	return screens.map(
-		( { path, label, title, description, hideBack, content, actionText, onSubmit, onBack } ) => (
+		( {
+			slug,
+			path,
+			label,
+			title,
+			description,
+			hideBack,
+			content,
+			actionText,
+			onSubmit,
+			onBack,
+		} ) => (
 			<NavigatorScreen key={ path } path={ path }>
 				<>
 					<NavigatorHeader
 						title={ <>{ title ?? label }</> }
 						description={ description }
 						hideBack={ hideBack }
-						onBack={ onBack }
+						onBack={ () => onBack?.( slug ) }
 					/>
 					{ content }
 					<div className="navigator-screen__footer">
@@ -28,12 +39,12 @@ const useNavigatorScreens = ( screens: NavigatorScreenObject[] ) => {
 							title={ translate( 'Back' ) }
 							borderless={ true }
 							aria-label={ translate( 'Navigate to the previous view' ) }
-							onClick={ onBack }
+							onClick={ () => onBack?.( slug ) }
 						>
 							<Gridicon icon="chevron-left" size={ 18 } />
 							{ translate( 'Back' ) }
 						</NavigatorBackButton>
-						<NavigatorBackButton as={ Button } primary onClick={ onSubmit }>
+						<NavigatorBackButton as={ Button } primary onClick={ () => onSubmit?.( slug ) }>
 							{ actionText }
 						</NavigatorBackButton>
 					</div>

--- a/packages/onboarding/src/navigator/navigator-screens/types.ts
+++ b/packages/onboarding/src/navigator/navigator-screens/types.ts
@@ -1,4 +1,5 @@
 export type NavigatorScreenObject = {
+	slug: string;
 	checked?: boolean;
 	icon?: JSX.Element;
 	label: string;
@@ -8,7 +9,7 @@ export type NavigatorScreenObject = {
 	hideBack?: boolean;
 	content: JSX.Element;
 	actionText: string;
-	onSelect?: () => void;
+	onSelect?: ( slug: string ) => void;
 	onSubmit?: () => void;
 	onBack?: () => void;
 };

--- a/packages/onboarding/src/navigator/navigator-screens/types.ts
+++ b/packages/onboarding/src/navigator/navigator-screens/types.ts
@@ -10,6 +10,6 @@ export type NavigatorScreenObject = {
 	content: JSX.Element;
 	actionText: string;
 	onSelect?: ( slug: string ) => void;
-	onSubmit?: () => void;
-	onBack?: () => void;
+	onSubmit?: ( slug: string ) => void;
+	onBack?: ( slug: string ) => void;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78419

## Proposed Changes

Add new events to the Colors & Fonts in the Design Preview

#### Colors

| Event | Descriptions | Screenshots |
| - | - | - |
| calypso_signup_design_preview_screen_select | Go to the Colors screen | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/1c812647-f71a-4086-9679-63791868ea1f) |
| calypso_signup_design_preview_color_variation_preview_click | Preview Colors | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/11538c95-84ec-4a55-ae4a-c61066fbe05d) |
| calypso_signup_design_preview_screen_back | Go back from the Colors screen | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/aa33efd8-54e9-4217-a47e-9f1fed61534f) |
| calypso_signup_design_preview_screen_submit | Save on the Colors screen | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/bb29667f-9ba0-487f-b585-22dff757cc14) |

#### Fonts

| Event | Descriptions | Screenshots |
| - | - | - |
| calypso_signup_design_preview_screen_select | Go to the Fonts screen | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/a7314425-a2ac-4776-8440-4b9086a8290b) | 
| calypso_signup_design_preview_font_variation_preview_click | Preview Fonts | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/f9805490-445c-47cf-aac9-34e4db38d34d) |
| calypso_signup_design_preview_screen_back | Go back from the Fonts screen | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/1f4880cc-2452-48c2-b6a3-9d44ccc3efb5) |
| calypso_signup_design_preview_screen_submit | Save on the Fonts screen | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/ae356181-808c-416a-bd14-6005d9a2de01) |


#### Upsell modal

| Event | Descriptions | Screenshots |
| - | - | - |
| calypso_signup_design_global_styles_gating_modal_show | Upsell Modal Show | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/dcb54b89-9961-4577-9041-d11275597007) |
| calypso_signup_design_global_styles_gating_modal_close_button_click | Upsell Modal Close | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/ea3df36a-3846-4a54-b32d-b6f4db0f7975) |
| calypso_signup_design_global_styles_gating_modal_checkout_button_click | Upgrade Plan | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/e05f5e29-3bbb-4bfa-8986-c6c907ae63b8) |
| calypso_signup_design_global_styles_gating_modal_try_button_click | Decide later | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/7a1c1763-357d-4075-9005-e399d6c4a607) |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>
* Continue to Design Picker
* Preview a design without the style variations, e.g.: Poema
* Ensure the events are fired correctly with the following steps
  * Select Colors/Fonts
  * Preview colors/fonts variations
  * Click the `<` or `Save` button
  * Continue
  * Ensure you see the Upsell Modal
  * Click “X”, “Decide later”, or “Upgrade plan”

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
