### PR TITLE
Disable Sentry and JS error reporting in calypso.live

### DIFF
--- a/client/lib/sentry/index.ts
+++ b/client/lib/sentry/index.ts
@@ -134,12 +134,7 @@ export async function initSentry( { beforeSend, userId }: SentryOptions ) {
 
 		// Enable Sentry only for 10% of requests or always in calypso.live for testing.
 		// Always disable if catch-js-errors is not available in the environment.
-		if (
-			! (
-				config.isEnabled( 'catch-js-errors' ) &&
-				( config( 'env_id' ) === 'wpcalypso' || Math.floor( Math.random() * 10 ) === 1 )
-			)
-		) {
+		if ( ! config.isEnabled( 'catch-js-errors' ) || Math.floor( Math.random() * 10 ) !== 1 ) {
 			// Set state to disabled to stop maintaining a queue of sentry method calls.
 			state = { state: 'disabled' };
 			// Note that the `clearQueues()` call in the finally block is still

--- a/client/lib/sentry/index.ts
+++ b/client/lib/sentry/index.ts
@@ -132,15 +132,21 @@ export async function initSentry( { beforeSend, userId }: SentryOptions ) {
 		}
 		state = { state: 'loading' };
 
-		// Enable Sentry only for 10% of requests or always in calypso.live for testing.
-		// Always disable if catch-js-errors is not available in the environment.
-		if ( ! config.isEnabled( 'catch-js-errors' ) || Math.floor( Math.random() * 10 ) !== 1 ) {
+		// Enable Sentry only for 10% of requests. Disable if catch-js-errors is not available in the environment.
+		// When always-enable-sentry is available, bypass the other checks.
+		if (
+			! config.isEnabled( 'always-enable-sentry' ) &&
+			( ! config.isEnabled( 'catch-js-errors' ) || Math.floor( Math.random() * 10 ) !== 1 )
+		) {
 			// Set state to disabled to stop maintaining a queue of sentry method calls.
 			state = { state: 'disabled' };
 			// Note that the `clearQueues()` call in the finally block is still
 			// executed after returning here, so cleanup does happen correctly.
 			return;
 		}
+
+		// eslint-disable-next-line no-console
+		console.info( 'Initializing error reporting...' );
 
 		const errorHandler = ( errorEvent: ErrorEvent ): void =>
 			void errorQueue.push( [

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -23,7 +23,7 @@
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
-		"catch-js-errors": true,
+		"catch-js-errors": false,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"cloudflare": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
Following a discussion with @fullofcaffeine, disable Sentry for wpcalypso and make sure we have a flag which can always enable it.

We don't really want to track JS errors for calypso.live, because it's practically a development environment and really isn't that actionable. We still track JS errors for horizon, staging, and production.


## Testing instructions
- Load calypso.live a few times. Sentry should not load at all.
- Load calypso.live with `?flags=always-enable-sentry` as the url param, and sentry should load every time.

To verify that "sentry loads", I've added a little console.info message. When it doesn't exist, it's not loading.
<img width="1728" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6265975/681abaf2-7213-4ff5-8d20-d3023c025d9c">
