### PR TITLE
Signup: Remove type casting for domainCartItem in useRecordSignupComplete

### DIFF
--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -1,5 +1,4 @@
 import { isDomainTransfer, isDomainMapping } from '@automattic/calypso-products';
-import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useSelect } from '@wordpress/data';
 import { useCallback } from 'react';
 import { USER_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
@@ -58,12 +57,10 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 			isBlankCanvas: theme?.includes( 'blank-canvas' ),
 			planProductSlug,
 			domainProductSlug,
-			isMapping: hasPaidDomainItem
-				? isDomainMapping( domainCartItem as MinimalRequestCartProduct )
-				: undefined,
-			isTransfer: hasPaidDomainItem
-				? isDomainTransfer( domainCartItem as MinimalRequestCartProduct )
-				: undefined,
+			isMapping:
+				hasPaidDomainItem && domainCartItem ? isDomainMapping( domainCartItem ) : undefined,
+			isTransfer:
+				hasPaidDomainItem && domainCartItem ? isDomainTransfer( domainCartItem ) : undefined,
 		} );
 	}, [ domainCartItem, flow, planCartItem, selectedDomain, siteCount, siteId, theme ] );
 };


### PR DESCRIPTION
## Proposed Changes

We are seeing fatal errors in calypso like this one: p1689692283726799-slack-C04U5A26MJB They read `Cannot use 'in' operator to search for 'product_slug' in undefined`. 

This is because there is code calling `isDomainMapping` with undefined by absing the `as` keyword in TypeScript to hide undefined values and break type checking. This particular case was added in https://github.com/Automattic/wp-calypso/pull/78844

In this PR we remove the `as MinimalRequestCartProduct` type casting and then just skip calling `isDomainMapping()` if the product does not exist.

## Testing Instructions

Make sure type checks pass.