### PR TITLE
New hosted site flow: add FAQ below plans grid

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/new-hosted-site-flow.scss
+++ b/client/landing/stepper/declarative-flow/internals/new-hosted-site-flow.scss
@@ -5,3 +5,8 @@
 .new-hosted-site .form-radios-bar.is-thumbnail {
 	flex-wrap: initial;
 }
+
+.new-hosted-site .plan-faq {
+	max-width: 1240px;
+	margin: 0 auto;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -42,7 +42,13 @@ const plans: Step = function Plans( { navigation, flow } ) {
 			hideFormattedHeader={ true }
 			isLargeSkipLayout={ false }
 			hideBack={ ! isAllowedToGoBack }
-			stepContent={ <PlansWrapper flowName={ flow } onSubmit={ handleSubmit } /> }
+			stepContent={
+				<PlansWrapper
+					flowName={ flow }
+					onSubmit={ handleSubmit }
+					shouldIncludeFAQ={ isNewHostedSiteCreationFlow( flow ) }
+				/>
+			}
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -27,6 +27,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { startedInHostingFlow } from 'calypso/landing/stepper/utils/hosting-flow';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
+import PlanFAQ from 'calypso/my-sites/plans-features-main/components/plan-faq';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getIntervalType } from 'calypso/signup/steps/plans/util';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -37,6 +38,7 @@ import type { PlansIntent } from 'calypso/my-sites/plan-features-2023-grid/hooks
 import './style.scss';
 
 interface Props {
+	shouldIncludeFAQ?: boolean;
 	flowName: string | null;
 	onSubmit: ( pickedPlan: MinimalRequestCartProduct | null ) => void;
 	plansLoaded: boolean;
@@ -155,6 +157,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					intent={ plansIntent }
 					replacePaidDomainWithFreeDomain={ replacePaidDomainWithFreeDomain }
 				/>
+				{ props.shouldIncludeFAQ && <PlanFAQ /> }
 			</div>
 		);
 	};

--- a/client/my-sites/plans-features-main/components/plan-faq.jsx
+++ b/client/my-sites/plans-features-main/components/plan-faq.jsx
@@ -18,7 +18,7 @@ const FoldableFAQ = styled( FoldableFAQComponent )`
 	}
 `;
 
-const PlanFAQ = ( { titanMonthlyRenewalCost } ) => {
+const PlanFAQ = ( { titanMonthlyRenewalCost = 0 } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const onFaqToggle = useCallback(
@@ -140,17 +140,28 @@ const PlanFAQ = ( { titanMonthlyRenewalCost } ) => {
 				question={ translate( 'Can I get an email account?' ) }
 				onToggle={ onFaqToggle }
 			>
-				{ translate(
-					'Absolutely! We offer a few different options to meet your needs. For most customers, our ' +
-						'Professional Email service is the smart choice. This robust hosted email solution is ' +
-						'available for any domain hosted with WordPress.com and starts at just %(titanMonthlyRenewalCost)s/mo per mailbox.{{br /}}{{br /}}' +
-						'We also offer a Google Workspace integration, and for users who need something simpler, you ' +
-						'can set up email forwarding for free.',
-					{
-						components: { br: <br /> },
-						args: { titanMonthlyRenewalCost },
-					}
-				) }
+				{ titanMonthlyRenewalCost
+					? translate(
+							'Absolutely! We offer a few different options to meet your needs. For most customers, our ' +
+								'Professional Email service is the smart choice. This robust hosted email solution is ' +
+								'available for any domain hosted with WordPress.com and starts at just %(titanMonthlyRenewalCost)s/mo per mailbox.{{br /}}{{br /}}' +
+								'We also offer a Google Workspace integration, and for users who need something simpler, you ' +
+								'can set up email forwarding for free.',
+							{
+								components: { br: <br /> },
+								args: { titanMonthlyRenewalCost },
+							}
+					  )
+					: translate(
+							'Absolutely! We offer a few different options to meet your needs. For most customers, our ' +
+								'Professional Email service is the smart choice. This robust hosted email solution is ' +
+								'available for any domain hosted with WordPress.com.{{br /}}{{br /}}' +
+								'We also offer a Google Workspace integration, and for users who need something simpler, you ' +
+								'can set up email forwarding for free.',
+							{
+								components: { br: <br /> },
+							}
+					  ) }
 			</FoldableFAQ>
 			<FoldableFAQ
 				id="faq-9"


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3035.

## Proposed Changes

Let's add the FAQ below the Plans grid so that users can have their questions answered before adding a plan to the cart:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/34a9edcf-0c8b-4145-aa0b-e8a4f19ac704)

I feel that all questions are worth including, except the first one. It's obvious that hosting is included if you're browsing `/setup/new-hosted-site`. Maybe we should remove that one, but then it's best to err on the safe side of redundancy than to start assuming things.

## Testing Instructions

Browse `/setup/new-hosted-site`, get to the plans step and verify the "Frequently Asked Questions" below the "Compare plans button".
