### PR TITLE
Payment Methods: Fix payment method styling when changing methods

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
@@ -109,8 +109,6 @@ function formatDate( cardExpiry: string ): string {
 
 const CardDetails = styled.span`
 	display: inline-block;
-	margin-right: 8px;
-
 	.rtl & {
 		margin-right: 0;
 		margin-left: 8px;
@@ -121,6 +119,11 @@ const CardHolderName = styled.span`
 	display: block;
 `;
 
+const CardInfo = styled.span`
+	display: flex;
+	flex-wrap: wrap;
+	column-gap: 1em;
+`;
 function ExistingCardLabel( {
 	last4,
 	cardExpiry,
@@ -147,16 +150,18 @@ function ExistingCardLabel( {
 		<Fragment>
 			<div>
 				<CardHolderName>{ cardholderName }</CardHolderName>
-				<CardDetails>{ maskedCardDetails }</CardDetails>
-				<span>{ `${ __( 'Expiry:' ) } ${ formatDate( cardExpiry ) }` }</span>
-				{ allowEditingTaxInfo && (
-					<TaxInfoArea
-						last4={ last4 }
-						brand={ brand }
-						storedDetailsId={ storedDetailsId }
-						paymentPartnerProcessorId={ paymentPartnerProcessorId }
-					/>
-				) }
+				<CardInfo>
+					<CardDetails>{ maskedCardDetails }</CardDetails>
+					<span>{ `${ __( 'Expiry:' ) } ${ formatDate( cardExpiry ) }` }</span>
+					{ allowEditingTaxInfo && (
+						<TaxInfoArea
+							last4={ last4 }
+							brand={ brand }
+							storedDetailsId={ storedDetailsId }
+							paymentPartnerProcessorId={ paymentPartnerProcessorId }
+						/>
+					) }
+				</CardInfo>
 			</div>
 			<div className="existing-credit-card__logo payment-logos">
 				<PaymentLogo brand={ brand } isSummary={ true } />

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -105,7 +105,6 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 	box-sizing: border-box;
 	width: 100%;
 	display: flex;
-	flex-wrap: wrap;
 	justify-content: space-between;
 	align-items: center;
 	align-content: center;


### PR DESCRIPTION
As noted [here](https://github.com/Automattic/wp-calypso/issues/79202), recent updates to the checkout section introduced a regression in the payment method styling found under the Change Payment Method section.

![image](https://github.com/Automattic/wp-calypso/assets/16580129/716050fe-0b51-437f-91e0-3c7125556d38)


Related to #79202 

## Proposed Changes

This PR removes margin from the payment method items and instead uses flexbox's `column-gap` property to space the different billing related items onto one single line.

To compensate for mobile devices, flex wrap is added to the newly created `<CardInfo>` section, and, flex wrap is removed from the card label wrapper to ensure the card logos are properly right aligned on mobile and desktop alike.

## Testing Instructions

* Go to any purchase that has a payment method and click on "Change Payment Method"
* Ensure that the card number, expiry, and billing information (including postal code) appear evenly spaced on one line on desktop
* Then, shrink the viewport slowly down to 400px, look for any odd clipping or issues with the spacing. Around 530px you should see this line properly wrap so that Billing Information drops down to the next line
* The card logo should always show on the right side of this content
* Under 400px the card logo should disappear

### Expected results:

**Desktop**

<img width="875" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/9717c199-29ab-4b61-9bc1-0fd810e8a658">


**Mobile above 400px**

<img width="588" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/38a6519d-2fc8-4c77-851d-a7e370d13eaf">


**Mobile below 400px**

<img width="320" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/775da3ce-1925-4317-86ec-bd5df6086821">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
