### PR TITLE
Launchpad: Track views as a side effect rather than on every render

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -33,6 +33,7 @@ const CustomerHomeLaunchpad = ( {
 	const tasklistCompleted = completedSteps === numberOfSteps;
 
 	useEffect( () => {
+		// Record task list view as a whole.
 		recordTracksEvent( 'calypso_launchpad_tasklist_viewed', {
 			checklist_slug: checklistSlug,
 			tasks: `,${ checklist?.map( ( task: Task ) => task.id ).join( ',' ) },`,
@@ -40,6 +41,16 @@ const CustomerHomeLaunchpad = ( {
 			number_of_steps: numberOfSteps,
 			number_of_completed_steps: completedSteps,
 			context: 'customer-home',
+		} );
+
+		// Record views for each task.
+		checklist?.map( ( task: Task ) => {
+			recordTracksEvent( 'calypso_launchpad_task_view', {
+				checklist_slug: checklistSlug,
+				task_id: task.id,
+				is_completed: task.completed,
+				context: 'customer-home',
+			} );
 		} );
 	}, [ checklist, checklistSlug, completedSteps, numberOfSteps, tasklistCompleted ] );
 

--- a/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
@@ -1,7 +1,6 @@
 import { useLaunchpad } from '@automattic/data-stores';
 import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
-import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -33,17 +32,6 @@ const LaunchpadIntentWrite = (): JSX.Element => {
 			context: 'customer-home',
 		} );
 	};
-
-	useEffect( () => {
-		checklist?.map( ( task: Task ) => {
-			recordTracksEvent( 'calypso_launchpad_task_view', {
-				checklist_slug: checklistSlug,
-				task_id: task.id,
-				is_completed: task.completed,
-				context: 'customer-home',
-			} );
-		} );
-	}, [] );
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
 		const completedTasks = tasks.filter( ( task: Task ) => task.completed );

--- a/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
@@ -1,6 +1,7 @@
 import { useLaunchpad } from '@automattic/data-stores';
 import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
+import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -33,6 +34,17 @@ const LaunchpadIntentWrite = (): JSX.Element => {
 		} );
 	};
 
+	useEffect( () => {
+		checklist?.map( ( task: Task ) => {
+			recordTracksEvent( 'calypso_launchpad_task_view', {
+				checklist_slug: checklistSlug,
+				task_id: task.id,
+				is_completed: task.completed,
+				context: 'customer-home',
+			} );
+		} );
+	}, [] );
+
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
 		const completedTasks = tasks.filter( ( task: Task ) => task.completed );
 		const incompleteTasks = tasks.filter( ( task: Task ) => ! task.completed );
@@ -40,13 +52,6 @@ const LaunchpadIntentWrite = (): JSX.Element => {
 		const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
 
 		return sortedTasks.map( ( task: Task ) => {
-			recordTracksEvent( 'calypso_launchpad_task_view', {
-				checklist_slug: checklistSlug,
-				task_id: task.id,
-				is_completed: task.completed,
-				context: 'customer-home',
-			} );
-
 			let actionDispatch;
 
 			switch ( task.id ) {

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -1,7 +1,7 @@
 import { useLaunchpad } from '@automattic/data-stores';
 import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -39,17 +39,6 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 			context: 'customer-home',
 		} );
 	};
-
-	useEffect( () => {
-		checklist?.map( ( task: Task ) => {
-			recordTracksEvent( 'calypso_launchpad_task_view', {
-				checklist_slug: checklistSlug,
-				task_id: task.id,
-				is_completed: task.completed,
-				context: 'customer-home',
-			} );
-		} );
-	}, [] );
 
 	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
 

--- a/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/keep-building.tsx
@@ -1,7 +1,7 @@
 import { useLaunchpad } from '@automattic/data-stores';
 import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -40,6 +40,17 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 		} );
 	};
 
+	useEffect( () => {
+		checklist?.map( ( task: Task ) => {
+			recordTracksEvent( 'calypso_launchpad_task_view', {
+				checklist_slug: checklistSlug,
+				task_id: task.id,
+				is_completed: task.completed,
+				context: 'customer-home',
+			} );
+		} );
+	}, [] );
+
 	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
@@ -49,13 +60,6 @@ const LaunchpadKeepBuilding = ( { site }: LaunchpadKeepBuildingProps ): JSX.Elem
 		const sortedTasks = [ ...completedTasks, ...incompleteTasks ];
 
 		return sortedTasks.map( ( task: Task ) => {
-			recordTracksEvent( 'calypso_launchpad_task_view', {
-				checklist_slug: checklistSlug,
-				task_id: task.id,
-				is_completed: task.completed,
-				context: 'customer-home',
-			} );
-
 			let actionDispatch;
 
 			switch ( task.id ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79565

## Proposed Changes

* Move the `*_task_view` Tracks event into a `useEffect` hook in the parent component so we can ensure it only fires on the first render.
* This fixes the bug where the view events fired every time someone clicked and dismissed the Share your site task in the Keep Building checklist.

<img width="1641" alt="Screenshot 2023-07-18 at 4 56 06 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/bc2eb746-c9fa-4d0f-b774-579717c7d0bc">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/start` and create a new site with the "Promote myself or business" intent
* Launch the site
* Open the Inspector and set your localStorage to debug tracks events, or use Tracks Vigilante
* Ensure the `calypso_launchpad_task_view` events still show on the initial render, with the appropriate properties.
* Click on "Share your site" task.
* Ensure you *don't* see additional view events fired when the modal appears, or when you close the modal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
