### PR TITLE
After switching theme, fetch latest site front page options

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryPosts from 'calypso/components/data/query-posts';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import EmptyContent from 'calypso/components/empty-content';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import ListEnd from 'calypso/components/list-end';
@@ -461,6 +462,7 @@ export default class PageList extends Component {
 		return (
 			<div>
 				<QueryPosts siteId={ siteId } query={ { ...query, page } } />
+				<QuerySiteSettings siteId={ siteId } />
 				<ConnectedPages
 					incrementPage={ this.incrementPage }
 					query={ { ...query, page } }

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryPosts from 'calypso/components/data/query-posts';
-import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import EmptyContent from 'calypso/components/empty-content';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import ListEnd from 'calypso/components/list-end';
@@ -462,7 +461,6 @@ export default class PageList extends Component {
 		return (
 			<div>
 				<QueryPosts siteId={ siteId } query={ { ...query, page } } />
-				<QuerySiteSettings siteId={ siteId } />
 				<ConnectedPages
 					incrementPage={ this.incrementPage }
 					query={ { ...query, page } }

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -9,7 +9,7 @@ import {
 	SITE_SETTINGS_SAVE_SUCCESS,
 	SITE_SETTINGS_UPDATE,
 } from 'calypso/state/action-types';
-import { requestSite } from 'calypso/state/sites/actions';
+import { requestSite, receiveSiteFrontPage } from 'calypso/state/sites/actions';
 import { normalizeSettings } from './utils';
 import 'calypso/state/site-settings/init';
 import 'calypso/state/ui/init';
@@ -68,6 +68,7 @@ export function requestSiteSettings( siteId ) {
 				};
 
 				dispatch( receiveSiteSettings( siteId, savedSettings ) );
+				dispatch( receiveSiteOptions( siteId, savedSettings ) );
 				dispatch( {
 					type: SITE_SETTINGS_REQUEST_SUCCESS,
 					siteId,
@@ -110,5 +111,11 @@ export function saveSiteSettings( siteId, settings = {} ) {
 
 				return error;
 			} );
+	};
+}
+
+export function receiveSiteOptions( siteId, settings ) {
+	return ( dispatch ) => {
+		dispatch( receiveSiteFrontPage( siteId, settings ) );
 	};
 }

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -258,15 +258,13 @@ export const updateSiteFrontPage = ( siteId, frontPageOptions ) => async ( dispa
 			page_for_posts_id: frontPageOptions.page_for_posts,
 		} );
 
-		dispatch( {
-			type: SITE_FRONT_PAGE_UPDATE,
-			siteId,
-			frontPageOptions: {
+		dispatch(
+			receiveSiteFrontPage( siteId, {
 				show_on_front: response.is_page_on_front ? 'page' : 'posts',
-				page_on_front: parseInt( response.page_on_front_id, 10 ),
-				page_for_posts: parseInt( response.page_for_posts_id, 10 ),
-			},
-		} );
+				page_on_front: response.page_on_front_id,
+				page_for_posts: response.page_for_posts_id,
+			} )
+		);
 	} catch {}
 };
 
@@ -279,6 +277,18 @@ function isPageOnFront( showOnFront ) {
 		default:
 			return undefined;
 	}
+}
+
+export function receiveSiteFrontPage( siteId, { show_on_front, page_on_front, page_for_posts } ) {
+	return {
+		type: SITE_FRONT_PAGE_UPDATE,
+		siteId,
+		frontPageOptions: {
+			show_on_front,
+			page_on_front: parseInt( page_on_front, 10 ),
+			page_for_posts: parseInt( page_for_posts, 10 ),
+		},
+	};
 }
 
 /**

--- a/client/state/themes/actions/theme-activated.js
+++ b/client/state/themes/actions/theme-activated.js
@@ -1,6 +1,7 @@
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { requestSitePosts } from 'calypso/state/posts/actions';
+import { requestSiteSettings } from 'calypso/state/site-settings/actions';
 import { THEME_ACTIVATE_SUCCESS } from 'calypso/state/themes/action-types';
 import {
 	getActiveTheme,
@@ -61,7 +62,9 @@ export function themeActivated(
 		// the admin bar to ensure that those updates are displayed in the UI.
 		dispatch( requestAdminMenu( siteId ) );
 
-		// Update pages in case the front page was updated on theme switch.
+		// In case the front page options were updated on theme switch,
+		// request the latest settings and pages to reflect them.
+		dispatch( requestSiteSettings( siteId ) );
 		dispatch( requestSitePosts( siteId, { type: 'page' } ) );
 	};
 }


### PR DESCRIPTION
Related to:

- #79511

## Proposed Changes

Switching to certain themes might update the front page options (aka "Your homepage displays" settings). This PR adds `<QuerySiteSettings/>` to the component that shows Pages page.

Unfortunately, somehow `receiveSiteSettings()` does not update incoming site options to the Redux store; so this PR also explicitly updates the front page options to the Redux store.

## Testing Instructions

1. Create a new site.
1. Skip the Design Picker theme selection, which will set the theme of your site to TT3.
1. Then, activate Meraki theme (or any theme in https://wordpress.com/themes/filter/auto-loading-homepage).
1. (Don't refresh the page) Go to Pages in the left sidebar.
1. Verify that you see this:

<img width="1073" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/9007dc67-4fb6-47cb-895c-89941369061b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
