### PR TITLE
Launchpad: Add the order property to the click task tracks event

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -71,13 +71,13 @@ const CustomerHomeLaunchpad = ( {
 		} );
 
 		// Record views for each task.
-		checklist?.map( ( task: Task, index: number ) => {
+		checklist?.map( ( task: Task ) => {
 			recordTracksEvent( 'calypso_launchpad_task_view', {
 				checklist_slug: checklistSlug,
 				task_id: task.id,
 				is_completed: task.completed,
 				context: 'customer-home',
-				order: index,
+				order: task.order,
 			} );
 		} );
 	}, [ checklist, checklistSlug, completedSteps, numberOfSteps, tasklistCompleted ] );

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -71,12 +71,13 @@ const CustomerHomeLaunchpad = ( {
 		} );
 
 		// Record views for each task.
-		checklist?.map( ( task: Task ) => {
+		checklist?.map( ( task: Task, index: number ) => {
 			recordTracksEvent( 'calypso_launchpad_task_view', {
 				checklist_slug: checklistSlug,
 				task_id: task.id,
 				is_completed: task.completed,
 				context: 'customer-home',
+				order: index,
 			} );
 		} );
 	}, [ checklist, checklistSlug, completedSteps, numberOfSteps, tasklistCompleted ] );

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -1,5 +1,9 @@
 import { Button, CircularProgressBar, Gridicon } from '@automattic/components';
