### PR TITLE
Bulk domain transfer flow: Redo resource copy update

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
@@ -77,10 +77,10 @@ export const CompleteDomainsTransferred = ( {
 						</a>
 					</div>
 					<div>
-						<h2> { __( 'Consider moving your sites too?' ) }</h2>
+						<h2> { __( 'Move your sites too' ) }</h2>
 						<p>
 							{ __(
-								'You can find step-by-step guides below that will help you move your site to WordPress.com'
+								'Why stop at the domain? Check out our step-by-step guides to bring your existing site to WordPress.com.'
 							) }
 						</p>
 						<a


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update footer resource copy to match recommended copy from https://github.com/Automattic/dotcom-forge/issues/2987

Correct copy:

<img width="318" alt="Screen Shot 2023-07-18 at 1 53 32 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/1536f983-043c-4d52-a356-5ad5eaa9f186">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the copy on /setup/domain-transfer/complete

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
