### PR TITLE
Hosted site flows: prevent anonymous browsing

### DIFF
--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { IMPORT_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from 'react';
+import { useEffect, useLayoutEffect } from 'react';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 import MigrationError from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/migration-error';
@@ -225,6 +225,18 @@ const importHostedSiteFlow: Flow = {
 		};
 
 		return { goNext, goBack, goToStep, submit };
+	},
+	useSideEffect() {
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+
+		useLayoutEffect( () => {
+			if ( ! userIsLoggedIn ) {
+				window.location.assign( '/start/hosting' );
+			}
+		}, [ userIsLoggedIn ] );
 	},
 };
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -23,8 +23,7 @@ export function generateFlows( {
 			name: HOSTING_LP_FLOW,
 			steps: [ 'user-hosting' ],
 			destination: getHostingFlowDestination,
-			description:
-				'Create an account and a blog and give the user the option of adding a domain and plan to the cart.',
+			description: 'Create an account and redirect the user to the hosted site flow forking step.',
 			lastModified: '2023-05-19',
 			showRecaptcha: true,
 		},

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -24,7 +24,7 @@ export function generateFlows( {
 			steps: [ 'user-hosting' ],
 			destination: getHostingFlowDestination,
 			description: 'Create an account and redirect the user to the hosted site flow forking step.',
-			lastModified: '2023-05-19',
+			lastModified: '2023-07-18',
 			showRecaptcha: true,
 		},
 		{

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -200,12 +200,15 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 }
 
 function getHostingFlowDestination( { siteId } ) {
-	return addQueryArgs(
-		{
-			'new-site': siteId,
-			'hosting-flow': true,
-		},
-		'/sites'
+	return (
+		getQueryArgs().redirect_to ??
+		addQueryArgs(
+			{
+				'new-site': siteId,
+				'hosting-flow': true,
+			},
+			'/sites'
+		)
 	);
 }
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -199,12 +199,11 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 	return `/home/${ siteSlug }`;
 }
 
-function getHostingFlowDestination( { siteId } ) {
+function getHostingFlowDestination() {
 	return (
 		getQueryArgs().redirect_to ??
 		addQueryArgs(
 			{
-				'new-site': siteId,
 				'hosting-flow': true,
 			},
 			'/sites'

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -200,15 +200,7 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 }
 
 function getHostingFlowDestination() {
-	return (
-		getQueryArgs().redirect_to ??
-		addQueryArgs(
-			{
-				'hosting-flow': true,
-			},
-			'/sites'
-		)
-	);
+	return '/sites?hosting-flow=true';
 }
 
 const flows = generateFlows( {


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3056.

## Proposed Changes

This PR gates `/setup/new-hosted-site` for logged in accounts. The original idea was to allow incognito browsing until the site creation step, but this was complicated to achieve due to the flow variation (hosting flow or not) and also I don't really see a lot of value in anonymous browsing since the user needs to sign in anyway, so let's just redirect first, keeping things simple.

Another good reason to sign in first is to maintain funnel compatibility. If we add the sign in step after plans, we'll need to create at least two funnels to account for this permutation, and that's a no-no for me.

Finally, there is no direct link to this flow as we want the user to decide whether they want to create a site from scratch or import one, so it makes more sense to send them to sign up first. I am thinking of dropping the `redirect_to` so that they always get redirected to `/sites`, seeing the forking step and then deciding. It feels like a better solution to me, but I'm not yet convinced because the user browsed `/setup/new-hosted-site` directly, so they're probably not interesting in importing a site.

Additionally, I perform a light clean up that might be out of scope of this PR, but no strong feelings in reverting them if you feel that's too unrelated to this PRs proposed changes.

## Testing Instructions

Browse `/setup/new-hosted-site` in incognito mode, and verify that you're redirected to `/start/hosting/user-hosting`. Log in and you should be redirected to `/sites?hosting-flow=true`.

Browse `/setup/import-hosted-site` in incognito mode, and verify that you're redirected to `/start/hosting/user-hosting`. Log in and you should be redirected to `/sites?hosting-flow=true`.