### PR TITLE
Send API error status as tracks error message to fix error from attempting to send react jsx

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -107,6 +107,7 @@ export function DomainCodePair( {
 		saleCost,
 		currencyCode = 'USD',
 		refetch,
+		errorStatus,
 	} = validation;
 
 	useEffect( () => {
@@ -119,10 +120,10 @@ export function DomainCodePair( {
 		if ( shouldReportError && ! valid && message ) {
 			recordTracksEvent( 'calypso_domain_transfer_domain_error', {
 				domain,
-				error: message,
+				error: errorStatus ? errorStatus : message,
 			} );
 		}
-	}, [ shouldReportError, valid, domain, message ] );
+	}, [ shouldReportError, valid, domain, message, errorStatus ] );
 
 	return (
 		<div className="domains__domain-info-and-validation">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -104,6 +104,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 			saleCost: validationResult?.sale_cost,
 			currencyCode: validationResult?.currency_code,
 			refetch,
+			errorStatus: validationResult?.status,
 		};
 	}
 
@@ -114,5 +115,6 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 			'An unknown error occurred while checking the domain transferability. Please try again or contact support'
 		),
 		refetch,
+		errorStatus: null,
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

We are currently mistakenly sending React JSX as a string `error` message for our `calypso_domain_transfer_domain_error` tracks event.

These changes send the `domainAvailability` related constant string as the error message instead. 

Console error before changes:
![image](https://github.com/Automattic/wp-calypso/assets/10482592/b4d2e339-d85e-45f3-ba8e-e681ac46aa22)


After:
![image](https://github.com/Automattic/wp-calypso/assets/10482592/2210e394-7d29-4cc2-b769-c68df71a6a07)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR or use live link
* Navigate to `/setup/domain-transfer/domains`
* Open browser console and network tab
* Enter a random domain and a random auth code. Wait a few seconds for the API validation results.
* Verify there is no console error related to tracks events.
* Test different validation scenario, verify the events are being sent correctly, and that there are no console errors.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


Fixes https://github.com/Automattic/dotcom-forge/issues/3098