### PR TITLE
Domain Transfer: FAQ: Add background color to separate

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -169,55 +169,60 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 	}
 
 	return (
-		<div className="bulk-domain-transfer__container">
-			{ Object.entries( domainsState ).map( ( [ key, domain ], index ) => (
-				<DomainCodePair
-					key={ key }
-					id={ key }
-					onChange={ handleChange }
-					onRemove={ removeDomain }
-					domain={ domain.domain }
-					auth={ domain.auth }
-					showLabels={ index === 0 }
-					hasDuplicates={ Object.values( domainsState ).some(
-						( { domain: otherDomain }, otherIndex ) =>
-							otherDomain && otherDomain === domain.domain && otherIndex < index
-					) }
-				/>
-			) ) }
-			{ domainCount < MAX_DOMAINS && (
-				<Button className="bulk-domain-transfer__add-domain" icon={ plus } onClick={ addDomain }>
-					{ __( 'Add another domain' ) }
-				</Button>
-			) }
-			<div className="bulk-domain-transfer__total-price">
-				<div>{ __( 'Total' ) }</div>
-				<div>{ getFormattedTotalPrice( domainsState ) }</div>
-			</div>
-			<FormLabel htmlFor="import-dns-records" className="bulk-domain-transfer__import-dns-records">
-				<FormInputCheckbox
-					id="import-dns-records"
-					onChange={ ( event ) => {
-						setShouldImportDomainTransferDnsRecords( event.target.checked );
-					} }
-					checked={ storedDomainsState.shouldImportDnsRecords }
-				/>
-				<span>{ __( 'Import DNS records from these domains' ) }</span>
-			</FormLabel>
-			<div className="bulk-domain-transfer__cta-container">
-				<Button
-					disabled={ numberOfValidDomains === 0 || ! allGood }
-					className="bulk-domain-transfer__cta"
-					onClick={ handleAddTransfer }
+		<>
+			<div className="bulk-domain-transfer__container">
+				{ Object.entries( domainsState ).map( ( [ key, domain ], index ) => (
+					<DomainCodePair
+						key={ key }
+						id={ key }
+						onChange={ handleChange }
+						onRemove={ removeDomain }
+						domain={ domain.domain }
+						auth={ domain.auth }
+						showLabels={ index === 0 }
+						hasDuplicates={ Object.values( domainsState ).some(
+							( { domain: otherDomain }, otherIndex ) =>
+								otherDomain && otherDomain === domain.domain && otherIndex < index
+						) }
+					/>
+				) ) }
+				{ domainCount < MAX_DOMAINS && (
+					<Button className="bulk-domain-transfer__add-domain" icon={ plus } onClick={ addDomain }>
+						{ __( 'Add another domain' ) }
+					</Button>
+				) }
+				<div className="bulk-domain-transfer__total-price">
+					<div>{ __( 'Total' ) }</div>
+					<div>{ getFormattedTotalPrice( domainsState ) }</div>
+				</div>
+				<FormLabel
+					htmlFor="import-dns-records"
+					className="bulk-domain-transfer__import-dns-records"
 				>
-					{ numberOfValidDomains === 0
-						? __( 'Transfer' )
-						: sprintf(
-								/* translators: %s: number valid domains */
-								_n( 'Transfer %s domain', 'Transfer %s domains', numberOfValidDomains ),
-								numberOfValidDomains
-						  ) }
-				</Button>
+					<FormInputCheckbox
+						id="import-dns-records"
+						onChange={ ( event ) => {
+							setShouldImportDomainTransferDnsRecords( event.target.checked );
+						} }
+						checked={ storedDomainsState.shouldImportDnsRecords }
+					/>
+					<span>{ __( 'Import DNS records from these domains' ) }</span>
+				</FormLabel>
+				<div className="bulk-domain-transfer__cta-container">
+					<Button
+						disabled={ numberOfValidDomains === 0 || ! allGood }
+						className="bulk-domain-transfer__cta"
+						onClick={ handleAddTransfer }
+					>
+						{ numberOfValidDomains === 0
+							? __( 'Transfer' )
+							: sprintf(
+									/* translators: %s: number valid domains */
+									_n( 'Transfer %s domain', 'Transfer %s domains', numberOfValidDomains ),
+									numberOfValidDomains
+							  ) }
+					</Button>
+				</div>
 			</div>
 			{
 				// Temporarily disable the FAQ section for non-English locales.
@@ -227,7 +232,7 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 					</div>
 				)
 			}
