### PR TITLE
Add '/plans' url to localizeurl

### DIFF
--- a/packages/i18n-utils/src/locales.ts
+++ b/packages/i18n-utils/src/locales.ts
@@ -11,6 +11,27 @@ export const localesWithGoBlog: Locale[] = [ 'en', 'pt-br', 'de', 'es', 'fr', 'i
 export const localesWithPrivacyPolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
 export const localesWithCookiePolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
 
+export const localesForPricePlans: Locale[] = [
+	'ar',
+	'de',
+	'el',
+	'es',
+	'fr',
+	'he',
+	'id',
+	'it',
+	'ja',
+	'ko',
+	'nl',
+	'pt-br',
+	'ro',
+	'ru',
+	'sv',
+	'tr',
+	'zh-cn',
+	'zh-tw',
+];
+
 type LocaleSubdomain = string;
 
 export const localesToSubdomains: Record< string, LocaleSubdomain > = {

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -169,7 +169,10 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 		return isLoggedIn ? url : suffixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
 	},
 	'wordpress.com/plans/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
-		return isLoggedIn ? url : prefixLocalizedUrlPath( localesForPricePlans )( url, localeSlug );
+		// if logged in, or url.pathname contains characters after `/plans/`, don't rewrite
+		return isLoggedIn || url.pathname.length > '/plans/'.length
+			? url
+			: prefixLocalizedUrlPath( localesForPricePlans )( url, localeSlug );
 	},
 	'wordpress.com/setup/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		return isLoggedIn ? url : suffixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -170,7 +170,7 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 	},
 	'wordpress.com/plans/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		// if logged in, or url.pathname contains characters after `/plans/`, don't rewrite
-		return isLoggedIn || url.pathname.length > '/plans/'.length
+		return isLoggedIn || url.pathname !== '/plans/'
 			? url
 			: prefixLocalizedUrlPath( localesForPricePlans )( url, localeSlug );
 	},

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -167,6 +167,9 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com/start/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		return isLoggedIn ? url : suffixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
 	},
+	'wordpress.com/plans/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
+		return isLoggedIn ? url : prefixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
+	},
 	'wordpress.com/setup/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		return isLoggedIn ? url : suffixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
 	},

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -11,6 +11,7 @@ import {
 	supportSiteLocales,
 	forumLocales,
 	magnificentNonEnLocales,
+	localesForPricePlans,
 	jetpackComLocales,
 	Locale,
 } from './locales';
@@ -168,7 +169,7 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 		return isLoggedIn ? url : suffixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
 	},
 	'wordpress.com/plans/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
-		return isLoggedIn ? url : prefixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
+		return isLoggedIn ? url : prefixLocalizedUrlPath( localesForPricePlans )( url, localeSlug );
 	},
 	'wordpress.com/setup/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		return isLoggedIn ? url : suffixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -509,7 +509,7 @@ describe( '#localizeUrl', () => {
 			'https://wordpress.com/plans/'
 		);
 
-		//Non Mag-16, Finnish
+		// Non Mag-16, Finnish
 		expect( localizeUrl( 'https://wordpress.com/plans/', 'fi', false ) ).toEqual(
 			'https://wordpress.com/plans/'
 		);

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -516,6 +516,23 @@ describe( '#localizeUrl', () => {
 		expect( localizeUrl( 'https://wordpress.com/plans/', 'fi', true ) ).toEqual(
 			'https://wordpress.com/plans/'
 		);
+
+		// Full path to a site plan
+		expect(
+			localizeUrl( 'https://wordpress.com/plans/example.wordpress.com', 'en', false )
+		).toEqual( 'https://wordpress.com/plans/example.wordpress.com/' );
+
+		expect(
+			localizeUrl( 'https://wordpress.com/plans/example.wordpress.com', 'en', true )
+		).toEqual( 'https://wordpress.com/plans/example.wordpress.com/' );
+
+		expect(
+			localizeUrl( 'https://wordpress.com/plans/example.wordpress.com', 'es', false )
+		).toEqual( 'https://wordpress.com/plans/example.wordpress.com/' );
+
+		expect(
+			localizeUrl( 'https://wordpress.com/plans/example.wordpress.com', 'es', true )
+		).toEqual( 'https://wordpress.com/plans/example.wordpress.com/' );
 	} );
 
 	test( 'WordPress.com new style support URLs', () => {

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -479,6 +479,21 @@ describe( '#localizeUrl', () => {
 		);
 	} );
 
+	test( 'WordPress.com plans URLs', () => {
+		expect( localizeUrl( 'https://wordpress.com/plans/', 'en', false ) ).toEqual(
+			'https://wordpress.com/plans/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/plans/', 'en', true ) ).toEqual(
+			'https://wordpress.com/plans/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/plans/', 'es', false ) ).toEqual(
+			'https://wordpress.com/es/plans/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/plans/', 'es', true ) ).toEqual(
+			'https://wordpress.com/plans/'
+		);
+	} );
+
 	test( 'WordPress.com new style support URLs', () => {
 		expect( localizeUrl( 'https://wordpress.com/support/reader/', 'de' ) ).toEqual(
 			'https://wordpress.com/de/support/reader/'

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -492,6 +492,30 @@ describe( '#localizeUrl', () => {
 		expect( localizeUrl( 'https://wordpress.com/plans/', 'es', true ) ).toEqual(
 			'https://wordpress.com/plans/'
 		);
+
+		// Greek
+		expect( localizeUrl( 'https://wordpress.com/plans/', 'el', false ) ).toEqual(
+			'https://wordpress.com/el/plans/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/plans/', 'el', true ) ).toEqual(
+			'https://wordpress.com/plans/'
+		);
+
+		// Romanian
+		expect( localizeUrl( 'https://wordpress.com/plans/', 'ro', false ) ).toEqual(
+			'https://wordpress.com/ro/plans/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/plans/', 'ro', true ) ).toEqual(
+			'https://wordpress.com/plans/'
+		);
+
+		//Non Mag-16, Finnish
+		expect( localizeUrl( 'https://wordpress.com/plans/', 'fi', false ) ).toEqual(
+			'https://wordpress.com/plans/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/plans/', 'fi', true ) ).toEqual(
+			'https://wordpress.com/plans/'
+		);
 	} );
 
 	test( 'WordPress.com new style support URLs', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/i18n-issues/issues/641
## Proposed Changes

* Add `/plans` support in `localizeUrl`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout locally
* Execute `yarn test-packages -- test/localize-url.js`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