-import { updateLaunchpadSettings, useLaunchpad } from '@automattic/data-stores';
+import {
+	updateLaunchpadSettings,
+	useLaunchpad,
+	sortLaunchpadTasksByCompletionStatus,
+} from '@automattic/data-stores';
 import { Launchpad, PermittedActions, Task, setUpActionsForTasks } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -29,9 +33,10 @@ const CustomerHomeLaunchpad = ( {
 
 	const translate = useTranslate();
 	const [ isDismissed, setIsDismissed ] = useState( false );
+	const useLaunchpadOptions = { onSuccess: sortLaunchpadTasksByCompletionStatus };
 	const {
 		data: { checklist, is_dismissed: initialIsChecklistDismissed },
-	} = useLaunchpad( siteSlug, checklistSlug );
+	} = useLaunchpad( siteSlug, checklistSlug, useLaunchpadOptions );
 
 	useEffect( () => {
 		setIsDismissed( initialIsChecklistDismissed );
@@ -135,7 +140,12 @@ const CustomerHomeLaunchpad = ( {
 			{ shareSiteModalIsOpen && site && (
 				<ShareSiteModal setModalIsOpen={ setShareSiteModalIsOpen } site={ site } />
 			) }
-			<Launchpad siteSlug={ siteSlug } checklistSlug={ checklistSlug } taskFilter={ taskFilter } />
+			<Launchpad
+				siteSlug={ siteSlug }
+				checklistSlug={ checklistSlug }
+				taskFilter={ taskFilter }
+				useLaunchpadOptions={ useLaunchpadOptions }
+			/>
 		</div>
 	);
 };

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -76,7 +76,15 @@ export const useLaunchpad = (
 	const key = [ 'launchpad', siteSlug, checklist_slug ];
 	return useQuery( {
 		queryKey: key,
-		queryFn: () => fetchLaunchpad( siteSlug, checklist_slug ),
+		queryFn: () =>
+			fetchLaunchpad( siteSlug, checklist_slug ).then( ( data ) => {
+				const tasks = data.checklist || [];
+				const completedTasks = tasks.filter( ( task: Task ) => task.completed );
+				const incompleteTasks = tasks.filter( ( task: Task ) => ! task.completed );
+				data.checklist = [ ...completedTasks, ...incompleteTasks ];
+
+				return data;
+			} ),
 		retry: 3,
 		initialData: {
 			site_intent: '',

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -1,11 +1,23 @@
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
-import type { Task } from '@automattic/launchpad';
 
 interface APIFetchOptions {
 	global: boolean;
 	path: string;
+}
+
+interface Task {
+	id: string;
+	completed: boolean;
+	disabled: boolean;
+	title: string;
+	subtitle?: string;
+	badgeText?: string;
+	actionDispatch?: () => void;
+	isLaunchTask?: boolean;
+	warning?: boolean;
+	order?: number;
 }
 
 interface ChecklistStatuses {
@@ -58,10 +70,10 @@ export const fetchLaunchpad = (
 		  } as APIFetchOptions );
 };
 
-function mapTask( task: Task, index: number ): Task {
+const mapTask = ( task: Task, index: number ) => {
 	task.order = index;
 	return task;
-}
+};
 
 export const useLaunchpad = (
 	siteSlug: string | null,

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -87,13 +87,18 @@ export function sortLaunchpadTasksByCompletionStatus( response: LaunchpadRespons
 	return response;
 }
 
+const defaultSuccessCallback = ( response: LaunchpadResponse ) => {
+	const tasks = response.checklist || [];
+	response.checklist = tasks.map( addOrderToTask );
+	return response;
+};
+
 export const useLaunchpad = (
 	siteSlug: string | null,
 	checklist_slug?: string | 0 | null | undefined,
 	options?: UseLaunchpadOptions
 ) => {
 	const key = [ 'launchpad', siteSlug, checklist_slug ];
-	const defaultSuccessCallback = ( response: LaunchpadResponse ) => response;
 	const onSuccessCallback = options?.onSuccess || defaultSuccessCallback;
 
 	return useQuery( {

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -1,22 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import type { Task } from '@automattic/launchpad';
 
 interface APIFetchOptions {
 	global: boolean;
 	path: string;
-}
-
-interface Task {
-	id: string;
-	completed: boolean;
-	disabled: boolean;
-	title: string;
-	subtitle?: string;
-	badgeText?: string;
-	actionDispatch?: () => void;
-	isLaunchTask?: boolean;
-	warning?: boolean;
 }
 
 interface ChecklistStatuses {
@@ -69,6 +58,11 @@ export const fetchLaunchpad = (
 		  } as APIFetchOptions );
 };
 
+const mapTask = ( task: Task, index: number ) => {
+	task.order = index;
+	return task;
+};
+
 export const useLaunchpad = (
 	siteSlug: string | null,
 	checklist_slug?: string | 0 | null | undefined
@@ -81,7 +75,7 @@ export const useLaunchpad = (
 				const tasks = data.checklist || [];
 				const completedTasks = tasks.filter( ( task: Task ) => task.completed );
 				const incompleteTasks = tasks.filter( ( task: Task ) => ! task.completed );
-				data.checklist = [ ...completedTasks, ...incompleteTasks ];
+				data.checklist = [ ...completedTasks, ...incompleteTasks ].map( mapTask );
 
 				return data;
 			} ),

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -58,10 +58,10 @@ export const fetchLaunchpad = (
 		  } as APIFetchOptions );
 };
 
-const mapTask = ( task: Task, index: number ) => {
+function mapTask( task: Task, index: number ): Task {
 	task.order = index;
 	return task;
-};
+}
 
 export const useLaunchpad = (
 	siteSlug: string | null,

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -2,12 +2,14 @@ import { useLaunchpad } from '@automattic/data-stores';
 import { useRef, useMemo } from 'react';
 import Checklist from './checklist';
 import type { Task } from './types';
+import type { UseLaunchpadOptions } from '@automattic/data-stores';
 
 export interface LaunchpadProps {
 	siteSlug: string | null;
 	checklistSlug?: string | 0 | null | undefined;
 	makeLastTaskPrimaryAction?: boolean;
 	taskFilter?: ( tasks: Task[] ) => Task[];
+	useLaunchpadOptions?: UseLaunchpadOptions;
 }
 
 const Launchpad = ( {
@@ -15,8 +17,9 @@ const Launchpad = ( {
 	checklistSlug,
 	taskFilter,
 	makeLastTaskPrimaryAction,
+	useLaunchpadOptions = {},
 }: LaunchpadProps ) => {
-	const launchpadData = useLaunchpad( siteSlug || '', checklistSlug );
+	const launchpadData = useLaunchpad( siteSlug || '', checklistSlug, useLaunchpadOptions );
 	const { isFetchedAfterMount, data } = launchpadData;
 	const tasks = useRef< Task[] >( [] );
 

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -21,12 +21,6 @@ export const setUpActionsForTasks = ( {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
 	const { setShareSiteModalIsOpen } = extraActions || {};
 
-	function mapTask( task: Task, index: number ) {
-		task.order = index;
-	}
-
-	tasks.map( mapTask );
-
 	//Record click events for tasks
 	const recordTaskClickTracksEvent = ( task: Task ) => {
 		recordTracksEvent( 'calypso_launchpad_task_clicked', {
@@ -45,7 +39,7 @@ export const setUpActionsForTasks = ( {
 	const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
 
 	// Add actions to sorted tasks.
-	return sortedTasks.map( ( task: Task ) => {
+	return sortedTasks.map( ( task: Task, sortedIndex: number ) => {
 		let action: () => void;
 		let logMissingCalypsoPath = false;
 
@@ -150,6 +144,6 @@ export const setUpActionsForTasks = ( {
 			action?.();
 		};
 
-		return { ...task, actionDispatch };
+		return { ...task, actionDispatch, order: sortedIndex };
 	} );
 };

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -21,11 +21,11 @@ export const setUpActionsForTasks = ( {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
 	const { setShareSiteModalIsOpen } = extraActions || {};
 
-	function mapTasks( task: Task, index: number ) {
+	function mapTask( task: Task, index: number ) {
 		task.order = index;
 	}
 
-	tasks.map( mapTasks );
+	tasks.map( mapTask );
 
 	//Record click events for tasks
 	const recordTaskClickTracksEvent = ( task: Task ) => {

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -22,13 +22,14 @@ export const setUpActionsForTasks = ( {
 	const { setShareSiteModalIsOpen } = extraActions || {};
 
 	//Record click events for tasks
-	const recordTaskClickTracksEvent = ( task: Task ) => {
+	const recordTaskClickTracksEvent = ( task: Task, order: number ) => {
 		recordTracksEvent( 'calypso_launchpad_task_clicked', {
 			checklist_slug: checklistSlug,
 			checklist_completed: tasklistCompleted,
 			task_id: task.id,
 			is_completed: task.completed,
 			context: launchpadContext,
+			order,
 		} );
 	};
 
@@ -38,7 +39,7 @@ export const setUpActionsForTasks = ( {
 	const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
 
 	// Add actions to sorted tasks.
-	return sortedTasks.map( ( task: Task ) => {
+	return sortedTasks.map( ( task: Task, index: number ) => {
 		let action: () => void;
 		let logMissingCalypsoPath = false;
 
@@ -139,7 +140,7 @@ export const setUpActionsForTasks = ( {
 		}
 
 		const actionDispatch = () => {
-			recordTaskClickTracksEvent( task );
+			recordTaskClickTracksEvent( task, index );
 			action?.();
 		};
 

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -33,13 +33,8 @@ export const setUpActionsForTasks = ( {
 		} );
 	};
 
-	// Sort task by completion status.
-	const completedTasks = tasks.filter( ( task: Task ) => task.completed );
-	const incompleteTasks = tasks.filter( ( task: Task ) => ! task.completed );
-	const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
-
-	// Add actions to sorted tasks.
-	return sortedTasks.map( ( task: Task, sortedIndex: number ) => {
+	// Add actions to the tasks.
+	return tasks.map( ( task: Task, sortedIndex: number ) => {
 		let action: () => void;
 		let logMissingCalypsoPath = false;
 

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -34,7 +34,7 @@ export const setUpActionsForTasks = ( {
 	};
 
 	// Add actions to the tasks.
-	return tasks.map( ( task: Task, sortedIndex: number ) => {
+	return tasks.map( ( task: Task ) => {
 		let action: () => void;
 		let logMissingCalypsoPath = false;
 
@@ -139,6 +139,6 @@ export const setUpActionsForTasks = ( {
 			action?.();
 		};
 
-		return { ...task, actionDispatch, order: sortedIndex };
+		return { ...task, actionDispatch };
 	} );
 };

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -21,15 +21,21 @@ export const setUpActionsForTasks = ( {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
 	const { setShareSiteModalIsOpen } = extraActions || {};
 
+	function mapTasks( task: Task, index: number ) {
+		task.order = index;
+	}
+
+	tasks.map( mapTasks );
+
 	//Record click events for tasks
-	const recordTaskClickTracksEvent = ( task: Task, order: number ) => {
+	const recordTaskClickTracksEvent = ( task: Task ) => {
 		recordTracksEvent( 'calypso_launchpad_task_clicked', {
 			checklist_slug: checklistSlug,
 			checklist_completed: tasklistCompleted,
 			task_id: task.id,
 			is_completed: task.completed,
 			context: launchpadContext,
-			order,
+			order: task.order,
 		} );
 	};
 
@@ -39,7 +45,7 @@ export const setUpActionsForTasks = ( {
 	const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
 
 	// Add actions to sorted tasks.
-	return sortedTasks.map( ( task: Task, index: number ) => {
+	return sortedTasks.map( ( task: Task ) => {
 		let action: () => void;
 		let logMissingCalypsoPath = false;
 
@@ -140,7 +146,7 @@ export const setUpActionsForTasks = ( {
 		}
 
 		const actionDispatch = () => {
-			recordTaskClickTracksEvent( task, index );
+			recordTaskClickTracksEvent( task );
 			action?.();
 		};
 

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -14,6 +14,7 @@ export interface Task {
 	calypso_path?: string;
 	target_repetitions?: number;
 	repetition_count?: number;
+	order?: number;
 }
 
 export type LaunchpadChecklist = Task[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

A while ago, we discussed that it would be valuable to know if the order of the tasks influences user behavior. This PRs adds the order of the tasks to the click, and the view task tracks events.

* Adds the order property to the click task tracks events 
* Adds the order property to the view task tracks events

![Screen Shot 2023-07-21 at 13 45 08](https://github.com/Automattic/wp-calypso/assets/1234758/ea558e2f-90e3-4074-995a-4a62ef29bc99)
![Screen Shot 2023-07-21 at 13 44 50](https://github.com/Automattic/wp-calypso/assets/1234758/e33e9297-3f1a-419f-bcb1-20f4c65f2923)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site with the build intent, or access the home page if you already have one.
* Click on a task
* Use Tracks Vigilant to see the events(calypso_launchpad_task_clicked, calypso_launchpad_task_view) and inspect the properties. Look for the "order" property and check if it matches with what you see.
* Make sure the Type is working correctly in the `mapTask` function. The `order` prop is not being recognized in my VS code, but I think it's a bug.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
