### PR TITLE
Paid Stats: Add display logic for free and paid purchase success notices

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -43,16 +43,11 @@ export async function queryNotices( siteId: number | null ): Promise< Notices > 
 	return processConflictNotices( payload );
 }
 
-export default function useNoticeVisibilityQuery(
-	siteId: number | null,
-	noticeId: string,
-	statsPurchaseSuccess: boolean
-) {
+export default function useNoticeVisibilityQuery( siteId: number | null, noticeId: string ) {
 	return useQuery( {
 		queryKey: [ 'stats', 'notices-visibility', siteId ],
 		queryFn: () => queryNotices( siteId ),
-		select: ( payload: Record< string, boolean > ): boolean =>
-			statsPurchaseSuccess || !! payload?.[ noticeId ],
+		select: ( payload: Record< string, boolean > ): boolean => !! payload?.[ noticeId ],
 		staleTime: 1000 * 30, // 30 seconds
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -2,8 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
 export type Notices = {
-	free_plan_purchase_success: boolean;
-	paid_plan_purchase_success: boolean;
 	new_stats_feedback: boolean;
 	opt_in_new_stats: boolean;
 	opt_out_new_stats: boolean;
@@ -45,11 +43,16 @@ export async function queryNotices( siteId: number | null ): Promise< Notices > 
 	return processConflictNotices( payload );
 }
 
-export default function useNoticeVisibilityQuery( siteId: number | null, noticeId: string ) {
+export default function useNoticeVisibilityQuery(
+	siteId: number | null,
+	noticeId: string,
+	statsPurchaseSuccess: boolean
+) {
 	return useQuery( {
 		queryKey: [ 'stats', 'notices-visibility', siteId ],
 		queryFn: () => queryNotices( siteId ),
-		select: ( payload: Record< string, boolean > ): boolean => !! payload?.[ noticeId ],
+		select: ( payload: Record< string, boolean > ): boolean =>
+			statsPurchaseSuccess || !! payload?.[ noticeId ],
 		staleTime: 1000 * 30, // 30 seconds
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -239,10 +239,11 @@ class StatsSite extends Component {
 					siteId={ siteId }
 					slug={ slug }
 				/>
-				<StatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
-
-				{ statsPurchaseSuccess && <p>Thank you for using Jetpack Stats</p> }
-
+				<StatsNotices
+					siteId={ siteId }
+					isOdysseyStats={ isOdysseyStats }
+					statsPurchaseSuccess={ statsPurchaseSuccess }
+				/>
 				<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -2,8 +2,6 @@ import config from '@automattic/calypso-config';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
-import useNoticeVisibilityQuery from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { StatsNoticeProps } from './types';
 
 const getStatsPurchaseURL = ( siteId: number | null ) => {
@@ -18,21 +16,13 @@ const getStatsPurchaseURL = ( siteId: number | null ) => {
 const FreePlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
-	const { data: showNotice } = useNoticeVisibilityQuery( siteId, 'free_plan_purchase_success' );
-	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
-		siteId,
-		'free_plan_purchase_success',
-		'postponed',
-		30 * 24 * 3600
-	);
 
 	const dismissNotice = () => {
 		setNoticeDismissed( true );
-		postponeNoticeAsync();
 	};
 
-	if ( noticeDismissed || ! showNotice ) {
-		// return null; this is for testing purposes. TODO uncomment
+	if ( noticeDismissed ) {
+		return null;
 	}
 
 	return (

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -18,6 +18,7 @@ const FreePlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 
 	const dismissNotice = () => {
+		// TODO: Remove the query string from the window URL without a refresh.
 		setNoticeDismissed( true );
 	};
 

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -10,7 +10,7 @@ import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-succ
 import LegacyStatsNotices from './legacy-notices';
 import OptOutNotice from './opt-out-notice';
 import PaidPlanPurchaseSuccessJetpackStatsNotice from './paid-plan-purchase-success-notice';
-import { StatsNoticesProps } from './types';
+import { NewStatsNoticesProps, StatsNoticesProps, PurchaseNoticesProps } from './types';
 import usePurchasesToUpdateSiteProducts from './use-purchases-to-update-site-products';
 import './style.scss';
 
@@ -18,7 +18,7 @@ import './style.scss';
  * New notices aim to support Calypso and Odyssey stats.
  * New notices are based on async API call and hence is faster than the old notices.
  */
-const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: StatsNoticesProps ) => {
+const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => {
 	const hasPaidStats = useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) );
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
@@ -33,6 +33,16 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		! hasPaidStats &&
 		hasLoadedPurchases;
 
+	return (
+		<>
+			{ showPaidStatsNotice && <DoYouLoveJetpackStatsNotice siteId={ siteId } /> }
+			{ isOdysseyStats && <OptOutNotice siteId={ siteId } /> }
+			{ isOdysseyStats && <FeedbackNotice siteId={ siteId } /> }
+		</>
+	);
+};
+
+const PostPurchaseNotices = ( { siteId, statsPurchaseSuccess }: PurchaseNoticesProps ) => {
 	// Check if the GET param is passed to show the Free or Paid plan purchase notices
 	const showFreePlanPurchaseSuccessNotice =
 		config.isEnabled( 'stats/paid-stats' ) && statsPurchaseSuccess === 'free';
@@ -45,9 +55,6 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 			{ showFreePlanPurchaseSuccessNotice && (
 				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
 			) }
-			{ showPaidStatsNotice && <DoYouLoveJetpackStatsNotice siteId={ siteId } /> }
-			{ isOdysseyStats && <OptOutNotice siteId={ siteId } /> }
-			{ isOdysseyStats && <FeedbackNotice siteId={ siteId } /> }
 		</>
 	);
 };
@@ -69,11 +76,14 @@ export default function StatsNotices( {
 		!! ( statsAdminVersion && version_compare( statsAdminVersion, '0.10.0-alpha', '>=' ) );
 
 	return supportNewStatsNotices ? (
-		<NewStatsNotices
-			siteId={ siteId }
-			isOdysseyStats={ isOdysseyStats }
-			statsPurchaseSuccess={ statsPurchaseSuccess }
-		/>
+		<>
+			<NewStatsNotices
+				siteId={ siteId }
+				isOdysseyStats={ isOdysseyStats }
+				statsPurchaseSuccess={ statsPurchaseSuccess }
+			/>
+			<PostPurchaseNotices siteId={ siteId } statsPurchaseSuccess={ statsPurchaseSuccess } />
+		</>
 	) : (
 		<LegacyStatsNotices siteId={ siteId } />
 	);

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -51,6 +51,7 @@ const PostPurchaseNotices = ( { siteId, statsPurchaseSuccess }: PurchaseNoticesP
 
 	return (
 		<>
+			{ /* TODO: Consider combining/refactoring these components into a single component */ }
 			{ showPaidPlanPurchaseSuccessNotice && <PaidPlanPurchaseSuccessJetpackStatsNotice /> }
 			{ showFreePlanPurchaseSuccessNotice && (
 				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -78,11 +78,7 @@ export default function StatsNotices( {
 
 	return supportNewStatsNotices ? (
 		<>
-			<NewStatsNotices
-				siteId={ siteId }
-				isOdysseyStats={ isOdysseyStats }
-				statsPurchaseSuccess={ statsPurchaseSuccess }
-			/>
+			<NewStatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
 			<PostPurchaseNotices siteId={ siteId } statsPurchaseSuccess={ statsPurchaseSuccess } />
 		</>
 	) : (

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -18,7 +18,7 @@ import './style.scss';
  * New notices aim to support Calypso and Odyssey stats.
  * New notices are based on async API call and hence is faster than the old notices.
  */
-const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
+const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: StatsNoticesProps ) => {
 	const hasPaidStats = useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) );
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
@@ -33,14 +33,15 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 		! hasPaidStats &&
 		hasLoadedPurchases;
 
-	const showFreePlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' ) && false;
-	const showPaidPlanPurchaseSuccessNotice = config.isEnabled( 'stats/paid-stats' ) && false;
+	// Check if the GET param is passed to show the Free or Paid plan purchase notices
+	const showFreePlanPurchaseSuccessNotice =
+		config.isEnabled( 'stats/paid-stats' ) && statsPurchaseSuccess === 'free';
+	const showPaidPlanPurchaseSuccessNotice =
+		config.isEnabled( 'stats/paid-stats' ) && statsPurchaseSuccess === 'paid';
 
 	return (
 		<>
-			{ showPaidPlanPurchaseSuccessNotice && (
-				<PaidPlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
-			) }
+			{ showPaidPlanPurchaseSuccessNotice && <PaidPlanPurchaseSuccessJetpackStatsNotice /> }
 			{ showFreePlanPurchaseSuccessNotice && (
 				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
 			) }
@@ -54,16 +55,25 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 /**
  * Return new or old StatsNotices components based on env.
  */
-export default function StatsNotices( { siteId, isOdysseyStats }: StatsNoticesProps ) {
+export default function StatsNotices( {
+	siteId,
+	isOdysseyStats,
+	statsPurchaseSuccess,
+}: StatsNoticesProps ) {
 	const statsAdminVersion = useSelector( ( state: object ) =>
 		getJetpackStatsAdminVersion( state, siteId )
 	);
+
 	const supportNewStatsNotices =
 		! isOdysseyStats ||
 		!! ( statsAdminVersion && version_compare( statsAdminVersion, '0.10.0-alpha', '>=' ) );
 
 	return supportNewStatsNotices ? (
-		<NewStatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
+		<NewStatsNotices
+			siteId={ siteId }
+			isOdysseyStats={ isOdysseyStats }
+			statsPurchaseSuccess={ statsPurchaseSuccess }
+		/>
 	) : (
 		<LegacyStatsNotices siteId={ siteId } />
 	);

--- a/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
@@ -2,30 +2,17 @@
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
-import useNoticeVisibilityQuery from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
-import { StatsNoticeProps } from './types';
 
-const PaidPlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
+const PaidPlanPurchaseSuccessJetpackStatsNotice = () => {
 	const translate = useTranslate();
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
-	const { data: showNotice } = useNoticeVisibilityQuery( siteId, 'paid_plan_purchase_success' );
-	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
-		siteId,
-		'paid_plan_purchase_success',
-		'postponed',
-		30 * 24 * 3600
-	);
 
 	const dismissNotice = () => {
 		setNoticeDismissed( true );
-		postponeNoticeAsync();
 	};
 
-	if ( noticeDismissed || ! showNotice ) {
-		console.log( 'paidNotice noticeDismissed', noticeDismissed );
-		console.log( 'paidNotice showNotice', showNotice );
-		// return null;
+	if ( noticeDismissed ) {
+		return null;
 	}
 
 	return (

--- a/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
@@ -8,6 +8,7 @@ const PaidPlanPurchaseSuccessJetpackStatsNotice = () => {
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 
 	const dismissNotice = () => {
+		// TODO: Remove the query string from the window URL without a refresh.
 		setNoticeDismissed( true );
 	};
 

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -14,4 +14,5 @@ export interface FeedbackNoticeBodyProps extends NoticeBodyProps {
 export interface StatsNoticesProps {
 	siteId: number | null;
 	isOdysseyStats?: boolean;
+	statsPurchaseSuccess?: string;
 }

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -16,3 +16,13 @@ export interface StatsNoticesProps {
 	isOdysseyStats?: boolean;
 	statsPurchaseSuccess?: string;
 }
+
+export interface NewStatsNoticesProps {
+	siteId: number | null;
+	isOdysseyStats?: boolean;
+}
+
+export interface PurchaseNoticesProps {
+	siteId: number | null;
+	statsPurchaseSuccess: string | undefined;
+}


### PR DESCRIPTION
Related to #78449 & #78450

## Proposed Changes

* This PR adds the display logic to receive a GET param and display the correct notices

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calyoso live branch
* Append the query param to the URL `?flags=stats/paid-stats&statsPurchaseSuccess=paid`
* Test that the paid purchase success banner appears
![image](https://github.com/Automattic/wp-calypso/assets/30754158/dead4461-b514-4b39-91ca-f77f56dbf1bc)

* Append the query param to the URL `?flags=stats/paid-stats&statsPurchaseSuccess=free`
* Test that the free purchase success banner appears 
![image](https://github.com/Automattic/wp-calypso/assets/30754158/475ac586-cd92-4625-8c63-e968a84a01c6)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
