### PR TITLE
Replaces 'missing payment method' message for in-app purchases.

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -446,6 +446,14 @@ class PurchaseItem extends Component {
 			return translate( 'Included with Plan' );
 		}
 
+		if ( purchase.isInAppPurchase ) {
+			return (
+				<div>
+					<span>{ translate( 'In-App Purchase' ) }</span>
+				</div>
+			);
+		}
+
 		if (
 			purchase.isAutoRenewEnabled &&
 			! hasPaymentMethod( purchase ) &&

--- a/client/me/purchases/purchase-item/test/index.js
+++ b/client/me/purchases/purchase-item/test/index.js
@@ -31,6 +31,26 @@ describe( 'PurchaseItem', () => {
 		} );
 	} );
 
+	describe( 'an in-app purchase', () => {
+		const purchase = {
+			isInAppPurchase: true,
+			isAutoRenewEnabled: false,
+		};
+
+		test( 'should not display warning', () => {
+			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
+
+			expect(
+				screen.queryByText( 'You don’t have a payment method to renew this subscription' )
+			).toBeNull();
+		} );
+
+		test( 'should display in-app purchase as the payment method', () => {
+			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
+			expect( screen.getByText( 'In-App Purchase' ) ).toBeInTheDocument();
+		} );
+	} );
+
 	test( 'should display warning if auto-renew is enabled but no payment method', () => {
 		const purchase = {
 			productSlug: 'business-bundle',


### PR DESCRIPTION
Replaces the message 'You don’t have a payment method to renew this subscription' with 'In-App Purchase' on the 'Payment Method' section of the `/me/purchases` page, for purchases made via in-app purchase.

Fixes #79548

## Proposed Changes

* Replaces the message 'You don’t have a payment method to renew this subscription' with 'In-App Purchase' on the 'Payment Method' section of the `/me/purchases` page, for purchases made via in-app purchase.

## Testing Instructions
* Have a subscription on your account that was paid for using in-app-purchases (payment method is 'iap_ios', or ping me and I can add one to your account).
* View the 'Purchases' summary in Calypso (e.g. /me/purchases)
* Assert that the payment method for the subscription shows 'In-App Purchase'

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Notes: text change is already a translated string

