### PR TITLE
Redirect to /domains/manage if jetpack site is selected

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -6,9 +6,7 @@ import ConnectDomainStep from 'calypso/components/domains/connect-domain-step';
 import TransferDomainStep from 'calypso/components/domains/transfer-domain-step';
 import UseMyDomain from 'calypso/components/domains/use-my-domain';
 import UseYourDomainStep from 'calypso/components/domains/use-your-domain-step';
-import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
-import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { sectionify } from 'calypso/lib/route';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -27,6 +25,7 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import {
 	getSelectedSiteId,
 	getSelectedSite,
@@ -37,7 +36,6 @@ import DomainSearch from './domain-search';
 import SiteRedirect from './domain-search/site-redirect';
 import EmailProvidersUpsell from './email-providers-upsell';
 
-const noop = () => {};
 const domainsAddHeader = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () => {
 		return translate( 'Select a site to add a domain' );
@@ -321,25 +319,8 @@ const jetpackNoDomainsWarning = ( context, next ) => {
 	const isJetpack = isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId );
 
 	if ( siteId && isJetpack ) {
-		context.primary = (
-			<Main>
-				<PageViewTracker
-					path={ context.path.startsWith( '/domains/add' ) ? '/domains/add' : '/domains/manage' }
-					title="My Sites > Domains > No Domains On Jetpack"
-				/>
-				<EmptyContent
-					title={ translate( 'Domains are not available for this site.' ) }
-					line={ translate(
-						'You can only purchase domains for sites hosted on WordPress.com at this time.'
-					) }
-					action={ translate( 'View Plans' ) }
-					actionURL={ '/plans/' + getSelectedSiteSlug( state ) }
-				/>
-			</Main>
-		);
-
-		makeLayout( context, noop );
-		clientRender( context );
+		context.store.dispatch( setSelectedSiteId( null ) );
+		page.redirect( '/domains/manage' );
 	} else {
 		next();
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3110

Not sure this safe at all, it seems to fix the initial issue but I'm seeing this function used across other routes, I think its probably ok to do this across all of them but it would be nice to go through each of them and check. 

Example usages: https://github.com/Automattic/wp-calypso/blob/5825d48762abc3e4edb6f1c581d30366d4b9f3d3/client/my-sites/domains/index.js#L179

## Proposed Changes

* Clear stored selected site id and redirect to /domains/manage when a jetpack site attempts to access or switch to the domains pages.

## Testing Instructions

* Load domains for a site, or the general /domains/manage all domains
* Switch to jp connected site
* Should not see the blank landing page: "Domains are not available for this site."
* Should be redirected to /domains/manage