### PR TITLE
Stats: Support Stats products as a card of plans

### DIFF
--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -187,8 +187,8 @@ export const INDIRECT_CHECKOUT_PRODUCT_STATS = (): SelectorProduct => ( {
 		items: [],
 	},
 	hidePrice: true,
-	// TODO: Refactor the checkout URL and update it when the Paid Stats purchase page is released.
-	externalUrl: '/stats/purchase/{siteSlug}?from=calypso-plans&flags=stats/paid-stats',
+	// TODO: Refactor the checkout URL.
+	externalUrl: '/stats/purchase/{siteSlug}?from=calypso-plans',
 } );
 
 export const INDIRECT_CHECKOUT_PRODUCT_STATS_PWYW_YEARLY = (): SelectorProduct => ( {

--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -41,6 +41,9 @@ import {
 	JETPACK_SECURITY_T1_PLANS,
 	JETPACK_SECURITY_T2_PLANS,
 	JETPACK_COMPLETE_PLANS,
+	PRODUCT_JETPACK_STATS_MONTHLY,
+	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
+	PRODUCT_JETPACK_STATS_FREE,
 } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import buildCardFeaturesFromItem from './build-card-features-from-item';
@@ -154,6 +157,63 @@ export const EXTERNAL_PRODUCTS_SLUG_MAP: Record< string, () => SelectorProduct >
 	[ PRODUCT_JETPACK_CRM_FREE_MONTHLY ]: EXTERNAL_PRODUCT_CRM_FREE_MONTHLY,
 	[ PRODUCT_JETPACK_CRM ]: EXTERNAL_PRODUCT_CRM,
 	[ PRODUCT_JETPACK_CRM_MONTHLY ]: EXTERNAL_PRODUCT_CRM_MONTHLY,
+};
+
+// Jetpack Stats
+
+const STATS_COMMERCIAL_PRICE = 10;
+const STATS_COMMERCIAL_CURRENCY = 'USD';
+
+export const INDIRECT_CHECKOUT_PRODUCT_STATS = (): SelectorProduct => ( {
+	productSlug: PRODUCT_JETPACK_STATS_MONTHLY,
+	term: TERM_MONTHLY,
+	displayTerm: TERM_ANNUALLY,
+	type: ITEM_TYPE_PRODUCT,
+	costProductSlug: PRODUCT_JETPACK_STATS_MONTHLY,
+	monthlyProductSlug: PRODUCT_JETPACK_STATS_MONTHLY,
+	iconSlug: 'jetpack_stats',
+	displayName: translate( 'Stats' ),
+	shortName: translate( 'Stats' ),
+	tagline: translate( 'Simple, yet powerful analytics' ),
+	displayPrice: STATS_COMMERCIAL_PRICE,
+	displayCurrency: STATS_COMMERCIAL_CURRENCY,
+	description: translate(
+		'With Jetpack Stats, you don’t need to be a data scientist to see how your site is performing.'
+	),
+	shortDescription: translate( 'Simple, yet powerful stats to grow your site.' ),
+	buttonLabel: translate( 'Get Stats' ),
+	features: {
+		items: [],
+	},
+	hidePrice: true,
+	externalUrl: '/stats/purchase/{siteSlug}?flags=stats/paid-stats',
+} );
+
+export const INDIRECT_CHECKOUT_PRODUCT_STATS_PWYW_YEARLY = (): SelectorProduct => ( {
+	...INDIRECT_CHECKOUT_PRODUCT_STATS(),
+	productSlug: PRODUCT_JETPACK_STATS_PWYW_YEARLY,
+	term: TERM_ANNUALLY,
+	costProductSlug: PRODUCT_JETPACK_STATS_PWYW_YEARLY,
+} );
+
+export const INDIRECT_CHECKOUT_PRODUCT_STATS_FREE = (): SelectorProduct => ( {
+	...INDIRECT_CHECKOUT_PRODUCT_STATS_PWYW_YEARLY(),
+	isFree: true,
+	productSlug: PRODUCT_JETPACK_STATS_FREE,
+} );
+
+// List of products showcased in the Plans grid but not sold via checkout URL directly.
+export const INDIRECT_CHECKOUT_PRODUCTS_LIST = [
+	PRODUCT_JETPACK_STATS_MONTHLY,
+	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
+	PRODUCT_JETPACK_STATS_FREE,
+];
+
+// Indrect checkout Product slugs to SelectorProduct.
+export const INDIRECT_CHECKOUT_PRODUCTS_SLUG_MAP: Record< string, () => SelectorProduct > = {
+	[ PRODUCT_JETPACK_STATS_MONTHLY ]: INDIRECT_CHECKOUT_PRODUCT_STATS,
+	[ PRODUCT_JETPACK_STATS_PWYW_YEARLY ]: INDIRECT_CHECKOUT_PRODUCT_STATS_PWYW_YEARLY,
+	[ PRODUCT_JETPACK_STATS_FREE ]: INDIRECT_CHECKOUT_PRODUCT_STATS_FREE,
 };
 
 /**

--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -187,8 +187,8 @@ export const INDIRECT_CHECKOUT_PRODUCT_STATS = (): SelectorProduct => ( {
 		items: [],
 	},
 	hidePrice: true,
-	// TODO: Refactor the naming for indirect checkout and update the URL when the Paid Stats purchase page is ready.
-	externalUrl: '/stats/purchase/{siteSlug}?flags=stats/paid-stats',
+	// TODO: Refactor the checkout URL and update it when the Paid Stats purchase page is released.
+	externalUrl: '/stats/purchase/{siteSlug}?from=calypso-plans&flags=stats/paid-stats',
 } );
 
 export const INDIRECT_CHECKOUT_PRODUCT_STATS_PWYW_YEARLY = (): SelectorProduct => ( {

--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -186,6 +186,7 @@ export const INDIRECT_CHECKOUT_PRODUCT_STATS = (): SelectorProduct => ( {
 		items: [],
 	},
 	hidePrice: true,
+	// TODO: Update the URL when the Paid Stats purchase page is ready.
 	externalUrl: '/stats/purchase/{siteSlug}?flags=stats/paid-stats',
 } );
 

--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -161,6 +161,7 @@ export const EXTERNAL_PRODUCTS_SLUG_MAP: Record< string, () => SelectorProduct >
 
 // Jetpack Stats
 
+// TODO: We'll need to internationalize currencies like we did for the purchase page.
 const STATS_COMMERCIAL_PRICE = 10;
 const STATS_COMMERCIAL_CURRENCY = 'USD';
 
@@ -186,7 +187,7 @@ export const INDIRECT_CHECKOUT_PRODUCT_STATS = (): SelectorProduct => ( {
 		items: [],
 	},
 	hidePrice: true,
-	// TODO: Update the URL when the Paid Stats purchase page is ready.
+	// TODO: Refactor the naming for indirect checkout and update the URL when the Paid Stats purchase page is ready.
 	externalUrl: '/stats/purchase/{siteSlug}?flags=stats/paid-stats',
 } );
 
@@ -210,7 +211,7 @@ export const INDIRECT_CHECKOUT_PRODUCTS_LIST = [
 	PRODUCT_JETPACK_STATS_FREE,
 ];
 
-// Indrect checkout Product slugs to SelectorProduct.
+// Indirect checkout Product slugs to SelectorProduct.
 export const INDIRECT_CHECKOUT_PRODUCTS_SLUG_MAP: Record< string, () => SelectorProduct > = {
 	[ PRODUCT_JETPACK_STATS_MONTHLY ]: INDIRECT_CHECKOUT_PRODUCT_STATS,
 	[ PRODUCT_JETPACK_STATS_PWYW_YEARLY ]: INDIRECT_CHECKOUT_PRODUCT_STATS_PWYW_YEARLY,

--- a/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
+++ b/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
@@ -7,6 +7,7 @@ import { addQueryArgs } from 'calypso/lib/route';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import {
 	EXTERNAL_PRODUCTS_LIST,
+	INDIRECT_CHECKOUT_PRODUCTS_LIST,
 	PURCHASE_FLOW_UPSELLS_MATRIX,
 } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { getYearlySlugFromMonthly } from 'calypso/my-sites/plans/jetpack-plans/convert-slug-terms';
@@ -151,6 +152,12 @@ export const getPurchaseURLCallback =
 		if ( purchase ) {
 			const relativePath = managePurchase( siteSlug, purchase.id );
 			return isJetpackCloud() ? `https://wordpress.com${ relativePath }` : relativePath;
+		}
+
+		// Visit the indirect checkout URL to determine the purchasable product on another page.
+		// TODO: Use the checkout URL and product page URL respectively to alternate the externalUrl.
+		if ( INDIRECT_CHECKOUT_PRODUCTS_LIST.includes( product.productSlug ) ) {
+			return product.externalUrl?.replace( '{siteSlug}', siteSlug ) || '';
 		}
 
 		let url;

--- a/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
@@ -6,6 +6,8 @@ import {
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
 	PLAN_JETPACK_SECURITY_T2_MONTHLY,
 	JETPACK_BACKUP_ADDON_PRODUCTS,
+	JETPACK_STATS_PRODUCTS,
+	PRODUCT_JETPACK_STATS_FREE,
 	getMonthlyPlanByYearly,
 	getYearlyPlanByMonthly,
 } from '@automattic/calypso-products';
@@ -101,6 +103,16 @@ export const getProductsToDisplay = ( {
 					product?.productSlug
 				)
 		)
+		// TODO: Identify a suitable Stats plan according to the site classification.
+		.filter( ( product ) => {
+			if (
+				( JETPACK_STATS_PRODUCTS as ReadonlyArray< string > ).includes( product?.productSlug )
+			) {
+				return product?.productSlug === PRODUCT_JETPACK_STATS_FREE;
+			}
+
+			return true;
+		} )
 		// Remove duplicates (only happens if the site somehow has the same product
 		// both purchased and included in a plan, very unlikely)
 		.filter( ( product ) => {

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
@@ -36,6 +36,7 @@ export const useProductLightbox = () => {
 					} )
 				);
 
+				// We don't need to show the lightbox for external and indirect checkout products since they have their own landing pages.
 				if (
 					! EXTERNAL_PRODUCTS_LIST.includes( product.productSlug ) &&
 					! INDIRECT_CHECKOUT_PRODUCTS_LIST.includes( product.productSlug )

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
@@ -2,7 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import { EXTERNAL_PRODUCTS_LIST } from '../../constants';
+import { EXTERNAL_PRODUCTS_LIST, INDIRECT_CHECKOUT_PRODUCTS_LIST } from '../../constants';
 import slugToSelectorProduct from '../../slug-to-selector-product';
 import { SelectorProduct } from '../../types';
 import { sanitizeLocationHash } from '../utils/sanitize-location-hash';
@@ -36,7 +36,10 @@ export const useProductLightbox = () => {
 					} )
 				);
 
-				if ( ! EXTERNAL_PRODUCTS_LIST.includes( product.productSlug ) ) {
+				if (
+					! EXTERNAL_PRODUCTS_LIST.includes( product.productSlug ) &&
+					! INDIRECT_CHECKOUT_PRODUCTS_LIST.includes( product.productSlug )
+				) {
 					setCurrentProduct( product );
 				}
 			};

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -42,6 +42,7 @@ import { UseStoreItemInfoProps } from '../types';
 import { useShoppingCartTracker } from './use-shopping-cart-tracker';
 const getIsDeprecated = ( item: SelectorProduct ) => Boolean( item.legacy );
 
+// TODO: Refactor indirect checkout products checking since they have only similar behaviors to external products but are different.
 const getIsExternal = ( item: SelectorProduct ) =>
 	EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ) ||
 	INDIRECT_CHECKOUT_PRODUCTS_LIST.includes( item.productSlug );

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -30,7 +30,11 @@ import {
 	isJetpackCloudCartEnabled,
 	isJetpackSiteMultiSite,
 } from 'calypso/state/sites/selectors';
-import { EXTERNAL_PRODUCTS_LIST, ITEM_TYPE_PLAN } from '../../constants';
+import {
+	EXTERNAL_PRODUCTS_LIST,
+	INDIRECT_CHECKOUT_PRODUCTS_LIST,
+	ITEM_TYPE_PLAN,
+} from '../../constants';
 import { buildCheckoutURL } from '../../get-purchase-url-callback';
 import productButtonLabel from '../../product-card/product-button-label';
 import { SelectorProduct } from '../../types';
@@ -39,7 +43,11 @@ import { useShoppingCartTracker } from './use-shopping-cart-tracker';
 const getIsDeprecated = ( item: SelectorProduct ) => Boolean( item.legacy );
 
 const getIsExternal = ( item: SelectorProduct ) =>
-	EXTERNAL_PRODUCTS_LIST.includes( item.productSlug );
+	EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ) ||
+	INDIRECT_CHECKOUT_PRODUCTS_LIST.includes( item.productSlug );
+
+const getIsIndirectCheckout = ( item: SelectorProduct ) =>
+	INDIRECT_CHECKOUT_PRODUCTS_LIST.includes( item.productSlug );
 
 const getIsMultisiteCompatible = ( item: SelectorProduct ) => {
 	if ( isJetpackPlanSlug( item.productSlug ) ) {
@@ -393,6 +401,7 @@ export const useStoreItemInfo = ( {
 			getCtaAriaLabel,
 			getIsDeprecated,
 			getIsExternal,
+			getIsIndirectCheckout,
 			getIsIncludedInPlan,
 			getIsIncludedInPlanOrSuperseded,
 			getIsMultisiteCompatible,

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -28,6 +28,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 		getCtaAriaLabel,
 		getIsDeprecated,
 		getIsExternal,
+		getIsIndirectCheckout,
 		getIsIncludedInPlan,
 		getIsIncludedInPlanOrSuperseded,
 		getIsMultisiteCompatible,
@@ -56,6 +57,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 					const isSuperseded = getIsSuperseded( item );
 					const isDeprecated = getIsDeprecated( item );
 					const isExternal = getIsExternal( item );
+					const isIndirectCheckout = getIsIndirectCheckout( item );
 					const isIncludedInPlanOrSuperseded = getIsIncludedInPlanOrSuperseded( item );
 					const isIncludedInPlan = getIsIncludedInPlan( item );
 					const isMultiSiteIncompatible = isMultisite && ! getIsMultisiteCompatible( item );
@@ -88,6 +90,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 									onClick={ onClickMoreInfoFactory( item ) }
 									item={ item }
 									isExternal={ isExternal }
+									externalLink={ isIndirectCheckout ? getCheckoutURL( item ) : '' }
 								/>
 							) }
 						</>
@@ -129,7 +132,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 								description={ description }
 								icon={ <img alt="" src={ getProductIcon( { productSlug: item.productSlug } ) } /> }
 								isCtaDisabled={ isCtaDisabled }
-								isCtaExternal={ isExternal }
+								isCtaExternal={ isExternal && ! isIndirectCheckout }
 								onClickCta={ onClickCta }
 								isProductInCart={ isProductInCart }
 								price={ price }

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
@@ -4,12 +4,17 @@ import { MoreInfoLinkProps } from '../types';
 
 import './style.scss';
 
-export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( { item, onClick, isExternal } ) => {
+export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( {
+	item,
+	onClick,
+	isExternal,
+	externalLink,
+} ) => {
 	const translate = useTranslate();
 
-	const isExternalLink = isExternal && item.externalUrl;
+	const isExternalLink = ( isExternal && item.externalUrl ) || !! externalLink;
 
-	const href = isExternalLink ? item.externalUrl : `#${ item.productSlug }`;
+	const href = isExternalLink ? externalLink || item.externalUrl : `#${ item.productSlug }`;
 
 	const target = isExternalLink ? '_blank' : undefined;
 

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
@@ -12,6 +12,7 @@ export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( {
 } ) => {
 	const translate = useTranslate();
 
+	// TODO: Refactor the external link with indirect checkout logic.
 	const isExternalLink = ( isExternal && item.externalUrl ) || !! externalLink;
 
 	const href = isExternalLink ? externalLink || item.externalUrl : `#${ item.productSlug }`;

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -109,6 +109,7 @@ export type MoreInfoLinkProps = {
 	item: SelectorProduct;
 	onClick?: VoidFunction;
 	isExternal?: boolean;
+	externalLink?: string;
 };
 
 export type PricingBreakdownProps = {

--- a/client/my-sites/plans/jetpack-plans/product-store/utils/get-sorted-displayable-products.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/utils/get-sorted-displayable-products.ts
@@ -8,6 +8,7 @@ import {
 	JETPACK_SOCIAL_PRODUCTS,
 	JETPACK_VIDEOPRESS_PRODUCTS,
 	JETPACK_AI_PRODUCTS,
+	JETPACK_STATS_PRODUCTS,
 } from '@automattic/calypso-products';
 import { SelectorProduct } from '../../types';
 
@@ -24,6 +25,7 @@ const DISPLAYABLE_PRODUCT_POSITION_MAP: Record< string, number > = {
 	...setProductsInPosition( JETPACK_VIDEOPRESS_PRODUCTS, 7 ),
 	...setProductsInPosition( JETPACK_CRM_PRODUCTS, 8 ),
 	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 9 ),
+	...setProductsInPosition( JETPACK_STATS_PRODUCTS, 10 ),
 };
 
 const sortByProductPosition = ( productA: SelectorProduct, productB: SelectorProduct ) => {

--- a/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
+++ b/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
@@ -42,6 +42,8 @@ import buildCardFeaturesFromItem from './build-card-features-from-item';
 import {
 	EXTERNAL_PRODUCTS_LIST,
 	EXTERNAL_PRODUCTS_SLUG_MAP,
+	INDIRECT_CHECKOUT_PRODUCTS_LIST,
+	INDIRECT_CHECKOUT_PRODUCTS_SLUG_MAP,
 	ITEM_TYPE_PRODUCT,
 	ITEM_TYPE_PLAN,
 } from './constants';
@@ -76,6 +78,10 @@ function objectIsSelectorProduct(
 function slugToItem( slug: string ): Plan | Product | SelectorProduct | null | undefined {
 	if ( EXTERNAL_PRODUCTS_LIST.includes( slug ) ) {
 		return EXTERNAL_PRODUCTS_SLUG_MAP[ slug ]();
+	}
+
+	if ( INDIRECT_CHECKOUT_PRODUCTS_LIST.includes( slug ) ) {
+		return INDIRECT_CHECKOUT_PRODUCTS_SLUG_MAP[ slug ]();
 	}
 
 	if ( slugIsJetpackProductSlug( slug ) ) {

--- a/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
@@ -18,6 +18,7 @@ import {
 	JETPACK_SEARCH_PRODUCTS,
 	JETPACK_PRODUCTS_LIST,
 	JETPACK_VIDEOPRESS_PRODUCTS,
+	JETPACK_STATS_PRODUCTS,
 	getPlan,
 } from '@automattic/calypso-products';
 import { useSelector } from 'calypso/state';
@@ -120,6 +121,15 @@ const useSelectorPageProducts = ( siteId: number | null ): PlanGridProducts => {
 		)
 	) {
 		availableProducts = [ ...availableProducts, ...JETPACK_BOOST_PRODUCTS ];
+	}
+
+	// If Jetpack Stats is directly or indirectly owned, continue, otherwise make it available.
+	if (
+		! ownedProducts.some( ( ownedProduct ) =>
+			( JETPACK_STATS_PRODUCTS as ReadonlyArray< string > ).includes( ownedProduct )
+		)
+	) {
+		availableProducts = [ ...availableProducts, ...JETPACK_STATS_PRODUCTS ];
 	}
 
 	const socialProductsToShow: string[] = [];

--- a/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	JETPACK_ANTI_SPAM_PRODUCTS,
 	PRODUCT_JETPACK_BACKUP_T0_YEARLY,
@@ -125,6 +126,7 @@ const useSelectorPageProducts = ( siteId: number | null ): PlanGridProducts => {
 
 	// If Jetpack Stats is directly or indirectly owned, continue, otherwise make it available.
 	if (
+		config.isEnabled( 'stats/paid-stats' ) &&
 		! ownedProducts.some( ( ownedProduct ) =>
 			( JETPACK_STATS_PRODUCTS as ReadonlyArray< string > ).includes( ownedProduct )
 		)

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -1,5 +1,6 @@
 import {
 	JETPACK_CRM_PRODUCTS,
+	JETPACK_STATS_PRODUCTS,
 	JETPACK_SOCIAL_ADVANCED_PRODUCTS,
 	TERM_MONTHLY,
 } from '@automattic/calypso-products';
@@ -189,6 +190,17 @@ const useItemPrice = (
 	if (
 		item &&
 		JETPACK_CRM_PRODUCTS.includes( item.productSlug as ( typeof JETPACK_CRM_PRODUCTS )[ number ] )
+	) {
+		discountedPrice = item.displayPrice || -1;
+		originalPrice = item.displayPrice || -1;
+	}
+
+	// Jetpack Stats price won't come from the API, so we need to hard-code it for now.
+	if (
+		item &&
+		JETPACK_STATS_PRODUCTS.includes(
+			item.productSlug as ( typeof JETPACK_STATS_PRODUCTS )[ number ]
+		)
 	) {
 		discountedPrice = item.displayPrice || -1;
 		originalPrice = item.displayPrice || -1;

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -195,7 +195,7 @@ const useItemPrice = (
 		originalPrice = item.displayPrice || -1;
 	}
 
-	// Jetpack Stats price won't come from the API, so we need to hard-code it for now.
+	// TODO: Fetch the price from the API when it's available.
 	if (
 		item &&
 		JETPACK_STATS_PRODUCTS.includes(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79402 

## Proposed Changes

* Introduce `INDIRECT_CHECKOUT_PRODUCTS_LIST` and `INDIRECT_CHECKOUT_PRODUCTS_SLUG_MAP` as constants to store the information for the `Jetpack Stats` purchase flow.
* Use indirect checkout URL to determine the purchasing product on the Stats purchase page: `/stats/purchase/${site-slug}?flags=stats/paid-stats`.
* Add external more info link for the Stats landing page.
* Gate the purchasable Stats card with the feature flag: `?flags=-stats/paid-stats`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> Note: This change is made only for displaying the Stats plan card of the self-hosted Jetpack site.

1. Spin this change up with the Calypso Live link.
2. Navigate to the Plans page with the feature flag: `/plans/${site-slug}?flags=stats/paid-stats`.
3. Ensure the `Get` button and more info link of the Stats card navigate to the purchase page: `/stats/purchase/${site-slug}?flags=stats/paid-stats`.

<img width="1330" alt="截圖 2023-07-19 上午4 35 48" src="https://github.com/Automattic/wp-calypso/assets/6869813/938f32b8-e7dc-47b0-8f31-1ddd70d99b8f">

4. Purchase the Stats with the commercial plan.
5. Navigate to the Plans page: `/plans/${site-slug}`.
6. Ensure the purchased Stats card displays with correct information.

<img width="1309" alt="截圖 2023-07-19 上午4 36 27" src="https://github.com/Automattic/wp-calypso/assets/6869813/cc243e10-5fe0-4ae0-bbcf-426df0b7b205">

7. Remove the subscription of Stats.
8. Ensure steps 2. and 3. work well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
