### PR TITLE
Jetpack Pro Dashboard: Hide WooCommerce Extensions section behind a feature flag

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -232,7 +233,7 @@ export default function IssueMultipleLicensesForm( {
 							</div>
 						</>
 					) }
-					{ wooExtensions && (
+					{ config.isEnabled( 'jetpack/pro-dashboard-woo-extensions' ) && wooExtensions && (
 						<>
 							<hr className="issue-multiple-licenses-form__separator" />
 							<p className="issue-multiple-licenses-form__description">

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -53,6 +53,7 @@
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": true,
 		"jetpack/pro-dashboard-monitor-paid-tier": true,
 		"jetpack/pro-dashboard-monitor-sms-notification": true,
+		"jetpack/pro-dashboard-woo-extensions": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -47,6 +47,7 @@
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": true,
 		"jetpack/pro-dashboard-monitor-paid-tier": true,
 		"jetpack/pro-dashboard-monitor-sms-notification": true,
+		"jetpack/pro-dashboard-woo-extensions": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -50,6 +50,7 @@
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": false,
 		"jetpack/pro-dashboard-monitor-paid-tier": false,
 		"jetpack/pro-dashboard-monitor-sms-notification": false,
+		"jetpack/pro-dashboard-woo-extensions": false,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -50,6 +50,7 @@
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": false,
 		"jetpack/pro-dashboard-monitor-paid-tier": false,
 		"jetpack/pro-dashboard-monitor-sms-notification": false,
+		"jetpack/pro-dashboard-woo-extensions": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Hide WooCommerce Extensions section behind a feature flag
* Originated from this report p1HpG7-nHw-p2#comment-64782

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access http://jetpack.cloud.localhost:3000/partner-portal/issue-license
* You should see an empty section on the bottom of the page with the title "WooCommerce Extensions"
* Flipping the feature flag on `development` to `false` should make the section disappear.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?