### PR TITLE
Plugin Details: Add billing period flags and change the selector accordingly

### DIFF
--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect, type FunctionComponent } from 'react';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { PluginAnnualSaving } from 'calypso/my-sites/plugins/plugin-saving';
 import { IntervalLength } from './constants';
-import type { FunctionComponent } from 'react';
 
 type PluginAnnualSavingLabelProps = {
 	isSelected: boolean;
@@ -53,6 +53,23 @@ const BillingIntervalSwitcher: FunctionComponent< Props > = ( props: Props ) => 
 	const translate = useTranslate();
 	const monthlyLabel = translate( 'Monthly' );
 	const annualLabel = translate( 'Annually' );
+
+	const searchParams = new URLSearchParams( document.location.search );
+	const monthlyParam = searchParams.get( 'monthly' );
+	const annualyParam = searchParams.get( 'annually' );
+
+	/**
+	 * Change the billing period based on query params, if passed
+	 */
+	useEffect( () => {
+		if ( monthlyParam !== null ) {
+			onChange( IntervalLength.MONTHLY );
+		}
+
+		if ( annualyParam !== null ) {
+			onChange( IntervalLength.ANNUALLY );
+		}
+	}, [ onChange, monthlyParam, annualyParam ] );
 
 	return (
 		<BillingIntervalSwitcherContainer>

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -55,21 +55,20 @@ const BillingIntervalSwitcher: FunctionComponent< Props > = ( props: Props ) => 
 	const annualLabel = translate( 'Annually' );
 
 	const searchParams = new URLSearchParams( document.location.search );
-	const monthlyParam = searchParams.get( 'monthly' );
-	const annualyParam = searchParams.get( 'annually' );
+	const billingIntervalParam = searchParams.get( 'interval' );
 
 	/**
 	 * Change the billing period based on query params, if passed
 	 */
 	useEffect( () => {
-		if ( monthlyParam !== null ) {
+		if ( billingIntervalParam === 'monthly' ) {
 			onChange( IntervalLength.MONTHLY );
 		}
 
-		if ( annualyParam !== null ) {
+		if ( billingIntervalParam === 'annually' ) {
 			onChange( IntervalLength.ANNUALLY );
 		}
-	}, [ onChange, monthlyParam, annualyParam ] );
+	}, [ onChange, billingIntervalParam ] );
 
 	return (
 		<BillingIntervalSwitcherContainer>

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -5,6 +5,7 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { Gridicon, Button } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useState, useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -143,6 +144,11 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	const toggleDisplayManageSitePluginsModal = useCallback( () => {
 		setDisplayManageSitePluginsModal( ! displayManageSitePluginsModal );
 	}, [ displayManageSitePluginsModal ] );
+
+	const onIntervalSwitcherChange = useCallback(
+		( interval ) => dispatch( setBillingInterval( interval ) ),
+		[ dispatch ]
+	);
 
 	// Activation and deactivation translations.
 	const activeText = translate( '{{span}}active{{/span}}', {
@@ -335,7 +341,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 				{ isMarketplaceProduct && ! plugin.isSaasProduct && (
 					<BillingIntervalSwitcher
 						billingPeriod={ billingPeriod }
-						onChange={ ( interval ) => dispatch( setBillingInterval( interval ) ) }
+						onChange={ onIntervalSwitcherChange }
 						plugin={ plugin }
 					/>
 				) }
@@ -363,7 +369,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 										<a
 											target="_blank"
 											rel="noopener noreferrer"
-											href="https://wordpress.com/tos/"
+											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
 										/>
 									),
 									thirdPartyTos: (


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/79514

## Proposed Changes

Add the `interval` query parameter that can receive the values `monthly` and `annually` to determine the version of the Marketplace product to be added to the cart.

This should still allow the user to change the billing option despite the flag and the page should still behave normally if no flag is passed.


## Testing Instructions
* Go to a plugin details page (Ex: `plugins/wordpress-seo-premium/:site`) from an atomic site
* Add the `annually` flag to the URL to change the billing selector (Ex: `plugins/wordpress-seo-premium/:site?interval=annually`)
* Verify if the `Annually` option is selected on the sidebar
* Add the `monthly` flag to the URL to change the billing selector (Ex: `plugins/wordpress-seo-premium/:site?interval=monthly`)
* Click on the CTA and check if the right option is shown on the cart
* Verify if the `Monthly` option is selected on the sidebar
* Click on the CTA and check if the right option is shown on the cart
* Remove the param and verify the selector still working as expected

![CleanShot 2023-07-19 at 12 51 29](https://github.com/Automattic/wp-calypso/assets/5039531/42baeaac-b125-4c2a-a4cb-199136a3c4c4)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
