### PR TITLE
Domain Transfer: Hide FAQ by feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import { DomainTransferData, DomainTransferForm } from '@automattic/data-stores';
 import formatCurrency from '@automattic/format-currency';
-import { useLocale } from '@automattic/i18n-utils';
 import { useDataLossWarning } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -85,8 +85,6 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 	const hasAnyDomains = Object.values( domainsState ).some(
 		( { domain, auth } ) => domain.trim() || auth.trim()
 	);
-
-	const localeSlug = useLocale();
 
 	useDataLossWarning( hasAnyDomains && enabledDataLossWarning );
 
@@ -219,14 +217,11 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 						  ) }
 				</Button>
 			</div>
-			{
-				// Temporarily disable the FAQ section for non-English locales.
-				( localeSlug === 'en' || localeSlug === 'en-gb' ) && (
-					<div className="bulk-domain-transfer__faqs">
-						<DomainTransferFAQ />
-					</div>
-				)
-			}
+			{ isEnabled( 'domain-transfer/faq' ) && (
+				<div className="bulk-domain-transfer__faqs">
+					<DomainTransferFAQ />
+				</div>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
## Proposed Changes

* Remove FAQ for now and hide behind `domain-transfer/faq` flag.,

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR
* Go to `/setup/domain-transfer/domains`
* Verify no FAQ
* Go to `/setup/domain-transfer/domains?flags=domain-transfer/faq`
* Verify FAQ displays

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
