### PR TITLE
Jetpack AI Assistant: clean up the feature flag usage after release

### DIFF
--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	PRODUCT_JETPACK_AI_MONTHLY,
 	PRODUCT_WPCOM_CUSTOM_DESIGN,
@@ -43,7 +42,6 @@ export interface AddOnMeta {
 // some memoization. executes far too many times
 const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 	const translate = useTranslate();
-	const aiAssistantAddOnIsEnabled = config.isEnabled( 'jetpack/ai-assistant-request-limit' );
 
 	const addOnsActive = [
 		{
@@ -130,11 +128,6 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 				// remove all upgrades smaller than the smallest purchased upgrade (we only allow purchasing upgrades in ascending order)
 				if ( spaceUpgradesPurchased.length && addOn.productSlug === PRODUCT_1GB_SPACE ) {
 					return ( addOn.quantity ?? 0 ) >= Math.min( ...spaceUpgradesPurchased );
-				}
-
-				// remove the Jetpack AI add-on if the feature flag is not enabled for the current environment
-				if ( addOn.productSlug === PRODUCT_JETPACK_AI_MONTHLY && ! aiAssistantAddOnIsEnabled ) {
-					return false;
 				}
 
 				// remove the Jetpack AI add-on if the site already supports the feature


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove the `jetpack/ai-assistant-request-limit` feature flag check from the Jetpack AI Assistant add-on card now that the card is already in production

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch on any environment
* Confirm the "Jetpack AI Assistant" add-on card is visible on any free simple site without the "Jetpack AI Monthly" plan
* Confirm that adding the `?flags=-jetpack/ai-assistant-request-limit` parameter on the add-ons page request does not affect the visibility of the card anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
