### PR TITLE
Domain Transfer: add full stop to the end of sentence in the footer.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/complete-domains-transferred.tsx
@@ -80,7 +80,7 @@ export const CompleteDomainsTransferred = ( {
 						<h2> { __( 'Consider moving your sites too?' ) }</h2>
 						<p>
 							{ __(
-								'You can find step-by-step guides below that will help you move your site to WordPress.com'
+								'You can find step-by-step guides below that will help you move your site to WordPress.com.'
 							) }
 						</p>
 						<a


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3115.

## Proposed Changes

Adds a full stop to the end of sentence.

## Testing Instructions

In calypso.live, navigate to `/setup/domain-transfer/complete` and look at the footer message on bottom right.

**Before**
![image](https://github.com/Automattic/wp-calypso/assets/6549265/c96d88f7-eefb-48e9-97f9-be5d9b9e5546)


**After**
![image](https://github.com/Automattic/wp-calypso/assets/6549265/c43af03b-a0a3-4ee4-81d6-197327a06f87)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