-		</div>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -359,8 +359,6 @@
 			margin-top: 2px;
 		}
 
-
-
 		.bulk-domain-transfer__total-price {
 			display: flex;
 			justify-content: space-between;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -356,6 +356,10 @@
 		}
 
 		.bulk-domain-transfer__faqs {
+			background: var(--studio-gray-0);
+			margin: 120px -100vw 0;
+			padding: 32px 100vw;
+
 			.foldable-faq__question {
 				padding: 16px 0;
 			}
@@ -370,9 +374,6 @@
 			}
 			li {
 				font-size: 1rem;
-			}
-			section {
-				margin-top: 120px;
 			}
 			ul {
 				list-style: none;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -456,6 +456,11 @@
 		padding: 32px 0;
 		width: 100%;
 
+		@media (max-width: $break-medium ) {
+			margin: 64px -20px 0;
+			padding: 32px 20px;
+		}
+
 		.foldable-faq__question {
 			padding: 16px 0;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -28,7 +28,8 @@
 
 	&.domains {
 		padding: 0;
-		width: 754px;
+		width: 100%;
+		min-width: 100%;
 
 		.step-container__header {
 			margin-top: 96px;
@@ -346,6 +347,9 @@
 	}
 
 	.bulk-domain-transfer__container {
+		width: 754px;
+		margin: 0 auto;
+		max-width: 100%;
 
 		.bulk-domain-transfer__add-domain {
 			font-size: 0.875rem;
@@ -355,31 +359,7 @@
 			margin-top: 2px;
 		}
 
-		.bulk-domain-transfer__faqs {
-			background: var(--studio-gray-0);
-			margin: 120px -100vw 0;
-			padding: 32px 100vw;
 
-			.foldable-faq__question {
-				padding: 16px 0;
-			}
-			.foldable-faq__question-text {
-				font-size: 1rem;
-			}
-			h2 {
-				font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-				font-size: 2rem;
-				margin: 24px 0;
-				text-align: center;
-			}
-			li {
-				font-size: 1rem;
-			}
-			ul {
-				list-style: none;
-				margin: 0 0 48px 0;
-			}
-		}
 
 		.bulk-domain-transfer__total-price {
 			display: flex;
@@ -470,5 +450,37 @@
 	button.loading-placeholder {
 		width: 150px;
 		@include placeholder();
+	}
+
+	.bulk-domain-transfer__faqs {
+		background: var(--studio-gray-0);
+		margin: 64px 0 0;
+		padding: 32px 0;
+		width: 100%;
+
+		.foldable-faq__question {
+			padding: 16px 0;
+		}
+		.foldable-faq__question-text {
+			font-size: 1rem;
+		}
+		h2 {
+			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+			font-size: 2rem;
+			margin: 24px 0;
+			text-align: center;
+		}
+		li {
+			font-size: 1rem;
+		}
+		section {
+			margin: 0 auto;
+			max-width: 100%;
+			width: 754px;
+		}
+		ul {
+			list-style: none;
+			margin: 0 0 48px 0;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -463,7 +463,12 @@
 
 		.foldable-faq__question {
 			padding: 16px 0;
+
+			.gridicon {
+				flex-shrink: 0;
+			}
 		}
+
 		.foldable-faq__question-text {
 			font-size: 1rem;
 		}


### PR DESCRIPTION
## Proposed Changes

* This is a follow-up to #79503 to add a background color to set the FAQ section apart.

<img width="641" alt="Screenshot 2023-07-18 at 4 40 41 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/915c49a1-8a6b-4c05-8022-1688fe0dfd06">
<img width="1575" alt="Screenshot 2023-07-18 at 4 40 35 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/487824a4-4d9e-4399-b28b-77fe9035ef1b">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout patch
* Go to `/setup/domain-transfer/domains`
* Verify background color exists
* Check in different browser and at different viewport widths

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
