### PR TITLE
Paid Stats: Add paid plan purchase success banner

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -3,6 +3,7 @@ import wpcom from 'calypso/lib/wp';
 
 export type Notices = {
 	free_plan_purchase_success: boolean;
+	paid_plan_purchase_success: boolean;
 	new_stats_feedback: boolean;
 	opt_in_new_stats: boolean;
 	opt_out_new_stats: boolean;

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -34,7 +34,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 		hasLoadedPurchases;
 
 	const showFreePlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' ) && false;
-	const showPaidPlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' ) && true;
+	const showPaidPlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' ) && false;
 
 	return (
 		<>

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -9,6 +9,7 @@ import FeedbackNotice from './feedback-notice';
 import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
 import LegacyStatsNotices from './legacy-notices';
 import OptOutNotice from './opt-out-notice';
+import PaidPlanPurchaseSuccessJetpackStatsNotice from './paid-plan-purchase-success-notice';
 import { StatsNoticesProps } from './types';
 import usePurchasesToUpdateSiteProducts from './use-purchases-to-update-site-products';
 import './style.scss';
@@ -33,9 +34,13 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 		hasLoadedPurchases;
 
 	const showFreePlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' ) && false;
+	const showPaidPlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' ) && true;
 
 	return (
 		<>
+			{ showPaidPlanPurchaseSuccessNotice && (
+				<PaidPlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
+			) }
 			{ showFreePlanPurchaseSuccessNotice && (
 				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
 			) }

--- a/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
@@ -1,0 +1,51 @@
+/* eslint-disable no-console */
+import NoticeBanner from '@automattic/components/src/notice-banner';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
+import useNoticeVisibilityQuery from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import { StatsNoticeProps } from './types';
+
+const PaidPlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
+	const translate = useTranslate();
+	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
+	const { data: showNotice } = useNoticeVisibilityQuery( siteId, 'paid_plan_purchase_success' );
+	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
+		siteId,
+		'paid_plan_purchase_success',
+		'postponed',
+		30 * 24 * 3600
+	);
+
+	const dismissNotice = () => {
+		setNoticeDismissed( true );
+		postponeNoticeAsync();
+	};
+
+	if ( noticeDismissed || ! showNotice ) {
+		console.log( 'paidNotice noticeDismissed', noticeDismissed );
+		console.log( 'paidNotice showNotice', showNotice );
+		// return null;
+	}
+
+	return (
+		<div className="inner-notice-container has-odyssey-stats-bg-color">
+			<NoticeBanner
+				level="success"
+				title={ translate( 'Thank you for supporting Jetpack Stats!' ) }
+				onClose={ dismissNotice }
+			>
+				{ translate(
+					"{{p}}You'll now get instant access to upcoming features, get priority support, and no ads in Jetpack Stats.{{/p}}",
+					{
+						components: {
+							p: <p />,
+						},
+					}
+				) }
+			</NoticeBanner>
+		</div>
+	);
+};
+
+export default PaidPlanPurchaseSuccessJetpackStatsNotice;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78450

## Proposed Changes

* This PR adds the paid plan purchase success banner. **note:** this only adds the banner, and a little background additions to make the banner possible. It does not add the logic for when/how to show the banner. That shall come in a followup PR next and this banner will not display by default until then. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test using this branch on your local Calypso env (not using live branches) 
* Locate the file `/my-sites/stats/stats-notices/index.tsx` and replace the line `35` `	const showPaidPlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' ) && false;` with `const showPaidPlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' ) && true;` in order to display the **paid** stats banner (not the free one) 
* Navigate to `/stats/day/{siteURL}`
* Verify you can see the `Thank you for supporting Jetpack Stats!` banner in green, and that the layout, formatting and design looks okay and that the upgrade link works as expected. 

![image](https://github.com/Automattic/wp-calypso/assets/30754158/8a5b0d5b-c97c-4c51-a4d1-8c5ad583aa1a)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
