### PR TITLE
Domain Transfer: FAQ: Correct punctuation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
@@ -80,7 +80,7 @@ const DomainTransferFAQ: FC = () => {
 							{ translate(
 								'No, the remaining time you have with your current registrar will be transferred ' +
 									"over when you move your domain. Furthermore, you will receive an additional year's " +
-									'registration free of charge when transferring any domain to WordPress.com'
+									'registration free of charge when transferring any domain to WordPress.com.'
 							) }
 						</FoldableFAQ>
 					</li>


### PR DESCRIPTION
## Proposed Changes

* Correct punctuation for FAQ item about transfer not being free. See pb6Nl-gI2-p2#comment-103336

## Testing Instructions

* Checkout PR
* Go to `/setup/domain-transfer/domains`
* Verify domain at end of sentence

Note: The FAQ section is currently behind a locale check. So, string freeze should not be necessary.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?