### PR TITLE
Remove plans URL parameter from eCommerce trial nudge in settings page

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -5,7 +5,6 @@ import {
 	WPCOM_FEATURES_NO_WPCOM_BRANDING,
 	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
 	FEATURE_STYLE_CUSTOMIZATION,
-	PLAN_ECOMMERCE_MONTHLY,
 } from '@automattic/calypso-products';
 import {
 	PLAN_PERSONAL,
@@ -638,12 +637,7 @@ export class SiteSettingsFormGeneral extends Component {
 				'Before you can share your store with the world, you need to {{a}}pick a plan{{/a}}.',
 				{
 					components: {
-						a: (
-							<a
-								href={ `/plans/${ siteSlug }?plan=${ PLAN_ECOMMERCE_MONTHLY }` }
-								onClick={ recordTracksEventForClick }
-							/>
-						),
+						a: <a href={ `/plans/${ siteSlug }` } onClick={ recordTracksEventForClick } />,
 					},
 				}
 			);


### PR DESCRIPTION
Related to #77667

## Proposed Changes

* This PR removes the `plan` URL parameter from the upgrade nudge we show on the Settings page for sites that are on the free eCommerce trial, as the additional URL parameter causes the underlying plan grid to display WordPress.com plans instead of the Woo Express plans.
  - The parameter needs to be removed because as of https://github.com/Automattic/wp-calypso/pull/77667, the `plan` URL parameter is referenced from within the plans grid

This was originally reported internally in p1689674396291679/1689673410.037769-slack-C03Q87XT1QF.

## Testing Instructions

* Set up a free eCommerce/ Woo Express trial site -- you can do that by visiting `/setup/wooexpress`
* Navigate to _Settings_ -> _General_
* Verify that the _Launch site_ section includes a nudge with the text "Before you can share your store with the world, you need to [pick a plan](https://wordpress.com/plans/wooexpress-mortally-mellow-typhoon.wpcomstaging.com)."
  - Confirm that the "pick a plan" link _doesn't_ include a `plan` URL parameter
* Click on the "pick a plan" link
* Verify that you are taken to the Plans page for the site and the plans grid shows the Woo Express Essential and Performance plans.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [N/A] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?